### PR TITLE
feat: add without_row_transforms scan opt-out

### DIFF
--- a/kernel/benches/metadata_bench.rs
+++ b/kernel/benches/metadata_bench.rs
@@ -66,22 +66,32 @@ fn scan_metadata_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("scan_metadata");
     group.sample_size(SCAN_METADATA_BENCH_SAMPLE_SIZE);
-    group.bench_function("scan_metadata", |b| {
-        b.iter(|| {
-            let scan = snapshot
-                .clone() // arc
-                .scan_builder()
-                .build()
-                .expect("Failed to build scan");
-            let metadata_iter = scan
-                .scan_metadata(engine.as_ref())
-                .expect("Failed to get scan metadata");
-            // kernel scans are lazy, we must consume iterator to do the work we want to test
-            for result in metadata_iter {
-                result.expect("Failed to process scan metadata");
-            }
-        })
-    });
+    // Benchmark both the default path (kernel builds a per-file transform expression for this
+    // partitioned table) and the `without_row_transforms` opt-out (which skips that build and the
+    // per-row partition-value parse that feeds it).
+    for without_row_transforms in [false, true] {
+        let id = if without_row_transforms {
+            "scan_metadata_without_row_transforms"
+        } else {
+            "scan_metadata"
+        };
+        group.bench_function(id, |b| {
+            b.iter(|| {
+                let mut builder = snapshot.clone().scan_builder();
+                if without_row_transforms {
+                    builder = builder.without_row_transforms();
+                }
+                let scan = builder.build().expect("Failed to build scan");
+                let metadata_iter = scan
+                    .scan_metadata(engine.as_ref())
+                    .expect("Failed to get scan metadata");
+                // kernel scans are lazy, we must consume iterator to do the work we want to test
+                for result in metadata_iter {
+                    result.expect("Failed to process scan metadata");
+                }
+            })
+        });
+    }
     group.finish();
 }
 

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -319,6 +319,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: true,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -78,6 +78,7 @@ struct InternalScanState {
     physical_stats_columns: HashSet<ColumnName>,
     #[serde(default)]
     is_catalog_managed: bool,
+    skip_row_transforms: bool,
 }
 
 /// Serializable processor state for distributed processing. This can be serialized using the
@@ -344,6 +345,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
+            skip_row_transforms,
         } = self.state_info.as_ref().clone();
 
         // Extract predicate from PhysicalPredicate
@@ -364,6 +366,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
+            skip_row_transforms,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
             .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
@@ -422,6 +425,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema: internal_state.physical_partition_schema,
             physical_stats_columns: internal_state.physical_stats_columns,
             is_catalog_managed: internal_state.is_catalog_managed,
