### PR TITLE
fix: update workload download to use local ca

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1429,16 @@ dependencies = [
  "serde_json",
  "sqlparser",
  "url",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -2969,6 +2985,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,7 +3806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4776,14 +4800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64",
+ "der",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
- "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -5039,15 +5064,6 @@ name = "webpki-root-certs"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
  "tempfile",
  "test-case",
@@ -1333,6 +1334,7 @@ dependencies = [
  "object_store 0.12.5",
  "rayon",
  "serde_json",
+ "sha2",
  "tar",
  "test_utils",
  "tokio",
@@ -4017,6 +4019,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -37,7 +37,10 @@ tracing = { version = "0.1", default-features = false }
 url = "2"
 
 [build-dependencies]
-ureq = "3.1"
+# native-tls validates against the OS trust store (like curl), so build-script downloads work
+# behind a sanctioned TLS-intercepting corporate proxy whose CA isn't in ureq's bundled
+# webpki-roots. See build.rs `build_agent`.
+ureq = { version = "3.1", default-features = false, features = ["native-tls", "gzip"] }
 flate2 = "1.1"
 tar = "0.4"
 

--- a/acceptance/Cargo.toml
+++ b/acceptance/Cargo.toml
@@ -42,6 +42,7 @@ url = "2"
 # webpki-roots. See build.rs `build_agent`.
 ureq = { version = "3.1", default-features = false, features = ["native-tls", "gzip"] }
 flate2 = "1.1"
+sha2 = "0.10"
 tar = "0.4"
 
 [dev-dependencies]

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -6,6 +6,7 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
 use tar::Archive;
 use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
@@ -14,6 +15,12 @@ const DAT_EXISTS_FILE_CHECK: &str = "tests/dat/.done";
 const DAT_OUTPUT_FOLDER: &str = "tests/dat";
 const DAT_VERSION: &str = "0.0.3";
 const ACCEPTANCE_WORKLOADS_VERSION: &str = "0.0.4";
+
+// SHA-256 of the release assets. Each download is otherwise trusted purely on TLS; verifying these
+// digests before extraction stops a tampered or MITM'd tarball from being unpacked to disk. Update
+// alongside the version constants above.
+const DAT_CHECKSUM: &str = "19c045bc6f4e8531d1985d0f7bb156d788e65078b435d613c8e4a9c753b4a982";
+const WORKLOAD_CHECKSUM: &str = "c129283e152239c810a6cf2e35571268bd7452fb379f6294abcee340f2436312";
 
 /// Workloads to skip on Windows due to invalid filename characters.
 /// Windows does not support these characters in filenames: < > : " | ? *
@@ -43,10 +50,10 @@ fn download_dat_files() -> Vec<u8> {
         "https://github.com/delta-incubator/dat/releases/download/v{DAT_VERSION}/deltalake-dat-v{DAT_VERSION}.tar.gz"
     );
 
-    download_tarball(&tarball_url)
+    download_tarball(&tarball_url, DAT_CHECKSUM)
 }
 
-fn download_tarball(url: &str) -> Vec<u8> {
+fn download_tarball(url: &str, expected_checksum: &str) -> Vec<u8> {
     let response = build_agent().get(url).call().unwrap();
 
     let mut tarball_data: Vec<u8> = Vec::new();
@@ -56,7 +63,22 @@ fn download_tarball(url: &str) -> Vec<u8> {
         .read_to_end(&mut tarball_data)
         .unwrap();
 
+    verify_checksum(&tarball_data, expected_checksum);
+
     tarball_data
+}
+
+/// Panic unless the SHA-256 of `data` equals `expected` (lowercase hex). Called before any
+/// extraction, so a download whose digest doesn't match the pinned value fails the build instead
+/// of being unpacked to disk.
+fn verify_checksum(data: &[u8], expected: &str) {
+    let actual: String = Sha256::digest(data)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    if actual != expected {
+        panic!("tarball checksum mismatch: expected {expected}, got {actual}");
+    }
 }
 
 /// Build a `ureq` agent that validates TLS against the OS trust store (native-tls) rather than
@@ -131,7 +153,7 @@ fn extract_acceptance_workloads() {
         "https://github.com/delta-incubator/dat/releases/download/v0.04-preview/v{ACCEPTANCE_WORKLOADS_VERSION}_dat_workloads.tar.gz"
     );
 
-    let tarball_data = download_tarball(&tarball_url);
+    let tarball_data = download_tarball(&tarball_url, WORKLOAD_CHECKSUM);
 
     // Extract tarball, skipping files with invalid Windows filenames
     let decoder = GzDecoder::new(BufReader::new(&tarball_data[..]));

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -16,11 +16,8 @@ const DAT_OUTPUT_FOLDER: &str = "tests/dat";
 const DAT_VERSION: &str = "0.0.3";
 const ACCEPTANCE_WORKLOADS_VERSION: &str = "0.0.4";
 
-// SHA-256 of the release assets. Each download is otherwise trusted purely on TLS; verifying these
-// digests before extraction stops a tampered or MITM'd tarball from being unpacked to disk. Update
-// alongside the version constants above.
-const DAT_CHECKSUM: &str = "19c045bc6f4e8531d1985d0f7bb156d788e65078b435d613c8e4a9c753b4a982";
-const WORKLOAD_CHECKSUM: &str = "c129283e152239c810a6cf2e35571268bd7452fb379f6294abcee340f2436312";
+const DAT_CHECKSUM: &str = "19c045bc6f4e8531d1985d0f7bb156d788e65078b435d613c8e4a9c753b4a982"; // dat checksum
+const WORKLOAD_CHECKSUM: &str = "c129283e152239c810a6cf2e35571268bd7452fb379f6294abcee340f2436312"; // workloads checksum
 
 /// Workloads to skip on Windows due to invalid filename characters.
 /// Windows does not support these characters in filenames: < > : " | ? *
@@ -81,14 +78,6 @@ fn verify_checksum(data: &[u8], expected: &str) {
     }
 }
 
-/// Build a `ureq` agent that validates TLS against the OS trust store (native-tls) rather than
-/// ureq's default rustls + bundled webpki-roots.
-///
-/// ureq defaults to `RootCerts::WebPki` to resist MITM proxies, but behind a sanctioned
-/// TLS-intercepting corporate proxy the interception CA lives in the system trust store and not
-/// in the Mozilla bundle, so the default backend rejects the chain with `UnknownIssuer`.
-/// `RootCerts::PlatformVerifier` makes native-tls use the system roots (like `curl`). Honors
-/// `HTTPS_PROXY` if set.
 fn build_agent() -> Agent {
     let tls_config = TlsConfig::builder()
         .provider(TlsProvider::NativeTls)

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -16,8 +16,11 @@ const DAT_OUTPUT_FOLDER: &str = "tests/dat";
 const DAT_VERSION: &str = "0.0.3";
 const ACCEPTANCE_WORKLOADS_VERSION: &str = "0.0.4";
 
-const DAT_CHECKSUM: &str = "19c045bc6f4e8531d1985d0f7bb156d788e65078b435d613c8e4a9c753b4a982"; // dat checksum
-const WORKLOAD_CHECKSUM: &str = "c129283e152239c810a6cf2e35571268bd7452fb379f6294abcee340f2436312"; // workloads checksum
+// SHA-256 of the release assets. Each download is otherwise trusted purely on TLS; verifying these
+// digests before extraction stops a tampered or MITM'd tarball from being unpacked to disk. Update
+// alongside the version constants above.
+const DAT_CHECKSUM: &str = "19c045bc6f4e8531d1985d0f7bb156d788e65078b435d613c8e4a9c753b4a982";
+const WORKLOAD_CHECKSUM: &str = "c129283e152239c810a6cf2e35571268bd7452fb379f6294abcee340f2436312";
 
 /// Workloads to skip on Windows due to invalid filename characters.
 /// Windows does not support these characters in filenames: < > : " | ? *
@@ -78,6 +81,17 @@ fn verify_checksum(data: &[u8], expected: &str) {
     }
 }
 
+<<<<<<< HEAD
+=======
+/// Build a `ureq` agent that validates TLS against the OS trust store (native-tls) rather than
+/// ureq's default rustls + bundled webpki-roots.
+///
+/// ureq defaults to `RootCerts::WebPki` to resist MITM proxies, but behind a sanctioned
+/// TLS-intercepting corporate proxy the interception CA lives in the system trust store and not
+/// in the Mozilla bundle, so the default backend rejects the chain with `UnknownIssuer`.
+/// `RootCerts::PlatformVerifier` makes native-tls use the system roots (like `curl`). Honors
+/// `HTTPS_PROXY` if set.
+>>>>>>> 72cc7707 (add workload checksum verification)
 fn build_agent() -> Agent {
     let tls_config = TlsConfig::builder()
         .provider(TlsProvider::NativeTls)

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -81,17 +81,7 @@ fn verify_checksum(data: &[u8], expected: &str) {
     }
 }
 
-<<<<<<< HEAD
-=======
-/// Build a `ureq` agent that validates TLS against the OS trust store (native-tls) rather than
-/// ureq's default rustls + bundled webpki-roots.
-///
-/// ureq defaults to `RootCerts::WebPki` to resist MITM proxies, but behind a sanctioned
-/// TLS-intercepting corporate proxy the interception CA lives in the system trust store and not
-/// in the Mozilla bundle, so the default backend rejects the chain with `UnknownIssuer`.
-/// `RootCerts::PlatformVerifier` makes native-tls use the system roots (like `curl`). Honors
-/// `HTTPS_PROXY` if set.
->>>>>>> 72cc7707 (add workload checksum verification)
+/// Build a `ureq` agent that validates TLS against the OS trust store (native-tls).
 fn build_agent() -> Agent {
     let tls_config = TlsConfig::builder()
         .provider(TlsProvider::NativeTls)

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
 use tar::Archive;
+use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 const DAT_EXISTS_FILE_CHECK: &str = "tests/dat/.done";
@@ -46,14 +47,7 @@ fn download_dat_files() -> Vec<u8> {
 }
 
 fn download_tarball(url: &str) -> Vec<u8> {
-    let response = if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
-        let proxy = Proxy::new(&proxy_url).unwrap();
-        let config = Agent::config_builder().proxy(proxy.into()).build();
-        let agent = Agent::new_with_config(config);
-        agent.get(url).call().unwrap()
-    } else {
-        ureq::get(url).call().unwrap()
-    };
+    let response = build_agent().get(url).call().unwrap();
 
     let mut tarball_data: Vec<u8> = Vec::new();
     response
@@ -63,6 +57,27 @@ fn download_tarball(url: &str) -> Vec<u8> {
         .unwrap();
 
     tarball_data
+}
+
+/// Build a `ureq` agent that validates TLS against the OS trust store (native-tls) rather than
+/// ureq's default rustls + bundled webpki-roots.
+///
+/// ureq defaults to `RootCerts::WebPki` to resist MITM proxies, but behind a sanctioned
+/// TLS-intercepting corporate proxy the interception CA lives in the system trust store and not
+/// in the Mozilla bundle, so the default backend rejects the chain with `UnknownIssuer`.
+/// `RootCerts::PlatformVerifier` makes native-tls use the system roots (like `curl`). Honors
+/// `HTTPS_PROXY` if set.
+fn build_agent() -> Agent {
+    let tls_config = TlsConfig::builder()
+        .provider(TlsProvider::NativeTls)
+        .root_certs(RootCerts::PlatformVerifier)
+        .build();
+    let mut config = Agent::config_builder().tls_config(tls_config);
+    if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
+        let proxy = Proxy::new(&proxy_url).unwrap();
+        config = config.proxy(Some(proxy));
+    }
+    Agent::new_with_config(config.build())
 }
 
 fn extract_dat_tarball(tarball_data: Vec<u8>) {

--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -97,12 +97,11 @@ fn build_agent() -> Agent {
         .provider(TlsProvider::NativeTls)
         .root_certs(RootCerts::PlatformVerifier)
         .build();
-    let mut config = Agent::config_builder().tls_config(tls_config);
-    if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
-        let proxy = Proxy::new(&proxy_url).unwrap();
-        config = config.proxy(Some(proxy));
-    }
-    Agent::new_with_config(config.build())
+    let config = Agent::config_builder()
+        .tls_config(tls_config)
+        .proxy(Proxy::try_from_env())
+        .build();
+    Agent::new_with_config(config)
 }
 
 fn extract_dat_tarball(tarball_data: Vec<u8>) {

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -17,7 +17,7 @@ arrow-57 = ["delta_kernel/arrow-57", "delta_kernel_workloads/arrow-57"]
 [build-dependencies]
 flate2 = "1.1"
 tar = "0.4"
-ureq = "3.1"
+ureq = { version = "3.1", default-features = false, features = ["native-tls", "gzip"] }
 
 [dependencies]
 delta_kernel = { path = "../kernel", features = ["default-engine-base", "internal-api"] }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -16,6 +16,7 @@ arrow-57 = ["delta_kernel/arrow-57", "delta_kernel_workloads/arrow-57"]
 
 [build-dependencies]
 flate2 = "1.1"
+sha2 = "0.10"
 tar = "0.4"
 ureq = { version = "3.1", default-features = false, features = ["native-tls", "gzip"] }
 

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -69,7 +69,7 @@ fn build_agent() -> Agent {
         .provider(TlsProvider::NativeTls)
         .root_certs(RootCerts::PlatformVerifier)
         .build();
-    let config = Agent::config_builder().tls_config(tls_config).proxy(Proxy::try_from_env())
+    let config = Agent::config_builder().tls_config(tls_config).proxy(Proxy::try_from_env());
     Agent::new_with_config(config.build())
 }
 

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -69,11 +69,7 @@ fn build_agent() -> Agent {
         .provider(TlsProvider::NativeTls)
         .root_certs(RootCerts::PlatformVerifier)
         .build();
-    let mut config = Agent::config_builder().tls_config(tls_config);
-    if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
-        let proxy = Proxy::new(&proxy_url).unwrap();
-        config = config.proxy(Some(proxy));
-    }
+    let config = Agent::config_builder().tls_config(tls_config).proxy(Proxy::try_from_env())
     Agent::new_with_config(config.build())
 }
 

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -6,12 +6,14 @@ use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
+use sha2::{Digest, Sha256};
 use tar::Archive;
 use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 const VERSION: &str = "0.0.5-preview"; // release tag
 const WORKLOADS_VERSION: &str = "0.0.5"; // version in filename
+const WORKLOAD_CHECKSUM: &str = "ddac5359eca42e7ec65b4a7cfc6f4bc1d629d9c204ba714ec15e4ae830c37ba2"; // benchmarks checksum
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -33,10 +35,10 @@ fn download_workloads() -> Vec<u8> {
     let tarball_url = format!(
         "https://github.com/delta-incubator/dat/releases/download/v{VERSION}/v{WORKLOADS_VERSION}_benchmark_workloads.tar.gz"
     );
-    download_tarball(&tarball_url)
+    download_tarball(&tarball_url, WORKLOAD_CHECKSUM)
 }
 
-fn download_tarball(url: &str) -> Vec<u8> {
+fn download_tarball(url: &str, expected_checksum: &str) -> Vec<u8> {
     let response = build_agent().get(url).call().unwrap();
 
     let mut data: Vec<u8> = Vec::new();
@@ -45,7 +47,21 @@ fn download_tarball(url: &str) -> Vec<u8> {
         .as_reader()
         .read_to_end(&mut data)
         .unwrap();
+    verify_checksum(&data, expected_checksum);
     data
+}
+
+/// Panic unless the SHA-256 of `data` equals `expected` (lowercase hex). Called before any
+/// extraction, so a download whose digest doesn't match the pinned value fails the build instead
+/// of being unpacked to disk.
+fn verify_checksum(data: &[u8], expected: &str) {
+    let actual: String = Sha256::digest(data)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+    if actual != expected {
+        panic!("tarball checksum mismatch: expected {expected}, got {actual}");
+    }
 }
 
 fn build_agent() -> Agent {

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use flate2::read::GzDecoder;
 use tar::Archive;
+use ureq::tls::{RootCerts, TlsConfig, TlsProvider};
 use ureq::{Agent, Proxy};
 
 const VERSION: &str = "0.0.5-preview"; // release tag
@@ -36,13 +37,7 @@ fn download_workloads() -> Vec<u8> {
 }
 
 fn download_tarball(url: &str) -> Vec<u8> {
-    let response = if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
-        let proxy = Proxy::new(&proxy_url).unwrap();
-        let config = Agent::config_builder().proxy(proxy.into()).build();
-        Agent::new_with_config(config).get(url).call().unwrap()
-    } else {
-        ureq::get(url).call().unwrap()
-    };
+    let response = build_agent().get(url).call().unwrap();
 
     let mut data: Vec<u8> = Vec::new();
     response
@@ -51,6 +46,19 @@ fn download_tarball(url: &str) -> Vec<u8> {
         .read_to_end(&mut data)
         .unwrap();
     data
+}
+
+fn build_agent() -> Agent {
+    let tls_config = TlsConfig::builder()
+        .provider(TlsProvider::NativeTls)
+        .root_certs(RootCerts::PlatformVerifier)
+        .build();
+    let mut config = Agent::config_builder().tls_config(tls_config);
+    if let Ok(proxy_url) = env::var("HTTPS_PROXY") {
+        let proxy = Proxy::new(&proxy_url).unwrap();
+        config = config.proxy(Some(proxy));
+    }
+    Agent::new_with_config(config.build())
 }
 
 fn extract_tarball(tarball_data: Vec<u8>, output_dir: &Path) {

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -69,7 +69,9 @@ fn build_agent() -> Agent {
         .provider(TlsProvider::NativeTls)
         .root_certs(RootCerts::PlatformVerifier)
         .build();
-    let config = Agent::config_builder().tls_config(tls_config).proxy(Proxy::try_from_env());
+    let config = Agent::config_builder()
+        .tls_config(tls_config)
+        .proxy(Proxy::try_from_env());
     Agent::new_with_config(config.build())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Change our benchmark downloading to use the `PlatformVerifier` certificate authority to fix workload downloading error from downloading from the DAT repo. Note that this updates the TLS trust model for building workloads locally; we now use the OS trust set rather than the compiled in Mozilla set of CAs.

Also added a small baked in checksum to verify that our tar is what we expect before uncompressing.

## How was this change tested?
Tested that workload downloads are no longer broken.