### PR TITLE
feat(kernel): untyped min/max stat accessors for data skipping

### DIFF
--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -780,6 +780,20 @@ pub trait DataSkippingPredicateEvaluator {
     /// Retrieves the maximum value of a column, if it exists and has the requested type.
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Self::ColumnStat>;
 
+    /// Retrieves the minimum value of a column without a caller-supplied type, resolving min/max
+    /// eligibility from the evaluator's own stats schema. Prefer [`Self::get_min_stat`] when the
+    /// column type is known; this is for type-erased callers like the FFI opaque rewrite.
+    ///
+    /// Defaults to `None` (abstain); evaluators that know their stats schema override it.
+    fn get_min_stat_schema_typed(&self, _col: &ColumnName) -> Option<Self::ColumnStat> {
+        None
+    }
+
+    /// Like [`Self::get_min_stat_schema_typed`], for the maximum value.
+    fn get_max_stat_schema_typed(&self, _col: &ColumnName) -> Option<Self::ColumnStat> {
+        None
+    }
+
     /// Retrieves the null count of a column, if it exists.
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Self::ColumnStat>;
 

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -73,7 +73,12 @@ fn as_sql_data_skipping_predicate(
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
-    as_sql_data_skipping_predicate_with_stats_columns(pred, partition_columns, &stats_columns)
+    as_sql_data_skipping_predicate_with_stats_columns(
+        pred,
+        partition_columns,
+        &stats_columns,
+        HashSet::new(),
+    )
 }
 
 /// Like [`as_sql_data_skipping_predicate`] but only rewrites references to columns in
@@ -83,8 +88,27 @@ pub(crate) fn as_sql_data_skipping_predicate_with_stats_columns(
     pred: &Pred,
     partition_columns: &HashSet<String>,
     stats_columns: &HashSet<ColumnName>,
+    min_max_columns: HashSet<ColumnName>,
 ) -> Option<Pred> {
-    DataSkippingPredicateCreator::new(partition_columns, stats_columns).eval_sql_where(pred)
+    DataSkippingPredicateCreator::with_min_max_columns(
+        partition_columns,
+        stats_columns,
+        min_max_columns,
+    )
+    .eval_sql_where(pred)
+}
+
+/// Physical leaf paths that carry `minValues` (equivalently `maxValues`) in `stats_schema` -- the
+/// min/max-eligible columns, whose min/max references the unified schema can resolve.
+fn min_max_eligible_columns(stats_schema: &SchemaRef) -> HashSet<ColumnName> {
+    let Some(DataType::Struct(min_values)) =
+        stats_schema.field(MIN_VALUES).map(StructField::data_type)
+    else {
+        return HashSet::new();
+    };
+    let leaves = min_values.leaves(None);
+    let (names, _types) = leaves.as_ref();
+    names.iter().cloned().collect()
 }
 
 #[internal_api]
@@ -194,6 +218,9 @@ impl DataSkippingFilter {
                     &predicate,
                     &partition_columns,
                     stats_columns,
+                    stats_schema
+                        .map(min_max_eligible_columns)
+                        .unwrap_or_default(),
                 )?),
             )
             .inspect_err(|e| error!("Failed to create skipping evaluator: {e}"))
@@ -451,13 +478,28 @@ struct DataSkippingPredicateCreator<'a> {
     /// Must match the column set used to build `physical_stats_schema`; otherwise the
     /// rewritten predicate references columns absent from the unified schema.
     stats_columns: &'a HashSet<ColumnName>,
+    /// Physical leaf paths that carry min/max in the stats schema -- a subset of `stats_columns`
+    /// (see [`min_max_eligible_columns`]). Lets the schema-typed accessors emit min/max references
+    /// without a caller-supplied type; empty when no stats schema is supplied (the schema-typed
+    /// accessors then abstain).
+    min_max_columns: HashSet<ColumnName>,
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
+    #[cfg(test)]
     fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
