### PR TITLE
feat: FFI implementation for latest_version_as_of, first_version_after

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use delta_kernel::actions::{Metadata, Protocol};
 use delta_kernel::history_manager::{
-    get_earliest_commit as kernel_get_earliest_commit, HistoryCommitType,
+    first_version_after as kernel_first_version_after,
+    get_earliest_commit as kernel_get_earliest_commit,
+    latest_version_as_of as kernel_latest_version_as_of, CommitAt, HistoryCommitType, Timestamp,
 };
 use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::{Snapshot, SnapshotRef};
@@ -1076,6 +1078,87 @@ fn get_earliest_commit_impl(
     )
 }
 
+/// A commit located by a timestamp query: a commit version paired with its timestamp. FFI-safe
+/// mirror of [`CommitAt`].
+#[repr(C)]
+pub struct FfiCommitAt {
+    /// The commit version.
+    pub version: Version,
+    /// Timestamp (milliseconds since the Unix epoch) associated with this commit. This is the
+    /// commit's in-commit timestamp (ICT) when ICT is enabled, otherwise the commit's file
+    /// modification time.
+    pub timestamp: Timestamp,
+}
+
+impl From<CommitAt> for FfiCommitAt {
+    fn from(commit: CommitAt) -> Self {
+        Self {
+            version: commit.version,
+            timestamp: commit.timestamp,
+        }
+    }
+}
+
+/// Get the latest commit (version and timestamp) within `snapshot`'s version range with a
+/// timestamp at or before `timestamp` (milliseconds since the Unix epoch). `commit_type` selects
+/// whether to return any version present in the log ([`FfiHistoryCommitType::Published`]) or only a
+/// version whose table can be fully reconstructed ([`FfiHistoryCommitType::Recreatable`]).
+///
+/// Returns an error if no version exists at or before `timestamp`,
+/// or when there is an error resolving the commit based on the [`FfiHistoryCommitType`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid snapshot handle and a valid engine handle.
+#[no_mangle]
+pub unsafe extern "C" fn latest_version_as_of(
+    snapshot: Handle<SharedSnapshot>,
+    engine: Handle<SharedExternEngine>,
+    timestamp: Timestamp,
+    commit_type: FfiHistoryCommitType,
+) -> ExternResult<FfiCommitAt> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let snapshot = unsafe { snapshot.as_ref() };
+    kernel_latest_version_as_of(
+        snapshot,
+        engine_ref.engine().as_ref(),
+        timestamp,
+        commit_type.into(),
+    )
+    .map(FfiCommitAt::from)
+    .into_extern_result(&engine_ref)
+}
+
+/// Get the first commit (version and timestamp) within `snapshot`'s version range with a
+/// timestamp at or after `timestamp` (milliseconds since the Unix epoch). `commit_type` selects
+/// whether to return any version present in the log ([`FfiHistoryCommitType::Published`]) or only a
+/// version whose table can be fully reconstructed ([`FfiHistoryCommitType::Recreatable`]).
+///
+/// Returns an error if no version exists at or after `timestamp`,
+/// or when there is an error resolving the commit based on the [`FfiHistoryCommitType`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid snapshot handle and a valid engine handle.
+#[no_mangle]
+pub unsafe extern "C" fn first_version_after(
+    snapshot: Handle<SharedSnapshot>,
+    engine: Handle<SharedExternEngine>,
+    timestamp: Timestamp,
+    commit_type: FfiHistoryCommitType,
+) -> ExternResult<FfiCommitAt> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let snapshot = unsafe { snapshot.as_ref() };
+    kernel_first_version_after(
+        snapshot,
+        engine_ref.engine().as_ref(),
+        timestamp,
+        commit_type.into(),
+    )
+    .map(FfiCommitAt::from)
+    .into_extern_result(&engine_ref)
+}
+
 /// Get the logical schema of the specified snapshot
 ///
 /// # Safety
@@ -1421,6 +1504,7 @@ mod tests {
         actions_to_string, actions_to_string_catalog_managed, actions_to_string_partitioned,
         actions_to_string_with_metadata, add_commit, add_staged_commit, create_table, TestAction,
         METADATA, METADATA_WITH_FEATURES, METADATA_WITH_TABLE_PROPERTIES,
+        TEST_ICT_ENABLEMENT_TIMESTAMP,
     };
     use url::Url;
 
