### PR TITLE
feat!: read interval types in default engine

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -174,7 +174,7 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
     ),
-    // Partitioned interval columns need a Scalar::Interval to materialize, not yet supported.
+    // partition values need Scalar::Interval; not yet supported
     (
         "Interval partition values not supported (needs Scalar::Interval)",
         &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -165,16 +165,19 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         ],
     ),
     (
-        "Interval reads not yet supported in the default engine",
+        "Arrow parquet reader cannot annotate Unknown logical type from BOOLEAN physical type",
         &[
-            "intv_001_interval_ym_basic/specs/intv_001_interval_ym_basic_read_all",
-            "intv_002_interval_dt_basic/specs/intv_002_interval_dt_basic_read_all",
-            "intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all",
-            "intv_004_interval_negative/specs/intv_004_interval_negative_read_all",
-            "intv_005_interval_mixed/specs/intv_005_interval_mixed_read_all",
-            "intv_boundary_values/specs/intv_boundary_values_read_all",
-            "intv_sub_second/specs/intv_sub_second_read_all",
+            "void_001_void_top_level/specs/void_001_void_top_level_read_all",
+            "void_002_void_nested_struct/specs/void_002_void_nested_struct_read_all",
+            "void_005_void_schema_evolution/specs/void_005_void_schema_evolution_read_all",
+            "void_006_void_multiple_columns/specs/void_006_void_multiple_columns_read_all",
+            "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
+    ),
+    // Partitioned interval columns need a Scalar::Interval to materialize, not yet supported.
+    (
+        "Interval partition values not supported (needs Scalar::Interval)",
+        &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],
     ),
     (
         "Cannot fall back to log replay when checkpoint files are missing or incomplete",

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -164,16 +164,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "var_null_top_level/specs/var_null_top_level_filter_null",
         ],
     ),
-    (
-        "Arrow parquet reader cannot annotate Unknown logical type from BOOLEAN physical type",
-        &[
-            "void_001_void_top_level/specs/void_001_void_top_level_read_all",
-            "void_002_void_nested_struct/specs/void_002_void_nested_struct_read_all",
-            "void_005_void_schema_evolution/specs/void_005_void_schema_evolution_read_all",
-            "void_006_void_multiple_columns/specs/void_006_void_multiple_columns_read_all",
-            "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
-        ],
-    ),
     // partition values need Scalar::Interval; not yet supported
     (
         "Interval partition values not supported (needs Scalar::Interval)",

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -709,6 +709,18 @@ mod tests {
         Ok(())
     }
 
+    // Asserts forward direction of Interval column mapping (year-month/day-time to Int32/Int64)
+    #[rstest]
+    #[case(DataType::INTERVAL_YEAR_MONTH, ArrowDataType::Int32)]
+    #[case(DataType::INTERVAL_DAY_TIME, ArrowDataType::Int64)]
+    fn test_interval_type_arrow_conversion(
+        #[case] kernel_type: DataType,
+        #[case] expected: ArrowDataType,
+    ) -> DeltaResult<()> {
+        assert_eq!(ArrowDataType::try_from_kernel(&kernel_type)?, expected);
+        Ok(())
+    }
+
     // Millisecond-precision timestamps (e.g. from externally-written checkpoint stats)
     // must convert like microsecond/nanosecond: UTC tz -> TIMESTAMP, no tz -> TIMESTAMP_NTZ.
     #[test]
@@ -794,15 +806,6 @@ mod tests {
             .to_string()
             .contains("Incorrect Variant Schema"));
         Ok(())
-    }
-
-    // Make sure that interval types error gracefully since unsupported
-    #[rstest]
-    #[case(DataType::INTERVAL_YEAR_MONTH)]
-    #[case(DataType::INTERVAL_DAY_TIME)]
-    fn test_interval_type_arrow_conversion_unsupported(#[case] dt: DataType) {
-        let result: Result<ArrowDataType, _> = (&dt).try_into_arrow();
-        assert!(matches!(result.unwrap_err(), ArrowError::SchemaError(_)));
     }
 
     /// Helper visitor to collect all field IDs from a kernel StructType

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -369,11 +369,8 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
                     PrimitiveType::Void => Ok(ArrowDataType::Null),
