### PR TITLE
feat: support timestamp-to-version conversion for staged commits

### DIFF
--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -415,9 +415,7 @@ pub(crate) fn timestamp_to_version(
     let staged_log_tail: Vec<ParsedLogPath> = snapshot
         .log_segment()
         .listed
-        .ascending_commit_files
-        .iter()
-        .filter(|c| c.file_type == LogPathFileType::StagedCommit)
+        .staged_commits()
         .cloned()
         .collect();
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -409,21 +409,30 @@ pub(crate) fn timestamp_to_version(
         _ => {}
     }
 
-    // TODO(#2443): Support staged commits (catalog-managed tables). Staged commits have ICT
-    // (required by catalog-managed), so timestamps are available. However, we currently
-    // rebuild the log segment from storage which doesn't include staged commits. To support
-    // this, we'd need to pass the snapshot's log_tail into the log segment construction.
-    let has_staged_commits = snapshot
+    // Catalog-managed tables carry staged commits that exist only in the snapshot's log_tail,
+    // not on the filesystem. These commits carry ICT, so to support timestamp conversion we pass
+    // the log_tail in for catalog-managed tables.
+    let staged_log_tail: Vec<ParsedLogPath> = snapshot
         .log_segment()
         .listed
         .ascending_commit_files
-        .last() // Use last since a log segment always ends with staged commits from `log_tail`
-        .is_some_and(|c| c.file_type == crate::path::LogPathFileType::StagedCommit);
-    if has_staged_commits {
-        return Err(LogHistoryError::internal_message(
-            "timestamp conversion not yet supported for snapshots with staged commits",
-        ));
-    }
+        .iter()
+        .filter(|c| c.file_type == LogPathFileType::StagedCommit)
+        .cloned()
+        .collect();
+
+    // The staged suffix must be directly adjacent to the published prefix with no version gap.
+    // Otherwise, for_timestamp_conversion's gap-trim would keep only the staged tail and silently
+    // drop the prefix, resolving the wrong version.
+    debug_assert!(
+        snapshot
+            .log_segment()
+            .listed
+            .ascending_commit_files
+            .windows(2)
+            .all(|w| w[1].version == w[0].version + 1),
+        "snapshot commit files must be contiguous for timestamp conversion"
+    );
 
     let listing_limit = match resolved_commit_type {
         HistoryCommitType::Published => None,
@@ -465,6 +474,7 @@ pub(crate) fn timestamp_to_version(
         snapshot.log_segment().log_root.clone(),
         snapshot.version(),
         listing_limit,
+        staged_log_tail,
     )
     .map_err(|e| {
         LogHistoryError::internal("failed to build log segment for timestamp conversion", e)
@@ -1043,6 +1053,7 @@ mod tests {
             snapshot.log_segment().log_root.clone(),
             snapshot.version(),
             None,
+            vec![],
         )
         .unwrap();
         (table, engine, snapshot, log_segment)
@@ -1157,6 +1168,7 @@ mod tests {
             snapshot.log_segment().log_root.clone(),
             snapshot.version(),
             None,
+            vec![],
         )
         .unwrap();
 

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -421,19 +421,6 @@ pub(crate) fn timestamp_to_version(
         .cloned()
         .collect();
 
-    // The staged suffix must be directly adjacent to the published prefix with no version gap.
-    // Otherwise, for_timestamp_conversion's gap-trim would keep only the staged tail and silently
-    // drop the prefix, resolving the wrong version.
-    debug_assert!(
-        snapshot
-            .log_segment()
-            .listed
-            .ascending_commit_files
-            .windows(2)
-            .all(|w| w[1].version == w[0].version + 1),
-        "snapshot commit files must be contiguous for timestamp conversion"
-    );
-
     let listing_limit = match resolved_commit_type {
         HistoryCommitType::Published => None,
         HistoryCommitType::Recreatable => {

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -445,10 +445,12 @@ impl LogSegment {
         }
 
         // TODO: compactions?
+        // TODO(#2796): table-changes does not supply a log_tail yet. CDF over a catalog-managed
+        // table will need the catalog's commits passed here to see unbackfilled staged commits.
         let listed_files = LogSegmentFiles::list_commits(
             storage,
             &log_root,
-            vec![],
+            vec![], // log-tail
             Some(start_version),
             end_version,
         )?;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -663,9 +663,7 @@ impl LogSegment {
 
     pub(crate) fn get_unpublished_catalog_commits(&self) -> DeltaResult<Vec<CatalogCommit>> {
         self.listed
-            .ascending_commit_files
-            .iter()
-            .filter(|file| file.file_type == LogPathFileType::StagedCommit)
+            .staged_commits()
             .filter(|file| {
                 self.listed
                     .max_published_version

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -445,8 +445,13 @@ impl LogSegment {
         }
 
         // TODO: compactions?
-        let listed_files =
-            LogSegmentFiles::list_commits(storage, &log_root, Some(start_version), end_version)?;
+        let listed_files = LogSegmentFiles::list_commits(
+            storage,
+            &log_root,
+            vec![],
+            Some(start_version),
+            end_version,
+        )?;
         // - Here check that the start version is correct.
         // - [`LogSegment::try_new`] will verify that the `end_version` is correct if present.
         // - [`LogSegmentFiles::list_commits`] also checks that there are no gaps between commits.
@@ -471,7 +476,9 @@ impl LogSegment {
     /// Constructs a [`LogSegment`] to be used for timestamp conversion. This [`LogSegment`] will
     /// consist only of contiguous commit files up to `end_version` (inclusive). If present,
     /// `limit` specifies the maximum length of the returned log segment. The log segment may be
-    /// shorter than `limit` if there are missing commits.
+    /// shorter than `limit` if there are missing commits. `log_tail` supplies caller-provided
+    /// commits (e.g. catalog-managed staged commits) that take precedence over the filesystem
+    /// listing.
     // This lists all files starting from `end-limit` if `limit` is defined. For large tables,
     // listing with a `limit` can be a significant speedup over listing _all_ the files in the log.
     pub(crate) fn for_timestamp_conversion(
@@ -479,6 +486,7 @@ impl LogSegment {
         log_root: Url,
         end_version: Version,
         limit: Option<NonZero<usize>>,
+        log_tail: Vec<ParsedLogPath>,
     ) -> DeltaResult<Self> {
         // Compute the version to start listing from.
         let start_from = limit
@@ -492,8 +500,13 @@ impl LogSegment {
 
         // this is a list of commits with possible gaps, we want to take the latest contiguous
         // chunk of commits
-        let mut listed_commits =
-            LogSegmentFiles::list_commits(storage, &log_root, start_from, Some(end_version))?;
+        let mut listed_commits = LogSegmentFiles::list_commits(
+            storage,
+            &log_root,
+            log_tail,
+            start_from,
+            Some(end_version),
+        )?;
 
         // remove gaps - return latest contiguous chunk of commits
         let commits = listed_commits.ascending_commit_files_mut();

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2341,29 +2341,69 @@ async fn commits_since() {
     assert_eq!(log_segment.commits_since_log_compaction_or_checkpoint(), 10);
 }
 
+/// A log built from `published` commit versions, `checkpoints`, and catalog-supplied `staged`
+/// commit versions, queried up to `end_version` (optionally bounded by `limit`), expecting
+/// `expected` commit versions in the resulting segment.
+struct TimestampConversionCase {
+    published: &'static [Version],
+    checkpoints: &'static [Version],
+    staged: &'static [Version],
+    end_version: Version,
+    limit: Option<usize>,
+    expected: &'static [Version],
+}
+
 /// `for_timestamp_conversion` returns the latest contiguous run of commit files (no checkpoint
 /// parts), merging any caller-provided `log_tail` over the filesystem listing.
 #[rstest]
 // Filesystem-only (no log_tail):
-#[case::full_range(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, None, &[0, 1, 2, 3, 4, 5, 6, 7])]
-#[case::old_end_version(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 5, None, &[0, 1, 2, 3, 4, 5])]
-#[case::only_contiguous_ranges(&[0, 1, 2, 3, 5, 6, 7], &[1, 3, 5], &[], 7, None, &[5, 6, 7])]
-#[case::with_limit(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, Some(3), &[5, 6, 7])]
-#[case::with_large_limit(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, Some(20), &[0, 1, 2, 3, 4, 5, 6, 7])]
+#[case::full_range(TimestampConversionCase {
+    published: &[0, 1, 2, 3, 4, 5, 6, 7], checkpoints: &[1, 3, 5], staged: &[],
+    end_version: 7, limit: None, expected: &[0, 1, 2, 3, 4, 5, 6, 7],
+})]
+#[case::old_end_version(TimestampConversionCase {
+    published: &[0, 1, 2, 3, 4, 5, 6, 7], checkpoints: &[1, 3, 5], staged: &[],
+    end_version: 5, limit: None, expected: &[0, 1, 2, 3, 4, 5],
+})]
+#[case::only_contiguous_ranges(TimestampConversionCase {
+    published: &[0, 1, 2, 3, 5, 6, 7], checkpoints: &[1, 3, 5], staged: &[],
+    end_version: 7, limit: None, expected: &[5, 6, 7],
+})]
+#[case::with_limit(TimestampConversionCase {
+    published: &[0, 1, 2, 3, 4, 5, 6, 7], checkpoints: &[1, 3, 5], staged: &[],
+    end_version: 7, limit: Some(3), expected: &[5, 6, 7],
+})]
+#[case::with_large_limit(TimestampConversionCase {
+    published: &[0, 1, 2, 3, 4, 5, 6, 7], checkpoints: &[1, 3, 5], staged: &[],
+    end_version: 7, limit: Some(20), expected: &[0, 1, 2, 3, 4, 5, 6, 7],
+})]
 // Catalog-managed staged commits supplied via the log_tail:
