### PR TITLE
fix: stop tracing events from warning on metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,9 +284,10 @@ Keep this list updated when new protocol features are added to kernel.
   any tracing macro inside a `tracing_subscriber::Layer` callback (`on_event`, `on_record`,
   `on_close`) while holding a span's `extensions_mut()` write lock will re-enter the layer
   and deadlock on the same lock. In `on_new_span`, no extension lock is held during
-  `attrs.record()`, so direct `warn!()` is safe there. In `on_event` and `on_record`, store
-  warnings in a `pending_warnings: Vec<String>` field on the visitor, take them out after
-  the extensions block closes, and emit via `warn!()` only then. See
+  `attrs.record()`, so direct `warn!()` is safe there. In `on_record`, store warnings in a
+  `pending_warnings: Vec<String>` field on the visitor, take them out after the extensions
+  block closes, and emit via `warn!()` only then. (`on_event`'s visitor does no
+  warning-eligible work, so it may run under the lock directly.) See
   `kernel/src/metrics/reporter.rs` for the canonical pattern.
 
 ## Code Style

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -148,12 +148,21 @@ where
         }
     }
 
-    // RUNTIME CHANNEL. Both on_event and on_record route Span::current().record(...) updates
-    // (and info!() events within a span) through EventVisitor -> MetricEvent::record_u64 /
-    // record_bool. The visitor's record_debug also handles `#[instrument(err)]`'s `error` field,
-    // flipping a success event into its failure counterpart.
+    // RUNTIME CHANNEL. on_record is the metric-write channel: it routes Span::record(...) updates
+    // through EventVisitor -> MetricEvent::record_u64 / record_bool / record_str. on_event carries
+    // log lines, not metric writes; its only metric effect is the `#[instrument(err)]` failure
+    // signal, which FailureFlipVisitor turns into the event's failure counterpart. Every other
+    // event field is ignored.
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
-        Self::drain_into_visitor(ctx.event_span(event), |v| event.record(v));
+        let Some(span) = ctx.event_span(event) else {
+            return;
+        };
+        let mut extensions = span.extensions_mut();
+        if let Some(visitor) = extensions.get_mut::<EventVisitor>() {
+            event.record(&mut FailureFlipVisitor {
+                event: &mut visitor.event,
+            });
+        }
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
@@ -256,14 +265,125 @@ impl Visit for EventVisitor {
         }
     }
 
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {
+        // Debug-typed fields carry no metric values; `.record()` only delivers u64/bool/str.
+    }
+}
+
+// ====================================================================
+// FailureFlipVisitor: the event channel's only metric effect
+// ====================================================================
+
+/// Event-path visitor for the synthetic event `#[instrument(err)]` emits on `Err` return.
+///
+/// Flips the span's in-flight success event to its failure counterpart and ignores every other
+/// field, so arbitrary log-line fields never reach the metric allowlist.
+struct FailureFlipVisitor<'a> {
+    event: &'a mut Option<MetricEvent>,
+}
+
+impl Visit for FailureFlipVisitor<'_> {
     fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
