### PR TITLE
feat: add sync checkpoint-shape resolution via PlanExecutor

### DIFF
--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -16,12 +16,9 @@ use crate::{DeltaResult, Error, StorageHandler, Version};
 /// the latest checkpoint without a full directory listing.
 const LAST_CHECKPOINT_FILE_NAME: &str = "_last_checkpoint";
 
-/// A more minimal version of LastCheckpointHint, storing only the version and schema.
-///
-/// This is primarily used by LogSegment to store necessary information about the latest
-/// checkpoint without retaining all of the metadata fields. If this struct grows
-/// to be similar in size to LastCheckpointHint, we should just switch to using LastCheckpointHint
-/// directly.
+/// A reduced view of [`LastCheckpointHint`] that [`crate::log_segment::LogSegment`] retains --
+/// just enough to validate and apply the hint without holding every metadata field. If this grows
+/// to be similar in size to `LastCheckpointHint`, we should switch to using it directly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[internal_api]
 pub(crate) struct LastCheckpointHintSummary {
@@ -32,6 +29,10 @@ pub(crate) struct LastCheckpointHintSummary {
     /// Useful for determining if `stats_parsed` is available for data skipping.
     /// `None` when the hint file did not include a `checkpointSchema` field.
     pub schema: Option<SchemaRef>,
+
+    /// File name of the V2 checkpoint the hint describes (`v2Checkpoint.path`); see
+    /// [`LastCheckpointHint::v2_checkpoint`]. `None` for V1 / classic checkpoints.
+    pub v2_checkpoint_path: Option<String>,
 }
 
 // Note: Schema can not be derived because the checkpoint schema is only known at runtime.
@@ -56,6 +57,22 @@ pub(crate) struct LastCheckpointHint {
     pub(crate) checksum: Option<String>,
     /// Additional metadata about the last checkpoint.
     pub(crate) tags: Option<HashMap<String, String>>,
+    /// For a V2 checkpoint, the embedded V2 checkpoint info. Identifies the specific checkpoint
+    /// file the hint describes. Absent for V1 / classic checkpoints.
+    pub(crate) v2_checkpoint: Option<LastCheckpointV2>,
+}
+
+/// The `v2Checkpoint` object embedded in a `_last_checkpoint` hint for a V2 checkpoint.
+///
+/// Only the `path` (the checkpoint file's name) is parsed; it identifies which V2 checkpoint the
+/// hint's fields describe, since several V2 checkpoints can share a version.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+#[internal_api]
+pub(crate) struct LastCheckpointV2 {
+    /// Bare file name of the V2 checkpoint this hint describes (a `path.getName()`-style value,
+    /// not a full path), matched against the selected checkpoint part's file name.
+    pub(crate) path: String,
 }
 
 impl LastCheckpointHint {
@@ -111,5 +128,42 @@ impl LastCheckpointHint {
     #[cfg(test)]
     pub(crate) fn to_json_bytes(&self) -> Vec<u8> {
         serde_json::to_vec(self).expect("Failed to convert LastCheckpointHint to JSON bytes")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real `_last_checkpoint` for a V2 checkpoint carries a `v2Checkpoint` object; we parse its
+    /// `path`. Extra `v2Checkpoint` fields a writer emits (e.g. `sizeInBytes`, `sidecarFiles`) are
+    /// ignored. Guards the `camelCase` wire key -- a rename would otherwise silently parse to
+    /// `None` (errors are swallowed in `try_read`) and disable the identity filter.
+    #[test]
+    fn parses_v2_checkpoint_path_from_wire_json() {
+        let json = br#"{
+            "version": 5,
+            "size": 10,
+            "v2Checkpoint": {
+                "path": "00000000000000000005.checkpoint.0190e8f5-uuid.parquet",
+                "sizeInBytes": 1234,
+                "sidecarFiles": []
+            }
+        }"#;
+        let hint: LastCheckpointHint = serde_json::from_slice(json).unwrap();
+        assert_eq!(
+            hint.v2_checkpoint,
+            Some(LastCheckpointV2 {
+                path: "00000000000000000005.checkpoint.0190e8f5-uuid.parquet".to_string(),
+            })
+        );
+    }
+
+    /// A `_last_checkpoint` without a `v2Checkpoint` object (V1 / classic) parses to `None`.
+    #[test]
+    fn v2_checkpoint_absent_parses_to_none() {
+        let json = br#"{"version": 5, "size": 10}"#;
+        let hint: LastCheckpointHint = serde_json::from_slice(json).unwrap();
+        assert!(hint.v2_checkpoint.is_none());
     }
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1198,7 +1198,7 @@ impl LogSegment {
     }
 
     /// Schema to read just the sidecar column from a checkpoint file.
-    fn sidecar_read_schema() -> SchemaRef {
+    pub(crate) fn sidecar_read_schema() -> SchemaRef {
         static SIDECAR_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             Arc::new(StructType::new_unchecked([StructField::nullable(
                 SIDECAR_NAME,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -262,12 +262,25 @@ impl LogSegment {
     /// this segment's checkpoint parquet.
     ///
     /// Returns `None` if there is no hint, if the hint omitted `checkpointSchema`, if this segment
-    /// has no checkpoint on disk, or if the hint's checkpoint version does not match this segment's
-    /// checkpoint version.
+    /// has no checkpoint on disk, if the hint's checkpoint version does not match this segment's
+    /// checkpoint version, or -- for a V2 hint -- if the hint does not describe the specific
+    /// checkpoint file this segment selected.
     pub(crate) fn checkpoint_schema(&self) -> Option<SchemaRef> {
         let m = self.last_checkpoint_metadata.as_ref()?;
         if Some(m.version) != self.checkpoint_version {
             return None;
+        }
+        // A `v2Checkpoint` hint names a specific checkpoint file. Several such checkpoints can
+        // share a version (e.g. concurrent writers), and the segment selects one independently of
+        // the hint, so the hint's schema is only valid when it names the checkpoint we selected --
+        // `checkpoint_parts.first()`, the same part whose footer the schema would otherwise be read
+        // from. A hint without `v2Checkpoint` describes a checkpoint with a deterministic
+        // per-version name, so the version match above is sufficient.
+        if let Some(hint_name) = &m.v2_checkpoint_path {
+            let selected = self.listed.checkpoint_parts.first()?;
+            if &selected.filename != hint_name {
+                return None;
+            }
         }
         m.schema.clone()
     }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -376,6 +376,7 @@ impl LogSegment {
                 .map(|hint| LastCheckpointHintSummary {
                     version: hint.version,
                     schema: hint.checkpoint_schema.clone(),
+                    v2_checkpoint_path: hint.v2_checkpoint.as_ref().map(|v2| v2.path.clone()),
                 });
 
         // The end_version is the time_travel_version, if present

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2824,6 +2824,7 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
         Some(LastCheckpointHintSummary {
             version: hint_version,
             schema: Some(hint_schema.clone()),
+            v2_checkpoint_path: None,
         }),
     )?;
 
@@ -2923,6 +2924,7 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
         use_hint.then(|| LastCheckpointHintSummary {
             version: 1,
             schema: Some(v1_schema.clone()),
+            v2_checkpoint_path: None,
         }),
     )?;
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -297,6 +297,7 @@ async fn build_snapshot_with_uuid_checkpoint_json() {
 #[tokio::test]
 async fn build_snapshot_with_correct_last_uuid_checkpoint() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: Some(1),
@@ -392,6 +393,7 @@ async fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
 #[tokio::test]
 async fn build_snapshot_with_out_of_date_last_checkpoint() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 3,
         size: 10,
         parts: None,
@@ -438,6 +440,7 @@ async fn build_snapshot_with_out_of_date_last_checkpoint() {
 #[tokio::test]
 async fn build_snapshot_with_correct_last_multipart_checkpoint() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: Some(3),
@@ -489,6 +492,7 @@ async fn build_snapshot_with_correct_last_multipart_checkpoint() {
 #[tokio::test]
 async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: Some(3),
@@ -535,6 +539,7 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
 #[tokio::test]
 async fn build_snapshot_with_bad_checkpoint_hint_fails() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: Some(1),
@@ -628,6 +633,7 @@ async fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_c
     // Snapshot should be made of the most recent complete checkpoint and the commit files that
     // follow it.
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 3,
         size: 10,
         parts: None,
@@ -739,6 +745,7 @@ async fn build_snapshot_without_checkpoints() {
 #[tokio::test]
 async fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: None,
@@ -787,6 +794,7 @@ async fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
 #[tokio::test]
 async fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 3,
         size: 10,
         parts: None,
@@ -829,6 +837,7 @@ async fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
 #[rstest::rstest]
 #[case::no_hint(None)]
 #[case::stale_hint(Some(LastCheckpointHint {
+    v2_checkpoint: None,
     version: 10, // stale: 10 > end_version 5, so it is discarded
     size: 10,
     parts: None,
@@ -2743,6 +2752,7 @@ async fn test_checkpoint_schema_propagation_from_hint() {
     ]));
 
     let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
         version: 5,
         size: 10,
         parts: Some(1),
@@ -2775,6 +2785,96 @@ async fn test_checkpoint_schema_propagation_from_hint() {
 
     assert_eq!(log_segment.last_checkpoint_version(), Some(5));
     assert_eq!(log_segment.checkpoint_schema().unwrap(), sample_schema);
+}
+
+/// A V2 checkpoint hint's schema is used only when the hint names the checkpoint file the segment
+/// selected. Multiple V2 checkpoints can share a version, so a hint describing a different
+/// same-version V2 checkpoint must be ignored (the version match alone is not enough).
+#[rstest]
+#[case::identity_matches(true)]
+#[case::identity_mismatch(false)]
+fn test_checkpoint_schema_v2_identity_filter(#[case] identity_matches: bool) -> DeltaResult<()> {
+    let (_store, log_root) = new_in_memory_store();
+
+    let selected = "00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.parquet";
+    let other = "00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet";
+    let checkpoint_file = log_root.join(selected)?.to_string();
+    let hint_name = if identity_matches { selected } else { other };
+
+    let hint_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+        "metadata",
+        StructType::new_unchecked([]),
+    )]));
+
+    let commit_v2 = create_log_path(log_root.join("00000000000000000002.json")?.as_str());
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, 1)],
+            ascending_commit_files: vec![commit_v2.clone()],
+            latest_commit_file: Some(commit_v2),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(LastCheckpointHintSummary {
+            version: 1,
+            schema: Some(hint_schema.clone()),
+            v2_checkpoint_path: Some(hint_name.to_string()),
+        }),
+    )?;
+
+    assert_eq!(log_segment.checkpoint_version, Some(1));
+    if identity_matches {
+        assert_eq!(log_segment.checkpoint_schema().as_ref(), Some(&hint_schema));
+    } else {
+        assert!(
+            log_segment.checkpoint_schema().is_none(),
+            "hint describing a different same-version V2 checkpoint must not be used"
+        );
+    }
+    Ok(())
+}
+
+/// Exercises the identity filter against real V2 checkpoint fixtures. When a table's
+/// `_last_checkpoint` carries a V2 identity that does NOT name the checkpoint the segment selected,
+/// the hint must be suppressed (not applied to the wrong file). `v2-classic-checkpoint-parquet` is
+/// exactly that case: its `_last_checkpoint` points at a UUID-named checkpoint while the segment
+/// selects the classic-named one, so `checkpoint_schema()` falls back to a footer read.
+#[rstest]
+#[case::parquet_with_last_checkpoint("v2-checkpoints-parquet-with-last-checkpoint")]
+#[case::json_with_last_checkpoint("v2-checkpoints-json-with-last-checkpoint")]
+#[case::parquet_with_sidecars("v2-checkpoints-parquet-with-sidecars")]
+#[case::json_with_sidecars("v2-checkpoints-json-with-sidecars")]
+#[case::classic_parquet("v2-classic-checkpoint-parquet")]
+fn checkpoint_schema_identity_on_real_v2_tables(#[case] table: &str) -> DeltaResult<()> {
+    use crate::utils::test_utils::load_test_table;
+
+    let (_engine, snapshot, _tempdir) = load_test_table(table)?;
+    let seg = snapshot.log_segment();
+    assert!(
+        seg.checkpoint_version.is_some(),
+        "{table}: expected a checkpoint"
+    );
+
+    if let Some(v2_path) = seg
+        .last_checkpoint_hint_summary()
+        .and_then(|s| s.v2_checkpoint_path)
+    {
+        let selected = &seg
+            .listed
+            .checkpoint_parts
+            .first()
+            .expect("checkpoint present")
+            .filename;
+        // A hint naming a different checkpoint than the one we selected must not be trusted.
+        if &v2_path != selected {
+            assert!(
+                seg.checkpoint_schema().is_none(),
+                "{table}: hint names {v2_path} but segment selected {selected}; must be suppressed"
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Checkpoint schema resolution uses the `_last_checkpoint` schema only when the hint's version
@@ -2854,6 +2954,70 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
     }
     assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
 
+    Ok(())
+}
+
+/// For a V2 (UUID-named) parquet checkpoint, `get_file_actions_schema_and_sidecars` uses the
+/// `_last_checkpoint` hint schema only when the hint names the selected checkpoint; a hint that
+/// names a different same-version V2 checkpoint is ignored and the footer is read instead.
+#[rstest]
+#[case::identity_matches(true)]
+#[case::identity_mismatch(false)]
+#[tokio::test]
+async fn test_get_file_actions_schema_v2_identity_filter(
+    #[case] identity_matches: bool,
+) -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    let selected = "00000000000000000001.checkpoint.3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet";
+    let other = "00000000000000000001.checkpoint.016ae953-37a9-438e-8683-9a9a4a79a395.parquet";
+
+    // Schema actually written to the selected (leaf, no-sidecar) V2 checkpoint footer.
+    let footer_schema = get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?;
+    add_checkpoint_to_store(&store, add_batch_simple(footer_schema.clone()), selected).await?;
+    let checkpoint_file = log_root.join(selected)?.to_string();
+    let cp_size = get_file_size(&store, &format!("_delta_log/{selected}")).await;
+
+    // A distinct hint schema so we can tell whether the hint or the footer was used.
+    let hint_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+        "metadata",
+        StructType::new_unchecked([]),
+    )]));
+    let hint_name = if identity_matches { selected } else { other };
+
+    let commit_v2_path = log_root.join("00000000000000000002.json")?.to_string();
+    let commit_v2 = create_log_path(&commit_v2_path);
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, cp_size)],
+            ascending_commit_files: vec![commit_v2.clone()],
+            latest_commit_file: Some(commit_v2),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(LastCheckpointHintSummary {
+            version: 1,
+            schema: Some(hint_schema.clone()),
+            v2_checkpoint_path: Some(hint_name.to_string()),
+        }),
+    )?;
+
+    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
+    let schema = schema.expect("leaf V2 checkpoint should yield a file actions schema");
+    if identity_matches {
+        assert_eq!(
+            schema, hint_schema,
+            "matching hint identity -> use hint schema"
+        );
+    } else {
+        assert_eq!(
+            schema, footer_schema,
+            "mismatched hint identity -> read footer schema, not the stale hint"
+        );
+    }
+    assert!(sidecars.is_empty(), "leaf V2 checkpoint has no sidecars");
     Ok(())
 }
 

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -4,10 +4,12 @@
 pub mod ir;
 pub mod proto;
 mod query_builder;
