### PR TITLE
refactor!: Add and use Schema::field_at and friends

### DIFF
--- a/benchmarks/src/predicate_parser.rs
+++ b/benchmarks/src/predicate_parser.rs
@@ -124,12 +124,7 @@ fn synthesize_expr(schema: &Schema, expr: &PExpr) -> Option<(KExpr, DataType)> {
         }
         PExpr::CompoundIdentifier(parts) => {
             let col_name = ColumnName::new(parts.iter().map(|p| p.value.clone()));
-            let ty = schema
-                .walk_column_fields(&col_name)
-                .ok()?
-                .last()?
-                .data_type()
-                .clone();
+            let ty = schema.field_at(&col_name).ok()?.data_type().clone();
             let expr = KExpr::column(parts.iter().map(|p| p.value.clone()));
             Some((expr, ty))
         }

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -76,15 +76,8 @@ pub(crate) fn validate_clustering_columns(
             )));
         }
 
-        // Walk the column path through nested structs and validate the leaf type.
-        // walk_column_fields validates: non-empty path, each field exists, intermediates are
-        // structs.
-        let fields = schema.walk_column_fields(col)?;
-        let leaf_type = fields
-            .last()
-            .ok_or_else(|| Error::generic(format!("Could not resolve column '{col}' in schema")))?
-            .data_type();
-        match leaf_type {
+        let field = schema.field_at(col)?;
+        match field.data_type() {
             DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype) => {}
             dt => {
                 return Err(Error::generic(format!(

--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -137,7 +137,7 @@ impl<'col> StatsColumnFilter<'col> {
                     continue;
                 }
                 // Verify the required column exists in schema before adding
-                if schema.walk_column_fields(col).is_ok() {
+                if schema.field_at(col).is_ok() {
                     tracing::warn!(
                         "Required column '{}' exceeds dataSkippingNumIndexedCols limit; \
                          adding anyway",

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -875,6 +875,29 @@ impl StructType {
         self.fields.get(name.as_ref())
     }
 
+    /// Retrieves the nested field named by the given column path.
+    ///
+    /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
+    /// a struct type.
+    pub fn field_at<'a>(&'a self, col: &ColumnName) -> DeltaResult<&'a StructField> {
+        let mut field = None;
+        self.visit_fields_of_path(col, |f| field = Some(f))?;
+        field.ok_or_else(|| Error::generic("Empty path"))
+    }
+
+    /// Visits all fields along the given column path.
+    ///
+    /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
+    /// a struct type.
+    #[internal_api]
+    pub(crate) fn visit_fields_of_path<'a>(
+        &'a self,
+        col: &ColumnName,
+        visit_field: impl FnMut(&'a StructField),
+    ) -> DeltaResult<()> {
+        self.visit_fields_of_path_by(col, |s, name| s.field(name), visit_field)
+    }
+
     /// Resolves a column path through nested structs, returning references to all
     /// [`StructField`]s along the path. The last element is the leaf field.
     ///
@@ -884,23 +907,25 @@ impl StructType {
     /// Returns an error if the path is empty, a field is not found, or an intermediate
     /// field is not a struct type.
     #[internal_api]
-    pub(crate) fn walk_column_fields<'a>(
+    pub(crate) fn fields_of_path<'a>(
         &'a self,
         col: &ColumnName,
     ) -> DeltaResult<Vec<&'a StructField>> {
-        self.walk_column_fields_by(col, |s, name| s.field(name))
+        let mut result = Vec::with_capacity(col.path().len());
+        self.visit_fields_of_path(col, |f| result.push(f))?;
+        Ok(result)
     }
 
-    /// Helper to walk through nested columns. For each path component in `col`, calls
-    ///                                                                                             
-    /// `find_field(current_struct, component)` to locate the matching field, then descends
-    ///                                                                                             
-    /// into the next nested struct. Returns references to all [`StructField`]s along the path.
-    pub(crate) fn walk_column_fields_by<'a, F>(
+    /// Visits all fields along the given column path, using a caller-provided field name resolver.
+    ///
+    /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
+    /// a struct type.
+    pub(crate) fn visit_fields_of_path_by<'a, F>(
         &'a self,
         col: &ColumnName,
         find_field: F,
-    ) -> DeltaResult<Vec<&'a StructField>>
+        mut visit_field: impl FnMut(&'a StructField),
+    ) -> DeltaResult<()>
     where
         F: for<'b> Fn(&'b StructType, &str) -> Option<&'b StructField>,
     {
@@ -909,14 +934,13 @@ impl StructType {
             return Err(Error::generic("Column path cannot be empty"));
         }
         let mut current_struct = self;
-        let mut fields = Vec::with_capacity(path.len());
         for (i, field_name) in path.iter().enumerate() {
             let field = find_field(current_struct, field_name).ok_or_else(|| {
                 Error::generic(format!(
                     "Could not resolve column '{col}': field '{field_name}' not found in schema"
                 ))
             })?;
-            fields.push(field);
+            visit_field(field);
             if i < path.len() - 1 {
                 let DataType::Struct(inner) = field.data_type() else {
                     return Err(Error::generic(format!(
@@ -927,7 +951,7 @@ impl StructType {
                 current_struct = inner;
             }
         }
-        Ok(fields)
+        Ok(())
     }
 
     /// Gets the field with the given name and its index.
@@ -3945,7 +3969,7 @@ mod tests {
     ) {
         let schema = walk_test_schema();
         let fields = schema
-            .walk_column_fields(&ColumnName::new(col_path.iter().copied()))
+            .fields_of_path(&ColumnName::new(col_path.iter().copied()))
             .unwrap();
         assert_eq!(fields.len(), expected_names.len());
         for (field, name) in fields.iter().zip(expected_names.iter()) {
@@ -3962,7 +3986,7 @@ mod tests {
     #[test]
     fn test_walk_column_fields_error(#[case] col_path: Vec<&str>, #[case] expected_error: &str) {
         let schema = walk_test_schema();
-        let result = schema.walk_column_fields(&ColumnName::new(col_path.iter().copied()));
+        let result = schema.fields_of_path(&ColumnName::new(col_path.iter().copied()));
         assert_result_error_with_message(result, expected_error);
     }
 

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -581,13 +581,8 @@ fn resolve_input_schema<'a>(
         Some(input_path) if !input_path.path().is_empty() => input_path,
         _ => return Ok(input_schema),
     };
-    let fields = input_schema.walk_column_fields(input_path)?;
-    let Some(leaf) = fields.last() else {
-        return Err(Error::internal_error(format!(
-            "walk_column_fields returned an empty field list for input path '{input_path}'"
-        )));
-    };
-    let DataType::Struct(nested_schema) = leaf.data_type() else {
+    let field = input_schema.field_at(input_path)?;
+    let DataType::Struct(nested_schema) = field.data_type() else {
         return Err(Error::generic(format!(
             "Patching failed: input path '{input_path}' references a non-struct field"
         )));

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -719,7 +719,7 @@ pub(crate) fn get_any_level_column_physical_name(
     col_name: &ColumnName,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<ColumnName> {
-    let fields = schema.walk_column_fields(col_name)?;
+    let fields = schema.fields_of_path(col_name)?;
     let physical_path: Vec<String> = fields
         .iter()
         .map(|field| -> DeltaResult<String> {
@@ -755,11 +755,16 @@ pub(crate) fn physical_to_logical_column_name(
     physical_col: &ColumnName,
     column_mapping_mode: ColumnMappingMode,
 ) -> DeltaResult<ColumnName> {
-    let fields = logical_schema.walk_column_fields_by(physical_col, |s, phys_name| {
-        s.fields()
-            .find(|f| f.physical_name(column_mapping_mode) == phys_name)
-    })?;
-    Ok(ColumnName::new(fields.iter().map(|f| f.name.clone())))
+    let mut fields = vec![];
+    logical_schema.visit_fields_of_path_by(
+        physical_col,
+        |s, phys_name| {
+            s.fields()
+                .find(|f| f.physical_name(column_mapping_mode) == phys_name)
+        },
+        |field| fields.push(field),
+    )?;
+    Ok(ColumnName::new(fields.iter().map(|f| &f.name)))
 }
 
 #[cfg(test)]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1138,7 +1138,7 @@ impl<S> Transaction<S> {
                     .iter()
                     .map(|col| {
                         let data_type = physical_schema
-                            .walk_column_fields(col)?
+                            .fields_of_path(col)?
                             .last()
                             .map(|field| field.data_type().clone())
                             .ok_or_else(|| {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Historically, `Schema::walk_column_fields[_by]` was the only easy way to follow a nested column name through a schema. But it materialize the path in a vec that most callers just discard.

Rename the method to `fields_of_path` and recast the underlying `walk_column_fields_by` as `visit_fields_of_path_by` (non-allocating). Then, introduce a new `visit_fields_of_path` easy path for non-allocating callers.

### This PR affects the following public APIs

New pub method `Schema::field_at()`

Semver also claims that renaming the old `Schema::walk_column_fields()` method is a breaking change, but it's `#[internal_api]`.

## How was this change tested?

Existing unit tests cover these changes.