### PR TITLE
test: non-blocking invalid-handle-code in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,13 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            ffi:
+              - 'ffi/src/handle.rs'
+              - 'ffi-proc-macros/**'
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
@@ -219,6 +226,9 @@ jobs:
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: test
         run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+      - name: trybuild tests
+        if: steps.filter.outputs.ffi == 'true'
+        run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,13 +208,6 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            ffi:
-              - 'ffi/src/handle.rs'
-              - 'ffi-proc-macros/**'
       - name: Install minimal stable with clippy and rustfmt
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
@@ -226,15 +219,37 @@ jobs:
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: test
         run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
-      - name: trybuild tests
-        if: steps.filter.outputs.ffi == 'true'
-        run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: metrics deadlock test
         shell: bash
         run: |
           output=$(cargo run --profile test --example metrics-tester)
           grep -q 'invalid_field' <<< "$output"
           grep -q 'Invalid uuid' <<< "$output"
+
+  # Non-blocking signal for rustc-version-sensitive trybuild tests. NOT a required check.
+  invalid-handle-code:
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install minimal stable
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: trybuild tests
+        id: trybuild
+        continue-on-error: true
+        run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
+      - name: notify on failure
+        if: steps.trybuild.outcome == 'failure'
+        run: |
+          echo "::warning title=invalid_handle_code trybuild tests failed::Non-blocking failure. Check whether the compile_fail expectations need updating for the current rustc, or whether handle.rs/ffi-proc-macros regressed."
+          echo "## invalid_handle_code trybuild tests failed (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Check whether the compile_fail expectations need updating for the current rustc, or whether \`ffi/src/handle.rs\` / \`ffi-proc-macros\` regressed." >> "$GITHUB_STEP_SUMMARY"
 
   ffi_test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
           grep -q 'invalid_field' <<< "$output"
           grep -q 'Invalid uuid' <<< "$output"
 
-  # Non-blocking signal for rustc-version-sensitive trybuild tests. NOT a required check.
+  # Fails red on trybuild drift, but kept out of required checks so it never blocks a merge.
   invalid-handle-code:
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
@@ -251,14 +251,12 @@ jobs:
           cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: trybuild tests
-        id: trybuild
-        continue-on-error: true
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
       - name: notify on failure
-        if: steps.trybuild.outcome == 'failure'
+        if: failure()
         run: |
-          echo "::warning title=invalid_handle_code trybuild tests failed::Non-blocking failure. Check whether the compile_fail expectations need updating for the current rustc, or whether handle.rs/ffi-proc-macros regressed."
-          echo "## invalid_handle_code trybuild tests failed (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning title=invalid_handle_code trybuild tests failed::Check whether the compile_fail expectations need updating for the current rustc, or whether handle.rs/ffi-proc-macros regressed."
+          echo "## invalid_handle_code trybuild tests failed" >> "$GITHUB_STEP_SUMMARY"
           echo "Check whether the compile_fail expectations need updating for the current rustc, or whether \`ffi/src/handle.rs\` / \`ffi-proc-macros\` regressed." >> "$GITHUB_STEP_SUMMARY"
 
   ffi_test:


### PR DESCRIPTION
## What changes are proposed in this pull request?

`invalid-handle-code` is a test that checks output against compiled rustc stderr files which may change slightly in format when a new rustc version gets released. This PR introduces `invalid-handle-code` in CI as a non-blocking step that runs in all PRs except for the merge queue to avoid unnecessary compute overhead. Upon a rustc version update that causes the expected stderr to change, this test fails, which flags the issue without blocking merge progress.

## How was this change tested?

The test passes in CI for this PR itself. I also show how the test fails upon changes to the `.stderr` files in [this branch](https://github.com/rajayush143/delta-kernel-rs/tree/test/invalid-handle-code-ci-redcheck-demo), mimicking real rustc updates that would cause failure.