-        match field.name() {
-            "return" => {} // default to the success case
-            "error" => {
-                // `#[instrument(err)]` records `error` when the wrapped function returns Err.
-                self.event = self.event.take().map(MetricEvent::into_failure);
-            }
-            _ => {}
+        if field.name() == "error" {
+            *self.event = self.event.take().map(MetricEvent::into_failure);
         }
+    }
+}
+
+// ====================================================================
+// Tests
+// ====================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::io::Error;
+    use std::sync::{Arc, Mutex};
+
+    use test_utils::{ensure_metrics_compatible_global_subscriber, LogWriter};
+    use tracing::field::Empty;
+    use tracing::subscriber::with_default;
+    use tracing::{info, info_span, instrument};
+    use tracing_subscriber::fmt::layer;
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use tracing_subscriber::registry;
+    use uuid::Uuid;
+
+    use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
+    use crate::metrics::{MetricEvent, WithMetricsReporterLayer as _};
+    use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+    /// Run `f` under a subscriber that layers the metrics layer over an fmt layer capturing to a
+    /// buffer, and return the captured log text -- so a test can assert on the warnings the metrics
+    /// layer emits.
+    fn capture_logs(f: impl FnOnce()) -> String {
+        ensure_metrics_compatible_global_subscriber();
+        let logs = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let logs_writer = Arc::clone(&logs);
+        let subscriber = registry()
+            .with(
+                layer()
+                    .with_writer(move || LogWriter(Arc::clone(&logs_writer)))
+                    .with_ansi(false),
+            )
+            .with_metrics_reporter_layer(Arc::new(CapturingReporter::default()));
+        with_default(subscriber, f);
+        let bytes = logs.lock().unwrap().clone();
+        String::from_utf8(bytes).unwrap()
+    }
+
+    // info_span! requires a string-literal name; assert it still matches the span const.
+    #[test]
+    fn log_event_field_inside_reporting_span_does_not_warn() {
+        assert_eq!(SNAPSHOT_COMPLETED_SPAN, "snap.build");
+        let logs = capture_logs(|| {
+            let span = info_span!(
+                "snap.build",
+                report = Empty,
+                operation_id = %Uuid::new_v4(),
+            );
+            let _enter = span.enter();
+            info!(log_tail_len = 5u64, "building snapshot");
+        });
+        assert!(
+            !logs.contains("Invalid field"),
+            "a log line's fields must not be judged as metric writes; got: {logs}"
+        );
+    }
+
+    #[test]
+    fn recorded_unknown_field_still_warns() {
+        assert_eq!(SNAPSHOT_COMPLETED_SPAN, "snap.build");
+        let logs = capture_logs(|| {
+            let span = info_span!(
+                "snap.build",
+                report = Empty,
+                operation_id = %Uuid::new_v4(),
+                bogus = Empty,
+            );
+            span.record("bogus", 7u64);
+        });
+        assert!(
+            logs.contains("Invalid field 'bogus' recorded on snap.build span"),
+            "an unrecognized .record() field is a declared-field typo and must still warn; got: {logs}"
+        );
+    }
+
+    #[instrument(name = SNAPSHOT_COMPLETED_SPAN, fields(report, operation_id = %Uuid::new_v4()), err)]
+    fn failing_build() -> Result<(), Error> {
+        Err(Error::other("boom"))
+    }
+
+    #[test]
+    fn instrument_err_event_still_flips_to_failure() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        let _ = failing_build();
+        assert!(
+            reporter
+                .events()
+                .iter()
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildFailure(_))),
+            "#[instrument(err)] must flip the success event to its failure form via on_event"
+        );
     }
 }

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -148,11 +148,10 @@ where
         }
     }
 
-    // RUNTIME CHANNEL. on_record is the metric-write channel: it routes Span::record(...) updates
-    // through EventVisitor -> MetricEvent::record_u64 / record_bool / record_str. on_event carries
-    // log lines, not metric writes; its only metric effect is the `#[instrument(err)]` failure
-    // signal, which FailureFlipVisitor turns into the event's failure counterpart. Every other
-    // event field is ignored.
+    // RUNTIME CHANNEL. on_event carries log lines, not metric writes; its only metric effect is the
+    // `#[instrument(err)]` failure signal, which FailureFlipVisitor turns into the event's failure
+    // counterpart. on_record is the metric-write channel: it routes Span::record(...) updates
+    // through EventVisitor -> MetricEvent::record_u64 / record_bool / record_str.
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
         let Some(span) = ctx.event_span(event) else {
             return;
@@ -266,7 +265,9 @@ impl Visit for EventVisitor {
     }
 
     fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {
-        // Debug-typed fields carry no metric values; `.record()` only delivers u64/bool/str.
+        // Kernel records every metric field as u64/bool/str (handled above). Anything arriving here
+        // is a debug-formatted log field (or a numeric type tracing forwards to record_debug), not
+        // a metric write.
     }
 }
 
@@ -284,6 +285,9 @@ struct FailureFlipVisitor<'a> {
 
 impl Visit for FailureFlipVisitor<'_> {
     fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+        // `#[instrument(err)]` emits a synthetic event with an `error` field (via Display, hence
