### PR TITLE
feat: add commit range iterator FFI bindings

### DIFF
--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -68,7 +68,8 @@ commit_range_builder_for(path, start_version, engine)
 
 The caller owns the builder and must call either `commit_range_builder_build` or
 `free_commit_range_builder`. Release the range with `free_commit_range` and the commits iterator
-with `free_commit_actions_iter`. Release the commit action iterator via `free_commit_action`.
+with `free_commit_actions_iter`. Each `SharedCommitAction` handed to the visitor must be released
+with `free_commit_action`.
 
 ## Write Flow
 

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -51,17 +51,24 @@ The caller owns the returned builder handle and must call either `snapshot_build
 
 ## Commit Range Flow
 
-A `CommitRange` describes a contiguous commits of table. Build one
-via the commit range builder (`ffi/src/commit_range.rs`):
+A `CommitRange` describes a contiguous range of a table's commits. Build one via the commit range
+builder (`ffi/src/commit_range.rs`):
 
 ```
 commit_range_builder_for(path, start_version, engine)
   -> commit_range_builder_set_end_version(builder, end_version)  // optional; else latest version
   -> commit_range_builder_build(builder)                         // -> SharedCommitRange, always consume builder
+  -> commit_range_commits(range, engine, actions, actions_len)   // -> SharedCommitActionsIterator
+       // or commit_range_commits_with_snapshot(range, engine, start_snapshot, actions, actions_len)
+  -> commit_range_commits_next(iter, ctx, visitor)               // visitor receives a SharedCommitAction
+       // in the visitor: commit_action_version / commit_action_timestamp
+       //                  commit_action_get_actions(action, engine) -> ExclusiveFileReadResultIterator
+       //                    -> read_result_next(...) -> free_read_result_iter(...)
 ```
 
 The caller owns the builder and must call either `commit_range_builder_build` or
-`free_commit_range_builder`. Release the range with `free_commit_range`.
+`free_commit_range_builder`. Release the range with `free_commit_range` and the commits iterator
+with `free_commit_actions_iter`. Release the commit action iterator via `free_commit_action`.
 
 ## Write Flow
 

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -415,7 +415,8 @@ mod tests {
     use crate::engine_funcs::{free_read_result_iter, read_result_next};
     use crate::error::KernelError;
     use crate::ffi_test_utils::{
-        allocate_err, assert_extern_result_error_with_message, build_snapshot, ok_or_panic,
+        allocate_err, assert_extern_result_error_with_message, assert_timestamp_is_recent,
+        build_snapshot, ok_or_panic,
     };
     use crate::{
         engine_to_handle, free_engine, free_engine_data, free_snapshot, kernel_string_slice,
@@ -461,10 +462,16 @@ mod tests {
         unsafe { ok_or_panic(commit_range_builder_build(builder)) }
     }
 
-    /// Engine visitor that reads each commit action's version, then frees the handle.
-    extern "C" fn collect_versions(ctx: NullableCvoid, commit_action: Handle<SharedCommitAction>) {
+    /// Engine visitor that reads each commit action's version, assert its timestamp is recent,
+    /// then frees the handle.
+    extern "C" fn collect_versions_and_assert_timestamp(
+        ctx: NullableCvoid,
+        commit_action: Handle<SharedCommitAction>,
+    ) {
         let versions = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut Vec<u64>) };
         let version = unsafe { commit_action_version(commit_action.shallow_copy()) };
+        let timestamp = unsafe { commit_action_timestamp(commit_action.shallow_copy()) };
+        assert_timestamp_is_recent(timestamp);
         versions.push(version);
         unsafe { free_commit_action(commit_action) }
     }
@@ -477,7 +484,7 @@ mod tests {
             ok_or_panic(commit_range_commits_next(
                 iter.shallow_copy(),
                 ctx,
-                collect_versions,
+                collect_versions_and_assert_timestamp,
             ))
         } {}
         versions

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -6,6 +6,7 @@ use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
 use url::Url;
 
+use crate::engine_funcs::{ExclusiveFileReadResultIterator, FileReadResultIterator};
 use crate::handle::Handle;
 use crate::{
     unwrap_and_parse_path_as_url, ExternEngine, ExternResult, IntoExternResult, KernelStringSlice,
@@ -214,6 +215,40 @@ pub unsafe extern "C" fn commit_action_timestamp(commit_action: Handle<SharedCom
     commit_action.timestamp()
 }
 
+/// Get an iterator over this commit's action batches, projected to the read schema the commit was
+/// created with. Each batch is the raw actions recorded in the commit JSON, with no column-mapping
+/// translation applied. Issues a fresh read on creation, so the call is fallible.
+///
+/// - `engine`: performs the JSON read and allocates errors.
+///
+/// The caller owns the returned iterator: drain it with [`read_result_next`] and release it with
+/// [`free_read_result_iter`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing valid commit action and engine handles.
+///
+/// [`read_result_next`]: crate::engine_funcs::read_result_next
+/// [`free_read_result_iter`]: crate::engine_funcs::free_read_result_iter
+#[no_mangle]
+pub unsafe extern "C" fn commit_action_get_actions(
+    commit_action: Handle<SharedCommitAction>,
+    engine: Handle<SharedExternEngine>,
+) -> ExternResult<Handle<ExclusiveFileReadResultIterator>> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let commit_action = unsafe { commit_action.as_ref() };
+    let engine_arc = unsafe { engine.clone_as_arc() };
+    commit_action_get_actions_impl(commit_action, engine_arc).into_extern_result(&engine_ref)
+}
+
+fn commit_action_get_actions_impl(
+    commit_action: &CommitAction,
+    engine: Arc<dyn ExternEngine>,
+) -> DeltaResult<Handle<ExclusiveFileReadResultIterator>> {
+    let actions = commit_action.get_actions(engine.engine().as_ref())?;
+    Ok(FileReadResultIterator::into_handle(actions, engine))
+}
+
 /// Free a [`CommitAction`].
 ///
 /// # Safety
@@ -384,11 +419,16 @@ mod tests {
     use test_utils::{actions_to_string, add_commit, TestAction};
 
     use super::*;
+    use crate::engine_data::engine_data_length;
+    use crate::engine_funcs::{free_read_result_iter, read_result_next};
     use crate::error::KernelError;
     use crate::ffi_test_utils::{
         allocate_err, assert_extern_result_error_with_message, build_snapshot, ok_or_panic,
     };
-    use crate::{engine_to_handle, free_engine, free_snapshot, kernel_string_slice};
+    use crate::{
+        engine_to_handle, free_engine, free_engine_data, free_snapshot, kernel_string_slice,
+        ExclusiveEngineData,
+    };
 
     /// Build an in-memory engine handle pre-loaded with a metadata-only commit at each version in
     /// `0..=last_version`. Returns `(engine_handle, table_root)`; the caller frees the engine.
@@ -612,6 +652,77 @@ mod tests {
         };
         assert_extern_result_error_with_message(result, KernelError::GenericError, None);
 
+        unsafe { free_commit_range(range) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    /// Context for [`drain_commit_actions`]: the engine handle used to fetch each commit's action
+    /// batches, plus a running total of action rows read across all commits.
+    struct GetActionsCtx {
+        engine: Handle<SharedExternEngine>,
+        total_rows: usize,
+    }
+
+    /// Inner visitor: add one `EngineData` batch's row count to the `usize` accumulator (passed via
+    /// `ctx`), then free the batch.
+    extern "C" fn count_rows(ctx: NullableCvoid, data: Handle<ExclusiveEngineData>) {
+        let total = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut usize) };
+        let mut data = data;
+        *total += unsafe { engine_data_length(&mut data) };
+        unsafe { free_engine_data(data) }
+    }
+
+    /// Outer visitor: read one commit's action batches via [`commit_action_get_actions`],
+    /// accumulating their row count, then free the read-result iterator and the commit action.
+    extern "C" fn drain_commit_actions(ctx: NullableCvoid, action: Handle<SharedCommitAction>) {
+        let ctx = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut GetActionsCtx) };
+        let iter = unsafe {
+            ok_or_panic(commit_action_get_actions(
+                action.shallow_copy(),
+                ctx.engine.shallow_copy(),
+            ))
+        };
+        let rows_ctx = Some(unsafe { NonNull::new_unchecked(&mut ctx.total_rows) }.cast());
+        while unsafe { ok_or_panic(read_result_next(iter.shallow_copy(), rows_ctx, count_rows)) } {}
+        unsafe { free_read_result_iter(iter) }
+        unsafe { free_commit_action(action) }
+    }
+
+    #[tokio::test]
+    async fn test_commit_action_get_actions_yields_action_batches(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root) = setup_engine_with_commits(1).await;
+        let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
+
+        let actions = [KernelDeltaAction::Metadata];
+        let iter = unsafe {
+            ok_or_panic(commit_range_commits(
+                range.shallow_copy(),
+                engine.shallow_copy(),
+                actions.as_ptr(),
+                actions.len(),
+            ))
+        };
+
+        let mut ctx = GetActionsCtx {
+            engine: engine.shallow_copy(),
+            total_rows: 0,
+        };
+        let ctx_ptr = Some(unsafe { NonNull::new_unchecked(&mut ctx) }.cast());
+        while unsafe {
+            ok_or_panic(commit_range_commits_next(
+                iter.shallow_copy(),
+                ctx_ptr,
+                drain_commit_actions,
+            ))
+        } {}
+
+        // Each commit file holds three action lines (commitInfo, protocol, metaData) and
+        // `get_actions` yields one row per line, so the two commits (v0, v1) total six rows.
+        assert_eq!(ctx.total_rows, 6);
+
+        unsafe { free_commit_actions_iter(iter) }
         unsafe { free_commit_range(range) }
         unsafe { free_engine(engine) }
         Ok(())

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use delta_kernel::commit_range::{CommitAction, CommitRange, DeltaAction};
 use delta_kernel::snapshot::SnapshotRef;
@@ -137,8 +137,6 @@ pub unsafe extern "C" fn free_commit_range(commit_range: Handle<SharedCommitRang
     commit_range.drop_handle();
 }
 
-// === CommitRange::commits ===
-
 /// FFI-safe mirror of [`DeltaAction`]: the Delta log action kinds a caller can request from
 /// [`commit_range_commits`].
 #[repr(C)]
@@ -174,7 +172,7 @@ impl From<KernelDeltaAction> for DeltaAction {
 }
 
 /// Copy a C array of [`KernelDeltaAction`] into a `Vec<DeltaAction>`. A null pointer or zero
-/// length yields an empty vector (which [`CommitRange::commits`] rejects).
+/// length yields an empty vector.
 ///
 /// # Safety
 ///
@@ -257,19 +255,17 @@ pub unsafe extern "C" fn free_commit_action(commit_action: Handle<SharedCommitAc
     commit_action.drop_handle();
 }
 
-/// Boxed iterator over the commits in a range. Each `next` validates the commit and may fail.
 type CommitActionIter = DeltaResultIteratorStatic<CommitAction>;
 
 /// Iterator handle returned by [`commit_range_commits`]. Holds the boxed kernel iterator behind a
-/// mutex (so it is safe to share across threads) plus an engine reference for error allocation and
-/// to keep the engine's async runtime alive while iterating.
+/// mutex (so it is safe to share across threads) plus an engine reference for error allocation.
 pub struct FfiCommitActionsIterator {
     data: Mutex<CommitActionIter>,
     engine: Arc<dyn ExternEngine>,
 }
 
 impl FfiCommitActionsIterator {
-    fn lock_iter(&self) -> DeltaResult<std::sync::MutexGuard<'_, CommitActionIter>> {
+    fn lock_iter(&self) -> DeltaResult<MutexGuard<'_, CommitActionIter>> {
         self.data
             .lock()
             .map_err(|_| Error::generic("poisoned commit-actions iterator mutex"))
@@ -280,8 +276,7 @@ impl FfiCommitActionsIterator {
 pub struct SharedCommitActionsIterator;
 
 /// Get an iterator over the commits in `commit_range`, yielding one [`CommitAction`] per commit.
-/// Each commit is validated against the protocol/metadata observed in the commits themselves; see
-/// [`commit_range_commits_with_snapshot`] to seed validation from a start snapshot instead.
+/// Use [`commit_range_commits_with_snapshot`] to seed the iterator from a start snapshot instead.
 ///
 /// - `engine`: performs the per-commit JSON reads and allocates errors.
 /// - `actions` / `actions_len`: the action kinds to project into each commit's read schema.
@@ -308,7 +303,7 @@ pub unsafe extern "C" fn commit_range_commits(
         .into_extern_result(&engine_ref)
 }
 
-/// Like [`commit_range_commits`], but seeds protocol/metadata validation from `start_snapshot`.
+/// Like [`commit_range_commits`], but seeds the iterator's protocol/metadata from `start_snapshot`.
 ///
 /// The snapshot's version must match the range's anchor (the start version for ascending ranges,
 /// the end version for descending ranges).
@@ -356,7 +351,7 @@ fn commit_range_commits_impl(
 
 /// Call `engine_visitor` with the next [`CommitAction`] in the range, returning `true` if an item
 /// was yielded and `false` once the iterator is exhausted. The visitor receives a
-/// [`SharedCommitAction`] it must free via [`free_commit_action`]. Per-commit protocol validation
+/// [`SharedCommitAction`] must free via [`free_commit_action`]. Per-commit protocol validation
 /// runs here, so a malformed commit surfaces as an error from this call.
 ///
 /// # Safety
@@ -399,11 +394,10 @@ fn commit_range_commits_next_impl(
 ///
 /// # Safety
 ///
-/// Caller is responsible for (at most once) passing a valid pointer returned by
-/// [`commit_range_commits`].
+/// Caller is responsible for passing a valid pointer.
 #[no_mangle]
-pub unsafe extern "C" fn free_commit_actions_iter(data: Handle<SharedCommitActionsIterator>) {
-    data.drop_handle();
+pub unsafe extern "C" fn free_commit_actions_iter(iter: Handle<SharedCommitActionsIterator>) {
+    iter.drop_handle();
 }
 
 #[cfg(test)]
@@ -467,21 +461,18 @@ mod tests {
         unsafe { ok_or_panic(commit_range_builder_build(builder)) }
     }
 
-    /// Visitor that reads each commit action's version (also touching the timestamp accessor) into
-    /// the `Vec<u64>` passed via `engine_context`, then frees the handle.
+    /// Engine visitor that reads each commit action's version, then frees the handle.
     extern "C" fn collect_versions(ctx: NullableCvoid, commit_action: Handle<SharedCommitAction>) {
-        let mut versions = unsafe { Box::from_raw(ctx.unwrap().as_ptr() as *mut Vec<u64>) };
+        let versions = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut Vec<u64>) };
         let version = unsafe { commit_action_version(commit_action.shallow_copy()) };
-        let _timestamp = unsafe { commit_action_timestamp(commit_action.shallow_copy()) };
         versions.push(version);
-        Box::leak(versions);
         unsafe { free_commit_action(commit_action) }
     }
 
     /// Drain a commit-actions iterator, returning the versions yielded in order.
     unsafe fn drain_versions(iter: Handle<SharedCommitActionsIterator>) -> Vec<u64> {
-        let versions_ptr = Box::into_raw(Box::new(Vec::<u64>::new()));
-        let ctx = Some(unsafe { NonNull::new_unchecked(versions_ptr) }.cast());
+        let mut versions = Vec::<u64>::new();
+        let ctx = Some(unsafe { NonNull::new_unchecked(&mut versions) }.cast());
         while unsafe {
             ok_or_panic(commit_range_commits_next(
                 iter.shallow_copy(),
@@ -489,7 +480,7 @@ mod tests {
                 collect_versions,
             ))
         } {}
-        *unsafe { Box::from_raw(versions_ptr) }
+        versions
     }
 
     #[rstest]
@@ -581,55 +572,43 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_commit_range_commits_no_snapshot_yields_each_commit(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (engine, table_root) = setup_engine_with_commits(1).await;
-        let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
-
-        let actions = [KernelDeltaAction::Metadata, KernelDeltaAction::Protocol];
-        let iter = unsafe {
-            ok_or_panic(commit_range_commits(
-                range.shallow_copy(),
-                engine.shallow_copy(),
-                actions.as_ptr(),
-                actions.len(),
-            ))
-        };
-        let versions = unsafe { drain_versions(iter.shallow_copy()) };
-        assert_eq!(versions, vec![0, 1]);
-
-        unsafe { free_commit_actions_iter(iter) }
-        unsafe { free_commit_range(range) }
-        unsafe { free_engine(engine) }
-        Ok(())
-    }
-
     #[rstest]
-    #[case::matched_anchor_yields_commit(1, 1, Some(vec![1]))]
-    #[case::mismatched_anchor_errors(0, 0, None)]
+    #[case::no_snapshot_yields_each_commit(false, 0, 1, Some(vec![0, 1]))]
+    #[case::snapshot_matched_anchor_yields_commit(true, 1, 1, Some(vec![1]))]
+    #[case::snapshot_mismatched_anchor_errors(true, 0, 0, None)]
     #[tokio::test]
-    async fn test_commit_range_commits_with_snapshot(
+    async fn test_commit_range_commits(
+        #[case] with_snapshot: bool,
         #[case] range_start: u64,
         #[case] range_end: u64,
         #[case] expected: Option<Vec<u64>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root) = setup_engine_with_commits(1).await;
-        let snapshot =
-            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
         let range =
             unsafe { build_range(table_root, range_start, range_end, engine.shallow_copy()) };
+        let actions = [KernelDeltaAction::Metadata, KernelDeltaAction::Protocol];
 
-        let actions = [KernelDeltaAction::Metadata];
+        let snapshot = with_snapshot.then(|| unsafe {
+            build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy())
+        });
         let result = unsafe {
-            commit_range_commits_with_snapshot(
-                range.shallow_copy(),
-                engine.shallow_copy(),
-                snapshot.shallow_copy(),
-                actions.as_ptr(),
-                actions.len(),
-            )
+            match &snapshot {
+                Some(snapshot) => commit_range_commits_with_snapshot(
+                    range.shallow_copy(),
+                    engine.shallow_copy(),
+                    snapshot.shallow_copy(),
+                    actions.as_ptr(),
+                    actions.len(),
+                ),
+                None => commit_range_commits(
+                    range.shallow_copy(),
+                    engine.shallow_copy(),
+                    actions.as_ptr(),
+                    actions.len(),
+                ),
+            }
         };
+
         match expected {
             Some(expected_versions) => {
                 let iter = ok_or_panic(result);
@@ -642,7 +621,9 @@ mod tests {
             }
         }
 
-        unsafe { free_snapshot(snapshot) }
+        if let Some(snapshot) = snapshot {
+            unsafe { free_snapshot(snapshot) }
+        }
         unsafe { free_commit_range(range) }
         unsafe { free_engine(engine) }
         Ok(())
@@ -676,8 +657,8 @@ mod tests {
         total_rows: usize,
     }
 
-    /// Inner visitor: add one `EngineData` batch's row count to the `usize` accumulator (passed via
-    /// `ctx`), then free the batch.
+    /// Engine visitor that calculuates `EngineData` batch's row to an accumulator, then free the
+    /// batch.
     extern "C" fn count_rows(ctx: NullableCvoid, data: Handle<ExclusiveEngineData>) {
         let total = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut usize) };
         let mut data = data;
@@ -685,7 +666,7 @@ mod tests {
         unsafe { free_engine_data(data) }
     }
 
-    /// Outer visitor: read one commit's action batches via [`commit_action_get_actions`],
+    /// Engine visitor that read one commit's action batches via [`commit_action_get_actions`],
     /// accumulating their row count, then free the read-result iterator and the commit action.
     extern "C" fn drain_commit_actions(ctx: NullableCvoid, action: Handle<SharedCommitAction>) {
         let ctx = unsafe { &mut *(ctx.unwrap().as_ptr() as *mut GetActionsCtx) };
@@ -730,8 +711,6 @@ mod tests {
             ))
         } {}
 
-        // Each commit file holds three action lines (commitInfo, protocol, metaData) and
-        // `get_actions` yields one row per line, so the two commits (v0, v1) total six rows.
         assert_eq!(ctx.total_rows, 6);
 
         unsafe { free_commit_actions_iter(iter) }

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -1,14 +1,15 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use delta_kernel::commit_range::CommitRange;
-use delta_kernel::{DeltaResult, Version};
+use delta_kernel::commit_range::{CommitAction, CommitRange, DeltaAction};
+use delta_kernel::snapshot::SnapshotRef;
+use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
 use url::Url;
 
 use crate::handle::Handle;
 use crate::{
     unwrap_and_parse_path_as_url, ExternEngine, ExternResult, IntoExternResult, KernelStringSlice,
-    SharedExternEngine,
+    NullableCvoid, SharedExternEngine, SharedSnapshot,
 };
 
 /// An opaque, shared handle owning a [`CommitRange`] produced by
@@ -135,8 +136,246 @@ pub unsafe extern "C" fn free_commit_range(commit_range: Handle<SharedCommitRang
     commit_range.drop_handle();
 }
 
+// === CommitRange::commits ===
+
+/// FFI-safe mirror of [`DeltaAction`]: the Delta log action kinds a caller can request from
+/// [`commit_range_commits`].
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KernelDeltaAction {
+    Add = 0,
+    Remove = 1,
+    Metadata = 2,
+    Protocol = 3,
+    CommitInfo = 4,
+    Cdc = 5,
+    DomainMetadata = 6,
+    SetTxn = 7,
+    CheckpointMetadata = 8,
+    Sidecar = 9,
+}
+
+impl From<KernelDeltaAction> for DeltaAction {
+    fn from(value: KernelDeltaAction) -> Self {
+        match value {
+            KernelDeltaAction::Add => DeltaAction::Add,
+            KernelDeltaAction::Remove => DeltaAction::Remove,
+            KernelDeltaAction::Metadata => DeltaAction::Metadata,
+            KernelDeltaAction::Protocol => DeltaAction::Protocol,
+            KernelDeltaAction::CommitInfo => DeltaAction::CommitInfo,
+            KernelDeltaAction::Cdc => DeltaAction::Cdc,
+            KernelDeltaAction::DomainMetadata => DeltaAction::DomainMetadata,
+            KernelDeltaAction::SetTxn => DeltaAction::SetTxn,
+            KernelDeltaAction::CheckpointMetadata => DeltaAction::CheckpointMetadata,
+            KernelDeltaAction::Sidecar => DeltaAction::Sidecar,
+        }
+    }
+}
+
+/// Copy a C array of [`KernelDeltaAction`] into a `Vec<DeltaAction>`. A null pointer or zero
+/// length yields an empty vector (which [`CommitRange::commits`] rejects).
+///
+/// # Safety
+///
+/// `ptr` must point to `len` valid [`KernelDeltaAction`] values that remain valid for this call.
+unsafe fn parse_actions(ptr: *const KernelDeltaAction, len: usize) -> Vec<DeltaAction> {
+    if ptr.is_null() || len == 0 {
+        return Vec::new();
+    }
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    slice.iter().map(|action| (*action).into()).collect()
+}
+
+/// An opaque, shared handle to a single [`CommitAction`] yielded by [`commit_range_commits_next`].
+/// The engine owns each handle passed to its visitor and must release it with
+/// [`free_commit_action`].
+#[handle_descriptor(target=CommitAction, mutable=false, sized=true)]
+pub struct SharedCommitAction;
+
+/// The commit version of this commit action.
+///
+/// # Safety
+///
+/// Caller must pass a valid commit action handle.
+#[no_mangle]
+pub unsafe extern "C" fn commit_action_version(commit_action: Handle<SharedCommitAction>) -> u64 {
+    let commit_action = unsafe { commit_action.as_ref() };
+    commit_action.version()
+}
+
+/// The commit timestamp (milliseconds since epoch) of this commit action.
+///
+/// # Safety
+///
+/// Caller must pass a valid commit action handle.
+#[no_mangle]
+pub unsafe extern "C" fn commit_action_timestamp(commit_action: Handle<SharedCommitAction>) -> i64 {
+    let commit_action = unsafe { commit_action.as_ref() };
+    commit_action.timestamp()
+}
+
+/// Free a [`CommitAction`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid handle.
+#[no_mangle]
+pub unsafe extern "C" fn free_commit_action(commit_action: Handle<SharedCommitAction>) {
+    commit_action.drop_handle();
+}
+
+/// Boxed iterator over the commits in a range. Each `next` validates the commit and may fail.
+type CommitActionIter = DeltaResultIteratorStatic<CommitAction>;
+
+/// Iterator handle returned by [`commit_range_commits`]. Holds the boxed kernel iterator behind a
+/// mutex (so it is safe to share across threads) plus an engine reference for error allocation and
+/// to keep the engine's async runtime alive while iterating.
+pub struct CommitActionsIterator {
+    data: Mutex<CommitActionIter>,
+    engine: Arc<dyn ExternEngine>,
+}
+
+impl CommitActionsIterator {
+    fn lock_iter(&self) -> DeltaResult<std::sync::MutexGuard<'_, CommitActionIter>> {
+        self.data
+            .lock()
+            .map_err(|_| Error::generic("poisoned commit-actions iterator mutex"))
+    }
+}
+
+#[handle_descriptor(target=CommitActionsIterator, mutable=false, sized=true)]
+pub struct SharedCommitActionsIterator;
+
+/// Get an iterator over the commits in `commit_range`, yielding one [`CommitAction`] per commit.
+/// Each commit is validated against the protocol/metadata observed in the commits themselves; see
+/// [`commit_range_commits_with_snapshot`] to seed validation from a start snapshot instead.
+///
+/// - `engine`: performs the per-commit JSON reads and allocates errors.
+/// - `actions` / `actions_len`: the action kinds to project into each commit's read schema.
+///
+/// Returns an error if `actions` is empty or contains duplicate kinds. The caller owns the
+/// returned iterator and must release it with [`free_commit_actions_iter`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing valid handles, and an `actions` pointer to `actions_len`
+/// valid [`KernelDeltaAction`] values.
+#[no_mangle]
+pub unsafe extern "C" fn commit_range_commits(
+    commit_range: Handle<ExclusiveCommitRange>,
+    engine: Handle<SharedExternEngine>,
+    actions: *const KernelDeltaAction,
+    actions_len: usize,
+) -> ExternResult<Handle<SharedCommitActionsIterator>> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let commit_range = unsafe { commit_range.as_ref() };
+    let engine_arc = unsafe { engine.clone_as_arc() };
+    let actions = unsafe { parse_actions(actions, actions_len) };
+    commit_range_commits_impl(commit_range, engine_arc, None, actions)
+        .into_extern_result(&engine_ref)
+}
+
+/// Like [`commit_range_commits`], but seeds protocol/metadata validation from `start_snapshot`.
+///
+/// The snapshot's version must match the range's anchor (the start version for ascending ranges,
+/// the end version for descending ranges).
+///
+/// Returns an error if `actions` is empty or contains duplicate kinds, or if `start_snapshot`
+/// belongs to a different table, its version does not match the range anchor, or its table does
+/// not support scanning. The caller owns the returned iterator and must release it with
+/// [`free_commit_actions_iter`].
+///
+/// # Safety
+///
+/// Caller is responsible for passing valid handles, and an `actions` pointer to `actions_len`
+/// valid [`KernelDeltaAction`] values.
+#[no_mangle]
+pub unsafe extern "C" fn commit_range_commits_with_snapshot(
+    commit_range: Handle<ExclusiveCommitRange>,
+    engine: Handle<SharedExternEngine>,
+    start_snapshot: Handle<SharedSnapshot>,
+    actions: *const KernelDeltaAction,
+    actions_len: usize,
+) -> ExternResult<Handle<SharedCommitActionsIterator>> {
+    let engine_ref = unsafe { engine.as_ref() };
+    let commit_range = unsafe { commit_range.as_ref() };
+    let engine_arc = unsafe { engine.clone_as_arc() };
+    let start_snapshot = unsafe { start_snapshot.clone_as_arc() };
+    let actions = unsafe { parse_actions(actions, actions_len) };
+    commit_range_commits_impl(commit_range, engine_arc, Some(start_snapshot), actions)
+        .into_extern_result(&engine_ref)
+}
+
+fn commit_range_commits_impl(
+    commit_range: &CommitRange,
+    engine: Arc<dyn ExternEngine>,
+    start_snapshot: Option<SnapshotRef>,
+    actions: Vec<DeltaAction>,
+) -> DeltaResult<Handle<SharedCommitActionsIterator>> {
+    let inner = commit_range.commits(engine.engine(), start_snapshot, &actions)?;
+    let boxed: CommitActionIter = Box::new(inner);
+    let iter = CommitActionsIterator {
+        data: Mutex::new(boxed),
+        engine,
+    };
+    Ok(Arc::new(iter).into())
+}
+
+/// Call `engine_visitor` with the next [`CommitAction`] in the range, returning `true` if an item
+/// was yielded and `false` once the iterator is exhausted. The visitor receives a
+/// [`SharedCommitAction`] it must free via [`free_commit_action`]. Per-commit protocol validation
+/// runs here, so a malformed commit surfaces as an error from this call.
+///
+/// # Safety
+///
+/// The iterator must be valid (returned by [`commit_range_commits`]) and not yet freed by
+/// [`free_commit_actions_iter`]. The visitor function pointer must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn commit_range_commits_next(
+    data: Handle<SharedCommitActionsIterator>,
+    engine_context: NullableCvoid,
+    engine_visitor: extern "C" fn(
+        engine_context: NullableCvoid,
+        commit_action: Handle<SharedCommitAction>,
+    ),
+) -> ExternResult<bool> {
+    let data = unsafe { data.as_ref() };
+    commit_range_commits_next_impl(data, engine_context, engine_visitor)
+        .into_extern_result(&data.engine.as_ref())
+}
+
+fn commit_range_commits_next_impl(
+    data: &CommitActionsIterator,
+    engine_context: NullableCvoid,
+    engine_visitor: extern "C" fn(
+        engine_context: NullableCvoid,
+        commit_action: Handle<SharedCommitAction>,
+    ),
+) -> DeltaResult<bool> {
+    let mut iter = data.lock_iter()?;
+    match iter.next().transpose()? {
+        Some(commit_action) => {
+            (engine_visitor)(engine_context, Arc::new(commit_action).into());
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Free a commit-actions iterator.
+///
+/// # Safety
+///
+/// Caller is responsible for (at most once) passing a valid pointer returned by
+/// [`commit_range_commits`].
+#[no_mangle]
+pub unsafe extern "C" fn free_commit_actions_iter(data: Handle<SharedCommitActionsIterator>) {
+    data.drop_handle();
+}
+
 #[cfg(test)]
 mod tests {
+    use std::ptr::NonNull;
     use std::sync::Arc;
 
     use delta_kernel::object_store::memory::InMemory;
@@ -147,9 +386,9 @@ mod tests {
     use super::*;
     use crate::error::KernelError;
     use crate::ffi_test_utils::{
-        allocate_err, assert_extern_result_error_with_message, ok_or_panic,
+        allocate_err, assert_extern_result_error_with_message, build_snapshot, ok_or_panic,
     };
-    use crate::{engine_to_handle, free_engine, kernel_string_slice};
+    use crate::{engine_to_handle, free_engine, free_snapshot, kernel_string_slice};
 
     /// Build an in-memory engine handle pre-loaded with a metadata-only commit at each version in
     /// `0..=last_version`. Returns `(engine_handle, table_root)`; the caller frees the engine.
@@ -170,6 +409,49 @@ mod tests {
         }
         let engine = DefaultEngineBuilder::new(storage.clone()).build();
         (engine_to_handle(Arc::new(engine), allocate_err), table_root)
+    }
+
+    /// Build a `[start_version, end_version]` commit range handle via the FFI builder API.
+    unsafe fn build_range(
+        table_root: &str,
+        start_version: u64,
+        end_version: u64,
+        engine: Handle<SharedExternEngine>,
+    ) -> Handle<ExclusiveCommitRange> {
+        let mut builder = unsafe {
+            ok_or_panic(commit_range_builder_for(
+                kernel_string_slice!(table_root),
+                start_version,
+                engine,
+            ))
+        };
+        unsafe { commit_range_builder_with_end_version(&mut builder, end_version) };
+        unsafe { ok_or_panic(commit_range_builder_build(builder)) }
+    }
+
+    /// Visitor that reads each commit action's version (also touching the timestamp accessor) into
+    /// the `Vec<u64>` passed via `engine_context`, then frees the handle.
+    extern "C" fn collect_versions(ctx: NullableCvoid, commit_action: Handle<SharedCommitAction>) {
+        let mut versions = unsafe { Box::from_raw(ctx.unwrap().as_ptr() as *mut Vec<u64>) };
+        let version = unsafe { commit_action_version(commit_action.shallow_copy()) };
+        let _timestamp = unsafe { commit_action_timestamp(commit_action.shallow_copy()) };
+        versions.push(version);
+        Box::leak(versions);
+        unsafe { free_commit_action(commit_action) }
+    }
+
+    /// Drain a commit-actions iterator, returning the versions yielded in order.
+    unsafe fn drain_versions(iter: Handle<SharedCommitActionsIterator>) -> Vec<u64> {
+        let versions_ptr = Box::into_raw(Box::new(Vec::<u64>::new()));
+        let ctx = Some(unsafe { NonNull::new_unchecked(versions_ptr) }.cast());
+        while unsafe {
+            ok_or_panic(commit_range_commits_next(
+                iter.shallow_copy(),
+                ctx,
+                collect_versions,
+            ))
+        } {}
+        *unsafe { Box::from_raw(versions_ptr) }
     }
 
     #[rstest]
@@ -257,6 +539,80 @@ mod tests {
         let result = unsafe { commit_range_builder_build(builder) };
         assert_extern_result_error_with_message(result, KernelError::GenericError, None);
 
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_commit_range_commits_no_snapshot_yields_each_commit(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root) = setup_engine_with_commits(1).await;
+        let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
+
+        let actions = [KernelDeltaAction::Metadata, KernelDeltaAction::Protocol];
+        let iter = unsafe {
+            ok_or_panic(commit_range_commits(
+                range.shallow_copy(),
+                engine.shallow_copy(),
+                actions.as_ptr(),
+                actions.len(),
+            ))
+        };
+        let versions = unsafe { drain_versions(iter.shallow_copy()) };
+        assert_eq!(versions, vec![0, 1]);
+
+        unsafe { free_commit_actions_iter(iter) }
+        unsafe { free_commit_range(range) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_commit_range_commits_with_snapshot_yields_anchored_commit(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root) = setup_engine_with_commits(1).await;
+        // Anchor at the latest version (v=1) and pin the range to [1, 1].
+        let snapshot =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+        let range = unsafe { build_range(table_root, 1, 1, engine.shallow_copy()) };
+
+        let actions = [KernelDeltaAction::Metadata];
+        let iter = unsafe {
+            ok_or_panic(commit_range_commits_with_snapshot(
+                range.shallow_copy(),
+                engine.shallow_copy(),
+                snapshot.shallow_copy(),
+                actions.as_ptr(),
+                actions.len(),
+            ))
+        };
+        let versions = unsafe { drain_versions(iter.shallow_copy()) };
+        assert_eq!(versions, vec![1]);
+
+        unsafe { free_commit_actions_iter(iter) }
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_commit_range(range) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_commit_range_commits_errors_on_empty_actions(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, table_root) = setup_engine_with_commits(1).await;
+        let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
+
+        let result = unsafe {
+            commit_range_commits(
+                range.shallow_copy(),
+                engine.shallow_copy(),
+                std::ptr::null(),
+                0,
+            )
+        };
+        assert_extern_result_error_with_message(result, KernelError::GenericError, None);
+
+        unsafe { free_commit_range(range) }
         unsafe { free_engine(engine) }
         Ok(())
     }

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -297,7 +297,7 @@ pub struct SharedCommitActionsIterator;
 /// valid [`KernelDeltaAction`] values.
 #[no_mangle]
 pub unsafe extern "C" fn commit_range_commits(
-    commit_range: Handle<ExclusiveCommitRange>,
+    commit_range: Handle<SharedCommitRange>,
     engine: Handle<SharedExternEngine>,
     actions: *const KernelDeltaAction,
     actions_len: usize,
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn commit_range_commits(
 /// valid [`KernelDeltaAction`] values.
 #[no_mangle]
 pub unsafe extern "C" fn commit_range_commits_with_snapshot(
-    commit_range: Handle<ExclusiveCommitRange>,
+    commit_range: Handle<SharedCommitRange>,
     engine: Handle<SharedExternEngine>,
     start_snapshot: Handle<SharedSnapshot>,
     actions: *const KernelDeltaAction,
@@ -457,7 +457,7 @@ mod tests {
         start_version: u64,
         end_version: u64,
         engine: Handle<SharedExternEngine>,
-    ) -> Handle<ExclusiveCommitRange> {
+    ) -> Handle<SharedCommitRange> {
         let mut builder = unsafe {
             ok_or_panic(commit_range_builder_for(
                 kernel_string_slice!(table_root),
@@ -465,7 +465,7 @@ mod tests {
                 engine,
             ))
         };
-        unsafe { commit_range_builder_with_end_version(&mut builder, end_version) };
+        unsafe { commit_range_builder_set_end_version(&mut builder, end_version) };
         unsafe { ok_or_panic(commit_range_builder_build(builder)) }
     }
 

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -215,11 +215,9 @@ pub unsafe extern "C" fn commit_action_timestamp(commit_action: Handle<SharedCom
     commit_action.timestamp()
 }
 
-/// Get an iterator over this commit's action batches, projected to the read schema the commit was
-/// created with. Each batch is the raw actions recorded in the commit JSON, with no column-mapping
-/// translation applied. Issues a fresh read on creation, so the call is fallible.
-///
-/// - `engine`: performs the JSON read and allocates errors.
+/// Get an iterator over this commit's action batches, projected to the read schema requested when
+/// the iterator was created (the `actions` passed to [`commit_range_commits`]). Each batch is the
+/// raw actions recorded in the commit JSON, with no column-mapping translation applied.
 ///
 /// The caller owns the returned iterator: drain it with [`read_result_next`] and release it with
 /// [`free_read_result_iter`].
@@ -607,29 +605,43 @@ mod tests {
         Ok(())
     }
 
+    #[rstest]
+    #[case::matched_anchor_yields_commit(1, 1, Some(vec![1]))]
+    #[case::mismatched_anchor_errors(0, 0, None)]
     #[tokio::test]
-    async fn test_commit_range_commits_with_snapshot_yields_anchored_commit(
+    async fn test_commit_range_commits_with_snapshot(
+        #[case] range_start: u64,
+        #[case] range_end: u64,
+        #[case] expected: Option<Vec<u64>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, table_root) = setup_engine_with_commits(1).await;
-        // Anchor at the latest version (v=1) and pin the range to [1, 1].
         let snapshot =
             unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
-        let range = unsafe { build_range(table_root, 1, 1, engine.shallow_copy()) };
+        let range =
+            unsafe { build_range(table_root, range_start, range_end, engine.shallow_copy()) };
 
         let actions = [KernelDeltaAction::Metadata];
-        let iter = unsafe {
-            ok_or_panic(commit_range_commits_with_snapshot(
+        let result = unsafe {
+            commit_range_commits_with_snapshot(
                 range.shallow_copy(),
                 engine.shallow_copy(),
                 snapshot.shallow_copy(),
                 actions.as_ptr(),
                 actions.len(),
-            ))
+            )
         };
-        let versions = unsafe { drain_versions(iter.shallow_copy()) };
-        assert_eq!(versions, vec![1]);
+        match expected {
+            Some(expected_versions) => {
+                let iter = ok_or_panic(result);
+                let versions = unsafe { drain_versions(iter.shallow_copy()) };
+                assert_eq!(versions, expected_versions);
+                unsafe { free_commit_actions_iter(iter) }
+            }
+            None => {
+                assert_extern_result_error_with_message(result, KernelError::GenericError, None);
+            }
+        }
 
-        unsafe { free_commit_actions_iter(iter) }
         unsafe { free_snapshot(snapshot) }
         unsafe { free_commit_range(range) }
         unsafe { free_engine(engine) }

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use delta_kernel::commit_range::{CommitAction, CommitRange, DeltaAction};
+use delta_kernel::commit_range::{CommitAction, CommitRange, DeltaAction as KernelDeltaAction};
 use delta_kernel::snapshot::SnapshotRef;
 use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Version};
 use delta_kernel_ffi_macros::handle_descriptor;
@@ -137,11 +137,11 @@ pub unsafe extern "C" fn free_commit_range(commit_range: Handle<SharedCommitRang
     commit_range.drop_handle();
 }
 
-/// FFI-safe mirror of [`DeltaAction`]: the Delta log action kinds a caller can request from
-/// [`commit_range_commits`].
+/// FFI-safe mirror of the kernel's [`KernelDeltaAction`]: the Delta log action kinds a caller can
+/// request from [`commit_range_commits`].
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KernelDeltaAction {
+pub enum DeltaAction {
     AddAction = 0,
     RemoveAction = 1,
     MetadataAction = 2,
@@ -154,30 +154,47 @@ pub enum KernelDeltaAction {
     SidecarAction = 9,
 }
 
-impl From<KernelDeltaAction> for DeltaAction {
-    fn from(value: KernelDeltaAction) -> Self {
+impl From<DeltaAction> for KernelDeltaAction {
+    fn from(value: DeltaAction) -> Self {
         match value {
-            KernelDeltaAction::AddAction => DeltaAction::Add,
-            KernelDeltaAction::RemoveAction => DeltaAction::Remove,
-            KernelDeltaAction::MetadataAction => DeltaAction::Metadata,
-            KernelDeltaAction::ProtocolAction => DeltaAction::Protocol,
-            KernelDeltaAction::CommitInfoAction => DeltaAction::CommitInfo,
-            KernelDeltaAction::CdcAction => DeltaAction::Cdc,
-            KernelDeltaAction::DomainMetadataAction => DeltaAction::DomainMetadata,
-            KernelDeltaAction::SetTxnAction => DeltaAction::SetTxn,
-            KernelDeltaAction::CheckpointMetadataAction => DeltaAction::CheckpointMetadata,
-            KernelDeltaAction::SidecarAction => DeltaAction::Sidecar,
+            DeltaAction::AddAction => KernelDeltaAction::Add,
+            DeltaAction::RemoveAction => KernelDeltaAction::Remove,
+            DeltaAction::MetadataAction => KernelDeltaAction::Metadata,
+            DeltaAction::ProtocolAction => KernelDeltaAction::Protocol,
+            DeltaAction::CommitInfoAction => KernelDeltaAction::CommitInfo,
+            DeltaAction::CdcAction => KernelDeltaAction::Cdc,
+            DeltaAction::DomainMetadataAction => KernelDeltaAction::DomainMetadata,
+            DeltaAction::SetTxnAction => KernelDeltaAction::SetTxn,
+            DeltaAction::CheckpointMetadataAction => KernelDeltaAction::CheckpointMetadata,
+            DeltaAction::SidecarAction => KernelDeltaAction::Sidecar,
         }
     }
 }
 
-/// Copy a C array of [`KernelDeltaAction`] into a `Vec<DeltaAction>`. A null pointer or zero
+impl From<KernelDeltaAction> for DeltaAction {
+    fn from(value: KernelDeltaAction) -> Self {
+        match value {
+            KernelDeltaAction::Add => DeltaAction::AddAction,
+            KernelDeltaAction::Remove => DeltaAction::RemoveAction,
+            KernelDeltaAction::Metadata => DeltaAction::MetadataAction,
+            KernelDeltaAction::Protocol => DeltaAction::ProtocolAction,
+            KernelDeltaAction::CommitInfo => DeltaAction::CommitInfoAction,
+            KernelDeltaAction::Cdc => DeltaAction::CdcAction,
+            KernelDeltaAction::DomainMetadata => DeltaAction::DomainMetadataAction,
+            KernelDeltaAction::SetTxn => DeltaAction::SetTxnAction,
+            KernelDeltaAction::CheckpointMetadata => DeltaAction::CheckpointMetadataAction,
+            KernelDeltaAction::Sidecar => DeltaAction::SidecarAction,
+        }
+    }
+}
+
+/// Copy a C array of [`DeltaAction`] into a `Vec<KernelDeltaAction>`. A null pointer or zero
 /// length yields an empty vector.
 ///
 /// # Safety
 ///
-/// `ptr` must point to `len` valid [`KernelDeltaAction`] values that remain valid for this call.
-unsafe fn parse_actions(ptr: *const KernelDeltaAction, len: usize) -> Vec<DeltaAction> {
+/// `ptr` must point to `len` valid [`DeltaAction`] values that remain valid for this call.
+unsafe fn parse_actions(ptr: *const DeltaAction, len: usize) -> Vec<KernelDeltaAction> {
     if ptr.is_null() || len == 0 {
         return Vec::new();
     }
@@ -287,12 +304,12 @@ pub struct SharedCommitActionsIterator;
 /// # Safety
 ///
 /// Caller is responsible for passing valid handles, and an `actions` pointer to `actions_len`
-/// valid [`KernelDeltaAction`] values.
+/// valid [`DeltaAction`] values.
 #[no_mangle]
 pub unsafe extern "C" fn commit_range_commits(
     commit_range: Handle<SharedCommitRange>,
     engine: Handle<SharedExternEngine>,
-    actions: *const KernelDeltaAction,
+    actions: *const DeltaAction,
     actions_len: usize,
 ) -> ExternResult<Handle<SharedCommitActionsIterator>> {
     let engine_ref = unsafe { engine.as_ref() };
@@ -316,13 +333,13 @@ pub unsafe extern "C" fn commit_range_commits(
 /// # Safety
 ///
 /// Caller is responsible for passing valid handles, and an `actions` pointer to `actions_len`
-/// valid [`KernelDeltaAction`] values.
+/// valid [`DeltaAction`] values.
 #[no_mangle]
 pub unsafe extern "C" fn commit_range_commits_with_snapshot(
     commit_range: Handle<SharedCommitRange>,
     engine: Handle<SharedExternEngine>,
     start_snapshot: Handle<SharedSnapshot>,
-    actions: *const KernelDeltaAction,
+    actions: *const DeltaAction,
     actions_len: usize,
 ) -> ExternResult<Handle<SharedCommitActionsIterator>> {
     let engine_ref = unsafe { engine.as_ref() };
@@ -338,7 +355,7 @@ fn commit_range_commits_impl(
     commit_range: &CommitRange,
     engine: Arc<dyn ExternEngine>,
     start_snapshot: Option<SnapshotRef>,
-    actions: Vec<DeltaAction>,
+    actions: Vec<KernelDeltaAction>,
 ) -> DeltaResult<Handle<SharedCommitActionsIterator>> {
     let inner = commit_range.commits(engine.engine(), start_snapshot, &actions)?;
     let boxed: CommitActionIter = Box::new(inner);
@@ -580,23 +597,44 @@ mod tests {
     }
 
     #[rstest]
-    #[case::no_snapshot_yields_each_commit(false, 0, 1, Some(vec![0, 1]))]
-    #[case::snapshot_matched_anchor_yields_commit(true, 1, 1, Some(vec![1]))]
-    #[case::snapshot_mismatched_anchor_errors(true, 0, 0, None)]
+    #[case(DeltaAction::AddAction, KernelDeltaAction::Add)]
+    #[case(DeltaAction::RemoveAction, KernelDeltaAction::Remove)]
+    #[case(DeltaAction::MetadataAction, KernelDeltaAction::Metadata)]
+    #[case(DeltaAction::ProtocolAction, KernelDeltaAction::Protocol)]
+    #[case(DeltaAction::CommitInfoAction, KernelDeltaAction::CommitInfo)]
+    #[case(DeltaAction::CdcAction, KernelDeltaAction::Cdc)]
+    #[case(DeltaAction::DomainMetadataAction, KernelDeltaAction::DomainMetadata)]
+    #[case(DeltaAction::SetTxnAction, KernelDeltaAction::SetTxn)]
+    #[case(
+        DeltaAction::CheckpointMetadataAction,
+        KernelDeltaAction::CheckpointMetadata
+    )]
+    #[case(DeltaAction::SidecarAction, KernelDeltaAction::Sidecar)]
+    fn test_delta_action_conversion_round_trips(
+        #[case] ffi_action: DeltaAction,
+        #[case] kernel_action: KernelDeltaAction,
+    ) {
+        assert_eq!(KernelDeltaAction::from(ffi_action), kernel_action);
+        assert_eq!(DeltaAction::from(kernel_action), ffi_action);
+    }
+
+    #[rstest]
+    #[case::no_snapshot_yields_each_commit(1, false, 0, 1, Some(vec![0, 1]))]
+    #[case::no_snapshot_multi_commit_yields_each_commit(3, false, 0, 3, Some(vec![0, 1, 2, 3]))]
+    #[case::snapshot_matched_anchor_yields_commit(1, true, 1, 1, Some(vec![1]))]
+    #[case::snapshot_mismatched_anchor_errors(1, true, 0, 0, None)]
     #[tokio::test]
     async fn test_commit_range_commits(
+        #[case] last_version: u64,
         #[case] with_snapshot: bool,
         #[case] range_start: u64,
         #[case] range_end: u64,
         #[case] expected: Option<Vec<u64>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let (engine, table_root) = setup_engine_with_commits(1).await;
+        let (engine, table_root) = setup_engine_with_commits(last_version).await;
         let range =
             unsafe { build_range(table_root, range_start, range_end, engine.shallow_copy()) };
-        let actions = [
-            KernelDeltaAction::MetadataAction,
-            KernelDeltaAction::ProtocolAction,
-        ];
+        let actions = [DeltaAction::MetadataAction, DeltaAction::ProtocolAction];
 
         let snapshot = with_snapshot.then(|| unsafe {
             build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy())
@@ -698,7 +736,7 @@ mod tests {
         let (engine, table_root) = setup_engine_with_commits(1).await;
         let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
 
-        let actions = [KernelDeltaAction::MetadataAction];
+        let actions = [DeltaAction::MetadataAction];
         let iter = unsafe {
             ok_or_panic(commit_range_commits(
                 range.shallow_copy(),

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -142,31 +142,31 @@ pub unsafe extern "C" fn free_commit_range(commit_range: Handle<SharedCommitRang
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KernelDeltaAction {
-    Add = 0,
-    Remove = 1,
-    Metadata = 2,
-    Protocol = 3,
-    CommitInfo = 4,
-    Cdc = 5,
-    DomainMetadata = 6,
-    SetTxn = 7,
-    CheckpointMetadata = 8,
-    Sidecar = 9,
+    AddAction = 0,
+    RemoveAction = 1,
+    MetadataAction = 2,
+    ProtocolAction = 3,
+    CommitInfoAction = 4,
+    CdcAction = 5,
+    DomainMetadataAction = 6,
+    SetTxnAction = 7,
+    CheckpointMetadataAction = 8,
+    SidecarAction = 9,
 }
 
 impl From<KernelDeltaAction> for DeltaAction {
     fn from(value: KernelDeltaAction) -> Self {
         match value {
-            KernelDeltaAction::Add => DeltaAction::Add,
-            KernelDeltaAction::Remove => DeltaAction::Remove,
-            KernelDeltaAction::Metadata => DeltaAction::Metadata,
-            KernelDeltaAction::Protocol => DeltaAction::Protocol,
-            KernelDeltaAction::CommitInfo => DeltaAction::CommitInfo,
-            KernelDeltaAction::Cdc => DeltaAction::Cdc,
-            KernelDeltaAction::DomainMetadata => DeltaAction::DomainMetadata,
-            KernelDeltaAction::SetTxn => DeltaAction::SetTxn,
-            KernelDeltaAction::CheckpointMetadata => DeltaAction::CheckpointMetadata,
-            KernelDeltaAction::Sidecar => DeltaAction::Sidecar,
+            KernelDeltaAction::AddAction => DeltaAction::Add,
+            KernelDeltaAction::RemoveAction => DeltaAction::Remove,
+            KernelDeltaAction::MetadataAction => DeltaAction::Metadata,
+            KernelDeltaAction::ProtocolAction => DeltaAction::Protocol,
+            KernelDeltaAction::CommitInfoAction => DeltaAction::CommitInfo,
+            KernelDeltaAction::CdcAction => DeltaAction::Cdc,
+            KernelDeltaAction::DomainMetadataAction => DeltaAction::DomainMetadata,
+            KernelDeltaAction::SetTxnAction => DeltaAction::SetTxn,
+            KernelDeltaAction::CheckpointMetadataAction => DeltaAction::CheckpointMetadata,
+            KernelDeltaAction::SidecarAction => DeltaAction::Sidecar,
         }
     }
 }
@@ -593,7 +593,10 @@ mod tests {
         let (engine, table_root) = setup_engine_with_commits(1).await;
         let range =
             unsafe { build_range(table_root, range_start, range_end, engine.shallow_copy()) };
-        let actions = [KernelDeltaAction::Metadata, KernelDeltaAction::Protocol];
+        let actions = [
+            KernelDeltaAction::MetadataAction,
+            KernelDeltaAction::ProtocolAction,
+        ];
 
         let snapshot = with_snapshot.then(|| unsafe {
             build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy())
@@ -695,7 +698,7 @@ mod tests {
         let (engine, table_root) = setup_engine_with_commits(1).await;
         let range = unsafe { build_range(table_root, 0, 1, engine.shallow_copy()) };
 
-        let actions = [KernelDeltaAction::Metadata];
+        let actions = [KernelDeltaAction::MetadataAction];
         let iter = unsafe {
             ok_or_panic(commit_range_commits(
                 range.shallow_copy(),

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -265,12 +265,12 @@ type CommitActionIter = DeltaResultIteratorStatic<CommitAction>;
 /// Iterator handle returned by [`commit_range_commits`]. Holds the boxed kernel iterator behind a
 /// mutex (so it is safe to share across threads) plus an engine reference for error allocation and
 /// to keep the engine's async runtime alive while iterating.
-pub struct CommitActionsIterator {
+pub struct FfiCommitActionsIterator {
     data: Mutex<CommitActionIter>,
     engine: Arc<dyn ExternEngine>,
 }
 
-impl CommitActionsIterator {
+impl FfiCommitActionsIterator {
     fn lock_iter(&self) -> DeltaResult<std::sync::MutexGuard<'_, CommitActionIter>> {
         self.data
             .lock()
@@ -278,7 +278,7 @@ impl CommitActionsIterator {
     }
 }
 
-#[handle_descriptor(target=CommitActionsIterator, mutable=false, sized=true)]
+#[handle_descriptor(target=FfiCommitActionsIterator, mutable=false, sized=true)]
 pub struct SharedCommitActionsIterator;
 
 /// Get an iterator over the commits in `commit_range`, yielding one [`CommitAction`] per commit.
@@ -349,7 +349,7 @@ fn commit_range_commits_impl(
 ) -> DeltaResult<Handle<SharedCommitActionsIterator>> {
     let inner = commit_range.commits(engine.engine(), start_snapshot, &actions)?;
     let boxed: CommitActionIter = Box::new(inner);
-    let iter = CommitActionsIterator {
+    let iter = FfiCommitActionsIterator {
         data: Mutex::new(boxed),
         engine,
     };
@@ -380,7 +380,7 @@ pub unsafe extern "C" fn commit_range_commits_next(
 }
 
 fn commit_range_commits_next_impl(
-    data: &CommitActionsIterator,
+    data: &FfiCommitActionsIterator,
     engine_context: NullableCvoid,
     engine_visitor: extern "C" fn(
         engine_context: NullableCvoid,

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -45,6 +45,17 @@ impl Drop for FileReadResultIterator {
     }
 }
 
+impl FileReadResultIterator {
+    /// Wrap a kernel `EngineData` iterator (paired with the engine that produced it) into a handle
+    /// the engine can drain via [`read_result_next`] and release with [`free_read_result_iter`].
+    pub(crate) fn into_handle(
+        data: FileDataReadResultIterator,
+        engine: Arc<dyn ExternEngine>,
+    ) -> Handle<ExclusiveFileReadResultIterator> {
+        Box::new(FileReadResultIterator { data, engine }).into()
+    }
+}
+
 /// Call the engine back with the next `EngineData` batch read by Parquet/Json handler. The
 /// _engine_ "owns" the data that is passed into the `engine_visitor`, since it is allocated by the
 /// `Engine` being used for log-replay. If the engine wants the kernel to free this data, it _must_

--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -120,6 +120,20 @@ pub(crate) fn assert_extern_result_error_with_message<T>(
     }
 }
 
+/// Assert that `timestamp` (milliseconds since the Unix epoch) was written within the last day.
+#[cfg(test)]
+pub(crate) fn assert_timestamp_is_recent(timestamp: i64) {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+    let one_day_ms = 24 * 60 * 60 * 1000;
+    assert!(
+        (now_ms - one_day_ms..=now_ms).contains(&timestamp),
+        "commit timestamp {timestamp} not within one day of now {now_ms}"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use std::panic;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2776/files) to review incremental changes.
- [stack/commit-range-ffi](https://github.com/delta-io/delta-kernel-rs/pull/2775) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2775/files)] [MERGED]
  - [**stack/commit-range-iterator**](https://github.com/delta-io/delta-kernel-rs/pull/2776) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2776/files)] ← _this PR_

---------
## What changes are proposed in this pull request?

Based on the PR #2775 that added the `CommitRange` handle and its builder; this PR adds the iteration layer that reads the raw commit actions.

New FFI surface in `ffi/src/commit_range.rs` wrapping `CommitRange::commits`:

- **Iteration** — `commit_range_commits` / `commit_range_commits_with_snapshot` produced a `SharedCommitActionsIterator`, which can be drained via the visitor-based `commit_range_commits_next` and released with `free_commit_actions_iter`.

- **Per-commit accessors** — caller can extract the commit's version, timestamp and an iterator of commit action via `commit_action_version`, `commit_action_timestamp`, and `commit_action_get_actions`.

- **`KernelDeltaAction`** — a `repr(C)` mirror of the kernel `DeltaAction` enum, used to project the action kinds read from each commit.

Example usage of the full builder + iterator flow is tracked in #2824.

## How was this change tested?

Unit tests in `ffi/src/commit_range.rs` covering the FFI boundary (marshaling, handle
ownership, error propagation).