-#[case::log_tail_joins_prefix(&[0, 1], &[], &[2, 3], 3, None, &[0, 1, 2, 3])]
-#[case::log_tail_gap_drops_prefix(&[0], &[], &[2, 3], 3, None, &[2, 3])]
-#[case::log_tail_across_checkpoint(&[0, 1, 2], &[2], &[3, 4], 4, None, &[0, 1, 2, 3, 4])]
-#[case::log_tail_with_limit(&[0, 1, 2, 3], &[], &[4, 5], 5, Some(3), &[3, 4, 5])]
+#[case::log_tail_joins_prefix(TimestampConversionCase {
+    published: &[0, 1], checkpoints: &[], staged: &[2, 3],
+    end_version: 3, limit: None, expected: &[0, 1, 2, 3],
+})]
+#[case::log_tail_gap_drops_prefix(TimestampConversionCase {
+    published: &[0], checkpoints: &[], staged: &[2, 3],
+    end_version: 3, limit: None, expected: &[2, 3],
+})]
+#[case::log_tail_across_checkpoint(TimestampConversionCase {
+    published: &[0, 1, 2], checkpoints: &[2], staged: &[3, 4],
+    end_version: 4, limit: None, expected: &[0, 1, 2, 3, 4],
+})]
+#[case::log_tail_with_limit(TimestampConversionCase {
+    published: &[0, 1, 2, 3], checkpoints: &[], staged: &[4, 5],
+    end_version: 5, limit: Some(3), expected: &[3, 4, 5],
+})]
 #[tokio::test]
