### PR TITLE
feat: add FFI function for get_earliest_delta

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -345,8 +345,8 @@ impl From<EngineExecError> for Error {
             | KernelError::ParseIntervalError
             | KernelError::ChangeDataFeedUnsupported
             | KernelError::ChangeDataFeedIncompatibleSchema
-            | KernelError::LiteralExpressionTransformError)
-            | KernelError::LogHistoryError => {
+            | KernelError::LiteralExpressionTransformError
+            | KernelError::LogHistoryError) => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
             #[cfg(feature = "default-engine-base")]

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -73,6 +73,7 @@ pub enum KernelError {
     LiteralExpressionTransformError = 40,
     CheckpointWriteError = 41,
     SchemaError = 42,
+    LogHistory = 43,
 }
 
 impl From<Error> for KernelError {
@@ -134,6 +135,7 @@ impl From<Error> for KernelError {
                 KernelError::LiteralExpressionTransformError
             }
             Error::Schema(_) => KernelError::SchemaError,
+            Error::LogHistory(_) => KernelError::LogHistory,
             _ => KernelError::UnknownError,
         }
     }

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -73,7 +73,7 @@ pub enum KernelError {
     LiteralExpressionTransformError = 40,
     CheckpointWriteError = 41,
     SchemaError = 42,
-    LogHistory = 43,
+    LogHistoryError = 43,
 }
 
 impl From<Error> for KernelError {
@@ -135,7 +135,7 @@ impl From<Error> for KernelError {
                 KernelError::LiteralExpressionTransformError
             }
             Error::Schema(_) => KernelError::SchemaError,
-            Error::LogHistory(_) => KernelError::LogHistory,
+            Error::LogHistory(_) => KernelError::LogHistoryError,
             _ => KernelError::UnknownError,
         }
     }
@@ -345,7 +345,8 @@ impl From<EngineExecError> for Error {
             | KernelError::ParseIntervalError
             | KernelError::ChangeDataFeedUnsupported
             | KernelError::ChangeDataFeedIncompatibleSchema
-            | KernelError::LiteralExpressionTransformError) => {
+            | KernelError::LiteralExpressionTransformError)
+            | KernelError::LogHistoryError => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
             #[cfg(feature = "default-engine-base")]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1597,7 +1597,8 @@ mod tests {
         Filesystem,
         /// Catalog-managed table with a single v0 metadata commit.
         CatalogManaged,
-        /// Filesystem-only table with a mock checkpoint created.
+        /// Filesystem table with commits at versions 2-4 (no commit 0) plus a mocked checkpoint at
+        /// version 4.
         CheckpointWithLogCleanUp,
         /// Empty store -- the log directory contains no commits.
         Empty,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1674,7 +1674,7 @@ mod tests {
         EarliestCommitTableSetupScenario::Empty,
         OptionalValue::None,
         FfiHistoryCommitType::Published,
-        Err(KernelError::LogHistory)
+        Err(KernelError::LogHistoryError)
     )]
     #[case::checkpoint_published(
         EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -12,7 +12,9 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 
 use delta_kernel::actions::{Metadata, Protocol};
-use delta_kernel::history_manager::HistoryCommitType;
+use delta_kernel::history_manager::{
+    get_earliest_commit as kernel_get_earliest_commit, HistoryCommitType,
+};
 use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::{Snapshot, SnapshotRef};
 use delta_kernel::{DeltaResult, Engine, EngineData, LogPath, Version};
