### PR TITLE
fix: accept LargeBinary and BinaryView for variant fields

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1073,11 +1073,11 @@ mod tests {
 
     use super::*;
     use crate::arrow::array::{
-        ArrayRef, BooleanArray, Int32Array, Int64Array, LargeStringArray, MapBuilder, StringArray,
-        StringBuilder, StructArray, TimestampMicrosecondArray,
+        ArrayRef, BooleanArray, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray,
+        MapBuilder, StringArray, StringBuilder, StructArray, TimestampMicrosecondArray,
     };
     use crate::arrow::datatypes::{
-        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
     use crate::expressions::{
         col, column_expr, column_expr_ref, lit, BinaryExpressionOp, Expression as Expr,
@@ -1892,6 +1892,31 @@ mod tests {
         assert_eq!(b_col.value(0), "hello");
         assert_eq!(b_col.value(1), "world");
         assert_eq!(b_col.value(2), "test");
+    }
+
+    #[test]
+    fn test_extract_variant_column_with_large_binary_fields() {
+        let fields: Fields = vec![
+            ArrowField::new("metadata", ArrowDataType::LargeBinary, false),
+            ArrowField::new("value", ArrowDataType::LargeBinary, false),
+        ]
+        .into();
+        let variant_arrow_type = ArrowDataType::Struct(fields.clone());
+        let metadata = Arc::new(LargeBinaryArray::from(vec![&[0x01, 0x00, 0x00][..]])) as ArrayRef;
+        let value = Arc::new(LargeBinaryArray::from(vec![&[0x0C, 0x01][..]])) as ArrayRef;
+        let variant = StructArray::try_new(fields, vec![metadata, value], None).unwrap();
+        let schema = ArrowSchema::new(vec![ArrowField::new("v", variant_arrow_type.clone(), true)]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(variant)]).unwrap();
+
+        let result = evaluate_expression(
+            &column_expr!("v"),
+            &batch,
+            Some(&DataType::unshredded_variant()),
+        )
+        .unwrap();
+
+        // The 64-bit offsets pass through without a cast back to 32-bit Binary.
+        assert_eq!(result.data_type(), &variant_arrow_type);
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1073,8 +1073,8 @@ mod tests {
 
     use super::*;
     use crate::arrow::array::{
-        ArrayRef, BooleanArray, Int32Array, Int64Array, LargeBinaryArray, LargeStringArray,
-        MapBuilder, StringArray, StringBuilder, StructArray, TimestampMicrosecondArray,
+        ArrayRef, BinaryArray, BooleanArray, Int32Array, Int64Array, LargeStringArray, MapBuilder,
+        StringArray, StringBuilder, StructArray, TimestampMicrosecondArray,
     };
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
@@ -1894,16 +1894,27 @@ mod tests {
         assert_eq!(b_col.value(2), "test");
     }
 
-    #[test]
-    fn test_extract_variant_column_with_large_binary_fields() {
+    #[rstest]
+    fn test_extract_variant_column_preserves_binary_representation(
+        #[values(
+            ArrowDataType::Binary,
+            ArrowDataType::LargeBinary,
+            ArrowDataType::BinaryView
+        )]
+        binary_type: ArrowDataType,
+    ) {
+        let metadata = cast(
+            &BinaryArray::from(vec![&[0x01, 0x00, 0x00][..]]),
+            &binary_type,
+        )
+        .unwrap();
+        let value = cast(&BinaryArray::from(vec![&[0x0C, 0x01][..]]), &binary_type).unwrap();
         let fields: Fields = vec![
-            ArrowField::new("metadata", ArrowDataType::LargeBinary, false),
-            ArrowField::new("value", ArrowDataType::LargeBinary, false),
+            ArrowField::new("metadata", binary_type.clone(), false),
+            ArrowField::new("value", binary_type, false),
         ]
         .into();
         let variant_arrow_type = ArrowDataType::Struct(fields.clone());
-        let metadata = Arc::new(LargeBinaryArray::from(vec![&[0x01, 0x00, 0x00][..]])) as ArrayRef;
-        let value = Arc::new(LargeBinaryArray::from(vec![&[0x0C, 0x01][..]])) as ArrayRef;
         let variant = StructArray::try_new(fields, vec![metadata, value], None).unwrap();
         let schema = ArrowSchema::new(vec![ArrowField::new("v", variant_arrow_type.clone(), true)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(variant)]).unwrap();
@@ -1915,7 +1926,7 @@ mod tests {
         )
         .unwrap();
 
-        // LargeBinary is preserved, not cast.
+        // The binary representation is preserved.
         assert_eq!(result.data_type(), &variant_arrow_type);
     }
 

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1915,7 +1915,7 @@ mod tests {
         )
         .unwrap();
 
-        // The 64-bit offsets pass through without a cast back to 32-bit Binary.
+        // LargeBinary is preserved, not cast.
         assert_eq!(result.data_type(), &variant_arrow_type);
     }
 

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1926,7 +1926,6 @@ mod tests {
         )
         .unwrap();
 
-        // The binary representation is preserved.
         assert_eq!(result.data_type(), &variant_arrow_type);
     }
 

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -384,10 +384,11 @@ mod apply_schema_validation_tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{Int32Array, RecordBatch, StructArray};
+    use crate::arrow::array::{ArrayRef, BinaryArray, Int32Array, RecordBatch, StructArray};
     use crate::arrow::buffer::{BooleanBuffer, NullBuffer};
+    use crate::arrow::compute::cast;
     use crate::arrow::datatypes::{
-        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+        DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
     use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
     use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
@@ -396,6 +397,34 @@ mod apply_schema_validation_tests {
         array_in_map_with_field_ids, assert_result_error_with_message,
         collect_arrow_field_metadata, complex_nested_with_field_ids,
     };
+
+    #[rstest]
+    fn apply_schema_accepts_any_binary_representation_for_variant(
+        #[values(
+            ArrowDataType::Binary,
+            ArrowDataType::LargeBinary,
+            ArrowDataType::BinaryView
+        )]
+        binary_type: ArrowDataType,
+    ) {
+        let metadata = cast(
+            &BinaryArray::from(vec![&[0x01, 0x00, 0x00][..]]),
+            &binary_type,
+        )
+        .unwrap();
+        let value = cast(&BinaryArray::from(vec![&[0x0C, 0x01][..]]), &binary_type).unwrap();
+        let fields: Fields = vec![
+            ArrowField::new("metadata", binary_type.clone(), false),
+            ArrowField::new("value", binary_type, false),
+        ]
+        .into();
+        let variant: ArrayRef =
+            Arc::new(StructArray::try_new(fields, vec![metadata, value], None).unwrap());
+
+        let result = apply_schema_to(&variant, &DataType::unshredded_variant()).unwrap();
+
+        assert_eq!(result.data_type(), variant.data_type());
+    }
 
     #[test]
     fn test_apply_schema_basic_functionality() {

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -79,8 +79,7 @@ impl EnsureDataTypes {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
             // A variant is physically a struct of binary fields. Validate it like a struct so
-            // that engines may use any arrow binary representation (Binary, LargeBinary,
-            // BinaryView) for its fields.
+            // that engines may use any arrow binary representation for its fields.
             (DataType::Variant(variant_fields), ArrowDataType::Struct(_)) => {
                 self.ensure_data_types(&DataType::Struct(variant_fields.clone()), arrow_type)
             }
@@ -328,7 +327,6 @@ mod tests {
     use super::*;
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Fields};
     use crate::engine::arrow_conversion::TryFromKernel as _;
-    use crate::engine::arrow_data::unshredded_variant_arrow_type;
     use crate::schema::{ArrayType, DataType, MapType, StructField};
     use crate::utils::test_utils::assert_result_error_with_message;
 
@@ -391,9 +389,20 @@ mod tests {
         assert!(!can_upcast_to_decimal(&Int64, 20u8, 1i8));
     }
 
-    fn variant_struct_arrow_type(binary_type: ArrowDataType, nullable: bool) -> ArrowDataType {
+    /// The canonical `unshredded_variant_arrow_type` shape with the binary representation and
+    /// field nullability swapped out.
+    fn unshredded_variant_arrow_type_with(
+        binary_type: ArrowDataType,
+        nullable: bool,
+    ) -> ArrowDataType {
         let metadata_field = ArrowField::new("metadata", binary_type.clone(), nullable);
         let value_field = ArrowField::new("value", binary_type, nullable);
+        ArrowDataType::Struct(vec![metadata_field, value_field].into())
+    }
+
+    fn wrong_field_names_variant_arrow_type() -> ArrowDataType {
+        let metadata_field = ArrowField::new("field_1", ArrowDataType::Binary, true);
+        let value_field = ArrowField::new("field_2", ArrowDataType::Binary, true);
         ArrowDataType::Struct(vec![metadata_field, value_field].into())
     }
 
@@ -409,7 +418,7 @@ mod tests {
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
-                &variant_struct_arrow_type(binary_type, false),
+                &unshredded_variant_arrow_type_with(binary_type, false),
                 ValidationMode::Full,
             )
             .unwrap(),
@@ -417,46 +426,24 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ensure_variants() {
-        fn incorrect_variant_arrow_type() -> ArrowDataType {
-            let metadata_field = ArrowField::new("field_1", ArrowDataType::Binary, true);
-            let value_field = ArrowField::new("field_2", ArrowDataType::Binary, true);
-            let fields = vec![metadata_field, value_field];
-            ArrowDataType::Struct(fields.into())
-        }
-
-        assert!(ensure_data_types(
-            &DataType::unshredded_variant(),
-            &unshredded_variant_arrow_type(),
-            ValidationMode::Full
-        )
-        .is_ok());
+    #[rstest]
+    #[case::wrong_field_names(
+        wrong_field_names_variant_arrow_type(),
+        "Missing Struct fields metadata, value"
+    )]
+    #[case::nullable_fields(
+        unshredded_variant_arrow_type_with(ArrowDataType::LargeBinary, true),
+        "metadata has nullablily false in kernel and true in arrow"
+    )]
+    #[case::not_a_struct(ArrowDataType::Binary, "Incorrect datatype")]
+    fn ensure_variant_rejects(#[case] arrow_type: ArrowDataType, #[case] expected_err: &str) {
         assert_result_error_with_message(
             ensure_data_types(
                 &DataType::unshredded_variant(),
-                &incorrect_variant_arrow_type(),
+                &arrow_type,
                 ValidationMode::Full,
             ),
-            "Invalid argument error: Missing Struct fields metadata, value",
-        );
-        // Full mode still enforces the non-nullability of the variant's fields.
-        assert_result_error_with_message(
-            ensure_data_types(
-                &DataType::unshredded_variant(),
-                &variant_struct_arrow_type(ArrowDataType::LargeBinary, true),
-                ValidationMode::Full,
-            ),
-            "metadata has nullablily false in kernel and true in arrow",
-        );
-        // A variant must be a struct in arrow.
-        assert_result_error_with_message(
-            ensure_data_types(
-                &DataType::unshredded_variant(),
-                &ArrowDataType::Binary,
-                ValidationMode::Full,
-            ),
-            "Invalid argument error: Incorrect datatype",
+            expected_err,
         );
     }
 

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -78,6 +78,12 @@ impl EnsureDataTypes {
             (DataType::Primitive(_), _) if arrow_type.is_primitive() => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
+            // A variant is physically a struct of binary fields. Validate it like a struct so
+            // that engines may use any arrow binary representation (Binary, LargeBinary,
+            // BinaryView) for its fields.
+            (DataType::Variant(variant_fields), ArrowDataType::Struct(_)) => {
+                self.ensure_data_types(&DataType::Struct(variant_fields.clone()), arrow_type)
+            }
             (&DataType::Variant(_), _) => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
@@ -317,6 +323,8 @@ fn metadata_eq(
 mod tests {
     use std::sync::Arc;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Fields};
     use crate::engine::arrow_conversion::TryFromKernel as _;
@@ -383,6 +391,32 @@ mod tests {
         assert!(!can_upcast_to_decimal(&Int64, 20u8, 1i8));
     }
 
+    fn variant_struct_arrow_type(binary_type: ArrowDataType, nullable: bool) -> ArrowDataType {
+        let metadata_field = ArrowField::new("metadata", binary_type.clone(), nullable);
+        let value_field = ArrowField::new("value", binary_type, nullable);
+        ArrowDataType::Struct(vec![metadata_field, value_field].into())
+    }
+
+    #[rstest]
+    fn ensure_variant_accepts_any_binary_representation(
+        #[values(
+            ArrowDataType::Binary,
+            ArrowDataType::LargeBinary,
+            ArrowDataType::BinaryView
+        )]
+        binary_type: ArrowDataType,
+    ) {
+        assert_eq!(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &variant_struct_arrow_type(binary_type, false),
+                ValidationMode::Full,
+            )
+            .unwrap(),
+            DataTypeCompat::Nested
+        );
+    }
+
     #[test]
     fn ensure_variants() {
         fn incorrect_variant_arrow_type() -> ArrowDataType {
@@ -404,8 +438,26 @@ mod tests {
                 &incorrect_variant_arrow_type(),
                 ValidationMode::Full,
             ),
+            "Invalid argument error: Missing Struct fields metadata, value",
+        );
+        // Full mode still enforces the non-nullability of the variant's fields.
+        assert_result_error_with_message(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &variant_struct_arrow_type(ArrowDataType::LargeBinary, true),
+                ValidationMode::Full,
+            ),
+            "metadata has nullablily false in kernel and true in arrow",
+        );
+        // A variant must be a struct in arrow.
+        assert_result_error_with_message(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &ArrowDataType::Binary,
+                ValidationMode::Full,
+            ),
             "Invalid argument error: Incorrect datatype",