-async fn for_timestamp_conversion_cases(
-    #[case] published: &[Version],
-    #[case] checkpoints: &[Version],
-    #[case] staged: &[Version],
-    #[case] end_version: Version,
-    #[case] limit: Option<usize>,
-    #[case] expected: &[Version],
-) {
+async fn for_timestamp_conversion_cases(#[case] case: TimestampConversionCase) {
+    let TimestampConversionCase {
+        published,
+        checkpoints,
+        staged,
+        end_version,
+        limit,
+        expected,
+    } = case;
     let mut paths: Vec<Path> = published
         .iter()
         .map(|v| delta_path_for_version(*v, "json"))

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -214,6 +214,24 @@ fn create_log_path_with_size(path: &str, size: u64) -> ParsedLogPath<FileMeta> {
     .unwrap()
 }
 
+/// Build a `log_tail` of staged commits at the given versions (memory:/// table root).
+fn staged_log_tail(versions: &[u64]) -> Vec<ParsedLogPath> {
+    let table_root = Url::parse("memory:///").expect("valid url");
+    versions
+        .iter()
+        .map(|version| staged_commit_path_for_version(*version))
+        .map(|path| {
+            ParsedLogPath::try_from(FileMeta {
+                location: table_root.join(path.as_ref()).unwrap(),
+                last_modified: 0,
+                size: 100,
+            })
+            .unwrap()
+            .unwrap()
+        })
+        .collect()
+}
+
 /// Gets the file size from the store for use in FileMeta
 async fn get_file_size(store: &Arc<InMemory>, path: &str) -> u64 {
     let object_meta = store.head(&Path::from(path)).await.unwrap();
@@ -1564,21 +1582,7 @@ async fn create_segment_for(segment: LogSegmentConfig<'_>) -> LogSegment {
         ));
     }
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None).await;
-    let table_root = Url::parse("memory:///").expect("valid url");
-    let staged_commits_log_tail: Vec<ParsedLogPath> = segment
-        .staged_commit_versions
-        .iter()
-        .map(|version| staged_commit_path_for_version(*version))
-        .map(|path| {
-            ParsedLogPath::try_from(FileMeta {
-                location: table_root.join(path.as_ref()).unwrap(),
-                last_modified: 0,
-                size: 100,
-            })
-            .unwrap()
-            .unwrap()
-        })
-        .collect();
+    let staged_commits_log_tail = staged_log_tail(segment.staged_commit_versions);
     LogSegment::for_snapshot_impl(
         storage.as_ref(),
         log_root.clone(),
@@ -2344,169 +2348,57 @@ async fn commits_since() {
     assert_eq!(log_segment.commits_since_log_compaction_or_checkpoint(), 10);
 }
 
+/// `for_timestamp_conversion` returns the latest contiguous run of commit files (no checkpoint
+/// parts), merging any caller-provided `log_tail` over the filesystem listing.
+#[rstest]
+// Filesystem-only (no log_tail):
+#[case::full_range(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, None, &[0, 1, 2, 3, 4, 5, 6, 7])]
+#[case::old_end_version(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 5, None, &[0, 1, 2, 3, 4, 5])]
+#[case::only_contiguous_ranges(&[0, 1, 2, 3, 5, 6, 7], &[1, 3, 5], &[], 7, None, &[5, 6, 7])]
+#[case::with_limit(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, Some(3), &[5, 6, 7])]
+#[case::with_large_limit(&[0, 1, 2, 3, 4, 5, 6, 7], &[1, 3, 5], &[], 7, Some(20), &[0, 1, 2, 3, 4, 5, 6, 7])]
+// Catalog-managed staged commits supplied via the log_tail:
+#[case::log_tail_joins_prefix(&[0, 1], &[], &[2, 3], 3, None, &[0, 1, 2, 3])]
+#[case::log_tail_gap_drops_prefix(&[0], &[], &[2, 3], 3, None, &[2, 3])]
+#[case::log_tail_across_checkpoint(&[0, 1, 2], &[2], &[3, 4], 4, None, &[0, 1, 2, 3, 4])]
+#[case::log_tail_with_limit(&[0, 1, 2, 3], &[], &[4, 5], 5, Some(3), &[3, 4, 5])]
 #[tokio::test]
-async fn for_timestamp_conversion_gets_commit_range() {
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(1, "json"),
-            delta_path_for_version(1, "checkpoint.parquet"),
-            delta_path_for_version(2, "json"),
-            delta_path_for_version(3, "json"),
-            delta_path_for_version(3, "checkpoint.parquet"),
-            delta_path_for_version(4, "json"),
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(5, "checkpoint.parquet"),
-            delta_path_for_version(6, "json"),
-            delta_path_for_version(7, "json"),
-        ],
-        None,
-    )
-    .await;
-
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 7, None).unwrap();
-    let commit_files = log_segment.listed.ascending_commit_files;
-    let checkpoint_parts = log_segment.listed.checkpoint_parts;
-
-    assert!(checkpoint_parts.is_empty());
-
-    let versions = commit_files.iter().map(|x| x.version).collect_vec();
-    assert_eq!(vec![0, 1, 2, 3, 4, 5, 6, 7], versions);
-}
-
-#[tokio::test]
-async fn for_timestamp_conversion_with_old_end_version() {
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(1, "json"),
-            delta_path_for_version(1, "checkpoint.parquet"),
-            delta_path_for_version(2, "json"),
-            delta_path_for_version(3, "json"),
-            delta_path_for_version(3, "checkpoint.parquet"),
-            delta_path_for_version(4, "json"),
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(5, "checkpoint.parquet"),
-            delta_path_for_version(6, "json"),
-            delta_path_for_version(7, "json"),
-        ],
-        None,
-    )
-    .await;
-
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 5, None).unwrap();
-    let commit_files = log_segment.listed.ascending_commit_files;
-    let checkpoint_parts = log_segment.listed.checkpoint_parts;
-
-    assert!(checkpoint_parts.is_empty());
-
-    let versions = commit_files.iter().map(|x| x.version).collect_vec();
-    assert_eq!(vec![0, 1, 2, 3, 4, 5], versions);
-}
-
-#[tokio::test]
-async fn for_timestamp_conversion_only_contiguous_ranges() {
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(1, "json"),
-            delta_path_for_version(1, "checkpoint.parquet"),
-            delta_path_for_version(2, "json"),
-            delta_path_for_version(3, "json"),
-            delta_path_for_version(3, "checkpoint.parquet"),
-            // version 4 is missing
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(5, "checkpoint.parquet"),
-            delta_path_for_version(6, "json"),
-            delta_path_for_version(7, "json"),
-        ],
-        None,
-    )
-    .await;
-
-    let log_segment =
-        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 7, None).unwrap();
-    let commit_files = log_segment.listed.ascending_commit_files;
-    let checkpoint_parts = log_segment.listed.checkpoint_parts;
-
-    assert!(checkpoint_parts.is_empty());
-
-    let versions = commit_files.iter().map(|x| x.version).collect_vec();
-    assert_eq!(vec![5, 6, 7], versions);
-}
-
-#[tokio::test]
-async fn for_timestamp_conversion_with_limit() {
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(1, "json"),
-            delta_path_for_version(1, "checkpoint.parquet"),
-            delta_path_for_version(2, "json"),
-            delta_path_for_version(3, "json"),
-            delta_path_for_version(3, "checkpoint.parquet"),
-            delta_path_for_version(4, "json"),
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(5, "checkpoint.parquet"),
-            delta_path_for_version(6, "json"),
-            delta_path_for_version(7, "json"),
-        ],
-        None,
-    )
-    .await;
+async fn for_timestamp_conversion_cases(
+    #[case] published: &[Version],
+    #[case] checkpoints: &[Version],
+    #[case] staged: &[Version],
+    #[case] end_version: Version,
+    #[case] limit: Option<usize>,
+    #[case] expected: &[Version],
+) {
+    let mut paths: Vec<Path> = published
+        .iter()
+        .map(|v| delta_path_for_version(*v, "json"))
+        .collect();
+    paths.extend(
+        checkpoints
+            .iter()
+            .map(|v| delta_path_for_version(*v, "checkpoint.parquet")),
+    );
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None).await;
 
     let log_segment = LogSegment::for_timestamp_conversion(
         storage.as_ref(),
         log_root.clone(),
-        7,
-        Some(NonZero::new(3).unwrap()),
+        end_version,
+        limit.map(|l| NonZero::new(l).unwrap()),
+        staged_log_tail(staged),
     )
     .unwrap();
