### PR TITLE
feat!: emit partitionValues_parsed via PartitionValuesOptions in scan output

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -59,6 +59,12 @@ pub(crate) struct CheckpointReadInfo {
     #[serde(default)]
     #[allow(unused)]
     pub has_partition_values_parsed: bool,
+    /// Whether `add.partitionValues` was dropped from the checkpoint read schema. Only set
+    /// when the caller allowed the drop and the checkpoint has a compatible pre-parsed
+    /// `partitionValues_parsed` column to serve as the sole partition value source.
+    #[serde(default)]
+    #[allow(unused)]
+    pub partition_values_dropped: bool,
     /// The schema used to read checkpoint files, potentially including stats_parsed.
     #[allow(unused)]
     pub checkpoint_read_schema: SchemaRef,
@@ -72,6 +78,7 @@ impl CheckpointReadInfo {
         Self {
             has_stats_parsed: false,
             has_partition_values_parsed: false,
+            partition_values_dropped: false,
             checkpoint_read_schema: get_log_add_schema().clone(),
         }
     }
@@ -689,6 +696,7 @@ impl LogSegment {
     /// IS NOT NULL predicates are automatically derived from `checkpoint_read_schema` and combined
     /// (AND) with `meta_predicate`, so callers only need to supply query-based skipping predicates.
     #[internal_api]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn read_actions_with_projected_checkpoint_actions(
         &self,
         engine: &dyn Engine,
@@ -697,6 +705,7 @@ impl LogSegment {
         meta_predicate: Option<PredicateRef>,
         stats_schema: Option<&StructType>,
         partition_schema: Option<&StructType>,
+        allow_partition_values_drop: bool,
     ) -> DeltaResult<
         ActionsWithCheckpointInfo<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send>,
     > {
@@ -719,6 +728,7 @@ impl LogSegment {
             effective_predicate,
             stats_schema,
             partition_schema,
+            allow_partition_values_drop,
         )?;
 
         Ok(ActionsWithCheckpointInfo {
@@ -743,6 +753,7 @@ impl LogSegment {
             None,
             None,
             None,
+            false,
         )?;
         Ok(result.actions)
     }
@@ -892,6 +903,7 @@ impl LogSegment {
         meta_predicate: Option<PredicateRef>,
         stats_schema: Option<&StructType>,
         partition_schema: Option<&StructType>,
+        allow_partition_values_drop: bool,
     ) -> DeltaResult<
         ActionsWithCheckpointInfo<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send>,
     > {
@@ -915,10 +927,16 @@ impl LogSegment {
             .zip(file_actions_schema.as_ref())
             .is_some_and(|(ps, fs)| Self::schema_has_compatible_partition_values_parsed(fs, ps));
 
+        // Skip reading the `add.partitionValues` string map when the caller allowed it and
+        // the pre-parsed column can serve as the sole partition value source. This avoids
+        // decoding the map column from checkpoint parquet entirely.
+        let partition_values_dropped = allow_partition_values_drop && has_partition_values_parsed;
+
         // Build final schema with any additional fields needed
         // (stats_parsed, partitionValues_parsed, sidecar)
         let needs_sidecar = need_file_actions && !sidecar_files.is_empty();
-        let needs_add_augmentation = has_stats_parsed || has_partition_values_parsed;
+        let needs_add_augmentation =
+            has_stats_parsed || has_partition_values_parsed || partition_values_dropped;
         let augmented_checkpoint_read_schema = if needs_add_augmentation || needs_sidecar {
             let mut new_fields: Vec<StructField> = if let (true, Some(add_field)) =
                 (needs_add_augmentation, action_schema.field("add"))
@@ -928,7 +946,11 @@ impl LogSegment {
                         "add field in action schema must be a struct",
                     ));
                 };
-                let mut add_fields: Vec<StructField> = add_struct.fields().cloned().collect();
+                let mut add_fields: Vec<StructField> = add_struct
+                    .fields()
+                    .filter(|f| !(partition_values_dropped && f.name() == "partitionValues"))
+                    .cloned()
+                    .collect();
 
                 if let (true, Some(ss)) = (has_stats_parsed, stats_schema) {
                     add_fields.push(StructField::nullable("stats_parsed", ss.clone()));
@@ -1031,6 +1053,7 @@ impl LogSegment {
         let checkpoint_info = CheckpointReadInfo {
             has_stats_parsed,
             has_partition_values_parsed,
+            partition_values_dropped,
             checkpoint_read_schema: augmented_checkpoint_read_schema,
         };
         Ok(ActionsWithCheckpointInfo {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1202,9 +1202,10 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         v2_checkpoint_read_schema.clone(),
-        None, // meta_predicate
-        None, // stats_schema
-        None, // partition_schema
+        None,  // meta_predicate
+        None,  // stats_schema
+        None,  // partition_schema
+        false, // allow_partition_values_drop
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1275,9 +1276,10 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         v2_checkpoint_read_schema.clone(),
-        None, // meta_predicate
-        None, // stats_schema
-        None, // partition_schema
+        None,  // meta_predicate
+        None,  // stats_schema
+        None,  // partition_schema
+        false, // allow_partition_values_drop
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1340,9 +1342,10 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         v2_checkpoint_read_schema.clone(),
-        None, // meta_predicate
-        None, // stats_schema
-        None, // partition_schema
+        None,  // meta_predicate
+        None,  // stats_schema
+        None,  // partition_schema
+        false, // allow_partition_values_drop
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1393,9 +1396,10 @@ async fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidec
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         v2_checkpoint_read_schema,
-        None, // meta_predicate
-        None, // stats_schema
-        None, // partition_schema
+        None,  // meta_predicate
+        None,  // stats_schema
+        None,  // partition_schema
+        false, // allow_partition_values_drop
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1485,9 +1489,10 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         v2_checkpoint_read_schema.clone(),
-        None, // meta_predicate
-        None, // stats_schema
-        None, // partition_schema
+        None,  // meta_predicate
+        None,  // stats_schema
+        None,  // partition_schema
+        false, // allow_partition_values_drop
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -3677,6 +3682,7 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
         None, // meta_predicate
         None, // stats_schema
         Some(&partition_schema),
+        false, // allow_partition_values_drop
     )?;
 
     // Verify that checkpoint_info reports partitionValues_parsed as available
@@ -3742,6 +3748,7 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
         None,
         None,
         Some(&partition_schema),
+        false, // allow_partition_values_drop
     )?;
 
     // Verify it's false

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -143,7 +143,9 @@ mod tests {
         AfterSequentialScanMetadata, ParallelScanMetadata, ParallelState,
     };
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
-    use crate::scan::log_replay::{ScanLogReplayProcessor, ScanStatsOptions};
+    use crate::scan::log_replay::{
+        ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+    };
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::get_simple_state_info;
     use crate::scan::StatsOptions;
@@ -210,6 +212,7 @@ mod tests {
             checkpoint_info,
             seen_file_keys,
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
     }
 

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -277,7 +277,9 @@ mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::log_segment::CheckpointReadInfo;
     use crate::metrics::{MetricEvent, ScanType, TableType};
-    use crate::scan::log_replay::{ScanLogReplayProcessor, ScanStatsOptions};
+    use crate::scan::log_replay::{
+        ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+    };
     use crate::scan::state_info::StateInfo;
     use crate::scan::PhysicalPredicate;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
@@ -308,6 +310,7 @@ mod tests {
             state_info,
             CheckpointReadInfo::without_stats_parsed(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -53,6 +53,18 @@ impl Default for ScanStatsOptions {
     }
 }
 
+/// Read-time partition value toggles consumed by [`ScanLogReplayProcessor`].
+#[derive(Clone, Copy, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ScanPartitionValuesOptions {
+    /// Leave the `fileConstantValues.partitionValues` string map null in scan metadata
+    /// output. The raw column is still read wherever it is the parse source for
+    /// `partitionValues_parsed` or per-row transforms.
+    pub(crate) skip_string_map: bool,
+    /// Emit the typed `partitionValues_parsed` struct column in scan metadata output,
+    /// independent of any predicate.
+    pub(crate) parsed_struct: bool,
+}
+
 /// Internal serializable state (schemas, transform spec, column mapping, etc.)
 /// NOTE: This is opaque to the user - it is passed through as a blob.
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -67,6 +79,8 @@ struct InternalScanState {
     physical_stats_schema: Option<SchemaRef>,
     #[serde(default)]
     stats_options: ScanStatsOptions,
+    #[serde(default)]
+    partition_values_options: ScanPartitionValuesOptions,
     /// Physical partition schema for checkpoint partition pruning via `partitionValues_parsed`
     physical_partition_schema: Option<SchemaRef>,
     /// Physical leaf paths which are expected to have stats collected. Carried alongside
@@ -155,6 +169,8 @@ pub struct ScanLogReplayProcessor {
     seen_file_keys: HashSet<FileActionKey>,
     /// Read-time stats options.
     stats_options: ScanStatsOptions,
+    /// Read-time partition value options.
+    partition_values_options: ScanPartitionValuesOptions,
     /// Information about checkpoint reading for stats optimization
     checkpoint_info: CheckpointReadInfo,
     /// Metrics related to the scan
@@ -178,6 +194,7 @@ impl ScanLogReplayProcessor {
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
         stats_options: ScanStatsOptions,
+        partition_values_options: ScanPartitionValuesOptions,
     ) -> DeltaResult<Self> {
         let dedup_capacity = state_info.dedup_capacity_hint();
         Self::new_with_seen_files(
@@ -186,6 +203,7 @@ impl ScanLogReplayProcessor {
             checkpoint_info,
             HashSet::with_capacity(dedup_capacity),
             stats_options,
+            partition_values_options,
         )
     }
 
@@ -200,16 +218,20 @@ impl ScanLogReplayProcessor {
     /// - `checkpoint_info`: Information about checkpoint reading for stats optimization
     /// - `seen_file_keys`: Pre-computed set of file action keys that have been seen
     /// - `stats_options`: Read-time stats options (see [`ScanStatsOptions`])
+    /// - `partition_values_options`: Read-time partition value options (see
+    ///   [`ScanPartitionValuesOptions`])
     pub(crate) fn new_with_seen_files(
         engine: &dyn Engine,
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
         seen_file_keys: HashSet<FileActionKey>,
         stats_options: ScanStatsOptions,
+        partition_values_options: ScanPartitionValuesOptions,
     ) -> DeltaResult<Self> {
         let CheckpointReadInfo {
             has_stats_parsed,
             has_partition_values_parsed,
+            partition_values_dropped,
             checkpoint_read_schema,
         } = checkpoint_info.clone();
         let ScanStatsOptions {
@@ -229,14 +251,22 @@ impl ScanLogReplayProcessor {
 
         // When skip_stats is enabled, disable both data column skipping and partition pruning.
         // Both rely on the same DataSkippingFilter columnar pass, so they are controlled together.
-        let (stats_schema_for_transform, partition_schema_for_transform) = if skip_stats {
-            (None, None)
+        let stats_schema_for_transform = if skip_stats {
+            None
         } else {
-            (
-                state_info.physical_stats_schema.clone(),
-                state_info.physical_partition_schema.clone(),
-            )
+            state_info.physical_stats_schema.clone()
         };
+
+        // The partition schema feeds two consumers: the DataSkippingFilter (predicate
+        // pruning, disabled by skip_stats together with stats) and the engine-facing
+        // `partitionValues_parsed` output column (requested via `parsed_struct`, independent
+        // of skip_stats). Either consumer keeps the transform emitting the column.
+        let partition_schema_for_transform =
+            if partition_values_options.parsed_struct || !skip_stats {
+                state_info.physical_partition_schema.clone()
+            } else {
+                None
+            };
 
         let output_schema = scan_row_schema_with_parsed_columns(
             stats_schema_for_transform.clone(),
@@ -266,6 +296,15 @@ impl ScanLogReplayProcessor {
             )
         };
 
+        // A dropped string-map column is only valid when the engine opted out of the string
+        // map: the transform then emits a null literal and never references the column.
+        require!(
+            !partition_values_dropped || partition_values_options.skip_string_map,
+            Error::internal_error(
+                "checkpoint dropped add.partitionValues but the engine requested the string map"
+            )
+        );
+
         Ok(Self {
             data_skipping_filter,
             // Log transform: parse JSON for stats, MapToStruct for partition values
@@ -278,6 +317,7 @@ impl ScanLogReplayProcessor {
                     synthesize_json,
                     partition_schema_for_transform.clone(),
                     false,
+                    partition_values_options.skip_string_map,
                 ),
                 output_schema.clone().into(),
             )?,
@@ -291,12 +331,14 @@ impl ScanLogReplayProcessor {
                     synthesize_json,
                     partition_schema_for_transform,
                     has_partition_values_parsed,
+                    partition_values_options.skip_string_map,
                 ),
                 output_schema.into(),
             )?,
             seen_file_keys,
             state_info,
             stats_options,
+            partition_values_options,
             checkpoint_info,
             metrics,
         })
@@ -358,6 +400,7 @@ impl ScanLogReplayProcessor {
             column_mapping_mode,
             physical_stats_schema,
             stats_options: self.stats_options,
+            partition_values_options: self.partition_values_options,
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
@@ -427,6 +470,7 @@ impl ScanLogReplayProcessor {
             state.checkpoint_info,
             state.seen_file_keys,
             internal_state.stats_options,
+            internal_state.partition_values_options,
         )
     }
 }
@@ -440,6 +484,10 @@ struct AddRemoveDedupVisitor<'a, D: Deduplicator> {
     selection_vector: Vec<bool>,
     state_info: Arc<StateInfo>,
     row_transform_exprs: Vec<Option<ExpressionRef>>,
+    /// Whether this batch's data lacks the `add.partitionValues` column (dropped from the
+    /// checkpoint read schema). The visitor then selects the reduced column list and splices
+    /// a null getter in its place so getter indices stay stable.
+    partition_values_dropped: bool,
     metrics: &'a ScanMetrics,
 }
 
@@ -448,6 +496,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         deduplicator: D,
         selection_vector: Vec<bool>,
         state_info: Arc<StateInfo>,
+        partition_values_dropped: bool,
         metrics: &'a ScanMetrics,
     ) -> AddRemoveDedupVisitor<'a, D> {
         AddRemoveDedupVisitor {
@@ -455,6 +504,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
             selection_vector,
             state_info,
             row_transform_exprs: Vec::new(),
+            partition_values_dropped,
             metrics,
         }
     }
@@ -497,11 +547,17 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
 
         // Parse partition values for building the per-row transform expression.
         // Partition pruning is handled by DataSkippingFilter in the columnar data skipping phase,
-        // so we only need to parse values here for the transform.
+        // so we only need to parse values here for the transform. When the column was dropped
+        // from the checkpoint read schema (only legal for transform specs without
+        // partition-derived columns), the empty map is never read by the transform.
         let partition_values = match &self.state_info.transform_spec {
             Some(transform) if is_add => {
-                let partition_values = getters[ScanLogReplayProcessor::ADD_PARTITION_VALUES_INDEX]
-                    .get(row, "add.partitionValues")?;
+                let partition_values = if self.partition_values_dropped {
+                    Default::default()
+                } else {
+                    getters[ScanLogReplayProcessor::ADD_PARTITION_VALUES_INDEX]
+                        .get(row, "add.partitionValues")?
+                };
                 parse_partition_values(
                     &self.state_info.logical_schema,
                     transform,
@@ -565,9 +621,22 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
             let (types, names) = types_and_names.into_iter().unzip();
             (names, types).into()
         });
+        // Variant of the checkpoint column list without `add.partitionValues`, for
+        // checkpoint batches whose read schema dropped the column. The data no longer
+        // contains the leaf, and extraction errors on missing leaves.
+        static NAMES_AND_TYPES_NO_PARTITION_VALUES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| {
+                let (names, types) = NAMES_AND_TYPES.as_ref();
+                let keep = |i: &usize| *i != 1;
+                let names: Vec<_> = (0..7).filter(keep).map(|i| names[i].clone()).collect();
+                let types: Vec<_> = (0..7).filter(keep).map(|i| types[i].clone()).collect();
+                (names, types).into()
+            });
         let (names, types) = NAMES_AND_TYPES.as_ref();
         if self.deduplicator.is_log_batch() {
             (names, types)
+        } else if self.partition_values_dropped {
+            NAMES_AND_TYPES_NO_PARTITION_VALUES.as_ref()
         } else {
             // All checkpoint actions are already reconciled and Remove actions in checkpoint files
             // only serve as tombstones for vacuum jobs. So we only need to examine the adds here.
@@ -579,7 +648,12 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
         let start = std::time::Instant::now();
 
         let is_log_batch = self.deduplicator.is_log_batch();
-        let expected_getters = if is_log_batch { 11 } else { 7 };
+        let partition_values_dropped = !is_log_batch && self.partition_values_dropped;
+        let expected_getters = match (is_log_batch, partition_values_dropped) {
+            (true, _) => 11,
+            (false, false) => 7,
+            (false, true) => 6,
+        };
         require!(
             getters.len() == expected_getters,
             Error::InternalError(format!(
@@ -587,6 +661,20 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
                 getters.len()
             ))
         );
+
+        // Re-insert a null getter where `add.partitionValues` would be, so the fixed getter
+        // indices used by the deduplicator and transform parsing stay valid.
+        let spliced: Vec<&dyn GetData<'_>>;
+        let getters = if partition_values_dropped {
+            let mut with_null = Vec::with_capacity(7);
+            with_null.push(getters[0]);
+            with_null.push(&() as &dyn GetData<'_>);
+            with_null.extend_from_slice(&getters[1..]);
+            spliced = with_null;
+            spliced.as_slice()
+        } else {
+            getters
+        };
 
         for row in 0..row_count {
             if self.selection_vector[row] {
@@ -686,6 +774,10 @@ fn scan_row_schema_with_parsed_columns(
 ///   value parsing is not needed.
 /// - `has_partition_values_parsed`: Whether checkpoint has pre-parsed partitionValues_parsed
 ///   column.
+/// - `skip_string_map`: When true, replaces the `fileConstantValues.partitionValues` string map
+///   output with a null literal. The raw column is then only referenced as the parse source for
+///   `partitionValues_parsed` when no pre-parsed column exists, which also allows the checkpoint
+///   reader to drop the raw column entirely when one does.
 ///
 /// The transform includes `stats_parsed` only when `physical_stats_schema` is Some,
 /// and `partitionValues_parsed` only when `partition_schema` is Some.
@@ -697,6 +789,7 @@ fn get_add_transform_expr(
     synthesize_json: bool,
     partition_schema: Option<SchemaRef>,
     has_partition_values_parsed: bool,
+    skip_string_map: bool,
 ) -> ExpressionRef {
     let stats_expr = if skip_stats {
         Arc::new(Expression::Literal(Scalar::Null(DataType::STRING)))
@@ -713,6 +806,13 @@ fn get_add_transform_expr(
     } else {
         column_expr_ref!("add.stats")
     };
+    let partition_values_expr = if skip_string_map {
+        Arc::new(Expression::Literal(Scalar::Null(
+            MapType::new(DataType::STRING, DataType::STRING, true).into(),
+        )))
+    } else {
+        column_expr_ref!("add.partitionValues")
+    };
     let mut fields = vec![
         column_expr_ref!("add.path"),
         column_expr_ref!("add.size"),
@@ -720,7 +820,7 @@ fn get_add_transform_expr(
         stats_expr,
         column_expr_ref!("add.deletionVector"),
         Arc::new(Expression::struct_from([
-            column_expr_ref!("add.partitionValues"),
+            partition_values_expr,
             column_expr_ref!("add.baseRowId"),
             column_expr_ref!("add.defaultRowCommitVersion"),
             column_expr_ref!("add.tags"),
@@ -840,6 +940,7 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
             deduplicator,
             selection_vector,
             self.state_info.clone(),
+            self.checkpoint_info.partition_values_dropped,
             &self.metrics,
         );
         visitor.visit_rows_of(actions.as_ref())?;
@@ -921,6 +1022,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             deduplicator,
             selection_vector,
             self.state_info.clone(),
+            !is_log_batch && self.checkpoint_info.partition_values_dropped,
             &self.metrics,
         );
         visitor.visit_rows_of(actions.as_ref())?;
@@ -962,12 +1064,18 @@ pub(crate) fn scan_action_iter(
     state_info: Arc<StateInfo>,
     checkpoint_info: CheckpointReadInfo,
     stats_options: ScanStatsOptions,
+    partition_values_options: ScanPartitionValuesOptions,
 ) -> DeltaResult<(
     impl Iterator<Item = DeltaResult<ScanMetadata>>,
     Arc<ScanMetrics>,
 )> {
-    let processor =
-        ScanLogReplayProcessor::new(engine, state_info, checkpoint_info, stats_options)?;
+    let processor = ScanLogReplayProcessor::new(
+        engine,
+        state_info,
+        checkpoint_info,
+        stats_options,
+        partition_values_options,
+    )?;
     let metrics = processor.metrics.clone();
     Ok((processor.process_actions_iter(action_iter), metrics))
 }
@@ -981,7 +1089,7 @@ mod tests {
 
     use super::{
         get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanStatsOptions, SerializableScanState,
+        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
@@ -1116,6 +1224,7 @@ mod tests {
             state_info,
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         for res in iter {
@@ -1144,6 +1253,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1230,6 +1340,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1275,6 +1386,7 @@ mod tests {
             Arc::new(get_simple_state_info(schema.clone(), vec![]).unwrap()),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1347,6 +1459,7 @@ mod tests {
             state_info.clone(),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1404,6 +1517,7 @@ mod tests {
             state_info.clone(),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1445,6 +1559,7 @@ mod tests {
                 state_info,
                 checkpoint_info.clone(),
                 ScanStatsOptions::default(),
+                ScanPartitionValuesOptions::default(),
             )
             .unwrap();
             let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1482,6 +1597,7 @@ mod tests {
             state_info,
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();
@@ -1516,6 +1632,7 @@ mod tests {
             state_info,
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();
@@ -1556,6 +1673,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             stats_options: ScanStatsOptions::default(),
+            partition_values_options: ScanPartitionValuesOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
@@ -1590,6 +1708,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             stats_options: ScanStatsOptions::default(),
+            partition_values_options: ScanPartitionValuesOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
@@ -1661,6 +1780,7 @@ mod tests {
                 skip_stats: true,
                 ..Default::default()
             },
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1751,6 +1871,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1837,6 +1958,7 @@ mod tests {
             true,  // synthesize_json
             partition_schema.clone(),
             has_partition_values_parsed,
+            false, // skip_string_map
         );
         assert_eq!(
             count_to_json(&with_synthesis),
@@ -1852,11 +1974,62 @@ mod tests {
             false, // synthesize_json
             partition_schema,
             has_partition_values_parsed,
+            false, // skip_string_map
         );
         assert_eq!(
             count_to_json(&without_synthesis),
             0,
             "expected no ToJson nodes anywhere in the transform when synthesis is skipped"
+        );
+    }
+
+    /// Returns the `fileConstantValues.partitionValues` source expression: the first field of the
+    /// struct_from at top-level index 5 of the add transform.
+    fn partition_values_source(expr: &ExpressionRef) -> Expression {
+        let Expression::Struct(top, _) = expr.as_ref() else {
+            panic!("add transform must be a struct, got {expr:?}");
+        };
+        let Expression::Struct(file_constant_values, _) = top[5].as_ref() else {
+            panic!("expected fileConstantValues struct at index 5");
+        };
+        file_constant_values[0].as_ref().clone()
+    }
+
+    #[test]
+    fn add_transform_nulls_string_map_when_skip_string_map() {
+        let partition_schema: Option<SchemaRef> = Some(Arc::new(StructType::new_unchecked([
+            StructField::nullable("date", DataType::DATE),
+        ])));
+
+        let kept = get_add_transform_expr(
+            None,  // physical_stats_schema
+            false, // has_stats_parsed
+            false, // skip_stats
+            true,  // synthesize_json
+            partition_schema.clone(),
+            false, // has_partition_values_parsed
+            false, // skip_string_map
+        );
+        assert!(
+            matches!(partition_values_source(&kept), Expression::Column(_)),
+            "string map should be read from the column when not skipped"
+        );
+
+        let skipped = get_add_transform_expr(
+            None,  // physical_stats_schema
+            false, // has_stats_parsed
+            false, // skip_stats
+            true,  // synthesize_json
+            partition_schema,
+            false, // has_partition_values_parsed
+            true,  // skip_string_map
+        );
+        assert!(
+            matches!(
+                partition_values_source(&skipped),
+                Expression::Literal(Scalar::Null(_))
+            ),
+            "string map should be a null literal when skipped"
         );
     }
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -33,6 +33,7 @@ use crate::scan::log_replay::{
 };
 use crate::scan::metrics::ScanMetrics;
 use crate::scan::state_info::StateInfo;
+use crate::scan::transform_spec::FieldTransformSpec;
 use crate::schema::{
     ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField, StructType,
     ToSchema as _,
@@ -187,12 +188,76 @@ impl StatsOptions {
     }
 }
 
+/// Engine-facing partition value options. Pass to [`ScanBuilder::with_partition_values`] to
+/// declare what partition value data the engine wants in scan metadata output. Two orthogonal
+/// axes, mirroring [`StatsOptions`]: the raw string map (`fileConstantValues.partitionValues`)
+/// and the typed struct (`partitionValues_parsed`).
+///
+/// Most consumers should pick one of the named constructors:
+/// - [`Self::string_map_only`] (default) -- raw string map only.
+/// - [`Self::all_struct`] -- typed struct only. Cheap path when the engine consumes
+///   `partitionValues_parsed` directly: the string map is left null in scan metadata output, and is
+///   skipped from the checkpoint parquet read entirely when the checkpoint carries a compatible
+///   native `partitionValues_parsed` column and no scan output column derives from partition
+///   values.
+/// - [`Self::all`] -- both representations.
+///
+/// When the typed struct is requested, scan metadata output gains a top-level
+/// `partitionValues_parsed` struct column with one typed nullable field per partition column
+/// (physical names, table partition-column order). On non-partitioned tables the column is
+/// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
+/// when present, otherwise from parsing the string map.
+#[derive(Clone, Debug)]
+pub struct PartitionValuesOptions {
+    /// Whether to populate the raw string map in `fileConstantValues.partitionValues`.
+    /// When false, the field stays in the scan row schema but is left null.
+    pub(crate) string_map: bool,
+
+    /// Whether to emit the typed `partitionValues_parsed` struct column.
+    pub(crate) parsed_struct: bool,
+}
+
+impl Default for PartitionValuesOptions {
+    /// String map only, no typed struct.
+    fn default() -> Self {
+        Self {
+            string_map: true,
+            parsed_struct: false,
+        }
+    }
+}
+
+impl PartitionValuesOptions {
+    /// Raw string map only. Equivalent to [`Default::default`].
+    pub fn string_map_only() -> Self {
+        Self::default()
+    }
+
+    /// Typed struct only, string map left null. Cheap path for engines that consume
+    /// `partitionValues_parsed` directly.
+    pub fn all_struct() -> Self {
+        Self {
+            string_map: false,
+            parsed_struct: true,
+        }
+    }
+
+    /// Both the raw string map and the typed struct.
+    pub fn all() -> Self {
+        Self {
+            string_map: true,
+            parsed_struct: true,
+        }
+    }
+}
+
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
     snapshot: SnapshotRef,
     logical_read_schema: Option<SchemaRef>,
     predicate: Option<PredicateRef>,
     stats: StatsOptions,
+    partition_values: PartitionValuesOptions,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -201,6 +266,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("logical_read_schema", &self.logical_read_schema)
             .field("predicate", &self.predicate)
             .field("stats", &self.stats)
+            .field("partition_values", &self.partition_values)
             .finish()
     }
 }
@@ -213,6 +279,7 @@ impl ScanBuilder {
             logical_read_schema: None,
             predicate: None,
             stats: StatsOptions::default(),
+            partition_values: PartitionValuesOptions::default(),
         }
     }
 
@@ -270,6 +337,16 @@ impl ScanBuilder {
         self
     }
 
+    /// Configure partition value output for the scan. See [`PartitionValuesOptions`].
+    ///
+    /// Defaults to [`PartitionValuesOptions::default`] (string map only). Engines that
+    /// consume `partitionValues_parsed` directly should pass
+    /// [`PartitionValuesOptions::all_struct`] to skip materializing the string map.
+    pub fn with_partition_values(mut self, partition_values: PartitionValuesOptions) -> Self {
+        self.partition_values = partition_values;
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -306,6 +383,7 @@ impl ScanBuilder {
             self.snapshot.table_configuration(),
             self.predicate,
             &self.stats,
+            &self.partition_values,
             (), // No classifier, default is for scans
         )?;
 
@@ -313,6 +391,7 @@ impl ScanBuilder {
             snapshot: self.snapshot,
             state_info: Arc::new(state_info),
             stats: self.stats,
+            partition_values: self.partition_values,
         })
     }
 }
@@ -572,6 +651,7 @@ pub struct Scan {
     snapshot: SnapshotRef,
     state_info: Arc<StateInfo>,
     stats: StatsOptions,
+    partition_values: PartitionValuesOptions,
 }
 
 impl std::fmt::Debug for Scan {
@@ -596,6 +676,30 @@ impl Scan {
             skip_stats: self.skip_stats(),
             synthesize_json: self.stats.synthesize_json,
         }
+    }
+
+    /// Build the partition-value read options passed to [`ScanLogReplayProcessor`].
+    fn partition_values_options(&self) -> log_replay::ScanPartitionValuesOptions {
+        log_replay::ScanPartitionValuesOptions {
+            skip_string_map: !self.partition_values.string_map,
+            parsed_struct: self.partition_values.parsed_struct,
+        }
+    }
+
+    /// Whether the checkpoint parquet read may drop the `add.partitionValues` string map
+    /// column. Requires the engine to have opted out of the string map, opted into the typed
+    /// struct (so the output still carries partition values), and a transform spec with no
+    /// partition-derived output columns (those parse the string map per row). The final
+    /// decision also requires a compatible native `partitionValues_parsed` checkpoint column,
+    /// which only the checkpoint reader can detect.
+    fn can_drop_partition_values_from_checkpoint(&self) -> bool {
+        let has_partition_transform = self.state_info.transform_spec.as_ref().is_some_and(|spec| {
+            spec.iter()
+                .any(|t| matches!(t, FieldTransformSpec::MetadataDerivedColumn { .. }))
+        });
+        !self.partition_values.string_map
+            && self.partition_values.parsed_struct
+            && !has_partition_transform
     }
 
     /// The table's root URL. Any relative paths returned from `scan_data` (or in a callback from
@@ -759,6 +863,7 @@ impl Scan {
                 checkpoint_info: CheckpointReadInfo {
                     has_stats_parsed: false,
                     has_partition_values_parsed: false,
+                    partition_values_dropped: false,
                     checkpoint_read_schema: restored_add_schema().clone(),
                 },
             };
@@ -811,6 +916,7 @@ impl Scan {
                 .as_ref()
                 .map(|s| s.as_ref()),
             None,
+            false,
         )?;
         let actions_with_checkpoint_info = ActionsWithCheckpointInfo {
             actions: result
@@ -848,6 +954,7 @@ impl Scan {
                     self.state_info.clone(),
                     actions_with_checkpoint_info.checkpoint_info,
                     self.stats_options(),
+                    self.partition_values_options(),
                 )?;
                 (Some(it), m)
             }
@@ -896,6 +1003,7 @@ impl Scan {
                     .physical_partition_schema
                     .as_ref()
                     .map(|s| s.as_ref()),
+                self.can_drop_partition_values_from_checkpoint(),
             )
     }
 
@@ -1010,6 +1118,7 @@ impl Scan {
         let checkpoint_info = CheckpointReadInfo {
             has_stats_parsed: false,
             has_partition_values_parsed: false,
+            partition_values_dropped: false,
             checkpoint_read_schema,
         };
         let processor = ScanLogReplayProcessor::new(
@@ -1017,6 +1126,7 @@ impl Scan {
             self.state_info.clone(),
             checkpoint_info,
             self.stats_options(),
+            self.partition_values_options(),
         )?;
         let sequential =
             SequentialPhase::try_new(processor, self.snapshot.log_segment(), engine.clone())?;

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -10,7 +10,7 @@ use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
-use crate::scan::{PhysicalPredicate, StatsOptions, StructStats};
+use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions, StructStats};
 use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
@@ -32,9 +32,11 @@ pub(crate) struct StateInfo {
     /// Physical stats schema for reading/parsing stats from checkpoint files.
     /// Used to construct checkpoint read schema with stats_parsed.
     pub(crate) physical_stats_schema: Option<SchemaRef>,
-    /// Physical partition schema with native types for partition pruning via
-    /// `partitionValues_parsed`. Fields use physical column names (for column mapping).
-    /// Only present when the table has partition columns and a predicate is provided.
+    /// Physical partition schema with native types for `partitionValues_parsed`. Fields use
+    /// physical column names (for column mapping) and are always nullable. Present when the
+    /// table has partition columns and either a predicate is provided (narrowed to
+    /// predicate-referenced columns, for partition pruning) or the engine requested the typed
+    /// struct in scan output (all partition columns).
     pub(crate) physical_partition_schema: Option<SchemaRef>,
     /// Physical leaf paths which are expected to have stats collected.
     ///
@@ -235,6 +237,8 @@ impl StateInfo {
     /// `predicate` - Optional predicate to filter data during the scan
     /// `stats` - Engine-facing stats options. Drives which stats columns appear in scan
     ///   metadata output and whether the JSON synthesis fallback fires.
+    /// `partition_values` - Engine-facing partition value options. Drives whether the typed
+    ///   `partitionValues_parsed` column appears in scan metadata output.
     /// `classifier` - The classifier to use for different scan types. Use `()` if not needed
     pub(crate) fn try_new<C: TransformFieldClassifier>(
         logical_read_schema: SchemaRef,
@@ -242,6 +246,7 @@ impl StateInfo {
         table_configuration: &TableConfiguration,
         predicate: Option<PredicateRef>,
         stats: &StatsOptions,
+        partition_values: &PartitionValuesOptions,
         classifier: C,
     ) -> DeltaResult<Self> {
         let partition_columns = table_configuration.partition_columns();
@@ -373,40 +378,59 @@ impl StateInfo {
             }
         }
 
-        // Build partition schema with physical names for partition pruning in data skipping.
-        // Only needed when we have a predicate and partition columns.
+        // Build partition schema with physical names, used for partition pruning in data
+        // skipping and for the engine-facing `partitionValues_parsed` output column. Needed
+        // when partition columns exist and either a predicate is present or the engine
+        // requested the typed struct in scan output.
         // partition_columns stores logical names (per Delta protocol), so we zip the table's
         // logical and physical schemas (same field ordering, guaranteed by `make_physical`)
         // to match logical names and extract the corresponding physical fields without
         // per-field metadata lookups.
-        let table_partition_schema = if !matches!(
+        let has_predicate = !matches!(
             physical_predicate,
             PhysicalPredicate::None | PhysicalPredicate::StaticSkipAll
-        ) && !partition_columns.is_empty()
-        {
-            let partition_fields: Vec<StructField> = table_configuration
-                .logical_schema()
-                .fields()
-                .zip(table_configuration.physical_schema().fields())
-                .filter(|(logical_f, _)| partition_columns.contains(logical_f.name()))
-                .map(|(_, physical_f)| physical_f.clone())
-                .collect();
-            if partition_fields.is_empty() {
-                None
+        );
+        let table_partition_schema =
+            if (has_predicate || partition_values.parsed_struct) && !partition_columns.is_empty() {
+                let partition_fields: Vec<StructField> = table_configuration
+                    .logical_schema()
+                    .fields()
+                    .zip(table_configuration.physical_schema().fields())
+                    .filter(|(logical_f, _)| partition_columns.contains(logical_f.name()))
+                    .map(|(_, physical_f)| physical_f.clone())
+                    .collect();
+                if partition_fields.is_empty() {
+                    None
+                } else {
+                    Some(Arc::new(StructType::new_unchecked(partition_fields)))
+                }
             } else {
-                Some(Arc::new(StructType::new_unchecked(partition_fields)))
-            }
-        } else {
-            None
-        };
+                None
+            };
 
-        let (physical_stats_schema, physical_partition_schema) = build_data_skipping_schemas(
+        let (physical_stats_schema, predicate_partition_schema) = build_data_skipping_schemas(
             &stats.struct_stats,
             &physical_predicate,
             &predicate_column_names,
             table_configuration,
-            table_partition_schema,
+            table_partition_schema.clone(),
         )?;
+
+        // When the engine requested the typed struct, emit all partition columns rather than
+        // the predicate-narrowed subset. The data skipping filter only references the columns
+        // its predicate needs, so the superset is safe for pruning too. Partition values
+        // extracted from the string map via MapToStruct are always nullable (map lookup can
+        // return null), so all fields are forced nullable.
+        let physical_partition_schema = if partition_values.parsed_struct {
+            table_partition_schema.map(|tps| {
+                let nullable_fields = tps
+                    .fields()
+                    .map(|f| StructField::nullable(f.name(), f.data_type().clone()));
+                Arc::new(StructType::new_unchecked(nullable_fields))
+            })
+        } else {
+            predicate_partition_schema
+        };
 
         let transform_spec =
             if !transform_spec.is_empty() || column_mapping_mode != ColumnMappingMode::None {
@@ -499,6 +523,29 @@ pub(crate) mod tests {
         metadata_cols: Vec<(&str, MetadataColumnSpec)>,
         stats: StatsOptions,
     ) -> DeltaResult<StateInfo> {
+        get_state_info_with_options(
+            schema,
+            partition_columns,
+            predicate,
+            features,
+            metadata_configuration,
+            metadata_cols,
+            stats,
+            PartitionValuesOptions::default(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn get_state_info_with_options(
+        schema: SchemaRef,
+        partition_columns: Vec<String>,
+        predicate: Option<PredicateRef>,
+        features: &[TableFeature],
+        metadata_configuration: HashMap<String, String>,
+        metadata_cols: Vec<(&str, MetadataColumnSpec)>,
+        stats: StatsOptions,
+        partition_values: PartitionValuesOptions,
+    ) -> DeltaResult<StateInfo> {
         let metadata = Metadata::try_new(
             None,
             None,
@@ -545,6 +592,7 @@ pub(crate) mod tests {
             &table_configuration,
             predicate,
             &stats,
+            &partition_values,
             (),
         )
     }
@@ -944,6 +992,7 @@ pub(crate) mod tests {
             &table_configuration,
             None,
             &StatsOptions::default(),
+            &PartitionValuesOptions::default(),
             (),
         );
         assert_result_error_with_message(
@@ -1179,6 +1228,95 @@ pub(crate) mod tests {
             "partition schema should use physical column name, not logical"
         );
         assert_eq!(field.data_type(), &DataType::DATE);
+    }
+
+    #[test]
+    fn partition_values_all_struct_emits_all_columns_without_predicate() {
+        // Requesting the typed struct must build a physical_partition_schema covering every
+        // partition column even with no predicate, where the predicate-only path emits none.
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("region", DataType::STRING),
+            StructField::nullable("date", DataType::DATE),
+        ]));
+
+        let state_info = get_state_info_with_options(
+            schema,
+            vec!["region".to_string(), "date".to_string()],
+            None,
+            &[],
+            HashMap::new(),
+            vec![],
+            StatsOptions::default(),
+            PartitionValuesOptions::all_struct(),
+        )
+        .unwrap();
+
+        let partition_schema = state_info
+            .physical_partition_schema
+            .as_ref()
+            .expect("all_struct should build a partition schema with no predicate");
+        let names: Vec<&str> = partition_schema
+            .fields()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["region", "date"]);
+        // MapToStruct lookups can return null, so every field must be nullable.
+        assert!(partition_schema.fields().all(|f| f.is_nullable()));
+    }
+
+    #[test]
+    fn partition_values_all_struct_survives_stats_none() {
+        // StatsOptions::none() disables data skipping but must not suppress the typed struct.
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("value", DataType::LONG),
+            StructField::nullable("date", DataType::DATE),
+        ]));
+
+        let state_info = get_state_info_with_options(
+            schema,
+            vec!["date".to_string()],
+            None,
+            &[],
+            HashMap::new(),
+            vec![],
+            StatsOptions::none(),
+            PartitionValuesOptions::all_struct(),
+        )
+        .unwrap();
+
+        let partition_schema = state_info
+            .physical_partition_schema
+            .as_ref()
+            .expect("all_struct should build a partition schema even when stats are disabled");
+        let names: Vec<&str> = partition_schema
+            .fields()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["date"]);
+    }
+
+    #[test]
+    fn partition_values_all_struct_omitted_for_non_partitioned_table() {
+        // A table without partition columns has no typed struct to emit.
+        let schema = Arc::new(StructType::new_unchecked(vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("value", DataType::STRING),
+        ]));
+
+        let state_info = get_state_info_with_options(
+            schema,
+            vec![],
+            None,
+            &[],
+            HashMap::new(),
+            vec![],
+            StatsOptions::default(),
+            PartitionValuesOptions::all_struct(),
+        )
+        .unwrap();
+
+        assert!(state_info.physical_partition_schema.is_none());
     }
 
     #[test]

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -12,7 +12,7 @@ use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::CheckpointReadInfo;
-use crate::scan::log_replay::{scan_action_iter, ScanStatsOptions};
+use crate::scan::log_replay::{scan_action_iter, ScanPartitionValuesOptions, ScanStatsOptions};
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::TransformSpec;
 use crate::schema::{SchemaRef, StructType};
@@ -178,6 +178,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         state_info,
         checkpoint_info,
         ScanStatsOptions::default(),
+        ScanPartitionValuesOptions::default(),
     )
     .unwrap();
     let mut batch_count = 0;

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -13,7 +13,7 @@ use super::TableChanges;
 use crate::actions::deletion_vector::split_vector;
 use crate::scan::field_classifiers::CdfTransformFieldClassifier;
 use crate::scan::state_info::StateInfo;
-use crate::scan::{PhysicalPredicate, StatsOptions};
+use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, PredicateRef};
 
@@ -123,6 +123,7 @@ impl TableChangesScanBuilder {
             self.table_changes.end_snapshot.table_configuration(),
             self.predicate,
             &StatsOptions::default(),
+            &PartitionValuesOptions::default(),
             CdfTransformFieldClassifier,
         )?;
 


### PR DESCRIPTION
> [!NOTE]
> Pairs with #2750 (independent; both target `main`). That PR speeds up the `MAP_TO_STRUCT`
> synthesis this feature uses when a table has no native parsed column, and carries the
> empty-string correctness fix. This PR works without it but is best landed alongside.
> Followed by #2754, which adds a transform opt-out built on this feature.

Adds `PartitionValuesOptions` and `ScanBuilder::with_partition_values`, mirroring `StatsOptions`,
so an engine can ask for the typed `partitionValues_parsed` struct in scan output instead of
parsing the raw string map itself.

When it's requested, scan output gains a top-level `partitionValues_parsed` column (one nullable
field per partition column, by physical name) regardless of any predicate. With `all_struct` the
string map is left null, and if the checkpoint already carries a native `partitionValues_parsed`
column the raw map is dropped from the parquet read entirely.

This is a breaking change: a public scan struct gains a field and a public method's parameter
count changes, so it needs a new major version.

### This PR affects the following public APIs

`scan::PartitionValuesOptions` and `ScanBuilder::with_partition_values` are new. The default
(string map only) is unchanged behaviorally, but the struct/method changes above are
source-breaking for code that constructs them directly.

## How was this change tested?

`cargo test -p delta_kernel`, plus tests for all-column emission without a predicate, survival
under `StatsOptions::none()`, omission on non-partitioned tables, and the null string-map output
under `skip_string_map`.