+            skip_row_transforms: internal_state.skip_row_transforms,
         });
 
         Self::new_with_seen_files(
@@ -502,7 +506,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         // Partition pruning is handled by DataSkippingFilter in the columnar data skipping phase,
         // so we only need to parse values here for the transform.
         let partition_values = match &self.state_info.transform_spec {
-            Some(transform) if is_add => {
+            Some(transform) if is_add && !self.state_info.skip_row_transforms => {
                 let partition_values = getters[ScanLogReplayProcessor::ADD_PARTITION_VALUES_INDEX]
                     .get(row, "add.partitionValues")?;
                 parse_partition_values(
@@ -519,25 +523,27 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         if self.deduplicator.check_and_record_seen(file_key) || !is_add {
             return Ok(false);
         }
-        let base_row_id: Option<i64> =
-            getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
-        let patch_expr = self
-            .state_info
-            .transform_spec
-            .as_ref()
-            .map(|transform_spec| {
-                get_transform_expr(
-                    transform_spec,
-                    partition_values,
-                    &self.state_info.physical_schema,
-                    base_row_id,
-                )
-            })
-            .transpose()?;
-        if patch_expr.is_some() {
-            // fill in any needed `None`s for previous rows
-            self.row_transform_exprs.resize_with(row, Default::default);
-            self.row_transform_exprs.push(patch_expr);
+        if !self.state_info.skip_row_transforms {
+            let base_row_id: Option<i64> =
+                getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
+            let patch_expr = self
+                .state_info
+                .transform_spec
+                .as_ref()
+                .map(|transform_spec| {
+                    get_transform_expr(
+                        transform_spec,
+                        partition_values,
+                        &self.state_info.physical_schema,
+                        base_row_id,
+                    )
+                })
+                .transpose()?;
+            if patch_expr.is_some() {
+                // fill in any needed `None`s for previous rows
+                self.row_transform_exprs.resize_with(row, Default::default);
+                self.row_transform_exprs.push(patch_expr);
+            }
         }
         self.metrics.record_active_add_file(size);
         Ok(true)
@@ -1111,6 +1117,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         });
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
@@ -1442,6 +1449,7 @@ mod tests {
                 physical_partition_schema: None,
                 physical_stats_columns: HashSet::new(),
                 is_catalog_managed: false,
+                skip_row_transforms: false,
             });
             let checkpoint_info = test_checkpoint_info();
             let processor = ScanLogReplayProcessor::new(
@@ -1480,6 +1488,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1514,6 +1523,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: true,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1526,6 +1536,43 @@ mod tests {
         let deserialized =
             ScanLogReplayProcessor::from_serializable_state(&engine, serialized).unwrap();
         assert!(deserialized.is_catalog_managed());
+    }
+
+    #[test]
+    fn test_serialization_round_trips_skip_row_transforms() {
+        let engine = SyncEngine::new();
+        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
+            "id",
+            DataType::INTEGER,
+            true,
+        )]));
+        for skip in [false, true] {
+            let state_info = Arc::new(StateInfo {
+                logical_schema: schema.clone(),
+                physical_schema: schema.clone(),
+                physical_predicate: PhysicalPredicate::None,
+                transform_spec: None,
+                column_mapping_mode: ColumnMappingMode::None,
+                physical_stats_schema: None,
+                physical_partition_schema: None,
+                physical_stats_columns: HashSet::new(),
+                is_catalog_managed: false,
+                skip_row_transforms: skip,
+            });
+            let processor = ScanLogReplayProcessor::new(
+                &engine,
+                state_info,
+                test_checkpoint_info(),
+                ScanStatsOptions::default(),
+            )
+            .unwrap();
+            let deserialized = ScanLogReplayProcessor::from_serializable_state(
+                &engine,
+                processor.into_serializable_state().unwrap(),
+            )
+            .unwrap();
+            assert_eq!(deserialized.state_info.skip_row_transforms, skip);
+        }
     }
 
     #[test]
@@ -1563,6 +1610,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
         let predicate = Arc::new(crate::expressions::Predicate::column(["id"]));
         let invalid_blob = serde_json::to_vec(&invalid_internal_state).unwrap();
@@ -1597,6 +1645,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
         let blob = serde_json::to_string(&invalid_internal_state).unwrap();
         let mut obj: serde_json::Value = serde_json::from_str(&blob).unwrap();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1538,41 +1538,39 @@ mod tests {
         assert!(deserialized.is_catalog_managed());
     }
 
-    #[test]
-    fn test_serialization_round_trips_skip_row_transforms() {
+    #[rstest]
+    fn test_serialization_round_trips_skip_row_transforms(#[values(false, true)] skip: bool) {
         let engine = SyncEngine::new();
         let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
             "id",
             DataType::INTEGER,
             true,
         )]));
