### PR TITLE
fix: timestamp offset fix

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2234,6 +2234,37 @@ mod tests {
     }
 
     #[test]
+    fn test_map_to_struct_timestamp_offset_normalized_to_utc() {
+        use crate::arrow::array::TimestampMicrosecondArray;
+
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("ts");
+        builder.values().append_value("2024-06-15T14:30:00+05:00");
+        builder.append(true).unwrap();
+
+        let map_array = builder.finish();
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "pv",
+            map_array.data_type().clone(),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
+
+        let output_schema =
+            StructType::new_unchecked(vec![StructField::nullable("ts", DataType::TIMESTAMP)]);
+        let result_type = DataType::from(output_schema);
+        let expr = Expr::map_to_struct(column_expr!("pv"));
+        let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
+        let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let ts = structs
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(ts.value(0), 1718443800000000); // 2024-06-15T09:30:00Z
+    }
+
+    #[test]
     fn test_map_to_struct_duplicate_keys() {
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("x");

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1032,7 +1032,7 @@ mod tests {
     use super::*;
     use crate::arrow::array::{
         ArrayRef, BooleanArray, Int32Array, Int64Array, LargeStringArray, MapBuilder, StringArray,
-        StringBuilder, StructArray,
+        StringBuilder, StructArray, TimestampMicrosecondArray,
     };
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
@@ -2235,8 +2235,6 @@ mod tests {
 
     #[test]
     fn test_map_to_struct_timestamp_offset_normalized_to_utc() {
-        use crate::arrow::array::TimestampMicrosecondArray;
-
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("ts");
         builder.values().append_value("2024-06-15T14:30:00+05:00");

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -709,11 +709,11 @@ impl PrimitiveType {
     /// protocol's [partition value serialization] rules. An empty string parses as
     /// [`Scalar::Null`].
     ///
-    /// Timestamp and TimestampNtz accept the space-separated form
-    /// `{year}-{month}-{day} {hour}:{minute}:{second}[.{fraction}]`. Timestamp (only) also
-    /// accepts ISO 8601 / RFC 3339 strings such as `1970-01-01T00:00:00.123456Z`; an explicit
-    /// offset is honored and the value is normalized to UTC. Spec-conformant writers emit only
-    /// the `Z` form, so accepting other offsets is reader leniency.
+    /// Timestamp and TimestampNtz accept the space-separated form `{year}-{month}-{day}
+    /// {hour}:{minute}:{second}[.{fraction}]`. Timestamp (only) also accepts ISO 8601 / RFC 3339
+    /// strings such as `1970-01-01T00:00:00.123456Z`; an explicit offset is honored and the value
+    /// is normalized to UTC. The spec stores timestamp partition values either without a zone
+    /// (interpreted in the writer's local time zone) or adjusted to UTC with a `Z` suffix.
     ///
     /// # Errors
     ///

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -1092,7 +1092,6 @@ mod tests {
         );
     }
 
-    // space-separated form (protocol partition-value format), accepted by both timestamp types
     #[rstest]
     #[case::seconds("2011-01-11 13:06:07", 1294751167000000)]
     #[case::fractional_seconds("2011-01-11 13:06:07.123456", 1294751167123456)]
@@ -1110,8 +1109,6 @@ mod tests {
         assert_eq!(p_type.parse_scalar(raw).unwrap(), expected);
     }
 
-    // ISO 8601 / RFC 3339 form, accepted by Timestamp only; offsets are honored and the
-    // value normalized to UTC
     #[rstest]
     #[case::z_fractional("1971-07-22T03:06:40.678910Z", 49000000678910)]
     #[case::z_seconds("1971-07-22T03:06:40Z", 49000000000000)]

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -705,6 +705,21 @@ impl PrimitiveType {
         DataType::Primitive(self.clone())
     }
 
+    /// Parses a serialized string into a [`Scalar`] of this primitive type, per the Delta
+    /// protocol's [partition value serialization] rules. An empty string parses as
+    /// [`Scalar::Null`].
+    ///
+    /// Timestamp and TimestampNtz accept the space-separated form
+    /// `{year}-{month}-{day} {hour}:{minute}:{second}[.{fraction}]`. Timestamp (only) also
+    /// accepts ISO 8601 / RFC 3339 strings such as `1970-01-01T00:00:00.123456Z`; an explicit
+    /// offset is honored and the value is normalized to UTC. Spec-conformant writers emit only
+    /// the `Z` form, so accepting other offsets is reader leniency.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ParseError`] if `raw` is not a valid encoding of this type.
+    ///
+    /// [partition value serialization]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
     pub fn parse_scalar(&self, raw: &str) -> Result<Scalar, Error> {
         use PrimitiveType::*;
 
@@ -741,20 +756,18 @@ impl PrimitiveType {
                 let days = date.signed_duration_since(DateTime::UNIX_EPOCH).num_days() as i32;
                 Ok(Scalar::Date(days))
             }
-            // NOTE: Timestamp and TimestampNtz are both parsed into microsecond since unix epoch.
-            // They may both have the format `{year}-{month}-{day} {hour}:{minute}:{second}`.
-            // Timestamps may additionally be encoded as a ISO 8601 formatted string such as
-            // `1970-01-01T00:00:00.123456Z`.
-            //
-            // The difference arises mostly in how they are to be handled on the engine side - i.e.
-            // timestampNTZ is not adjusted to UTC, this is just so we can
-            // (de-)serialize it as a date sting. https://github.com/delta-io/delta/blob/master/PROTOCOL.md#partition-value-serialization
+            // NOTE: Timestamp and TimestampNtz are both parsed into microseconds since unix
+            // epoch. The difference arises mostly in how they are to be handled on the engine
+            // side - i.e. timestampNTZ is not adjusted to UTC, this is just so we can
+            // (de-)serialize it as a date string.
             TimestampNtz | Timestamp => {
                 let mut timestamp = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f");
 
                 if timestamp.is_err() && *self == Timestamp {
-                    // Note: `%+` specifies the ISO 8601 / RFC 3339 format
-                    timestamp = NaiveDateTime::parse_from_str(raw, "%+");
+                    // `%+` is chrono's relaxed ISO 8601 / RFC 3339 parser: unlike the stricter
+                    // DateTime::parse_from_rfc3339, it also accepts a space or lowercase `t`
+                    // separator and colon-less offsets (e.g. `+0530`).
+                    timestamp = DateTime::parse_from_str(raw, "%+").map(|dt| dt.naive_utc());
                 }
                 let timestamp = timestamp.map_err(|_| self.parse_error(raw))?;
                 let timestamp = Utc.from_utc_datetime(&timestamp);
@@ -835,6 +848,8 @@ impl PrimitiveType {
 #[cfg(test)]
 mod tests {
     use std::f32::consts::PI;
+
+    use rstest::rstest;
 
     use super::*;
     use crate::expressions::{column_expr, BinaryPredicateOp};
@@ -1077,48 +1092,61 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_timestamp_parse() {
-        let assert_timestamp_eq = |scalar_string, micros| {
-            let scalar = PrimitiveType::Timestamp
-                .parse_scalar(scalar_string)
-                .unwrap();
-            assert_eq!(scalar, Scalar::Timestamp(micros));
+    // space-separated form (protocol partition-value format), accepted by both timestamp types
+    #[rstest]
+    #[case::seconds("2011-01-11 13:06:07", 1294751167000000)]
+    #[case::fractional_seconds("2011-01-11 13:06:07.123456", 1294751167123456)]
+    #[case::epoch("1970-01-01 00:00:00", 0)]
+    fn test_timestamp_space_form_parse(
+        #[values(PrimitiveType::Timestamp, PrimitiveType::TimestampNtz)] p_type: PrimitiveType,
+        #[case] raw: &str,
+        #[case] micros: i64,
+    ) {
+        let expected = match p_type {
+            PrimitiveType::Timestamp => Scalar::Timestamp(micros),
+            PrimitiveType::TimestampNtz => Scalar::TimestampNtz(micros),
+            _ => unreachable!(),
         };
-        assert_timestamp_eq("1971-07-22T03:06:40.678910Z", 49000000678910);
-        assert_timestamp_eq("1971-07-22T03:06:40Z", 49000000000000);
-        assert_timestamp_eq("2011-01-11 13:06:07", 1294751167000000);
-        assert_timestamp_eq("2011-01-11 13:06:07.123456", 1294751167123456);
-        assert_timestamp_eq("1970-01-01 00:00:00", 0);
+        assert_eq!(p_type.parse_scalar(raw).unwrap(), expected);
     }
 
-    #[test]
-    fn test_timestamp_ntz_parse() {
-        let assert_timestamp_eq = |scalar_string, micros| {
-            let scalar = PrimitiveType::TimestampNtz
-                .parse_scalar(scalar_string)
-                .unwrap();
-            assert_eq!(scalar, Scalar::TimestampNtz(micros));
-        };
-        assert_timestamp_eq("2011-01-11 13:06:07", 1294751167000000);
-        assert_timestamp_eq("2011-01-11 13:06:07.123456", 1294751167123456);
-        assert_timestamp_eq("1970-01-01 00:00:00", 0);
+    // ISO 8601 / RFC 3339 form, accepted by Timestamp only; offsets are honored and the
+    // value normalized to UTC
+    #[rstest]
+    #[case::z_fractional("1971-07-22T03:06:40.678910Z", 49000000678910)]
+    #[case::z_seconds("1971-07-22T03:06:40Z", 49000000000000)]
+    #[case::z("2024-06-15T14:30:00Z", 1718461800000000)]
+    #[case::lowercase_t_z("2024-06-15t14:30:00z", 1718461800000000)]
+    #[case::zero_offset("2024-06-15T14:30:00+00:00", 1718461800000000)]
+    #[case::negative_zero_offset("2024-06-15T14:30:00-00:00", 1718461800000000)]
+    #[case::positive_offset("2024-06-15T14:30:00+05:00", 1718443800000000)] // 09:30:00Z
+    #[case::negative_offset("2024-06-15T14:30:00-05:00", 1718479800000000)] // 19:30:00Z
+    #[case::half_hour_offset("2024-06-15T14:30:00+05:30", 1718442000000000)] // 09:00:00Z
+    #[case::colonless_offset("2024-06-15T14:30:00+0530", 1718442000000000)] // 09:00:00Z
+    #[case::fractional_with_offset("2024-06-15T14:30:00.456+05:00", 1718443800456000)]
+    #[case::space_separator_with_offset("2024-06-15 14:30:00+05:00", 1718443800000000)]
+    #[case::pre_epoch_after_normalization("1970-01-01T00:00:00+05:00", -18000000000)]
+    fn test_timestamp_iso8601_parse(#[case] raw: &str, #[case] micros: i64) {
+        let scalar = PrimitiveType::Timestamp.parse_scalar(raw).unwrap();
+        assert_eq!(scalar, Scalar::Timestamp(micros));
     }
 
-    #[test]
-    fn test_timestamp_parse_fails() {
-        let assert_timestamp_fails = |p_type: &PrimitiveType, scalar_string| {
-            let res = p_type.parse_scalar(scalar_string);
-            assert!(res.is_err());
-        };
-
-        let p_type = PrimitiveType::TimestampNtz;
-        assert_timestamp_fails(&p_type, "1971-07-22T03:06:40.678910Z");
-        assert_timestamp_fails(&p_type, "1971-07-22T03:06:40Z");
-        assert_timestamp_fails(&p_type, "1971-07-22");
-
-        let p_type = PrimitiveType::Timestamp;
-        assert_timestamp_fails(&p_type, "1971-07-22");
+    #[rstest]
+    // TimestampNtz has no ISO 8601 fallback: rejects Z, offsets, and date-only
+    #[case::ntz_z_fractional(PrimitiveType::TimestampNtz, "1971-07-22T03:06:40.678910Z")]
+    #[case::ntz_z(PrimitiveType::TimestampNtz, "1971-07-22T03:06:40Z")]
+    #[case::ntz_offset(PrimitiveType::TimestampNtz, "2024-06-15T14:30:00+05:00")]
+    #[case::ntz_space_offset(PrimitiveType::TimestampNtz, "2024-06-15 14:30:00+05:00")]
+    #[case::ntz_date_only(PrimitiveType::TimestampNtz, "1971-07-22")]
+    // Timestamp rejects date-only and the T-form without a trailing Z or offset
+    #[case::date_only(PrimitiveType::Timestamp, "1971-07-22")]
+    #[case::zoneless_t_form(PrimitiveType::Timestamp, "2024-06-15T14:30:00")]
+    // out-of-range offsets and UTC normalizations that overflow chrono's datetime range
+    // error cleanly rather than being misinterpreted
+    #[case::offset_out_of_range(PrimitiveType::Timestamp, "2024-06-15T14:30:00+24:00")]
+    #[case::normalization_overflow(PrimitiveType::Timestamp, "-262143-01-01T00:00:00+05:00")]
+    fn test_timestamp_parse_fails(#[case] p_type: PrimitiveType, #[case] raw: &str) {
+        assert!(p_type.parse_scalar(raw).is_err());
     }
 
     #[test]

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -576,6 +576,12 @@ fn test_get_partition_value() {
             PrimitiveType::Timestamp,
             Scalar::Timestamp(123456),
         ),
+        (
+            // RFC 3339 with a non-UTC offset: normalized to UTC (1969-12-31T19:00:00Z)
+            "1970-01-01T00:00:00+05:00",
+            PrimitiveType::Timestamp,
+            Scalar::Timestamp(-18000000000),
+        ),
     ];
 
     for (raw, data_type, expected) in &cases {

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -570,10 +570,9 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
 
 // === RFC 3339 offset partition values (#2733) ===
 //
-// A foreign writer can emit a timestamp partition value with a non-UTC RFC 3339 offset
-// (spec-conformant writers emit only the `Z` form). The offset must be honored and the
-// value normalized to UTC. Before the #2733 fix, `2024-06-15T14:30:00+05:00` was read as
-// 14:30 UTC instead of 09:30 UTC, silently inverting partition pruning.
+// A foreign writer can emit a timestamp partition value with a non-UTC RFC 3339 offset. The
+// offset must be honored and the value normalized to UTC, e.g. `2024-06-15T14:30:00+05:00`
+// denotes 09:30 UTC, not 14:30 UTC.
 
 /// Builds a Delta commit body containing a `commitInfo` plus one stats-less Add per
 /// `(path, ts_partition_value)`.
@@ -628,8 +627,7 @@ async fn partition_pruning_honors_rfc3339_offset_partition_values(
     let nine_thirty_utc_us: i64 = 1_718_443_800_000_000; // 2024-06-15T09:30:00Z
     let fourteen_thirty_utc_us: i64 = 1_718_461_800_000_000; // 2024-06-15T14:30:00Z
 
-    // ts == 09:30Z must keep only file_A (its +05:00 value normalized to 09:30 UTC). Before
-    // the fix this kept zero files: file_A's offset was dropped, so it read as 14:30 UTC.
+    // ts == 09:30Z must keep only file_A (its +05:00 value normalized to 09:30 UTC).
     let predicate = Arc::new(Pred::eq(
         column_expr!("ts"),
         Expr::literal(Scalar::Timestamp(nine_thirty_utc_us)),
@@ -639,7 +637,7 @@ async fn partition_pruning_honors_rfc3339_offset_partition_values(
         1
     );
 
-    // ts == 14:30Z must keep only file_B. Before the fix this kept both files.
+    // ts == 14:30Z must keep only file_B.
     let predicate = Arc::new(Pred::eq(
         column_expr!("ts"),
         Expr::literal(Scalar::Timestamp(fourteen_thirty_utc_us)),

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{Int64Array, RecordBatch};
 use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{
     column_expr, Expression as Expr, Predicate as Pred, PredicateRef, Scalar,
@@ -23,6 +24,8 @@ use delta_kernel::expressions::{
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{Snapshot, SnapshotRef};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
@@ -561,6 +564,89 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     assert_eq!(
         surviving_files(&table_path, engine, predicate, use_parallel)?,
         2
+    );
+    Ok(())
+}
+
+// === RFC 3339 offset partition values (#2733) ===
+//
+// A foreign writer can emit a timestamp partition value with a non-UTC RFC 3339 offset
+// (spec-conformant writers emit only the `Z` form). The offset must be honored and the
+// value normalized to UTC. Before the #2733 fix, `2024-06-15T14:30:00+05:00` was read as
+// 14:30 UTC instead of 09:30 UTC, silently inverting partition pruning.
+
+/// Builds a Delta commit body containing a `commitInfo` plus one stats-less Add per
+/// `(path, ts_partition_value)`.
+fn commit_with_ts_partitioned_adds(version: u64, adds: &[(&str, &str)]) -> String {
+    let mut lines = vec![format!(
+        r#"{{"commitInfo":{{"timestamp":1700000000000,"operation":"WRITE","version":{version}}}}}"#
+    )];
+    for (path, ts) in adds {
+        lines.push(format!(
+            r#"{{"add":{{"path":"{path}","size":1024,"modificationTime":1700000000000,"dataChange":true,"partitionValues":{{"ts":"{ts}"}}}}}}"#
+        ));
+    }
+    lines.join("\n")
+}
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn partition_pruning_honors_rfc3339_offset_partition_values(
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("ts", DataType::TIMESTAMP),
+        StructField::nullable("v", DataType::LONG),
+    ])?);
+    create_table(&table_path, schema, "Test/1.0")
+        .with_data_layout(DataLayout::partitioned(["ts"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // v1: adds in the style of an offset-emitting foreign writer. Pruning never opens data
+    // files, so fake paths are fine. The two partition values denote *different* instants:
+    // file_A is 2024-06-15T09:30:00Z once its +05:00 offset is honored, file_B is 14:30:00Z.
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        1,
+        commit_with_ts_partitioned_adds(
+            1,
+            &[
+                ("file_A.parquet", "2024-06-15T14:30:00+05:00"),
+                ("file_B.parquet", "2024-06-15T14:30:00Z"),
+            ],
+        ),
+    )
+    .await?;
+
+    let nine_thirty_utc_us: i64 = 1_718_443_800_000_000; // 2024-06-15T09:30:00Z
+    let fourteen_thirty_utc_us: i64 = 1_718_461_800_000_000; // 2024-06-15T14:30:00Z
+
+    // ts == 09:30Z must keep only file_A (its +05:00 value normalized to 09:30 UTC). Before
+    // the fix this kept zero files: file_A's offset was dropped, so it read as 14:30 UTC.
+    let predicate = Arc::new(Pred::eq(
+        column_expr!("ts"),
+        Expr::literal(Scalar::Timestamp(nine_thirty_utc_us)),
+    ));
+    assert_eq!(
+        surviving_files(&table_path, engine.clone(), predicate, use_parallel)?,
+        1
+    );
+
+    // ts == 14:30Z must keep only file_B. Before the fix this kept both files.
+    let predicate = Arc::new(Pred::eq(
+        column_expr!("ts"),
+        Expr::literal(Scalar::Timestamp(fourteen_thirty_utc_us)),
+    ));
+    assert_eq!(
+        surviving_files(&table_path, engine, predicate, use_parallel)?,
+        1
     );
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Previously timestamps in `PrimitiveType::parse_scalar` did not support [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339) and would instead silently discard the timestamp offset. This PR correctly parses the timestamp offset and converts the timestamp to UTC. Fixes #2733.

## How was this change tested?
Unit tests:
- parameterized rstest cases in scalars.rs covering RFC 3339 offset forms (Z,
  offsets, colon-less +0530, fractional seconds), plus negative cases (out-of-range/overflow
  offsets, TimestampNtz rejecting offsets).
  - Expression + partition-value tests

Integration test:
- partition_pruning_honors_rfc3339_offset_partition_values (sequential +
parallel) verifies pruning keeps the right file once offsets are honored.