### PR TITLE
fix: update use statements in default engine doc strings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,8 @@ jobs:
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: test
         run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+      - name: doc tests
+        run: cargo test --locked --workspace --all-features --doc
       - name: trybuild tests
         if: steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -104,8 +104,8 @@ pub struct DefaultEngine<E: TaskExecutor> {
 ///
 /// ```no_run
 /// # use std::sync::Arc;
-/// # use delta_kernel::engine::default::DefaultEngineBuilder;
-/// # use delta_kernel::engine::default::executor::tokio::TokioBackgroundExecutor;
+/// # use delta_kernel_default_engine::DefaultEngineBuilder;
+/// # use delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 /// # use delta_kernel::object_store::local::LocalFileSystem;
 /// // Build a DefaultEngine with default executor
 /// let engine = DefaultEngineBuilder::new(Arc::new(LocalFileSystem::new()))

--- a/default-engine/src/storage.rs
+++ b/default-engine/src/storage.rs
@@ -47,7 +47,7 @@ pub fn insert_url_handler(
 ///
 /// ```rust
 /// # use url::Url;
-/// # use delta_kernel::engine::default::storage::store_from_url;
+/// # use delta_kernel_default_engine::storage::store_from_url;
 /// # use delta_kernel::DeltaResult;
 /// # fn example() -> DeltaResult<()> {
 /// let url = Url::parse("file:///path/to/table")?;
@@ -71,7 +71,7 @@ pub fn store_from_url(url: &Url) -> delta_kernel::DeltaResult<Arc<dyn ObjectStor
 /// ```rust
 /// # use url::Url;
 /// # use std::collections::HashMap;
-/// # use delta_kernel::engine::default::storage::store_from_url_opts;
+/// # use delta_kernel_default_engine::storage::store_from_url_opts;
 /// # use delta_kernel::DeltaResult;
 /// # fn example() -> DeltaResult<()> {
 /// let url = Url::parse("s3://my-bucket/path/to/table")?;


### PR DESCRIPTION
* Fixes `use` statements in the default engine doc strings.
* Adds a `cargo test --doc` run in CI to catch problems like this in future. This is required because `nextest` doesn't support running doc tests.

Fixes #2800


