### PR TITLE
fix: restore CRC-rooted P&M replay removed by #2678

### DIFF
--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -72,53 +72,39 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 impl LogSegment {
-    /// Try to build the CRC at this segment's `end_version` from this segment's on-disk
-    /// `latest_crc_file`. See [`Self::try_build_incremental_crc_with_base`].
-    pub(crate) fn try_build_incremental_crc(
-        &self,
-        engine: &dyn Engine,
-        incremental_replay: IncrementalReplay,
-    ) -> DeltaResult<Option<Arc<Crc>>> {
-        self.try_build_incremental_crc_with_base(
-            engine,
-            None, /* in_memory_base */
-            incremental_replay,
-        )
-    }
-
-    /// Try to build the CRC at this segment's `end_version` from the latest available base: the
-    /// in-memory base (e.g. the CRC the updating snapshot holds) or this segment's on-disk CRC.
+    /// Try to build the CRC at this segment's `end_version` from the caller's resolved `base` CRC.
     /// Handles three cases:
     /// - Case 1: no base CRC available -> return None
     /// - Case 2: base CRC at `end_version` -> return it as-is
     /// - Case 3: stale base CRC older than `end_version` -> advance it to `end_version` when
     ///   `incremental_replay` permits, else fall back to normal log replay (return None)
-    pub(crate) fn try_build_incremental_crc_with_base(
+    pub(crate) fn try_build_crc_within_budget(
         &self,
         engine: &dyn Engine,
-        in_memory_base: Option<&Arc<Crc>>,
+        base: Option<&Arc<Crc>>,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Option<Arc<Crc>>> {
-        let Some(base_crc) = self.pick_latest_base_crc(engine, in_memory_base) else {
-            return Ok(None); // Case 1 (1A: absent, 1B: read failed)
+        let Some(base) = base else {
+            return Ok(None);
         };
-        if base_crc.version == self.end_version {
-            return Ok(Some(base_crc)); // Case 2
+        if base.version == self.end_version {
+            return Ok(Some(base.clone()));
         }
-        // Case 3: advance only within the caller's commit budget.
-        if !incremental_replay.should_advance(base_crc.version, self.end_version)? {
+        if !incremental_replay.should_advance(base.version, self.end_version)? {
             return Ok(None);
         }
-        let advanced = self.build_incremental_crc_from_base(engine, &base_crc)?;
+        let advanced = self.build_incremental_crc_from_base(engine, base)?;
         Ok(Some(Arc::new(advanced)))
     }
 
-    fn pick_latest_base_crc(
+    /// Pick the latest CRC to use as an advance base: this segment's on-disk CRC or
+    /// `in_memory_base` (e.g. the CRC an updating snapshot holds), whichever is newer. A failed
+    /// on-disk read falls back to `in_memory_base`. Returns None when neither is available.
+    pub(crate) fn pick_latest_base_crc(
         &self,
         engine: &dyn Engine,
         in_memory_base: Option<&Arc<Crc>>,
     ) -> Option<Arc<Crc>> {
-        // A failed on-disk read falls back to the in-memory base.
         let preferred_disk_crc = self
             .listed
             .latest_crc_file
@@ -127,6 +113,13 @@ impl LogSegment {
         preferred_disk_crc
             .and_then(|f| read_crc_file_or_none(engine, f))
             .or_else(|| in_memory_base.cloned())
+    }
+
+    /// Read this segment's latest on-disk CRC (`latest_crc_file`), at whatever version it sits.
+    /// Returns None when there is no CRC file or the read fails. The returned CRC may be stale
+    /// (older than `end_version`).
+    pub(crate) fn read_latest_crc(&self, engine: &dyn Engine) -> Option<Arc<Crc>> {
+        self.pick_latest_base_crc(engine, /* in_memory_base */ None)
     }
 
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -20,7 +20,7 @@ use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
 use crate::path::ParsedLogPath;
-use crate::snapshot::IncrementalReplay;
+use crate::snapshot::{IncrementalReplay, SnapshotRef};
 use crate::{DeltaResult, Engine, Snapshot};
 
 // ============================================================================
@@ -32,11 +32,11 @@ const SCHEMA_STRING: &str = r#"{"type":"struct","fields":[{"name":"id","type":"i
 const COMMIT_INFO_TIMESTAMP: i64 = 1587968586154;
 const DEFAULT_OPERATION: &str = "TEST_OP";
 
-fn protocol_v2() -> Protocol {
+fn protocol_a() -> Protocol {
     Protocol::try_new_modern(["v2Checkpoint"], ["v2Checkpoint"]).unwrap()
 }
 
-fn protocol_v2_dv() -> Protocol {
+fn protocol_b() -> Protocol {
     Protocol::try_new_modern(
         ["v2Checkpoint", "deletionVectors"],
         ["v2Checkpoint", "deletionVectors"],
@@ -44,7 +44,7 @@ fn protocol_v2_dv() -> Protocol {
     .unwrap()
 }
 
-fn protocol_v2_dv_ntz() -> Protocol {
+fn protocol_c() -> Protocol {
     Protocol::try_new_modern(
         ["v2Checkpoint", "deletionVectors", "timestampNtz"],
         ["v2Checkpoint", "deletionVectors", "timestampNtz"],
@@ -52,7 +52,7 @@ fn protocol_v2_dv_ntz() -> Protocol {
     .unwrap()
 }
 
-fn protocol_v2_ict() -> Protocol {
+fn protocol_ict() -> Protocol {
     Protocol::try_new_modern(["v2Checkpoint"], ["v2Checkpoint", "inCommitTimestamp"]).unwrap()
 }
 
@@ -105,7 +105,7 @@ fn metadata_ict() -> Metadata {
 fn create_table_actions() -> Vec<serde_json::Value> {
     vec![
         commit_info("CREATE", None),
-        protocol(protocol_v2()),
+        protocol(protocol_a()),
         metadata(metadata_a()),
     ]
 }
@@ -113,7 +113,7 @@ fn create_table_actions() -> Vec<serde_json::Value> {
 fn create_table_actions_with_ict() -> Vec<serde_json::Value> {
     vec![
         commit_info("CREATE", None),
-        protocol(protocol_v2_ict()),
+        protocol(protocol_ict()),
         metadata(metadata_a()),
     ]
 }
@@ -406,11 +406,14 @@ impl BuiltCrcTest {
         )
     }
 
-    /// Build a snapshot at `version` (or latest if `None`) and return it
+    /// Build a snapshot at `version` (or latest if `None`) under `mode`, returning it
     /// alongside a human-readable label like `"v2"` or `"latest"`.
-    fn snapshot_at(&self, version: Option<u64>) -> (crate::snapshot::SnapshotRef, String) {
-        let mut builder = Snapshot::builder_for(self.url.clone())
-            .with_incremental_crc_replay(IncrementalReplay::Unlimited);
+    fn snapshot_at_with_replay(
+        &self,
+        version: Option<u64>,
+        mode: IncrementalReplay,
+    ) -> (SnapshotRef, String) {
+        let mut builder = Snapshot::builder_for(self.url.clone()).with_incremental_crc_replay(mode);
         if let Some(v) = version {
             builder = builder.at_version(v);
         }
@@ -419,8 +422,22 @@ impl BuiltCrcTest {
         (snapshot, label)
     }
 
-    fn snapshot_latest_with_replay(&self, mode: IncrementalReplay) -> crate::snapshot::SnapshotRef {
-        Snapshot::builder_for(self.url.clone())
+    /// Build a snapshot at `version` with no incremental CRC replay (the `Disabled` default).
+    fn snapshot_at(&self, version: Option<u64>) -> (SnapshotRef, String) {
+        self.snapshot_at_with_replay(version, IncrementalReplay::Disabled)
+    }
+
+    fn snapshot_latest_with_replay(&self, mode: IncrementalReplay) -> SnapshotRef {
+        self.snapshot_at_with_replay(None, mode).0
+    }
+
+    /// Build a snapshot at `from_version`, then incrementally advance it to latest under `mode`.
+    fn snapshot_from(&self, from_version: u64, mode: IncrementalReplay) -> SnapshotRef {
+        let base = Snapshot::builder_for(self.url.clone())
+            .at_version(from_version)
+            .build(&self.engine)
+            .unwrap();
+        Snapshot::builder_from(base)
             .with_incremental_crc_replay(mode)
             .build(&self.engine)
             .unwrap()
@@ -432,18 +449,27 @@ impl BuiltCrcTest {
         expected_protocol: &Protocol,
         expected_metadata: &Metadata,
     ) {
-        let (snapshot, label) = self.snapshot_at(version.into());
-        let table_config = snapshot.table_configuration();
-        assert_eq!(
-            table_config.protocol(),
-            expected_protocol,
-            "Protocol mismatch at {label}"
-        );
-        assert_eq!(
-            table_config.metadata(),
-            expected_metadata,
-            "Metadata mismatch at {label}"
-        );
+        let version = version.into();
+        // Protocol and Metadata must resolve identically regardless of the CRC replay budget
+        // (no advance / bounded advance / unbounded advance), so assert across the spectrum.
+        for mode in [
+            IncrementalReplay::Disabled,
+            IncrementalReplay::UpToCommits(2),
+            IncrementalReplay::Unlimited,
+        ] {
+            let (snapshot, label) = self.snapshot_at_with_replay(version, mode);
+            let table_config = snapshot.table_configuration();
+            assert_eq!(
+                table_config.protocol(),
+                expected_protocol,
+                "Protocol mismatch at {label} ({mode:?})"
+            );
+            assert_eq!(
+                table_config.metadata(),
+                expected_metadata,
+                "Metadata mismatch at {label} ({mode:?})"
+            );
+        }
     }
 
     fn assert_ict(&self, version: impl Into<Option<u64>>, expected_ict: Option<i64>) {
@@ -479,7 +505,7 @@ async fn test_get_p_m_from_delta_no_checkpoint() {
             0, // <-- P & M from here
             [
                 commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2()),
+                protocol(protocol_a()),
                 metadata(metadata_a()),
             ],
         )
@@ -487,19 +513,16 @@ async fn test_get_p_m_from_delta_no_checkpoint() {
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2(), &metadata_a());
+        .assert_p_m(None, &protocol_a(), &metadata_a());
 }
 
 #[tokio::test]
 async fn test_get_p_and_m_from_different_deltas() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(
             1, // <-- P from here
-            [
-                commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2_dv()),
-            ],
+            [commit_info(DEFAULT_OPERATION, None), protocol(protocol_b())],
         )
         .commit(
             2, // <-- M from here
@@ -507,36 +530,36 @@ async fn test_get_p_and_m_from_different_deltas() {
         )
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
+        .assert_p_m(None, &protocol_b(), &metadata_b());
 }
 
 #[tokio::test]
 async fn test_get_p_m_from_checkpoint() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
+        .v2_checkpoint(0, protocol_a(), metadata_a()) // <-- P & M from here
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2(), &metadata_a());
+        .assert_p_m(None, &protocol_a(), &metadata_a());
 }
 
 #[tokio::test]
 async fn test_get_p_m_from_delta_after_checkpoint() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(
             1, // <-- P & M from here
             [
                 commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2_dv()),
+                protocol(protocol_b()),
                 metadata(metadata_b()),
             ],
         )
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
+        .assert_p_m(None, &protocol_b(), &metadata_b());
 }
 
 // ============================================================================
@@ -546,13 +569,13 @@ async fn test_get_p_m_from_delta_after_checkpoint() {
 #[tokio::test]
 async fn test_get_p_m_from_crc_at_target() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(2, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
+        .crc(2, protocol_b(), metadata_b(), None) // <-- P & M from here
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
+        .assert_p_m(None, &protocol_b(), &metadata_b());
 }
 
 #[tokio::test]
@@ -560,32 +583,32 @@ async fn test_crc_preferred_over_delta_at_target() {
     // The P & M for the 002.crc and 002.json should NOT be different in practice.
     // We only do this for this test so we can differentiate which P & M is used.
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(
             2, // <-- P from here
             [
                 commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2_dv()),
+                protocol(protocol_b()),
                 metadata(metadata_a()),
             ],
         )
-        .crc(2, protocol_v2_dv_ntz(), metadata_b(), None) // <-- P & M from here
+        .crc(2, protocol_c(), metadata_b(), None) // <-- P & M from here
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv_ntz(), &metadata_b());
+        .assert_p_m(None, &protocol_c(), &metadata_b());
 }
 
 #[tokio::test]
 async fn test_corrupt_crc_at_target_falls_back() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
+        .v2_checkpoint(0, protocol_a(), metadata_a()) // <-- P & M from here
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .corrupt_crc(2) // <-- Corrupt! Fall back to replay.
         .build()
         .await
-        .assert_p_m(None, &protocol_v2(), &metadata_a());
+        .assert_p_m(None, &protocol_a(), &metadata_a());
 }
 
 #[tokio::test]
@@ -593,27 +616,27 @@ async fn test_crc_wins_over_checkpoint() {
     // The P & M for the 002.crc and the v2 checkpoint should NOT be different in practice.
     // We only do this for this test so we can differentiate which P & M is used.
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
-        .v2_checkpoint(2, protocol_v2(), metadata_a())
-        .crc(2, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
+        .v2_checkpoint(2, protocol_a(), metadata_a())
+        .crc(2, protocol_b(), metadata_b(), None) // <-- P & M from here
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
+        .assert_p_m(None, &protocol_b(), &metadata_b());
 }
 
 #[tokio::test]
 async fn test_checkpoint_on_corrupt_crc() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
-        .v2_checkpoint(2, protocol_v2(), metadata_a()) // <-- P & M from here
+        .v2_checkpoint(2, protocol_a(), metadata_a()) // <-- P & M from here
         .corrupt_crc(2) // <-- Corrupt! Fall back to replay.
         .build()
         .await
-        .assert_p_m(None, &protocol_v2(), &metadata_a());
+        .assert_p_m(None, &protocol_a(), &metadata_a());
 }
 
 // ============================================================================
@@ -623,58 +646,55 @@ async fn test_checkpoint_on_corrupt_crc() {
 #[tokio::test]
 async fn test_crc_at_earlier_version() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- P & M from here
+        .crc(1, protocol_b(), metadata_b(), None) // <-- P & M from here
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_b());
+        .assert_p_m(None, &protocol_b(), &metadata_b());
 }
 
 #[tokio::test]
 async fn test_get_p_from_newer_delta_over_older_crc() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- M from here
+        .crc(1, protocol_b(), metadata_b(), None) // <-- M from here
         .commit(
             2,
-            [
-                commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2_dv_ntz()),
-            ],
+            [commit_info(DEFAULT_OPERATION, None), protocol(protocol_c())],
         )
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv_ntz(), &metadata_b());
+        .assert_p_m(None, &protocol_c(), &metadata_b());
 }
 
 #[tokio::test]
 async fn test_get_m_from_newer_delta_over_older_crc() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(1, protocol_v2_dv(), metadata_b(), None) // <-- P from here
+        .crc(1, protocol_b(), metadata_b(), None) // <-- P from here
         .commit(
             2, // <-- M from here
             [commit_info(DEFAULT_OPERATION, None), metadata(metadata_a())],
         )
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_a());
+        .assert_p_m(None, &protocol_b(), &metadata_a());
 }
 
 #[tokio::test]
 async fn test_corrupt_crc_at_non_target_version_falls_back() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a()) // <-- P & M from here
+        .v2_checkpoint(0, protocol_a(), metadata_a()) // <-- P & M from here
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .corrupt_crc(1) // <-- Corrupt! Fall back to replay.
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2(), &metadata_a());
+        .assert_p_m(None, &protocol_a(), &metadata_a());
 }
 
 #[tokio::test]
@@ -684,17 +704,17 @@ async fn test_crc_before_checkpoint_is_ignored() {
             0,
             [
                 commit_info(DEFAULT_OPERATION, None),
-                protocol(protocol_v2()),
+                protocol(protocol_a()),
                 metadata(metadata_a()),
             ],
         )
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(1, protocol_v2_dv_ntz(), metadata_b(), None)
-        .v2_checkpoint(2, protocol_v2_dv(), metadata_a()) // <-- P & M from here
+        .crc(1, protocol_c(), metadata_b(), None)
+        .v2_checkpoint(2, protocol_b(), metadata_a()) // <-- P & M from here
         .commit(3, [commit_info(DEFAULT_OPERATION, None)])
         .build()
         .await
-        .assert_p_m(None, &protocol_v2_dv(), &metadata_a());
+        .assert_p_m(None, &protocol_b(), &metadata_a());
 }
 
 // ============================================================================
@@ -704,9 +724,9 @@ async fn test_crc_before_checkpoint_is_ignored() {
 #[tokio::test]
 async fn test_ict_from_crc_at_snapshot_version() {
     CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2_ict(), metadata_ict())
+        .v2_checkpoint(0, protocol_ict(), metadata_ict())
         .commit(1, [commit_info(DEFAULT_OPERATION, Some(2000))])
-        .crc(1, protocol_v2_ict(), metadata_ict(), 1000) // <-- ICT from here
+        .crc(1, protocol_ict(), metadata_ict(), 1000) // <-- ICT from here
         .build()
         .await
         .assert_ict(None, Some(1000));
@@ -715,9 +735,9 @@ async fn test_ict_from_crc_at_snapshot_version() {
 #[tokio::test]
 async fn test_ict_errors_when_crc_has_no_ict() {
     let setup = CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2_ict(), metadata_ict())
+        .v2_checkpoint(0, protocol_ict(), metadata_ict())
         .commit(1, [commit_info(DEFAULT_OPERATION, Some(2000))])
-        .crc(1, protocol_v2_ict(), metadata_ict(), None)
+        .crc(1, protocol_ict(), metadata_ict(), None)
         .build()
         .await;
 
@@ -806,9 +826,9 @@ fn txn_entry(app_id: &str, version: i64, last_updated: Option<i64>) -> (String, 
 // === Protocol / metadata ===
 
 #[rstest]
-#[case::newest_p_wins(vec![protocol(protocol_v2_dv()), commit_info("WRITE", None)], protocol_v2_dv(), metadata_a())]
-#[case::newest_m_wins(vec![metadata(metadata_b()), commit_info("WRITE", None)], protocol_v2(), metadata_b())]
-#[case::base_preserved_when_segment_has_none(vec![commit_info("WRITE", None)], protocol_v2(), metadata_a())]
+#[case::newest_p_wins(vec![protocol(protocol_b()), commit_info("WRITE", None)], protocol_b(), metadata_a())]
+#[case::newest_m_wins(vec![metadata(metadata_b()), commit_info("WRITE", None)], protocol_a(), metadata_b())]
+#[case::base_preserved_when_segment_has_none(vec![commit_info("WRITE", None)], protocol_a(), metadata_a())]
 #[tokio::test]
 async fn test_p_m_propagation(
     #[case] v1_actions: Vec<Value>,
@@ -816,7 +836,7 @@ async fn test_p_m_propagation(
     #[case] expected_m: Metadata,
 ) {
     let base = Crc {
-        protocol: protocol_v2(),
+        protocol: protocol_a(),
         metadata: metadata_a(),
         ..crc_complete_empty_dm_set_txn()
     };
@@ -1050,7 +1070,7 @@ async fn test_from_disk_advances_file_stats() {
     let built = CrcReadTest::new()
         .commit(0, create_table_actions())
         // Base CRC: a (100 B, bin 0) + b (10_000 B, bin 1).
-        .crc_with_files(0, protocol_v2(), metadata_a(), None, &[100, 10_000])
+        .crc_with_files(0, protocol_a(), metadata_a(), None, &[100, 10_000])
         .commit(1, [commit_info("WRITE", None), add("c", 20_000)]) // c lands in bin 2
         .commit(2, [remove("a", Some(100)), commit_info("WRITE", None)]) // a removed from bin 0
         .build()
@@ -1075,7 +1095,7 @@ async fn test_from_disk_no_histogram_means_no_result_histogram() {
     // Empty file_sizes => no histogram persisted on disk.
     let built = CrcReadTest::new()
         .commit(0, create_table_actions())
-        .crc(0, protocol_v2(), metadata_a(), None)
+        .crc(0, protocol_a(), metadata_a(), None)
         .commit(1, [commit_info("WRITE", None), add("a", 100)])
         .build()
         .await;
@@ -1091,7 +1111,7 @@ async fn test_from_disk_with_non_zero_crc_version() {
         .commit(0, create_table_actions())
         .commit(1, [commit_info("WRITE", None), add("a", 100)])
         .commit(2, [commit_info("WRITE", None), add("b", 200)])
-        .crc_with_files(2, protocol_v2(), metadata_a(), None, &[100, 200])
+        .crc_with_files(2, protocol_a(), metadata_a(), None, &[100, 200])
         .commit(3, [commit_info("WRITE", None), add("c", 300)])
         .build()
         .await;
@@ -1110,7 +1130,7 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
     // more, removes an older file, updates metadata, and stamps an ICT. The create_table_actions
     // (and the base) use an ICT-enabled protocol so the v=2 ICT is well-formed.
     let base = Crc {
-        protocol: protocol_v2_ict(),
+        protocol: protocol_ict(),
         metadata: metadata_a(),
         ..crc_complete_empty_dm_set_txn()
     };
@@ -1142,7 +1162,7 @@ async fn test_full_replay_across_two_commits_propagates_all_state() {
         .unwrap();
 
     // Newest commit's M and ICT win; protocol stays at create_table_actions's ICT-enabled choice.
-    assert_eq!(crc.protocol, protocol_v2_ict());
+    assert_eq!(crc.protocol, protocol_ict());
     assert_eq!(crc.metadata, metadata_b());
     assert_eq!(crc.in_commit_timestamp_opt, Some(9999));
 
@@ -1183,14 +1203,79 @@ async fn test_stale_crc_advanced_only_within_replay_budget(
     #[case] expected_crc_version: Option<u64>,
 ) {
     let built = CrcReadTest::new()
-        .v2_checkpoint(0, protocol_v2(), metadata_a())
+        .v2_checkpoint(0, protocol_a(), metadata_a())
         .commit(1, [commit_info(DEFAULT_OPERATION, None)])
         .commit(2, [commit_info(DEFAULT_OPERATION, None)])
         .commit(3, [commit_info(DEFAULT_OPERATION, None)])
-        .crc(crc_version, protocol_v2(), metadata_a(), None)
+        .crc(crc_version, protocol_a(), metadata_a(), None)
         .build()
         .await;
     let snapshot = built.snapshot_latest_with_replay(mode);
     assert_eq!(snapshot.version(), 3);
     assert_eq!(snapshot.crc().map(|c| c.version), expected_crc_version);
+}
+
+// ============================================================================
+// Tests: incremental build (builder_from) reads P&M from the CRC
+// ============================================================================
+
+// `builder_from` (incremental snapshot) Protocol resolution.
+// - CRC layouts: no new CRC / CRC below a json change / CRC above a json change / CRC at latest.
+// - Replay modes: normal CRC replay / incremental CRC replay (Unlimited).
+// The JSON protocol change is `protocol_b`; the CRC carries `protocol_c`, which matches no JSON
+// version, so the result traces its source. The newer JSON change wins when it is above the CRC;
+// otherwise the CRC supersedes it.
+#[rstest]
+#[case::no_crc(6, None, protocol_b())] // change found by replay
+#[case::crc_below_change(8, Some(6), protocol_b())] // newer JSON change wins
+#[case::crc_above_change(6, Some(8), protocol_c())] // CRC supersedes the change
+#[case::crc_at_latest(6, Some(10), protocol_c())] // CRC at end version
+#[tokio::test]
+async fn test_incremental_build_from_reads_protocol_from_crc(
+    #[case] protocol_change_version: u64,
+    #[case] crc_version: Option<u64>,
+    #[case] expected_protocol: Protocol,
+    // Protocol & Metadata must resolve identically regardless of the CRC replay strategy or
+    // budget.
+    #[values(
+        IncrementalReplay::Disabled,
+        IncrementalReplay::UpToCommits(2),
+        IncrementalReplay::Unlimited
+    )]
+    mode: IncrementalReplay,
+) {
+    // ====== GIVEN =====
+    // v0 sets protocol_a; v5 is the "from" Snapshot version.
+    let mut setup = CrcReadTest::new().commit(
+        0,
+        [
+            commit_info(DEFAULT_OPERATION, None),
+            protocol(protocol_a()),
+            metadata(metadata_a()),
+        ],
+    );
+    // `protocol_change_version` has a JSON commit changing the protocol to protocol_b.
+    for v in 1..=10 {
+        let mut actions = vec![commit_info(DEFAULT_OPERATION, None)];
+        if v == protocol_change_version {
+            actions.push(protocol(protocol_b()));
+        }
+        setup = setup.commit(v, actions);
+    }
+    if let Some(v) = crc_version {
+        // Hack: the CRC carries protocol_c, matching no JSON version.
+        setup = setup.crc(v, protocol_c(), metadata_a(), None);
+    }
+    let built = setup.build().await;
+
+    // ====== WHEN =====
+    let snapshot = built.snapshot_from(5, mode);
+
+    // ====== THEN =====
+    assert_eq!(snapshot.version(), 10);
+    assert_eq!(
+        snapshot.table_configuration().protocol(),
+        &expected_protocol,
+        "protocol_change@{protocol_change_version} crc={crc_version:?} mode={mode:?}"
+    );
 }

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -3,30 +3,34 @@
 //! This module contains the methods that perform a lightweight log replay to extract the latest
 //! Protocol and Metadata actions from a [`LogSegment`].
 
-use tracing::instrument;
+use std::sync::Arc;
+
+use tracing::{info, instrument};
 
 use super::LogSegment;
 use crate::actions::{get_commit_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
+use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
 use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
 use crate::metrics::MetricId;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
-    /// Read the latest Protocol and Metadata from this log segment via full log replay.
+    /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
     /// Returns an error if either is missing.
     ///
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
     /// snapshot creation where both Protocol and Metadata must exist.
     ///
     /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %operation_id), skip(engine))]
+    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %operation_id), skip(engine, crc))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
+        crc: Option<&Arc<Crc>>,
         operation_id: MetricId,
     ) -> DeltaResult<(Metadata, Protocol)> {
-        match self.read_protocol_metadata_opt(engine)? {
+        match self.read_protocol_metadata_opt(engine, crc)? {
             (Some(m), Some(p)) => Ok((m, p)),
             (None, Some(_)) => Err(Error::MissingMetadata),
             (Some(_), None) => Err(Error::MissingProtocol),
@@ -34,14 +38,66 @@ impl LogSegment {
         }
     }
 
-    /// Read the latest Protocol and Metadata from this log segment via full log replay,
-    /// stopping early once both are found. Returns `None` for either if not found.
+    /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
+    /// Returns `None` for either if not found.
     ///
     /// This is the unchecked variant of [`Self::read_protocol_metadata`], used for incremental
     /// snapshot updates where the caller can fall back to an existing snapshot's Protocol and
     /// Metadata.
+    ///
+    /// The `crc` parameter is the CRC eagerly resolved by the caller; it is used to
+    /// short-circuit or seed the replay.
     #[instrument(name = "log_seg.load_p_m", skip_all, err)]
     pub(crate) fn read_protocol_metadata_opt(
+        &self,
+        engine: &dyn Engine,
+        crc: Option<&Arc<Crc>>,
+    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
+        // Case 1: If CRC at target version, use it directly and exit early.
+        if let Some(crc) = crc.filter(|c| c.version == self.end_version) {
+            info!("P&M from CRC at target version {}", self.end_version);
+            return Ok((Some(crc.metadata.clone()), Some(crc.protocol.clone())));
+        }
+
+        // We didn't return above, so we need to do log replay to find P&M.
+        //
+        // Case 2: CRC exists at an earlier version => Prune the log segment to only replay
+        //         commits *after* the CRC version.
+        //   (a) If we find new P&M in the pruned replay, return it.
+        //   (b) If we don't find new P&M, fall back to the CRC.
+        //
+        // Case 3: No CRC exists => Full P&M log replay.
+
+        if let Some(crc) = crc.filter(|c| c.version < self.end_version) {
+            // Case 2(a): Replay only commits after CRC version
+            info!(
+                "Pruning log segment to commits after CRC version {}",
+                crc.version
+            );
+            let pruned = self.segment_after_version(crc.version);
+            let (metadata_opt, protocol_opt) = pruned.replay_for_pm(engine)?;
+
+            if metadata_opt.is_some() && protocol_opt.is_some() {
+                info!("Found P&M from pruned log replay");
+                return Ok((metadata_opt, protocol_opt));
+            }
+
+            // Case 2(b): P&M incomplete from pruned replay, use the CRC.
+            // Use `or_else` so any newer P or M found in the pruned replay takes priority
+            // over the (older) CRC values.
+            info!("P&M fallback to CRC (no P&M changes after CRC version)");
+            return Ok((
+                metadata_opt.or_else(|| Some(crc.metadata.clone())),
+                protocol_opt.or_else(|| Some(crc.protocol.clone())),
+            ));
+        }
+
+        // Case 3: Full P&M log replay.
+        self.replay_for_pm(engine)
+    }
+
+    /// Replays the log segment for Protocol and Metadata, stopping early once both are found.
+    fn replay_for_pm(
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -53,8 +53,9 @@ impl Snapshot {
     /// Case F:     C1 .. S1 ====== S2              [C1+1, S2]   (S1, S2]   incremental update
     /// ```
     ///
-    /// In the incremental cases (D.2, F), the existing snapshot's P+M at `S1` is the baseline
-    /// and only commits in `(S1, S2]` are replayed.
+    /// In the incremental cases (D.2, F), the existing snapshot's P+M at `S1` is the baseline, and
+    /// only commits in `(S1, S2]` are replayed for newer P+M on top of it. A base CRC newer than
+    /// `S1`, when present, serves as the baseline instead.
     ///
     /// - **A.** `T == S1`: return the existing snapshot unchanged.
     /// - **B.** `T < S1`: error. The incremental path only moves forward.
@@ -294,14 +295,15 @@ impl Snapshot {
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
         // `incremental_replay`.
-        let crc = combined_log_segment.try_build_incremental_crc_with_base(
+        let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
+        let crc_at_version = combined_log_segment.try_build_crc_within_budget(
             engine,
-            existing_snapshot.crc(),
+            base_crc.as_ref(),
             incremental_replay,
         )?;
 
         let existing_table_config = existing_snapshot.table_configuration();
-        let (new_metadata, new_protocol) = match &crc {
+        let (new_metadata, new_protocol) = match &crc_at_version {
             Some(crc) => {
                 // If we were able to build a new CRC, then re-use it for TableConfiguration
                 // creation.
@@ -313,10 +315,15 @@ impl Snapshot {
             }
             None => {
                 // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
-                // scanned any log files). Perform normal P & M replay.
+                // scanned any log files). Replay the new commits `(existing_snapshot_version, end]`
+                // for P&M, rooted at the base CRC when it is newer than the existing snapshot
+                // (else the existing snapshot is the baseline).
+                let newer_base = base_crc
+                    .as_ref()
+                    .filter(|c| c.version > existing_snapshot_version);
                 combined_log_segment
                     .segment_after_version(existing_snapshot_version)
-                    .read_protocol_metadata_opt(engine)?
+                    .read_protocol_metadata_opt(engine, newer_base)?
             }
         };
         let table_configuration = TableConfiguration::try_new_from(
@@ -330,7 +337,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            crc,
+            crc_at_version,
         )?))
     }
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -170,8 +170,10 @@ impl Snapshot {
         })
     }
 
-    /// Create a new [`Snapshot`] from a freshly-listed [`LogSegment`], taking Protocol and
-    /// Metadata from the resolved CRC when one is present.
+    /// Create a new [`Snapshot`] from a freshly-listed [`LogSegment`]. Takes Protocol and Metadata
+    /// from the latest on-disk CRC, advanced to the segment's end version when `incremental_replay`
+    /// permits, or used to root Protocol and Metadata log replay otherwise. Falls back to full log
+    /// replay when no CRC is present.
     #[instrument(err, fields(version, operation_id = %operation_id), skip(engine))]
     fn try_new_from_log_segment(
         location: Url,
@@ -180,13 +182,22 @@ impl Snapshot {
         operation_id: MetricId,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Self> {
-        let crc = log_segment.try_build_incremental_crc(engine, incremental_replay)?;
+        // Step 1: read the latest on-disk CRC and, if usable, advance it to the end version
+        //         (or use it as-is when already there) per `incremental_replay`.
+        let base_crc = log_segment.read_latest_crc(engine);
+        let crc_at_version = log_segment.try_build_crc_within_budget(
+            engine,
+            base_crc.as_ref(),
+            incremental_replay,
+        )?;
 
+        // Step 2: P&M from that CRC, else log replay rooted at the base CRC, checkpoint, or
+        //         first commit.
         // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
         //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
-        let (metadata, protocol) = match crc.as_deref() {
+        let (metadata, protocol) = match crc_at_version.as_deref() {
             Some(c) => (c.metadata.clone(), c.protocol.clone()),
-            None => log_segment.read_protocol_metadata(engine, operation_id)?,
+            None => log_segment.read_protocol_metadata(engine, base_crc.as_ref(), operation_id)?,
         };
 
         let table_configuration =
@@ -194,7 +205,7 @@ impl Snapshot {
 
         tracing::Span::current().record("version", table_configuration.version());
 
-        Self::new_with_crc(log_segment, table_configuration, crc)
+        Self::new_with_crc(log_segment, table_configuration, crc_at_version)
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -234,28 +234,34 @@ async fn snapshot_with_crc_at_target_version_skips_json_replay() -> DeltaResult<
 }
 
 // ============================================================================
-// Scenario 6: CRC at a prior version (CRC exists but is older than latest)
+// Scenario 6: CRC older than the latest version
 // ============================================================================
 // TODO: migrate to TestTableBuilder when CRC LogState variants land (#2284)
 
-/// When a CRC file exists at an older version than the snapshot, the kernel advances it to the
-/// target version via reverse-replay: it reads the tail commits (those after the CRC version)
-/// once and reads the base CRC from storage. P&M come from the advanced CRC, so there is no
-/// separate P&M scan.
+/// A CRC older than the snapshot version: kernel roots Protocol & Metadata at the CRC and reads
+/// only the commits above it (plus the CRC), never the first commit. Both modes:
+/// - `Disabled` (default): the tail is replayed for P&M, falling back to the CRC's P&M; the stale
+///   CRC is not advanced, so the snapshot stores no CRC.
+/// - `Unlimited`: the same tail is reverse-replayed to advance the CRC to the target version, which
+///   the snapshot stores.
 ///
-/// This is a normal, expected table state -- having a CRC from a previous version is
-/// not an error or degraded condition.
+/// Reading only the tail (not the first commit) is the regression guard: a full-log replay under
+/// `Disabled` would read v0 too.
 ///
-/// `write_checksum` requires stats from a post-commit snapshot (not a freshly built
-/// one), so this test uses `create_table` commit -> `post_commit_snapshot` ->
-/// `write_checksum` to write the CRC at v0.
+/// `write_checksum` needs stats from a post-commit snapshot, so this uses `create_table` ->
+/// `post_commit_snapshot` -> `write_checksum` to write the CRC at v0.
+#[rstest]
+#[case::disabled(IncrementalReplay::Disabled, None)]
+#[case::unlimited(IncrementalReplay::Unlimited, Some(2))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn crc_at_prior_version_advances_via_reverse_replay() -> DeltaResult<()> {
+async fn crc_at_prior_version_roots_replay_at_crc_for_both_modes(
+    #[case] mode: IncrementalReplay,
+    #[case] expected_crc_version: Option<u64>,
+) -> DeltaResult<()> {
     let (_temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
 
-    // commit 0: create table; write CRC from the post-commit snapshot.
-    // `write_checksum` requires an in-memory CRC computed during the transaction.
+    // commit 0: create table, then write its CRC (write_checksum needs the post-commit CRC).
     let create_committed = create_table(&table_path, simple_schema(), "Test/1.0")
         .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(setup_engine.as_ref())?
@@ -285,18 +291,18 @@ async fn crc_at_prior_version_advances_via_reverse_replay() -> DeltaResult<()> {
             .clone();
     }
 
-    // Measurement: build snapshot at latest (v2); CRC is at v0 (two versions behind)
+    // Measurement: build the snapshot at latest (v2); the CRC is at v0, two versions behind.
     let (measure_engine, reporter, _guard) = measuring_engine(Arc::new(LocalFileSystem::new()));
     let snap = Snapshot::builder_for(table_url)
-        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+        .with_incremental_crc_replay(mode)
         .build(&measure_engine)?;
-    assert_eq!(snap.crc().expect("stale CRC advanced to v2").version, 2);
+    assert_eq!(snap.crc().map(|c| c.version), expected_crc_version);
 
     assert_eq!(reporter.snapshot_completions.get(), 1);
     assert_eq!(reporter.log_segment_loads.get(), 1);
     assert_eq!(reporter.commit_files.get(), 3); // v0, v1, v2
 
-    // Reverse-replay reads the tail commits v1 and v2 (after the CRC at v0) in one JSON call.
+    // Only the tail commits v1 and v2 (after the CRC at v0) are read, in one JSON call.
     assert_eq!(reporter.json_read_calls.get(), 1);
     assert_eq!(reporter.json_files_read.get(), 2);
     // The base CRC at v0 is read from storage.


### PR DESCRIPTION
## What changes are proposed in this pull request?

#2678 dropped the CRC-rooted Protocol & Metadata replay that #1790 added: under the default `IncrementalReplay::Disabled`, a stale CRC no longer roots P&M replay, so loading falls back to full checkpoint replay. This reverts most of #2678's change to that path while keeping its incremental CRC-advance feature.

The bug slipped through because #2678 rewired the affected tests to `Unlimited` in the same PR. Tests now run BOTH paths: the default (CRC-rooted replay) and `Unlimited` (incremental advance).

## How was this change tested?

Existing UTs. We now run all CRC tests against both (1) normal P & M replay against a root CRC and (2) incremental CRC