-                    PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
-                        Err(ArrowError::SchemaError(format!(
-                            "Interval types are not yet supported in the default engine: {p}"
-                        )))
-                    }
+                    PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
+                    PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1491,3 +1491,15 @@ fn test_void_scalar_to_array() {
     assert_eq!(array.len(), 5);
     assert_eq!(*array.data_type(), DataType::Null);
 }
+
+// Unit test to ensure `Scalar::validate` rejects interval types
+#[rstest]
+#[case::year_month(KernelDataType::INTERVAL_YEAR_MONTH)]
+#[case::day_time(KernelDataType::INTERVAL_DAY_TIME)]
+fn test_interval_scalar_to_array_unsupported(#[case] interval_type: KernelDataType) {
+    let result = Scalar::Null(interval_type).to_array(1);
+    assert!(
+        matches!(result, Err(crate::error::Error::Unsupported(_))),
+        "expected Unsupported, got {result:?}"
+    );
+}

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1492,7 +1492,7 @@ fn test_void_scalar_to_array() {
     assert_eq!(*array.data_type(), DataType::Null);
 }
 
-// Unit test to ensure `Scalar::validate` rejects interval types
+// Unit test to ensure scalars reject interval types
 #[rstest]
 #[case::year_month(KernelDataType::INTERVAL_YEAR_MONTH)]
 #[case::day_time(KernelDataType::INTERVAL_DAY_TIME)]

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -898,6 +898,23 @@ mod tests {
         );
     }
 
+    #[rstest]
+    fn interval_rejects_incompatible_arrow_types(
+        #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,
+        #[values(
+            ArrowDataType::Utf8,
+            ArrowDataType::Boolean,
+            ArrowDataType::Date32,
+            ArrowDataType::Float64
+        )]
+        arrow_type: ArrowDataType,
+    ) {
+        assert_result_error_with_message(
+            ensure_data_types(&interval, &arrow_type, ValidationMode::TypesAndNames),
+            "Incorrect datatype",
+        );
+    }
+
     /// Ensures that every kernel-level checkpoint reinterpretation rule in
     /// `PrimitiveType::is_checkpoint_cast_compatible` has a corresponding Arrow cast
     /// in `check_cast_compat`. If one side is updated without the other, this test fails.

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -876,6 +876,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn interval_maps_to_physical_integer() {
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_YEAR_MONTH,
+                &ArrowDataType::Int32,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_DAY_TIME,
+                &ArrowDataType::Int64,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+    }
+
     /// Ensures that every kernel-level checkpoint reinterpretation rule in
     /// `PrimitiveType::is_checkpoint_cast_compatible` has a corresponding Arrow cast
     /// in `check_cast_compat`. If one side is updated without the other, this test fails.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2769/files) to review incremental changes.
- [**stack/interval_reads_engine**](https://github.com/delta-io/delta-kernel-rs/pull/2769) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2769/files)] ← _this PR_
  - [stack/interval-reads-feature](https://github.com/delta-io/delta-kernel-rs/pull/2880) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2880/files/21a1fbb3f198f05ba8f40cf29ab57a472832dc91..602480e64fa74a0ef59015d1de282cf4a6fe10a5)]
    - [stack/interval_write_support](https://github.com/delta-io/delta-kernel-rs/pull/2845) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2845/files/602480e64fa74a0ef59015d1de282cf4a6fe10a5..39353a4de9a591afac5e18503fef825c07715536)]
      - [stack/interval_scalars](https://github.com/delta-io/delta-kernel-rs/pull/2854) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2854/files/39353a4de9a591afac5e18503fef825c07715536..a19ba2800f690ae049c648e2b3102eb4aa4a447e)]
        - [stack/interval_ffi_changes](https://github.com/delta-io/delta-kernel-rs/pull/2903) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2903/files/a19ba2800f690ae049c648e2b3102eb4aa4a447e..6f04535206b4b659c8e028e064102da52db12fdc)]

---------
## What changes are proposed in this pull request?

Support interval types in default engine. Use raw Arrow::Int for interval types, gracefully error everywhere else (Scalars, stats, etc.). We assume raw int32/int64 in Parquet, as per the [RFC](https://github.com/delta-io/delta/pull/7078).

This should remain open until RFC gets merged in as an official proposal.

## How was this change tested?

Existing `intv_*` tests pass, new unit tests added & existing unit tests modified.