@@ -1030,17 +1032,14 @@ impl From<FfiHistoryCommitType> for HistoryCommitType {
 
 /// Get the earliest commit version available in the table's `_delta_log/` directory.
 ///
-/// The returned version is a lower bound only -- a concurrent log-cleanup operation may delete the
-/// underlying file before the caller acts on it.
-///
 /// # Parameters
 /// - `engine`: engine handle used to list the log directory.
 /// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
 /// - `earliest_ratified_commit_version`: for catalog-managed tables, the earliest version the
 ///   catalog has ratified a commit at; pass `OptionalValue::None` for filesystem-only tables.
-/// - `commit_type`: selects the query. [`FfiHistoryCommitType::Published`] returns the lowest
-///   published commit; [`FfiHistoryCommitType::Recreatable`] returns the earliest fully
-///   reconstructable version (commit 0 or the earliest complete checkpoint).
+/// - `commit_type`: selects the query. [`FfiHistoryCommitType::Published`] returns the earliest
+///   commit; [`FfiHistoryCommitType::Recreatable`] returns the earliest fully reconstructable
+///   version.
 ///
 /// # Safety
 ///
@@ -1069,7 +1068,7 @@ fn get_earliest_commit_impl(
     earliest_ratified_commit_version: OptionalValue<Version>,
     commit_type: FfiHistoryCommitType,
 ) -> DeltaResult<Version> {
-    delta_kernel::history_manager::get_earliest_commit(
+    kernel_get_earliest_commit(
         extern_engine.engine().as_ref(),
         &log_root?,
         earliest_ratified_commit_version.into(),
@@ -1610,16 +1609,14 @@ mod tests {
     ) -> Handle<SharedExternEngine> {
         match setup {
             EarliestCommitTableSetupScenario::Filesystem => {
-                let (_storage, engine, snapshot) =
-                    make_engine_and_v0_snapshot(table_root).await.unwrap();
+                let (_, engine, snapshot) = make_engine_and_v0_snapshot(table_root).await.unwrap();
                 unsafe { free_snapshot(snapshot) };
                 engine
             }
             EarliestCommitTableSetupScenario::CatalogManaged => {
-                let (_storage, engine, snapshot) =
-                    make_catalog_managed_engine_and_v0_snapshot(table_root)
-                        .await
-                        .unwrap();
+                let (_, engine, snapshot) = make_catalog_managed_engine_and_v0_snapshot(table_root)
+                    .await
+                    .unwrap();
                 unsafe { free_snapshot(snapshot) };
                 engine
             }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1592,15 +1592,10 @@ mod tests {
     }
 
     enum EarliestCommitTableSetupScenario {
-        /// Filesystem-only table with a single v0 metadata commit.
-        Filesystem,
-        /// Catalog-managed table with a single v0 metadata commit.
-        CatalogManaged,
-        /// Filesystem table with commits at versions 2-4 (no commit 0) plus a mocked checkpoint at
-        /// version 4.
-        CheckpointWithLogCleanUp,
-        /// Empty store -- the log directory contains no commits.
-        Empty,
+        FilesystemV0Commit,
+        CatalogManagedV0Commit,
+        FilesystemV4CheckpointWithEarliestCommitAtV2,
+        NoCommits,
     }
 
     async fn setup_earliest_commit_table(
@@ -1608,19 +1603,19 @@ mod tests {
         table_root: &str,
     ) -> Handle<SharedExternEngine> {
         match setup {
-            EarliestCommitTableSetupScenario::Filesystem => {
+            EarliestCommitTableSetupScenario::FilesystemV0Commit => {
                 let (_, engine, snapshot) = make_engine_and_v0_snapshot(table_root).await.unwrap();
                 unsafe { free_snapshot(snapshot) };
                 engine
             }
-            EarliestCommitTableSetupScenario::CatalogManaged => {
+            EarliestCommitTableSetupScenario::CatalogManagedV0Commit => {
                 let (_, engine, snapshot) = make_catalog_managed_engine_and_v0_snapshot(table_root)
                     .await
                     .unwrap();
                 unsafe { free_snapshot(snapshot) };
                 engine
             }
-            EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp => {
+            EarliestCommitTableSetupScenario::FilesystemV4CheckpointWithEarliestCommitAtV2 => {
                 let storage = Arc::new(InMemory::new());
                 for version in 2..=4 {
                     add_commit(
@@ -1647,43 +1642,49 @@ mod tests {
                     allocate_err,
                 )
             }
-            EarliestCommitTableSetupScenario::Empty => get_default_engine(table_root),
+            EarliestCommitTableSetupScenario::NoCommits => get_default_engine(table_root),
         }
     }
 
     #[rstest]
     #[case::fs_published(
-        EarliestCommitTableSetupScenario::Filesystem,
+        EarliestCommitTableSetupScenario::FilesystemV0Commit,
         OptionalValue::None,
         FfiHistoryCommitType::Published,
         Ok(0)
     )]
     #[case::fs_recreatable(
-        EarliestCommitTableSetupScenario::Filesystem,
+        EarliestCommitTableSetupScenario::FilesystemV0Commit,
         OptionalValue::None,
         FfiHistoryCommitType::Recreatable,
         Ok(0)
     )]
     #[case::cm_ratified_zero(
-        EarliestCommitTableSetupScenario::CatalogManaged,
+        EarliestCommitTableSetupScenario::CatalogManagedV0Commit,
         OptionalValue::Some(0),
         FfiHistoryCommitType::Published,
         Ok(0)
     )]
+    #[case::cm_with_empty_delta_log(
+        EarliestCommitTableSetupScenario::NoCommits,
+        OptionalValue::Some(0),
+        FfiHistoryCommitType::Published,
+        Err(KernelError::GenericError)
+    )]
     #[case::empty_log_errors(
-        EarliestCommitTableSetupScenario::Empty,
+        EarliestCommitTableSetupScenario::NoCommits,
         OptionalValue::None,
         FfiHistoryCommitType::Published,
         Err(KernelError::LogHistoryError)
     )]
     #[case::checkpoint_published(
-        EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp,
+        EarliestCommitTableSetupScenario::FilesystemV4CheckpointWithEarliestCommitAtV2,
         OptionalValue::None,
         FfiHistoryCommitType::Published,
         Ok(2)
     )]
     #[case::checkpoint_recreatable(
