### PR TITLE
feat: accept millisecond-precision timestamps in arrow-to-kernel conversion

### DIFF
--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -577,9 +577,11 @@ mod tests {
     use delta_kernel::arrow::array::{
         Array, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array, Float64Array,
         Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
-        TimestampMicrosecondArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray,
     };
-    use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+    use delta_kernel::arrow::datatypes::{
+        DataType as ArrowDataType, Field, Schema as ArrowSchema, TimeUnit,
+    };
     use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
     use delta_kernel::engine::arrow_data::ArrowEngineData;
     use delta_kernel::object_store::local::LocalFileSystem;
@@ -591,7 +593,9 @@ mod tests {
         PutOptions, PutPayload, PutResult, Result,
     };
     use delta_kernel::parquet::arrow::{ARROW_SCHEMA_META_KEY, PARQUET_FIELD_ID_META_KEY};
-    use delta_kernel::schema::{ColumnMetadataKey, MetadataValue, StructField, StructType};
+    use delta_kernel::schema::{
+        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
     use delta_kernel::EngineData;
     use delta_kernel_default_engine_test_utils::{
         assert_result_error_with_message, current_time_ms,
@@ -867,6 +871,96 @@ mod tests {
 
         assert_eq!(data.len(), 1);
         assert_eq!(data[0].num_rows(), 10);
+    }
+
+    // A Parquet file can physically store TIMESTAMP(MILLIS) (for example, checkpoint stats
+    // written by a non-kernel writer). End to end, the default engine must (a) convert the
+    // millisecond footer schema to the kernel's microsecond TIMESTAMP / TIMESTAMP_NTZ, and
+    // (b) rescale the values to microseconds (x1000) when reading them into that schema.
+    #[tokio::test]
+    async fn test_read_millisecond_timestamps() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("ms_timestamps.parquet");
+
+        // 1700000000123 ms since epoch -> 1_700_000_000_123_000 us.
+        let ms: i64 = 1_700_000_000_123;
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "ts_utc",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into())),
+                true,
+            ),
+            Field::new(
+                "ts_ntz",
+                ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(TimestampMillisecondArray::from(vec![ms]).with_timezone("UTC"))
+                    as Arc<dyn Array>,
+                Arc::new(TimestampMillisecondArray::from(vec![ms])) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap();
+
+        let mut writer = ArrowWriter::try_new(
+            std::fs::File::create(&file_path).unwrap(),
+            arrow_schema,
+            None,
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let file_size = std::fs::metadata(&file_path).unwrap().len();
+        let file_meta = FileMeta {
+            location: Url::from_file_path(&file_path).unwrap(),
+            last_modified: 0,
+            size: file_size,
+        };
+
+        let handler = DefaultParquetHandler::new(
+            Arc::new(LocalFileSystem::new()),
+            Arc::new(TokioBackgroundExecutor::new()),
+        );
+
+        // (a) Footer schema: millisecond timestamps convert to the kernel's microsecond types.
+        let footer = handler.read_parquet_footer(&file_meta).unwrap();
+        assert_eq!(
+            footer.schema.field("ts_utc").unwrap().data_type(),
+            &DataType::TIMESTAMP
+        );
+        assert_eq!(
+            footer.schema.field("ts_ntz").unwrap().data_type(),
+            &DataType::TIMESTAMP_NTZ
+        );
+
+        // (b) Data path: values are rescaled ms -> us when read into the microsecond schema.
+        let data: Vec<RecordBatch> = handler
+            .read_parquet_files(slice::from_ref(&file_meta), footer.schema.clone(), None)
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].num_rows(), 1);
+        let expected_us = ms * 1_000;
+        for col_idx in 0..2 {
+            let col = data[0]
+                .column(col_idx)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .unwrap();
+            assert_eq!(
+                col.value(0),
+                expected_us,
+                "column {col_idx} should be rescaled to us"
+            );
+        }
     }
 
     #[rstest::rstest]

--- a/docs/user-guide/src/concepts/schema_and_types.md
+++ b/docs/user-guide/src/concepts/schema_and_types.md
@@ -25,6 +25,8 @@ The `DataType` enum represents all types supported by the Delta protocol:
 | `DataType::TIMESTAMP` | N/A | Microsecond precision, adjusted to UTC |
 | `DataType::TIMESTAMP_NTZ` | N/A | Microsecond precision, no timezone |
 
