### PR TITLE
feat: add column defaults struct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,10 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
 - `arrow-conversion`, `arrow-expression` -- Arrow interop (auto-enabled by `default-engine-base`)
 - `prettyprint` -- enables Arrow pretty-print helpers (primarily test/example oriented)
 - `clustered-table` -- clustered table write support (experimental)
-- `column-defaults-in-dev` -- column defaults write support (experimental, in development).
-  Gates `KernelSupport::Supported` for the `allowColumnDefaults` writer feature; with the
-  cargo feature off, writes to tables listing this feature are blocked.
+- `column-defaults-in-dev` -- column defaults support (experimental, in development). Gates
+  `KernelSupport::Supported` for the `allowColumnDefaults` writer feature (writes to tables
+  listing this feature are blocked with the cargo feature off), and also gates the `ColumnDefault`
+  carrier type and the SQL literal parser (`parse_sql`).
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -29,8 +29,6 @@ mod scalars;
 #[cfg(feature = "column-defaults-in-dev")]
 mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
-// TODO(#2630): Wire up `parse_sql` to column-defaults and remove this allow
-#[allow(unused_imports)]
 pub(crate) use self::sql::parse_sql;
 
 pub type ExpressionRef = std::sync::Arc<Expression>;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -12,10 +12,6 @@
 //! Delta metadata contains today. If the supported SQL surface grows, options include moving
 //! parsing behind the [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 
-// `parse_sql` has no in-crate caller yet; it will be wired up by the column-defaults work
-// (#2630).
-#![allow(dead_code)]
-
 use crate::expressions::{Expression, Scalar};
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -4,18 +4,16 @@ use crate::expressions::{parse_sql, Expression, Scalar};
 use crate::schema::DataType;
 use crate::{DeltaResult, Error};
 
-/// A column-level default value parsed from the `CURRENT_DEFAULT` metadata key of a
+/// A column-level default parsed from the `CURRENT_DEFAULT` metadata key of a
 /// [`StructField`](crate::schema::StructField).
 ///
-/// The carrier holds the raw SQL string ([`raw_sql`](Self::raw_sql)) and the column's declared
-/// type ([`data_type`](Self::data_type)). On construction the kernel eagerly parses the SQL with
-/// its built-in SQL parser and caches the result. Callers check whether that parse succeeded
-/// via [`is_kernel_parsable`](Self::is_kernel_parsable) and resolve the default to a [`Scalar`]
-/// via [`evaluate`](Self::evaluate). When the kernel cannot parse the SQL (e.g. a function call
-/// such as `current_timestamp()`), connectors with richer SQL support may evaluate
-/// [`raw_sql`](Self::raw_sql) themselves.
+/// Holds the raw SQL and the column's declared type. On construction the kernel parses the SQL
+/// with its built-in parser and caches the result. [`to_scalar`](Self::to_scalar) returns the
+/// parsed [`Scalar`], or `None` when the kernel could not parse the SQL (e.g.
+/// `current_timestamp()`), in which case a connector can evaluate [`raw_sql`](Self::raw_sql)
+/// itself.
 ///
-/// The declared type is borrowed from the logical schema, which always outlives the carrier.
+/// The declared type is borrowed from the logical schema, which outlives the carrier.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ColumnDefault<'a> {
     raw_sql: String,