+pub mod scan_shape;
 
 use bytes::Bytes;
 pub use ir::{IoOperation, Operation};
 pub use query_builder::QueryPlanBuilder;
+pub use scan_shape::{CheckpointShape, ScanShape, StatsInfo};
 
 use crate::{
     AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta, ParquetFooter,

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -4,12 +4,13 @@
 pub mod ir;
 pub mod proto;
 mod query_builder;
-pub mod scan_shape;
+mod scan_shape;
 
 use bytes::Bytes;
 pub use ir::{IoOperation, Operation};
 pub use query_builder::QueryPlanBuilder;
-pub use scan_shape::{CheckpointShape, ScanShape, StatsInfo};
+#[allow(unused_imports)]
+pub(crate) use scan_shape::{CheckpointShape, ScanShape, StatsInfo};
 
 use crate::{
     AsAny, DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta, ParquetFooter,

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -13,18 +13,16 @@
 //! the plan-construction surface and the reconciliation pipeline: a caller resolves the shape
 //! here, then feeds it into a (separately built) reconciliation plan.
 
-use std::sync::Arc;
-
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{Sidecar, SIDECAR_NAME};
+use crate::actions::SIDECAR_NAME;
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
 use crate::plans::ir::nodes::FileType;
 use crate::plans::{IoOperation, Operation, PlanExecutor, QueryPlanBuilder};
-use crate::schema::{SchemaRef, StructField, StructType, ToSchema};
+use crate::schema::SchemaRef;
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, FileMeta};
 
@@ -40,9 +38,8 @@ pub enum CheckpointShape {
     /// The checkpoint files ARE the leaves -- `add` / `remove` rows are stored inline. Covers
     /// classic V1 checkpoints and V2 checkpoints that inline their actions (no sidecars).
     Leaf,
-    /// V2 multipart manifest -- `files` are the manifest parts; the leaf rows live in sidecar
-    /// parquet files the manifest references (resolved lazily by the reconciliation plan, not
-    /// stored here).
+    /// V2 manifest -- the checkpoint files reference sidecar parquet files that hold the leaf
+    /// `add` / `remove` rows (resolved lazily by the reconciliation plan, not stored here).
     Manifest,
 }
 
@@ -53,7 +50,8 @@ pub enum CheckpointShape {
 pub struct StatsInfo {
     /// The requested (projected) stats schema the reconciliation plan should produce.
     pub schema: SchemaRef,
-    /// `true` iff the checkpoint surfaces `add.stats_parsed` compatible with [`Self::schema`].
+    /// `true` iff the snapshot surfaces `add.stats_parsed` compatible with [`Self::schema`] --
+    /// read from the checkpoint footer for a leaf, or a sidecar footer for a manifest.
     pub has_parsed_stats: bool,
 }
 
@@ -80,8 +78,8 @@ impl ScanShape {
     ///
     /// # Errors
     ///
-    /// Propagates executor failures from the footer reads or the manifest scan, and any error
-    /// resolving a sidecar reference to a [`FileMeta`].
+    /// Propagates executor failures from the footer reads or the manifest scan, errors visiting the
+    /// `sidecar` column, and any error resolving a sidecar reference to a [`FileMeta`].
     pub fn resolve(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
@@ -104,74 +102,70 @@ impl ScanShape {
             return Ok(make_info(CheckpointShape::None, false));
         };
         let file_format = checkpoint_file_type(first);
-        let files: Vec<FileMeta> = parts.iter().map(|p| p.location.clone()).collect();
 
         // Classify leaf vs manifest by whether the checkpoint actually references sidecars. A
         // `sidecar` *column* in the schema is necessary but NOT sufficient: a V2 checkpoint that
         // inlines its actions still carries an all-null `sidecar` column. So we drain that column
         // whenever it could be populated, and treat an empty drain as an inline leaf.
         //
-        // Parquet exposes its schema in the footer: no `sidecar` column means a V1 leaf, and that
-        // footer IS the leaf schema we probe for parsed stats. JSON has no footer, so we always
-        // drain. Either way: >=1 sidecar => manifest, 0 => leaf.
-        let mut leaf_parsed_stats = None;
+        // Parquet exposes its schema in the footer (or the `_last_checkpoint` hint): no `sidecar`
+        // column means a V1 leaf, and that schema IS the leaf schema we probe for parsed stats.
+        // JSON has no footer, so we always drain. Either way: >=1 sidecar => manifest, 0 => leaf.
+        let mut leaf_parsed_stats = false;
         let sidecar = match file_format {
             FileType::Parquet => {
-                let cp_schema = read_footer_schema(exec, first.location.clone())?;
+                // Prefer the `_last_checkpoint` schema hint to avoid a footer read; it describes
+                // this same top-level checkpoint file (for a leaf, that is the leaf schema).
+                let cp_schema = match seg.checkpoint_schema() {
+                    Some(schema) => schema,
+                    None => read_footer_schema(exec, first.location.clone())?,
+                };
                 let sidecar = if cp_schema.contains(SIDECAR_NAME) {
-                    collect_sidecar(exec, files, file_format, &seg.log_root)?
+                    collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
                 } else {
                     None
                 };
                 match sidecar {
                     Some(sidecar) => Some(sidecar),
                     // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
-                    // leaf): either way the footer we read is the leaf schema, so probe it here.
+                    // leaf): either way `cp_schema` is the leaf schema, so probe it for parsed
+                    // stats when the caller requested them.
                     _ => {
-                        leaf_parsed_stats = stats_probe(Some(&cp_schema), stats_schema);
+                        leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
+                            LogSegment::schema_has_compatible_stats_parsed(
+                                cp_schema.as_ref(),
+                                reqd.as_ref(),
+                            )
+                        });
                         None
                     }
                 }
             }
-            FileType::Json => collect_sidecar(exec, files, file_format, &seg.log_root)?,
+            FileType::Json => {
+                collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
+            }
         };
 
-        if sidecar.is_none() {
+        let Some(sidecar) = sidecar else {
             // A JSON leaf has no footer to probe and surfaces stats only as JSON strings, so its
-            // parsed answer falls through to `false`.
-            return Ok(make_info(
-                CheckpointShape::Leaf,
-                leaf_parsed_stats.unwrap_or(false),
-            ));
-        }
+            // parsed answer stays `false`.
+            return Ok(make_info(CheckpointShape::Leaf, leaf_parsed_stats));
+        };
 
         // Manifest: the leaf rows -- and their stats -- live in the sidecars, so the sidecar
         // footer is authoritative for parsed stats. The `_last_checkpoint` hint describes the
-        // manifest, not the leaves, so we deliberately do NOT consult it. Probe the first sidecar
-        // only when stats were requested.
-        // Classification drained these sidecars; the leaf path returned above, so a manifest
-        // always carries at least one. An empty list would simply leave parsed stats `false`.
-        let has_parsed_stats = match (stats_schema, sidecar) {
-            (Some(reqd), Some(sidecar)) => {
-                let side_schema = read_footer_schema(exec, sidecar.clone())?;
+        // manifest, not the leaves, so we deliberately do NOT consult it. Probe the sidecar only
+        // when stats were requested.
+        let has_parsed_stats = match stats_schema {
+            Some(reqd) => {
+                let side_schema = read_footer_schema(exec, sidecar)?;
                 LogSegment::schema_has_compatible_stats_parsed(side_schema.as_ref(), reqd.as_ref())
             }
-            _ => false,
+            None => false,
         };
 
         Ok(make_info(CheckpointShape::Manifest, has_parsed_stats))
     }
-}
-
-/// Compare a checkpoint/leaf `schema` against a `requested` stats schema, returning whether the
-/// checkpoint surfaces compatible native parsed stats. Returns `None` when either input is
-/// absent (no schema to probe, or stats not requested).
-fn stats_probe(schema: Option<&SchemaRef>, requested: Option<&SchemaRef>) -> Option<bool> {
-    let (schema, requested) = (schema?, requested?);
-    Some(LogSegment::schema_has_compatible_stats_parsed(
-        schema.as_ref(),
-        requested.as_ref(),
-    ))
 }
 
 /// Footer-read a parquet file's schema through the executor.
@@ -182,49 +176,44 @@ fn read_footer_schema(exec: &dyn PlanExecutor, file: FileMeta) -> DeltaResult<Sc
     Ok(footer.schema)
 }
 
-/// Scan the manifest `files` and drain their `sidecar` column through [`SidecarVisitor`],
-/// resolving each reference to a [`FileMeta`] under `log_root`.
+/// Scan the checkpoint `file` and drain its `sidecar` column through [`SidecarVisitor`], resolving
+/// the first reference to a [`FileMeta`] under `log_root`.
 ///
 /// This mimics a streaming reducer kernel-side: it pulls each batch from the executor's result
-/// stream and visits its rows, rather than crossing the engine boundary with a reducer sink.
-/// The scan projects only the `sidecar` column, so manifest action rows (`add` / `remove`) read
-/// as null and are skipped by the visitor.
+/// stream and visits its rows, stopping as soon as a sidecar reference appears. The scan projects
+/// only the `sidecar` column, so manifest action rows (`add` / `remove`) read as null and are
+/// skipped by the visitor.
 fn collect_sidecar(
     exec: &dyn PlanExecutor,
-    files: Vec<FileMeta>,
+    file: FileMeta,
     file_format: FileType,
     log_root: &Url,
 ) -> DeltaResult<Option<FileMeta>> {
+    let read_schema = LogSegment::sidecar_read_schema();
     let plan = match file_format {
-        FileType::Parquet => QueryPlanBuilder::scan_parquet(files, sidecar_scan_schema()),
-        FileType::Json => QueryPlanBuilder::scan_json(files, sidecar_scan_schema()),
+        FileType::Parquet => QueryPlanBuilder::scan_parquet(vec![file], read_schema),
+        FileType::Json => QueryPlanBuilder::scan_json(vec![file], read_schema),
     }
     .build()?;
     let data = exec.execute_op(Operation::QueryPlan(plan))?.into_data()?;
 
     let mut visitor = SidecarVisitor::default();
     for batch in data {
+        visitor.visit_rows_of(batch?.as_ref())?;
         if !visitor.sidecars.is_empty() {
             break;
         }
-        visitor.visit_rows_of(batch?.as_ref())?;
     }
-    match visitor.sidecars.pop() {
+    match visitor.sidecars.first() {
         Some(sidecar) => Ok(Some(sidecar.to_filemeta(log_root)?)),
         None => Ok(None),
     }
 }
 
-/// Manifest scan schema: just the `sidecar` column. Narrowing to that one column avoids paying
-/// the read cost for the action columns we never inspect here.
-fn sidecar_scan_schema() -> SchemaRef {
-    Arc::new(StructType::new_unchecked([StructField::nullable(
-        SIDECAR_NAME,
-        Sidecar::to_schema(),
-    )]))
-}
-
-/// A checkpoint part's encoding, derived from its file extension.
+/// A checkpoint part's scan encoding (JSON vs Parquet). The file extension is the authoritative
+/// signal: `LogPathFileType` does not distinguish a JSON from a Parquet `UuidCheckpoint`.
+/// Multi-part V1 checkpoints are always Parquet and carry no `sidecar` column, so they classify as
+/// leaves without a drain.
 fn checkpoint_file_type(part: &ParsedLogPath) -> FileType {
     if part.extension == "json" {
         FileType::Json
@@ -235,66 +224,32 @@ fn checkpoint_file_type(part: &ParsedLogPath) -> FileType {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rstest::rstest;
 
     use super::*;
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::load_test_table;
 
-    /// The checkpoint variant a table is expected to resolve to.
-    #[derive(Debug)]
-    enum Expected {
-        None,
-        Leaf(FileType),
-        Manifest(FileType),
-    }
-
     #[rstest]
-    #[case::no_checkpoint("app-txn-no-checkpoint", Expected::None)]
-    #[case::leaf_parquet(
-        "with_checkpoint_no_last_checkpoint",
-        Expected::Leaf(FileType::Parquet)
-    )]
-    #[case::manifest_parquet(
-        "v2-checkpoints-parquet-with-sidecars",
-        Expected::Manifest(FileType::Parquet)
-    )]
-    #[case::manifest_json(
-        "v2-checkpoints-json-with-sidecars",
-        Expected::Manifest(FileType::Json)
-    )]
+    #[case::no_checkpoint("app-txn-no-checkpoint", CheckpointShape::None)]
+    #[case::leaf_parquet("with_checkpoint_no_last_checkpoint", CheckpointShape::Leaf)]
+    #[case::manifest_parquet("v2-checkpoints-parquet-with-sidecars", CheckpointShape::Manifest)]
+    #[case::manifest_json("v2-checkpoints-json-with-sidecars", CheckpointShape::Manifest)]
     // A V2 JSON checkpoint with no sidecar references inlines its actions: a leaf, not a manifest.