+Both timestamp types are microsecond precision. A Parquet file can store timestamps at a coarser physical precision, such as millisecond, when it was written by a non-kernel writer. Kernel always expects microsecond values, so the reader must rescale them to microseconds. The default engine does this for you. If you implement your own engine, your handlers must perform this conversion themselves when reading both data files and metadata, such as checkpoint statistics.
+
 #### Decimal
 
 Decimals have a precision (1 to 38 inclusive) and a scale (0 to precision inclusive):

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -586,6 +586,15 @@ impl TryFromArrow<&ArrowDataType> for DataType {
             {
                 Ok(DataType::TIMESTAMP)
             }
+            // Millisecond is coarser than the kernel's microsecond logical timestamp, so
+            // mapping it onto the logical type is a lossless upscale (values are rescaled
+            // x1000 by the engine on read). Accept it like the microsecond/nanosecond arms.
+            ArrowDataType::Timestamp(TimeUnit::Millisecond, None) => Ok(DataType::TIMESTAMP_NTZ),
+            ArrowDataType::Timestamp(TimeUnit::Millisecond, Some(tz))
+                if tz.eq_ignore_ascii_case("utc") =>
+            {
+                Ok(DataType::TIMESTAMP)
+            }
             ArrowDataType::Struct(fields) => DataType::try_struct_type_from_results(
                 fields.iter().map(|field| field.as_ref().try_into_kernel()),
             )
@@ -694,6 +703,22 @@ mod tests {
 
         let kernel_type = DataType::try_from_arrow(&ArrowDataType::Null)?;
         assert_eq!(kernel_type, DataType::Primitive(PrimitiveType::Void));
+
+        Ok(())
+    }
+
+    // Millisecond-precision timestamps (e.g. from externally-written checkpoint stats)
+    // must convert like microsecond/nanosecond: UTC tz -> TIMESTAMP, no tz -> TIMESTAMP_NTZ.
+    #[test]
+    fn test_millisecond_timestamp_conversion() -> DeltaResult<()> {
+        let utc = DataType::try_from_arrow(&ArrowDataType::Timestamp(
+            TimeUnit::Millisecond,
+            Some("UTC".into()),
+        ))?;
+        assert_eq!(utc, DataType::TIMESTAMP);
+
+        let ntz = DataType::try_from_arrow(&ArrowDataType::Timestamp(TimeUnit::Millisecond, None))?;
+        assert_eq!(ntz, DataType::TIMESTAMP_NTZ);
 
         Ok(())
     }

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -588,7 +588,7 @@ impl TryFromArrow<&ArrowDataType> for DataType {
             }
             // Millisecond is coarser than the kernel's microsecond logical timestamp, so
             // mapping it onto the logical type is a lossless upscale (values are rescaled
-            // x1000 by the engine on read). Accept it like the microsecond/nanosecond arms.
+            // x1000 by the engine on read).
             ArrowDataType::Timestamp(TimeUnit::Millisecond, None) => Ok(DataType::TIMESTAMP_NTZ),
             ArrowDataType::Timestamp(TimeUnit::Millisecond, Some(tz))
                 if tz.eq_ignore_ascii_case("utc") =>

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -749,6 +749,16 @@ pub trait ParquetHandler: AsAny {
     /// 2. **Field Name**: If no field ID is present in the `physical_schema`'s [`StructField`] or
     ///    no matching parquet field ID is found, fall back to matching by column name
     ///
+    /// # Type coercion
+    ///
+    /// A matched Parquet column whose physical type differs from the `physical_schema`
+    /// [`StructField`] must be coerced to the requested type. In particular, timestamp columns MUST
+    /// be normalized to the protocol specified microsecond precision: a `TIMESTAMP(MILLIS)` (or
+    /// any other non-microsecond unit) column read into a `TIMESTAMP` / `TIMESTAMP_NTZ` field
+    /// must be rescaled to microseconds (a finer unit such as nanosecond is truncated). The
+    /// default engine does this via `arrow::compute::cast` while reordering columns to the
+    /// requested schema.
+    ///
     /// # Metadata Columns
     ///
     /// The ParquetHandler must support virtual metadata columns that provide additional information


### PR DESCRIPTION
## What changes are proposed in this pull request?

Arrow-to-kernel type conversion (`TryFromArrow for DataType`) previously rejected
`Timestamp(Millisecond, _)`, returning an error for any table whose stats schema carried
millisecond-precision timestamps (for example, checkpoint stats produced by external,
non-kernel writers).

The kernel's logical timestamp is microsecond-precision, so millisecond is a strictly
coarser unit and maps onto the logical type as a lossless upscale (values are rescaled
x1000 by the engine on read). This adds millisecond arms alongside the existing
microsecond/nanosecond handling:

- `Timestamp(Millisecond, None)` -> `TIMESTAMP_NTZ`
- `Timestamp(Millisecond, Some("utc"))` -> `TIMESTAMP`

The change is purely permissive: it accepts input that previously errored and does not
alter any existing mapping. Not a breaking change.

## How is the value handled in the default engine?

This conversion only makes the millisecond type **accepted**; it does not touch values. The
kernel's logical timestamp is always microsecond precision, so the actual ms -> us rescale
happens when the engine's Parquet reader resolves a file's physical columns into the requested
schema. The flow:

1. Kernel asks the engine to read the file using a physical schema whose timestamp columns are
   microsecond precision (the logical type).
2. The reader matches each physical Parquet column to the requested schema. When a file's column
   is a timestamp at a different precision (for example, millisecond), the reader coerces it to
   the requested microsecond type.
3. The coercion rescales the underlying int64 values to microseconds (millisecond is multiplied
   by 1000), and the rescaled column is returned in the requested schema.

The default engine does this automatically, so a column physically stored as millisecond yields
correct microsecond values (not off by 1000x).

## What does a connector need to do?

A connector that uses the default engine gets this for free. A connector that implements its own
engine is responsible for the same coercion in its own Parquet reader: whenever a file's physical
timestamp precision differs from the microsecond type the kernel requested, it must rescale the
values to microseconds before returning them. This applies when reading both data files and
metadata, such as checkpoint statistics.

## How was this change tested?

Added `test_millisecond_timestamp_conversion` (arrow_conversion unit test) asserting UTC-tz
millisecond converts to `TIMESTAMP` and no-tz millisecond converts to `TIMESTAMP_NTZ`.

Added `test_read_millisecond_timestamps`, an end-to-end default-engine test that writes a Parquet
file with `TIMESTAMP(MILLIS)` columns and verifies the footer schema converts to the kernel's
microsecond types and the read rescales the values to microseconds.

Also ran `cargo clippy --all-features --tests -- -D warnings` and `cargo doc`.
