### PR TITLE
feat!: read interval types

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -174,17 +174,13 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
     ),
+    // Interval columns read as their physical integer (i32 months / i64 microseconds), which
+    // the rest of the intv_* suite now passes. Partitioned interval columns additionally
+    // require materializing the partition value as a Scalar, which interval does not yet
+    // support (no Scalar::Interval variant).
     (
-        "Interval types not supported in schema deserialization",
-        &[
-            "intv_001_interval_ym_basic/",
-            "intv_002_interval_dt_basic/",
-            "intv_003_interval_partitioned/",
-            "intv_004_interval_negative/",
-            "intv_005_interval_mixed/",
-            "intv_boundary_values/",
-            "intv_sub_second/",
-        ],
+        "Interval partition values not supported (needs Scalar::Interval)",
+        &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],
     ),
     (
         "Cannot fall back to log replay when checkpoint files are missing or incomplete",

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -174,10 +174,7 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
     ),
-    // Interval columns read as their physical integer (i32 months / i64 microseconds), which
-    // the rest of the intv_* suite now passes. Partitioned interval columns additionally
-    // require materializing the partition value as a Scalar, which interval does not yet
-    // support (no Scalar::Interval variant).
+    // Partitioned interval columns need a Scalar::Interval to materialize, not yet supported.
     (
         "Interval partition values not supported (needs Scalar::Interval)",
         &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -499,7 +499,6 @@ impl NullTypeTag {
                 PrimitiveType::Date => (Self::Date, 0, 0),
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
-                // Interval types have no FFI null-literal tag yet; treat as non-primitive.
                 PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
                     (Self::NonPrimitive, 0, 0)
                 }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -499,6 +499,10 @@ impl NullTypeTag {
                 PrimitiveType::Date => (Self::Date, 0, 0),
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
+                // Interval types have no FFI null-literal tag yet; treat as non-primitive.
+                PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
+                    (Self::NonPrimitive, 0, 0)
+                }
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
                 // Void has no dedicated FFI tag. The current predicate-construction path is
                 // not expected to produce a void-typed literal null; if one ever reaches this

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -341,7 +341,6 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
             &DataType::VOID => call!(visit_void),
             &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => {
-                // No FFI visitor callback for interval types yet; the field is skipped.
                 tracing::warn!("Skipping unsupported interval field '{name}' in FFI schema visit");
             }
         }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -340,6 +340,10 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
             &DataType::VOID => call!(visit_void),
+            &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => {
+                // No FFI visitor callback for interval types yet; the field is skipped.
+                tracing::warn!("Skipping unsupported interval field '{name}' in FFI schema visit");
+            }
         }
     }
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -369,6 +369,10 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
                     PrimitiveType::Void => Ok(ArrowDataType::Null),
+                    // Exposed as the physical integer (i32 months / i64 microseconds); interval
+                    // semantics live in the Delta logical schema.
+                    PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
+                    PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -369,8 +369,6 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
                     PrimitiveType::Void => Ok(ArrowDataType::Null),
-                    // Exposed as the physical integer (i32 months / i64 microseconds); interval
-                    // semantics live in the Delta logical schema.
                     PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
                     PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                 }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -213,6 +213,11 @@ impl Scalar {
                     "Variant is not supported as scalar yet.",
                 ));
             }