+        Self::with_min_max_columns(partition_columns, stats_columns, HashSet::new())
+    }
+
+    fn with_min_max_columns(
+        partition_columns: &'a HashSet<String>,
+        stats_columns: &'a HashSet<ColumnName>,
+        min_max_columns: HashSet<ColumnName>,
+    ) -> Self {
         Self {
             partition_columns,
             stats_columns,
+            min_max_columns,
         }
     }
 
@@ -511,6 +553,34 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             Some(Expr::from(
                 ColumnName::new(["stats_parsed", MAX_VALUES]).join(col),
             ))
+        }
+    }
+
+    /// Minimum value of a column without a caller-supplied type. Partition columns return the
+    /// exact partition value; data columns return the `minValues` reference only when the column
+    /// actually carries min/max in the stats schema (`min_max_columns`); otherwise `None`.
+    fn get_min_stat_schema_typed(&self, col: &ColumnName) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            Some(joined_column_expr!("partitionValues_parsed", col))
+        } else if self.min_max_columns.contains(col) {
+            Some(Expr::from(
+                ColumnName::new(["stats_parsed", MIN_VALUES]).join(col),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Like [`Self::get_min_stat_schema_typed`], for the maximum value.
+    fn get_max_stat_schema_typed(&self, col: &ColumnName) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            Some(joined_column_expr!("partitionValues_parsed", col))
+        } else if self.min_max_columns.contains(col) {
+            Some(Expr::from(
+                ColumnName::new(["stats_parsed", MAX_VALUES]).join(col),
+            ))
+        } else {
+            None
         }
     }
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -366,10 +366,7 @@ fn test_sql_where() {
 fn test_timestamp_stats_enabled() {
     let empty = HashSet::new();
     let stats_columns: HashSet<ColumnName> = [column_name!("timestamp_col")].into_iter().collect();
-    let creator = DataSkippingPredicateCreator {
-        partition_columns: &empty,
-        stats_columns: &stats_columns,
-    };
+    let creator = DataSkippingPredicateCreator::new(&empty, &stats_columns);
     let col = &column_name!("timestamp_col");
 
     assert!(
@@ -392,6 +389,79 @@ fn test_timestamp_stats_enabled() {
             .is_some(),
         "get_max_stat should return Some for timestamp_ntz maxValues"
     );
+}
+
+#[test]
+fn schema_typed_stat_accessors_resolve_by_eligibility() {
+    let partition_columns: HashSet<String> = ["part"].into_iter().map(String::from).collect();
+    let stats_columns: HashSet<ColumnName> = [column_name!("a"), column_name!("nullcount_only")]
+        .into_iter()
+        .collect();
+    // Only `a` carries min/max in the stats schema; `nullcount_only` is statted but ineligible.
+    let min_max_columns: HashSet<ColumnName> = [column_name!("a")].into_iter().collect();
+    let creator = DataSkippingPredicateCreator::with_min_max_columns(
+        &partition_columns,
+        &stats_columns,
+        min_max_columns,
+    );
+
+    // Eligible data column -> stats_parsed.{min,max}Values ref, no caller-supplied type.
+    assert_eq!(
+        creator.get_min_stat_schema_typed(&column_name!("a")),
+        Some(Expr::from(ColumnName::new([
+            "stats_parsed",
+            "minValues",
+            "a"
+        ])))
+    );
+    assert_eq!(
+        creator.get_max_stat_schema_typed(&column_name!("a")),
+        Some(Expr::from(ColumnName::new([
+            "stats_parsed",
+            "maxValues",
+            "a"
+        ])))
+    );
+
+    // Partition column -> exact partition value (type is irrelevant for partitions).
+    assert_eq!(
+        creator.get_min_stat_schema_typed(&column_name!("part")),
+        Some(Expr::from(ColumnName::new([
+            "partitionValues_parsed",
+            "part"
+        ])))
+    );
+
+    // Statted but min/max-ineligible, and unknown columns -> None (engine gets null bounds).
+    assert!(creator
+        .get_min_stat_schema_typed(&column_name!("nullcount_only"))
+        .is_none());
+    assert!(creator
+        .get_max_stat_schema_typed(&column_name!("unknown"))
+        .is_none());
+}
+
+#[test]
+fn min_max_eligible_columns_reads_minvalues_leaves() {
+    let min_values = StructType::new_unchecked([
+        StructField::nullable("a", DataType::INTEGER),
+        StructField::nullable("b", DataType::INTEGER),
+    ]);
+    let stats_schema: SchemaRef = Arc::new(StructType::new_unchecked([
+        StructField::nullable(MIN_VALUES, min_values),
+        StructField::nullable(NUM_RECORDS, DataType::LONG),
+    ]));
+    let cols = min_max_eligible_columns(&stats_schema);
+    assert_eq!(cols.len(), 2);
+    assert!(cols.contains(&column_name!("a")));
+    assert!(cols.contains(&column_name!("b")));
+
+    // A stats schema with no minValues (e.g. partition-only) yields an empty set.
+    let no_min: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+        NUM_RECORDS,
+        DataType::LONG,
+    )]));
+    assert!(min_max_eligible_columns(&no_min).is_empty());
 }
 
 #[test]
