### PR TITLE
refactor: Eagerly materialize the physical no-partition-schema

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -10,7 +10,7 @@
 //! [`Schema`]: crate::schema::Schema
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
 use tracing::warn;
@@ -87,40 +87,24 @@ fn validate_partition_columns(metadata: &Metadata, logical_schema: &StructType) 
     Ok(())
 }
 
-/// Physical schema variants for a table.
+/// Builds the physical data schema (partition columns excluded) from the `full` physical schema.
 ///
-/// - `full`: physical representations of all columns from [`TableConfiguration::logical_schema`].
-/// - `without_partition`: lazily computed variant that excludes partition columns.
-///
-/// Note:
-/// `without_partition` is wrapped in an `Arc` so that the lazily-initialized schema is shared
-/// across clones of this struct (and therefore across clones of [`TableConfiguration`]).  Without
-/// Arc'ing the lock, clones of a [`TableConfiguration`] with an uninitialized schema would clone
-/// the empty `OnceLock`, meaning later schema loads would unnecessarily store independent
-/// copies of the same schema.
-#[derive(Debug, Clone, Eq)]
-struct PhysicalSchemas {
-    full: SchemaRef,
-    without_partition: Arc<OnceLock<SchemaRef>>,
-}
-
-impl PhysicalSchemas {
-    fn new(full: SchemaRef) -> Self {
-        Self {
-            full,
-            without_partition: Arc::new(OnceLock::new()),
-        }
-    }
-}
-
-impl PartialEq for PhysicalSchemas {
-    fn eq(&self, other: &Self) -> bool {
-        // `without_partition` is deterministically derived from `full` and partition columns
-        // (compared via `metadata` in TableConfiguration's PartialEq), so comparing it is
-        // redundant. Two PhysicalSchemas with the same `full` are considered equal even if
-        // one has `without_partition` initialized and the other does not.
-        self.full == other.full
-    }
+/// Partition columns are excluded because their values live in the Add action's `partitionValues`,
+/// not in the data files. `logical_schema` must be the logical schema `full_physical_schema` was
+/// derived from (same field order), so partition columns can be matched positionally.
+fn build_physical_data_schema(
+    full_physical_schema: &StructType,
+    logical_schema: &StructType,
+    partition_columns: &[String],
+) -> SchemaRef {
+    let partition_columns: HashSet<&str> = partition_columns.iter().map(|s| s.as_str()).collect();
+    let fields = logical_schema
+        .fields()
+        .zip(full_physical_schema.fields())
+        .filter(|(logical_field, _)| !partition_columns.contains(logical_field.name().as_str()))
+        .map(|(_, physical_field)| physical_field.clone());
+    // Safety: subset of an already-valid schema.
+    Arc::new(StructType::new_unchecked(fields))
 }
 
 /// Holds all the configuration for a table at a specific version. This includes the supported
@@ -140,7 +124,10 @@ pub(crate) struct TableConfiguration {
     protocol: Protocol,
     /// Logical schema: field names are the user-facing (logical) column names.
     logical_schema: SchemaRef,
-    physical_schemas: PhysicalSchemas,
+    /// Physical schema for all columns (field names respect column mapping mode).
+    physical_schema: SchemaRef,
+    /// The subset of the physical schema that remains after excluding partition columns.
+    physical_data_schema_without_partition_columns: SchemaRef,
     table_properties: TableProperties,
     column_mapping_mode: ColumnMappingMode,
     table_root: Url,
@@ -205,11 +192,16 @@ impl TableConfiguration {
         let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
 
         let physical_schema = Arc::new(logical_schema.make_physical(column_mapping_mode)?);
-        let physical_schemas = PhysicalSchemas::new(physical_schema);
+        let physical_data_schema_without_partition_columns = build_physical_data_schema(
+            &physical_schema,
+            &logical_schema,
+            metadata.partition_columns(),
+        );
 
         let table_config = Self {
             logical_schema,
-            physical_schemas,
+            physical_schema,
+            physical_data_schema_without_partition_columns,
             metadata,
             protocol,
             table_properties,
@@ -416,26 +408,7 @@ impl TableConfiguration {
 
     /// Returns the physical data schema excluding partition columns.
     pub(crate) fn physical_data_schema_without_partition_columns(&self) -> SchemaRef {
-        self.physical_schemas
-            .without_partition
-            .get_or_init(|| {
-                let partition_columns: HashSet<&str> = self
-                    .partition_columns()
-                    .iter()
-                    .map(|s| s.as_str())
-                    .collect();
-                // Safety: subset of an already-valid schema.
-                Arc::new(StructType::new_unchecked(
-                    self.logical_schema()
-                        .fields()
-                        .zip(self.physical_schemas.full.fields())
-                        .filter(|(logical_field, _)| {
-                            !partition_columns.contains(logical_field.name().as_str())
-                        })
-                        .map(|(_, physical_field)| physical_field.clone()),
-                ))
-            })
-            .clone()
+        self.physical_data_schema_without_partition_columns.clone()
     }
 
     /// Translates `delta.dataSkippingStatsColumns` entries to physical column names.
@@ -493,7 +466,7 @@ impl TableConfiguration {
     /// physical column names derived from column mapping metadata.
     #[internal_api]
     pub(crate) fn physical_schema(&self) -> SchemaRef {
-        self.physical_schemas.full.clone()
+        self.physical_schema.clone()
     }
 
     /// Whether partition column values must be materialized into data files.
@@ -2155,82 +2128,6 @@ mod test {
         assert!(partition_schema.field("phys_part_b").is_some());
         assert!(partition_schema.field("part_a").is_none());
         assert!(partition_schema.field("part_b").is_none());
-    }
-
-    /// Verifies that the lazily-computed physical-without-partition schema is shared across
-    /// clones of `TableConfiguration` (both direct clones and the no-P/M version-bump path in
-    /// `try_new_from`), while configurations built from independent or updated metadata each
-    /// get their own `Arc<OnceLock>` and therefore their own schema allocation. This guards
-    /// against the per-version memory amplification seen when callers retain many adjacent
-    /// versions of a wide table.
-    #[test]
-    fn test_physical_data_schema_without_partition_columns_is_shared_across_clones() {
-        let base = create_partitioned_table_config_with_column_mapping(
-            partitioned_schema_with_column_mapping(),
-            "name",
-            vec!["part_a".to_string(), "part_b".to_string()],
-            [],
-        );
-
-        let clone_direct = base.clone();
-        let clone_bumped = TableConfiguration::try_new_from(&base, None, None, 1).unwrap();
-
-        let schema_from_bumped = clone_bumped.physical_data_schema_without_partition_columns();
-
-        let schema_from_base = base.physical_data_schema_without_partition_columns();
-        let schema_from_direct = clone_direct.physical_data_schema_without_partition_columns();
-        assert!(
-            Arc::ptr_eq(&schema_from_bumped, &schema_from_base),
-            "version-bumped clone and base should share the cached SchemaRef"
-        );
-        assert!(
-            Arc::ptr_eq(&schema_from_bumped, &schema_from_direct),
-            "direct .clone() and base should share the cached SchemaRef"
-        );
-
-        // A separately constructed TableConfiguration with the same logical schema must NOT
-        // share storage -- each construction allocates its own Arc<OnceLock>.
-        let independent = create_partitioned_table_config_with_column_mapping(
-            partitioned_schema_with_column_mapping(),
-            "name",
-            vec!["part_a".to_string(), "part_b".to_string()],
-            [],
-        );
-        let schema_from_independent = independent.physical_data_schema_without_partition_columns();
-        assert_eq!(
-            schema_from_independent.as_ref(),
-            schema_from_base.as_ref(),
-            "independent config should produce an equal schema"
-        );
-        assert!(
-            !Arc::ptr_eq(&schema_from_independent, &schema_from_base),
-            "independent TableConfiguration must not share the cached SchemaRef"
-        );
-
-        // try_new_from that actually changes metadata (here: drop one partition column) must
-        // also build a fresh PhysicalSchemas. The new cached schema differs from the original.
-        let new_schema = partitioned_schema_with_column_mapping();
-        let new_metadata = Metadata::try_new(
-            None,
-            None,
-            new_schema,
-            vec!["part_a".to_string()],
-            0,
-            HashMap::from_iter([(COLUMN_MAPPING_MODE.to_string(), "name".to_string())]),
-        )
-        .unwrap();
-        let updated = TableConfiguration::try_new_from(&base, Some(new_metadata), None, 2).unwrap();
-        let schema_from_updated = updated.physical_data_schema_without_partition_columns();
-        assert!(
-            !Arc::ptr_eq(&schema_from_updated, &schema_from_base),
-            "updated metadata must allocate a fresh OnceLock cell"
-        );
-        assert_ne!(
-            schema_from_updated.as_ref(),
-            schema_from_base.as_ref(),
-            "updated metadata changes which columns are partition columns, so the schemas \
-             must differ"
-        );
     }
 
     #[test]

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -87,26 +87,6 @@ fn validate_partition_columns(metadata: &Metadata, logical_schema: &StructType) 
     Ok(())
 }
 
-/// Builds the physical data schema (partition columns excluded) from the `full` physical schema.
-///
-/// Partition columns are excluded because their values live in the Add action's `partitionValues`,
-/// not in the data files. `logical_schema` must be the logical schema `full_physical_schema` was
-/// derived from (same field order), so partition columns can be matched positionally.
-fn build_physical_data_schema(
-    full_physical_schema: &StructType,
-    logical_schema: &StructType,
-    partition_columns: &[String],
-) -> SchemaRef {
-    let partition_columns: HashSet<&str> = partition_columns.iter().map(|s| s.as_str()).collect();
-    let fields = logical_schema
-        .fields()
-        .zip(full_physical_schema.fields())
-        .filter(|(logical_field, _)| !partition_columns.contains(logical_field.name().as_str()))
-        .map(|(_, physical_field)| physical_field.clone());
-    // Safety: subset of an already-valid schema.
-    Arc::new(StructType::new_unchecked(fields))
-}
-
 /// Holds all the configuration for a table at a specific version. This includes the supported
 /// reader and writer features, table properties, schema, version, and table root. This can be used
 /// to check whether a table supports a feature or has it enabled. For example, deletion vector
@@ -192,11 +172,22 @@ impl TableConfiguration {
         let column_mapping_mode = column_mapping_mode(&protocol, &table_properties);
 
         let physical_schema = Arc::new(logical_schema.make_physical(column_mapping_mode)?);
-        let physical_data_schema_without_partition_columns = build_physical_data_schema(
-            &physical_schema,
-            &logical_schema,
-            metadata.partition_columns(),
-        );
+        let physical_data_schema_without_partition_columns = {
+            let partition_columns: HashSet<&str> = metadata
+                .partition_columns()
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            let fields = logical_schema
+                .fields()
+                .zip(physical_schema.fields())
+                .filter(|(logical_field, _)| {
+                    !partition_columns.contains(logical_field.name().as_str())
+                })
+                .map(|(_, physical_field)| physical_field.clone());
+            // Safety: subset of an already-valid schema.
+            Arc::new(StructType::new_unchecked(fields))
+        };
 
         let table_config = Self {
             logical_schema,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, it was "lazily" computed by a `OnceLock` trigger... but (a) it's dirt cheap to compute; and (b) most non-trivial snapshot uses will anyway access it (**) so lazy init buys nothing while adding complexity.

The physical no-partitions schema is used by:
* scan
* CDF
* checkpointing logic
* transactional writes

## How was this change tested?

Internal refactor that mostly deletes code. Existing unit tests cover the change.