@@ -1769,7 +1853,7 @@ mod tests {
         // create_table with "inCommitTimestamp" in writer_features sets up:
         //   - protocol v3.7 with writerFeatures=["inCommitTimestamp"]
         //   - metadata config: enableInCommitTimestamps=true, enablement version/timestamp
-        //   - commitInfo with inCommitTimestamp=1612345678 (fixed test value)
+        //   - commitInfo with inCommitTimestamp=TEST_ICT_ENABLEMENT_TIMESTAMP
         create_table(
             storage.clone(),
             Url::parse(table_root)?,
@@ -1792,7 +1876,67 @@ mod tests {
                 engine.shallow_copy(),
             ))
         };
-        assert_eq!(ts, 1612345678_i64);
+        assert_eq!(ts, TEST_ICT_ENABLEMENT_TIMESTAMP);
+
+        unsafe { free_snapshot(snap) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    type HistoryQueryFn = unsafe extern "C" fn(
+        Handle<SharedSnapshot>,
+        Handle<SharedExternEngine>,
+        Timestamp,
+        FfiHistoryCommitType,
+    ) -> ExternResult<FfiCommitAt>;
+
+    #[rstest]
+    #[case::latest_version_query_at_ict(latest_version_as_of, TEST_ICT_ENABLEMENT_TIMESTAMP, Ok((0, TEST_ICT_ENABLEMENT_TIMESTAMP)))]
+    #[case::first_version_after_query_at_ict(first_version_after, TEST_ICT_ENABLEMENT_TIMESTAMP, Ok((0, TEST_ICT_ENABLEMENT_TIMESTAMP)))]
+    #[case::latest_version_query_out_of_range(latest_version_as_of, TEST_ICT_ENABLEMENT_TIMESTAMP - 1, Err(KernelError::LogHistoryError))]
+    #[case::first_version_after_query_out_of_range(first_version_after, TEST_ICT_ENABLEMENT_TIMESTAMP + 1, Err(KernelError::LogHistoryError))]
+    #[tokio::test]
+    async fn test_snapshot_version_at_timestamp_cases(
+        #[case] query: HistoryQueryFn,
+        #[case] timestamp: Timestamp,
+        #[case] expected: Result<(Version, Timestamp), KernelError>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let storage = Arc::new(InMemory::new());
+        let table_root = "memory:///test_table/";
+
+        create_table(
+            storage.clone(),
+            Url::parse(table_root)?,
+            Arc::new(StructType::try_new([]).unwrap()),
+            &[],
+            true,
+            vec![],
+            vec!["inCommitTimestamp"],
+        )
+        .await?;
+
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let snap =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+
+        let result = unsafe {
+            query(
+                snap.shallow_copy(),
+                engine.shallow_copy(),
+                timestamp,
+                FfiHistoryCommitType::Recreatable,
+            )
+        };
+
+        match expected {
+            Ok((version, ts)) => {
+                let commit = ok_or_panic(result);
+                assert_eq!(commit.version, version);
+                assert_eq!(commit.timestamp, ts);
+            }
+            Err(kind) => assert_extern_result_error_with_message(result, kind, None),
+        }
 
         unsafe { free_snapshot(snap) }
         unsafe { free_engine(engine) }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1900,6 +1900,8 @@ mod tests {
         #[case] query: HistoryQueryFn,
         #[case] timestamp: i64,
         #[case] expected: Result<(Version, i64), KernelError>,
+        #[values(FfiHistoryCommitType::Published, FfiHistoryCommitType::Recreatable)]
+        commit_type: FfiHistoryCommitType,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let storage = Arc::new(InMemory::new());
         let table_root = "memory:///test_table/";
@@ -1925,7 +1927,7 @@ mod tests {
                 snap.shallow_copy(),
                 engine.shallow_copy(),
                 timestamp,
-                FfiHistoryCommitType::Recreatable,
+                commit_type,
             )
         };
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -15,7 +15,7 @@ use delta_kernel::actions::{Metadata, Protocol};
 use delta_kernel::history_manager::{
     first_version_after as kernel_first_version_after,
     get_earliest_commit as kernel_get_earliest_commit,
-    latest_version_as_of as kernel_latest_version_as_of, CommitAt, HistoryCommitType, Timestamp,
+    latest_version_as_of as kernel_latest_version_as_of, CommitAt, HistoryCommitType,
 };
 use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::{Snapshot, SnapshotRef};
@@ -1087,7 +1087,7 @@ pub struct FfiCommitAt {
     /// Timestamp (milliseconds since the Unix epoch) associated with this commit. This is the
     /// commit's in-commit timestamp (ICT) when ICT is enabled, otherwise the commit's file
     /// modification time.
-    pub timestamp: Timestamp,
+    pub timestamp: i64,
 }
 
 impl From<CommitAt> for FfiCommitAt {
@@ -1114,7 +1114,7 @@ impl From<CommitAt> for FfiCommitAt {
 pub unsafe extern "C" fn latest_version_as_of(
     snapshot: Handle<SharedSnapshot>,
     engine: Handle<SharedExternEngine>,
-    timestamp: Timestamp,
+    timestamp: i64,
     commit_type: FfiHistoryCommitType,
 ) -> ExternResult<FfiCommitAt> {
     let engine_ref = unsafe { engine.as_ref() };
@@ -1144,7 +1144,7 @@ pub unsafe extern "C" fn latest_version_as_of(
 pub unsafe extern "C" fn first_version_after(
     snapshot: Handle<SharedSnapshot>,
     engine: Handle<SharedExternEngine>,
-    timestamp: Timestamp,
+    timestamp: i64,
     commit_type: FfiHistoryCommitType,
 ) -> ExternResult<FfiCommitAt> {
     let engine_ref = unsafe { engine.as_ref() };
@@ -1886,7 +1886,7 @@ mod tests {
     type HistoryQueryFn = unsafe extern "C" fn(
         Handle<SharedSnapshot>,
         Handle<SharedExternEngine>,
-        Timestamp,
+        i64,
         FfiHistoryCommitType,
     ) -> ExternResult<FfiCommitAt>;
 
@@ -1898,8 +1898,8 @@ mod tests {
     #[tokio::test]
     async fn test_snapshot_version_at_timestamp_cases(
         #[case] query: HistoryQueryFn,
-        #[case] timestamp: Timestamp,
-        #[case] expected: Result<(Version, Timestamp), KernelError>,
+        #[case] timestamp: i64,
+        #[case] expected: Result<(Version, i64), KernelError>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let storage = Arc::new(InMemory::new());
         let table_root = "memory:///test_table/";

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -589,6 +589,10 @@ pub fn engine_store_setup(
     (storage, engine, url)
 }
 
+/// Fixed in-commit timestamp (milliseconds since the Unix epoch) written by [`create_table`] when
+/// the `inCommitTimestamp` writer feature is enabled.
+pub const TEST_ICT_ENABLEMENT_TIMESTAMP: i64 = 1612345678;
+
 // we provide this table creation function since we only do appends to existing tables for now.
 // this will just create an empty table with the given schema. (just protocol + metadata actions)
 // For property-gated writer features, this helper also writes the corresponding enablement
@@ -649,7 +653,7 @@ pub async fn create_table(
             );
             config.insert(
                 "delta.inCommitTimestampEnablementTimestamp".to_string(),
-                json!("1612345678"),
+                json!(TEST_ICT_ENABLEMENT_TIMESTAMP.to_string()),
             );
         }
         if writer_features.contains(&"changeDataFeed") {
@@ -682,7 +686,7 @@ pub async fn create_table(
     // Add commitInfo with ICT if ICT is enabled
     let commit_info = if writer_features.contains(&"inCommitTimestamp") {
         // When ICT is enabled from version 0, we need to include it in the initial commit
-        let timestamp = 1612345678i64; // Use a fixed timestamp for testing
+        let timestamp = TEST_ICT_ENABLEMENT_TIMESTAMP;
         Some(json!({
             "commitInfo": {
                 "timestamp": timestamp,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implemented the FFI function for `history_manager::latest_version_as_of` and `history_manager::first_version_after`, allowing the connector in other languages to resolve the timestamp to a commit version.  

FFI function `latest_version_as_of` / `first_version_after` — wrap the kernel `history_manager` functions of the same name. Each takes a snapshot handle, engine handle,  a timestamp (milliseconds since the Unix epoch), and a `FfiHistoryCommitType`, and returns `ExternResult<FfiCommitAt>`.

## How was this change tested?

- New FFI unit test was added.