@@ -1453,9 +1523,13 @@ fn stats_columns_gate_rewrite(
     #[case] stats: HashSet<ColumnName>,
     #[case] expected: &str,
 ) {
-    let result =
-        as_sql_data_skipping_predicate_with_stats_columns(&pred, &partition_columns, &stats)
-            .expect("SQL-WHERE rewrite always returns Some for these cases");
+    let result = as_sql_data_skipping_predicate_with_stats_columns(
+        &pred,
+        &partition_columns,
+        &stats,
+        HashSet::new(),
+    )
+    .expect("SQL-WHERE rewrite always returns Some for these cases");
     assert_eq!(result.to_string(), expected);
 }
 
@@ -1469,9 +1543,13 @@ fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
     );
     let stats = stats_cols(&["stat"]);
-    let result =
-        as_sql_data_skipping_predicate_with_stats_columns(&pred, &Default::default(), &stats)
-            .unwrap();
+    let result = as_sql_data_skipping_predicate_with_stats_columns(
+        &pred,
+        &Default::default(),
+        &stats,
+        HashSet::new(),
+    )
+    .unwrap();
     let resolver = HashMap::from_iter([(
         column_name!("stats_parsed.maxValues.stat"),
         Scalar::from(50i32),


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2759/files) to review incremental changes.
- [**stack/chiin/untyped-skipping-stats**](https://github.com/delta-io/delta-kernel-rs/pull/2759) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2759/files)]
  - [stack/chiin/ffi-opaque-callback-eval](https://github.com/delta-io/delta-kernel-rs/pull/2627) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2627/files/06866186e9f20fd7c8ab0c0a5730096411f406db..f03461807e0d6f64fec9c3c969644f223157f5f0)]

---------
## What changes are proposed in this pull request?

Adds untyped min/max stat accessors to `DataSkippingPredicateEvaluator`: `get_min_stat_schema_typed` and `get_max_stat_schema_typed` (default `None`). They resolve min/max eligibility from the evaluator's stats schema instead of a caller-supplied type (induced from the literal type).

`DataSkippingPredicateCreator` gains a `min_max_columns` by getting the`minValues` leaves of the stats schema, via `min_max_eligible_columns`

This lets a caller emit `minValues`/`maxValues` references the unified stats schema can resolve, instead of guessing a type from a neighboring literal. The accessors default to `None`, so evaluators that don't carry a stats schema (parquet row-group skipping, etc.) are unaffected.

Base of the stack -- #2627 is the first consumer of these accessors.

## How was this change tested?

New unit tests in `kernel/src/scan/data_skipping/tests.rs`: `untyped_stat_accessors_resolve_by_eligibility` (partition / eligible / ineligible / unknown columns) and `min_max_eligible_columns_reads_minvalues_leaves`. Existing data-skipping tests continue to pass.