### PR TITLE
fix: update benchmark ci to checkout merge head

### DIFF
--- a/.github/SECURITY_MODEL.md
+++ b/.github/SECURITY_MODEL.md
@@ -1,14 +1,16 @@
 # Benchmark workflow security model
 
-Scope: [`benchmark.yml`](workflows/benchmark.yml) (runs bench on PR head) and
+Scope: [`benchmark.yml`](workflows/benchmark.yml) (runs bench on the PR merge
+commit -- PR head merged into base) and
 [`benchmark-post-comment.yml`](workflows/benchmark-post-comment.yml) (posts the
 result comment in base-branch context). Other workflows in this repo may follow
 different patterns -- this document is specific to the benchmark pair.
 
 ## Running untrusted PR code
 
-The `run-benchmark` job in `benchmark.yml` checks out the PR head and runs
-its build + bench harness. To bound what that code can do:
+The `run-benchmark` job in `benchmark.yml` checks out the PR merge commit (PR
+head merged into base) and runs its build + bench harness. To bound what that
+code can do:
 
 - Workflow-level `permissions: {}` is the default; each job opts in to the
   minimum scope it needs. `run-benchmark` declares only `contents: read`,
@@ -16,8 +18,8 @@ its build + bench harness. To bound what that code can do:
   a read-only token from GitHub by default under the `pull_request` event.
 - `actions/checkout` uses `persist-credentials: false` so the token isn't
   left in the local git config after checkout.
-- `cargo install critcmp` runs *before* the PR-head checkout, so the PR's
-  `.cargo/config.toml` cannot redirect the registry for that install.
+- `cargo install critcmp` runs *before* the PR merge-commit checkout, so the
+  PR's `.cargo/config.toml` cannot redirect the registry for that install.
 
 Do not add other secrets or grant write permissions to `run-benchmark`.
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -194,7 +194,13 @@ jobs:
         run: cargo install critcmp --version 0.1.8
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ steps.pr.outputs.head_sha }}
+          # Check out the integration commit (PR head merged into base) that
+          # GitHub maintains at refs/pull/<N>/merge -- the same ref build.yml
+          # and the test jobs resolve to via their bare checkout. Benchmarking
+          # this measures the PR as it would land, not the raw head. An
+          # unmergeable PR has no maintained merge ref, so the checkout fails
+          # and the job stops (parity with build/test; see SECURITY_MODEL.md).
+          ref: refs/pull/${{ steps.pr.outputs.pr_number }}/merge
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -2,7 +2,8 @@
 # Benchmark comparison script for pull requests.
 #
 # Called by .github/workflows/benchmark.yml (run-benchmark job) after the repo
-# has been checked out at the PR head. Writes the formatted markdown comparison
+# has been checked out at the PR's merge commit (refs/pull/<N>/merge -- PR head
+# merged into base). Writes the formatted markdown comparison
 # to /tmp/bench-comment.md; the companion benchmark-post-comment.yml workflow
 # downloads it as an artifact and posts the PR comment in base-branch context.
 #
@@ -86,8 +87,11 @@ echo "mem: $(free -m | awk '/^Mem:/ {print $2 " MB total, " $7 " MB available"}'
 echo "==========================="
 
 # ---------------------------------------------------------------------------
-# 3. Benchmark the PR branch (already checked out by the workflow)
+# 3. Benchmark the integration commit (PR head merged into base)
 # ---------------------------------------------------------------------------
+# HEAD is the merge commit checked out by the workflow; capture it so step 5 can
+# restore this tree after the base checkout below.
+MERGE_SHA=$(git rev-parse HEAD)
 (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER")
 
 # ---------------------------------------------------------------------------
@@ -105,12 +109,14 @@ git checkout FETCH_HEAD
 #    benchmarks/ci/parse_critcmp.py for the format and tier thresholds).
 #      - Parses actual duration values (not rank factors) to compute a ratio
 # ---------------------------------------------------------------------------
-# Step 3 left the working tree on the base branch, so parse_critcmp.py on disk
-# is the base version. Restore the PR-head tree so the comment is formatted by
-# the PR's own formatter (a formatter change is then exercised on the PR that
-# introduces it). Only tracked sources move; the `base`/`changes` criterion
-# baselines live in gitignored benchmarks/target/ and survive the checkout.
-git checkout "$HEAD_SHA"
+# Step 4 left the working tree on the base branch, so parse_critcmp.py on disk
+# is the base version. Restore the merge tree so the comment is formatted by the
+# PR's own formatter (a formatter change is then exercised on the PR that
+# introduces it). The raw PR-head SHA is not reachable in the shallow merge-ref
+# checkout, so restore the merge commit captured in step 3. Only tracked sources
+# move; the `base`/`changes` criterion baselines live in gitignored
+# benchmarks/target/ and survive the checkout.
+git checkout "$MERGE_SHA"
 # Use `critcmp` to compare the criterion output for `base` and `changes`. We use `critcmp` instead of manually
 # parsing criterion outputs because criterion may update its output format. By using `critcmp`, we inherit all
 # updated criterion output parsing.


### PR DESCRIPTION
## What changes are proposed in this pull request?
Previously benchmarking compared the PR's HEAD with Main's HEAD rather than attempting to merge the PR into main and comparing that ref to Main's HEAD. As a result sometimes benchmarking would appear to have regressions or improvements which did not truly exist. This PR fixes the comparison and doesn't run the benchmark if the PR is unable to merge.

## How was this change tested?
Checked that benchmarking correctly runs in this PR body and analyzed for security vulnerabilities.