-    #[case::leaf_json_inline(
-        "v2-checkpoints-json-without-sidecars",
-        Expected::Leaf(FileType::Json)
-    )]
+    #[case::leaf_json_inline("v2-checkpoints-json-without-sidecars", CheckpointShape::Leaf)]
     // A V2 parquet checkpoint carries a `sidecar` column even when it inlines its actions; with
     // zero sidecar references it is still a leaf, so the column alone must not classify it.
-    #[case::leaf_parquet_inline(
-        "v2-checkpoints-parquet-without-sidecars",
-        Expected::Leaf(FileType::Parquet)
-    )]
-    fn resolve_classifies_checkpoint(#[case] table: &str, #[case] expected: Expected) {
+    #[case::leaf_parquet_inline("v2-checkpoints-parquet-without-sidecars", CheckpointShape::Leaf)]
+    fn resolve_classifies_checkpoint(#[case] table: &str, #[case] expected: CheckpointShape) {
         let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
         let exec = SyncPlanExecutor::new();
         // No stats requested: topology only.
         let shape = ScanShape::resolve(&exec, snapshot.as_ref(), None, None).unwrap();
         assert!(shape.stats.is_none(), "{table}: stats not requested");
-        match (expected, &shape.checkpoint) {
-            (Expected::None, CheckpointShape::None) => {}
-            (Expected::Leaf(fmt), CheckpointShape::Leaf { files, file_format }) => {
-                assert!(
-                    !files.is_empty(),
-                    "{table}: leaf must have checkpoint files"
-                );
-                assert_eq!(*file_format, fmt, "{table}: file format mismatch");
-            }
-            (Expected::Manifest(fmt), CheckpointShape::Manifest { files, file_format }) => {
-                assert!(!files.is_empty(), "{table}: manifest must have parts");
-                assert_eq!(*file_format, fmt, "{table}: file format mismatch");
-            }
-            (expected, actual) => panic!("{table}: expected {expected:?}, got {actual:?}"),
-        }
+        assert_eq!(shape.checkpoint, expected, "{table}: checkpoint shape");
     }
 
     /// When stats are requested, `StatsInfo` carries the requested schema verbatim and reports
@@ -326,6 +281,28 @@ mod tests {
             stats.has_parsed_stats, expect_parsed,
             "{table}: parsed-stats detection"
         );
+    }
+
+    /// `partition_schema` is threaded through verbatim, independent of checkpoint topology.
+    #[rstest]
+    #[case::no_checkpoint("app-txn-no-checkpoint")]
+    #[case::manifest("v2-checkpoints-parquet-with-sidecars")]
+    fn resolve_passes_partition_schema_through(#[case] table: &str) {
+        let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
+        let exec = SyncPlanExecutor::new();
+        let partition_schema: SchemaRef =
+            Arc::new(StructType::new_unchecked([StructField::nullable(
+                "p",
+                DataType::INTEGER,
+            )]));
+        let shape = ScanShape::resolve(
+            &exec,
+            snapshot.as_ref(),
+            None,
+            Some(partition_schema.clone()),
+        )
+        .unwrap();
+        assert_eq!(shape.partition_schema, Some(partition_schema), "{table}");
     }
 
     /// A minimal requested stats schema: empty `minValues` / `maxValues` structs. Compatibility

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -13,7 +13,7 @@
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::CHECKPOINT_METADATA_NAME;
+use crate::actions::SIDECAR_NAME;
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
@@ -52,7 +52,7 @@ pub struct StatsInfo {
     pub has_parsed_stats: bool,
 }
 
-/// Resolved reconciliation shape: checkpoint topology, stats wiring, and partition schema.
+/// Resolved reconciliation shape: checkpoint topology and stats wiring.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScanShape {
     /// What kind of checkpoint the snapshot has.
@@ -60,8 +60,6 @@ pub struct ScanShape {
     /// Stats wiring. `None` when the caller didn't request stats; otherwise the projected stats
     /// schema and whether the checkpoint surfaces it natively.
     pub stats: Option<StatsInfo>,
-    /// Partition schema to surface as `partitionValues_parsed`, when partitioned.
-    pub partition_schema: Option<SchemaRef>,
 }
 
 impl ScanShape {
@@ -73,7 +71,6 @@ impl ScanShape {
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
         stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<SchemaRef>,
     ) -> DeltaResult<ScanShape> {
         let seg = snapshot.log_segment();
 
@@ -83,7 +80,6 @@ impl ScanShape {
                 schema,
                 has_parsed_stats,
             }),
-            partition_schema: partition_schema.clone(),
         };
 
         let parts = &seg.listed.checkpoint_parts;
@@ -92,30 +88,28 @@ impl ScanShape {
         };
         let file_format = checkpoint_file_type(first);
 