+        // record_debug) when the wrapped fn returns Err. That field name is a tracing convention,
+        // not ours; `instrument_err_event_still_flips_to_failure` guards against it drifting.
         if field.name() == "error" {
             *self.event = self.event.take().map(MetricEvent::into_failure);
         }
@@ -368,6 +372,39 @@ mod tests {
         );
     }
 
+    // A log line whose field name collides with a real metric field must NOT overwrite the value a
+    // genuine `span.record` wrote -- the core guarantee of narrowing on_event to
+    // FailureFlipVisitor. capture_logs discards the reporter, so this test installs a
+    // CapturingReporter to inspect the reported event.
+    #[test]
+    fn log_event_reusing_a_metric_field_name_does_not_overwrite_recorded_metric() {
+        assert_eq!(SNAPSHOT_COMPLETED_SPAN, "snap.build");
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        {
+            let span = info_span!(
+                "snap.build",
+                report = Empty,
+                operation_id = %Uuid::new_v4(),
+                version = Empty,
+            );
+            let _enter = span.enter();
+            span.record("version", 7u64); // real metric write via the on_record channel
+            info!(version = 999u64, "noise"); // log line reusing the metric field name (on_event)
+        } // span close -> report
+        let events = reporter.events();
+        let Some(MetricEvent::SnapshotBuildSuccess(success)) = events
+            .iter()
+            .find(|e| matches!(e, MetricEvent::SnapshotBuildSuccess(_)))
+        else {
+            panic!("expected a snapshot build success event; got: {events:?}");
+        };
+        assert_eq!(
+            success.version, 7,
+            "an on_event log field must not overwrite a span.record metric"
+        );
+    }
+
     #[instrument(name = SNAPSHOT_COMPLETED_SPAN, fields(report, operation_id = %Uuid::new_v4()), err)]
     fn failing_build() -> Result<(), Error> {
         Err(Error::other("boom"))
@@ -384,6 +421,31 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, MetricEvent::SnapshotBuildFailure(_))),
             "#[instrument(err)] must flip the success event to its failure form via on_event"
+        );
+    }
+
+    #[instrument(name = SNAPSHOT_COMPLETED_SPAN, fields(report, operation_id = %Uuid::new_v4()), ret)]
+    fn succeeding_build() -> Result<(), Error> {
+        Ok(())
+    }
+
+    #[test]
+    fn instrument_ret_event_does_not_flip_to_failure() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        let _ = succeeding_build();
+        let events = reporter.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildSuccess(_))),
+            "#[instrument(ret)]'s `return` field must NOT flip success to failure; got: {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::SnapshotBuildFailure(_))),
+            "a successful #[instrument(ret)] must not emit a failure event; got: {events:?}"
         );
     }
 }

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -150,8 +150,7 @@ where
 
     // RUNTIME CHANNEL. on_event carries log lines, not metric writes; its only metric effect is the
     // `#[instrument(err)]` failure signal, which FailureFlipVisitor turns into the event's failure
-    // counterpart. on_record is the metric-write channel: it routes Span::record(...) updates
-    // through EventVisitor -> MetricEvent::record_u64 / record_bool / record_str.
+    // counterpart.
     fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
         let Some(span) = ctx.event_span(event) else {
             return;
@@ -287,16 +286,12 @@ impl Visit for FailureFlipVisitor<'_> {
     fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
         // `#[instrument(err)]` emits a synthetic event with an `error` field (via Display, hence
         // record_debug) when the wrapped fn returns Err. That field name is a tracing convention,
-        // not ours; `instrument_err_event_still_flips_to_failure` guards against it drifting.
+        // not kernel's.
         if field.name() == "error" {
             *self.event = self.event.take().map(MetricEvent::into_failure);
         }
     }
 }
