### PR TITLE
ci: run body validator on synchronize and reopened

### DIFF
--- a/.github/workflows/pr-body-validator.yml
+++ b/.github/workflows/pr-body-validator.yml
@@ -2,7 +2,9 @@ name: Validate PR Body
 
 on:
   pull_request:
-    types: [opened, edited]
+    # synchronize is required: validate-body is a required check, and required checks must
+    # re-report on every new head SHA or the PR blocks on "Expected, waiting for status".
+    types: [opened, edited, reopened, synchronize]
   merge_group:
 
 jobs:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `synchronize` and `reopened` to the body validator's `pull_request` trigger types, matching the title validator.

`validate-body` is a required status check, so it must report on every head SHA. With only `[opened, edited]`, any push after PR open leaves the check unreported on the new head and the PR blocks on "Expected, waiting for status" until the body is manually edited.

## How was this change tested?

Observed on #2721: after a push, all `synchronize`-triggered checks reported but `validate-body` did not; a no-op body edit (`edited` event) unblocked it.
