### PR TITLE
feat: emit partitionValues_parsed via PartitionValuesOptions in scan output

### DIFF
--- a/docs/user-guide/src/reading/scan_metadata.md
+++ b/docs/user-guide/src/reading/scan_metadata.md
@@ -246,6 +246,45 @@ If the scan has no predicate, this returns `None`.
 > physical predicate, and the `ScanFile` data together. Workers need all four to read files
 > correctly.
 
+## Typed partition values
+
+Kernel reads each file's partition values from the Delta log and exposes them on its
+`ScanFile` as a raw string map. Kernel's `transform_to_logical` could materialize them as
+typed columns. If your connector assembles output rows itself instead of using that transform,
+it parses the string map per file.
+
+To have Kernel hand you the typed values directly, opt in with `with_partition_values`:
+
+```rust,no_run
+# extern crate delta_kernel;
+# extern crate delta_kernel_default_engine;
+# use std::sync::Arc;
+# use delta_kernel_default_engine::DefaultEngine;
+# use delta_kernel_default_engine::storage::store_from_url;
+# use delta_kernel::scan::PartitionValuesOptions;
+# use delta_kernel::{DeltaResult, Snapshot};
+# fn example() -> DeltaResult<()> {
+# let url = delta_kernel::try_parse_uri("/tmp/table")?;
+# let store = store_from_url(&url)?;
+# let engine = DefaultEngine::builder(store).build();
+# let snapshot = Snapshot::builder_for(url).build(&engine)?;
+let scan = snapshot
+    .scan_builder()
+    .with_partition_values(PartitionValuesOptions::with_struct())
+    .build()?;
+# Ok(())
+# }
+```
+
+Scan metadata output then gains a top-level `partitionValues_parsed` column with one typed,
+nullable field per partition column (by physical name). You read it as a typed column instead
+of parsing the string map per file. The raw string map is still present, so this option only
+adds the typed column.
+
+> [!TIP]
+> When the checkpoint already stores typed partition values, Kernel reads that column directly
+> and skips parsing entirely.
+
 ## What's next
 
 - [Column Selection](./column_selection.md): projecting specific columns

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2253,6 +2253,43 @@ mod tests {
     }
 
     #[test]