-        )
+        );
     }
 
     #[test]

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -79,7 +79,7 @@ impl EnsureDataTypes {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
             // A variant is physically a struct of binary fields. Validate it like a struct so
-            // that engines may use any arrow binary representation for its fields.
+            // that engines may use any Arrow binary representation for its fields.
             (DataType::Variant(variant_fields), ArrowDataType::Struct(_)) => {
                 self.ensure_data_types(&DataType::Struct(variant_fields.clone()), arrow_type)
             }
@@ -150,14 +150,14 @@ impl EnsureDataTypes {
                         }
                     }
                     ValidationMode::TypesAndNames | ValidationMode::Full => {
-                        // Name-based matching: look up kernel fields by arrow field name.
-                        // Full mode additionally checks nullability and metadata.
-                        let mapped_fields = arrow_fields
-                            .iter()
-                            .filter_map(|f| kernel_fields.field(f.name()));
-
+                        // Name-based matching: look up the kernel field for each arrow field by
+                        // name. Arrow fields with no kernel counterpart are ignored. Full mode
+                        // additionally checks nullability and metadata.
                         let mut found_fields = 0;
-                        for (kernel_field, arrow_field) in mapped_fields.zip(arrow_fields) {
+                        for arrow_field in arrow_fields {
+                            let Some(kernel_field) = kernel_fields.field(arrow_field.name()) else {
+                                continue;
+                            };
                             self.ensure_nullability_and_metadata(kernel_field, arrow_field)?;
                             self.ensure_data_types(
                                 &kernel_field.data_type,
@@ -199,7 +199,7 @@ impl EnsureDataTypes {
             && kernel_field_is_nullable != arrow_field_is_nullable
         {
             Err(Error::Generic(format!(
-                "{desc} has nullablily {kernel_field_is_nullable} in kernel and {arrow_field_is_nullable} in arrow",
+                "{desc} has nullability {kernel_field_is_nullable} in kernel and {arrow_field_is_nullable} in arrow",
             )))
         } else {
             Ok(())
@@ -389,8 +389,7 @@ mod tests {
         assert!(!can_upcast_to_decimal(&Int64, 20u8, 1i8));
     }
 
-    /// The canonical `unshredded_variant_arrow_type` shape with the binary representation and
-    /// field nullability swapped out.
+    /// An unshredded variant arrow type with a chosen binary representation and field nullability.
     fn unshredded_variant_arrow_type_with(
         binary_type: ArrowDataType,
         nullable: bool,
@@ -406,6 +405,17 @@ mod tests {
         ArrowDataType::Struct(vec![metadata_field, value_field].into())
     }
 
+    /// Build a variant-shaped arrow struct from `(name, type)` pairs, all non-nullable.
+    fn variant_arrow_struct(
+        fields: impl IntoIterator<Item = (&'static str, ArrowDataType)>,
+    ) -> ArrowDataType {
+        let fields: Vec<_> = fields
+            .into_iter()
+            .map(|(name, data_type)| ArrowField::new(name, data_type, false))
+            .collect();
+        ArrowDataType::Struct(fields.into())
+    }
+
     #[rstest]
     fn ensure_variant_accepts_any_binary_representation(
         #[values(
@@ -414,12 +424,55 @@ mod tests {
             ArrowDataType::BinaryView
         )]
         binary_type: ArrowDataType,
+        #[values(ValidationMode::TypesAndNames, ValidationMode::Full)] mode: ValidationMode,
     ) {
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
                 &unshredded_variant_arrow_type_with(binary_type, false),
+                mode,
+            )
+            .unwrap(),
+            DataTypeCompat::Nested
+        );
+    }
+
+    /// `metadata` and `value` may use different binary representations within the same struct,
+    /// and extra fields (e.g. a shredded `typed_value`) are ignored regardless of their position.
+    #[rstest]
+    #[case::mixed_binary_representations(variant_arrow_struct([
+        ("metadata", ArrowDataType::Binary),
+        ("value", ArrowDataType::LargeBinary),
+    ]))]
+    #[case::extra_field_last(variant_arrow_struct([
+        ("metadata", ArrowDataType::Binary),
+        ("value", ArrowDataType::Binary),
+        ("typed_value", ArrowDataType::Int64),
+    ]))]
+    #[case::extra_field_interleaved(variant_arrow_struct([
+        ("metadata", ArrowDataType::Binary),
+        ("typed_value", ArrowDataType::Int64),
+        ("value", ArrowDataType::Binary),
+    ]))]
+    fn ensure_variant_accepts_extra_and_mixed_fields(#[case] arrow_type: ArrowDataType) {
+        assert_eq!(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &arrow_type,
                 ValidationMode::Full,
+            )
+            .unwrap(),
+            DataTypeCompat::Nested
+        );
+    }
+
+    #[test]
+    fn ensure_variant_nullable_fields_accepted_without_full_validation() {
+        assert_eq!(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &unshredded_variant_arrow_type_with(ArrowDataType::LargeBinary, true),
+                ValidationMode::TypesAndNames,
             )
             .unwrap(),
             DataTypeCompat::Nested
@@ -433,9 +486,16 @@ mod tests {
     )]
     #[case::nullable_fields(
         unshredded_variant_arrow_type_with(ArrowDataType::LargeBinary, true),