-        for skip in [false, true] {
-            let state_info = Arc::new(StateInfo {
-                logical_schema: schema.clone(),
-                physical_schema: schema.clone(),
-                physical_predicate: PhysicalPredicate::None,
-                transform_spec: None,
-                column_mapping_mode: ColumnMappingMode::None,
-                physical_stats_schema: None,
-                physical_partition_schema: None,
-                physical_stats_columns: HashSet::new(),
-                is_catalog_managed: false,
-                skip_row_transforms: skip,
-            });
-            let processor = ScanLogReplayProcessor::new(
-                &engine,
-                state_info,
-                test_checkpoint_info(),
-                ScanStatsOptions::default(),
-            )
-            .unwrap();
-            let deserialized = ScanLogReplayProcessor::from_serializable_state(
-                &engine,
-                processor.into_serializable_state().unwrap(),
-            )
-            .unwrap();
-            assert_eq!(deserialized.state_info.skip_row_transforms, skip);
-        }
+        let state_info = Arc::new(StateInfo {
+            logical_schema: schema.clone(),
+            physical_schema: schema.clone(),
+            physical_predicate: PhysicalPredicate::None,
+            transform_spec: None,
+            column_mapping_mode: ColumnMappingMode::None,
+            physical_stats_schema: None,
+            physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
+            is_catalog_managed: false,
+            skip_row_transforms: skip,
+        });
+        let processor = ScanLogReplayProcessor::new(
+            &engine,
+            state_info,
+            test_checkpoint_info(),
+            ScanStatsOptions::default(),
+        )
+        .unwrap();
+        let deserialized = ScanLogReplayProcessor::from_serializable_state(
+            &engine,
+            processor.into_serializable_state().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(deserialized.state_info.skip_row_transforms, skip);
     }
 
     #[test]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -194,6 +194,7 @@ pub struct ScanBuilder {
     predicate: Option<PredicateRef>,
     stats: StatsOptions,
     correlation_id: Option<Arc<str>>,
+    without_row_transforms: bool,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -203,6 +204,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("predicate", &self.predicate)
             .field("stats", &self.stats)
             .field("correlation_id", &self.correlation_id)
+            .field("without_row_transforms", &self.without_row_transforms)
             .finish()
     }
 }
@@ -216,6 +218,7 @@ impl ScanBuilder {
             predicate: None,
             stats: StatsOptions::default(),
             correlation_id: None,
+            without_row_transforms: false,
         }
     }
 
@@ -287,6 +290,22 @@ impl ScanBuilder {
         self
     }
 