-    let commit_files = log_segment.listed.ascending_commit_files;
-    let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
-    assert!(checkpoint_parts.is_empty());
-
-    let versions = commit_files.iter().map(|x| x.version).collect_vec();
-    assert_eq!(vec![5, 6, 7], versions);
-}
-
-#[tokio::test]
-async fn for_timestamp_conversion_with_large_limit() {
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(0, "json"),
-            delta_path_for_version(1, "json"),
-            delta_path_for_version(1, "checkpoint.parquet"),
-            delta_path_for_version(2, "json"),
-            delta_path_for_version(3, "json"),
-            delta_path_for_version(3, "checkpoint.parquet"),
-            delta_path_for_version(4, "json"),
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(5, "checkpoint.parquet"),
-            delta_path_for_version(6, "json"),
-            delta_path_for_version(7, "json"),
-        ],
-        None,
-    )
-    .await;
-
-    let log_segment = LogSegment::for_timestamp_conversion(
-        storage.as_ref(),
-        log_root.clone(),
-        7,
-        Some(NonZero::new(20).unwrap()),
-    )
-    .unwrap();
-    let commit_files = log_segment.listed.ascending_commit_files;
-    let checkpoint_parts = log_segment.listed.checkpoint_parts;
-
-    assert!(checkpoint_parts.is_empty());
-
-    let versions = commit_files.iter().map(|x| x.version).collect_vec();
-    assert_eq!(vec![0, 1, 2, 3, 4, 5, 6, 7], versions);
+    assert!(log_segment.listed.checkpoint_parts.is_empty());
+    let versions = log_segment
+        .listed
+        .ascending_commit_files
+        .iter()
+        .map(|x| x.version)
+        .collect_vec();
+    assert_eq!(expected, versions.as_slice());
 }
 
 #[tokio::test]