-        "metadata has nullablily false in kernel and true in arrow"
+        "metadata has nullability false in kernel and true in arrow"
     )]
     #[case::not_a_struct(ArrowDataType::Binary, "Incorrect datatype")]
+    #[case::non_binary_value(
+        variant_arrow_struct([
+            ("metadata", ArrowDataType::Binary),
+            ("value", ArrowDataType::Utf8),
+        ]),
+        "Incorrect datatype"
+    )]
     fn ensure_variant_rejects(#[case] arrow_type: ArrowDataType, #[case] expected_err: &str) {
         assert_result_error_with_message(
             ensure_data_types(
@@ -488,7 +548,7 @@ mod tests {
                 arrow_field.data_type(),
                 ValidationMode::Full,
             ),
-            "Generic delta kernel error: Map has nullablily false in kernel and true in arrow",
+            "Generic delta kernel error: Map has nullability false in kernel and true in arrow",
         );
         assert_result_error_with_message(
             ensure_data_types(
@@ -528,7 +588,7 @@ mod tests {
                 &ArrowDataType::new_list(ArrowDataType::Int64, false),
                 ValidationMode::Full,
             ),
-            "Generic delta kernel error: List has nullablily true in kernel and false in arrow",
+            "Generic delta kernel error: List has nullability true in kernel and false in arrow",
         );
     }
 
@@ -606,7 +666,7 @@ mod tests {
                 arrow_nullable_mismatch_simple.data_type(),
                 ValidationMode::Full,
             ),
-            "Generic delta kernel error: w has nullablily true in kernel and false in arrow",
+            "Generic delta kernel error: w has nullability true in kernel and false in arrow",
         );
     }
 

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -478,6 +478,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ensure_variant_accepts_reversed_field_order() {
+        let arrow_type = variant_arrow_struct([
+            ("value", ArrowDataType::Binary),
+            ("metadata", ArrowDataType::Binary),
+        ]);
+        assert_eq!(
+            ensure_data_types(
+                &DataType::unshredded_variant(),
+                &arrow_type,
+                ValidationMode::Full,
+            )
+            .unwrap(),
+            DataTypeCompat::Nested
+        );
+    }
+
     #[rstest]
     #[case::wrong_field_names(wrong_field_names_variant_arrow_type(), "missing field")]
     #[case::extra_field_last(

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -78,10 +78,31 @@ impl EnsureDataTypes {
             (DataType::Primitive(_), _) if arrow_type.is_primitive() => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
-            // A variant is physically a struct of binary fields. Validate it like a struct so
-            // that engines may use any Arrow binary representation for its fields.
-            (DataType::Variant(variant_fields), ArrowDataType::Struct(_)) => {
-                self.ensure_data_types(&DataType::Struct(variant_fields.clone()), arrow_type)
+            // A variant is physically `struct<metadata, value>` of binary fields. Accept any Arrow
+            // binary representation for the fields, but require exactly the variant's fields by
+            // name so a shredded layout (extra `typed_value`) cannot pass as an
+            // unshredded variant.
+            (DataType::Variant(variant_fields), ArrowDataType::Struct(arrow_fields)) => {
+                require!(arrow_fields.len() == variant_fields.num_fields(), {
+                    make_arrow_error(format!(
+                        "Variant struct has {} fields, expected {}",
+                        arrow_fields.len(),
+                        variant_fields.num_fields(),
+                    ))
+                });
+                for kernel_field in variant_fields.fields() {
+                    let Some(arrow_field) = arrow_fields
+                        .iter()
+                        .find(|arrow_field| arrow_field.name() == &kernel_field.name)
+                    else {
+                        return Err(make_arrow_error(format!(
+                            "Variant struct is missing field `{}`",
+                            kernel_field.name
+                        )));
+                    };
+                    self.ensure_data_types(&kernel_field.data_type, arrow_field.data_type())?;
+                }
+                Ok(DataTypeCompat::Nested)
             }
             (&DataType::Variant(_), _) => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
@@ -150,14 +171,14 @@ impl EnsureDataTypes {
                         }
                     }
                     ValidationMode::TypesAndNames | ValidationMode::Full => {
-                        // Name-based matching: look up the kernel field for each arrow field by
-                        // name. Arrow fields with no kernel counterpart are ignored. Full mode
-                        // additionally checks nullability and metadata.
+                        // Name-based matching: look up kernel fields by arrow field name.
+                        // Full mode additionally checks nullability and metadata.
+                        let mapped_fields = arrow_fields
+                            .iter()
+                            .filter_map(|f| kernel_fields.field(f.name()));
+
                         let mut found_fields = 0;
-                        for arrow_field in arrow_fields {
-                            let Some(kernel_field) = kernel_fields.field(arrow_field.name()) else {
-                                continue;
-                            };
+                        for (kernel_field, arrow_field) in mapped_fields.zip(arrow_fields) {
                             self.ensure_nullability_and_metadata(kernel_field, arrow_field)?;
                             self.ensure_data_types(
                                 &kernel_field.data_type,
@@ -416,6 +437,8 @@ mod tests {
         ArrowDataType::Struct(fields.into())
     }
 
+    /// The `metadata`/`value` fields are accepted for any binary representation, in any validation
+    /// mode, regardless of arrow field nullability.
     #[rstest]
     fn ensure_variant_accepts_any_binary_representation(
         #[values(
@@ -425,11 +448,12 @@ mod tests {
         )]
         binary_type: ArrowDataType,
         #[values(ValidationMode::TypesAndNames, ValidationMode::Full)] mode: ValidationMode,
+        #[values(false, true)] nullable: bool,
     ) {
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
-                &unshredded_variant_arrow_type_with(binary_type, false),
+                &unshredded_variant_arrow_type_with(binary_type, nullable),
                 mode,
             )
             .unwrap(),
@@ -437,24 +461,12 @@ mod tests {
         );
     }
 
-    /// `metadata` and `value` may use different binary representations within the same struct,
-    /// and extra fields (e.g. a shredded `typed_value`) are ignored regardless of their position.
-    #[rstest]
-    #[case::mixed_binary_representations(variant_arrow_struct([
-        ("metadata", ArrowDataType::Binary),
-        ("value", ArrowDataType::LargeBinary),
-    ]))]
-    #[case::extra_field_last(variant_arrow_struct([
-        ("metadata", ArrowDataType::Binary),
-        ("value", ArrowDataType::Binary),
-        ("typed_value", ArrowDataType::Int64),
-    ]))]
-    #[case::extra_field_interleaved(variant_arrow_struct([
-        ("metadata", ArrowDataType::Binary),
-        ("typed_value", ArrowDataType::Int64),
-        ("value", ArrowDataType::Binary),
-    ]))]
-    fn ensure_variant_accepts_extra_and_mixed_fields(#[case] arrow_type: ArrowDataType) {
+    #[test]
+    fn ensure_variant_accepts_mixed_binary_representations() {
+        let arrow_type = variant_arrow_struct([
+            ("metadata", ArrowDataType::Binary),
+            ("value", ArrowDataType::LargeBinary),
+        ]);
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
@@ -466,29 +478,31 @@ mod tests {
         );
     }
 
-    #[test]
-    fn ensure_variant_nullable_fields_accepted_without_full_validation() {
-        assert_eq!(
-            ensure_data_types(
-                &DataType::unshredded_variant(),
-                &unshredded_variant_arrow_type_with(ArrowDataType::LargeBinary, true),
-                ValidationMode::TypesAndNames,
-            )
-            .unwrap(),
-            DataTypeCompat::Nested
-        );
-    }
-
     #[rstest]
-    #[case::wrong_field_names(
-        wrong_field_names_variant_arrow_type(),
-        "Missing Struct fields metadata, value"
+    #[case::wrong_field_names(wrong_field_names_variant_arrow_type(), "missing field")]
+    #[case::extra_field_last(
+        variant_arrow_struct([
+            ("metadata", ArrowDataType::Binary),
+            ("value", ArrowDataType::Binary),
+            ("typed_value", ArrowDataType::Int64),
+        ]),
+        "expected 2"
     )]