-        // Classify leaf vs manifest. Only V2 checkpoints can reference sidecars, and a V2
-        // checkpoint is marked by a `checkpointMetadata` column in its schema -- so a
-        // parquet checkpoint whose schema (footer or `_last_checkpoint` hint) lacks that
-        // column is a classic V1 leaf with no sidecars to drain, and that schema IS the
-        // leaf schema we probe for parsed stats. For a V2 checkpoint we drain the `sidecar`
-        // column: an empty drain is an inline leaf (V2 checkpoints carry an all-null
-        // `sidecar` column even when inlining), >=1 a manifest. JSON checkpoints are always
-        // V2 and have no footer schema, so we always drain.
+        // Classify leaf vs manifest by the `sidecar` column -- the direct indicator of a
+        // manifest. Only V2 checkpoints carry it; a parquet checkpoint whose schema (footer or
+        // `_last_checkpoint` hint) lacks it has no sidecars and is a leaf, and that schema IS the
+        // leaf schema we probe for parsed stats. When present we drain it: empty -> inline leaf,
+        // non-empty -> manifest. JSON checkpoints have no footer schema, so we always drain.
+        //
+        // TODO(#2770): when `_last_checkpoint` embeds the V2 sidecar references, classify from
+        // those to skip this footer read / drain, falling back to draining when absent.
         let mut leaf_parsed_stats = false;
         let sidecar = match file_format {
             FileType::Parquet => {
-                // Prefer the `_last_checkpoint` schema hint to avoid a footer read; it describes
-                // this same top-level checkpoint file (for a leaf, that is the leaf schema).
+                // Prefer the `_last_checkpoint` schema hint to avoid a footer read.
                 let cp_schema = match seg.checkpoint_schema() {
                     Some(schema) => schema,
                     None => read_footer_schema(exec, first.location.clone())?,
                 };
-                let sidecar = if cp_schema.contains(CHECKPOINT_METADATA_NAME) {
+                let sidecar = if cp_schema.contains(SIDECAR_NAME) {
                     collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
                 } else {
                     None
                 };
-                // `cp_schema` is the leaf schema here (classic V1, or inline V2 with no sidecars),
-                // so probe it for parsed stats when the caller requested them.
+                // `cp_schema` is the leaf schema here, so probe it for parsed stats when requested.
                 if sidecar.is_none() {
                     leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
                         LogSegment::schema_has_compatible_stats_parsed(
@@ -217,9 +211,7 @@ mod tests {
     use crate::utils::test_utils::load_test_table;
 
     /// Resolves checkpoint shape and, when stats are requested, whether parsed stats are
-    /// available. `expect_parsed = None` skips the stats probe (checkpoint-only cases). A
-    /// partition schema is varied (present/absent) across every case to assert it passes through
-    /// verbatim, independent of checkpoint topology and stats.
+    /// available. `expect_parsed = None` skips the stats probe (checkpoint-only cases).
     #[rstest]
     #[case::no_checkpoint("app-txn-no-checkpoint", CheckpointShape::None, None)]
     #[case::leaf_parquet("with_checkpoint_no_last_checkpoint", CheckpointShape::Leaf, None)]
@@ -235,15 +227,13 @@ mod tests {
         CheckpointShape::Leaf,
         Some(false)
     )]
-    // A V2 parquet checkpoint carries a `sidecar` column even when it inlines its actions; with
-    // zero sidecar references it is still a leaf, so the column alone must not classify it.
+    // Regression guard: a V2 parquet checkpoint's all-null `sidecar` column alone must not
+    // classify it as a manifest -- only a non-empty drain does.
     #[case::leaf_parquet_inline(
         "v2-checkpoints-parquet-without-sidecars",
         CheckpointShape::Leaf,
         None
     )]
-    // A multi-part V1 checkpoint is always parquet and carries no `sidecar` column: a leaf.
-    // It surfaces struct stats via its checkpoint footer / `_last_checkpoint` hint.
     #[case::leaf_multipart("v1-multi-part-struct-stats-only", CheckpointShape::Leaf, Some(true))]
     #[case::json_stats_classic(
         "v2-classic-checkpoint-parquet",
@@ -267,37 +257,20 @@ mod tests {
         CheckpointShape::Manifest,
         Some(true)
     )]
-    fn resolve_checkpoint_stats_and_partition(
+    fn resolve_checkpoint_and_stats(
         #[case] table: &str,
         #[case] expected_checkpoint: CheckpointShape,
         #[case] expect_parsed: Option<bool>,
-        #[values(false, true)] with_partition: bool,
     ) {
         let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
         let exec = SyncPlanExecutor::new();
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
-        let partition_schema: Option<SchemaRef> = with_partition.then(|| {
-            Arc::new(StructType::new_unchecked([StructField::nullable(
-                "p",
-                DataType::INTEGER,
-            )]))
-        });
 
-        let shape = ScanShape::resolve(
-            &exec,
-            snapshot.as_ref(),
-            stats_schema.as_ref(),
-            partition_schema.clone(),
-        )
-        .unwrap();
+        let shape = ScanShape::resolve(&exec, snapshot.as_ref(), stats_schema.as_ref()).unwrap();
 
         assert_eq!(
             shape.checkpoint, expected_checkpoint,
             "{table}: checkpoint shape"
-        );
-        assert_eq!(
-            shape.partition_schema, partition_schema,
-            "{table}: partition schema passthrough"
         );
 
         match expect_parsed {

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -6,9 +6,12 @@
 //!        legacy multi-part checkpoints.
 //!     3) manifest-level checkpoints, containing references to sidecar files that hold the file
 //!        contents.
-//! When stats are requested, it also resolves how those stats are surfaced (a structured
-//! `add.stats_parsed` struct vs a JSON `add.stats` string). The probe is driven through a
-//! [`PlanExecutor`].
+//! When stats are requested, it also resolves whether the checkpoint contains parsed stats
+//! (a structured `add.stats_parsed` struct) rather than only JSON `add.stats` strings. The probe
+//! is driven through a [`PlanExecutor`].
+
+// This module is wired up by the forthcoming FSR builder; allow its currently unused surface.
+#![allow(unused)]
 
 use url::Url;
 
@@ -25,49 +28,48 @@ use crate::{DeltaResult, FileMeta};
 
 /// Topology of a snapshot's checkpoint(s).
 ///
-/// The two non-empty shapes differ in where the leaf `add` / `remove` rows live: `Leaf` keeps
-/// them in the checkpoint files themselves; `Manifest` keeps them in sidecar parquet files
+/// The two non-empty shapes differ in where the `add` / `remove` actions live: `Leaf` stores
+/// them in the checkpoint files themselves; `Manifest` stores them in sidecar parquet files
 /// referenced by the checkpoint.
 #[derive(Clone, Debug, PartialEq)]
-pub enum CheckpointShape {
-    /// No checkpoint files: log replay degenerates to commit-only.
+pub(crate) enum CheckpointShape {
+    /// No checkpoint files for this log segment.
     None,
-    /// The checkpoint files ARE the leaves -- `add` / `remove` rows are stored inline. Covers
-    /// classic V1 checkpoints and V2 checkpoints that inline their actions (no sidecars).
+    /// The checkpoint files ARE the leaves -- `add` / `remove` actions are stored inline. Covers
+    /// classic V1 checkpoints, V2 checkpoints that inline their actions (no sidecars), and
+    /// legacy multi-part checkpoints.
     Leaf,
-    /// V2 manifest -- the checkpoint files reference sidecar parquet files that hold the leaf
-    /// `add` / `remove` rows (resolved lazily by the reconciliation plan, not stored here).
+    /// V2 manifest -- the checkpoint file reference sidecar parquet files that hold the
+    /// `add` / `remove` actions.
     Manifest,
 }
 
-/// Stats wiring resolved for a scan that requested stats: the projected stats schema plus
-/// whether the snapshot's checkpoint files surface column stats as a native `add.stats_parsed`
-/// struct (`true`) or as a JSON `add.stats` string (`false`).
+/// Stats info for resolved checkpoint. This contains the projected stats schema that unifies
+/// the requested stats schema, and the schema that exists in the checkpoint. It also determines
+/// whether the snapshot's checkpoint files contain already-parsed stats or not.
 #[derive(Clone, Debug, PartialEq)]
-pub struct StatsInfo {
-    /// The requested (projected) stats schema the reconciliation plan should produce.
-    pub schema: SchemaRef,
-    /// `true` iff the snapshot surfaces `add.stats_parsed` compatible with [`Self::schema`] --
-    /// read from the checkpoint footer for a leaf, or a sidecar footer for a manifest.
-    pub has_parsed_stats: bool,
+pub(crate) struct StatsInfo {
+    /// The stats schema to use for log replay. This may be pruned down if the checkpoint contains
+    /// stats that are a subset of the requested stats schema.
+    pub(crate) schema: SchemaRef,
+    /// `true` if the checkpoint contains `add.stats_parsed` compatible with [`Self::schema`]
+    pub(crate) has_parsed_stats: bool,
 }
 
-/// Resolved reconciliation shape: checkpoint topology and stats wiring.
+/// Resolved reconciliation shape: checkpoint topology and stats handling.
 #[derive(Clone, Debug, PartialEq)]
-pub struct ScanShape {
+pub(crate) struct ScanShape {
     /// What kind of checkpoint the snapshot has.
-    pub checkpoint: CheckpointShape,
-    /// Stats wiring. `None` when the caller didn't request stats; otherwise the projected stats
-    /// schema and whether the checkpoint surfaces it natively.
-    pub stats: Option<StatsInfo>,
+    pub(crate) checkpoint: CheckpointShape,
+    /// How checkpoint stats should be handled. `None` when the caller didn't request stats.
+    /// Otherwise contains projected stats schema and whether the checkpoint has parsed stats.
+    pub(crate) stats: Option<StatsInfo>,
 }
 
 impl ScanShape {
     /// Resolve `snapshot`'s scan shape. Determines the checkpoint topology and, when `stats_schema`
-    /// is `Some`, whether the checkpoint surfaces native parsed stats compatible with it. For a
-    /// leaf the parsed-stats answer comes from the checkpoint footer; for a manifest it comes from
-    /// a sidecar footer.
-    pub fn resolve(
+    /// is `Some`, whether the checkpoint contains parsed stats compatible with it.
+    pub(crate) fn resolve(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
         stats_schema: Option<&SchemaRef>,
@@ -128,15 +130,15 @@ impl ScanShape {
         };
 
         let Some(sidecar) = sidecar else {
-            // A JSON leaf has no footer to probe and surfaces stats only as JSON strings, so its
+            // A JSON leaf has no footer to probe and contains stats only as JSON strings, so its
             // parsed answer stays `false`.
             return Ok(make_info(CheckpointShape::Leaf, leaf_parsed_stats));
         };
 
-        // Manifest: the leaf rows -- and their stats -- live in the sidecars, so the sidecar
-        // footer is authoritative for parsed stats. The `_last_checkpoint` hint describes the
-        // manifest, not the leaves, so we deliberately do NOT consult it. Probe the sidecar only
-        // when stats were requested.
+        // Manifest: the `add` / `remove` actions -- and their stats -- live in the sidecars, so
+        // the sidecar footer is authoritative for parsed stats. The `_last_checkpoint` hint
+        // describes the manifest, not the leaves, so we deliberately do NOT consult it. Probe the
+        // sidecar only when stats were requested.
         let has_parsed_stats = match stats_schema {
             Some(reqd) => {
                 let side_schema = read_footer_schema(exec, sidecar)?;

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -3,23 +3,26 @@
 //! Probes a snapshot's checkpoint topology -- no checkpoint, an inline *leaf* checkpoint, or a
 //! V2 *manifest* that references sidecars -- and, when stats are requested, resolves how those
 //! stats are surfaced (native `add.stats_parsed` struct vs JSON `add.stats` string). The probe is
-//! driven synchronously through a [`PlanExecutor`]. A checkpoint is a manifest only if it actually
-//! references sidecars: a parquet footer with no `sidecar` column is a leaf outright, but otherwise
-//! (a `sidecar` column present, or any JSON checkpoint) the column is drained through
+//! driven synchronously through a [`PlanExecutor`]. A V2 checkpoint is identified by a
+//! `checkpointMetadata` column in its schema (the footer or `_last_checkpoint` hint); only V2
+//! checkpoints can reference sidecars, so a parquet checkpoint lacking that column is a classic V1
+//! leaf outright. For a V2 (or any JSON) checkpoint the `sidecar` column is drained through
 //! [`SidecarVisitor`] -- no references means an inline leaf, one or more a manifest. For a
-//! manifest, that same first sidecar then answers the parsed-stats probe via its footer.
+//! manifest, that first sidecar then answers the parsed-stats probe via its footer.
 //!
 //! This is the IO-bearing front half of log-replay planning. It is deliberately independent of
 //! the plan-construction surface and the reconciliation pipeline: a caller resolves the shape
 //! here, then feeds it into a (separately built) reconciliation plan.
 //!
-//! Sibling: `LogSegment::get_file_actions_schema_and_sidecars` performs the same leaf/manifest
-//! classification for the engine-driven read path; the two must stay in sync.
+//! Sibling: `LogSegment::get_file_actions_schema_and_sidecars` reaches the same leaf/manifest
+//! outcome for the engine-driven read path, though it detects V2 via the `sidecar` column rather
+//! than `checkpointMetadata` (the latter is the spec-mandated V2 marker -- every V2 checkpoint
+//! carries it, classic V1 never does). Keep their behavior aligned.
 
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::SIDECAR_NAME;
+use crate::actions::CHECKPOINT_METADATA_NAME;
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
@@ -81,8 +84,9 @@ impl ScanShape {
     ///
     /// # Errors
     ///
-    /// Propagates executor failures from the footer reads or the manifest scan, errors visiting the
-    /// `sidecar` column, and any error resolving a sidecar reference to a [`FileMeta`].
+    /// Propagates executor failures from the footer reads or the sidecar-drain scan, errors
+    /// visiting the `sidecar` column, and any error resolving a sidecar reference to a
+    /// [`FileMeta`].
     pub fn resolve(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
@@ -106,14 +110,14 @@ impl ScanShape {
         };
         let file_format = checkpoint_file_type(first);
 
-        // Classify leaf vs manifest by whether the checkpoint actually references sidecars. A
-        // `sidecar` *column* in the schema is necessary but NOT sufficient: a V2 checkpoint that
-        // inlines its actions still carries an all-null `sidecar` column. So we drain that column
-        // whenever it could be populated, and treat an empty drain as an inline leaf.
-        //
-        // Parquet exposes its schema in the footer (or the `_last_checkpoint` hint): no `sidecar`
-        // column means a V1 leaf, and that schema IS the leaf schema we probe for parsed stats.
-        // JSON has no footer, so we always drain. Either way: >=1 sidecar => manifest, 0 => leaf.
+        // Classify leaf vs manifest. Only V2 checkpoints can reference sidecars, and a V2
+        // checkpoint is marked by a `checkpointMetadata` column in its schema -- so a
+        // parquet checkpoint whose schema (footer or `_last_checkpoint` hint) lacks that
+        // column is a classic V1 leaf with no sidecars to drain, and that schema IS the
+        // leaf schema we probe for parsed stats. For a V2 checkpoint we drain the `sidecar`
+        // column: an empty drain is an inline leaf (V2 checkpoints carry an all-null
+        // `sidecar` column even when inlining), >=1 a manifest. JSON checkpoints are always
+        // V2 and have no footer schema, so we always drain.
         let mut leaf_parsed_stats = false;
         let sidecar = match file_format {
             FileType::Parquet => {
@@ -123,14 +127,14 @@ impl ScanShape {
                     Some(schema) => schema,
                     None => read_footer_schema(exec, first.location.clone())?,
                 };
-                let sidecar = if cp_schema.contains(SIDECAR_NAME) {
+                let sidecar = if cp_schema.contains(CHECKPOINT_METADATA_NAME) {
                     collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
                 } else {
                     None
                 };
-                // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
-                // leaf): either way `cp_schema` is the leaf schema, so probe it for parsed stats
-                // when the caller requested them.
+                // No `checkpointMetadata` column (classic V1 leaf) or a V2 checkpoint that inlines
+                // its actions (drain found no sidecars): either way `cp_schema` is the leaf schema,
+                // so probe it for parsed stats when the caller requested them.
                 if sidecar.is_none() {
                     leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
                         LogSegment::schema_has_compatible_stats_parsed(

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -12,6 +12,9 @@
 //! This is the IO-bearing front half of log-replay planning. It is deliberately independent of
 //! the plan-construction surface and the reconciliation pipeline: a caller resolves the shape
 //! here, then feeds it into a (separately built) reconciliation plan.
+//!
+//! Sibling: `LogSegment::get_file_actions_schema_and_sidecars` performs the same leaf/manifest
+//! classification for the engine-driven read path; the two must stay in sync.
 
 use url::Url;
 
@@ -125,21 +128,18 @@ impl ScanShape {
                 } else {
                     None
                 };
-                match sidecar {
-                    Some(sidecar) => Some(sidecar),
-                    // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
-                    // leaf): either way `cp_schema` is the leaf schema, so probe it for parsed
-                    // stats when the caller requested them.
-                    _ => {
-                        leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
-                            LogSegment::schema_has_compatible_stats_parsed(
-                                cp_schema.as_ref(),
-                                reqd.as_ref(),
-                            )
-                        });
-                        None
-                    }
+                // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
+                // leaf): either way `cp_schema` is the leaf schema, so probe it for parsed stats
+                // when the caller requested them.
+                if sidecar.is_none() {
+                    leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
+                        LogSegment::schema_has_compatible_stats_parsed(
+                            cp_schema.as_ref(),
+                            reqd.as_ref(),
+                        )
+                    });
                 }
+                sidecar
             }
             FileType::Json => {
                 collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
@@ -243,6 +243,8 @@ mod tests {
     // A V2 parquet checkpoint carries a `sidecar` column even when it inlines its actions; with
     // zero sidecar references it is still a leaf, so the column alone must not classify it.
     #[case::leaf_parquet_inline("v2-checkpoints-parquet-without-sidecars", CheckpointShape::Leaf)]
+    // A multi-part V1 checkpoint is always parquet and carries no `sidecar` column: a leaf.
+    #[case::leaf_multipart("v1-multi-part-struct-stats-only", CheckpointShape::Leaf)]
     fn resolve_classifies_checkpoint(#[case] table: &str, #[case] expected: CheckpointShape) {
         let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
         let exec = SyncPlanExecutor::new();
@@ -258,13 +260,18 @@ mod tests {
     /// `maxValues` request is trivially compatible, so this isolates "does the checkpoint have
     /// an `add.stats_parsed` struct at all".
     #[rstest]
-    #[case::json_stats_manifest("v2-classic-checkpoint-parquet", false)]
+    #[case::json_stats_classic_leaf("v2-classic-checkpoint-parquet", false)]
     #[case::json_stats_sidecars("v2-checkpoints-parquet-with-sidecars", false)]
     #[case::struct_stats_leaf("v2-classic-parquet-struct-stats-only", true)]
     // Manifest sidecar probe: the parsed-stats answer comes from a sidecar footer, exercising the
     // JSON drain-then-probe path (JSON) and the lazy parquet drain (parquet).
     #[case::struct_stats_json_manifest("v2-json-sidecars-struct-stats-only", true)]
     #[case::struct_stats_parquet_manifest("v2-parquet-sidecars-struct-stats-only", true)]
+    // A multi-part V1 leaf surfaces struct stats via its checkpoint footer / `_last_checkpoint`
+    // hint.
+    #[case::struct_stats_multipart_leaf("v1-multi-part-struct-stats-only", true)]
+    // A JSON leaf has no footer, so it never reports native parsed stats even when requested.
+    #[case::json_leaf_no_parsed("v2-checkpoints-json-without-sidecars", false)]
     fn resolve_reports_parsed_stats(#[case] table: &str, #[case] expect_parsed: bool) {
         let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
         let exec = SyncPlanExecutor::new();

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -1,23 +1,14 @@
-//! Checkpoint-shape resolution for scan / FSR log replay.
+//! Checkpoint-shape resolution for scan
 //!
-//! Probes a snapshot's checkpoint topology -- no checkpoint, an inline *leaf* checkpoint, or a
-//! V2 *manifest* that references sidecars -- and, when stats are requested, resolves how those
-//! stats are surfaced (native `add.stats_parsed` struct vs JSON `add.stats` string). The probe is
-//! driven synchronously through a [`PlanExecutor`]. A V2 checkpoint is identified by a
-//! `checkpointMetadata` column in its schema (the footer or `_last_checkpoint` hint); only V2
-//! checkpoints can reference sidecars, so a parquet checkpoint lacking that column is a classic V1
-//! leaf outright. For a V2 (or any JSON) checkpoint the `sidecar` column is drained through
-//! [`SidecarVisitor`] -- no references means an inline leaf, one or more a manifest. For a
-//! manifest, that first sidecar then answers the parsed-stats probe via its footer.
-//!
-//! This is the IO-bearing front half of log-replay planning. It is deliberately independent of
-//! the plan-construction surface and the reconciliation pipeline: a caller resolves the shape
-//! here, then feeds it into a (separately built) reconciliation plan.
-//!
-//! Sibling: `LogSegment::get_file_actions_schema_and_sidecars` reaches the same leaf/manifest
-//! outcome for the engine-driven read path, though it detects V2 via the `sidecar` column rather
-//! than `checkpointMetadata` (the latter is the spec-mandated V2 marker -- every V2 checkpoint
-//! carries it, classic V1 never does). Keep their behavior aligned.
+//! Probes a snapshot's checkpoint topology, categorizing it into one of:
+//!     1) no checkpoint
+//!     2) leaf-level checkpoints, containing only file contents. This includes single-part and
+//!        legacy multi-part checkpoints.
+//!     3) manifest-level checkpoints, containing references to sidecar files that hold the file
+//!        contents.
+//! When stats are requested, it also resolves how those stats are surfaced (a structured
+//! `add.stats_parsed` struct vs a JSON `add.stats` string). The probe is driven through a
+//! [`PlanExecutor`].
 
 use url::Url;
 
@@ -74,19 +65,10 @@ pub struct ScanShape {
 }
 
 impl ScanShape {
-    /// Resolve `snapshot`'s scan shape, driving all IO synchronously through `exec`.
-    ///
-    /// Determines the checkpoint topology and, when `stats_schema` is `Some`, whether the
-    /// checkpoint surfaces native parsed stats compatible with it. For a leaf the parsed-stats
-    /// answer comes from the checkpoint footer; for a manifest it comes from a sidecar footer.
-    /// The `_last_checkpoint` hint describes the manifest rather than the leaf rows, so it is not
-    /// consulted for the parsed-stats decision.
-    ///
-    /// # Errors
-    ///
-    /// Propagates executor failures from the footer reads or the sidecar-drain scan, errors
-    /// visiting the `sidecar` column, and any error resolving a sidecar reference to a
-    /// [`FileMeta`].
+    /// Resolve `snapshot`'s scan shape. Determines the checkpoint topology and, when `stats_schema`
+    /// is `Some`, whether the checkpoint surfaces native parsed stats compatible with it. For a
+    /// leaf the parsed-stats answer comes from the checkpoint footer; for a manifest it comes from
+    /// a sidecar footer.
     pub fn resolve(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
@@ -132,8 +114,7 @@ impl ScanShape {
                 } else {
                     None
                 };
-                // No `checkpointMetadata` column (classic V1 leaf) or a V2 checkpoint that inlines
-                // its actions (drain found no sidecars): either way `cp_schema` is the leaf schema,
+                // `cp_schema` is the leaf schema here (classic V1, or inline V2 with no sidecars),
                 // so probe it for parsed stats when the caller requested them.
                 if sidecar.is_none() {
                     leaf_parsed_stats = stats_schema.is_some_and(|reqd| {
@@ -146,6 +127,8 @@ impl ScanShape {
                 sidecar
             }
             FileType::Json => {
+                // JSON checkpoints have no footer schema, so drain the `sidecar` column to
+                // classify: empty -> inline leaf, non-empty -> manifest.
                 collect_sidecar(exec, first.location.clone(), file_format, &seg.log_root)?
             }
         };
@@ -182,11 +165,6 @@ fn read_footer_schema(exec: &dyn PlanExecutor, file: FileMeta) -> DeltaResult<Sc
 
 /// Scan the checkpoint `file` and drain its `sidecar` column through [`SidecarVisitor`], resolving
 /// the first reference to a [`FileMeta`] under `log_root`.
-///
-/// This mimics a streaming reducer kernel-side: it pulls each batch from the executor's result
-/// stream and visits its rows, stopping as soon as a sidecar reference appears. The scan projects
-/// only the `sidecar` column, so manifest action rows (`add` / `remove`) read as null and are
-/// skipped by the visitor.
 fn collect_sidecar(
     exec: &dyn PlanExecutor,
     file: FileMeta,
@@ -233,96 +211,127 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::load_test_table;
 
+    /// Resolves checkpoint shape and, when stats are requested, whether parsed stats are
+    /// available. `expect_parsed = None` skips the stats probe (checkpoint-only cases). A
+    /// partition schema is varied (present/absent) across every case to assert it passes through
+    /// verbatim, independent of checkpoint topology and stats.
     #[rstest]
-    #[case::no_checkpoint("app-txn-no-checkpoint", CheckpointShape::None)]
-    #[case::leaf_parquet("with_checkpoint_no_last_checkpoint", CheckpointShape::Leaf)]
-    #[case::manifest_parquet("v2-checkpoints-parquet-with-sidecars", CheckpointShape::Manifest)]
-    #[case::manifest_json("v2-checkpoints-json-with-sidecars", CheckpointShape::Manifest)]
+    #[case::no_checkpoint("app-txn-no-checkpoint", CheckpointShape::None, None)]
+    #[case::leaf_parquet("with_checkpoint_no_last_checkpoint", CheckpointShape::Leaf, None)]
+    #[case::manifest_parquet(
+        "v2-checkpoints-parquet-with-sidecars",
+        CheckpointShape::Manifest,
+        Some(false)
+    )]
+    #[case::manifest_json("v2-checkpoints-json-with-sidecars", CheckpointShape::Manifest, None)]
     // A V2 JSON checkpoint with no sidecar references inlines its actions: a leaf, not a manifest.
-    #[case::leaf_json_inline("v2-checkpoints-json-without-sidecars", CheckpointShape::Leaf)]
+    #[case::leaf_json_inline(
+        "v2-checkpoints-json-without-sidecars",
+        CheckpointShape::Leaf,
+        Some(false)
+    )]
     // A V2 parquet checkpoint carries a `sidecar` column even when it inlines its actions; with
     // zero sidecar references it is still a leaf, so the column alone must not classify it.
-    #[case::leaf_parquet_inline("v2-checkpoints-parquet-without-sidecars", CheckpointShape::Leaf)]
+    #[case::leaf_parquet_inline(
+        "v2-checkpoints-parquet-without-sidecars",
+        CheckpointShape::Leaf,
+        None
+    )]
     // A multi-part V1 checkpoint is always parquet and carries no `sidecar` column: a leaf.
-    #[case::leaf_multipart("v1-multi-part-struct-stats-only", CheckpointShape::Leaf)]
-    fn resolve_classifies_checkpoint(#[case] table: &str, #[case] expected: CheckpointShape) {
-        let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
-        let exec = SyncPlanExecutor::new();
-        // No stats requested: topology only.
-        let shape = ScanShape::resolve(&exec, snapshot.as_ref(), None, None).unwrap();
-        assert!(shape.stats.is_none(), "{table}: stats not requested");
-        assert_eq!(shape.checkpoint, expected, "{table}: checkpoint shape");
-    }
-
-    /// When stats are requested, `StatsInfo` carries the requested schema verbatim and reports
-    /// whether the checkpoint surfaces it as native parsed stats: `true` for the
-    /// struct-stats-only tables, `false` for the JSON-stats tables. An empty `minValues` /
-    /// `maxValues` request is trivially compatible, so this isolates "does the checkpoint have
-    /// an `add.stats_parsed` struct at all".
-    #[rstest]
-    #[case::json_stats_classic_leaf("v2-classic-checkpoint-parquet", false)]
-    #[case::json_stats_sidecars("v2-checkpoints-parquet-with-sidecars", false)]
-    #[case::struct_stats_leaf("v2-classic-parquet-struct-stats-only", true)]
+    // It surfaces struct stats via its checkpoint footer / `_last_checkpoint` hint.
+    #[case::leaf_multipart("v1-multi-part-struct-stats-only", CheckpointShape::Leaf, Some(true))]
+    #[case::json_stats_classic(
+        "v2-classic-checkpoint-parquet",
+        CheckpointShape::Manifest,
+        Some(false)
+    )]
+    #[case::struct_stats_leaf(
+        "v2-classic-parquet-struct-stats-only",
+        CheckpointShape::Leaf,
+        Some(true)
+    )]
     // Manifest sidecar probe: the parsed-stats answer comes from a sidecar footer, exercising the
     // JSON drain-then-probe path (JSON) and the lazy parquet drain (parquet).
-    #[case::struct_stats_json_manifest("v2-json-sidecars-struct-stats-only", true)]
-    #[case::struct_stats_parquet_manifest("v2-parquet-sidecars-struct-stats-only", true)]
-    // A multi-part V1 leaf surfaces struct stats via its checkpoint footer / `_last_checkpoint`
-    // hint.
-    #[case::struct_stats_multipart_leaf("v1-multi-part-struct-stats-only", true)]
-    // A JSON leaf has no footer, so it never reports native parsed stats even when requested.
-    #[case::json_leaf_no_parsed("v2-checkpoints-json-without-sidecars", false)]
-    fn resolve_reports_parsed_stats(#[case] table: &str, #[case] expect_parsed: bool) {
+    #[case::struct_stats_json_manifest(
+        "v2-json-sidecars-struct-stats-only",
+        CheckpointShape::Manifest,
+        Some(true)
+    )]
+    #[case::struct_stats_parquet_manifest(
+        "v2-parquet-sidecars-struct-stats-only",
+        CheckpointShape::Manifest,
+        Some(true)
+    )]
+    fn resolve_checkpoint_stats_and_partition(
+        #[case] table: &str,
+        #[case] expected_checkpoint: CheckpointShape,
+        #[case] expect_parsed: Option<bool>,
+        #[values(false, true)] with_partition: bool,
+    ) {
         let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
         let exec = SyncPlanExecutor::new();
-        let stats_schema = probe_stats_schema();
-
-        let shape =
-            ScanShape::resolve(&exec, snapshot.as_ref(), Some(&stats_schema), None).unwrap();
-        let stats = shape.stats.expect("stats requested");
-        assert_eq!(
-            stats.schema, stats_schema,
-            "{table}: schema passed through verbatim"
-        );
-        assert_eq!(
-            stats.has_parsed_stats, expect_parsed,
-            "{table}: parsed-stats detection"
-        );
-    }
-
-    /// `partition_schema` is threaded through verbatim, independent of checkpoint topology.
-    #[rstest]
-    #[case::no_checkpoint("app-txn-no-checkpoint")]
-    #[case::manifest("v2-checkpoints-parquet-with-sidecars")]
-    fn resolve_passes_partition_schema_through(#[case] table: &str) {
-        let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
-        let exec = SyncPlanExecutor::new();
-        let partition_schema: SchemaRef =
+        let stats_schema = expect_parsed.map(|_| probe_stats_schema());
+        let partition_schema: Option<SchemaRef> = with_partition.then(|| {
             Arc::new(StructType::new_unchecked([StructField::nullable(
                 "p",
                 DataType::INTEGER,
-            )]));
+            )]))
+        });
+
         let shape = ScanShape::resolve(
             &exec,
             snapshot.as_ref(),
-            None,
-            Some(partition_schema.clone()),
+            stats_schema.as_ref(),
+            partition_schema.clone(),
         )
         .unwrap();
-        assert_eq!(shape.partition_schema, Some(partition_schema), "{table}");
+
+        assert_eq!(
+            shape.checkpoint, expected_checkpoint,
+            "{table}: checkpoint shape"
+        );
+        assert_eq!(
+            shape.partition_schema, partition_schema,
+            "{table}: partition schema passthrough"
+        );
+
+        match expect_parsed {
+            None => assert!(shape.stats.is_none(), "{table}: stats not requested"),
+            Some(parsed) => {
+                let stats = shape.stats.expect("stats requested");
+                assert_eq!(
+                    stats.schema,
+                    stats_schema.unwrap(),
+                    "{table}: schema passed through verbatim"
+                );
+                assert_eq!(
+                    stats.has_parsed_stats, parsed,
+                    "{table}: parsed-stats detection"
+                );
+            }
+        }
     }
 
-    /// A minimal requested stats schema: empty `minValues` / `maxValues` structs. Compatibility
-    /// then reduces to whether the checkpoint carries an `add.stats_parsed` struct.
+    /// A realistic requested stats schema mirroring the `*-struct-stats-only` fixtures
+    /// (`id: long, value: string`): `numRecords` plus `minValues` / `maxValues` over the data
+    /// columns. Compatibility then exercises real per-column type matching against the
+    /// checkpoint's `add.stats_parsed`, not just the presence of the struct.
     fn probe_stats_schema() -> SchemaRef {
-        let empty = || StructType::new_unchecked([]);
+        let columns = || {
+            StructType::new_unchecked([
+                StructField::nullable("id", DataType::LONG),
+                StructField::nullable("value", DataType::STRING),
+            ])
+        };
         Arc::new(StructType::new_unchecked([
-            StructField::nullable("minValues", empty()),
-            StructField::nullable("maxValues", empty()),
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(MIN_VALUES, columns()),
+            StructField::nullable(MAX_VALUES, columns()),
         ]))
     }
 }

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -1,0 +1,360 @@
+//! Checkpoint-shape resolution for scan / FSR log replay.
+//!
+//! Probes a snapshot's checkpoint topology -- no checkpoint, an inline *leaf* checkpoint, or a
+//! V2 *manifest* that references sidecars -- and, when stats are requested, resolves how those
+//! stats are surfaced (native `add.stats_parsed` struct vs JSON `add.stats` string). The probe is
+//! driven synchronously through a [`PlanExecutor`]. A checkpoint is a manifest only if it actually
+//! references sidecars: a parquet footer with no `sidecar` column is a leaf outright, but otherwise
+//! (a `sidecar` column present, or any JSON checkpoint) the column is drained through
+//! [`SidecarVisitor`] -- no references means an inline leaf, one or more a manifest. For a
+//! manifest, that same first sidecar then answers the parsed-stats probe via its footer.
+//!
+//! This is the IO-bearing front half of log-replay planning. It is deliberately independent of
+//! the plan-construction surface and the reconciliation pipeline: a caller resolves the shape
+//! here, then feeds it into a (separately built) reconciliation plan.
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::actions::visitors::SidecarVisitor;
+use crate::actions::{Sidecar, SIDECAR_NAME};
+use crate::engine_data::RowVisitor;
+use crate::log_segment::LogSegment;
+use crate::path::ParsedLogPath;
+use crate::plans::ir::nodes::FileType;
+use crate::plans::{IoOperation, Operation, PlanExecutor, QueryPlanBuilder};
+use crate::schema::{SchemaRef, StructField, StructType, ToSchema};
+use crate::snapshot::Snapshot;
+use crate::{DeltaResult, FileMeta};
+
+/// Topology of a snapshot's checkpoint(s).
+///
+/// The two non-empty shapes differ in where the leaf `add` / `remove` rows live: `Leaf` keeps
+/// them in the checkpoint files themselves; `Manifest` keeps them in sidecar parquet files
+/// referenced by the checkpoint.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CheckpointShape {
+    /// No checkpoint files: log replay degenerates to commit-only.
+    None,
+    /// The checkpoint files ARE the leaves -- `add` / `remove` rows are stored inline. Covers
+    /// classic V1 checkpoints and V2 checkpoints that inline their actions (no sidecars).
+    Leaf {
+        /// The checkpoint files.
+        files: Vec<FileMeta>,
+        /// How the checkpoint files are encoded.
+        file_format: FileType,
+    },
+    /// V2 multipart manifest -- `files` are the manifest parts; the leaf rows live in sidecar
+    /// parquet files the manifest references (resolved lazily by the reconciliation plan, not
+    /// stored here).
+    Manifest {
+        /// The manifest (top-level checkpoint) files.
+        files: Vec<FileMeta>,
+        /// How the manifest files are encoded.
+        file_format: FileType,
+    },
+}
+
+/// Stats wiring resolved for a scan that requested stats: the projected stats schema plus
+/// whether the snapshot's checkpoint files surface column stats as a native `add.stats_parsed`
+/// struct (`true`) or as a JSON `add.stats` string (`false`).
+#[derive(Clone, Debug, PartialEq)]
+pub struct StatsInfo {
+    /// The requested (projected) stats schema the reconciliation plan should produce.
+    pub schema: SchemaRef,
+    /// `true` iff the checkpoint surfaces `add.stats_parsed` compatible with [`Self::schema`].
+    pub has_parsed_stats: bool,
+}
+
+/// Resolved reconciliation shape: checkpoint topology, stats wiring, and partition schema.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScanShape {
+    /// What kind of checkpoint the snapshot has.
+    pub checkpoint: CheckpointShape,
+    /// Stats wiring. `None` when the caller didn't request stats; otherwise the projected stats
+    /// schema and whether the checkpoint surfaces it natively.
+    pub stats: Option<StatsInfo>,
+    /// Partition schema to surface as `partitionValues_parsed`, when partitioned.
+    pub partition_schema: Option<SchemaRef>,
+}
+
+impl ScanShape {
+    /// Resolve `snapshot`'s scan shape, driving all IO synchronously through `exec`.
+    ///
+    /// Determines the checkpoint topology and, when `stats_schema` is `Some`, whether the
+    /// checkpoint surfaces native parsed stats compatible with it. For a leaf the parsed-stats
+    /// answer comes from the checkpoint footer; for a manifest it comes from a sidecar footer.
+    /// The `_last_checkpoint` hint describes the manifest rather than the leaf rows, so it is not
+    /// consulted for the parsed-stats decision.
+    ///
+    /// # Errors
+    ///
+    /// Propagates executor failures from the footer reads or the manifest scan, and any error
+    /// resolving a sidecar reference to a [`FileMeta`].
+    pub fn resolve(
+        exec: &dyn PlanExecutor,
+        snapshot: &Snapshot,
+        stats_schema: Option<&SchemaRef>,
+        partition_schema: Option<SchemaRef>,
+    ) -> DeltaResult<ScanShape> {
+        let seg = snapshot.log_segment();
+
+        let make_info = |checkpoint, has_parsed_stats| ScanShape {
+            checkpoint,
+            stats: stats_schema.cloned().map(|schema| StatsInfo {
+                schema,
+                has_parsed_stats,
+            }),
+            partition_schema: partition_schema.clone(),
+        };
+
+        let parts = &seg.listed.checkpoint_parts;
+        let Some(first) = parts.first() else {
+            return Ok(make_info(CheckpointShape::None, false));
+        };
+        let file_format = checkpoint_file_type(first);
+        let files: Vec<FileMeta> = parts.iter().map(|p| p.location.clone()).collect();
+
+        // Classify leaf vs manifest by whether the checkpoint actually references sidecars. A
+        // `sidecar` *column* in the schema is necessary but NOT sufficient: a V2 checkpoint that
+        // inlines its actions still carries an all-null `sidecar` column. So we drain that column
+        // whenever it could be populated, and treat an empty drain as an inline leaf.
+        //
+        // Parquet exposes its schema in the footer: no `sidecar` column means a V1 leaf, and that
+        // footer IS the leaf schema we probe for parsed stats. JSON has no footer, so we always
+        // drain. Either way: >=1 sidecar => manifest, 0 => leaf.
+        let mut leaf_parsed_stats = None;
+        let (is_manifest, sidecars) = match file_format {
+            FileType::Parquet => {
+                let cp_schema = read_footer_schema(exec, first.location.clone())?;
+                let sidecars = if cp_schema.contains(SIDECAR_NAME) {
+                    Some(collect_sidecars(
+                        exec,
+                        files.clone(),
+                        file_format,
+                        &seg.log_root,
+                    )?)
+                } else {
+                    None
+                };
+                match sidecars {
+                    Some(sidecars) if !sidecars.is_empty() => (true, Some(sidecars)),
+                    // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
+                    // leaf): either way the footer we read is the leaf schema, so probe it here.
+                    _ => {
+                        leaf_parsed_stats = stats_probe(Some(&cp_schema), stats_schema);
+                        (false, None)
+                    }
+                }
+            }
+            FileType::Json => {
+                let sidecars = collect_sidecars(exec, files.clone(), file_format, &seg.log_root)?;
+                (!sidecars.is_empty(), Some(sidecars))
+            }
+        };
+
+        if !is_manifest {
+            // A JSON leaf has no footer to probe and surfaces stats only as JSON strings, so its
+            // parsed answer falls through to `false`.
+            return Ok(make_info(
+                CheckpointShape::Leaf { files, file_format },
+                leaf_parsed_stats.unwrap_or(false),
+            ));
+        }
+
+        // Manifest: the leaf rows -- and their stats -- live in the sidecars, so the sidecar
+        // footer is authoritative for parsed stats. The `_last_checkpoint` hint describes the
+        // manifest, not the leaves, so we deliberately do NOT consult it. Probe the first sidecar
+        // only when stats were requested.
+        // Classification drained these sidecars; the leaf path returned above, so a manifest
+        // always carries at least one. An empty list would simply leave parsed stats `false`.
+        let sidecars = sidecars.unwrap_or_default();
+        let has_parsed_stats = match (stats_schema, sidecars.first()) {
+            (Some(reqd), Some(sidecar)) => {
+                let side_schema = read_footer_schema(exec, sidecar.clone())?;
+                LogSegment::schema_has_compatible_stats_parsed(side_schema.as_ref(), reqd.as_ref())
+            }
+            _ => false,
+        };
+
+        Ok(make_info(
+            CheckpointShape::Manifest { files, file_format },
+            has_parsed_stats,
+        ))
+    }
+}
+
+/// Compare a checkpoint/leaf `schema` against a `requested` stats schema, returning whether the
+/// checkpoint surfaces compatible native parsed stats. Returns `None` when either input is
+/// absent (no schema to probe, or stats not requested).
+fn stats_probe(schema: Option<&SchemaRef>, requested: Option<&SchemaRef>) -> Option<bool> {
+    let (schema, requested) = (schema?, requested?);
+    Some(LogSegment::schema_has_compatible_stats_parsed(
+        schema.as_ref(),
+        requested.as_ref(),
+    ))
+}
+
+/// Footer-read a parquet file's schema through the executor.
+fn read_footer_schema(exec: &dyn PlanExecutor, file: FileMeta) -> DeltaResult<SchemaRef> {
+    let footer = exec
+        .execute_op(Operation::IoOperation(IoOperation::ParquetFooter { file }))?
+        .into_parquet_footer()?;
+    Ok(footer.schema)
+}
+
+/// Scan the manifest `files` and drain their `sidecar` column through [`SidecarVisitor`],
+/// resolving each reference to a [`FileMeta`] under `log_root`.
+///
+/// This mimics a streaming reducer kernel-side: it pulls each batch from the executor's result
+/// stream and visits its rows, rather than crossing the engine boundary with a reducer sink.
+/// The scan projects only the `sidecar` column, so manifest action rows (`add` / `remove`) read
+/// as null and are skipped by the visitor.
+fn collect_sidecars(
+    exec: &dyn PlanExecutor,
+    files: Vec<FileMeta>,
+    file_format: FileType,
+    log_root: &Url,
+) -> DeltaResult<Vec<FileMeta>> {
+    let plan = match file_format {
+        FileType::Parquet => QueryPlanBuilder::scan_parquet(files, sidecar_scan_schema()),
+        FileType::Json => QueryPlanBuilder::scan_json(files, sidecar_scan_schema()),
+    }
+    .build()?;
+    let data = exec.execute_op(Operation::QueryPlan(plan))?.into_data()?;
+
+    let mut visitor = SidecarVisitor::default();
+    for batch in data {
+        visitor.visit_rows_of(batch?.as_ref())?;
+    }
+    visitor
+        .sidecars
+        .into_iter()
+        .map(|sidecar| sidecar.to_filemeta(log_root))
+        .collect()
+}
+
+/// Manifest scan schema: just the `sidecar` column. Narrowing to that one column avoids paying
+/// the read cost for the action columns we never inspect here.
+fn sidecar_scan_schema() -> SchemaRef {
+    Arc::new(StructType::new_unchecked([StructField::nullable(
+        SIDECAR_NAME,
+        Sidecar::to_schema(),
+    )]))
+}
+
+/// A checkpoint part's encoding, derived from its file extension.
+fn checkpoint_file_type(part: &ParsedLogPath) -> FileType {
+    if part.extension == "json" {
+        FileType::Json
+    } else {
+        FileType::Parquet
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::utils::test_utils::load_test_table;
+
+    /// The checkpoint variant a table is expected to resolve to.
+    #[derive(Debug)]
+    enum Expected {
+        None,
+        Leaf(FileType),
+        Manifest(FileType),
+    }
+
+    #[rstest]
+    #[case::no_checkpoint("app-txn-no-checkpoint", Expected::None)]
+    #[case::leaf_parquet(
+        "with_checkpoint_no_last_checkpoint",
+        Expected::Leaf(FileType::Parquet)
+    )]
+    #[case::manifest_parquet(
+        "v2-checkpoints-parquet-with-sidecars",
+        Expected::Manifest(FileType::Parquet)
+    )]
+    #[case::manifest_json(
+        "v2-checkpoints-json-with-sidecars",
+        Expected::Manifest(FileType::Json)
+    )]
+    // A V2 JSON checkpoint with no sidecar references inlines its actions: a leaf, not a manifest.
+    #[case::leaf_json_inline(
+        "v2-checkpoints-json-without-sidecars",
+        Expected::Leaf(FileType::Json)
+    )]
+    // A V2 parquet checkpoint carries a `sidecar` column even when it inlines its actions; with
+    // zero sidecar references it is still a leaf, so the column alone must not classify it.
+    #[case::leaf_parquet_inline(
+        "v2-checkpoints-parquet-without-sidecars",
+        Expected::Leaf(FileType::Parquet)
+    )]
+    fn resolve_classifies_checkpoint(#[case] table: &str, #[case] expected: Expected) {
+        let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
+        let exec = SyncPlanExecutor::new();
+        // No stats requested: topology only.
+        let shape = ScanShape::resolve(&exec, snapshot.as_ref(), None, None).unwrap();
+        assert!(shape.stats.is_none(), "{table}: stats not requested");
+        match (expected, &shape.checkpoint) {
+            (Expected::None, CheckpointShape::None) => {}
+            (Expected::Leaf(fmt), CheckpointShape::Leaf { files, file_format }) => {
+                assert!(
+                    !files.is_empty(),
+                    "{table}: leaf must have checkpoint files"
+                );
+                assert_eq!(*file_format, fmt, "{table}: file format mismatch");
+            }
+            (Expected::Manifest(fmt), CheckpointShape::Manifest { files, file_format }) => {
+                assert!(!files.is_empty(), "{table}: manifest must have parts");
+                assert_eq!(*file_format, fmt, "{table}: file format mismatch");
+            }
+            (expected, actual) => panic!("{table}: expected {expected:?}, got {actual:?}"),
+        }
+    }
+
+    /// When stats are requested, `StatsInfo` carries the requested schema verbatim and reports
+    /// whether the checkpoint surfaces it as native parsed stats: `true` for the
+    /// struct-stats-only tables, `false` for the JSON-stats tables. An empty `minValues` /
+    /// `maxValues` request is trivially compatible, so this isolates "does the checkpoint have
+    /// an `add.stats_parsed` struct at all".
+    #[rstest]
+    #[case::json_stats_manifest("v2-classic-checkpoint-parquet", false)]
+    #[case::json_stats_sidecars("v2-checkpoints-parquet-with-sidecars", false)]
+    #[case::struct_stats_leaf("v2-classic-parquet-struct-stats-only", true)]
+    // Manifest sidecar probe: the parsed-stats answer comes from a sidecar footer, exercising the
+    // JSON drain-then-probe path (JSON) and the lazy parquet drain (parquet).
+    #[case::struct_stats_json_manifest("v2-json-sidecars-struct-stats-only", true)]
+    #[case::struct_stats_parquet_manifest("v2-parquet-sidecars-struct-stats-only", true)]
+    fn resolve_reports_parsed_stats(#[case] table: &str, #[case] expect_parsed: bool) {
+        let (_engine, snapshot, _tempdir) = load_test_table(table).unwrap();
+        let exec = SyncPlanExecutor::new();
+        let stats_schema = probe_stats_schema();
+
+        let shape =
+            ScanShape::resolve(&exec, snapshot.as_ref(), Some(&stats_schema), None).unwrap();
+        let stats = shape.stats.expect("stats requested");
+        assert_eq!(
+            stats.schema, stats_schema,
+            "{table}: schema passed through verbatim"
+        );
+        assert_eq!(
+            stats.has_parsed_stats, expect_parsed,
+            "{table}: parsed-stats detection"
+        );
+    }
+
+    /// A minimal requested stats schema: empty `minValues` / `maxValues` structs. Compatibility
+    /// then reduces to whether the checkpoint carries an `add.stats_parsed` struct.
+    fn probe_stats_schema() -> SchemaRef {
+        let empty = || StructType::new_unchecked([]);
+        Arc::new(StructType::new_unchecked([
+            StructField::nullable("minValues", empty()),
+            StructField::nullable("maxValues", empty()),
+        ]))
+    }
+}