-        EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp,
+        EarliestCommitTableSetupScenario::FilesystemV4CheckpointWithEarliestCommitAtV2,
         OptionalValue::None,
         FfiHistoryCommitType::Recreatable,
         Ok(4)

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1016,9 +1016,9 @@ pub unsafe extern "C" fn snapshot_timestamp(
 #[repr(C)]
 pub enum FfiHistoryCommitType {
     /// Maps to [`HistoryCommitType::Published`].
-    Published,
+    Published = 0,
     /// Maps to [`HistoryCommitType::Recreatable`].
-    Recreatable,
+    Recreatable = 1,
 }
 
 impl From<FfiHistoryCommitType> for HistoryCommitType {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -12,6 +12,7 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 
 use delta_kernel::actions::{Metadata, Protocol};
+use delta_kernel::history_manager::HistoryCommitType;
 use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::{Snapshot, SnapshotRef};
 use delta_kernel::{DeltaResult, Engine, EngineData, LogPath, Version};
@@ -183,6 +184,15 @@ impl<T> From<Option<T>> for OptionalValue<T> {
         match item {
             Some(value) => OptionalValue::Some(value),
             None => OptionalValue::None,
+        }
+    }
+}
+
+impl<T> From<OptionalValue<T>> for Option<T> {
+    fn from(value: OptionalValue<T>) -> Self {
+        match value {
+            OptionalValue::Some(value) => Some(value),
+            OptionalValue::None => None,
         }
     }
 }
@@ -999,6 +1009,74 @@ pub unsafe extern "C" fn snapshot_timestamp(
         .into_extern_result(&engine_ref)
 }
 
+/// Selects which commit type to return for the history_manager query. FFI-safe mirror of
+/// [`HistoryCommitType`].
+#[repr(C)]
+pub enum FfiHistoryCommitType {
+    /// Maps to [`HistoryCommitType::Published`].
+    Published,
+    /// Maps to [`HistoryCommitType::Recreatable`].
+    Recreatable,
+}
+
+impl From<FfiHistoryCommitType> for HistoryCommitType {
+    fn from(commit_type: FfiHistoryCommitType) -> Self {
+        match commit_type {
+            FfiHistoryCommitType::Published => Self::Published,
+            FfiHistoryCommitType::Recreatable => Self::Recreatable,
+        }
+    }
+}
+
+/// Get the earliest commit version available in the table's `_delta_log/` directory.
+///
+/// The returned version is a lower bound only -- a concurrent log-cleanup operation may delete the
+/// underlying file before the caller acts on it.
+///
+/// # Parameters
+/// - `engine`: engine handle used to list the log directory.
+/// - `log_root`: URL of the table's `_delta_log/` directory (must end with `/`).
+/// - `earliest_ratified_commit_version`: for catalog-managed tables, the earliest version the
+///   catalog has ratified a commit at; pass `OptionalValue::None` for filesystem-only tables.
+/// - `commit_type`: selects the query. [`FfiHistoryCommitType::Published`] returns the lowest
+///   published commit; [`FfiHistoryCommitType::Recreatable`] returns the earliest fully
+///   reconstructable version (commit 0 or the earliest complete checkpoint).
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid `log_root` string slice and a valid engine handle.
+#[no_mangle]
+pub unsafe extern "C" fn get_earliest_commit(
+    engine: Handle<SharedExternEngine>,
+    log_root: KernelStringSlice,
+    earliest_ratified_commit_version: OptionalValue<Version>,
+    commit_type: FfiHistoryCommitType,
+) -> ExternResult<Version> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let log_root = unsafe { unwrap_and_parse_path_as_url(log_root) };
+    get_earliest_commit_impl(
+        engine_ref,
+        log_root,
+        earliest_ratified_commit_version,
+        commit_type,
+    )
+    .into_extern_result(&engine_ref)
+}
+
+fn get_earliest_commit_impl(
+    extern_engine: &dyn ExternEngine,
+    log_root: DeltaResult<Url>,
+    earliest_ratified_commit_version: OptionalValue<Version>,
+    commit_type: FfiHistoryCommitType,
+) -> DeltaResult<Version> {
+    delta_kernel::history_manager::get_earliest_commit(
+        extern_engine.engine().as_ref(),
+        &log_root?,
+        earliest_ratified_commit_version.into(),
+        commit_type.into(),
+    )
+}
+
 /// Get the logical schema of the specified snapshot
 ///
 /// # Safety
