### PR TITLE
feat!: add caller-supplied correlation id to operation metric events

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -318,7 +318,7 @@ impl LogSegment {
         name = LOG_SEGMENT_LOADED_SPAN,
         err,
         skip(storage, time_travel_version),
-        fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
+        fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""), num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
     )]
     #[internal_api]
     pub(crate) fn for_snapshot(

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -23,7 +23,7 @@ impl LogSegment {
     /// snapshot creation where both Protocol and Metadata must exist.
     ///
     /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed), skip(engine, crc))]
+    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, crc))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -7,6 +7,7 @@
 
 use std::fmt;
 use std::str::FromStr as _;
+use std::sync::Arc;
 use std::time::Duration;
 
 use delta_kernel_derive::internal_api;
@@ -192,9 +193,11 @@ impl MetricEvent {
             if let Self::TransactionCommitSuccess(e) = self {
                 let operation_id = e.operation_id;
                 let table_type = e.table_type;
+                let correlation_id = e.correlation_id.take();
                 *self = Self::TransactionCommitFailure(TransactionCommitFailure {
                     operation_id,
                     table_type,
+                    correlation_id,
                     reason: value.parse().unwrap_or(CommitFailureReason::Error),
                 });
             }
@@ -214,21 +217,25 @@ impl MetricEvent {
             Self::LogSegmentLoadSuccess(e) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
                 operation_id: e.operation_id,
                 table_type: e.table_type,
+                correlation_id: e.correlation_id,
             }),
             Self::ProtocolMetadataLoadSuccess(e) => {
                 Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
                     operation_id: e.operation_id,
                     table_type: e.table_type,
+                    correlation_id: e.correlation_id,
                 })
             }
             Self::SnapshotBuildSuccess(e) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
                 operation_id: e.operation_id,
                 table_type: e.table_type,
+                correlation_id: e.correlation_id,
             }),
             Self::TransactionCommitSuccess(e) => {
                 Self::TransactionCommitFailure(TransactionCommitFailure {
                     operation_id: e.operation_id,
                     table_type: e.table_type,
+                    correlation_id: e.correlation_id,
                     reason: CommitFailureReason::Error,
                 })
             }
@@ -298,6 +305,9 @@ pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 pub struct LogSegmentLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 
     // === Set during span lifetime ===
@@ -319,6 +329,7 @@ impl LogSegmentLoadSuccess {
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
+            correlation_id: correlation_id_from_attrs(attrs),
             num_commit_files: 0,
             num_checkpoint_files: 0,
             num_compaction_files: 0,
@@ -357,6 +368,7 @@ impl fmt::Display for LogSegmentLoadSuccess {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             duration,
             num_commit_files,
             num_checkpoint_files,
@@ -366,6 +378,7 @@ impl fmt::Display for LogSegmentLoadSuccess {
         write!(
             f,
             "LogSegmentLoadSuccess(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, \
              duration={duration:?}, commits={num_commit_files}, \
              checkpoints={num_checkpoint_files}, compactions={num_compaction_files}, \
              has_latest_crc={has_latest_crc_file})"
@@ -377,6 +390,9 @@ impl fmt::Display for LogSegmentLoadSuccess {
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadFailure {
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 }
 
@@ -384,8 +400,8 @@ impl fmt::Display for LogSegmentLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "LogSegmentLoadFailure(id={}, table_type={})",
-            self.operation_id, self.table_type
+            "LogSegmentLoadFailure(id={}, table_type={}, correlation_id={:?})",
+            self.operation_id, self.table_type, self.correlation_id
         )
     }
 }
@@ -401,6 +417,9 @@ pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 pub struct ProtocolMetadataLoadSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 
     // === Set on span close ===
@@ -414,6 +433,7 @@ impl ProtocolMetadataLoadSuccess {
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
+            correlation_id: correlation_id_from_attrs(attrs),
             duration: Duration::default(),
         }
     }
@@ -428,11 +448,13 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             duration,
         } = self;
         write!(
             f,
-            "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, duration={duration:?})"
+            "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, duration={duration:?})"
         )
     }
 }
@@ -441,6 +463,9 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadFailure {
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 }
 
@@ -448,8 +473,8 @@ impl fmt::Display for ProtocolMetadataLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "ProtocolMetadataLoadFailure(id={}, table_type={})",
-            self.operation_id, self.table_type
+            "ProtocolMetadataLoadFailure(id={}, table_type={}, correlation_id={:?})",
+            self.operation_id, self.table_type, self.correlation_id
         )
     }
 }
@@ -465,6 +490,9 @@ pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 pub struct SnapshotBuildSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 
     // === Set during span lifetime ===
@@ -481,6 +509,7 @@ impl SnapshotBuildSuccess {
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
+            correlation_id: correlation_id_from_attrs(attrs),
             version: 0,
             duration: Duration::default(),
         }
