### PR TITLE
ci: fail bench job on 15% regressions and tighten the bench comment

### DIFF
--- a/.github/workflows/benchmark-post-comment.yml
+++ b/.github/workflows/benchmark-post-comment.yml
@@ -10,9 +10,22 @@
 # `pull_request` / `push` / `merge_group` / `issue_comment` with `contents: read`
 # only -- it has no write scope on PR-triggered runs from forks (read-only
 # GITHUB_TOKEN per GitHub's default), so it cannot post a comment itself.
-# Instead, it uploads the comment body as an artifact, and this workflow runs
-# in base-branch context (which does have write scope), downloads the artifact,
-# and posts/updates the PR comment.
+# Instead, run-benchmarks.sh writes the comment body to /tmp/bench-comment.md,
+# benchmark.yml uploads that file as the `bench-comment` artifact, and this
+# workflow (running in base-branch context, which does have write scope)
+# downloads it and posts/updates the PR comment.
+#
+# Two jobs, routed by whether the `bench-comment` artifact exists:
+#
+#   bench succeeds: `bench-comment` uploaded
+#       -> post-comment posts the table; post-failure-comment skips
+#   bench fails
+#     ├─ regression gate tripped (a benchmark >=15% slower): benchmark.yml
+#     │    uploads `bench-comment` before the gate runs, so it exists despite
+#     │    the failed job
+#     │      -> post-comment posts the table; post-failure-comment skips
+#     └─ broke before writing /tmp/bench-comment.md (e.g. compile error)
+#          -> no artifact; post-failure-comment posts a static failure note
 #
 # Pattern is identical to pr-validator.yml + comment-on-title-failure.yml.
 #
@@ -48,11 +61,12 @@ concurrency:
 jobs:
   post-comment:
     name: Post benchmark results
-    # Only post when the upstream succeeded AND the upstream event was a PR
-    # event with a conversation to post to. `merge_group` and `push: main`
-    # runs of workflow A have no PR to comment on.
+    # Post when the upstream succeeded OR failed (a failure is usually the
+    # regression gate tripping, and the result table still exists), and the
+    # upstream event was a PR event with a conversation to post to.
+    # `merge_group` and `push: main` runs of workflow A have no PR to comment on.
     if: >
-      github.event.workflow_run.conclusion == 'success'
+      contains(fromJSON('["success","failure","timed_out"]'), github.event.workflow_run.conclusion)
       && (github.event.workflow_run.event == 'pull_request'
           || github.event.workflow_run.event == 'issue_comment')
     runs-on: ubuntu-latest
@@ -166,10 +180,10 @@ jobs:
   post-failure-comment:
     name: Post benchmark failure note
     # Replace any existing success comment with a failure note so reviewers