@@ -2517,7 +2409,8 @@ async fn for_timestamp_conversion_no_commit_files() {
     )
     .await;
 
-    let res = LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None);
+    let res =
+        LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None, vec![]);
     assert_result_error_with_message(res, "Generic delta kernel error: No files in log segment");
 }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -214,21 +214,14 @@ fn create_log_path_with_size(path: &str, size: u64) -> ParsedLogPath<FileMeta> {
     .unwrap()
 }
 
-/// Build a `log_tail` of staged commits at the given versions (memory:/// table root).
-fn staged_log_tail(versions: &[u64]) -> Vec<ParsedLogPath> {
-    let table_root = Url::parse("memory:///").expect("valid url");
+/// Builds a staged-commit log path (`ParsedLogPath`) for each version: a
+/// `memory:///_delta_log/_staged_commits/<v>.<uuid>.json` entry that parses to
+/// `file_type: StagedCommit`.
+fn staged_commit_log_paths(versions: &[Version]) -> Vec<ParsedLogPath> {
     versions
         .iter()
-        .map(|version| staged_commit_path_for_version(*version))
-        .map(|path| {
-            ParsedLogPath::try_from(FileMeta {
-                location: table_root.join(path.as_ref()).unwrap(),
-                last_modified: 0,
-                size: 100,
-            })
-            .unwrap()
-            .unwrap()
-        })
+        .map(|v| staged_commit_path_for_version(*v))
+        .map(|path| create_log_path_with_size(&format!("memory:///{}", path.as_ref()), 100))
         .collect()
 }
 
@@ -1582,7 +1575,7 @@ async fn create_segment_for(segment: LogSegmentConfig<'_>) -> LogSegment {
         ));
     }
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None).await;
-    let staged_commits_log_tail = staged_log_tail(segment.staged_commit_versions);
+    let staged_commits_log_tail = staged_commit_log_paths(segment.staged_commit_versions);
     LogSegment::for_snapshot_impl(
         storage.as_ref(),
         log_root.clone(),
@@ -2387,7 +2380,7 @@ async fn for_timestamp_conversion_cases(
         log_root.clone(),
         end_version,
         limit.map(|l| NonZero::new(l).unwrap()),
-        staged_log_tail(staged),
+        staged_commit_log_paths(staged),
     )
     .unwrap();
 

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -471,24 +471,50 @@ impl LogSegmentFiles {
     pub(crate) fn list_commits(
         storage: &dyn StorageHandler,
         log_root: &Url,
+        log_tail: Vec<ParsedLogPath>,
         start_version: Option<Version>,
         end_version: Option<Version>,
     ) -> DeltaResult<Self> {
-        // TODO: plumb through a log_tail provided by our caller
+        debug_assert!(
+            log_tail.iter().all(|entry| entry.is_commit()),
+            "log_tail should only contain commits"
+        );
+        debug_assert!(
+            log_tail
+                .windows(2)
+                .all(|w| w[1].version == w[0].version + 1),
+            "log_tail must be a contiguous ascending run of commit versions"
+        );
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
         let fs_iter = list_from_storage(storage, log_root, start, end)?;
 
+        let log_tail_start_version = log_tail.first().map(|f| f.version);
         let mut listed_commits = Vec::new();
         let mut max_published_version: Option<Version> = None;
-
+        // Filesystem commits, skipping any covered by the log_tail.
         for file_result in fs_iter {
             let file = file_result?;
-            if matches!(file.file_type, LogPathFileType::Commit) {
-                should_process_log_file(&file); // warns if 0 bytes
-                max_published_version = max_published_version.max(Some(file.version));
-                listed_commits.push(file);
+            if file.file_type != LogPathFileType::Commit {
+                continue;
             }
+            max_published_version = max_published_version.max(Some(file.version));
+            if log_tail_start_version.is_some_and(|tail_start| file.version >= tail_start) {
+                continue;
+            }
+            should_process_log_file(&file); // warns if 0 bytes
+            listed_commits.push(file);
+        }
+
+        // Log_tail commits, extending the filesystem prefix in ascending order.
+        for file in log_tail {
+            if file.version < start || file.version > end {
+                continue;
+            }
+            if file.file_type == LogPathFileType::Commit {
+                max_published_version = max_published_version.max(Some(file.version));
+            }
+            listed_commits.push(file);
         }
 
         let latest_commit_file = listed_commits.last().cloned();

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -431,6 +431,7 @@ impl LogSegmentFiles {
         &self.ascending_commit_files
     }
 
+    /// The staged (unpublished) commit files, in ascending version order.
     pub(crate) fn staged_commits(&self) -> impl Iterator<Item = &ParsedLogPath> {
         self.ascending_commit_files
             .iter()
@@ -474,6 +475,10 @@ impl LogSegmentFiles {
 
     /// List all commits between the provided `start_version` (inclusive) and `end_version`
     /// (inclusive). All other types are ignored.
+    ///
+    /// `log_tail` is a contiguous run of commits ending at the table's latest version. It takes
+    /// precedence over the filesystem listing, and is required for catalog-managed tables, whose
+    /// unbackfilled staged commits exist only here.
     pub(crate) fn list_commits(
         storage: &dyn StorageHandler,
         log_root: &Url,

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -431,6 +431,12 @@ impl LogSegmentFiles {
         &self.ascending_commit_files
     }
 
+    pub(crate) fn staged_commits(&self) -> impl Iterator<Item = &ParsedLogPath> {
+        self.ascending_commit_files
+            .iter()
+            .filter(|f| f.file_type == LogPathFileType::StagedCommit)
+    }
+
     pub(crate) fn ascending_commit_files_mut(&mut self) -> &mut Vec<ParsedLogPath> {
         &mut self.ascending_commit_files
     }
@@ -478,12 +484,6 @@ impl LogSegmentFiles {
         debug_assert!(
             log_tail.iter().all(|entry| entry.is_commit()),
             "log_tail should only contain commits"
-        );
-        debug_assert!(
-            log_tail
-                .windows(2)
-                .all(|w| w[1].version == w[0].version + 1),
-            "log_tail must be a contiguous ascending run of commit versions"
         );
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1154,10 +1154,113 @@ async fn test_list_commits_zero_byte_commit_kept() {
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result =
-        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, Some(0), Some(2)).unwrap();
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(2))
+            .unwrap();
     assert_eq!(result.ascending_commit_files.len(), 3);
     assert_eq!(result.ascending_commit_files[2].version, 2);
     assert_eq!(result.ascending_commit_files[2].location.size, 0);
+}
+
+/// `list_commits` merges a caller-provided `log_tail` over the filesystem listing: the log_tail
+/// supersedes filesystem commits at overlapping versions and is clipped to `[start, end]`, while
+/// the published watermark counts only filesystem (published) commits.
+#[rstest]
+// log_tail supersedes filesystem at overlapping versions; filesystem commits still set the
+// watermark.
+#[case::supersedes_filesystem(
+    &[0, 1, 2],
+    &[1, 2],
+    Some(0), Some(2),
+    &[(0, CommitSource::Filesystem), (1, CommitSource::Catalog), (2, CommitSource::Catalog)],
+    Some(2),
+)]
+// staged tail extends the prefix but does not move the published watermark.
+#[case::staged_tail_keeps_watermark(
+    &[0],
+    &[1, 2],
+    Some(0), Some(2),
+    &[(0, CommitSource::Filesystem), (1, CommitSource::Catalog), (2, CommitSource::Catalog)],
+    Some(0),
+)]
+// log_tail entries below `start` are dropped (filesystem v3 superseded by the tail).
+#[case::drops_tail_below_start(
+    &[3],
+    &[2, 3, 4],
+    Some(3), Some(4),
+    &[(3, CommitSource::Catalog), (4, CommitSource::Catalog)],
+    Some(3),
+)]
+// log_tail entries above `end` are dropped.
+#[case::drops_tail_above_end(
+    &[3],
+    &[2, 3, 4],
+    Some(3), Some(3),
+    &[(3, CommitSource::Catalog)],
+    Some(3),
+)]
+#[tokio::test]
+async fn list_commits_merges_log_tail(
+    #[case] filesystem_commits: &[Version],
+    #[case] staged: &[Version],
+    #[case] start: Option<Version>,
+    #[case] end: Option<Version>,
+    #[case] expected: &[(Version, CommitSource)],
+    #[case] expected_max_published: Option<Version>,
+) {
+    let (storage, log_root) = create_storage(
+        filesystem_commits
+            .iter()
+            .map(|v| (*v, LogPathFileType::Commit, CommitSource::Filesystem))
+            .collect(),
+    )
+    .await;
+    let log_tail: Vec<ParsedLogPath> = staged
+        .iter()
+        .map(|v| {
+            make_parsed_log_path_with_source(
+                *v,
+                LogPathFileType::StagedCommit,
+                CommitSource::Catalog,
+            )
+        })
+        .collect();
+
+    let result =
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, log_tail, start, end).unwrap();
+
+    let commits = &result.ascending_commit_files;
+    assert_eq!(commits.len(), expected.len());
+    for (commit, (version, source)) in commits.iter().zip(expected) {
+        assert_eq!(commit.version, *version);
+        assert_source(commit, *source);
+    }
+    assert_eq!(result.max_published_version, expected_max_published);
+    if let Some((last_version, _)) = expected.last() {
+        assert_eq!(result.latest_commit_file.unwrap().version, *last_version);
+    }
+}
+
+#[tokio::test]
+async fn test_list_commits_keeps_commits_across_checkpoint() {
+    let mut files: Vec<_> = (0..=5)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    files.push((
+        3,
+        LogPathFileType::SinglePartCheckpoint,
+        CommitSource::Filesystem,
+    ));
+    let (storage, log_root) = create_storage(files).await;
+
+    let result =
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(5))
+            .unwrap();
+    let versions: Vec<_> = result
+        .ascending_commit_files
+        .iter()
+        .map(|c| c.version)
+        .collect();
+    assert_eq!(versions, vec![0, 1, 2, 3, 4, 5]);
 }
 
 // ---------------------------------------------------------------------------