--- a/kernel/src/plans/scan_shape.rs
+++ b/kernel/src/plans/scan_shape.rs
@@ -39,21 +39,11 @@ pub enum CheckpointShape {
     None,
     /// The checkpoint files ARE the leaves -- `add` / `remove` rows are stored inline. Covers
     /// classic V1 checkpoints and V2 checkpoints that inline their actions (no sidecars).
-    Leaf {
-        /// The checkpoint files.
-        files: Vec<FileMeta>,
-        /// How the checkpoint files are encoded.
-        file_format: FileType,
-    },
+    Leaf,
     /// V2 multipart manifest -- `files` are the manifest parts; the leaf rows live in sidecar
     /// parquet files the manifest references (resolved lazily by the reconciliation plan, not
     /// stored here).
-    Manifest {
-        /// The manifest (top-level checkpoint) files.
-        files: Vec<FileMeta>,
-        /// How the manifest files are encoded.
-        file_format: FileType,
-    },
+    Manifest,
 }
 
 /// Stats wiring resolved for a scan that requested stats: the projected stats schema plus
@@ -125,40 +115,32 @@ impl ScanShape {
         // footer IS the leaf schema we probe for parsed stats. JSON has no footer, so we always
         // drain. Either way: >=1 sidecar => manifest, 0 => leaf.
         let mut leaf_parsed_stats = None;
-        let (is_manifest, sidecars) = match file_format {
+        let sidecar = match file_format {
             FileType::Parquet => {
                 let cp_schema = read_footer_schema(exec, first.location.clone())?;
-                let sidecars = if cp_schema.contains(SIDECAR_NAME) {
-                    Some(collect_sidecars(
-                        exec,
-                        files.clone(),
-                        file_format,
-                        &seg.log_root,
-                    )?)
+                let sidecar = if cp_schema.contains(SIDECAR_NAME) {
+                    collect_sidecar(exec, files, file_format, &seg.log_root)?
                 } else {
                     None
                 };
-                match sidecars {
-                    Some(sidecars) if !sidecars.is_empty() => (true, Some(sidecars)),
+                match sidecar {
+                    Some(sidecar) => Some(sidecar),
                     // No `sidecar` column (V1 leaf) or column present but unreferenced (V2 inline
                     // leaf): either way the footer we read is the leaf schema, so probe it here.
                     _ => {
                         leaf_parsed_stats = stats_probe(Some(&cp_schema), stats_schema);
-                        (false, None)
+                        None
                     }
                 }
             }
-            FileType::Json => {
-                let sidecars = collect_sidecars(exec, files.clone(), file_format, &seg.log_root)?;
-                (!sidecars.is_empty(), Some(sidecars))
-            }
+            FileType::Json => collect_sidecar(exec, files, file_format, &seg.log_root)?,
         };
 
-        if !is_manifest {
+        if sidecar.is_none() {
             // A JSON leaf has no footer to probe and surfaces stats only as JSON strings, so its
             // parsed answer falls through to `false`.
             return Ok(make_info(
-                CheckpointShape::Leaf { files, file_format },
+                CheckpointShape::Leaf,
                 leaf_parsed_stats.unwrap_or(false),
             ));
         }
@@ -169,8 +151,7 @@ impl ScanShape {
         // only when stats were requested.
         // Classification drained these sidecars; the leaf path returned above, so a manifest
         // always carries at least one. An empty list would simply leave parsed stats `false`.
-        let sidecars = sidecars.unwrap_or_default();
-        let has_parsed_stats = match (stats_schema, sidecars.first()) {
+        let has_parsed_stats = match (stats_schema, sidecar) {
             (Some(reqd), Some(sidecar)) => {
                 let side_schema = read_footer_schema(exec, sidecar.clone())?;
                 LogSegment::schema_has_compatible_stats_parsed(side_schema.as_ref(), reqd.as_ref())
@@ -178,10 +159,7 @@ impl ScanShape {
             _ => false,
         };
 
-        Ok(make_info(
-            CheckpointShape::Manifest { files, file_format },
-            has_parsed_stats,
-        ))
+        Ok(make_info(CheckpointShape::Manifest, has_parsed_stats))
     }
 }
 
@@ -211,12 +189,12 @@ fn read_footer_schema(exec: &dyn PlanExecutor, file: FileMeta) -> DeltaResult<Sc
 /// stream and visits its rows, rather than crossing the engine boundary with a reducer sink.
 /// The scan projects only the `sidecar` column, so manifest action rows (`add` / `remove`) read
 /// as null and are skipped by the visitor.
-fn collect_sidecars(
+fn collect_sidecar(
     exec: &dyn PlanExecutor,
     files: Vec<FileMeta>,
     file_format: FileType,
     log_root: &Url,
-) -> DeltaResult<Vec<FileMeta>> {
+) -> DeltaResult<Option<FileMeta>> {
     let plan = match file_format {
         FileType::Parquet => QueryPlanBuilder::scan_parquet(files, sidecar_scan_schema()),
         FileType::Json => QueryPlanBuilder::scan_json(files, sidecar_scan_schema()),
@@ -226,13 +204,15 @@ fn collect_sidecars(
 
     let mut visitor = SidecarVisitor::default();
     for batch in data {
+        if !visitor.sidecars.is_empty() {
+            break;
+        }
         visitor.visit_rows_of(batch?.as_ref())?;
     }
-    visitor
-        .sidecars
-        .into_iter()
-        .map(|sidecar| sidecar.to_filemeta(log_root))
-        .collect()
+    match visitor.sidecars.pop() {
+        Some(sidecar) => Ok(Some(sidecar.to_filemeta(log_root)?)),
+        None => Ok(None),
+    }
 }
 
 /// Manifest scan schema: just the `sidecar` column. Narrowing to that one column avoids paying

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1306,6 +1306,7 @@ mod tests {
 
     fn valid_last_checkpoint() -> (Vec<u8>, LastCheckpointHint) {
         let checkpoint = LastCheckpointHint {
+            v2_checkpoint: None,
             version: 1,
             size: 8,
             parts: None,


### PR DESCRIPTION
> Stacked on #2777 (base: `_last_checkpoint` identity-matching). Until #2777 merges, this PR's diff includes the base's 2 commits; review the scan_shape commits on top.

## What changes are proposed in this pull request?

This PR adds `ScanShape`, a helper type that resolves the checkpoint topology for a scan (behind the `declarative-plans` feature). This is done for two reasons:

1. Determine whether a checkpoint is a **manifest** checkpoint (a V2 checkpoint whose file actions are stored in sidecars) or a **leaf** checkpoint that stores file actions directly in the log-listed checkpoint. This is denoted by `CheckpointShape` (either `Leaf`, `Manifest`, or `None`).
2. If stats were requested, determine whether the checkpoint contains parsed stats. This is represented by `StatsInfo`.

`ScanShape::resolve` requires a `PlanExecutor`.

## How was this change tested?

New unit tests in `kernel/src/plans/scan_shape.rs`, parameterized over real fixture tables, covering:

- V2 JSON manifest
- V2 JSON leaf
- V2 parquet manifest
- V2 parquet leaf
- multi-part leaf
- single-part leaf