-    # don't see stale-green after a regression-causing push that breaks the
-    # bench itself. `timed_out` counts as failure for our purposes; we skip
-    # `cancelled` (a superseding run will post its own update) and `skipped`
-    # (nothing meaningful happened, e.g., draft).
+    # don't see stale-green after a push that breaks the bench itself.
+    # `timed_out` counts as failure for our purposes; we skip `cancelled` (a
+    # superseding run will post its own update) and `skipped` (nothing
+    # meaningful happened, e.g., draft).
     if: >
       contains(fromJSON('["failure","timed_out"]'), github.event.workflow_run.conclusion)
       && (github.event.workflow_run.event == 'pull_request'
@@ -242,16 +256,30 @@ jobs:
           else
             printf 'number=%s\n' "$NUM" >> "$GITHUB_OUTPUT"
           fi
+      - name: Probe for bench comment artifact
+        # Detect whether the bench produced a comment artifact; continue-on-error
+        # so "absent" is a clean outcome rather than a job failure. The find/post
+        # steps below run only when it's absent: when present, the failure was the
+        # gate tripping and post-comment owns the comment (see the header routing).
+        id: probe-body
+        if: steps.pr.outputs.skip != 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: bench-comment
+          path: /tmp/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - name: Find existing bench comment
         id: find
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.probe-body.outcome != 'success'
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         with:
           issue-number: ${{ steps.pr.outputs.number }}
           comment-author: 'github-actions[bot]'
           body-includes: '<!-- delta-kernel-bench-comment -->'
       - name: Post or update failure note
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.probe-body.outcome != 'success'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
@@ -261,6 +289,6 @@ jobs:
           edit-mode: replace
           body: |
             <!-- delta-kernel-bench-comment -->
-            ## Benchmark results
+            ## Benchmark results: ❌ Fail
 
-            <sub>Benchmark run failed. [See workflow run](${{ env.RUN_URL }}) for details.</sub>
+            <sub>Benchmark run failed before producing results. [See workflow run](${{ env.RUN_URL }}) for details.</sub>

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,11 @@
 # as an artifact; that workflow downloads it and posts/updates the PR comment
 # in base-branch context (which has the write scope this workflow lacks under
 # pull_request from a fork).
+#
+# The run-benchmark job fails if any benchmark regresses past the fail
+# threshold in benchmarks/ci/parse_critcmp.py, unless the PR carries the
+# ignore-benchmark-failure label. The comment artifact is uploaded before that
+# gate runs, so the result table still gets posted on a gate failure.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -142,6 +147,18 @@ jobs:
           printf 'head_sha=%s\n' "$HEAD_SHA" >> "$GITHUB_OUTPUT"
           printf 'base_ref=%s\n'  "$BASE_REF"  >> "$GITHUB_OUTPUT"
           printf 'pr_number=%s\n' "$NUM"      >> "$GITHUB_OUTPUT"
+          # Read labels here, in trusted pre-checkout context, so the
+          # regression gate's override decision can't be influenced by PR code
+          # that runs later. Capture into a variable before matching:
+          # `gh ... | grep -q` would let grep close the pipe early and trip
+          # pipefail. On any read error LABELS is empty and the gate stays
+          # enforced.
+          LABELS=$(gh pr view "$NUM" --repo "$REPO" --json labels --jq '.labels[].name' || true)
+          if grep -qx 'ignore-benchmark-failure' <<< "$LABELS"; then
+            printf 'ignore_failure=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'ignore_failure=false\n' >> "$GITHUB_OUTPUT"
+          fi
       - name: Stash PR number for the post-comment workflow
         # Written to /tmp/pr-number.txt and uploaded as its own artifact in
         # the next step. The two-step shape (write then upload) keeps the
@@ -203,14 +220,28 @@ jobs:
           TRIGGER:  ${{ github.event_name == 'issue_comment' && '/bench' || 'auto-push' }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BENCH_IGNORE_FAILURE: ${{ steps.pr.outputs.ignore_failure }}
         run: bash benchmarks/ci/run-benchmarks.sh
       - name: Upload bench comment
         # Default `if: success()` -- a bench failure leaves no body to post.
-        # The post-failure-comment workflow doesn't need this artifact; it
-        # uses the separately-uploaded bench-pr-number artifact (or the
-        # workflow_run.head_branch lookup, depending on upstream event) to
-        # learn which PR to post the static failure note on.
+        # Runs before the regression gate below so the artifact exists even
+        # when the gate fails the job.
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bench-comment
           path: /tmp/bench-comment.md
+      - name: Enforce benchmark regression gate
+        # parse_critcmp.py wrote "true" to this file iff some benchmark crossed
+        # its fail threshold. Fail the job on a regression unless the PR opted
+        # out with the ignore-benchmark-failure label (resolved pre-checkout in
+        # the trusted metadata step).
+        env:
+          IGNORE_FAILURE: ${{ steps.pr.outputs.ignore_failure }}
+        run: |
+          set -u
+          REGRESSED=$(tr -d '[:space:]' < /tmp/bench-regression.txt 2>/dev/null || echo false)
+          if [[ "$REGRESSED" == "true" && "$IGNORE_FAILURE" != "true" ]]; then
+            echo "::error::A benchmark regressed by at least 15%. Add the 'ignore-benchmark-failure' label to override this gate." >&2
+            exit 1
+          fi
+          echo "Regression gate passed (regressed=$REGRESSED, ignore_failure=$IGNORE_FAILURE)."

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -109,6 +109,10 @@ so the bench job itself runs with a read-only token even on fork PRs. To bench a
 override the tags or filter, post a `/bench` comment as documented below -- it updates the
 same comment that the auto-trigger uses.
 
+The bench job fails if any benchmark is at least 15% slower than the base branch. The result
+comment is still posted so you can see which benchmark regressed. To merge anyway (for an
+expected or noise-driven regression), add the `ignore-benchmark-failure` label to the PR.
+
 To trigger benchmarks on a pull request manually, post a comment using the following syntax:
 
 ```

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -3,34 +3,46 @@
 Parse critcmp output and format it as a GitHub-flavoured Markdown comment.
 
 Reads the output of `critcmp base changes` from stdin and writes:
-  1. A summary block listing the largest slowdown, the fastest speedup,
-     and the count of significant slowdowns/speedups.
-  2. A `<details>` block (closed by default) containing the full
-     per-benchmark table with columns: Test | Base | PR | Change.
+  1. The comment's header line, ending with a pass/fail verdict that mirrors
+     the regression-gate outcome (BENCH_IGNORE_FAILURE=true renders the
+     label-override variant).
+  2. A one-line summary of how many benchmarks fell into each tier, ordered
+     fastest to slowest.
+  3. A `<details>` block (closed by default) containing the full
+     per-benchmark table with columns: Test | Change | Base | PR.
+  4. The tier legend as a small-text footer line.
 
-A change is "significant" when it is at least 2x in either direction
-(ratio >= 2.0 for slowdown, ratio <= 0.5 for speedup). The summary includes
-every slowdown and speedup; significant ones get a 🐌/🚀 marker in the
-Change cell.
+Each benchmark is bucketed by its displayed PR/base multiplier into a tier with
+a marker emoji (see the threshold constants). When any benchmark lands in the
+slowest tier, the run records a regression in the file named by
+BENCH_REGRESSION_FILE (if set) so the workflow can fail the job.
 
 Usage:
     critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
 """
+import os
 import re
 import sys
 
-# Significance threshold for slowdowns/speedups (2x in either direction).
-SIGNIFICANCE_THRESHOLD = 2.0
+# Tiers compare the 2-decimal multiplier the table displays ("1.15x slower",
+# "1.15x faster"), so a row's marker always matches its Change cell.
+ROCKET_THRESHOLD = 1.15
+GRAY_THRESHOLD = 1.03
+FAIL_THRESHOLD = 1.15
 
-# Ratios within this of 1.0 count as no change: rendered "1.00x" with no marker
-# and excluded from the summary's slowdown/speedup counts.
-NEUTRAL_THRESHOLD = 1e-3
+# |ratio - 1| within this renders as "1.00x" with no faster/slower suffix
+# (half of the 2-decimal display step).
+NEUTRAL_THRESHOLD = 0.005
 
-# Emoji markers for the Change cell, by side and severity.
-SIGNIFICANT_SLOWDOWN = '🐌'  # ratio >= SIGNIFICANCE_THRESHOLD
-SLIGHT_SLOWDOWN = '🚧'  # 1.0 < ratio < SIGNIFICANCE_THRESHOLD
-SLIGHT_SPEEDUP = '✅'  # 1.0 / SIGNIFICANCE_THRESHOLD < ratio < 1.0
-SIGNIFICANT_SPEEDUP = '🚀'  # ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
+# Tier markers for the Change cell, fastest to slowest.
+ROCKET = '🚀'         # at least 1.15x faster
+GREEN_CHECK = '✅'    # faster or unchanged
+GRAY_CHECK = '☑️'     # at most 1.03x slower
+CONSTRUCTION = '🚧'   # between 1.03x and 1.15x slower
+RED_X = '❌'          # at least 1.15x slower (fails the job)
+
+# Fastest to slowest; drives both the summary order and the legend.
+TIERS = [ROCKET, GREEN_CHECK, GRAY_CHECK, CONSTRUCTION, RED_X]
 
 def to_ms(value, units):
     """Convert a critcmp duration to milliseconds.
@@ -65,7 +77,6 @@ def parse_rows(lines):
       base_display: base duration string or 'N/A'
       chg_display:  changes duration string or 'N/A'
       ratio:        chg_ms / base_ms, or None if either side is missing/zero
-      significant:  bool, False if ratio is None
     """
     rows = []
     for line in lines[2:]:  # skip critcmp header rows
@@ -89,7 +100,6 @@ def parse_rows(lines):
         base_display = base_dur_str or 'N/A'
         chg_display  = chg_dur_str  or 'N/A'
         ratio = None
-        significant = False
 
         if base_dur_str and chg_dur_str:
             base_p = parse_duration(base_dur_str)
@@ -104,17 +114,12 @@ def parse_rows(lines):
                 # benches (sub-nanosecond rounding) as N/A.
                 if base_ms != 0 and chg_ms != 0:
                     ratio = chg_ms / base_ms
-                    significant = (
-                        ratio >= SIGNIFICANCE_THRESHOLD
-                        or ratio <= 1.0 / SIGNIFICANCE_THRESHOLD
-                    )
 
         rows.append({
             'name': name,
             'base_display': base_display,
             'chg_display': chg_display,
             'ratio': ratio,
-            'significant': significant,
         })
     return rows
 
@@ -128,51 +133,60 @@ def format_difference(ratio):
         return f'{ratio:.2f}x slower'
     return f'{1.0 / ratio:.2f}x faster'
 
-def change_emoji(ratio, significant):
-    """Pick an emoji indicator for the Change cell.
-
-    See the module-level emoji constants for the marker assignments. Returns
-    an empty string for ratios near 1.0 or N/A rows.
-    """
-    if ratio is None or abs(ratio - 1.0) < NEUTRAL_THRESHOLD:
+def change_emoji(ratio):
+    """Pick the tier marker for the Change cell from the displayed 2-decimal
+    multiplier. Empty string for N/A rows."""
+    if ratio is None:
         return ''
-    if ratio > 1.0:
-        return SIGNIFICANT_SLOWDOWN if significant else SLIGHT_SLOWDOWN
-    return SIGNIFICANT_SPEEDUP if significant else SLIGHT_SPEEDUP
+    if ratio < 1.0:
+        return ROCKET if round(1.0 / ratio, 2) >= ROCKET_THRESHOLD else GREEN_CHECK
+    shown = round(ratio, 2)
+    if shown <= 1.0:
+        return GREEN_CHECK
+    if shown <= GRAY_THRESHOLD:
+        return GRAY_CHECK
+    if shown < FAIL_THRESHOLD:
+        return CONSTRUCTION
+    return RED_X
+
+def render_verdict(regressed, ignored):
+    """Render the pass/fail verdict shown in the comment's header line,
+    mirroring the job's regression-gate outcome."""
+    mult = f'{FAIL_THRESHOLD:.2f}x'
+    if not regressed:
+        return '✅ Pass'
+    if ignored:
+        return f'⚠️ Pass (≥{mult} slowdown ignored)'
+    return f'❌ Fail (a benchmark is ≥{mult} slower)'
 
 def render_summary(rows):
-    """Render the summary block. The counts and the largest-slowdown/fastest-speedup
-    lines include every slowdown and speedup regardless of the 2x significance
-    threshold; the per-row emoji marker is what distinguishes significant from
-    slight changes.
+    """Render the per-tier counts on one line, fastest to slowest. N/A rows
+    (added/removed benchmarks) are appended only when present."""
+    counts = {tier: 0 for tier in TIERS}
+    na = 0
+    for r in rows:
+        emoji = change_emoji(r['ratio'])
+        if emoji:
+            counts[emoji] += 1
+        else:
+            na += 1
+    parts = [f"{tier} {counts[tier]}" for tier in TIERS]
+    if na:
+        parts.append(f"N/A {na}")
+    return "**Summary:** " + " &nbsp;·&nbsp; ".join(parts)
 
-    Rows within NEUTRAL_THRESHOLD of 1.0 are excluded since they are neither slowdowns
-    nor speedups. N/A rows (ratio is None) are excluded for the same reason.
-    """
-    slow = [r for r in rows if r['ratio'] is not None and r['ratio'] - 1.0 >= NEUTRAL_THRESHOLD]
-    fast = [r for r in rows if r['ratio'] is not None and 1.0 - r['ratio'] >= NEUTRAL_THRESHOLD]
-
-    if slow:
-        worst = max(slow, key=lambda r: r['ratio'])
-        largest_slowdown = f"`{worst['name']}` ({format_difference(worst['ratio'])})"
-    else:
-        largest_slowdown = "no benchmarks slowed down"
-
-    if fast:
-        best = min(fast, key=lambda r: r['ratio'])
-        fastest_speedup = f"`{best['name']}` ({format_difference(best['ratio'])})"
-    else:
-        fastest_speedup = "no benchmarks sped up"
-
-    lines = [
-        "**Summary**",
-        "",
-        f"- Largest slowdown: {largest_slowdown}",
-        f"- Fastest speedup: {fastest_speedup}",
-        f"- Benchmarks slowed down: {len(slow)}",
-        f"- Benchmarks sped up: {len(fast)}",
-    ]
-    return "\n".join(lines)
+def render_legend():
+    """Render the tier legend as a small-text line for the comment footer."""
+    fail = f'{FAIL_THRESHOLD:.2f}x'
+    gray = f'{GRAY_THRESHOLD:.2f}x'
+    rocket = f'{ROCKET_THRESHOLD:.2f}x'
+    return (
+        f"<sub>Legend: {ROCKET} ≥{rocket} faster &nbsp;·&nbsp;"
+        f"{GREEN_CHECK} faster or unchanged &nbsp;·&nbsp;"
+        f"{GRAY_CHECK} ≤{gray} slower &nbsp;·&nbsp;"
+        f"{CONSTRUCTION} {gray}-{fail} slower &nbsp;·&nbsp;"
+        f"{RED_X} ≥{fail} slower</sub>"
+    )
 
 def render_table(rows):
     """Render the per-benchmark table wrapped in a closed-by-default <details> block."""
@@ -180,23 +194,16 @@ def render_table(rows):
     out.append("<details>")
     out.append(f"<summary>Per-benchmark results ({len(rows)} rows)</summary>")
     out.append("")
-    out.append(
-        f"**Legend:** {SIGNIFICANT_SLOWDOWN} ≥ 2x slower &nbsp;·&nbsp;"
-        f"{SLIGHT_SLOWDOWN} < 2x slower &nbsp;·&nbsp;"
-        f"{SLIGHT_SPEEDUP} < 2x faster &nbsp;·&nbsp;"
-        f"{SIGNIFICANT_SPEEDUP} ≥ 2x faster"
-    )
-    out.append("")
-    out.append("| Test | Base         | PR               | Change |")
-    out.append("|------|--------------|------------------|--------|")
+    out.append("| Test | Change | Base         | PR               |")
+    out.append("|------|--------|--------------|------------------|")
     for r in rows:
         name_cell = f"`{r['name']}`" if r['name'] else ''
         difference = format_difference(r['ratio'])
-        emoji = change_emoji(r['ratio'], r['significant'])
+        emoji = change_emoji(r['ratio'])
         # Non-breaking spaces keep the marker and ratio on one line so the
         # Change cell renders without wrapping.
         change_cell = f"{emoji} {difference}".strip().replace(" ", "&nbsp;")
-        out.append(f"| {name_cell} | {r['base_display']} | {r['chg_display']} | {change_cell} |")
+        out.append(f"| {name_cell} | {change_cell} | {r['base_display']} | {r['chg_display']} |")
     out.append("")
     out.append("</details>")
     return "\n".join(out)
@@ -204,9 +211,23 @@ def render_table(rows):
 def main():
     lines = sys.stdin.read().splitlines()
     rows = parse_rows(lines)
+    regressed = any(change_emoji(r['ratio']) == RED_X for r in rows)
+    ignored = os.environ.get('BENCH_IGNORE_FAILURE') == 'true'
+
+    print(f'## Benchmark results: {render_verdict(regressed, ignored)}')
+    print("")
     print(render_summary(rows))
     print("")
     print(render_table(rows))
+    print("")
+    print(render_legend())
+
+    # Record whether any benchmark crossed FAIL_THRESHOLD so the workflow can
+    # fail the job (unless overridden by the ignore-benchmark-failure label).
+    flag_path = os.environ.get('BENCH_REGRESSION_FILE')
+    if flag_path:
+        with open(flag_path, 'w') as f:
+            f.write('true' if regressed else 'false')
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -15,6 +15,10 @@
 #                body under the issue_comment path.
 #   TRIGGER    - (optional) human-readable label for what kicked off the run
 #                ("auto-push" or "/bench"). Used in the comment header.
+#   BENCH_IGNORE_FAILURE - (optional) "true" when the PR carries the
+#                ignore-benchmark-failure label. Passed through to
+#                parse_critcmp.py so the comment's verdict line says the
+#                regression gate is overridden.
 
 set -euo pipefail
 shopt -s extglob
@@ -70,12 +74,24 @@ echo "Parsed filter: ${FILTER:-<none>}"
 [[ -n "$TAGS" ]] && export BENCH_TAGS="$TAGS"
 
 # ---------------------------------------------------------------------------
-# 2. Benchmark the PR branch (already checked out by the workflow)
+# 2. Log the runner environment
+#    GitHub-hosted runners draw from a heterogeneous pool (varying CPU model,
+#    cache size, neighbor load). Logging hardware and load per run gives us the
+#    data to attribute run-to-run variance to the machine vs. the code.
+# ---------------------------------------------------------------------------
+echo "=== Runner environment ==="
+lscpu | grep -E '^(Model name|CPU\(s\)|Thread|CPU( max| min)? MHz|L[123][a-z]* cache)' || true
+echo "loadavg: $(cat /proc/loadavg)"
+echo "mem: $(free -m | awk '/^Mem:/ {print $2 " MB total, " $7 " MB available"}')"
+echo "==========================="
+
+# ---------------------------------------------------------------------------
+# 3. Benchmark the PR branch (already checked out by the workflow)
 # ---------------------------------------------------------------------------
 (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER")
 
 # ---------------------------------------------------------------------------
-# 3. Switch to the base branch and benchmark it
+# 4. Switch to the base branch and benchmark it
 #    The benchmarks/target/ directory is not tracked by git, so the
 #    "changes" baseline files are preserved across the branch switch.
 # ---------------------------------------------------------------------------
@@ -84,9 +100,9 @@ git checkout FETCH_HEAD
 (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
 
 # ---------------------------------------------------------------------------
-# 4. Compare baselines with critcmp and format as a markdown comment
-#    (summary block + collapsed per-benchmark table; see
-#    benchmarks/ci/parse_critcmp.py for the format and significance rules).
+# 5. Compare baselines with critcmp and format as a markdown comment
+#    (per-tier summary line + collapsed per-benchmark table; see
+#    benchmarks/ci/parse_critcmp.py for the format and tier thresholds).
 #      - Parses actual duration values (not rank factors) to compute a ratio
 # ---------------------------------------------------------------------------
 # Step 3 left the working tree on the base branch, so parse_critcmp.py on disk
@@ -98,30 +114,33 @@ git checkout "$HEAD_SHA"
 # Use `critcmp` to compare the criterion output for `base` and `changes`. We use `critcmp` instead of manually
 # parsing criterion outputs because criterion may update its output format. By using `critcmp`, we inherit all
 # updated criterion output parsing.
+#
+# parse_critcmp.py records whether any benchmark regressed past its fail
+# threshold in this file; benchmark.yml's gate step reads it to fail the job.
+export BENCH_REGRESSION_FILE=/tmp/bench-regression.txt
 COMPARISON=$((cd benchmarks && critcmp base changes) | python3 benchmarks/ci/parse_critcmp.py)
 
 # ---------------------------------------------------------------------------
-# 5. Write results to /tmp/bench-comment.md
+# 6. Write results to /tmp/bench-comment.md
 #    benchmark.yml uploads this as an artifact; benchmark-post-comment.yml
 #    downloads it and posts the PR comment in base-branch context.
 # ---------------------------------------------------------------------------
 SHORT_SHA="${HEAD_SHA:0:7}"
 
-# Metadata line shows commit + what fired this run + the active tags/filter so
-# a reviewer can tell at a glance which configuration produced the displayed
-# numbers (the same comment is reused across auto-trigger and /bench runs).
+# Metadata footer shows commit + what fired this run + the active tags/filter +
+# when the comment was last refreshed, so a reviewer can tell at a glance which
+# configuration produced the displayed numbers (the same comment is reused
+# across auto-trigger and /bench runs).
 SUMMARY="Commit: \`${SHORT_SHA}\` &middot; Trigger: ${TRIGGER:-auto-push}"
 [[ -n "$TAGS" ]]   && SUMMARY+=" &middot; Tags: \`${TAGS}\`"
 [[ -n "$FILTER" ]] && SUMMARY+=" &middot; Filter: \`${FILTER}\`"
+SUMMARY+=" &middot; Updated: $(TZ=America/Los_Angeles date '+%Y-%m-%d %H:%M %Z')"
 
 # Leading marker is an HTML comment, invisible to readers; the post-comment
 # job uses it as a stable identifier for find-and-update so each push reuses
 # the same comment instead of stacking new ones.
 {
   echo "<!-- delta-kernel-bench-comment -->"
-  echo "## Benchmark results"
-  echo ""
-  echo "<sub>${SUMMARY}</sub>"
-  echo ""
   echo "$COMPARISON"
+  echo "<sub>${SUMMARY}</sub>"
 } > /tmp/bench-comment.md


### PR DESCRIPTION
## What changes are proposed in this pull request?

**CUJ change:**
The benchmark CI job now fails when any benchmark is at least 15% slower than the base branch.

Add the `ignore-benchmark-failure` label to a PR to override the gate (e.g. for known noise).

**Comment format changes:**
- The header line ends with a pass/fail verdict (CHECK Pass / WARNING Pass with regression ignored / X Fail).
- The summary is now a single line of per-tier emoji counts, fastest to slowest.
- The Change column moved next to the benchmark name
- The legend and run metadata (commit, trigger, tags, last-updated timestamp in PT) moved to a small-text footer.

**Other**
- Also logs the runner's CPU/memory/load in the job output for later analysis of run-to-run variance.

## How was this change tested?

Ran `parse_critcmp.py` against synthetic critcmp output covering every tier, every verdict variant, and the N/A case. Workflow YAML and shell syntax validated locally.

Gate + label validated end-to-end on a fork test PR ([scottsand-db#3](https://github.com/scottsand-db/delta-kernel-rs/pull/3)) that adds an artificial 20ms sleep to `SnapshotBuilder::build`:
- [Attempt 1](https://github.com/scottsand-db/delta-kernel-rs/actions/runs/27428285352/attempts/1) (no label): 8 benches flagged X, comment artifact uploaded, job fails at the regression gate.
- [Attempt 2](https://github.com/scottsand-db/delta-kernel-rs/actions/runs/27428285352) (added `ignore-benchmark-failure`, re-ran): same regression, verdict renders "WARNING Pass (15%+ regression ignored)", job passes.

The new failure-path comment posting can only be exercised after merge: `workflow_run` always executes the default-branch copy of benchmark-post-comment.yml.
