### PR TITLE
test: assert row_id is unique for row tracking enabled feature sets

### DIFF
--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use delta_kernel::schema::MetadataColumnSpec;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -16,7 +17,7 @@ use test_utils::table_builder::{
     version_at_mid, version_incremental_to_latest, version_latest, DataLayoutConfig, FeatureSet,
     LogState, TableConfig, VersionTarget,
 };
-use test_utils::{build_snapshot, default_sweep, read_scan};
+use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan};
 
 /// `TestTableBuilder`'s default is one file per data commit with this many rows, so a
 /// snapshot at version `v` has exactly `v * ROWS_PER_COMMIT` total rows. File count
@@ -48,10 +49,20 @@ fn test_cross_product_read_write(
     };
     assert_eq!(snap.version(), expected_version);
 
-    let scan = snap.scan_builder().build()?;
-    let batches = read_scan(&scan, engine)?;
+    let scan = snap.clone().scan_builder().build()?;
+    let batches = read_scan(&scan, engine.clone())?;
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, expected_version as usize * ROWS_PER_COMMIT);
+
+    if snap.table_properties().enable_row_tracking == Some(true) {
+        let scan_schema = Arc::new(
+            snap.schema()
+                .add_metadata_column("row_id", MetadataColumnSpec::RowId)?,
+        );
+        let scan = snap.scan_builder().with_schema(scan_schema).build()?;
+        let batches = read_scan(&scan, engine)?;
+        assert_row_ids_unique(&batches);
+    }
 
     Ok(())
 }

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -17,8 +17,8 @@ use tempfile::{tempdir, TempDir};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    begin_transaction, create_default_engine_mt_executor, create_table, engine_store_setup,
-    load_and_begin_transaction, read_scan, test_read,
+    begin_transaction, collect_row_ids, create_default_engine_mt_executor, create_table,
+    engine_store_setup, load_and_begin_transaction, read_scan, test_read,
 };
 use url::Url;
 
@@ -821,20 +821,6 @@ fn read_row_id_scan(
     );
     let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
     read_scan(&scan, engine)
-}
-
-/// Collect all `row_id` values from scan results across all batches by column name.
-fn collect_row_ids(batches: &[RecordBatch]) -> Vec<i64> {
-    batches
-        .iter()
-        .flat_map(|b| {
-            b.column_by_name("row_id")
-                .expect("row_id column not found in batch")
-                .as_primitive::<Int64Type>()
-                .values()
-                .to_vec()
-        })
-        .collect()
 }
 
 /// Basic read: write one file with 3 rows, verify row IDs are sequential starting from 0.

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -141,7 +141,7 @@ define_sweeps! {
         version_incremental_to_latest()
     ),
 }
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 pub use counting_reporter::{
@@ -152,11 +152,13 @@ use delta_kernel::actions::{
     get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use delta_kernel::arrow::array::{
-    Array, ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray, RecordBatch,
-    StringArray, StructArray,
+    Array, ArrayRef, AsArray, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray,
+    RecordBatch, StringArray, StructArray,
 };
 use delta_kernel::arrow::buffer::OffsetBuffer;
-use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+use delta_kernel::arrow::datatypes::{
+    DataType as ArrowDataType, Field, Int64Type, Schema as ArrowSchema,
+};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::util::pretty::pretty_format_batches;
 use delta_kernel::committer::{
@@ -1128,6 +1130,33 @@ pub fn assert_result_error_with_message<T, E: ToString>(res: Result<T, E>, messa
             );
         }
     }
+}
+
+/// Collect `row_id` values from scan batches produced with a `MetadataColumnSpec::RowId` schema.
+pub fn collect_row_ids(batches: &[RecordBatch]) -> Vec<i64> {
+    batches
+        .iter()
+        .flat_map(|b| {
+            b.column_by_name("row_id")
+                .expect("row_id column not found in batch")
+                .as_primitive::<Int64Type>()
+                .values()
+                .to_vec()
+        })
+        .collect()
+}
+
+/// Assert every `row_id` across the batches is unique.
+pub fn assert_row_ids_unique(batches: &[RecordBatch]) {
+    let row_ids = collect_row_ids(batches);
+    let unique: HashSet<i64> = row_ids.iter().copied().collect();
+    assert_eq!(
+        unique.len(),
+        row_ids.len(),
+        "row IDs must be globally unique: found {} duplicate(s) among {} row(s)",
+        row_ids.len() - unique.len(),
+        row_ids.len(),
+    );
 }
 
 /// Creates add file metadata for one or more files without partition values.


### PR DESCRIPTION
## What changes are proposed in this pull request?
There are currently integration tests being built out using `TestTableBuilder` that test the public API surface of delta kernel. `TestTableBuilder` mocks kernel's write path to create an in-memory representation, and it is utilized to test different delta table states (involves different feature sets). The `row_tracking` feature enables the synthetic generation of `row_id` on read. The added test within the integration tests ensures `row_id` uniqueness through all `row_tracking` enabled feature sets. 

## How was this change tested?
Tested by running `cargo nextest run -p delta_kernel --test integration --all-features test_cross_product_read_write`, which is the test that is modified within this PR.