+            DataType::INTERVAL_YEAR_MONTH | DataType::INTERVAL_DAY_TIME => {
+                return Err(Error::unsupported(
+                    "Interval is not supported as scalar yet.",
+                ));
+            }
         }
         Ok(())
     }

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -699,8 +699,6 @@ mod tests {
 
     #[test]
     fn interval_maps_to_physical_integer() {
-        // Interval types are read as their physical integer (i32 months / i64 microseconds),
-        // matching the on-disk Parquet representation -- no cast needed.
         assert_eq!(
             ensure_data_types(
                 &DataType::INTERVAL_YEAR_MONTH,

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -697,6 +697,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn interval_maps_to_physical_integer() {
+        // Interval types are read as their physical integer (i32 months / i64 microseconds),
+        // matching the on-disk Parquet representation -- no cast needed.
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_YEAR_MONTH,
+                &ArrowDataType::Int32,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_DAY_TIME,
+                &ArrowDataType::Int64,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+    }
+
     /// Ensures that every kernel-level checkpoint reinterpretation rule in
     /// `PrimitiveType::is_checkpoint_cast_compatible` has a corresponding Arrow cast
     /// in `check_cast_compat`. If one side is updated without the other, this test fails.

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -194,6 +194,7 @@ fn extract_min_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
         (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.min_opt()?),
         (TimestampNtz, Statistics::Int32(s)) => timestamp_from_date(s.min_opt())?,
         (TimestampNtz, _) => return None, // TODO: Int96 timestamps
+        (IntervalYearMonth | IntervalDayTime, _) => return None,
         (Decimal(d), Statistics::Int32(i)) => DecimalData::try_new(*i.min_opt()?, *d).ok()?.into(),
         (Decimal(d), Statistics::Int64(i)) => DecimalData::try_new(*i.min_opt()?, *d).ok()?.into(),
         (Decimal(d), Statistics::FixedLenByteArray(b)) => {
@@ -240,6 +241,7 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
         (TimestampNtz, Statistics::Int64(s)) => Scalar::TimestampNtz(*s.max_opt()?),
         (TimestampNtz, Statistics::Int32(s)) => timestamp_from_date(s.max_opt())?,
         (TimestampNtz, _) => return None, // TODO: Int96 timestamps
+        (IntervalYearMonth | IntervalDayTime, _) => return None,
         (Decimal(d), Statistics::Int32(i)) => DecimalData::try_new(*i.max_opt()?, *d).ok()?.into(),
         (Decimal(d), Statistics::Int64(i)) => DecimalData::try_new(*i.max_opt()?, *d).ok()?.into(),
         (Decimal(d), Statistics::FixedLenByteArray(b)) => {

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -768,6 +768,9 @@ impl PrimitiveType {
                     _ => unreachable!(),
                 }
             }
+            IntervalYearMonth | IntervalDayTime => Err(Error::unsupported(
+                "Interval types are not supported as scalar or partition values",
+            )),
         }
     }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1682,6 +1682,10 @@ pub enum PrimitiveType {
     #[serde(rename = "timestamp_ntz")]
     TimestampNtz,
     Void,
+    #[serde(rename = "interval year to month")]
+    IntervalYearMonth,
+    #[serde(rename = "interval day to second")]
+    IntervalDayTime,
     #[serde(serialize_with = "serialize_decimal", untagged)]
     Decimal(DecimalType),
 }
@@ -1789,6 +1793,8 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             "timestamp" => Ok(PrimitiveType::Timestamp),
             "timestamp_ntz" => Ok(PrimitiveType::TimestampNtz),
             "void" => Ok(PrimitiveType::Void),
+            "interval year to month" => Ok(PrimitiveType::IntervalYearMonth),
+            "interval day to second" => Ok(PrimitiveType::IntervalDayTime),
             decimal_str if decimal_str.starts_with("decimal(") && decimal_str.ends_with(')') => {
                 // Parse decimal type
                 let mut parts = decimal_str[8..decimal_str.len() - 1].split(',');
@@ -1838,6 +1844,8 @@ impl Display for PrimitiveType {
             PrimitiveType::Date => write!(f, "date"),
             PrimitiveType::Timestamp => write!(f, "timestamp"),
             PrimitiveType::TimestampNtz => write!(f, "timestamp_ntz"),
+            PrimitiveType::IntervalYearMonth => write!(f, "interval year to month"),
+            PrimitiveType::IntervalDayTime => write!(f, "interval day to second"),
             PrimitiveType::Decimal(dtype) => {
                 write!(f, "decimal({},{})", dtype.precision(), dtype.scale())
             }
@@ -1974,6 +1982,8 @@ impl DataType {
     pub const TIMESTAMP: Self = DataType::Primitive(PrimitiveType::Timestamp);
     pub const TIMESTAMP_NTZ: Self = DataType::Primitive(PrimitiveType::TimestampNtz);
     pub const VOID: Self = DataType::Primitive(PrimitiveType::Void);
+    pub const INTERVAL_YEAR_MONTH: Self = DataType::Primitive(PrimitiveType::IntervalYearMonth);
+    pub const INTERVAL_DAY_TIME: Self = DataType::Primitive(PrimitiveType::IntervalDayTime);
 
     /// Create a new decimal type with the given precision and scale.
     pub fn decimal(precision: u8, scale: u8) -> DeltaResult<Self> {
@@ -2483,6 +2493,8 @@ mod tests {
     #[case("date", DataType::DATE)]
     #[case("timestamp", DataType::TIMESTAMP)]
     #[case("timestamp_ntz", DataType::TIMESTAMP_NTZ)]
+    #[case("interval year to month", DataType::INTERVAL_YEAR_MONTH)]
+    #[case("interval day to second", DataType::INTERVAL_DAY_TIME)]
     fn test_primitive_type_deserialization_still_works(
         #[case] type_str: &str,
         #[case] expected_type: DataType,
@@ -2570,10 +2582,27 @@ mod tests {
     #[case("\"date\"", DataType::DATE)]
     #[case("\"timestamp\"", DataType::TIMESTAMP)]
     #[case("\"timestamp_ntz\"", DataType::TIMESTAMP_NTZ)]
+    #[case("\"interval year to month\"", DataType::INTERVAL_YEAR_MONTH)]
+    #[case("\"interval day to second\"", DataType::INTERVAL_DAY_TIME)]
     #[case("\"variant\"", DataType::unshredded_variant())]
     fn test_data_type_deserialization(#[case] type_json: &str, #[case] expected: DataType) {
         let data_type: DataType = serde_json::from_str(type_json).unwrap();
         assert_eq!(data_type, expected);
+    }
+
+    #[rstest]
+    #[case(PrimitiveType::IntervalYearMonth, "interval year to month")]
+    #[case(PrimitiveType::IntervalDayTime, "interval day to second")]
+    fn test_interval_type_name_round_trips(#[case] ptype: PrimitiveType, #[case] name: &str) {
+        assert_eq!(ptype.to_string(), name);
+        assert_eq!(
+            serde_json::to_string(&ptype).unwrap(),
+            format!("\"{name}\"")
+        );
+        assert_eq!(
+            serde_json::from_str::<PrimitiveType>(&format!("\"{name}\"")).unwrap(),
+            ptype
+        );
     }
 
     #[test]

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -187,6 +187,11 @@ fn column_types_for(dt: &DataType) -> DeltaResult<&'static ColumnNamesAndTypes> 
         &DataType::TIMESTAMP => Ok(&COL_TYPES_TIMESTAMP),
         &DataType::TIMESTAMP_NTZ => Ok(&COL_TYPES_TIMESTAMP_NTZ),
         DataType::Primitive(PrimitiveType::Decimal(_)) => Ok(&COL_TYPES_DECIMAL),
+        &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => {
+            Err(Error::internal_error(format!(
+                "Interval types are not yet supported for stats validation: {dt}"
+            )))
+        }
         &DataType::VOID
         | DataType::Struct(_)
         | DataType::Array(_)
@@ -220,6 +225,11 @@ fn is_stat_present<'b>(
         &DataType::BINARY => Ok(getter.get_binary(row_idx, field_name)?.is_some()),
         DataType::Primitive(PrimitiveType::Decimal(_)) => {
             Ok(getter.get_decimal(row_idx, field_name)?.is_some())
+        }
+        &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => {
+            Err(Error::internal_error(format!(
+                "Interval types are not yet supported for stats presence check: {data_type}"
+            )))
         }
         &DataType::VOID
         | DataType::Struct(_)

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1717,6 +1717,9 @@ fn scalar_for_type(data_type: &DataType, seed: usize) -> Scalar {
                     .expect("test seed produced invalid decimal")
             }
             PrimitiveType::Void => panic!("void type is not a valid partition column"),
+            PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
+                panic!("interval types are not supported as partition values")
+            }
         },
         other => panic!("partition columns must be primitive types, got: {other:?}"),
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for interval type reads in Kernel. Made the following changes (split by core kernel and default engine):
- Core Kernel: serde (de)serialization, change expected passing DAT tests
- Engine: use raw Arrow::Int for interval types, gracefully error everywhere else (Scalars, stats, etc.)

See [design doc](https://docs.google.com/document/d/1Ph5_KnZvIASPidGZYmrRY8aXR_B5OMX9CYYs39Xjt-A/edit?usp=sharing) for more details.

## How was this change tested?

Modified existing unit tests and added new unit tests. `intv_*` DAT tests pass.