+    fn test_map_to_struct_ignores_undeclared_key() {
+        // A partition map can carry a key for a column the current schema no longer declares
+        // (a dropped or repartitioned column). MapToStruct projects only the declared output
+        // fields and ignores undeclared keys rather than erroring on them.
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("region");
+        builder.values().append_value("us");
+        builder.keys().append_value("created_at"); // dropped partition column, not in schema
+        builder.values().append_value("2024-01-15");
+        builder.append(true).unwrap();
+
+        let map_array = builder.finish();
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "pv",
+            map_array.data_type().clone(),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
+
+        let output_schema =
+            StructType::new_unchecked(vec![StructField::nullable("region", DataType::STRING)]);
+        let result_type = DataType::from(output_schema);
+        let expr = Expr::map_to_struct(column_expr!("pv"));
+        let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
+        let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
+
+        // Only the declared `region` field is emitted; the undeclared `created_at` key is ignored.
+        assert_eq!(structs.num_columns(), 1);
+        let regions = structs
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(regions.value(0), "us");
+    }
+
+    #[test]
     fn test_map_to_struct_parse_error() {
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("count");

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -143,7 +143,9 @@ mod tests {
         AfterSequentialScanMetadata, ParallelScanMetadata, ParallelState,
     };
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
-    use crate::scan::log_replay::{ScanLogReplayProcessor, ScanStatsOptions};
+    use crate::scan::log_replay::{
+        ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+    };
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::get_simple_state_info;
     use crate::scan::StatsOptions;
@@ -210,6 +212,7 @@ mod tests {
             checkpoint_info,
             seen_file_keys,
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
     }
 

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -294,7 +294,9 @@ mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::log_segment::CheckpointReadInfo;
     use crate::metrics::{MetricEvent, ScanType, TableType};
-    use crate::scan::log_replay::{ScanLogReplayProcessor, ScanStatsOptions};
+    use crate::scan::log_replay::{
+        ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+    };
     use crate::scan::state_info::StateInfo;
     use crate::scan::PhysicalPredicate;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
@@ -326,6 +328,7 @@ mod tests {
             state_info,
             CheckpointReadInfo::without_stats_parsed(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -53,6 +53,14 @@ impl Default for ScanStatsOptions {
     }
 }
 
+/// Read-time partition value toggles consumed by [`ScanLogReplayProcessor`].
+#[derive(Clone, Copy, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ScanPartitionValuesOptions {
+    /// Emit the typed `partitionValues_parsed` struct column in scan metadata output,
+    /// independent of any predicate.
+    pub(crate) parsed_struct: bool,
+}
+
 /// Internal serializable state (schemas, transform spec, column mapping, etc.)
 /// NOTE: This is opaque to the user - it is passed through as a blob.
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -67,6 +75,8 @@ struct InternalScanState {
     physical_stats_schema: Option<SchemaRef>,
     #[serde(default)]
     stats_options: ScanStatsOptions,
+    #[serde(default)]
+    partition_values_options: ScanPartitionValuesOptions,
     /// Physical partition schema for checkpoint partition pruning via `partitionValues_parsed`
     physical_partition_schema: Option<SchemaRef>,
     /// Physical leaf paths which are expected to have stats collected. Carried alongside
@@ -156,6 +166,8 @@ pub struct ScanLogReplayProcessor {
     seen_file_keys: HashSet<FileActionKey>,
     /// Read-time stats options.
     stats_options: ScanStatsOptions,
+    /// Read-time partition value options.
+    partition_values_options: ScanPartitionValuesOptions,
     /// Information about checkpoint reading for stats optimization
     checkpoint_info: CheckpointReadInfo,
     /// Metrics related to the scan
@@ -179,6 +191,7 @@ impl ScanLogReplayProcessor {
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
         stats_options: ScanStatsOptions,
+        partition_values_options: ScanPartitionValuesOptions,
     ) -> DeltaResult<Self> {
         let dedup_capacity = state_info.dedup_capacity_hint();
         Self::new_with_seen_files(
@@ -187,6 +200,7 @@ impl ScanLogReplayProcessor {
             checkpoint_info,
             HashSet::with_capacity(dedup_capacity),
             stats_options,
+            partition_values_options,
         )
     }
 
@@ -201,12 +215,15 @@ impl ScanLogReplayProcessor {
     /// - `checkpoint_info`: Information about checkpoint reading for stats optimization
     /// - `seen_file_keys`: Pre-computed set of file action keys that have been seen
     /// - `stats_options`: Read-time stats options (see [`ScanStatsOptions`])
+    /// - `partition_values_options`: Read-time partition value options (see
+    ///   [`ScanPartitionValuesOptions`])
     pub(crate) fn new_with_seen_files(
         engine: &dyn Engine,
         state_info: Arc<StateInfo>,
         checkpoint_info: CheckpointReadInfo,
         seen_file_keys: HashSet<FileActionKey>,
         stats_options: ScanStatsOptions,
+        partition_values_options: ScanPartitionValuesOptions,
     ) -> DeltaResult<Self> {
         let CheckpointReadInfo {
             has_stats_parsed,
@@ -230,14 +247,22 @@ impl ScanLogReplayProcessor {
 
         // When skip_stats is enabled, disable both data column skipping and partition pruning.
         // Both rely on the same DataSkippingFilter columnar pass, so they are controlled together.
-        let (stats_schema_for_transform, partition_schema_for_transform) = if skip_stats {
-            (None, None)
+        let stats_schema_for_transform = if skip_stats {
+            None
         } else {
-            (
-                state_info.physical_stats_schema.clone(),
-                state_info.physical_partition_schema.clone(),
-            )
+            state_info.physical_stats_schema.clone()
         };
+
+        // The partition schema feeds two consumers: the DataSkippingFilter (predicate
+        // pruning, disabled by skip_stats together with stats) and the engine-facing
+        // `partitionValues_parsed` output column (requested via `parsed_struct`, independent
+        // of skip_stats). Either consumer keeps the transform emitting the column.
+        let partition_schema_for_transform =
+            if partition_values_options.parsed_struct || !skip_stats {
+                state_info.physical_partition_schema.clone()
+            } else {
+                None
+            };
 
         let output_schema = scan_row_schema_with_parsed_columns(
             stats_schema_for_transform.clone(),
@@ -301,6 +326,7 @@ impl ScanLogReplayProcessor {
             seen_file_keys,
             state_info,
             stats_options,
+            partition_values_options,
             checkpoint_info,
             metrics,
         })
@@ -363,6 +389,7 @@ impl ScanLogReplayProcessor {
             column_mapping_mode,
             physical_stats_schema,
             stats_options: self.stats_options,
+            partition_values_options: self.partition_values_options,
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
@@ -434,6 +461,7 @@ impl ScanLogReplayProcessor {
             state.checkpoint_info,
             state.seen_file_keys,
             internal_state.stats_options,
+            internal_state.partition_values_options,
         )
     }
 }
@@ -580,7 +608,8 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
         } else {
             // All checkpoint actions are already reconciled and Remove actions in checkpoint files
             // only serve as tombstones for vacuum jobs. So we only need to examine the adds here.
-            (&names[..7], &types[..7])
+            let add_count = ScanLogReplayProcessor::REMOVE_PATH_INDEX;
+            (&names[..add_count], &types[..add_count])
         }
     }
 
@@ -649,11 +678,14 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
     ]))
 });
 
-/// Build the scan row schema with optional `stats_parsed` and `partitionValues_parsed` columns.
+/// Build the scan-row schema, appending the opt-in typed `stats_parsed` / `partitionValues_parsed`
+/// columns when requested.
 ///
-/// When `stats_schema` is provided, adds a `stats_parsed` struct column with that schema.
-/// When `partition_schema` is provided, adds a `partitionValues_parsed` struct column with that
-/// schema.
+/// These typed columns are appended at the top level (siblings of `fileConstantValues`) rather than
+/// nested inside it. This mirrors `stats_parsed`, keeps `fileConstantValues` a fixed shape
+/// regardless of the engine's options, and keeps data-skipping paths uniform:
+/// `partitionValues_parsed.<col>` parallels `stats_parsed.minValues.<col>`. The checkpoint source
+/// is also `add.partitionValues_parsed`, a sibling of `add.stats_parsed`.
 fn scan_row_schema_with_parsed_columns(
     stats_schema: Option<SchemaRef>,
     partition_schema: Option<SchemaRef>,
@@ -750,7 +782,8 @@ fn get_add_transform_expr(
         fields.push(Arc::new(stats_parsed_expr));
     }
 
-    // Add partitionValues_parsed when partition columns are needed for data skipping
+    // Add partitionValues_parsed when partition columns are needed for data skipping or for the
+    // engine-facing typed output column.
     if partition_schema.is_some() {
         let pv_parsed_expr = if has_partition_values_parsed {
             // Checkpoint has partitionValues_parsed column - read directly
@@ -972,12 +1005,18 @@ pub(crate) fn scan_action_iter(
     state_info: Arc<StateInfo>,
     checkpoint_info: CheckpointReadInfo,
     stats_options: ScanStatsOptions,
+    partition_values_options: ScanPartitionValuesOptions,
 ) -> DeltaResult<(
     impl Iterator<Item = DeltaResult<ScanMetadata>>,
     Arc<ScanMetrics>,
 )> {
-    let processor =
-        ScanLogReplayProcessor::new(engine, state_info, checkpoint_info, stats_options)?;
+    let processor = ScanLogReplayProcessor::new(
+        engine,
+        state_info,
+        checkpoint_info,
+        stats_options,
+        partition_values_options,
+    )?;
     let metrics = processor.metrics.clone();
     Ok((processor.process_actions_iter(action_iter), metrics))
 }
@@ -991,7 +1030,7 @@ mod tests {
 
     use super::{
         get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanStatsOptions, SerializableScanState,
+        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
@@ -1127,6 +1166,7 @@ mod tests {
             state_info,
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         for res in iter {
@@ -1155,6 +1195,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1241,6 +1282,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1286,6 +1328,7 @@ mod tests {
             Arc::new(get_simple_state_info(schema.clone(), vec![]).unwrap()),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1358,6 +1401,7 @@ mod tests {
             state_info.clone(),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1415,6 +1459,7 @@ mod tests {
             state_info.clone(),
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1457,6 +1502,7 @@ mod tests {
                 state_info,
                 checkpoint_info.clone(),
                 ScanStatsOptions::default(),
+                ScanPartitionValuesOptions::default(),
             )
             .unwrap();
             let deserialized = ScanLogReplayProcessor::from_serializable_state(
@@ -1495,6 +1541,7 @@ mod tests {
             state_info,
             checkpoint_info.clone(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();
@@ -1530,6 +1577,7 @@ mod tests {
             state_info,
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let serialized = processor.into_serializable_state().unwrap();
@@ -1605,6 +1653,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             stats_options: ScanStatsOptions::default(),
+            partition_values_options: ScanPartitionValuesOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
@@ -1640,6 +1689,7 @@ mod tests {
             column_mapping_mode: ColumnMappingMode::None,
             physical_stats_schema: None,
             stats_options: ScanStatsOptions::default(),
+            partition_values_options: ScanPartitionValuesOptions::default(),
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
@@ -1712,6 +1762,7 @@ mod tests {
                 skip_stats: true,
                 ..Default::default()
             },
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 
@@ -1802,6 +1853,7 @@ mod tests {
             Arc::new(state_info),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1611,6 +1611,7 @@ mod tests {
             state_info,
             test_checkpoint_info(),
             ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
         )
         .unwrap();
         let deserialized = ScanLogReplayProcessor::from_serializable_state(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -187,6 +187,36 @@ impl StatsOptions {
     }
 }
 
+/// Engine-facing partition value options. Pass to [`ScanBuilder::with_partition_values`] to
+/// declare whether scan metadata output includes the typed `partitionValues_parsed` struct
+/// alongside the raw string map (`fileConstantValues.partitionValues`), which is always present.
+///
+/// When the typed struct is requested, scan metadata output gains a top-level
+/// `partitionValues_parsed` struct column with one typed nullable field per partition column
+/// (physical names, table partition-column order). On non-partitioned tables the column is
+/// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
+/// when present, otherwise from parsing the string map.
+#[derive(Clone, Debug, Default)]
+pub struct PartitionValuesOptions {
+    /// Whether to emit the typed `partitionValues_parsed` struct column.
+    pub(crate) parsed_struct: bool,
+}
+
+impl PartitionValuesOptions {
+    /// Raw string map only, no typed struct. Equivalent to [`Default::default`].
+    pub fn string_map_only() -> Self {
+        Self::default()
+    }
+
+    /// Emit the typed `partitionValues_parsed` struct alongside the raw string map. Lets engines
+    /// consume `partitionValues_parsed` directly instead of parsing the string map per row.
+    pub fn with_struct() -> Self {
+        Self {
+            parsed_struct: true,
+        }
+    }
+}
+
 /// Builder to scan a snapshot of a table.
 pub struct ScanBuilder {
     snapshot: SnapshotRef,
@@ -195,6 +225,7 @@ pub struct ScanBuilder {
     stats: StatsOptions,
     correlation_id: Option<Arc<str>>,
     without_row_transforms: bool,
+    partition_values: PartitionValuesOptions,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -205,6 +236,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("stats", &self.stats)
             .field("correlation_id", &self.correlation_id)
             .field("without_row_transforms", &self.without_row_transforms)
+            .field("partition_values", &self.partition_values)
             .finish()
     }
 }
@@ -219,6 +251,7 @@ impl ScanBuilder {
             stats: StatsOptions::default(),
             correlation_id: None,
             without_row_transforms: false,
+            partition_values: PartitionValuesOptions::default(),
         }
     }
 
@@ -306,6 +339,16 @@ impl ScanBuilder {
         self
     }
 
+    /// Configure partition value output for the scan. See [`PartitionValuesOptions`].
+    ///
+    /// Defaults to [`PartitionValuesOptions::default`] (string map only). Engines that
+    /// consume `partitionValues_parsed` directly should pass
+    /// [`PartitionValuesOptions::with_struct`] to also emit the typed struct column.
+    pub fn with_partition_values(mut self, partition_values: PartitionValuesOptions) -> Self {
+        self.partition_values = partition_values;
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -342,6 +385,7 @@ impl ScanBuilder {
             self.snapshot.table_configuration(),
             self.predicate,
             &self.stats,
+            &self.partition_values,
             (), // No classifier, default is for scans
         )?;
 
@@ -354,6 +398,7 @@ impl ScanBuilder {
             state_info: Arc::new(state_info),
             stats: self.stats,
             correlation_id: self.correlation_id,
+            partition_values: self.partition_values,
         })
     }
 }
@@ -614,6 +659,7 @@ pub struct Scan {
     state_info: Arc<StateInfo>,
     stats: StatsOptions,
     correlation_id: Option<Arc<str>>,
+    partition_values: PartitionValuesOptions,
 }
 
 impl std::fmt::Debug for Scan {
@@ -638,6 +684,13 @@ impl Scan {
         log_replay::ScanStatsOptions {
             skip_stats: self.skip_stats(),
             synthesize_json: self.stats.synthesize_json,
+        }
+    }
+
+    /// Build the partition-value read options passed to [`ScanLogReplayProcessor`].
+    fn partition_values_options(&self) -> log_replay::ScanPartitionValuesOptions {
+        log_replay::ScanPartitionValuesOptions {
+            parsed_struct: self.partition_values.parsed_struct,
         }
     }
 
@@ -892,6 +945,7 @@ impl Scan {
                     self.state_info.clone(),
                     actions_with_checkpoint_info.checkpoint_info,
                     self.stats_options(),
+                    self.partition_values_options(),
                 )?;
                 (Some(it), m)
             }
@@ -1062,6 +1116,7 @@ impl Scan {
             self.state_info.clone(),
             checkpoint_info,
             self.stats_options(),
+            self.partition_values_options(),
         )?;
         let sequential =
             SequentialPhase::try_new(processor, self.snapshot.log_segment(), engine.clone())?;
@@ -1194,7 +1249,10 @@ impl Scan {
     }
 }
 
-/// Get the schema that scan rows (from [`Scan::scan_metadata`]) will be returned with.
+/// Get the base schema that scan rows (from [`Scan::scan_metadata`]) will be returned with.
+///
+/// This is the base shape; engines may add trailing `*_parsed` columns by opting in via
+/// [`StatsOptions`] (`stats_parsed`) or [`PartitionValuesOptions`] (`partitionValues_parsed`).
 ///
 /// It is:
 /// ```ignored

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -10,7 +10,7 @@ use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
 use crate::scan::field_classifiers::TransformFieldClassifier;
 use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
-use crate::scan::{PhysicalPredicate, StatsOptions, StructStats};
+use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions, StructStats};
 use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
@@ -32,9 +32,11 @@ pub(crate) struct StateInfo {
     /// Physical stats schema for reading/parsing stats from checkpoint files.
     /// Used to construct checkpoint read schema with stats_parsed.
     pub(crate) physical_stats_schema: Option<SchemaRef>,
-    /// Physical partition schema with native types for partition pruning via
-    /// `partitionValues_parsed`. Fields use physical column names (for column mapping).
-    /// Only present when the table has partition columns and a predicate is provided.
+    /// Physical partition schema with native types for `partitionValues_parsed`. Fields use
+    /// physical column names (for column mapping) and are always nullable. Present when the
+    /// table has partition columns and either a predicate is provided (narrowed to
+    /// predicate-referenced columns, for partition pruning) or the engine requested the typed
+    /// struct in scan output (all partition columns).
     pub(crate) physical_partition_schema: Option<SchemaRef>,
     /// Physical leaf paths which are expected to have stats collected.
     ///
@@ -241,6 +243,8 @@ impl StateInfo {
     /// `predicate` - Optional predicate to filter data during the scan
     /// `stats` - Engine-facing stats options. Drives which stats columns appear in scan
     ///   metadata output and whether the JSON synthesis fallback fires.
+    /// `partition_values` - Engine-facing partition value options. Drives whether the typed
+    ///   `partitionValues_parsed` column appears in scan metadata output.
     /// `classifier` - The classifier to use for different scan types. Use `()` if not needed
     pub(crate) fn try_new<C: TransformFieldClassifier>(
         logical_read_schema: SchemaRef,
@@ -248,6 +252,7 @@ impl StateInfo {
         table_configuration: &TableConfiguration,
         predicate: Option<PredicateRef>,
         stats: &StatsOptions,
+        partition_values: &PartitionValuesOptions,
         classifier: C,
     ) -> DeltaResult<Self> {
         let partition_columns = table_configuration.partition_columns();
@@ -379,40 +384,59 @@ impl StateInfo {
             }
         }
 
-        // Build partition schema with physical names for partition pruning in data skipping.
-        // Only needed when we have a predicate and partition columns.
+        // Build partition schema with physical names, used for partition pruning in data
+        // skipping and for the engine-facing `partitionValues_parsed` output column. Needed
+        // when partition columns exist and either a predicate is present or the engine
+        // requested the typed struct in scan output.
         // partition_columns stores logical names (per Delta protocol), so we zip the table's
         // logical and physical schemas (same field ordering, guaranteed by `make_physical`)
         // to match logical names and extract the corresponding physical fields without
         // per-field metadata lookups.
-        let table_partition_schema = if !matches!(
+        let has_predicate = !matches!(
             physical_predicate,
             PhysicalPredicate::None | PhysicalPredicate::StaticSkipAll
-        ) && !partition_columns.is_empty()
-        {
-            let partition_fields: Vec<StructField> = table_configuration
-                .logical_schema()
-                .fields()
-                .zip(table_configuration.physical_schema().fields())
-                .filter(|(logical_f, _)| partition_columns.contains(logical_f.name()))
-                .map(|(_, physical_f)| physical_f.clone())
-                .collect();
-            if partition_fields.is_empty() {
-                None
+        );
+        let table_partition_schema =
+            if (has_predicate || partition_values.parsed_struct) && !partition_columns.is_empty() {
+                let partition_fields: Vec<StructField> = table_configuration
+                    .logical_schema()
+                    .fields()
+                    .zip(table_configuration.physical_schema().fields())
+                    .filter(|(logical_f, _)| partition_columns.contains(logical_f.name()))
+                    .map(|(_, physical_f)| physical_f.clone())
+                    .collect();
+                if partition_fields.is_empty() {
+                    None
+                } else {
+                    Some(Arc::new(StructType::new_unchecked(partition_fields)))
+                }
             } else {
-                Some(Arc::new(StructType::new_unchecked(partition_fields)))
-            }
-        } else {
-            None
-        };
+                None
+            };
 
-        let (physical_stats_schema, physical_partition_schema) = build_data_skipping_schemas(
+        let (physical_stats_schema, predicate_partition_schema) = build_data_skipping_schemas(
             &stats.struct_stats,
             &physical_predicate,
             &predicate_column_names,
             table_configuration,
-            table_partition_schema,
+            table_partition_schema.clone(),
         )?;
+
+        // When the engine requested the typed struct, emit all partition columns rather than
+        // the predicate-narrowed subset. The data skipping filter only references the columns
+        // its predicate needs, so the superset is safe for pruning too. All fields are forced
+        // nullable: MapToStruct can yield null even for a non-nullable column (a missing key, or
+        // the protocol's empty-string-is-null rule), and a non-nullable field would then error.
+        let physical_partition_schema = if partition_values.parsed_struct {
+            table_partition_schema.map(|tps| {
+                let nullable_fields = tps
+                    .fields()
+                    .map(|f| StructField::nullable(f.name(), f.data_type().clone()));
+                Arc::new(StructType::new_unchecked(nullable_fields))
+            })
+        } else {
+            predicate_partition_schema
+        };
 
         let transform_spec =
             if !transform_spec.is_empty() || column_mapping_mode != ColumnMappingMode::None {
@@ -506,6 +530,29 @@ pub(crate) mod tests {
         metadata_cols: Vec<(&str, MetadataColumnSpec)>,
         stats: StatsOptions,
     ) -> DeltaResult<StateInfo> {
+        get_state_info_with_options(
+            schema,
+            partition_columns,
+            predicate,
+            features,
+            metadata_configuration,
+            metadata_cols,
+            stats,
+            PartitionValuesOptions::default(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn get_state_info_with_options(
+        schema: SchemaRef,
+        partition_columns: Vec<String>,
+        predicate: Option<PredicateRef>,
+        features: &[TableFeature],
+        metadata_configuration: HashMap<String, String>,
+        metadata_cols: Vec<(&str, MetadataColumnSpec)>,
+        stats: StatsOptions,
+        partition_values: PartitionValuesOptions,
+    ) -> DeltaResult<StateInfo> {
         let metadata = Metadata::try_new(
             None,
             None,
@@ -552,6 +599,7 @@ pub(crate) mod tests {
             &table_configuration,
             predicate,
             &stats,
+            &partition_values,
             (),
         )
     }
@@ -951,6 +999,7 @@ pub(crate) mod tests {
             &table_configuration,
             None,
             &StatsOptions::default(),
+            &PartitionValuesOptions::default(),
             (),
         );
         assert_result_error_with_message(
@@ -1186,6 +1235,74 @@ pub(crate) mod tests {
             "partition schema should use physical column name, not logical"
         );
         assert_eq!(field.data_type(), &DataType::DATE);
+    }
+
+    /// `with_struct` builds `physical_partition_schema` from all partition columns (independent of
+    /// predicate and `StatsOptions::none`), and omits it entirely on non-partitioned tables.
+    #[rstest]
+    #[case::all_columns_without_predicate(
+        vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("region", DataType::STRING),
+            StructField::nullable("date", DataType::DATE),
+        ],
+        vec!["region".to_string(), "date".to_string()],
+        StatsOptions::default(),
+        Some(vec!["region", "date"]),
+    )]
+    #[case::survives_stats_none(
+        vec![
+            StructField::nullable("value", DataType::LONG),
+            StructField::nullable("date", DataType::DATE),
+        ],
+        vec!["date".to_string()],
+        StatsOptions::none(),
+        Some(vec!["date"]),
+    )]
+    #[case::omitted_for_non_partitioned_table(
+        vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("value", DataType::STRING),
+        ],
+        vec![],
+        StatsOptions::default(),
+        None,
+    )]
+    fn partition_values_with_struct(
+        #[case] fields: Vec<StructField>,
+        #[case] partition_columns: Vec<String>,
+        #[case] stats: StatsOptions,
+        #[case] expected_names: Option<Vec<&str>>,
+    ) {
+        let schema = Arc::new(StructType::new_unchecked(fields));
+        let state_info = get_state_info_with_options(
+            schema,
+            partition_columns,
+            None,
+            &[],
+            HashMap::new(),
+            vec![],
+            stats,
+            PartitionValuesOptions::with_struct(),
+        )
+        .unwrap();
+
+        match expected_names {
+            Some(expected) => {
+                let partition_schema = state_info
+                    .physical_partition_schema
+                    .as_ref()
+                    .expect("with_struct should build a partition schema");
+                let names: Vec<&str> = partition_schema
+                    .fields()
+                    .map(|f| f.name().as_str())
+                    .collect();
+                assert_eq!(names, expected);
+                // MapToStruct lookups can return null, so every field must be nullable.
+                assert!(partition_schema.fields().all(|f| f.is_nullable()));
+            }
+            None => assert!(state_info.physical_partition_schema.is_none()),
+        }
     }
 
     #[test]

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -12,7 +12,7 @@ use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::CheckpointReadInfo;
-use crate::scan::log_replay::{scan_action_iter, ScanStatsOptions};
+use crate::scan::log_replay::{scan_action_iter, ScanPartitionValuesOptions, ScanStatsOptions};
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::TransformSpec;
 use crate::schema::{SchemaRef, StructType};
@@ -179,6 +179,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         state_info,
         checkpoint_info,
         ScanStatsOptions::default(),
+        ScanPartitionValuesOptions::default(),
     )
     .unwrap();
     let mut batch_count = 0;

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -13,7 +13,7 @@ use super::TableChanges;
 use crate::actions::deletion_vector::split_vector;
 use crate::scan::field_classifiers::CdfTransformFieldClassifier;
 use crate::scan::state_info::StateInfo;
-use crate::scan::{PhysicalPredicate, StatsOptions};
+use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, PredicateRef};
 
@@ -123,6 +123,7 @@ impl TableChangesScanBuilder {
             self.table_changes.end_snapshot.table_configuration(),
             self.predicate,
             &StatsOptions::default(),
+            &PartitionValuesOptions::default(),
             CdfTransformFieldClassifier,
         )?;
 

--- a/kernel/tests/integration/main.rs
+++ b/kernel/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod golden_tables;
 mod hdfs;
 mod log;
 mod metrics;
+mod parsed_partition_values;
 mod parsed_stats;
 mod read;
 mod write;

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -1,0 +1,113 @@
+//! Integration tests for parsed partition-value output (`partitionValues_parsed`).
+
+use delta_kernel::arrow::array::{Array, BooleanArray, RecordBatch, StructArray};
+use delta_kernel::arrow::compute::filter_record_batch;
+use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::scan::PartitionValuesOptions;
+use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::Snapshot;
+use rstest::rstest;
+use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
+use test_utils::table_builder::{partitioned, version_latest, FeatureSet, LogState, TableConfig};
+use test_utils::{get_column, test_context};
+
+/// Requesting the typed struct via `with_struct()` on a partitioned table must emit a
+/// `partitionValues_parsed` column with one field per partition column, keyed by physical name.
+///
+/// Run across every column mapping mode and both partition-value sources:
+/// - `native_checkpoint = false`: no checkpoint, so the struct is synthesized from the
+///   `partitionValues` string map via `MAP_TO_STRUCT`.
+/// - `native_checkpoint = true`: a checkpoint with `writeStatsAsStruct=true`, so the checkpoint
+///   carries a native `partitionValues_parsed` column that kernel reads directly.
+///
+/// Both sources key on physical names, so a logical-vs-physical mismatch under `Id`/`Name` mapping
+/// would surface every partition value as null. The builder writes well-defined (non-null)
+/// partition values, so the non-null assertion guards physical-name matching in all combinations.
+#[rstest]
+fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
+    #[values(
+        ColumnMappingMode::None,
+        ColumnMappingMode::Id,
+        ColumnMappingMode::Name
+    )]
+    cm_mode: ColumnMappingMode,
+    #[values(false, true)] native_checkpoint: bool,
+) {
+    let cm_str = match cm_mode {
+        ColumnMappingMode::None => "none",
+        ColumnMappingMode::Id => "id",
+        ColumnMappingMode::Name => "name",
+    };
+    // A native `partitionValues_parsed` checkpoint column is only written when
+    // `writeStatsAsStruct=true`; otherwise the struct is synthesized from the string map on read.
+    let log_state = if native_checkpoint {
+        LogState::with_latest_version(1).with_checkpoint_at([1])
+    } else {
+        LogState::with_latest_version(1)
+    };
+    let table_config = if native_checkpoint {
+        TableConfig::new().write_stats_as_struct(true)
+    } else {
+        TableConfig::new()
+    };
+    let (engine, snapshot, _table) = test_context!(
+        log_state,
+        FeatureSet::empty().column_mapping(cm_str),
+        partitioned(),
+        table_config,
+        version_latest(),
+    );
+
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()
+        .unwrap();
+
+    let scan_metadata_results: Vec<_> = scan
+        .scan_metadata(&engine)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert!(
+        !scan_metadata_results.is_empty(),
+        "Should have scan metadata"
+    );
+
+    let mut file_count = 0;
+    for scan_metadata in scan_metadata_results {
+        let (underlying_data, selection_vector) = scan_metadata.scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(underlying_data)
+            .unwrap()
+            .into();
+        let filtered_batch =
+            filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
+        if filtered_batch.num_rows() == 0 {
+            continue;
+        }
+
+        let pv_parsed = get_column!(filtered_batch, "partitionValues_parsed", StructArray);
+
+        // `partitioned()` partitions by all 13 primitive types in `partitioned_schema()`.
+        assert_eq!(
+            pv_parsed.num_columns(),
+            13,
+            "expected one parsed field per partition column (cm={cm_str}, native_checkpoint={native_checkpoint})"
+        );
+
+        // Every partition value the builder writes is well-defined, so each field must be
+        // non-null. A logical-vs-physical name mismatch under column mapping would surface nulls.
+        for field in pv_parsed.columns() {
+            assert_eq!(
+                field.null_count(),
+                0,
+                "partition value unexpectedly null (cm={cm_str}, native_checkpoint={native_checkpoint})"
+            );
+        }
+
+        file_count += filtered_batch.num_rows();
+    }
+
+    assert_eq!(file_count, 1, "Should have processed exactly one file");
+}

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -3,8 +3,9 @@
 use delta_kernel::arrow::array::{Array, BooleanArray, RecordBatch, StructArray};
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::expressions::ColumnName;
 use delta_kernel::scan::PartitionValuesOptions;
-use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::Snapshot;
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
@@ -58,11 +59,22 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
         version_latest(),
     );
 
+    let schema = snapshot.schema();
     let scan = snapshot
         .scan_builder()
         .with_partition_values(PartitionValuesOptions::with_struct())
         .build()
         .unwrap();
+
+    // Resolve the physical name kernel uses for a partition column under the active mapping mode.
+    let physical_name = |logical: &str| -> String {
+        get_any_level_column_physical_name(schema.as_ref(), &ColumnName::new([logical]), cm_mode)
+            .unwrap()
+            .into_inner()
+            .into_iter()
+            .next()
+            .unwrap()
+    };
 
     let scan_metadata_results: Vec<_> = scan
         .scan_metadata(&engine)
@@ -103,6 +115,17 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
                 field.null_count(),
                 0,
                 "partition value unexpectedly null (cm={cm_str}, native_checkpoint={native_checkpoint})"
+            );
+        }
+
+        // The struct must be keyed by physical name. Under Id/Name mapping the physical name
+        // differs from the logical name, so a logical-keyed struct would fail this lookup.
+        for logical in ["part_int", "part_string"] {
+            let phys = physical_name(logical);
+            assert!(
+                pv_parsed.column_by_name(&phys).is_some(),
+                "partitionValues_parsed should key {logical} by physical name {phys} \
+                 (cm={cm_str}, native_checkpoint={native_checkpoint})"
             );
         }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `PartitionValuesOptions` and `ScanBuilder::with_partition_values`, mirroring `StatsOptions`,
so an engine can ask for the typed `partitionValues_parsed` struct in scan output instead of
parsing the raw string map itself.

With `PartitionValuesOptions::all_struct()`, scan output gains a top-level `partitionValues_parsed`
column (one nullable field per partition column, by physical name, in table order), regardless of
any predicate. Values come from the checkpoint's native `partitionValues_parsed` column when
present, otherwise from parsing the raw string map via `MAP_TO_STRUCT`. 

## How was this change tested?

`cargo test -p delta_kernel`, plus tests for all-column emission without a predicate, survival
under `StatsOptions::none()`, and omission on non-partitioned tables.