+    /// Declare that the engine will reconstruct logical rows itself and will not consume
+    /// [`ScanMetadata::scan_file_transforms`].
+    ///
+    /// The kernel then skips building the per-file transform expressions and the per-row
+    /// partition-value parse done only to build them. The returned `scan_file_transforms` is left
+    /// empty (each row's transform is `None`); use [`Scan::scan_metadata`] for listing.
+    ///
+    /// With this set the engine must itself apply every physical-to-logical fixup the transform
+    /// would normally perform: partition column injection, column-mapping renames, and generated
+    /// row ids. Deletion vectors are unaffected: they are delivered per file in the scan metadata
+    /// regardless. [`Scan::execute`] returns an error.
+    pub fn without_row_transforms(mut self) -> Self {
+        self.without_row_transforms = true;
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -317,7 +336,7 @@ impl ScanBuilder {
             .table_configuration()
             .ensure_operation_supported(Operation::Scan)?;
 
-        let state_info = StateInfo::try_new(
+        let mut state_info = StateInfo::try_new(
             logical_read_schema,
             table_schema,
             self.snapshot.table_configuration(),
@@ -325,6 +344,10 @@ impl ScanBuilder {
             &self.stats,
             (), // No classifier, default is for scans
         )?;
+
+        // Retain the transform spec but skip building per-file expressions, which also skips the
+        // per-row partition-value parse done only to build them.
+        state_info.skip_row_transforms = self.without_row_transforms;
 
         Ok(Scan {
             snapshot: self.snapshot,
@@ -1053,12 +1076,23 @@ impl Scan {
     /// the data for the query. Each [`EngineData`] in the resultant iterator is a portion of the
     /// final table data. Generally connectors/engines will want to use [`Scan::scan_metadata`] so
     /// they can have more control over the execution of the scan.
+    ///
+    /// Returns an error if the scan was built with [`ScanBuilder::without_row_transforms`]; use
+    /// [`Scan::scan_metadata`] instead.
     // This calls [`Scan::scan_metadata`] to get an iterator of `ScanMetadata` actions for the scan,
     // and then uses the `engine`'s [`crate::ParquetHandler`] to read the actual table data.
     pub fn execute(
         &self,
         engine: Arc<dyn Engine>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<Box<dyn EngineData>>>> {
+        if self.state_info.skip_row_transforms {
+            return Err(Error::unsupported(
+                "Scan::execute is not supported when the scan was built with \
+                 without_row_transforms; use scan_metadata for listing and read data with your \
+                 own reader",
+            ));
+        }
+
         fn scan_metadata_callback(batches: &mut Vec<state::ScanFile>, file: state::ScanFile) {
             batches.push(file);
         }

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -47,6 +47,12 @@ pub(crate) struct StateInfo {
     /// Whether the table is catalog-managed, used to label scan metric events. Converted to a
     /// [`TableType`](crate::metrics::TableType) at event construction.
     pub(crate) is_catalog_managed: bool,
+    /// When set, log replay does not build per-file transform expressions:
+    /// `parse_partition_values` and `get_transform_expr` are skipped and every
+    /// `ScanMetadata::scan_file_transforms` entry is left `None`. `transform_spec` is retained
+    /// so the scan can still describe the transform structurally. Set by
+    /// [`ScanBuilder::without_row_transforms`](crate::scan::ScanBuilder::without_row_transforms).
+    pub(crate) skip_row_transforms: bool,
 }
 
 /// Validating the metadata columns also extracts information needed to properly construct the full
@@ -425,6 +431,7 @@ impl StateInfo {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed: table_configuration.is_catalog_managed(),
+            skip_row_transforms: false,
         })
     }
 

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -168,6 +168,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         physical_partition_schema: None,
         physical_stats_columns: HashSet::new(),
         is_catalog_managed: false,
+        skip_row_transforms: false,
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
     let (iter, _metrics) = scan_action_iter(

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -410,6 +410,144 @@ fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     );
 }
 
+/// Loads `table`'s v0 snapshot with a [`SyncEngine`], for the `without_row_transforms` tests.
+fn without_transforms_snapshot(table: &str) -> (Arc<SyncEngine>, Arc<Snapshot>) {
+    let path = std::fs::canonicalize(PathBuf::from(table)).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = Arc::new(SyncEngine::new());
+    let snapshot = Snapshot::builder_for(url)
+        .at_version(0)
+        .build(engine.as_ref())
+        .unwrap();
+    (engine, snapshot)
+}
+
+/// A partitioned table and a column-mapped table both build a transform spec.
+/// `without_row_transforms` retains the spec but sets `skip_row_transforms`, so log replay
+/// builds no per-file expressions while the structural transform stays describable.
+#[rstest]
+#[case::partitioned("./tests/data/basic_partitioned/")]
+#[case::column_mapping("./tests/data/partition_cm/name/")]
+fn test_without_row_transforms_retains_spec_and_sets_skip(#[case] table: &str) {
+    let (_engine, snapshot) = without_transforms_snapshot(table);
+
+    let scan = snapshot.clone().scan_builder().build().unwrap();
+    assert!(scan.state_info.transform_spec.is_some());
+    assert!(!scan.state_info.skip_row_transforms);
+
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+    assert!(scan.state_info.transform_spec.is_some());
+    assert!(scan.state_info.skip_row_transforms);
+}
+
+/// `scan_metadata` still lists files, and every emitted per-file transform is `None`.
+#[test]
+fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
+    let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    let mut saw_file = false;
+    for metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let metadata = metadata.unwrap();
+        assert!(
+            metadata.scan_file_transforms.iter().all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        saw_file = true;
+    }
+    assert!(
+        saw_file,
+        "scan_metadata should still list files under without_row_transforms"
+    );
+}
+
+#[test]
+fn test_without_row_transforms_rejects_execute() {
+    let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+    let err = scan
+        .execute(engine)
+        .err()
+        .expect("execute must error when row transforms are skipped");
+    assert!(
+        err.to_string().contains("without_row_transforms"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Row commit version metadata columns are unsupported by scans, so requesting one errors at
+/// build time regardless of `without_row_transforms`.
+#[rstest]
+fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_transforms: bool) {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let schema = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("rcv", MetadataColumnSpec::RowCommitVersion)
+            .unwrap(),
+    );
+    let mut builder = snapshot.scan_builder().with_schema(schema);
+    if without_row_transforms {
+        builder = builder.without_row_transforms();
+    }
+    let err = builder
+        .build()
+        .expect_err("row commit version columns are unsupported by scans");
+    assert!(
+        err.to_string()
+            .contains("Row commit versions not supported"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Deletion vectors flow through scan metadata independently of the row transform, so they are
+/// still surfaced under `without_row_transforms` while every per-file transform is `None`.
+#[test]
+fn test_without_row_transforms_scan_metadata_surfaces_deletion_vectors() {
+    // The deletion vector is added at the latest version, so load the full table (not v0).
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    fn dv_callback(seen: &mut bool, scan_file: ScanFile) {
+        *seen |= scan_file.dv_info.deletion_vector.is_some();
+    }
+    let mut saw_dv = false;
+    for res in scan.scan_metadata(&engine).unwrap() {
+        let scan_metadata = res.unwrap();
+        assert!(
+            scan_metadata
+                .scan_file_transforms
+                .iter()
+                .all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        saw_dv = scan_metadata.visit_scan_files(saw_dv, dv_callback).unwrap();
+    }
+    assert!(
+        saw_dv,
+        "deletion vector info should still be surfaced under without_row_transforms"
+    );
+}
+
 fn get_files_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<String>> {
     let scan_metadata_iter = scan.scan_metadata(engine)?;
     fn scan_metadata_callback(paths: &mut Vec<String>, scan_file: ScanFile) {

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use ::test_utils::get_column;
+use ::test_utils::{get_column, load_test_data};
 use bytes::Bytes;
 use rstest::rstest;
 
@@ -444,9 +444,11 @@ fn test_without_row_transforms_retains_spec_and_sets_skip(#[case] table: &str) {
     assert!(scan.state_info.skip_row_transforms);
 }
 
-/// `scan_metadata` still lists files, and every emitted per-file transform is `None`.
+/// Under `without_row_transforms`, `scan_metadata` still lists files and surfaces the partition
+/// values a connector needs to reconstruct rows itself, while every per-file transform is `None`.
+/// Deletion vectors are covered by the sibling test.
 #[test]
-fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
+fn test_without_row_transforms_scan_metadata_lists_files_with_partition_values() {
     let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
     let scan = snapshot
         .scan_builder()
@@ -454,8 +456,51 @@ fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
         .build()
         .unwrap();
 
-    let mut saw_file = false;
+    // (saw a file, saw non-empty partition values)
+    fn collect(acc: &mut (bool, bool), scan_file: ScanFile) {
+        acc.0 = true;
+        acc.1 |= !scan_file.partition_values.is_empty();
+    }
+    let mut acc = (false, false);
     for metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let metadata = metadata.unwrap();
+        assert!(
+            metadata.scan_file_transforms.iter().all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        acc = metadata.visit_scan_files(acc, collect).unwrap();
+    }
+    let (saw_file, saw_partition_values) = acc;
+    assert!(
+        saw_file,
+        "scan_metadata should still list files under without_row_transforms"
+    );
+    assert!(
+        saw_partition_values,
+        "partition values must still be surfaced so the connector can inject them itself"
+    );
+}
+
+/// Column mapping also builds a per-file transform (the physical-to-logical rename). Under
+/// `without_row_transforms`, `scan_metadata` still lists a column-mapped table's files with every
+/// per-file transform `None`, leaving the rename to the connector.
+#[test]
+fn test_without_row_transforms_scan_metadata_lists_files_column_mapping() {
+    let table = "table-with-columnmapping-mode-name";
+    let tempdir = load_test_data("tests/golden_data", table).unwrap();
+    // Golden tables extract to `<name>/delta/` (with a sibling `expected/`).
+    let table_path = tempdir.path().join(table).join("delta");
+    let url = url::Url::from_directory_path(table_path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    let mut saw_file = false;
+    for metadata in scan.scan_metadata(&engine).unwrap() {
         let metadata = metadata.unwrap();
         assert!(
             metadata.scan_file_transforms.iter().all(Option::is_none),
@@ -465,7 +510,7 @@ fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
     }
     assert!(
         saw_file,
-        "scan_metadata should still list files under without_row_transforms"
+        "scan_metadata should list the column-mapped table's files under without_row_transforms"
     );
 }
 

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -190,6 +190,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         }
     }
 
@@ -413,6 +414,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
 
         let result = get_cdf_transform_expr(&scan_file, &state_info, &physical_schema);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2756/files) to review incremental changes.
- [**stack/without-row-transforms**](https://github.com/delta-io/delta-kernel-rs/pull/2756) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2756/files)] ← _this PR_
  - [stack/scan-transform-load](https://github.com/delta-io/delta-kernel-rs/pull/2821) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2821/files/ed7b687231886835f9e926a12119da75af4ceb1e..8a262151eec8516fcd089787982017c4368869c1)]

---------
## What changes are proposed in this pull request?

Adds `ScanBuilder::without_row_transforms()` for connectors that reconstruct logical rows themselves (a configured scan node rather than an expression evaluator) and so never consume `ScanMetadata::scan_file_transforms`.

When set, log replay skips building the per-file transform expressions and the per-row partition-value parse done only to feed them, leaving every `scan_file_transforms` entry `None`. The `transform_spec` is retained so the scan still knows its structure. `Scan::execute()` errors under the opt-out; use `scan_metadata()` for listing. Deletion vectors are unaffected, delivered per file in the scan metadata regardless. The flag lives on `StateInfo` and is serialized so the distributed log-replay path honors it.

Skipping the transform loses no information, because a connector can already assemble everything it does from the public scan APIs:

- the logical output schema (`Scan::logical_schema()`) gives the target columns and their order;
- the physical read schema (`Scan::physical_schema()`) gives the columns read from the data file, carrying their physical names and Parquet field ids under column mapping;
- the logical columns absent from the physical schema are the injected ones (partition columns);
- each scan-file row from `scan_metadata()` carries that file's partition values (keyed by physical name), base row id, and deletion vector (see `scan_row_schema()`).

From these a connector injects partition constants, computes row ids as `base_row_id + row_index`, applies column-mapping renames, and applies deletion vectors itself, so the kernel's per-file expression is redundant for it. A follow-up stacked PR serves the same structure from the kernel as a descriptor so connectors don't re-derive it.

## Benchmark

`cargo bench --bench metadata_bench -- scan_metadata` on `300k-add-files-100-col-partitioned` (300k Add files, 100 columns, partitioned), default path vs. the opt-out:

| case | `scan_metadata` (median) |
|---|---|
| default (builds per-file transforms) | 753 ms |
| `without_row_transforms()` | 459 ms |

~39% faster (~1.64x): the opt-out skips the per-file `parse_partition_values` + `get_transform_expr` build. The win scales with the transform cost (partitioning / column mapping / row tracking); plain tables have no transform to skip and are unaffected.

## How was this change tested?

`cargo test -p delta_kernel`: the opt-out retains the spec while setting the skip flag (partitioned and column-mapped tables), `scan_metadata` lists files with every per-file transform `None`, `execute()` errors, deletion vectors still surface, row-commit-version columns still error at build, and the skip flag round-trips through the distributed serde state. Benchmark coverage added to `metadata_bench`.