@@ -28,16 +26,17 @@ pub struct ColumnDefault<'a> {
 impl<'a> ColumnDefault<'a> {
     /// Build a `ColumnDefault` from a raw SQL string and the column's declared type.
     ///
-    /// The kernel attempts to parse `raw_sql` via the built-in SQL parser using `data_type` as the
-    /// expected target type. A parse failure is **not** an error -- the parsed form is left empty
-    /// and `Ok` is returned -- because not every stored default is a literal the kernel knows how
-    /// to interpret (use [`is_kernel_parsable`](Self::is_kernel_parsable) to check).
+    /// Parses `raw_sql` with the built-in SQL parser, targeting `data_type`. A parse failure is
+    /// not an error: the cached form is left empty and [`to_scalar`](Self::to_scalar) returns
+    /// `None` so the connector can handle the raw SQL.
     ///
     /// # Errors
     ///
     /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
     /// `raw_sql` is not `NULL` (case-insensitive).
-    pub fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
+    // No production caller yet, remove this allow when that wiring exists.
+    #[allow(unused)]
+    pub(crate) fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
         // Spark only allows a non-primitive column default when it is NULL; match that behavior.
         if data_type.as_primitive_opt().is_none() && !is_null {
@@ -55,9 +54,6 @@ impl<'a> ColumnDefault<'a> {
     }
 
     /// The raw SQL expression as stored in the column's metadata.
-    ///
-    /// Connectors with a SQL engine richer than the kernel's SQL parser can evaluate this
-    /// directly when [`is_kernel_parsable`](Self::is_kernel_parsable) returns `false`.
     pub fn raw_sql(&self) -> &str {
         &self.raw_sql
     }
@@ -67,29 +63,19 @@ impl<'a> ColumnDefault<'a> {
         self.data_type
     }
 
-    /// Returns `true` when the kernel parsed [`raw_sql`](Self::raw_sql) into a form it can
-    /// evaluate, and `false` otherwise.
-    pub fn is_kernel_parsable(&self) -> bool {
-        self.parsed_sql.is_some()
-    }
-
-    /// Evaluate the parsed default to a [`Scalar`].
+    /// The default as a [`Scalar`], or `None` when the kernel could not parse the SQL.
     ///
-    /// Returns `Ok(None)` when the kernel could not parse [`raw_sql`](Self::raw_sql) (i.e.
-    /// [`is_kernel_parsable`](Self::is_kernel_parsable) is `false`); the caller may fall back to
-    /// its own SQL engine using [`raw_sql`](Self::raw_sql).
+    /// On `None` the connector can evaluate [`raw_sql`](Self::raw_sql) with its own SQL engine.
     ///
     /// # Errors
     ///
-    /// Returns an error if the parsed default is not a literal (the parser never produces such
-    /// expressions, so this is defensive).
-    pub fn evaluate(&self) -> DeltaResult<Option<Scalar>> {
-        let Some(expr) = self.parsed_sql.as_ref() else {
-            return Ok(None);
-        };
-        match expr {
-            Expression::Literal(scalar) => Ok(Some(scalar.clone())),
-            other => Err(Error::generic(format!(
+    /// Returns an error if the parsed default is not a literal. The parser only emits literals, so
+    /// this is defensive.
+    pub fn to_scalar(&self) -> DeltaResult<Option<Scalar>> {
+        match &self.parsed_sql {
+            None => Ok(None),
+            Some(Expression::Literal(scalar)) => Ok(Some(scalar.clone())),
+            Some(other) => Err(Error::generic(format!(
                 "kernel cannot evaluate non-literal column default expression: {other:?}"
             ))),
         }
@@ -121,11 +107,11 @@ mod tests {
     /// Expected outcome of [`ColumnDefault::new`] for one `(raw_sql, data_type)` pair.
     #[derive(Debug)]
     enum Expect {
-        /// Parsable; `evaluate` yields this scalar.
+        /// `to_scalar` yields `Some(this)`.
         Parsed(Scalar),
-        /// Parsable `NULL`; `evaluate` yields `Scalar::Null` of the column's type.
+        /// `to_scalar` yields `Some(Scalar::Null)` of the column's type.
         ParsedNull,
-        /// Not kernel-parsable; `evaluate` yields `None`.
+        /// `to_scalar` yields `None`.
         Unparsable,
         /// `new` fails with an error containing this substring.
         NewErr(&'static str),
@@ -179,19 +165,19 @@ mod tests {
     ) {
         match (ColumnDefault::new(raw_sql.into(), &data_type), expect) {
             (Ok(d), Expect::Parsed(scalar)) => {
-                assert!(d.is_kernel_parsable());
-                assert_eq!(d.evaluate().unwrap(), Some(scalar));
                 assert_eq!(d.raw_sql(), raw_sql);
                 assert_eq!(d.data_type(), &data_type);
+                assert_eq!(d.to_scalar().unwrap(), Some(scalar));
             }
             (Ok(d), Expect::ParsedNull) => {
-                assert!(d.is_kernel_parsable());
-                assert_eq!(d.evaluate().unwrap(), Some(Scalar::Null(data_type.clone())));
+                assert_eq!(
+                    d.to_scalar().unwrap(),
+                    Some(Scalar::Null(data_type.clone()))
+                );
             }
             (Ok(d), Expect::Unparsable) => {
-                assert!(!d.is_kernel_parsable());
-                assert_eq!(d.evaluate().unwrap(), None);
-                // A parse failure must not drop the raw SQL -- connectors fall back to it.
+                assert_eq!(d.to_scalar().unwrap(), None);
+                // A parse failure must not drop the raw SQL; connectors fall back to it.
                 assert_eq!(d.raw_sql(), raw_sql);
             }
             (Err(e), Expect::NewErr(needle)) => {
@@ -204,9 +190,9 @@ mod tests {
     }
 
     #[test]
-    fn evaluate_errors_on_non_literal_parsed_expression() {
-        // The parser only emits literals in normal use; construct a non-literal directly to reach
-        // the defensive error arm.
+    fn to_scalar_errors_on_non_literal_parsed_expression() {
+        // The parser only emits literals, so construct a non-literal directly to reach the
+        // defensive error arm.
         let int_ty = DataType::INTEGER;
         let d = ColumnDefault {
             raw_sql: "x".into(),
@@ -214,7 +200,7 @@ mod tests {
             parsed_sql: Some(Expression::column(["x"])),
         };
         let err = d
-            .evaluate()
+            .to_scalar()
             .expect_err("non-literal parsed expression must error")
             .to_string();
         assert!(err.contains("non-literal"), "got: {err}");

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -34,12 +34,8 @@ impl ColumnDefault {
     /// # Errors
     ///
     /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
-    /// `raw_sql` is not `NULL`. The Delta protocol requires defaults on these types -- in
-    /// particular Variant columns -- to be `NULL`; this is a defense-in-depth check independent of
-    /// the parser.
+    /// `raw_sql` is not `NULL`.
     pub fn new(raw_sql: String, data_type: DataType) -> DeltaResult<Self> {
-        // The protocol only permits NULL defaults on non-primitive types (incl. Variant). Reject
-        // anything else up front rather than silently treating it as unparsable.
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
         if data_type.as_primitive_opt().is_none() && !is_null {
             return Err(Error::generic(format!(
@@ -69,11 +65,6 @@ impl ColumnDefault {
 
     /// Returns `true` when the kernel parsed [`raw_sql`](Self::raw_sql) into a form it can
     /// evaluate, and `false` otherwise.
-    ///
-    /// A cheap, side-effect-free predicate -- it does not require an [`Engine`] -- that lets a
-    /// connector decide upfront whether to resolve the default via [`evaluate`](Self::evaluate)
-    /// (kernel-parsable defaults) or through its own SQL engine acting on
-    /// [`raw_sql`](Self::raw_sql) (everything else).
     pub fn is_kernel_parsable(&self) -> bool {
         self.parsed_sql.is_some()
     }
@@ -216,7 +207,7 @@ mod tests {
 
     #[test]
     fn evaluate_returns_none_for_unparsable_default() {
-        let d = ColumnDefault::new("current_timestamp()".into(), DataType::TIMESTAMP).unwrap();
+        let d = ColumnDefault::new("unparsable_sql()".into(), DataType::TIMESTAMP).unwrap();
         assert!(!d.is_kernel_parsable());
         assert_eq!(d.evaluate(&UnusedEngine).unwrap(), None);
     }

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -2,7 +2,7 @@
 
 use crate::expressions::{parse_sql, Expression, Scalar};
 use crate::schema::DataType;
-use crate::{DeltaResult, Engine, Error};
+use crate::{DeltaResult, Error};
 
 /// A column-level default value parsed from the `CURRENT_DEFAULT` metadata key of a
 /// [`StructField`](crate::schema::StructField).
@@ -42,7 +42,8 @@ impl<'a> ColumnDefault<'a> {
         // Spark only allows a non-primitive column default when it is NULL; match that behavior.
         if data_type.as_primitive_opt().is_none() && !is_null {
             return Err(Error::generic(format!(
-                "column default for non-primitive type {data_type:?} must be NULL, got {raw_sql:?}"
+                "non-null column default for non-primitive type {data_type:?} is not \
+                 supported, got {raw_sql:?}"
             )));
         }
         let parsed_sql = parse_sql(&raw_sql, data_type).ok();
@@ -82,7 +83,7 @@ impl<'a> ColumnDefault<'a> {
     ///
     /// Returns an error if the parsed default is not a literal (the parser never produces such
     /// expressions, so this is defensive).
-    pub fn evaluate(&self, _engine: &dyn Engine) -> DeltaResult<Option<Scalar>> {
+    pub fn evaluate(&self) -> DeltaResult<Option<Scalar>> {
         let Some(expr) = self.parsed_sql.as_ref() else {
             return Ok(None);
         };
@@ -97,126 +98,109 @@ impl<'a> ColumnDefault<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use chrono::{DateTime, NaiveDate, TimeZone, Utc};
     use rstest::rstest;
 
     use super::*;
     use crate::schema::{ArrayType, MapType, StructField};
-    use crate::{EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
-
-    /// A stand-in [`Engine`] whose handlers all panic. [`ColumnDefault::evaluate`] resolves
-    /// literal defaults by AST destructure, so it must never reach a handler.
-    struct UnusedEngine;
-
-    impl Engine for UnusedEngine {
-        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-            unimplemented!("evaluate must not touch the engine for literal defaults")
-        }
-        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-            unimplemented!()
-        }
-        fn json_handler(&self) -> Arc<dyn JsonHandler> {
-            unimplemented!()
-        }
-        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-            unimplemented!()
-        }
-    }
 
     fn struct_ty() -> DataType {
         DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
     }
 
-    #[test]
-    fn new_parsable_literal_exposes_raw_sql_type_and_evaluates() {
-        let data_type = DataType::INTEGER;
-        let d = ColumnDefault::new("42".into(), &data_type).unwrap();
-        assert_eq!(d.raw_sql(), "42");
-        assert_eq!(d.data_type(), &DataType::INTEGER);
-        assert!(d.is_kernel_parsable());
-        assert_eq!(d.parsed_sql, Some(Expression::literal(Scalar::Integer(42))));
-        assert_eq!(
-            d.evaluate(&UnusedEngine).unwrap(),
-            Some(Scalar::Integer(42))
-        );
+    fn date_days(year: i32, month: u32, day: u32) -> i32 {
+        let nd = NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        Utc.from_utc_datetime(&nd)
+            .signed_duration_since(DateTime::UNIX_EPOCH)
+            .num_days() as i32
     }
 
-    #[test]
-    fn new_parses_string_and_null_literals() {
-        let string_ty = DataType::STRING;
-        let s = ColumnDefault::new("'hello'".into(), &string_ty).unwrap();
-        assert_eq!(
-            s.parsed_sql,
-            Some(Expression::literal(Scalar::String("hello".into())))
-        );
-
-        let int_ty = DataType::INTEGER;
-        let n = ColumnDefault::new("NULL".into(), &int_ty).unwrap();
-        assert_eq!(
-            n.parsed_sql,
-            Some(Expression::literal(Scalar::Null(DataType::INTEGER)))
-        );
+    /// Expected outcome of [`ColumnDefault::new`] for one `(raw_sql, data_type)` pair.
+    #[derive(Debug)]
+    enum Expect {
+        /// Parsable; `evaluate` yields this scalar.
+        Parsed(Scalar),
+        /// Parsable `NULL`; `evaluate` yields `Scalar::Null` of the column's type.
+        ParsedNull,
+        /// Not kernel-parsable; `evaluate` yields `None`.
+        Unparsable,
+        /// `new` fails with an error containing this substring.
+        NewErr(&'static str),
     }
 
     #[rstest]
-    #[case::integer("42", DataType::INTEGER, true)]
-    #[case::string("'hello'", DataType::STRING, true)]
-    #[case::boolean("TRUE", DataType::BOOLEAN, true)]
-    #[case::date("DATE '2024-01-01'", DataType::DATE, true)]
-    #[case::null_primitive("NULL", DataType::INTEGER, true)]
-    #[case::function_call("current_timestamp()", DataType::TIMESTAMP, false)]
-    #[case::type_mismatch("'not an int'", DataType::INTEGER, false)]
-    #[case::arithmetic("1 + 1", DataType::INTEGER, false)]
-    fn is_kernel_parsable_reflects_parse_outcome(
-        #[case] raw_sql: &str,
-        #[case] data_type: DataType,
-        #[case] parsable: bool,
-    ) {
-        let d = ColumnDefault::new(raw_sql.into(), &data_type).unwrap();
-        assert_eq!(d.is_kernel_parsable(), parsable);
-        // A parse failure must not drop the raw SQL -- connectors fall back to it.
-        assert_eq!(d.raw_sql(), raw_sql);
-    }
-
-    #[rstest]
-    #[case::array(DataType::from(ArrayType::new(DataType::INTEGER, true)), "ARRAY(1)")]
-    #[case::map(
-        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
-        "MAP('k', 1)"
+    #[case::integer("42", DataType::INTEGER, Expect::Parsed(Scalar::Integer(42)))]
+    #[case::string("'hello'", DataType::STRING, Expect::Parsed(Scalar::String("hello".into())))]
+    #[case::boolean("TRUE", DataType::BOOLEAN, Expect::Parsed(Scalar::Boolean(true)))]
+    #[case::date(
+        "DATE '2024-01-01'",
+        DataType::DATE,
+        Expect::Parsed(Scalar::Date(date_days(2024, 1, 1)))
     )]
-    #[case::struct_type(struct_ty(), "STRUCT(1)")]
-    #[case::variant(DataType::unshredded_variant(), "1")]
-    fn new_rejects_non_primitive_with_non_null_default(
-        #[case] data_type: DataType,
+    #[case::null_primitive("NULL", DataType::INTEGER, Expect::ParsedNull)]
+    #[case::null_array(
+        "NULL",
+        DataType::from(ArrayType::new(DataType::INTEGER, true)),
+        Expect::ParsedNull
+    )]
+    #[case::null_map(
+        "NULL",
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
+        Expect::ParsedNull
+    )]
+    #[case::null_struct("NULL", struct_ty(), Expect::ParsedNull)]
+    #[case::null_variant("NULL", DataType::unshredded_variant(), Expect::ParsedNull)]
+    #[case::function_call("current_timestamp()", DataType::TIMESTAMP, Expect::Unparsable)]
+    #[case::type_mismatch("'not an int'", DataType::INTEGER, Expect::Unparsable)]
+    #[case::arithmetic("1 + 1", DataType::INTEGER, Expect::Unparsable)]
+    #[case::non_primitive_array(
+        "ARRAY(1)",
+        DataType::from(ArrayType::new(DataType::INTEGER, true)),
+        Expect::NewErr("not supported")
+    )]
+    #[case::non_primitive_map(
+        "MAP('k', 1)",
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
+        Expect::NewErr("not supported")
+    )]
+    #[case::non_primitive_struct("STRUCT(1)", struct_ty(), Expect::NewErr("not supported"))]
+    #[case::non_primitive_variant(
+        "1",
+        DataType::unshredded_variant(),
+        Expect::NewErr("not supported")
+    )]
+    fn column_default_from_new(
         #[case] raw_sql: &str,
+        #[case] data_type: DataType,
+        #[case] expect: Expect,
     ) {
-        let err = ColumnDefault::new(raw_sql.into(), &data_type)
-            .expect_err("non-primitive non-NULL default must error")
-            .to_string();
-        assert!(err.contains("must be NULL"), "got: {err}");
-    }
-
-    #[rstest]
-    #[case::array(DataType::from(ArrayType::new(DataType::INTEGER, true)))]
-    #[case::map(DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)))]
-    #[case::struct_type(struct_ty())]
-    #[case::variant(DataType::unshredded_variant())]
-    fn new_allows_non_primitive_null_default(#[case] data_type: DataType) {
-        let d = ColumnDefault::new("NULL".into(), &data_type).unwrap();
-        assert!(d.is_kernel_parsable());
-        assert_eq!(
-            d.evaluate(&UnusedEngine).unwrap(),
-            Some(Scalar::Null(data_type.clone()))
-        );
-    }
-
-    #[test]
-    fn evaluate_returns_none_for_unparsable_default() {
-        let data_type = DataType::TIMESTAMP;
-        let d = ColumnDefault::new("unparsable_sql()".into(), &data_type).unwrap();
-        assert!(!d.is_kernel_parsable());
-        assert_eq!(d.evaluate(&UnusedEngine).unwrap(), None);
+        match (ColumnDefault::new(raw_sql.into(), &data_type), expect) {
+            (Ok(d), Expect::Parsed(scalar)) => {
+                assert!(d.is_kernel_parsable());
+                assert_eq!(d.evaluate().unwrap(), Some(scalar));
+                assert_eq!(d.raw_sql(), raw_sql);
+                assert_eq!(d.data_type(), &data_type);
+            }
+            (Ok(d), Expect::ParsedNull) => {
+                assert!(d.is_kernel_parsable());
+                assert_eq!(d.evaluate().unwrap(), Some(Scalar::Null(data_type.clone())));
+            }
+            (Ok(d), Expect::Unparsable) => {
+                assert!(!d.is_kernel_parsable());
+                assert_eq!(d.evaluate().unwrap(), None);
+                // A parse failure must not drop the raw SQL -- connectors fall back to it.
+                assert_eq!(d.raw_sql(), raw_sql);
+            }
+            (Err(e), Expect::NewErr(needle)) => {
+                assert!(e.to_string().contains(needle), "got: {e}");
+            }
+            (result, expect) => {
+                panic!("unexpected outcome for {raw_sql:?}: {result:?} vs {expect:?}")
+            }
+        }
     }
 
     #[test]
@@ -230,7 +214,7 @@ mod tests {
             parsed_sql: Some(Expression::column(["x"])),
         };
         let err = d
-            .evaluate(&UnusedEngine)
+            .evaluate()
             .expect_err("non-literal parsed expression must error")
             .to_string();
         assert!(err.contains("non-literal"), "got: {err}");

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -9,21 +9,23 @@ use crate::{DeltaResult, Engine, Error};
 ///
 /// The carrier holds the raw SQL string ([`raw_sql`](Self::raw_sql)) and the column's declared
 /// type ([`data_type`](Self::data_type)). On construction the kernel eagerly parses the SQL with
-/// its built-in literal parser and caches the result. Callers check whether that parse succeeded
+/// its built-in SQL parser and caches the result. Callers check whether that parse succeeded
 /// via [`is_kernel_parsable`](Self::is_kernel_parsable) and resolve the default to a [`Scalar`]
 /// via [`evaluate`](Self::evaluate). When the kernel cannot parse the SQL (e.g. a function call
-/// such as `current_timestamp()`), connectors with richer SQL support fall back to evaluating
+/// such as `current_timestamp()`), connectors with richer SQL support may evaluate
 /// [`raw_sql`](Self::raw_sql) themselves.
+///
+/// The declared type is borrowed from the logical schema, which always outlives the carrier.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ColumnDefault {
+pub struct ColumnDefault<'a> {
     raw_sql: String,
-    data_type: DataType,
+    data_type: &'a DataType,
     /// The default parsed as a kernel [`Expression`], or `None` if the kernel's
     /// built-in SQL parser could not parse it.
     parsed_sql: Option<Expression>,
 }
 
-impl ColumnDefault {
+impl<'a> ColumnDefault<'a> {
     /// Build a `ColumnDefault` from a raw SQL string and the column's declared type.
     ///
     /// The kernel attempts to parse `raw_sql` via the built-in SQL parser using `data_type` as the
@@ -34,15 +36,16 @@ impl ColumnDefault {
     /// # Errors
     ///
     /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
-    /// `raw_sql` is not `NULL`.
-    pub fn new(raw_sql: String, data_type: DataType) -> DeltaResult<Self> {
+    /// `raw_sql` is not `NULL` (case-insensitive).
+    pub fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
+        // Spark only allows a non-primitive column default when it is NULL; match that behavior.
         if data_type.as_primitive_opt().is_none() && !is_null {
             return Err(Error::generic(format!(
                 "column default for non-primitive type {data_type:?} must be NULL, got {raw_sql:?}"
             )));
         }
-        let parsed_sql = parse_sql(&raw_sql, &data_type).ok();
+        let parsed_sql = parse_sql(&raw_sql, data_type).ok();
         Ok(Self {
             raw_sql,
             data_type,
@@ -52,7 +55,7 @@ impl ColumnDefault {
 
     /// The raw SQL expression as stored in the column's metadata.
     ///
-    /// Connectors with a SQL engine richer than the kernel's literal parser can evaluate this
+    /// Connectors with a SQL engine richer than the kernel's SQL parser can evaluate this
     /// directly when [`is_kernel_parsable`](Self::is_kernel_parsable) returns `false`.
     pub fn raw_sql(&self) -> &str {
         &self.raw_sql
@@ -60,7 +63,7 @@ impl ColumnDefault {
 
     /// The declared type of the column whose default this is.
     pub fn data_type(&self) -> &DataType {
-        &self.data_type
+        self.data_type
     }
 
     /// Returns `true` when the kernel parsed [`raw_sql`](Self::raw_sql) into a form it can
@@ -72,8 +75,8 @@ impl ColumnDefault {
     /// Evaluate the parsed default to a [`Scalar`].
     ///
     /// Returns `Ok(None)` when the kernel could not parse [`raw_sql`](Self::raw_sql) (i.e.
-    /// [`is_kernel_parsable`](Self::is_kernel_parsable) is `false`); the caller is expected to
-    /// fall back to its own SQL engine using [`raw_sql`](Self::raw_sql).
+    /// [`is_kernel_parsable`](Self::is_kernel_parsable) is `false`); the caller may fall back to
+    /// its own SQL engine using [`raw_sql`](Self::raw_sql).
     ///
     /// # Errors
     ///
@@ -127,7 +130,8 @@ mod tests {
 
     #[test]
     fn new_parsable_literal_exposes_raw_sql_type_and_evaluates() {
-        let d = ColumnDefault::new("42".into(), DataType::INTEGER).unwrap();
+        let data_type = DataType::INTEGER;
+        let d = ColumnDefault::new("42".into(), &data_type).unwrap();
         assert_eq!(d.raw_sql(), "42");
         assert_eq!(d.data_type(), &DataType::INTEGER);
         assert!(d.is_kernel_parsable());
@@ -140,13 +144,15 @@ mod tests {
 
     #[test]
     fn new_parses_string_and_null_literals() {
-        let s = ColumnDefault::new("'hello'".into(), DataType::STRING).unwrap();
+        let string_ty = DataType::STRING;
+        let s = ColumnDefault::new("'hello'".into(), &string_ty).unwrap();
         assert_eq!(
             s.parsed_sql,
             Some(Expression::literal(Scalar::String("hello".into())))
         );
 
-        let n = ColumnDefault::new("NULL".into(), DataType::INTEGER).unwrap();
+        let int_ty = DataType::INTEGER;
+        let n = ColumnDefault::new("NULL".into(), &int_ty).unwrap();
         assert_eq!(
             n.parsed_sql,
             Some(Expression::literal(Scalar::Null(DataType::INTEGER)))
@@ -167,7 +173,7 @@ mod tests {
         #[case] data_type: DataType,
         #[case] parsable: bool,
     ) {
-        let d = ColumnDefault::new(raw_sql.into(), data_type).unwrap();
+        let d = ColumnDefault::new(raw_sql.into(), &data_type).unwrap();
         assert_eq!(d.is_kernel_parsable(), parsable);
         // A parse failure must not drop the raw SQL -- connectors fall back to it.
         assert_eq!(d.raw_sql(), raw_sql);
@@ -185,7 +191,7 @@ mod tests {
         #[case] data_type: DataType,
         #[case] raw_sql: &str,
     ) {
-        let err = ColumnDefault::new(raw_sql.into(), data_type)
+        let err = ColumnDefault::new(raw_sql.into(), &data_type)
             .expect_err("non-primitive non-NULL default must error")
             .to_string();
         assert!(err.contains("must be NULL"), "got: {err}");
@@ -197,17 +203,18 @@ mod tests {
     #[case::struct_type(struct_ty())]
     #[case::variant(DataType::unshredded_variant())]
     fn new_allows_non_primitive_null_default(#[case] data_type: DataType) {
-        let d = ColumnDefault::new("NULL".into(), data_type.clone()).unwrap();
+        let d = ColumnDefault::new("NULL".into(), &data_type).unwrap();
         assert!(d.is_kernel_parsable());
         assert_eq!(
             d.evaluate(&UnusedEngine).unwrap(),
-            Some(Scalar::Null(data_type))
+            Some(Scalar::Null(data_type.clone()))
         );
     }
 
     #[test]
     fn evaluate_returns_none_for_unparsable_default() {
-        let d = ColumnDefault::new("unparsable_sql()".into(), DataType::TIMESTAMP).unwrap();
+        let data_type = DataType::TIMESTAMP;
+        let d = ColumnDefault::new("unparsable_sql()".into(), &data_type).unwrap();
         assert!(!d.is_kernel_parsable());
         assert_eq!(d.evaluate(&UnusedEngine).unwrap(), None);
     }
@@ -216,9 +223,10 @@ mod tests {
     fn evaluate_errors_on_non_literal_parsed_expression() {
         // The parser only emits literals in normal use; construct a non-literal directly to reach
         // the defensive error arm.
+        let int_ty = DataType::INTEGER;
         let d = ColumnDefault {
             raw_sql: "x".into(),
-            data_type: DataType::INTEGER,
+            data_type: &int_ty,
             parsed_sql: Some(Expression::column(["x"])),
         };
         let err = d

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -1,0 +1,239 @@
+//! A typed wrapper around Delta's `CURRENT_DEFAULT` column metadata
+
+use crate::expressions::{parse_sql, Expression, Scalar};
+use crate::schema::DataType;
+use crate::{DeltaResult, Engine, Error};
+
+/// A column-level default value parsed from the `CURRENT_DEFAULT` metadata key of a
+/// [`StructField`](crate::schema::StructField).
+///
+/// The carrier holds the raw SQL string ([`raw_sql`](Self::raw_sql)) and the column's declared
+/// type ([`data_type`](Self::data_type)). On construction the kernel eagerly parses the SQL with
+/// its built-in literal parser and caches the result. Callers check whether that parse succeeded
+/// via [`is_kernel_parsable`](Self::is_kernel_parsable) and resolve the default to a [`Scalar`]
+/// via [`evaluate`](Self::evaluate). When the kernel cannot parse the SQL (e.g. a function call
+/// such as `current_timestamp()`), connectors with richer SQL support fall back to evaluating
+/// [`raw_sql`](Self::raw_sql) themselves.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDefault {
+    raw_sql: String,
+    data_type: DataType,
+    /// The default parsed as a kernel [`Expression`], or `None` if the kernel's
+    /// built-in SQL parser could not parse it.
+    parsed_sql: Option<Expression>,
+}
+
+impl ColumnDefault {
+    /// Build a `ColumnDefault` from a raw SQL string and the column's declared type.
+    ///
+    /// The kernel attempts to parse `raw_sql` via the built-in SQL parser using `data_type` as the
+    /// expected target type. A parse failure is **not** an error -- the parsed form is left empty
+    /// and `Ok` is returned -- because not every stored default is a literal the kernel knows how
+    /// to interpret (use [`is_kernel_parsable`](Self::is_kernel_parsable) to check).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
+    /// `raw_sql` is not `NULL`. The Delta protocol requires defaults on these types -- in
+    /// particular Variant columns -- to be `NULL`; this is a defense-in-depth check independent of
+    /// the parser.
+    pub fn new(raw_sql: String, data_type: DataType) -> DeltaResult<Self> {
+        // The protocol only permits NULL defaults on non-primitive types (incl. Variant). Reject
+        // anything else up front rather than silently treating it as unparsable.
+        let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
+        if data_type.as_primitive_opt().is_none() && !is_null {
+            return Err(Error::generic(format!(
+                "column default for non-primitive type {data_type:?} must be NULL, got {raw_sql:?}"
+            )));
+        }
+        let parsed_sql = parse_sql(&raw_sql, &data_type).ok();
+        Ok(Self {
+            raw_sql,
+            data_type,
+            parsed_sql,
+        })
+    }
+
+    /// The raw SQL expression as stored in the column's metadata.
+    ///
+    /// Connectors with a SQL engine richer than the kernel's literal parser can evaluate this
+    /// directly when [`is_kernel_parsable`](Self::is_kernel_parsable) returns `false`.
+    pub fn raw_sql(&self) -> &str {
+        &self.raw_sql
+    }
+
+    /// The declared type of the column whose default this is.
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Returns `true` when the kernel parsed [`raw_sql`](Self::raw_sql) into a form it can
+    /// evaluate, and `false` otherwise.
+    ///
+    /// A cheap, side-effect-free predicate -- it does not require an [`Engine`] -- that lets a
+    /// connector decide upfront whether to resolve the default via [`evaluate`](Self::evaluate)
+    /// (kernel-parsable defaults) or through its own SQL engine acting on
+    /// [`raw_sql`](Self::raw_sql) (everything else).
+    pub fn is_kernel_parsable(&self) -> bool {
+        self.parsed_sql.is_some()
+    }
+
+    /// Evaluate the parsed default to a [`Scalar`].
+    ///
+    /// Returns `Ok(None)` when the kernel could not parse [`raw_sql`](Self::raw_sql) (i.e.
+    /// [`is_kernel_parsable`](Self::is_kernel_parsable) is `false`); the caller is expected to
+    /// fall back to its own SQL engine using [`raw_sql`](Self::raw_sql).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the parsed default is not a literal (the parser never produces such
+    /// expressions, so this is defensive).
+    pub fn evaluate(&self, _engine: &dyn Engine) -> DeltaResult<Option<Scalar>> {
+        let Some(expr) = self.parsed_sql.as_ref() else {
+            return Ok(None);
+        };
+        match expr {
+            Expression::Literal(scalar) => Ok(Some(scalar.clone())),
+            other => Err(Error::generic(format!(
+                "kernel cannot evaluate non-literal column default expression: {other:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rstest::rstest;
+
+    use super::*;
+    use crate::schema::{ArrayType, MapType, StructField};
+    use crate::{EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
+
+    /// A stand-in [`Engine`] whose handlers all panic. [`ColumnDefault::evaluate`] resolves
+    /// literal defaults by AST destructure, so it must never reach a handler.
+    struct UnusedEngine;
+
+    impl Engine for UnusedEngine {
+        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+            unimplemented!("evaluate must not touch the engine for literal defaults")
+        }
+        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+            unimplemented!()
+        }
+        fn json_handler(&self) -> Arc<dyn JsonHandler> {
+            unimplemented!()
+        }
+        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+            unimplemented!()
+        }
+    }
+
+    fn struct_ty() -> DataType {
+        DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
+    }
+
+    #[test]
+    fn new_parsable_literal_exposes_raw_sql_type_and_evaluates() {
+        let d = ColumnDefault::new("42".into(), DataType::INTEGER).unwrap();
+        assert_eq!(d.raw_sql(), "42");
+        assert_eq!(d.data_type(), &DataType::INTEGER);
+        assert!(d.is_kernel_parsable());
+        assert_eq!(d.parsed_sql, Some(Expression::literal(Scalar::Integer(42))));
+        assert_eq!(
+            d.evaluate(&UnusedEngine).unwrap(),
+            Some(Scalar::Integer(42))
+        );
+    }
+
+    #[test]
+    fn new_parses_string_and_null_literals() {
+        let s = ColumnDefault::new("'hello'".into(), DataType::STRING).unwrap();
+        assert_eq!(
+            s.parsed_sql,
+            Some(Expression::literal(Scalar::String("hello".into())))
+        );
+
+        let n = ColumnDefault::new("NULL".into(), DataType::INTEGER).unwrap();
+        assert_eq!(
+            n.parsed_sql,
+            Some(Expression::literal(Scalar::Null(DataType::INTEGER)))
+        );
+    }
+
+    #[rstest]
+    #[case::integer("42", DataType::INTEGER, true)]
+    #[case::string("'hello'", DataType::STRING, true)]
+    #[case::boolean("TRUE", DataType::BOOLEAN, true)]
+    #[case::date("DATE '2024-01-01'", DataType::DATE, true)]
+    #[case::null_primitive("NULL", DataType::INTEGER, true)]
+    #[case::function_call("current_timestamp()", DataType::TIMESTAMP, false)]
+    #[case::type_mismatch("'not an int'", DataType::INTEGER, false)]
+    #[case::arithmetic("1 + 1", DataType::INTEGER, false)]
+    fn is_kernel_parsable_reflects_parse_outcome(
+        #[case] raw_sql: &str,
+        #[case] data_type: DataType,
+        #[case] parsable: bool,
+    ) {
+        let d = ColumnDefault::new(raw_sql.into(), data_type).unwrap();
+        assert_eq!(d.is_kernel_parsable(), parsable);
+        // A parse failure must not drop the raw SQL -- connectors fall back to it.
+        assert_eq!(d.raw_sql(), raw_sql);
+    }
+
+    #[rstest]
+    #[case::array(DataType::from(ArrayType::new(DataType::INTEGER, true)), "ARRAY(1)")]
+    #[case::map(
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
+        "MAP('k', 1)"
+    )]
+    #[case::struct_type(struct_ty(), "STRUCT(1)")]
+    #[case::variant(DataType::unshredded_variant(), "1")]
+    fn new_rejects_non_primitive_with_non_null_default(
+        #[case] data_type: DataType,
+        #[case] raw_sql: &str,
+    ) {
+        let err = ColumnDefault::new(raw_sql.into(), data_type)
+            .expect_err("non-primitive non-NULL default must error")
+            .to_string();
+        assert!(err.contains("must be NULL"), "got: {err}");
+    }
+
+    #[rstest]
+    #[case::array(DataType::from(ArrayType::new(DataType::INTEGER, true)))]
+    #[case::map(DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)))]
+    #[case::struct_type(struct_ty())]
+    #[case::variant(DataType::unshredded_variant())]
+    fn new_allows_non_primitive_null_default(#[case] data_type: DataType) {
+        let d = ColumnDefault::new("NULL".into(), data_type.clone()).unwrap();
+        assert!(d.is_kernel_parsable());
+        assert_eq!(
+            d.evaluate(&UnusedEngine).unwrap(),
+            Some(Scalar::Null(data_type))
+        );
+    }
+
+    #[test]
+    fn evaluate_returns_none_for_unparsable_default() {
+        let d = ColumnDefault::new("current_timestamp()".into(), DataType::TIMESTAMP).unwrap();
+        assert!(!d.is_kernel_parsable());
+        assert_eq!(d.evaluate(&UnusedEngine).unwrap(), None);
+    }
+
+    #[test]
+    fn evaluate_errors_on_non_literal_parsed_expression() {
+        // The parser only emits literals in normal use; construct a non-literal directly to reach
+        // the defensive error arm.
+        let d = ColumnDefault {
+            raw_sql: "x".into(),
+            data_type: DataType::INTEGER,
+            parsed_sql: Some(Expression::column(["x"])),
+        };
+        let err = d
+            .evaluate(&UnusedEngine)
+            .expect_err("non-literal parsed expression must error")
+            .to_string();
+        assert!(err.contains("non-literal"), "got: {err}");
+    }
+}

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -23,6 +23,10 @@ use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
+#[cfg(feature = "column-defaults-in-dev")]
+mod column_default;
+#[cfg(feature = "column-defaults-in-dev")]
+pub use column_default::ColumnDefault;
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::DeltaResult;
 use test_utils::{schema_with_column_defaults, test_table_setup};
@@ -40,6 +40,33 @@ fn test_schema_with_column_defaults_errors_on_unknown_column() {
     assert!(
         err.contains("does_not_exist"),
         "error should name the unknown column; got: {err}",
+    );
+}
+
+#[test]
+fn test_schema_with_column_defaults_reports_all_unknown_columns() {
+    let schema = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+
+    let err =
+        schema_with_column_defaults(&schema, HashMap::from([("ghost1", "1"), ("ghost2", "2")]))
+            .expect_err("all unknown columns must produce an error")
+            .to_string();
+    assert!(err.contains("ghost1"), "error must name ghost1; got: {err}");
+    assert!(err.contains("ghost2"), "error must name ghost2; got: {err}");
+}
+
+#[test]
+fn test_schema_with_column_defaults_overwrites_existing_default() {
+    let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+    let with_first = schema_with_column_defaults(&base, HashMap::from([("c", "1")])).unwrap();
+    let with_second =
+        schema_with_column_defaults(&with_first, HashMap::from([("c", "99")])).unwrap();
+
+    let field = with_second.field("c").expect("c field must exist");
+    assert_eq!(
+        field.get_config_value(&ColumnMetadataKey::CurrentDefault),
+        Some(&MetadataValue::String("99".to_string())),
+        "second call must overwrite the first CURRENT_DEFAULT value",
     );
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -746,21 +746,20 @@ pub fn schema_with_column_defaults(
     schema: &StructType,
     mut column_defaults: HashMap<&str, &str>,
 ) -> DeltaResult<SchemaRef> {
-    let mut augmented_fields = Vec::with_capacity(schema.fields().len());
-    for field in schema.fields() {
-        let augmented = match column_defaults.remove(field.name.as_str()) {
+    let augmented_fields: Vec<_> = schema
+        .fields()
+        .map(|field| match column_defaults.remove(field.name.as_str()) {
             Some(sql) => field.clone().add_metadata([(
                 ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
                 MetadataValue::String(sql.to_string()),
             )]),
             None => field.clone(),
-        };
-        augmented_fields.push(augmented);
-    }
+        })
+        .collect();
     if !column_defaults.is_empty() {
-        let unknown: Vec<&str> = column_defaults.into_keys().collect();
         return Err(Error::generic(format!(
-            "column defaults reference unknown top-level columns: {unknown:?}"
+            "column defaults reference unknown top-level columns: {:?}",
+            column_defaults.into_keys().collect::<Vec<_>>()
         )));
     }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2797/files) to review incremental changes.
- [stack/column-defaults-feature-flag](https://github.com/delta-io/delta-kernel-rs/pull/2636) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2636/files)] [MERGED]
  - [stack/column-defaults-sql-parser](https://github.com/delta-io/delta-kernel-rs/pull/2670) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2670/files)] [MERGED]
    - [stack/column-defaults-create-helper](https://github.com/delta-io/delta-kernel-rs/pull/2686) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2686/files)] [MERGED]
      - [**stack/column-defaults-struct**](https://github.com/delta-io/delta-kernel-rs/pull/2797) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2797/files)] ← _this PR_
        - [stack/column-defaults-schema-method](https://github.com/delta-io/delta-kernel-rs/pull/2808) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2808/files/3c9a58f54a89e530137cd906c5957a505048590c..ddceb253a2adfbb35d9554c947ff4cf92927672a)]
          - stack/column-defaults-ffi-support

---------
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2797/files) to review incremental changes.
- [stack/column-defaults-feature-flag](https://github.com/delta-io/delta-kernel-rs/pull/2636) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2636/files)] [MERGED]
  - [stack/column-defaults-sql-parser](https://github.com/delta-io/delta-kernel-rs/pull/2670) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2670/files)] [MERGED]
    - [stack/column-defaults-create-helper](https://github.com/delta-io/delta-kernel-rs/pull/2686) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2686/files)] [MERGED]
      - [**stack/column-defaults-struct**](https://github.com/delta-io/delta-kernel-rs/pull/2797) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2797/files)]
        - [stack/column-defaults-schema-method](https://github.com/delta-io/delta-kernel-rs/pull/2808) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2808/files/3c9a58f54a89e530137cd906c5957a505048590c..b434e99ffcb762ddf558852519f90db5662c3ed6)]
          - stack/column-defaults-ffi-support

---------
## What changes are proposed in this pull request?
This PR adds the in memory kernel representation of column defaults. This method will be constructed at write time through either the schema or transaction methods which are yet to be implemented. Currently this struct is not wired up.

## How was this change tested?
New Unit Tests.

## Resources
Tracking Issue #2630