### PR TITLE
chore: default plan executor errors instead of panics

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -966,11 +966,10 @@ pub trait Engine: AsAny {
 
     /// Get the connector provided [`PlanExecutor`].
     ///
-    /// The default implementation panics for now because the feature is still under development.
+    /// The default implementation returns a trivial executor that errors on every operation.
     #[cfg(feature = "declarative-plans")]
-    #[allow(clippy::panic)]
     fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        unimplemented!("this engine does not provide a PlanExecutor")
+        Arc::new(())
     }
 }
 

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -22,6 +22,17 @@ pub trait PlanExecutor: AsAny {
     fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult>;
 }
 
+/// The unit type is a trivial [`PlanExecutor`] that rejects every operation. It backs
+/// [`Engine::plan_executor`](crate::Engine::plan_executor)'s default so callers can attempt plan
+/// execution unconditionally and fall back on the resulting error when no real executor exists.
+impl PlanExecutor for () {
+    fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
+        Err(Error::unsupported(
+            "this engine does not provide a PlanExecutor",
+        ))
+    }
+}
+
 /// The result of executing an [`Operation`].
 ///
 /// Each variant describes a different shape of output that a plan can possibly produce.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Today, asking the default engine for a declarative plan executor panics with `unimplemented!`. Change that to return a trivial executor whose `execute` method is hard-wired to return Err. That way we can start wiring up declarative plan support without bringing down the system.

## How was this change tested?

N/A - dead code behind a feature flag