-
-// ====================================================================
-// Tests
-// ====================================================================
 
 #[cfg(test)]
 mod tests {
@@ -335,9 +330,9 @@ mod tests {
         String::from_utf8(bytes).unwrap()
     }
 
-    // info_span! requires a string-literal name; assert it still matches the span const.
     #[test]
     fn log_event_field_inside_reporting_span_does_not_warn() {
+        // info_span! requires a string-literal name; assert it still matches the span const.
         assert_eq!(SNAPSHOT_COMPLETED_SPAN, "snap.build");
         let logs = capture_logs(|| {
             let span = info_span!(

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -73,6 +73,7 @@ impl AlterTableTransaction {
             // now: safe, but misses the true-case optimization delta-spark applies.
             is_blind_append: false,
             dv_matched_files: vec![],
+            num_dv_updates: 0,
             physical_clustering_columns: None,
             _state: PhantomData,
         })

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -173,6 +173,7 @@ impl CreateTableTransaction {
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
+            num_dv_updates: 0,
             physical_clustering_columns: clustering_columns,
             _state: PhantomData,
         })

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -246,10 +246,7 @@ pub struct Transaction<S = ExistingTable> {
     // Files matched by update_deletion_vectors() with new DV descriptors appended. These are used
     // to generate remove/add action pairs during commit, ensuring file statistics are preserved.
     dv_matched_files: Vec<FilteredEngineData>,
-    // Count of files whose deletion vector was updated. Unlike num_add_files/num_remove_files
-    // (derived from file_stats at commit time), a DV update lowers to a remove+add pair and so
-    // can't be distinguished from an ordinary rewrite by counting files -- we accumulate the
-    // count as update_deletion_vectors() validates each call instead.
+    // Count of files whose deletion vector was updated.
     num_dv_updates: usize,
     // Clustering columns from domain metadata. Only populated if the ClusteredTable feature is
     // enabled. Used for determining which columns require statistics collection. Expected to be

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -246,8 +246,10 @@ pub struct Transaction<S = ExistingTable> {
     // Files matched by update_deletion_vectors() with new DV descriptors appended. These are used
     // to generate remove/add action pairs during commit, ensuring file statistics are preserved.
     dv_matched_files: Vec<FilteredEngineData>,
-    // Count of files whose deletion vector was updated, accumulated across
-    // update_deletion_vectors() calls from each call's validated descriptor count.
+    // Count of files whose deletion vector was updated. Unlike num_add_files/num_remove_files
+    // (derived from file_stats at commit time), a DV update lowers to a remove+add pair and so
+    // can't be distinguished from an ordinary rewrite by counting files -- we accumulate the
+    // count as update_deletion_vectors() validates each call instead.
     num_dv_updates: usize,
     // Clustering columns from domain metadata. Only populated if the ClusteredTable feature is
     // enabled. Used for determining which columns require statistics collection. Expected to be

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 
 use delta_kernel_derive::internal_api;
-use tracing::{info, instrument};
+use tracing::instrument;
 
 use crate::actions::{
     as_log_add_schema, CommitInfo, DomainMetadata, Metadata, Protocol, SetTransaction,
@@ -246,6 +246,9 @@ pub struct Transaction<S = ExistingTable> {
     // Files matched by update_deletion_vectors() with new DV descriptors appended. These are used
     // to generate remove/add action pairs during commit, ensuring file statistics are preserved.
     dv_matched_files: Vec<FilteredEngineData>,
+    // Count of files whose deletion vector was updated, accumulated across
+    // update_deletion_vectors() calls from each call's validated descriptor count.
+    num_dv_updates: usize,
     // Clustering columns from domain metadata. Only populated if the ClusteredTable feature is
     // enabled. Used for determining which columns require statistics collection. Expected to be
     // physical column names.
@@ -336,6 +339,7 @@ impl<S> Transaction<S> {
             commit_version = self.get_commit_version(),
             num_add_files,
             num_remove_files,
+            num_dv_updates,
             add_files_bytes,
             remove_files_bytes,
             is_blind_append,
@@ -349,14 +353,6 @@ impl<S> Transaction<S> {
     )]
     pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult<S>> {
         let commit_start = Instant::now();
-        // Fields-only event: these feed the `txn.commit` metric via the layer's `on_event`
-        // channel. `num_dv_updates` has no other source (it is not a declared span field and
-        // gets no `span.record` below), so this event must keep its structured fields.
-        info!(
-            num_add_files = self.add_files_metadata.len(),
-            num_remove_files = self.remove_files_metadata.len(),
-            num_dv_updates = self.dv_matched_files.len(),
-        );
 
         // Some table features don't yet support removeFiles. Reject here.
         if !self.remove_files_metadata.is_empty() {
@@ -557,6 +553,7 @@ impl<S> Transaction<S> {
         let span = tracing::Span::current();
         span.record("num_add_files", file_stats.gross_add_files);
         span.record("num_remove_files", file_stats.gross_remove_files);
+        span.record("num_dv_updates", self.num_dv_updates as u64);
         span.record("add_files_bytes", file_stats.gross_add_bytes);
         span.record("remove_files_bytes", file_stats.gross_remove_bytes);
         span.record("is_blind_append", self.is_blind_append);
@@ -1016,7 +1013,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
             .effective_table_config
             .is_feature_enabled(&TableFeature::AllowColumnDefaults)
         {
-            info!(
+            tracing::info!(
                 "allowColumnDefaults is not enabled; the schema may contain orphaned column-default metadata"
             );
             return Ok(HashMap::new());

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -107,6 +107,7 @@ impl Transaction {
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
+            num_dv_updates: 0,
             physical_clustering_columns: clustering_columns,
             _state: PhantomData,
         })
@@ -344,6 +345,8 @@ impl Transaction {
         }
 
         self.dv_matched_files.extend(matched_files);
+        // matched_dv_files is this call's validated count of files whose DV was updated.
+        self.num_dv_updates += matched_dv_files;
         Ok(())
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -345,7 +345,6 @@ impl Transaction {
         }
 
         self.dv_matched_files.extend(matched_files);
-        // Reached only after the count == descriptors check above, so this can't over-count.
         self.num_dv_updates += matched_dv_files;
         Ok(())
     }

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -345,7 +345,7 @@ impl Transaction {
         }
 
         self.dv_matched_files.extend(matched_files);
-        // matched_dv_files is this call's validated count of files whose DV was updated.
+        // Reached only after the count == descriptors check above, so this can't over-count.
         self.num_dv_updates += matched_dv_files;
         Ok(())
     }

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use delta_kernel::actions::deletion_vector::DeletionVectorDescriptor;
+use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::actions::deletion_vector_writer::{
     KernelDeletionVector, StreamingDeletionVectorWriter,
 };
@@ -420,6 +420,28 @@ pub async fn create_dv_table_with_files(
 
     let paths: Vec<String> = file_paths.iter().map(|&s| s.to_string()).collect();
     Ok((store, engine, table_url, paths))
+}
+
+/// Build a `path -> descriptor` map assigning each file a distinct synthetic DV descriptor.
+pub fn sequential_dv_descriptors(
+    file_paths: &[String],
+) -> HashMap<String, DeletionVectorDescriptor> {
+    file_paths
+        .iter()
+        .enumerate()
+        .map(|(idx, path)| {
+            (
+                path.clone(),
+                DeletionVectorDescriptor {
+                    storage_type: DeletionVectorStorageType::PersistedRelative,
+                    path_or_inline_dv: format!("dv_file_{idx}.bin"),
+                    offset: Some(idx as i32 * 10),
+                    size_in_bytes: 40 + idx as i32,
+                    cardinality: idx as i64 + 1,
+                },
+            )
+        })
+        .collect()
 }
 
 /// Extracts scan files from a snapshot for use in deletion vector updates.

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -3,11 +3,8 @@
 //! Each test builds a table, attaches a metrics reporter, runs a commit, and asserts the
 //! commit metrics a real connector would observe.
 
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use delta_kernel::actions::deletion_vector::DeletionVectorDescriptor;
-use delta_kernel::actions::deletion_vector::DeletionVectorStorageType::PersistedRelative;
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::metrics::{MetricEvent, MetricsReporter, TableType, TransactionCommitSuccess};
@@ -19,14 +16,16 @@ use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
-    begin_transaction, insert_data, insert_data_with, install_thread_local_metrics_reporter,
-    test_table_setup_mt,
+    begin_transaction, create_add_files_metadata, insert_data, insert_data_with,
+    install_thread_local_metrics_reporter, test_table_setup_mt,
 };
 use url::Url;
 
 use super::table_type::{create_simple_table, make_committer};
 use super::{measuring_engine, simple_schema};
-use crate::common::write_utils::{create_dv_table_with_files, get_scan_files};
+use crate::common::write_utils::{
+    create_dv_table_with_files, get_scan_files, sequential_dv_descriptors,
+};
 
 /// Reporter that keeps the last `TransactionCommitSuccess` for field-level assertions.
 #[derive(Debug, Default)]
@@ -37,6 +36,17 @@ impl MetricsReporter for LastCommitSuccess {
         if let MetricEvent::TransactionCommitSuccess(success) = event {
             *self.0.lock().unwrap() = Some(success);
         }
+    }
+}
+
+impl LastCommitSuccess {
+    /// Returns the last captured commit-success event, panicking if none was recorded.
+    fn take_success(&self) -> TransactionCommitSuccess {
+        self.0
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("commit success event")
     }
 }
 
@@ -78,12 +88,7 @@ async fn commit_append_emits_success_metrics(
     .await?
     .unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(success.table_type, TableType::PathBased);
     assert_eq!(success.commit_version, 1);
     assert_eq!(success.num_add_files, 1);
@@ -94,6 +99,43 @@ async fn commit_append_emits_success_metrics(
     assert_eq!(success.data_change, data_change);
     assert_eq!(success.is_blind_append, is_blind_append);
     assert!(success.total_duration >= success.prepare_duration + success.committer_duration);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_reports_added_file_count_not_batch_count() -> DeltaResult<()> {
+    // num_add_files counts added FILES, not add_files() batches: two batches of two files each
+    // must report 4. A regression to add_files_metadata.len() (a batch count) would report 2.
+    let (_temp_dir, table_url) = setup_empty_table()?;
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let engine = Arc::new(DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new())).build());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+    let snap = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+
+    let mut txn = begin_transaction(snap, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .with_data_change(true);
+    let add_files_schema = txn.add_files_schema();
+    // Two separate add_files() calls -> two batches, four files total.
+    let batches = vec![
+        vec![
+            ("f0.parquet", 1024, 1_000_000, Some(3)),
+            ("f1.parquet", 1124, 1_000_001, Some(3)),
+        ],
+        vec![
+            ("f2.parquet", 1224, 1_000_002, Some(3)),
+            ("f3.parquet", 1324, 1_000_003, Some(3)),
+        ],
+    ];
+    for batch in batches {
+        let metadata = create_add_files_metadata(add_files_schema, batch)
+            .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
+        txn.add_files(metadata);
+    }
+    txn.commit(engine.as_ref())?.unwrap_committed();
+
+    let success = reporter.take_success();
+    assert_eq!(success.num_add_files, 4);
     Ok(())
 }
 
@@ -111,12 +153,7 @@ async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
         .commit(setup_engine.as_ref())?
         .unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(success.commit_version, 0);
     assert_eq!(success.correlation_id.as_deref(), Some("commit-req-1"));
     Ok(())
@@ -147,12 +184,7 @@ async fn create_table_builder_carries_correlation_id(
         .commit(engine.as_ref())?
         .unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(success.commit_version, 0);
     assert_eq!(success.correlation_id.as_deref(), expected);
     Ok(())
@@ -194,12 +226,7 @@ async fn alter_table_builder_carries_correlation_id(
         .commit(engine.as_ref())?
         .unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(success.commit_version, 1);
     assert_eq!(success.correlation_id.as_deref(), expected);
     Ok(())
@@ -264,12 +291,7 @@ async fn commit_success_carries_table_type(#[case] catalog_managed: bool) -> Del
     .await?
     .unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(
         success.table_type,
         TableType::from_catalog_managed(catalog_managed)
@@ -300,29 +322,47 @@ async fn commit_dv_update_reports_updated_file_count_not_batch_count(
         .with_data_change(true);
 
     let mut scan_files = get_scan_files(snapshot, engine.as_ref())?;
-    let dv_map: HashMap<String, DeletionVectorDescriptor> = file_paths
-        .iter()
-        .enumerate()
-        .map(|(idx, path)| {
-            let descriptor = DeletionVectorDescriptor {
-                storage_type: PersistedRelative,
-                path_or_inline_dv: format!("dv_file_{idx}.bin"),
-                offset: Some(idx as i32 * 10),
-                size_in_bytes: 40 + idx as i32,
-                cardinality: idx as i64 + 1,
-            };
-            (path.to_string(), descriptor)
-        })
-        .collect();
+    let dv_map = sequential_dv_descriptors(&file_paths);
     txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
     txn.commit(engine.as_ref())?.unwrap_committed();
 
-    let success = reporter
-        .0
-        .lock()
-        .unwrap()
-        .clone()
-        .expect("commit success event");
+    let success = reporter.take_success();
     assert_eq!(success.num_dv_updates, 3);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_dv_update_accumulates_file_count_across_calls(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // num_dv_updates must accumulate (`+=`) across multiple update_deletion_vectors calls on one
+    // transaction: two calls updating one file each must report 2, not the last call's 1.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::STRING),
+    ])?);
+    let file_names = &["file0.parquet", "file1.parquet"];
+    let (_store, engine, table_url, file_paths) =
+        create_dv_table_with_files("dv_metrics_multi_call_table", schema, file_names).await?;
+
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?
+        .with_operation("UPDATE".to_string())
+        .with_data_change(true);
+
+    // Each call re-derives scan files from the same snapshot and updates exactly one file, so
+    // matched_dv_files is 1 per call and the accumulator must reach 2.
+    let all_descriptors = sequential_dv_descriptors(&file_paths);
+    for path in &file_paths {
+        let mut scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
+        let dv_map = std::iter::once((path.clone(), all_descriptors[path].clone())).collect();
+        txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
+    }
+    txn.commit(engine.as_ref())?.unwrap_committed();
+
+    let success = reporter.take_success();
+    assert_eq!(success.num_dv_updates, 2);
     Ok(())
 }

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -3,25 +3,30 @@
 //! Each test builds a table, attaches a metrics reporter, runs a commit, and asserts the
 //! commit metrics a real connector would observe.
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use delta_kernel::actions::deletion_vector::DeletionVectorDescriptor;
+use delta_kernel::actions::deletion_vector::DeletionVectorStorageType::PersistedRelative;
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::metrics::{MetricEvent, MetricsReporter, TableType, TransactionCommitSuccess};
 use delta_kernel::object_store::local::LocalFileSystem;
-use delta_kernel::schema::{DataType, StructField};
+use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
-    insert_data, insert_data_with, install_thread_local_metrics_reporter, test_table_setup_mt,
+    begin_transaction, insert_data, insert_data_with, install_thread_local_metrics_reporter,
+    test_table_setup_mt,
 };
 use url::Url;
 
 use super::table_type::{create_simple_table, make_committer};
 use super::{measuring_engine, simple_schema};
+use crate::common::write_utils::{create_dv_table_with_files, get_scan_files};
 
 /// Reporter that keeps the last `TransactionCommitSuccess` for field-level assertions.
 #[derive(Debug, Default)]
@@ -269,5 +274,55 @@ async fn commit_success_carries_table_type(#[case] catalog_managed: bool) -> Del
         success.table_type,
         TableType::from_catalog_managed(catalog_managed)
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn commit_dv_update_reports_updated_file_count_not_batch_count(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Three files get a new deletion vector in a single update_deletion_vectors call.
+    // num_dv_updates must be the count of updated FILES (3), not the number of scan-metadata
+    // batches they arrive in -- a single batch carrying all three would otherwise report 1.
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::STRING),
+    ])?);
+    let file_names = &["file0.parquet", "file1.parquet", "file2.parquet"];
+    let (_store, engine, table_url, file_paths) =
+        create_dv_table_with_files("dv_metrics_table", schema, file_names).await?;
+
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?
+        .with_operation("UPDATE".to_string())
+        .with_data_change(true);
+
+    let mut scan_files = get_scan_files(snapshot, engine.as_ref())?;
+    let dv_map: HashMap<String, DeletionVectorDescriptor> = file_paths
+        .iter()
+        .enumerate()
+        .map(|(idx, path)| {
+            let descriptor = DeletionVectorDescriptor {
+                storage_type: PersistedRelative,
+                path_or_inline_dv: format!("dv_file_{idx}.bin"),
+                offset: Some(idx as i32 * 10),
+                size_in_bytes: 40 + idx as i32,
+                cardinality: idx as i64 + 1,
+            };
+            (path.to_string(), descriptor)
+        })
+        .collect();
+    txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
+    txn.commit(engine.as_ref())?.unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(success.num_dv_updates, 3);
     Ok(())
 }

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -16,8 +16,8 @@ use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
-    begin_transaction, create_add_files_metadata, insert_data, insert_data_with,
-    install_thread_local_metrics_reporter, test_table_setup_mt,
+    assert_result_error_with_message, begin_transaction, create_add_files_metadata, insert_data,
+    insert_data_with, install_thread_local_metrics_reporter, test_table_setup_mt,
 };
 use url::Url;
 
@@ -321,6 +321,18 @@ async fn commit_dv_update_reports_updated_file_count_not_batch_count(
         .with_operation("UPDATE".to_string())
         .with_data_change(true);
 
+    let mut paths_with_unmatched = file_paths.clone();
+    paths_with_unmatched.push("missing.parquet".to_string());
+    let mut scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
+    assert_result_error_with_message(
+        txn.update_deletion_vectors(
+            sequential_dv_descriptors(&paths_with_unmatched),
+            scan_files.drain(..).map(Ok),
+        ),
+        "Number of matched DV files does not match number of new DV descriptors: 3 != 4",
+    );
+
+    // A failed call with an unmatched path must not contribute its three matched files.
     let mut scan_files = get_scan_files(snapshot, engine.as_ref())?;
     let dv_map = sequential_dv_descriptors(&file_paths);
     txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -26,8 +26,8 @@ use test_utils::{
 use url::Url;
 
 use crate::common::write_utils::{
-    create_dv_table_with_files, get_scan_files, get_simple_int_schema, set_table_properties,
-    write_data_and_check_result_and_stats,
+    create_dv_table_with_files, get_scan_files, get_simple_int_schema, sequential_dv_descriptors,
+    set_table_properties, write_data_and_check_result_and_stats,
 };
 
 #[tokio::test]
@@ -543,17 +543,7 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
     let mut scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
 
     // Update deletion vectors for all 3 files in a single call
-    let mut dv_map = HashMap::new();
-    for (idx, file_path) in file_paths.iter().enumerate() {
-        let descriptor = DeletionVectorDescriptor {
-            storage_type: DeletionVectorStorageType::PersistedRelative,
-            path_or_inline_dv: format!("dv_file_{idx}.bin"),
-            offset: Some(idx as i32 * 10),
-            size_in_bytes: 40 + idx as i32,
-            cardinality: idx as i64 + 1,
-        };
-        dv_map.insert(file_path.to_string(), descriptor);
-    }
+    let dv_map = sequential_dv_descriptors(&file_paths);
 
     txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Treat tracing events inside metric spans as log output rather than metric field updates. Metric values now come from span attributes and `Span::record`, while `#[instrument(err)]` events still convert success metrics to failures. This prevents unrelated log fields from producing invalid-field warnings or overwriting metric values.
- Report transaction file metrics using actual file counts. `num_add_files` and `num_remove_files` come from commit-time file statistics. For `num_dv_updates`, the transaction accumulates the number of matched files after each validated `update_deletion_vectors` call instead of counting `FilteredEngineData` scan-metadata batches, so the metric remains correct for multiple files in one batch and across multiple calls.

## How was this change tested?

Added unit and integration coverage for:

- log-event fields not warning or overwriting metric values;
- invalid span-recorded fields still warning and `#[instrument(err)]` still reporting failures;
- added-file metrics counting files across batches;
- DV-update metrics counting multiple files in one batch and accumulating across calls.

Validated with:

- `cargo +nightly fmt --check`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo nextest run --workspace --all-features`