@@ -504,12 +533,14 @@ impl fmt::Display for SnapshotBuildSuccess {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             version,
             duration,
         } = self;
         write!(
             f,
-            "SnapshotBuildSuccess(id={operation_id}, table_type={table_type}, version={version}, duration={duration:?})"
+            "SnapshotBuildSuccess(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, version={version}, duration={duration:?})"
         )
     }
 }
@@ -522,6 +553,9 @@ impl fmt::Display for SnapshotBuildSuccess {
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildFailure {
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
 }
 
@@ -529,8 +563,8 @@ impl fmt::Display for SnapshotBuildFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SnapshotBuildFailure(id={}, table_type={})",
-            self.operation_id, self.table_type
+            "SnapshotBuildFailure(id={}, table_type={}, correlation_id={:?})",
+            self.operation_id, self.table_type, self.correlation_id
         )
     }
 }
@@ -546,6 +580,9 @@ pub(crate) const TRANSACTION_COMMIT_SPAN: &str = "txn.commit";
 pub struct TransactionCommitSuccess {
     // === Set on span creation ===
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
     pub commit_version: u64,
 
@@ -575,6 +612,7 @@ impl TransactionCommitSuccess {
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
+            correlation_id: correlation_id_from_attrs(attrs),
             commit_version: v.commit_version,
             num_add_files: 0,
             num_remove_files: 0,
@@ -629,6 +667,7 @@ impl fmt::Display for TransactionCommitSuccess {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             commit_version,
             num_add_files,
             num_remove_files,
@@ -643,7 +682,8 @@ impl fmt::Display for TransactionCommitSuccess {
         } = self;
         write!(
             f,
-            "TransactionCommitSuccess(id={operation_id}, table_type={table_type}, version={commit_version}, \
+            "TransactionCommitSuccess(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, version={commit_version}, \
              total_duration={total_duration:?}, prepare={prepare_duration:?}, committer={committer_duration:?}, \
              add_files={num_add_files}, remove_files={num_remove_files}, \
              add_bytes={add_files_bytes}, remove_bytes={remove_files_bytes}, \
@@ -672,6 +712,9 @@ pub enum CommitFailureReason {
 #[derive(Debug, Clone)]
 pub struct TransactionCommitFailure {
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
     pub reason: CommitFailureReason,
 }
@@ -681,11 +724,13 @@ impl fmt::Display for TransactionCommitFailure {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             reason,
         } = self;
         write!(
             f,
-            "TransactionCommitFailure(id={operation_id}, table_type={table_type}, reason={reason})"
+            "TransactionCommitFailure(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, reason={reason})"
         )
     }
 }
@@ -1059,9 +1104,10 @@ impl fmt::Display for TableType {
 }
 
 /// Operation-scoped values threaded through the snapshot-load chain to label its metric events.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SnapshotLoadMetricContext {
     pub(crate) operation_id: MetricId,
+    pub(crate) correlation_id: Option<Arc<str>>,
     pub(crate) is_catalog_managed: bool,
 }
 
@@ -1081,6 +1127,28 @@ pub(crate) fn read_is_catalog_managed(attrs: &Attributes<'_>) -> bool {
     v.0
 }
 
+/// The `correlation_id` string span field carried by every event that records it. Empty means the
+/// caller did not supply one.
+pub(crate) const CORRELATION_ID_FIELD: &str = "correlation_id";
+
+/// Extract the optional caller-supplied correlation id from span attributes; empty or absent
+/// yields `None`.
+pub(crate) fn correlation_id_from_attrs(attrs: &Attributes<'_>) -> Option<Arc<str>> {
+    #[derive(Default)]
+    struct CorrelationIdVisitor(Option<Arc<str>>);
+    impl Visit for CorrelationIdVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == CORRELATION_ID_FIELD && !value.is_empty() {
+                self.0 = Some(value.into());
+            }
+        }
+        fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+    }
+    let mut v = CorrelationIdVisitor::default();
+    attrs.record(&mut v);
+    v.0
+}
+
 /// A `parallel_scan_metadata` scan emits **two** events (one per phase) sharing the same
 /// `operation_id`; `scan_metadata` emits one event with [`ScanType::Full`].
 #[derive(Debug, Clone)]
@@ -1088,6 +1156,9 @@ pub struct ScanMetadataCompleted {
     // === Set on span creation ===
     /// Unique ID to correlate this scan with other events.
     pub operation_id: MetricId,
+    /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
+    /// own request or operation id.
+    pub correlation_id: Option<Arc<str>>,
     /// Whether the scanned table is path-based or catalog-managed.
     pub table_type: TableType,
     /// Which scan execution path produced this event.
@@ -1123,6 +1194,7 @@ impl ScanMetadataCompleted {
         Self {
             operation_id: MetricId(v.operation_id),
             table_type: TableType::from_catalog_managed(v.is_catalog_managed),
+            correlation_id: v.correlation_id,
             scan_type: ScanType::parse(&v.scan_type),
             duration: Duration::from_nanos(v.duration_ns),
             num_add_files_seen: v.num_add_files_seen,
@@ -1143,6 +1215,7 @@ impl fmt::Display for ScanMetadataCompleted {
         let Self {
             operation_id,
             table_type,
+            correlation_id,
             scan_type,
             duration,
             num_add_files_seen,
@@ -1157,7 +1230,8 @@ impl fmt::Display for ScanMetadataCompleted {
         } = self;
         write!(
             f,
-            "ScanMetadataCompleted(id={operation_id}, table_type={table_type}, scan_type={scan_type}, duration={duration:?}, \
+            "ScanMetadataCompleted(id={operation_id}, table_type={table_type}, \
+             correlation_id={correlation_id:?}, scan_type={scan_type}, duration={duration:?}, \
              add_files_seen={num_add_files_seen}, active_add_files={num_active_add_files}, \
              active_add_files_bytes={active_add_files_bytes}, \
              remove_files_seen={num_remove_files_seen}, non_file_actions={num_non_file_actions}, \
@@ -1171,6 +1245,7 @@ impl fmt::Display for ScanMetadataCompleted {
 struct ScanMetadataCompletedAttrs {
     operation_id: Uuid,
     is_catalog_managed: bool,
+    correlation_id: Option<Arc<str>>,
     scan_type: String,
     duration_ns: u64,
     num_add_files_seen: u64,
@@ -1188,6 +1263,12 @@ impl Visit for ScanMetadataCompletedAttrs {
     fn record_bool(&mut self, field: &Field, value: bool) {
         if field.name() == IS_CATALOG_MANAGED_FIELD {
             self.is_catalog_managed = value;
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == CORRELATION_ID_FIELD && !value.is_empty() {
+            self.correlation_id = Some(value.into());
         }
     }
 
@@ -1427,6 +1508,7 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         report = tracing::field::Empty,
         operation_id = %e.operation_id,
         is_catalog_managed = e.table_type.is_catalog_managed(),
+        correlation_id = e.correlation_id.as_deref().unwrap_or(""),
         scan_type = %e.scan_type,
         duration_ns = e.duration.as_nanos() as u64,
         num_add_files_seen = e.num_add_files_seen,
@@ -1451,6 +1533,7 @@ mod tests {
         TransactionCommitSuccess {
             operation_id,
             table_type: TableType::PathBased,
+            correlation_id: None,
             commit_version: 1,
             num_add_files: 0,
             num_remove_files: 0,
@@ -1503,5 +1586,43 @@ mod tests {
         };
         assert_eq!(failure.operation_id, id);
         assert_eq!(failure.reason, CommitFailureReason::Error);
+    }
+
+    #[test]
+    fn record_str_failure_reason_flip_preserves_correlation_id() {
+        let mut success = commit_success(MetricId::new());
+        success.correlation_id = Some("commit-req-1".into());
+        let mut event = MetricEvent::TransactionCommitSuccess(success);
+        event.record_str("failure_reason", "conflict").unwrap();
+        let MetricEvent::TransactionCommitFailure(failure) = event else {
+            panic!("expected TransactionCommitFailure");
+        };
+        assert_eq!(failure.correlation_id.as_deref(), Some("commit-req-1"));
+    }
+
+    #[test]
+    fn into_failure_preserves_correlation_id() {
+        let mut success = commit_success(MetricId::new());
+        success.correlation_id = Some("commit-req-2".into());
+        let MetricEvent::TransactionCommitFailure(failure) =
+            MetricEvent::TransactionCommitSuccess(success).into_failure()
+        else {
+            panic!("expected TransactionCommitFailure");
+        };
+        assert_eq!(failure.correlation_id.as_deref(), Some("commit-req-2"));
+
+        let snapshot = SnapshotBuildSuccess {
+            operation_id: MetricId::new(),
+            table_type: TableType::PathBased,
+            correlation_id: Some("snap-req-3".into()),
+            version: 0,
+            duration: Duration::default(),
+        };
+        let MetricEvent::SnapshotBuildFailure(failure) =
+            MetricEvent::SnapshotBuildSuccess(snapshot).into_failure()
+        else {
+            panic!("expected SnapshotBuildFailure");
+        };
+        assert_eq!(failure.correlation_id.as_deref(), Some("snap-req-3"));
     }
 }

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -494,6 +494,73 @@ mod tests {
         Ok(())
     }
 
+    /// A caller-supplied correlation id reaches both the sequential and parallel phase
+    /// `ScanMetadataCompleted` events. The sequential event is emitted before any serialization so
+    /// it always carries the id. The parallel event carries it in-memory but loses it when
+    /// `ParallelState` is rebuilt from bytes, a documented limitation shared with `operation_id`
+    /// (tracked in #2736). Workers are driven inline (not on spawned threads) so every emission
+    /// stays on the thread holding the metrics reporter guard.
+    #[rstest::rstest]
+    #[case::in_memory(false, Some("scan-corr-xyz"))]
+    #[case::across_serde_boundary(true, None)]
+    fn parallel_scan_metadata_phases_carry_correlation_id(
+        #[case] with_serde: bool,
+        #[case] expected_parallel: Option<&str>,
+    ) -> DeltaResult<()> {
+        // This table has checkpoint sidecars, so the sequential phase yields a parallel phase.
+        let (engine, snapshot, _tempdir) = load_test_table("v2-checkpoints-json-with-sidecars")?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let scan = snapshot
+            .scan_builder()
+            .with_correlation_id("scan-corr-xyz")
+            .build()?;
+        let mut sequential = scan.parallel_scan_metadata(engine.clone())?;
+        for sm in sequential.by_ref() {
+            sm?;
+        }
+        let AfterSequentialScanMetadata::Parallel { state, files } = sequential.finish()? else {
+            panic!("table with sidecars should require a parallel phase");
+        };
+        let state = if with_serde {
+            Arc::new(ParallelState::from_bytes(
+                engine.as_ref(),
+                &state.into_bytes()?,
+            )?)
+        } else {
+            Arc::new(*state)
+        };
+        let mut parallel = ParallelScanMetadata::try_new(engine.clone(), state.clone(), files)?;
+        for sm in parallel.by_ref() {
+            sm?;
+        }
+        state.log_metrics();
+
+        let correlation_for = |phase: ScanType| {
+            reporter.events().into_iter().find_map(|e| match e {
+                MetricEvent::ScanMetadataCompleted(s) if s.scan_type == phase => {
+                    Some(s.correlation_id)
+                }
+                _ => None,
+            })
+        };
+        assert_eq!(
+            correlation_for(ScanType::SequentialPhase)
+                .expect("expected a sequential-phase event")
+                .as_deref(),
+            Some("scan-corr-xyz"),
+        );
+        assert_eq!(
+            correlation_for(ScanType::ParallelPhase)
+                .expect("expected a parallel-phase event")
+                .as_deref(),
+            expected_parallel,
+        );
+        Ok(())
+    }
+
     /// Extract a metric value from logs by searching for "metric_name=value"
     fn extract_metric(logs: &str, metric_name: &str) -> u64 {
         let Some(pos) = logs.find(&format!("{}=", metric_name)) else {

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -35,16 +35,22 @@ pub enum AfterSequentialScanMetadata {
 pub struct SequentialScanMetadata {
     pub(crate) sequential: SequentialPhase<ScanLogReplayProcessor>,
     operation_id: MetricId,
+    /// Opaque, caller-supplied correlation id propagated to both phases' metric events.
+    correlation_id: Option<Arc<str>>,
     start: Instant,
     span: Span,
 }
 
 impl SequentialScanMetadata {
-    pub(crate) fn new(sequential: SequentialPhase<ScanLogReplayProcessor>) -> Self {
+    pub(crate) fn new(
+        sequential: SequentialPhase<ScanLogReplayProcessor>,
+        correlation_id: Option<Arc<str>>,
+    ) -> Self {
         let operation_id = MetricId::new();
         Self {
             sequential,
             operation_id,
+            correlation_id,
             start: Instant::now(),
             // TODO: Associate a unique scan ID with this span to correlate sequential and parallel
             // phases
@@ -59,6 +65,7 @@ impl SequentialScanMetadata {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
                     processor.is_catalog_managed(),
+                    self.correlation_id,
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -72,6 +79,7 @@ impl SequentialScanMetadata {
                 let event = processor.get_metrics().to_event(
                     self.operation_id,
                     processor.is_catalog_managed(),
+                    self.correlation_id.clone(),
                     ScanType::SequentialPhase,
                     self.start.elapsed(),
                 );
@@ -85,6 +93,7 @@ impl SequentialScanMetadata {
                     state: Box::new(ParallelState {
                         inner: processor,
                         operation_id: self.operation_id,
+                        correlation_id: self.correlation_id,
                         parallel_start: Instant::now(),
                     }),
                     files,
@@ -111,6 +120,10 @@ pub struct ParallelState {
     inner: ScanLogReplayProcessor,
     /// Operation ID inherited from the sequential phase for event correlation.
     operation_id: MetricId,
+    /// Opaque, caller-supplied correlation id inherited from the sequential phase. Does not
+    /// survive the serialization boundary; a reconstructed state carries `None` (tracked in
+    /// #2736).
+    correlation_id: Option<Arc<str>>,
     /// Start time for the parallel phase, set when this state is created.
     parallel_start: Instant,
 }
@@ -148,6 +161,7 @@ impl ParallelState {
         let event = self.inner.get_metrics().to_event(
             self.operation_id,
             self.inner.is_catalog_managed(),
+            self.correlation_id.clone(),
             ScanType::ParallelPhase,
             self.parallel_start.elapsed(),
         );
@@ -192,7 +206,10 @@ impl ParallelState {
         let inner = ScanLogReplayProcessor::from_serializable_state(engine, state)?;
         Ok(Self {
             inner,
+            // Neither operation_id nor correlation_id survive the serialization boundary today; a
+            // reconstructed state starts a fresh operation_id and has no correlation_id (#2736).
             operation_id: MetricId::new(),
+            correlation_id: None,
             parallel_start: Instant::now(),
         })
     }

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -1,6 +1,7 @@
 //! Metrics for scan log replay operations.
 
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use tracing::info;
@@ -111,12 +112,14 @@ impl ScanMetrics {
         &self,
         operation_id: MetricId,
         is_catalog_managed: bool,
+        correlation_id: Option<Arc<str>>,
         scan_type: ScanType,
         duration: Duration,
     ) -> ScanMetadataCompleted {
         ScanMetadataCompleted {
             operation_id,
             table_type: TableType::from_catalog_managed(is_catalog_managed),
+            correlation_id,
             scan_type,
             duration,
             num_add_files_seen: self.num_add_files_seen.load(Ordering::Relaxed),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -193,6 +193,7 @@ pub struct ScanBuilder {
     logical_read_schema: Option<SchemaRef>,
     predicate: Option<PredicateRef>,
     stats: StatsOptions,
+    correlation_id: Option<Arc<str>>,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -201,6 +202,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("logical_read_schema", &self.logical_read_schema)
             .field("predicate", &self.predicate)
             .field("stats", &self.stats)
+            .field("correlation_id", &self.correlation_id)
             .finish()
     }
 }
@@ -213,6 +215,7 @@ impl ScanBuilder {
             logical_read_schema: None,
             predicate: None,
             stats: StatsOptions::default(),
+            correlation_id: None,
         }
     }
 
@@ -270,6 +273,20 @@ impl ScanBuilder {
         self
     }
 
+    /// Attach an opaque, caller-supplied correlation id for joining this scan's metric events to
+    /// the caller's own request or operation id. An empty id is treated as unset. When unset,
+    /// behavior is unchanged.
+    ///
+    /// Note: like `operation_id`, the correlation id does not currently survive the
+    /// [`Scan::parallel_scan_metadata`] serialization boundary. A [`ParallelState`] reconstructed
+    /// from serialized bytes on a remote worker carries no correlation id (tracked in #2736).
+    ///
+    /// [`ParallelState`]: crate::scan::ParallelState
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -313,6 +330,7 @@ impl ScanBuilder {
             snapshot: self.snapshot,
             state_info: Arc::new(state_info),
             stats: self.stats,
+            correlation_id: self.correlation_id,
         })
     }
 }
@@ -572,6 +590,7 @@ pub struct Scan {
     snapshot: SnapshotRef,
     state_info: Arc<StateInfo>,
     stats: StatsOptions,
+    correlation_id: Option<Arc<str>>,
 }
 
 impl std::fmt::Debug for Scan {
@@ -580,6 +599,7 @@ impl std::fmt::Debug for Scan {
             .field("schema", &self.state_info.logical_schema)
             .field("predicate", &self.state_info.physical_predicate)
             .field("stats", &self.stats)
+            .field("correlation_id", &self.correlation_id)
             .finish()
     }
 }
@@ -835,6 +855,7 @@ impl Scan {
         let start = Instant::now();
         let operation_id = MetricId::new();
         let is_catalog_managed = self.snapshot.table_configuration().is_catalog_managed();
+        let correlation_id = self.correlation_id.clone();
 
         let (iter, metrics) = match self.state_info.physical_predicate {
             PhysicalPredicate::StaticSkipAll => {
@@ -857,6 +878,7 @@ impl Scan {
             let event = metrics.to_event(
                 operation_id,
                 is_catalog_managed,
+                correlation_id,
                 ScanType::Full,
                 start.elapsed(),
             );
@@ -1021,7 +1043,10 @@ impl Scan {
         let sequential =
             SequentialPhase::try_new(processor, self.snapshot.log_segment(), engine.clone())?;
 
-        Ok(SequentialScanMetadata::new(sequential))
+        Ok(SequentialScanMetadata::new(
+            sequential,
+            self.correlation_id.clone(),
+        ))
     }
 
     /// Perform an "all in one" scan. This will use the provided `engine` to read and process all

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1589,6 +1589,7 @@ mod scan_metadata_completed_tests {
     fn run_scan(
         table: &str,
         predicate: Option<Arc<Pred>>,
+        correlation_id: Option<&str>,
     ) -> (
         Arc<CapturingReporter>,
         tracing::subscriber::DefaultGuard,
@@ -1603,6 +1604,9 @@ mod scan_metadata_completed_tests {
         let mut builder = snapshot.scan_builder();
         if let Some(pred) = predicate {
             builder = builder.with_predicate(pred);
+        }
+        if let Some(id) = correlation_id {
+            builder = builder.with_correlation_id(id);
         }
         let scan = builder.build().unwrap();
         let results: Vec<_> = scan
@@ -1656,7 +1660,7 @@ mod scan_metadata_completed_tests {
         #[case] expected_removes: u64,
         #[case] expected_filtered: u64,
     ) {
-        let (reporter, _guard, _) = run_scan(table, predicate);
+        let (reporter, _guard, _) = run_scan(table, predicate, None);
         let MetricEvent::ScanMetadataCompleted(e) = get_scan_event(&reporter) else {
             panic!("expected ScanMetadataCompleted");
         };
@@ -1666,6 +1670,19 @@ mod scan_metadata_completed_tests {
         assert_eq!(e.active_add_files_bytes, expected_active_bytes);
         assert_eq!(e.num_remove_files_seen, expected_removes);
         assert_eq!(e.num_predicate_filtered, expected_filtered);
+    }
+
+    // The parallel-scan paths (both sequential and parallel phase events) are covered by
+    // `parallel_scan_metadata_phases_carry_correlation_id` in `parallel::parallel_phase`.
+    #[rstest]
+    #[case::with_id(Some("scan-req-1"))]
+    #[case::without_id(None)]
+    fn scan_metadata_completed_carries_correlation_id(#[case] correlation_id: Option<&str>) {
+        let (reporter, _guard, _) = run_scan("./tests/data/parsed-stats/", None, correlation_id);
+        let MetricEvent::ScanMetadataCompleted(e) = get_scan_event(&reporter) else {
+            panic!("expected ScanMetadataCompleted");
+        };
+        assert_eq!(e.correlation_id.as_deref(), correlation_id);
     }
 
     #[test]

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -1,5 +1,7 @@
 //! Builder for creating [`Snapshot`] instances.
 
+use std::sync::Arc;
+
 use tracing::{info, instrument};
 
 use crate::log_path::LogPath;
@@ -43,6 +45,9 @@ pub struct SnapshotBuilder {
     incremental_replay: IncrementalReplay,
     /// Kernel-minted id correlating this build's metric events with its child events.
     operation_id: MetricId,
+    /// Opaque, caller-supplied id recorded on this build's metric events. Not interpreted by
+    /// kernel; set via [`with_correlation_id`](Self::with_correlation_id).
+    correlation_id: Option<Arc<str>>,
 }
 
 /// Controls whether kernel replays commits to advance a stale base CRC (the existing snapshot's
@@ -103,6 +108,7 @@ impl SnapshotBuilder {
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
+            correlation_id: None,
         }
     }
 
@@ -115,6 +121,7 @@ impl SnapshotBuilder {
             max_catalog_version: None,
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
+            correlation_id: None,
         }
     }
 
@@ -177,6 +184,14 @@ impl SnapshotBuilder {
         self
     }
 
+    /// Attach an opaque, caller-supplied correlation id for joining this build's metric events to
+    /// the caller's own request or operation id. An empty id is treated as unset. When unset,
+    /// behavior is unchanged.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
+    }
+
     // ============================================================================
     // Terminal: build the Snapshot
     // ============================================================================
@@ -199,7 +214,7 @@ impl SnapshotBuilder {
     #[instrument(
         name = SNAPSHOT_COMPLETED_SPAN,
         skip_all,
-        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %self.operation_id, is_catalog_managed = self.max_catalog_version.is_some()),
+        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %self.operation_id, is_catalog_managed = self.max_catalog_version.is_some(), correlation_id = self.correlation_id.as_deref().unwrap_or("")),
         err
     )]
     pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
@@ -220,11 +235,13 @@ impl SnapshotBuilder {
             max_catalog_version,
             incremental_replay,
             operation_id,
+            correlation_id,
         } = self;
 
         let metric_context = SnapshotLoadMetricContext {
             operation_id,
             is_catalog_managed: max_catalog_version.is_some(),
+            correlation_id,
         };
 
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
@@ -244,7 +261,7 @@ impl SnapshotBuilder {
                     table_url.join("_delta_log/")?,
                     log_tail,
                     effective_version,
-                    metric_context,
+                    metric_context.clone(),
                 )?;
                 Snapshot::try_new_from_log_segment(
                     table_url,
@@ -730,6 +747,56 @@ mod tests {
         assert!(
             snap_duration >= segment_duration,
             "SnapshotBuildSuccess.duration ({snap_duration:?}) should be >= LogSegmentLoadSuccess.duration ({segment_duration:?})"
+        );
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case::with_id(Some("req-abc-123"))]
+    #[case::without_id(None)]
+    #[test_log::test(tokio::test)]
+    async fn snapshot_build_and_child_events_carry_correlation_id(
+        #[case] correlation_id: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+
+        let (reporter, _guard) = measuring_reporter();
+        let mut builder = SnapshotBuilder::new_for(table_root);
+        if let Some(id) = correlation_id {
+            builder = builder.with_correlation_id(id);
+        }
+        builder.build(engine.as_ref())?;
+
+        // The build event and its snapshot-load child events must all carry the id, since they
+        // ride the same SnapshotLoadMetricContext.
+        let events = reporter.events();
+        let id_of = |pick: fn(&MetricEvent) -> Option<&Option<Arc<str>>>| {
+            events
+                .iter()
+                .find_map(pick)
+                .expect("expected event")
+                .as_deref()
+                .map(str::to_string)
+        };
+        let build_id = id_of(|e| match e {
+            MetricEvent::SnapshotBuildSuccess(s) => Some(&s.correlation_id),
+            _ => None,
+        });
+        let segment_id = id_of(|e| match e {
+            MetricEvent::LogSegmentLoadSuccess(s) => Some(&s.correlation_id),
+            _ => None,
+        });
+        let metadata_id = id_of(|e| match e {
+            MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(&s.correlation_id),
+            _ => None,
+        });
+        let expected = correlation_id.map(str::to_string);
+        assert_eq!(build_id, expected);
+        assert_eq!(segment_id, expected, "log-segment child must carry the id");
+        assert_eq!(
+            metadata_id, expected,
+            "protocol/metadata child must carry the id"
         );
         Ok(())
     }

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -82,7 +82,7 @@ impl Snapshot {
     ///
     /// [`SnapshotBuilder::at_version`]: crate::snapshot::SnapshotBuilder::at_version
     /// [`SnapshotBuilder::with_max_catalog_version`]: crate::snapshot::SnapshotBuilder::with_max_catalog_version
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id), skip(engine, target_version))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, target_version))]
     pub(super) fn try_new_from(
         existing_snapshot: Arc<Snapshot>,
         log_tail: Vec<ParsedLogPath>,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -174,7 +174,7 @@ impl Snapshot {
     /// from the latest on-disk CRC, advanced to the segment's end version when `incremental_replay`
     /// permits, or used to root Protocol and Metadata log replay otherwise. Falls back to full log
     /// replay when no CRC is present.
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id), skip(engine))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
         log_segment: LogSegment,

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -49,6 +49,7 @@ impl AlterTableTransaction {
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
+            correlation_id: None,
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
             should_emit_protocol: false,

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -152,6 +152,7 @@ impl CreateTableTransaction {
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
+            correlation_id: None,
             read_snapshot_opt: None,
             effective_table_config,
             should_emit_protocol: true,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -209,6 +209,9 @@ pub struct Transaction<S = ExistingTable> {
     span: tracing::Span,
     // Correlates all metric events emitted by this transaction.
     operation_id: MetricId,
+    // Opaque, caller-supplied id recorded on this transaction's commit metric events alongside
+    // `operation_id`. Set via `with_correlation_id`; not interpreted by kernel.
+    correlation_id: Option<Arc<str>>,
     // The snapshot this transaction is based on. None for CREATE TABLE (no pre-existing table).
     // Use `read_snapshot()` to access; it returns an error if None.
     read_snapshot_opt: Option<SnapshotRef>,
@@ -338,6 +341,7 @@ impl<S> Transaction<S> {
             report,
             operation_id = %self.operation_id,
             is_catalog_managed = self.effective_table_config.is_catalog_managed(),
+            correlation_id = self.correlation_id.as_deref().unwrap_or(""),
             commit_version = self.get_commit_version(),
             num_add_files,
             num_remove_files,
@@ -599,6 +603,14 @@ impl<S> Transaction<S> {
     /// Set the engine info field of this transaction's commit info action. This field is optional.
     pub fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
         self.engine_info = Some(engine_info.into());
+        self
+    }
+
+    /// Attach an opaque, caller-supplied correlation id for joining this transaction's commit
+    /// metric events to the caller's own request or operation id. An empty id is treated as unset.
+    /// When unset, behavior is unchanged.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
         self
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -79,6 +79,7 @@ impl Transaction {
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
+            correlation_id: None,
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
             should_emit_protocol: false,

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -92,6 +92,29 @@ async fn commit_append_emits_success_metrics(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
+    let (_temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    create_table(&table_path, simple_schema(), "Test/1.0")
+        .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .with_correlation_id("commit-req-1")
+        .commit(setup_engine.as_ref())?
+        .unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(success.commit_version, 0);
+    assert_eq!(success.correlation_id.as_deref(), Some("commit-req-1"));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn commit_conflict_emits_conflict_metric() -> DeltaResult<()> {
     // GIVEN a table at v0 (00.json) and a snapshot pinned to it.
     let (_temp_dir, table_url) = setup_empty_table()?;

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -452,6 +452,7 @@ mod tests {
         reporter.report(MetricEvent::SnapshotBuildSuccess(SnapshotBuildSuccess {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
+            correlation_id: None,
             version: 0,
             duration: dur(),
         }));
@@ -464,6 +465,7 @@ mod tests {
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
+            correlation_id: None,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,
@@ -483,6 +485,7 @@ mod tests {
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
+            correlation_id: None,
             duration: dur(),
             num_commit_files: 3,
             num_checkpoint_files: 1,
@@ -559,6 +562,7 @@ mod tests {
             TransactionCommitSuccess {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
+                correlation_id: None,
                 commit_version: 1,
                 num_add_files: 3,
                 num_remove_files: 2,
@@ -591,6 +595,7 @@ mod tests {
                 TransactionCommitFailure {
                     operation_id: MetricId::new(),
                     table_type: TableType::PathBased,
+                    correlation_id: None,
                     reason,
                 },
             ));
@@ -608,12 +613,14 @@ mod tests {
             ProtocolMetadataLoadSuccess {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
+                correlation_id: None,
                 duration: dur(),
             },
         ));
         reporter.report(MetricEvent::SnapshotBuildFailure(SnapshotBuildFailure {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
+            correlation_id: None,
         }));
         assert_eq!(reporter.snapshot_completions.get(), 0);
     }
@@ -636,6 +643,7 @@ mod tests {
         reporter.report(MetricEvent::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
+            correlation_id: None,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #2731.

Kernel mints its own random `MetricId` per operation, but a connector has no way to tie those kernel operations back to its own request id. When you're looking at kernel logs and metrics from the engine side, there's no structured link from a kernel `operation_id` to, say, a Spark Connect operation id, so you end up reconstructing the mapping by hand from interleaved driver logs.

This adds an optional, opaque, caller-supplied `correlation_id` that you can set on the snapshot/scan/transaction builders. Kernel doesn't interpret it; it just records it on each operation's terminal metric event, next to the existing `operation_id`:

```rust
let snapshot = Snapshot::builder_for(url)
    .with_correlation_id(request_id)
    .build(engine)?;
```

The setters map to these events:

- `SnapshotBuilder::with_correlation_id` -> `SnapshotBuildSuccess` / `SnapshotBuildFailure`
- `ScanBuilder::with_correlation_id` -> `ScanMetadataCompleted`
- `Transaction::with_correlation_id` -> `TransactionCommitSuccess` / `TransactionCommitFailure`

When unset, the field is an empty string that decodes to `None`, so behavior is unchanged. Kernel keeps minting its own per-operation `MetricId`; the correlation id is an additional field, not a replacement, so the 1:N case (one request driving many kernel operations) still works.

There's no new state on `Engine`. The id travels with the operation's own state, which is also how it survives the cross-thread split in `parallel_scan_metadata` (threaded into `SequentialScanMetadata` and inherited by `ParallelState`).

It rides the metric machinery #2721 introduced for `table_type`: `correlation_id` is carried on `SnapshotLoadMetricContext` and recorded on every operation metric event beside `operation_id` and `table_type`. That includes the snapshot-load child events (log-segment and protocol-metadata loads), the scan event, and the transaction-commit events, so a connector can join any kernel metric event back to its request id directly, not only the terminal one.

### This PR affects the following public APIs

New (non-breaking) additions:

- `with_correlation_id(impl Into<Arc<str>>)` on `SnapshotBuilder`, `ScanBuilder`, and `Transaction`.

Breaking:

- A `correlation_id: Option<Arc<str>>` field is added to the five terminal `MetricEvent` payload structs. These are public, non-`#[non_exhaustive]` structs, so the new field breaks downstream struct literals and exhaustive matches, hence `feat!`.

### Design alternatives considered

Hanging the id off the `Engine` or a `MetricsReporter` instead of the operation. The tempting shortcut is to hand the correlation id to the engine (or to a reporter) once and let it tag every event it emits. The lifecycles don't line up:

1/ The `Engine`, and any reporter wired into it, is long-lived and shared. It holds I/O clients, the runtime, and the handlers, and is reused across many operations and threads. Identity here is per operation, not per engine.
2/ A single caller request routinely drives several kernel operations on the same engine: a snapshot build per referenced table, plus scan(s), plus transaction(s), plus incremental re-resolves. A "current correlation id" stored on the shared engine or reporter would be shared mutable state that races across those concurrent operations, with no single correct value to hold.
3/ This is the same reason kernel's own `operation_id` already lives on per-operation spans and events rather than on the shared reporter. The correlation id has to travel with the operation's state for the same reason, and that is also what lets it survive the cross-thread and distributed split in `parallel_scan_metadata`, where a reporter-level or thread-local value would simply be lost.

So the id is set on the per-operation builder and threaded with the operation, mirroring `operation_id`. For the same lifecycle reason it's kept as a separate field rather than folded into `operation_id`: the two are distinct concerns (kernel's per-operation id versus the caller's request id), and `operation_id` stays a clean `Uuid` rather than an opaque composite string.

### Known limitation

The correlation id, like `operation_id`, does not survive the `parallel_scan_metadata` serialization boundary. A `ParallelState` rebuilt from bytes on a remote worker starts fresh with no correlation id. This is documented on `with_correlation_id` and pinned by a test, and is tracked as a follow-up in #2736 (which covers both `operation_id` and `correlation_id`).

## How was this change tested?

New unit and integration tests cover snapshot build success and failure carryover, full-scan and parallel-scan (both phases) propagation, transaction commit success plus the conflict and terminal-error failure flips, the serde-boundary limitation, and the empty-string to `None` round trip. Existing `cargo fmt`, `clippy`, `doc`, and the test suite all pass.