-    #[case::nullable_fields(
-        unshredded_variant_arrow_type_with(ArrowDataType::LargeBinary, true),
-        "metadata has nullability false in kernel and true in arrow"
+    #[case::extra_field_interleaved(
+        variant_arrow_struct([
+            ("metadata", ArrowDataType::Binary),
+            ("typed_value", ArrowDataType::Int64),
+            ("value", ArrowDataType::Binary),
+        ]),
+        "expected 2"
     )]
-    #[case::not_a_struct(ArrowDataType::Binary, "Incorrect datatype")]
+    #[case::missing_field(
+        variant_arrow_struct([
+            ("metadata", ArrowDataType::Binary),
+            ("typed_value", ArrowDataType::Int64),
+        ]),
+        "missing field"
+    )]
     #[case::non_binary_value(
         variant_arrow_struct([
             ("metadata", ArrowDataType::Binary),
@@ -496,6 +510,7 @@ mod tests {
         ]),
         "Incorrect datatype"
     )]
+    #[case::not_a_struct(ArrowDataType::Binary, "Incorrect datatype")]
     fn ensure_variant_rejects(#[case] arrow_type: ArrowDataType, #[case] expected_err: &str) {
         assert_result_error_with_message(
             ensure_data_types(

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -78,14 +78,20 @@ impl EnsureDataTypes {
             (DataType::Primitive(_), _) if arrow_type.is_primitive() => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
-            // A variant is physically `struct<metadata, value>` of binary fields. Accept any Arrow
-            // binary representation for the fields, but require exactly the variant's fields by
-            // name so a shredded layout (extra `typed_value`) cannot pass as an
-            // unshredded variant.
+            // A variant is physically a struct of binary fields, matched by name. Accept any Arrow
+            // binary representation for the fields; their nullability is irrelevant to the physical
+            // wrapper. Requiring exactly the variant's fields keeps this in sync with
+            // `validate_parquet_variant`. The rejection of shredded layouts relies on the kernel
+            // type being unshredded (the only variant kernel constructs today).
             (DataType::Variant(variant_fields), ArrowDataType::Struct(arrow_fields)) => {
                 require!(arrow_fields.len() == variant_fields.num_fields(), {
+                    let unexpected = arrow_fields
+                        .iter()
+                        .map(|f| f.name().as_str())
+                        .filter(|name| variant_fields.field(name).is_none())
+                        .join(", ");
                     make_arrow_error(format!(
-                        "Variant struct has {} fields, expected {}",
+                        "Variant struct has {} fields, expected {} (unexpected: [{unexpected}])",
                         arrow_fields.len(),
                         variant_fields.num_fields(),
                     ))
@@ -410,35 +416,20 @@ mod tests {
         assert!(!can_upcast_to_decimal(&Int64, 20u8, 1i8));
     }
 
-    /// An unshredded variant arrow type with a chosen binary representation and field nullability.
-    fn unshredded_variant_arrow_type_with(
-        binary_type: ArrowDataType,
-        nullable: bool,
-    ) -> ArrowDataType {
-        let metadata_field = ArrowField::new("metadata", binary_type.clone(), nullable);
-        let value_field = ArrowField::new("value", binary_type, nullable);
-        ArrowDataType::Struct(vec![metadata_field, value_field].into())
-    }
-
-    fn wrong_field_names_variant_arrow_type() -> ArrowDataType {
-        let metadata_field = ArrowField::new("field_1", ArrowDataType::Binary, true);
-        let value_field = ArrowField::new("field_2", ArrowDataType::Binary, true);
-        ArrowDataType::Struct(vec![metadata_field, value_field].into())
-    }
-
-    /// Build a variant-shaped arrow struct from `(name, type)` pairs, all non-nullable.
+    /// Build a variant-shaped arrow struct from `(name, type)` pairs with the given nullability.
     fn variant_arrow_struct(
         fields: impl IntoIterator<Item = (&'static str, ArrowDataType)>,
+        nullable: bool,
     ) -> ArrowDataType {
         let fields: Vec<_> = fields
             .into_iter()
-            .map(|(name, data_type)| ArrowField::new(name, data_type, false))
+            .map(|(name, data_type)| ArrowField::new(name, data_type, nullable))
             .collect();
         ArrowDataType::Struct(fields.into())
     }
 
-    /// The `metadata`/`value` fields are accepted for any binary representation, in any validation
-    /// mode, regardless of arrow field nullability.
+    /// The `metadata`/`value` fields are accepted for any binary representation, in both name-based
+    /// validation modes, regardless of arrow field nullability.
     #[rstest]
     fn ensure_variant_accepts_any_binary_representation(
         #[values(
@@ -450,23 +441,25 @@ mod tests {
         #[values(ValidationMode::TypesAndNames, ValidationMode::Full)] mode: ValidationMode,
         #[values(false, true)] nullable: bool,
     ) {
+        let arrow_type = variant_arrow_struct(
+            [("metadata", binary_type.clone()), ("value", binary_type)],
+            nullable,
+        );
         assert_eq!(
-            ensure_data_types(
-                &DataType::unshredded_variant(),
-                &unshredded_variant_arrow_type_with(binary_type, nullable),
-                mode,
-            )
-            .unwrap(),
+            ensure_data_types(&DataType::unshredded_variant(), &arrow_type, mode).unwrap(),
             DataTypeCompat::Nested
         );
     }
 
     #[test]
     fn ensure_variant_accepts_mixed_binary_representations() {
-        let arrow_type = variant_arrow_struct([
-            ("metadata", ArrowDataType::Binary),
-            ("value", ArrowDataType::LargeBinary),
-        ]);
+        let arrow_type = variant_arrow_struct(
+            [
+                ("metadata", ArrowDataType::Binary),
+                ("value", ArrowDataType::LargeBinary),
+            ],
+            false,
+        );
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
@@ -480,10 +473,13 @@ mod tests {
 
     #[test]
     fn ensure_variant_accepts_reversed_field_order() {
-        let arrow_type = variant_arrow_struct([
-            ("value", ArrowDataType::Binary),
-            ("metadata", ArrowDataType::Binary),
-        ]);
+        let arrow_type = variant_arrow_struct(
+            [
+                ("value", ArrowDataType::Binary),
+                ("metadata", ArrowDataType::Binary),
+            ],
+            false,
+        );
         assert_eq!(
             ensure_data_types(
                 &DataType::unshredded_variant(),
@@ -496,35 +492,50 @@ mod tests {
     }
 
     #[rstest]
-    #[case::wrong_field_names(wrong_field_names_variant_arrow_type(), "missing field")]
+    #[case::wrong_field_names(
+        variant_arrow_struct(
+            [("field_1", ArrowDataType::Binary), ("field_2", ArrowDataType::Binary)],
+            false,
+        ),
+        "missing field"
+    )]
     #[case::extra_field_last(
-        variant_arrow_struct([
-            ("metadata", ArrowDataType::Binary),
-            ("value", ArrowDataType::Binary),
-            ("typed_value", ArrowDataType::Int64),
-        ]),
+        variant_arrow_struct(
+            [
+                ("metadata", ArrowDataType::Binary),
+                ("value", ArrowDataType::Binary),
+                ("typed_value", ArrowDataType::Int64),
+            ],
+            false,
+        ),
         "expected 2"
     )]
     #[case::extra_field_interleaved(
-        variant_arrow_struct([
-            ("metadata", ArrowDataType::Binary),
-            ("typed_value", ArrowDataType::Int64),
-            ("value", ArrowDataType::Binary),
-        ]),
+        variant_arrow_struct(
+            [
+                ("metadata", ArrowDataType::Binary),
+                ("typed_value", ArrowDataType::Int64),
+                ("value", ArrowDataType::Binary),
+            ],
+            false,
+        ),
         "expected 2"
     )]
     #[case::missing_field(
-        variant_arrow_struct([
-            ("metadata", ArrowDataType::Binary),
-            ("typed_value", ArrowDataType::Int64),
-        ]),
+        variant_arrow_struct(
+            [
+                ("metadata", ArrowDataType::Binary),
+                ("typed_value", ArrowDataType::Int64),
+            ],
+            false,
+        ),
         "missing field"
     )]
     #[case::non_binary_value(
-        variant_arrow_struct([
-            ("metadata", ArrowDataType::Binary),
-            ("value", ArrowDataType::Utf8),
-        ]),
+        variant_arrow_struct(
+            [("metadata", ArrowDataType::Binary), ("value", ArrowDataType::Utf8)],
+            false,
+        ),
         "Incorrect datatype"
     )]
     #[case::not_a_struct(ArrowDataType::Binary, "Incorrect datatype")]


### PR DESCRIPTION
## What changes are proposed in this pull request?

`ensure_data_types` required a variant's arrow type to exactly match `struct<metadata: Binary, value: Binary>`. Engines that buffer variant columns with 64-bit offsets (`LargeBinary`) or views (`BinaryView`) failed expression evaluation with an "Incorrect datatype" error.

A variant is now validated as a `struct<metadata, value>` whose fields may use any arrow binary representation (`Binary`, `LargeBinary`, or `BinaryView`). The fields are matched by name and the struct must contain exactly those fields, so a shredded layout (an extra `typed_value` field) is still rejected, matching the existing `validate_parquet_variant` read guard.

## How was this change tested?

New unit tests covering `Binary`, `LargeBinary`, and `BinaryView` (and mixed representations across the two fields) for `ensure_data_types`, `apply_schema`, and variant column extraction, plus rejection of shredded, missing, and non-binary field shapes.
