### PR TITLE
Clarify corrupt workload expected failures

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -245,16 +245,27 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         &["cm_err_003_invalid_mode/specs/cm_err_003_invalid_mode_error"],
     ),
     (
-        "Reads corrupt/invalid commit or checkpoint without error",
+        "CRC fast path can mask corrupt/invalid commit JSON during snapshot construction",
         &[
             "corrupt_truncated_commit_json_error",
-            "cp_err_missing_protocol/specs/cp_err_missing_protocol_error",
-            "ct_corrupt_parquet/specs/ct_corrupt_parquet_error",
             "ct_invalid_json_error",
-            "dsReadCorruptCheckpoint/specs/dsReadCorruptCheckpoint_error",
             "dsReadCorruptJson_error",
+        ],
+    ),
+    (
+        "CRC or checkpoint hints can mask invalid checkpoint contents during snapshot construction",
+        &[
+            "cp_err_missing_protocol/specs/cp_err_missing_protocol_error",
+            "dsReadCorruptCheckpoint/specs/dsReadCorruptCheckpoint_error",
             "dsReadModifyCheckpoint/specs/dsReadModifyCheckpoint_error",
         ],
+    ),
+    // Keep corrupt data parquet separate from log/checkpoint corruption. Making snapshot
+    // construction validate referenced data files has a different compatibility and cost profile
+    // than failing closed on invalid Delta log state.
+    (
+        "Snapshot construction does not validate referenced data parquet files",
+        &["ct_corrupt_parquet/specs/ct_corrupt_parquet_error"],
     ),
     (
         "Does not reject duplicate actions in commit",


### PR DESCRIPTION
## Summary

- split the broad corrupt/invalid workload expected-failure bucket into commit JSON, checkpoint, and data parquet categories
- call out that validating referenced data files during snapshot construction is a separate compatibility and cost decision from failing closed on invalid Delta log state

Related issue: #2753

## Why

The old bucket mixed a few different failure modes under one reason: CRC-masked commit JSON corruption, invalid checkpoint contents, and corrupt referenced data parquet. Keeping those boundaries separate should make future fixes easier to review and remove from the expected-failure list one category at a time.

## Validation

- `rustfmt --edition 2021 --check acceptance/tests/acceptance_workloads_reader.rs`
- `cargo test -p acceptance --test acceptance_workloads_reader corrupt_truncated_commit_json_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader cp_err_missing_protocol_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader ct_corrupt_parquet_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader ct_invalid_json_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader dsReadCorruptCheckpoint_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader dsReadCorruptJson_error -- --nocapture`
- `cargo test -p acceptance --test acceptance_workloads_reader dsReadModifyCheckpoint_error -- --nocapture`