--- a/kernel/tests/integration/log/log_tail.rs
+++ b/kernel/tests/integration/log/log_tail.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use delta_kernel::history_manager::{first_version_after, latest_version_as_of, HistoryCommitType};
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::Snapshot;
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
@@ -160,6 +161,67 @@ async fn basic_snapshot_with_log_tail_staged_commits() -> Result<(), Box<dyn std
             .location,
         table_url.join(delta_path_for_version(0, "json").as_ref())?
     );
+
+    Ok(())
+}
+
+/// Timestamp-to-version resolution must see catalog-managed staged commits (issue #2443). Staged
+/// commits carry in-commit timestamps, so resolution feeds them in as the log_tail rather than
+/// erroring on snapshots that contain staged commits.
+#[tokio::test]
+async fn timestamp_resolution_with_staged_commits() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    let ict_v0: i64 = 1587968586154;
+    let ict_v1: i64 = ict_v0 + 100;
+    let ict_v2: i64 = ict_v0 + 200;
+    let staged_ict_body = |ict: i64| {
+        format!(
+            r#"{{"commitInfo":{{"timestamp":{ict},"inCommitTimestamp":{ict},"operation":"WRITE","isBlindAppend":true}}}}"#
+        )
+    };
+
+    // publish v0; v1, v2 are ratified staged commits. Also include the corresponding ICT to each
+    // version.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string_catalog_managed(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let path1 = add_staged_commit(table_root, storage.as_ref(), 1, staged_ict_body(ict_v1)).await?;
+    let path2 = add_staged_commit(table_root, storage.as_ref(), 2, staged_ict_body(ict_v2)).await?;
+
+    let log_tail = vec![
+        create_log_path(&table_url, path1),
+        create_log_path(&table_url, path2),
+    ];
+    let snapshot = Snapshot::builder_for(table_root)
+        .with_log_tail(log_tail)
+        .with_max_catalog_version(2)
+        .build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), 2);
+
+    // latest_version_as_of rounds down; ICT between v1 and v2 rounds to v1.
+    let e = engine.as_ref();
+    let ct = HistoryCommitType::Published;
+    assert_eq!(latest_version_as_of(&snapshot, e, ict_v1, ct)?.version, 1);
+    assert_eq!(
+        latest_version_as_of(&snapshot, e, ict_v1 + 50, ct)?.version,
+        1
+    );
+    assert_eq!(latest_version_as_of(&snapshot, e, ict_v2, ct)?.version, 2);
+    // timestamps before v0 is out of range
+    assert!(latest_version_as_of(&snapshot, e, ict_v0 - 1, ct).is_err());
+
+    // first_version_after rounds up; ICT between v0 and v1 rounds to v1.
+    assert_eq!(
+        first_version_after(&snapshot, e, ict_v0 + 1, ct)?.version,
+        1
+    );
+    assert_eq!(first_version_after(&snapshot, e, ict_v2, ct)?.version, 2);
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Timestamp to version resolution errors on catalog-managed snapshots with ratified, unpublished commits. `timestamp_to_version` rebuilt its log segment from the filesystem and dropped the snapshot's log tail. Now, `list_commits` / `for_timestamp_conversion` accept a `log_tail`, and `timestamp_to_version` feeds in the snapshot's staged commits and drops the guard. Resolves #2443.


## How was this change tested?
New integration test for timestamp resolution over staged commits.