@@ -1510,6 +1588,133 @@ mod tests {
 
         unsafe { free_snapshot(snapshot1) }
         unsafe { free_snapshot(snapshot2) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    enum EarliestCommitTableSetupScenario {
+        /// Filesystem-only table with a single v0 metadata commit.
+        Filesystem,
+        /// Catalog-managed table with a single v0 metadata commit.
+        CatalogManaged,
+        /// Filesystem-only table with a mock checkpoint created.
+        CheckpointWithLogCleanUp,
+        /// Empty store -- the log directory contains no commits.
+        Empty,
+    }
+
+    async fn setup_earliest_commit_table(
+        setup: &EarliestCommitTableSetupScenario,
+        table_root: &str,
+    ) -> Handle<SharedExternEngine> {
+        match setup {
+            EarliestCommitTableSetupScenario::Filesystem => {
+                let (_storage, engine, snapshot) =
+                    make_engine_and_v0_snapshot(table_root).await.unwrap();
+                unsafe { free_snapshot(snapshot) };
+                engine
+            }
+            EarliestCommitTableSetupScenario::CatalogManaged => {
+                let (_storage, engine, snapshot) =
+                    make_catalog_managed_engine_and_v0_snapshot(table_root)
+                        .await
+                        .unwrap();
+                unsafe { free_snapshot(snapshot) };
+                engine
+            }
+            EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp => {
+                let storage = Arc::new(InMemory::new());
+                for version in 2..=4 {
+                    add_commit(
+                        table_root,
+                        storage.as_ref(),
+                        version,
+                        actions_to_string(vec![TestAction::Metadata]),
+                    )
+                    .await
+                    .unwrap();
+                }
+                let checkpoint_version = 4;
+                let checkpoint =
+                    format!("_delta_log/{:020}.checkpoint.parquet", checkpoint_version);
+                let table_url = Url::parse(table_root).unwrap();
+                let checkpoint_path =
+                    Path::from_url_path(table_url.join(&checkpoint).unwrap().path()).unwrap();
+                storage
+                    .put(&checkpoint_path, "x".to_string().into())
+                    .await
+                    .unwrap();
+                engine_to_handle(
+                    Arc::new(DefaultEngineBuilder::new(storage).build()),
+                    allocate_err,
+                )
+            }
+            EarliestCommitTableSetupScenario::Empty => get_default_engine(table_root),
+        }
+    }
+
+    #[rstest]
+    #[case::fs_published(
+        EarliestCommitTableSetupScenario::Filesystem,
+        OptionalValue::None,
+        FfiHistoryCommitType::Published,
+        Ok(0)
+    )]
+    #[case::fs_recreatable(
+        EarliestCommitTableSetupScenario::Filesystem,
+        OptionalValue::None,
+        FfiHistoryCommitType::Recreatable,
+        Ok(0)
+    )]
+    #[case::cm_ratified_zero(
+        EarliestCommitTableSetupScenario::CatalogManaged,
+        OptionalValue::Some(0),
+        FfiHistoryCommitType::Published,
+        Ok(0)
+    )]
+    #[case::empty_log_errors(
+        EarliestCommitTableSetupScenario::Empty,
+        OptionalValue::None,
+        FfiHistoryCommitType::Published,
+        Err(KernelError::LogHistory)
+    )]
+    #[case::checkpoint_published(
+        EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp,
+        OptionalValue::None,
+        FfiHistoryCommitType::Published,
+        Ok(2)
+    )]
+    #[case::checkpoint_recreatable(
+        EarliestCommitTableSetupScenario::CheckpointWithLogCleanUp,
+        OptionalValue::None,
+        FfiHistoryCommitType::Recreatable,
+        Ok(4)
+    )]
+    #[tokio::test]
+    async fn test_get_earliest_commit_cases(
+        #[case] setup: EarliestCommitTableSetupScenario,
+        #[case] earliest_ratified: OptionalValue<Version>,
+        #[case] commit_type: FfiHistoryCommitType,
+        #[case] expected: Result<Version, KernelError>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let table_root = "memory:///earliest_commit/";
+        let log_root = "memory:///earliest_commit/_delta_log/";
+        let engine = setup_earliest_commit_table(&setup, table_root).await;
+
+        let result = unsafe {
+            get_earliest_commit(
+                engine.shallow_copy(),
+                kernel_string_slice!(log_root),
+                earliest_ratified,
+                commit_type,
+            )
+        };
+
+        match expected {
+            Ok(version) => assert_eq!(ok_or_panic(result), version),
+            Err(kind) => assert_extern_result_error_with_message(result, kind, None),
+        }
+
         unsafe { free_engine(engine) }
         Ok(())
     }


### PR DESCRIPTION

## What changes are proposed in this pull request?

This PR added an FFI implementation of the history_manager::get_earliest_delta function, allowing connectors written in other languages (C/C++/Java/...) querying the earliest commit version in the delta_log of the Delta table. Connectors can use the FfiHistoryCommitType to control the returned history commit type.

- FfiHistoryCommitType::Published will find the earliest commit available in the delta_log. However, it does not guarantee the table can be constructed from that version.
- FfiHistoryCommitType::Recreatable will find the earliest commit version that the table can be constructed from and replay forward to the lastest version.

## How was this change tested?

- New unit test was added, verifying the new FFI function return the expected result.
