### PR TITLE
perf: terminate log listing before paging through staged commits

### DIFF
--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -1906,6 +1906,16 @@ mod tests {
     #[case::ratified_zero_on_empty_log(vec![], Some(0), Expected::CCv2MissingV0FilesystemCommit)]
     #[case::commits_have_no_anchor(commit_path(2..=3), None, Expected::NoRecreatableCommit)]
     #[case::ratified_zero_commits_no_anchor(commit_path(2..=3), Some(0), Expected::NoRecreatableCommit)]
+    #[case::staged_commits_and_last_checkpoint_ignored(
+        {
+            let mut p = truncated_log(vec![single_part_checkpoint_path(5)], 5..=9);
+            p.push("_delta_log/_last_checkpoint".to_string());
+            p.push(format!("_delta_log/_staged_commits/{:020}.{}.json", 9, Uuid::new_v4()));
+            p
+        },
+        None,
+        Expected::Version(5)
+    )]
     fn earliest_recreatable_returns_expected(
         #[case] paths: Vec<String>,
         #[case] ratified: Option<Version>,

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -59,7 +59,9 @@ pub(crate) struct LogSegmentFiles {
 
 /// Returns a lazy iterator of [`ParsedLogPath`]s from the filesystem over versions
 /// `[start_version, end_version]`. The iterator handles parsing, filtering out non-listable
-/// files (e.g. staged commits, dot-prefixed files), and stopping at `end_version`.
+/// files (e.g. dot-prefixed files), and stopping at `end_version`. It stops consuming the
+/// underlying listing at the first path past the version-named region, so directories like
+/// `_staged_commits/` are never paged through.
 ///
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
@@ -74,12 +76,11 @@ pub(crate) fn list_from_storage(
     let log_root_str = log_root.to_string();
     let files = storage
         .list_from(&start_from)?
-        // The listing is recursive and sorted by full path, and every file kernel lists has a
-        // 20-digit version prefix. Once a path sorts past '9' nothing relevant can follow, so stop
-        // pulling listing pages there. In particular this avoids paging through
-        // `_staged_commits/`, which can hold thousands of files and is only consumed via
-        // `log_tail` ('_' sorts after '9'). Paths outside `log_root` are conservatively kept;
-        // parsing filters them below.
+        // The listing is sorted by full path and every listable log file begins with a 20-digit
+        // version, so nothing relevant follows the first relative path starting past '9'. Stopping
+        // there avoids paging through `_staged_commits/` ('_' > '9'), which can hold thousands of
+        // files. A path that doesn't strip the log_root prefix is kept; parsing discards it.
+        // TODO(#2740): push the bound into the listing request itself.
         .take_while(move |meta_res| match meta_res {
             Ok(meta) => meta
                 .location

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -25,7 +25,7 @@ use url::Url;
 
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
-use crate::path::{LogPathFileType, ParsedLogPath};
+use crate::path::{may_begin_listable_log_path, LogPathFileType, ParsedLogPath};
 use crate::{DeltaResult, Error, StorageHandler, Version};
 
 #[cfg(test)]
@@ -61,7 +61,7 @@ pub(crate) struct LogSegmentFiles {
 /// `[start_version, end_version]`. The iterator handles parsing, filtering out non-listable
 /// files (e.g. dot-prefixed files), and stopping at `end_version`. It stops consuming the
 /// underlying listing at the first path past the version-named region, so directories like
-/// `_staged_commits/` are never paged through.
+/// `_staged_commits/` and `_sidecars/` are never paged through.
 ///
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
@@ -76,18 +76,17 @@ pub(crate) fn list_from_storage(
     let log_root_str = log_root.to_string();
     let files = storage
         .list_from(&start_from)?
-        // The listing is sorted by full path and every listable log file begins with a 20-digit
-        // version, so nothing relevant follows the first relative path starting past '9'. Stopping
-        // there avoids paging through `_staged_commits/` ('_' > '9'), which can hold thousands of
-        // files. A path that doesn't strip the log_root prefix is kept; parsing discards it.
+        // The listing is sorted by full path, so nothing relevant follows the first relative path
+        // past the version-named region (see `may_begin_listable_log_path`). Stopping there avoids
+        // paging through `_staged_commits/` and `_sidecars/`, which can hold thousands of files.
+        // A path that doesn't strip the log_root prefix is kept; parsing discards it.
         // TODO(#2740): push the bound into the listing request itself.
         .take_while(move |meta_res| match meta_res {
             Ok(meta) => meta
                 .location
                 .as_str()
                 .strip_prefix(&log_root_str)
-                .and_then(|rel| rel.as_bytes().first())
-                .is_none_or(|b| *b <= b'9'),
+                .is_none_or(may_begin_listable_log_path),
             Err(_) => true,
         })
         .map(|meta| ParsedLogPath::try_from(meta?))

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -71,8 +71,24 @@ pub(crate) fn list_from_storage(
     end_version: Version,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_from = log_root.join(&format!("{start_version:020}"))?;
+    let log_root_str = log_root.to_string();
     let files = storage
         .list_from(&start_from)?
+        // The listing is recursive and sorted by full path, and every file kernel lists has a
+        // 20-digit version prefix. Once a path sorts past '9' nothing relevant can follow, so stop
+        // pulling listing pages there. In particular this avoids paging through
+        // `_staged_commits/`, which can hold thousands of files and is only consumed via
+        // `log_tail` ('_' sorts after '9'). Paths outside `log_root` are conservatively kept;
+        // parsing filters them below.
+        .take_while(move |meta_res| match meta_res {
+            Ok(meta) => meta
+                .location
+                .as_str()
+                .strip_prefix(&log_root_str)
+                .and_then(|rel| rel.as_bytes().first())
+                .is_none_or(|b| *b <= b'9'),
+            Err(_) => true,
+        })
         .map(|meta| ParsedLogPath::try_from(meta?))
         // NOTE: this filters out .crc files etc which start with "." - some engines
         // produce `.something.parquet.crc` corresponding to `something.parquet`. Kernel

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -490,6 +490,35 @@ async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() 
     assert_eq!(storage.items_listed(), 4);
 }
 
+// Any path past the version-named region stops the listing, not just `_staged_commits/`:
+// checkpoint sidecars under `_sidecars/` and non-underscore names whose first byte sorts
+// past '9' (e.g. 'Z'). Both sentinels sort before `_staged_commits/`, so no staged commit
+// is ever consumed.
+#[rstest]
+#[case::sidecar("_delta_log/_sidecars/016ae953-37a9-438e-8683-9a9a4a79a395.parquet")]
+#[case::non_underscore_sentinel("_delta_log/Zsentinel")]
+#[tokio::test]
+async fn test_listing_stops_at_first_non_version_named_path(#[case] sentinel_path: &str) {
+    let mut log_files = vec![
+        (0, LogPathFileType::Commit, CommitSource::Filesystem),
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (2, LogPathFileType::Commit, CommitSource::Filesystem),
+    ];
+    log_files.extend((0..50).map(|v| (v, LogPathFileType::StagedCommit, CommitSource::Filesystem)));
+
+    let (storage, log_root) = create_storage_with_raw_paths(log_files, &[sentinel_path]).await;
+    let storage = CountingStorageHandler::new(storage);
+
+    let (commits, _, _, _, latest_commit, max_pub) =
+        list_and_destructure(&storage, &log_root, vec![], None, None);
+
+    assert_eq!(commits.len(), 3);
+    assert_eq!(latest_commit.unwrap().version, 2);
+    assert_eq!(max_pub, Some(2));
+    // 3 commits plus the sentinel that stops the listing
+    assert_eq!(storage.items_listed(), 4);
+}
+
 #[tokio::test]
 async fn test_listing_stops_at_last_checkpoint_marker() {
     // In a real table `_last_checkpoint` sorts before `_staged_commits/` ('_la' < '_st'), so

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -54,8 +54,24 @@ fn log_path_for_file_type(version: Version, file_type: &LogPathFileType) -> Stri
 async fn create_storage(
     log_files: Vec<(Version, LogPathFileType, CommitSource)>,
 ) -> (Arc<dyn StorageHandler>, Url) {
+    create_storage_with_raw_paths(log_files, &[]).await
+}
+
+/// Like [`create_storage`] but also writes `raw_paths` verbatim, for log entries that
+/// [`log_path_for_file_type`] cannot produce (e.g. `_last_checkpoint`).
+async fn create_storage_with_raw_paths(
+    log_files: Vec<(Version, LogPathFileType, CommitSource)>,
+    raw_paths: &[&str],
+) -> (Arc<dyn StorageHandler>, Url) {
     let store = Arc::new(InMemory::new());
     let log_root = Url::parse("memory:///_delta_log/").unwrap();
+
+    for path in raw_paths {
+        store
+            .put(&ObjectPath::from(*path), bytes::Bytes::from("raw").into())
+            .await
+            .expect("Failed to put raw test file");
+    }
 
     for (version, file_type, source) in log_files {
         let path = log_path_for_file_type(version, &file_type);
@@ -450,27 +466,6 @@ async fn test_listing_omits_staged_commits() {
 }
 
 #[tokio::test]
-async fn test_listing_with_large_end_version() {
-    let log_files = vec![
-        (0, LogPathFileType::Commit, CommitSource::Filesystem),
-        (1, LogPathFileType::Commit, CommitSource::Filesystem), // <-- max_published_version
-        (2, LogPathFileType::StagedCommit, CommitSource::Filesystem),
-    ];
-
-    let (storage, log_root) = create_storage(log_files).await;
-    // note we let you request end version past the end of log. up to consumer to interpret
-    let (commits, _, _, _, latest_commit, max_pub) =
-        list_and_destructure(storage.as_ref(), &log_root, vec![], None, Some(3));
-
-    // we must only see two regular commits
-    assert_eq!(commits.len(), 2);
-    assert_eq!(commits[0].version, 0);
-    assert_eq!(commits[1].version, 1);
-    assert_eq!(latest_commit.unwrap().version, 1);
-    assert_eq!(max_pub, Some(1));
-}
-
-#[tokio::test]
 async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -493,6 +488,63 @@ async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() 
     assert_eq!(max_pub, Some(2));
     // 3 commits plus the single staged commit that stops the listing
     assert_eq!(storage.items_listed(), 4);
+}
+
+#[tokio::test]
+async fn test_listing_stops_at_last_checkpoint_marker() {
+    // In a real table `_last_checkpoint` sorts before `_staged_commits/` ('_la' < '_st'), so
+    // it is the path that stops the listing.
+    let mut log_files = vec![
+        (0, LogPathFileType::Commit, CommitSource::Filesystem),
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (2, LogPathFileType::Commit, CommitSource::Filesystem),
+        (
+            2,
+            LogPathFileType::SinglePartCheckpoint,
+            CommitSource::Filesystem,
+        ),
+        (2, LogPathFileType::Crc, CommitSource::Filesystem),
+    ];
+    log_files.extend((0..50).map(|v| (v, LogPathFileType::StagedCommit, CommitSource::Filesystem)));
+
+    let (storage, log_root) =
+        create_storage_with_raw_paths(log_files, &["_delta_log/_last_checkpoint"]).await;
+    let storage = CountingStorageHandler::new(storage);
+
+    let (commits, _, checkpoint_parts, latest_crc, latest_commit, max_pub) =
+        list_and_destructure(&storage, &log_root, vec![], None, None);
+
+    // The checkpoint at version 2 subsumes all commits; only latest_commit_file is retained
+    assert!(commits.is_empty());
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(checkpoint_parts[0].version, 2);
+    assert_eq!(latest_crc.unwrap().version, 2);
+    assert_eq!(latest_commit.unwrap().version, 2);
+    assert_eq!(max_pub, Some(2));
+    // 5 version-named files plus the `_last_checkpoint` that stops the listing; no staged
+    // commit is ever consumed
+    assert_eq!(storage.items_listed(), 6);
+}
+
+#[tokio::test]
+async fn test_listing_with_large_end_version() {
+    let log_files = vec![
+        (0, LogPathFileType::Commit, CommitSource::Filesystem),
+        (1, LogPathFileType::Commit, CommitSource::Filesystem), // <-- max_published_version
+        (2, LogPathFileType::StagedCommit, CommitSource::Filesystem),
+    ];
+
+    let (storage, log_root) = create_storage(log_files).await;
+    // note we let you request end version past the end of log. up to consumer to interpret
+    let (commits, _, _, _, latest_commit, max_pub) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, Some(3));
+
+    // we must only see two regular commits
+    assert_eq!(commits.len(), 2);
+    assert_eq!(commits[0].version, 0);
+    assert_eq!(commits[1].version, 1);
+    assert_eq!(latest_commit.unwrap().version, 1);
+    assert_eq!(max_pub, Some(1));
 }
 
 #[tokio::test]

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -116,12 +116,14 @@ fn assert_source(commit: &ParsedLogPath, expected_source: CommitSource) {
     );
 }
 
-/// A [`StorageHandler`] wrapper that counts the number of `list_from` calls.
-/// Used to verify that `list_with_backward_checkpoint_scan` issues the expected
-/// number of storage listing requests.
+/// A [`StorageHandler`] wrapper that counts the number of `list_from` calls and the number of
+/// items consumed from the returned iterators. Used to verify that
+/// `list_with_backward_checkpoint_scan` issues the expected number of storage listing requests,
+/// and that listing terminates without consuming files past the version-named region.
 struct CountingStorageHandler {
     inner: Arc<dyn StorageHandler>,
     list_from_count: AtomicU32,
+    items_listed: Arc<AtomicU32>,
 }
 
 impl CountingStorageHandler {
@@ -129,11 +131,16 @@ impl CountingStorageHandler {
         Self {
             inner,
             list_from_count: AtomicU32::new(0),
+            items_listed: Arc::new(AtomicU32::new(0)),
         }
     }
 
     fn call_count(&self) -> u32 {
         self.list_from_count.load(Ordering::Relaxed)
+    }
+
+    fn items_listed(&self) -> u32 {
+        self.items_listed.load(Ordering::Relaxed)
     }
 }
 
@@ -143,7 +150,11 @@ impl StorageHandler for CountingStorageHandler {
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
         self.list_from_count.fetch_add(1, Ordering::Relaxed);
-        self.inner.list_from(path)
+        let items_listed = self.items_listed.clone();
+        let iter = self.inner.list_from(path)?;
+        Ok(Box::new(iter.inspect(move |_| {
+            items_listed.fetch_add(1, Ordering::Relaxed);
+        })))
     }
 
     fn read_files(
@@ -457,6 +468,31 @@ async fn test_listing_with_large_end_version() {
     assert_eq!(commits[1].version, 1);
     assert_eq!(latest_commit.unwrap().version, 1);
     assert_eq!(max_pub, Some(1));
+}
+
+#[tokio::test]
+async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() {
+    let mut log_files = vec![
+        (0, LogPathFileType::Commit, CommitSource::Filesystem),
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (2, LogPathFileType::Commit, CommitSource::Filesystem),
+    ];
+    // Staged commits sort after every version-named file ('_' > '9'), so a sorted listing
+    // reaches them only after all relevant files. None should be consumed beyond the first.
+    log_files
+        .extend((0..100).map(|v| (v, LogPathFileType::StagedCommit, CommitSource::Filesystem)));
+
+    let (storage, log_root) = create_storage(log_files).await;
+    let storage = CountingStorageHandler::new(storage);
+
+    let (commits, _, _, _, latest_commit, max_pub) =
+        list_and_destructure(&storage, &log_root, vec![], None, None);
+
+    assert_eq!(commits.len(), 3);
+    assert_eq!(latest_commit.unwrap().version, 2);
+    assert_eq!(max_pub, Some(2));
+    // 3 commits plus the single staged commit that stops the listing
+    assert_eq!(storage.items_listed(), 4);
 }
 
 #[tokio::test]

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -108,6 +108,18 @@ fn path_contains_delta_log_dir(mut path_segments: std::str::Split<'_, char>) -> 
     path_segments.any(|p| p == DELTA_LOG_DIR)
 }
 
+/// Returns whether `rel_path`, a path relative to the `_delta_log/` directory, could still be
+/// within the version-named region of a lexicographically sorted log listing.
+///
+/// Every listable log file begins with a 20-digit version, so its first byte is an ASCII digit.
+/// Paths like `_staged_commits/`, `_sidecars/`, and `_last_checkpoint` sort after every
+/// version-named file because `'_'` (0x5F) > `'9'` (0x39), so a sorted listing can stop at the
+/// first relative path whose first byte sorts past `'9'`. An empty `rel_path` is conservatively
+/// kept.
+pub(crate) fn may_begin_listable_log_path(rel_path: &str) -> bool {
+    rel_path.as_bytes().first().is_none_or(|b| *b <= b'9')
+}
+
 impl<Location: AsUrl> ParsedLogPath<Location> {
     /// Estimated heap size in bytes, best-effort estimate.
     ///

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -114,8 +114,13 @@ fn path_contains_delta_log_dir(mut path_segments: std::str::Split<'_, char>) -> 
 /// Every listable log file begins with a 20-digit version, so its first byte is an ASCII digit.
 /// Paths like `_staged_commits/`, `_sidecars/`, and `_last_checkpoint` sort after every
 /// version-named file because `'_'` (0x5F) > `'9'` (0x39), so a sorted listing can stop at the
-/// first relative path whose first byte sorts past `'9'`. An empty `rel_path` is conservatively
-/// kept.
+/// first relative path whose first byte sorts past `'9'`.
+///
+/// This is a scan bound, not a log-file filter, so it must not require a digit first byte: a
+/// path sorting before `'0'` (e.g. a dot-prefixed `.{version}.json.crc` written by some engines)
+/// can still be followed by version-named files, and stopping there would silently drop them.
+/// Such paths are kept here and discarded by [`ParsedLogPath`] parsing instead. An empty
+/// `rel_path` is conservatively kept.
 pub(crate) fn may_begin_listable_log_path(rel_path: &str) -> bool {
     rel_path.as_bytes().first().is_none_or(|b| *b <= b'9')
 }
@@ -572,6 +577,23 @@ pub(crate) mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         assert!(url.path().ends_with('/'));
         url
+    }
+
+    #[test]
+    fn test_may_begin_listable_log_path() {
+        // version-named files, and anything sorting before them, keep the scan going
+        assert!(may_begin_listable_log_path("00000000000000000010.json"));
+        assert!(may_begin_listable_log_path(
+            ".00000000000000000010.json.crc"
+        ));
+        assert!(may_begin_listable_log_path(""));
+        // paths sorting past '9' end the version-named region
+        assert!(!may_begin_listable_log_path("_last_checkpoint"));
+        assert!(!may_begin_listable_log_path("_sidecars/3a0d65cd.parquet"));
+        assert!(!may_begin_listable_log_path(
+            "_staged_commits/00000000000000000010.3a0d65cd.json"
+        ));
+        assert!(!may_begin_listable_log_path("Zsentinel"));
     }
 
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

When building a log segment, staged commits returned by the storage listing were filtered out only after the listing had already paged through them. Since `_delta_log/_staged_commits/` sorts after every version-named file, a listing with no upper bound (any snapshot at the latest version) only ended once the store ran out of keys, so every snapshot build paged through the entire staged commits directory. On catalog-managed tables that accumulate staged commits, these extra LIST calls can dominate snapshot load time.

This PR stops consuming the listing at the first path that sorts past the version-named region, relying on the sorted-listing guarantee of `StorageHandler::list_from`.

## How was this change tested?

New unit test 