### PR TITLE
refactor!: rename plan node NodeKind as Operator

### DIFF
--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -99,11 +99,11 @@ message SemiJoinNode {
 }
 
 // ============================================================================
-// NodeKind
+// Operator
 // ============================================================================
 
-message NodeKind {
-  oneof kind {
+message Operator {
+  oneof op {
     // Sources (0 inputs)
     ScanParquetNode scan_parquet = 1;
     ScanJsonNode scan_json = 2;
@@ -123,7 +123,7 @@ message NodeKind {
 // ============================================================================
 
 message PlanNode {
-  NodeKind kind = 1;
+  Operator op = 1;
   repeated RefId inputs = 2;
   RefId output = 3;
 }

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -14,7 +14,7 @@ use super::json::SyncJsonHandler;
 use super::parquet::SyncParquetHandler;
 use super::storage::SyncStorageHandler;
 use crate::object_store::DynObjectStore;
-use crate::plans::ir::nodes::{NodeKind, ScanJson, ScanParquet};
+use crate::plans::ir::nodes::{Operator, ScanJson, ScanParquet};
 use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation, PlanExecutor, PlanResult};
 use crate::{
@@ -106,19 +106,19 @@ impl SyncPlanExecutor {
 
     fn execute_query(&self, query: Plan) -> DeltaResult<PlanResult> {
         let node = into_single_node_plan(query)?;
-        match node.kind {
-            NodeKind::ScanJson(ScanJson { files, schema, .. }) => {
+        match node.op {
+            Operator::ScanJson(ScanJson { files, schema, .. }) => {
                 let files: Vec<FileMeta> = files.into_iter().map(|f| f.meta).collect();
                 let iter = self.json.read_json_files(&files, schema, None)?;
                 Ok(PlanResult::Data(iter))
             }
-            NodeKind::ScanParquet(ScanParquet { files, schema, .. }) => {
+            Operator::ScanParquet(ScanParquet { files, schema, .. }) => {
                 let files: Vec<FileMeta> = files.into_iter().map(|f| f.meta).collect();
                 let iter = self.parquet.read_parquet_files(&files, schema, None)?;
                 Ok(PlanResult::Data(iter))
             }
             other => Err(Error::generic(format!(
-                "SyncPlanExecutor only supports ScanJson / ScanParquet, got NodeKind::{other}",
+                "SyncPlanExecutor only supports ScanJson / ScanParquet, got Operator::{other}",
             ))),
         }
     }

--- a/kernel/src/plans/ir/mod.rs
+++ b/kernel/src/plans/ir/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! - [`operation`] -- top-level [`Operation`] dispatch (I/O vs query) consumed by
 //!   [`PlanExecutor`](super::PlanExecutor).
-//! - [`nodes`] -- the plan nodes: [`nodes::NodeKind`] and its payload structs.
+//! - [`nodes`] -- the plan nodes: [`nodes::Operator`] and its payload structs.
 //! - [`plan`] -- plan topology: [`plan::Plan`] holds a sequence of [`plan::PlanNode`]s wired into a
 //!   DAG by their [`plan::RefId`] inputs and outputs.
 pub mod nodes;

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -1,6 +1,6 @@
 //! Plan node operator kinds and their payloads.
 //!
-//! [`NodeKind`] enumerates every operator. Each operator's payload struct is defined
+//! [`Operator`] enumerates every operator. Each operator's payload struct is defined
 //! below.
 
 use strum::Display;
@@ -11,10 +11,10 @@ use crate::schema::SchemaRef;
 use crate::FileMeta;
 
 // ============================================================================
-// NodeKind: enumerates every operator kind
+// Operator: enumerates every operator kind
 // ============================================================================
 
-/// Plan node operator kinds.
+/// Plan node operators.
 ///
 /// Output schemas are stored on the payload struct for operators whose caller
 /// declares them (`ScanParquet`, `ScanJson`, `Values`, `Load`, `Project`,
@@ -24,7 +24,7 @@ use crate::FileMeta;
 /// - `UnionAll` from its inputs' common schema.
 /// - `SemiJoin` from the probe input.
 #[derive(Debug, Clone, Display)]
-pub enum NodeKind {
+pub enum Operator {
     // === Source operators (0 inputs) =========================================
     ScanParquet(ScanParquet),
     ScanJson(ScanJson),

--- a/kernel/src/plans/ir/plan.rs
+++ b/kernel/src/plans/ir/plan.rs
@@ -1,6 +1,6 @@
 //! Plan containers ([`Plan`], [`PlanNode`]) and the [`RefId`] value handle.
 
-pub use super::nodes::NodeKind;
+pub use super::nodes::Operator;
 
 // ============================================================================
 // RefIds and plan nodes
@@ -13,14 +13,14 @@ pub use super::nodes::NodeKind;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RefId(pub u32);
 
-/// One node in a plan: an operator kind, its input RefIds, and its output RefId.
+/// One node in a plan: an [`Operator`], its input RefIds, and its output RefId.
 ///
-/// `inputs` order is interpreted per [`NodeKind`] (e.g. for `NodeKind::SemiJoin` the
-/// convention is `[probe, build]`). `NodeKind::UnionAll` emits the rows of all inputs
+/// `inputs` order is interpreted per [`Operator`] (e.g. for `Operator::SemiJoin` the
+/// convention is `[probe, build]`). `Operator::UnionAll` emits the rows of all inputs
 /// regardless of input order.
 #[derive(Debug, Clone)]
 pub struct PlanNode {
-    pub kind: NodeKind,
+    pub op: Operator,
     pub inputs: Vec<RefId>,
     pub output: RefId,
 }
@@ -32,9 +32,9 @@ pub struct PlanNode {
 /// A plan: an ordered sequence of [`PlanNode`]s forming a dataflow DAG.
 ///
 /// A [`RefId`] is an opaque value handle naming the output of one plan node. Each
-/// [`PlanNode`] is a triple `(kind, inputs, output)`:
+/// [`PlanNode`] is a triple `(op, inputs, output)`:
 ///
-/// - `kind` ([`NodeKind`]) is the operator: a source like `ScanParquet` or a transform like
+/// - `op` ([`Operator`]) is the operator: a source like `ScanParquet` or a transform like
 ///   `Project`.
 /// - `inputs` is a `Vec<RefId>` naming the upstream values the operator reads from.
 /// - `output` is the RefId the operator produces.
@@ -65,11 +65,11 @@ pub struct PlanNode {
 /// ```text
 /// Plan {
 ///     nodes: vec![
-///         PlanNode { kind: ScanParquet(..), inputs: vec![],                   output: RefId(0) },
-///         PlanNode { kind: ScanParquet(..), inputs: vec![],                   output: RefId(1) },
-///         PlanNode { kind: Filter(..),      inputs: vec![RefId(0)],           output: RefId(2) },
-///         PlanNode { kind: Filter(..),      inputs: vec![RefId(1)],           output: RefId(3) },
-///         PlanNode { kind: UnionAll(..),    inputs: vec![RefId(2), RefId(3)], output: RefId(4) },
+///         PlanNode { op: ScanParquet(..), inputs: vec![],                   output: RefId(0) },
+///         PlanNode { op: ScanParquet(..), inputs: vec![],                   output: RefId(1) },
+///         PlanNode { op: Filter(..),      inputs: vec![RefId(0)],           output: RefId(2) },
+///         PlanNode { op: Filter(..),      inputs: vec![RefId(1)],           output: RefId(3) },
+///         PlanNode { op: UnionAll(..),    inputs: vec![RefId(2), RefId(3)], output: RefId(4) },
 ///     ],
 /// }
 /// ```

--- a/kernel/src/plans/proto/mod.rs
+++ b/kernel/src/plans/proto/mod.rs
@@ -8,7 +8,7 @@
 //!   ...).
 //! - [`expressions`] -- mirror of `kernel/src/expressions/mod.rs` and `scalars.rs` (`Expression`,
 //!   `Predicate`, `Scalar`, `ColumnName`, ...).
-//! - [`plan`] -- mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (`Plan`, `PlanNode`, `NodeKind`,
+//! - [`plan`] -- mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (`Plan`, `PlanNode`, `Operator`,
 //!   `RefId`, per-variant payload messages).
 
 pub mod schema {

--- a/kernel/src/plans/query_builder.rs
+++ b/kernel/src/plans/query_builder.rs
@@ -4,7 +4,7 @@
 //! it will grow to support multi-node plans. Until then, multi-node [`Plan`]s are
 //! constructed directly via [`Plan`] / [`PlanNode`].
 
-use super::ir::nodes::{NodeKind, ScanFile, ScanJson, ScanParquet};
+use super::ir::nodes::{Operator, ScanFile, ScanJson, ScanParquet};
 use super::ir::plan::{Plan, PlanNode, RefId};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, FileMeta};
@@ -12,7 +12,7 @@ use crate::{DeltaResult, FileMeta};
 /// Builder for constructing a single-node [`Plan`].
 #[derive(Debug)]
 pub struct QueryPlanBuilder {
-    kind: NodeKind,
+    op: Operator,
 }
 
 impl QueryPlanBuilder {
@@ -21,7 +21,7 @@ impl QueryPlanBuilder {
     /// See [`ScanJson`] for parameter semantics.
     pub fn scan_json(files: Vec<FileMeta>, schema: SchemaRef) -> Self {
         Self {
-            kind: NodeKind::ScanJson(ScanJson {
+            op: Operator::ScanJson(ScanJson {
                 files: files.into_iter().map(ScanFile::from).collect(),
                 file_constant_columns: vec![],
                 schema,
@@ -34,7 +34,7 @@ impl QueryPlanBuilder {
     /// See [`ScanParquet`] for parameter semantics.
     pub fn scan_parquet(files: Vec<FileMeta>, schema: SchemaRef) -> Self {
         Self {
-            kind: NodeKind::ScanParquet(ScanParquet {
+            op: Operator::ScanParquet(ScanParquet {
                 files: files.into_iter().map(ScanFile::from).collect(),
                 file_constant_columns: vec![],
                 schema,
@@ -51,7 +51,7 @@ impl QueryPlanBuilder {
     pub fn build(self) -> DeltaResult<Plan> {
         Ok(Plan {
             nodes: vec![PlanNode {
-                kind: self.kind,
+                op: self.op,
                 inputs: vec![],
                 output: RefId(0),
             }],
@@ -107,18 +107,18 @@ mod tests {
         let result = plan.result();
         let [node] = <[_; 1]>::try_from(plan.nodes).expect("single-node plan");
         assert_eq!(Some(node.output), result);
-        let (NodeKind::ScanJson(ScanJson {
+        let (Operator::ScanJson(ScanJson {
             files: scan_files,
             schema: node_schema,
             ..
         })
-        | NodeKind::ScanParquet(ScanParquet {
+        | Operator::ScanParquet(ScanParquet {
             files: scan_files,
             schema: node_schema,
             ..
-        })) = node.kind
+        })) = node.op
         else {
-            panic!("expected ScanJson / ScanParquet, got {:?}", node.kind);
+            panic!("expected ScanJson / ScanParquet, got {:?}", node.op);
         };
         let scan_metas: Vec<FileMeta> = scan_files.into_iter().map(|f| f.meta).collect();
         assert_eq!(scan_metas, files);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Declarative query plans have a notion of `NodeKind` that is hard to grok. Rename it as `Operation` instead, since it describes what operation a plan node performs.

NOTE: not really a breaking change because declarative plans are still experimental

## How was this change tested?

Class rename. Compilation suffices.