### PR TITLE
feat: add schema and transaction methods for column defaults

### DIFF
--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -34,8 +34,6 @@ impl<'a> ColumnDefault<'a> {
     ///
     /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
     /// `raw_sql` is not `NULL` (case-insensitive).
-    // No production caller yet, remove this allow when that wiring exists.
-    #[allow(unused)]
     pub(crate) fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
         // Spark only allows a non-primitive column default when it is NULL; match that behavior.

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -4181,7 +4181,8 @@ mod tests {
         #[rstest]
         #[case::parsable_literal(DataType::INTEGER, "42", true)]
         #[case::null_primitive(DataType::INTEGER, "NULL", true)]
-        #[case::unparsable_primitive(DataType::TIMESTAMP, "current_timestamp()", false)]
+        #[case::unparsable_function_call(DataType::TIMESTAMP, "current_timestamp()", false)]
+        #[case::unparsable_type_mismatch(DataType::TIMESTAMP, "0.18", false)]
         fn exposes_default_for_primitive(
             #[case] data_type: DataType,
             #[case] raw_sql: &str,

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -487,11 +487,10 @@ impl StructField {
     /// ([`ColumnMetadataKey::CurrentDefault`]) metadata, if present.
     ///
     /// - `Ok(None)` -- no `CURRENT_DEFAULT` metadata.
-    /// - `Ok(Some(_))` -- present as a [`MetadataValue::String`] and accepted by
-    ///   [`ColumnDefault::new`].
+    /// - `Ok(Some(_))` -- present as a [`MetadataValue::String`] and accepted by [`ColumnDefault`].
     /// - `Err(_)` -- present but malformed: either not a [`MetadataValue::String`] (the protocol
     ///   defines `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected
-    ///   by [`ColumnDefault::new`] (e.g. a non-NULL default on a non-primitive type).
+    ///   by [`ColumnDefault`] (e.g. a non-NULL default on a non-primitive type).
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault<'_>>> {
         let raw_sql = match self.get_config_value(&ColumnMetadataKey::CurrentDefault) {
@@ -4186,7 +4185,7 @@ mod tests {
         fn exposes_default_for_primitive(
             #[case] data_type: DataType,
             #[case] raw_sql: &str,
-            #[case] is_kernel_parsable: bool,
+            #[case] parsable: bool,
         ) {
             let field = field_with_default(data_type.clone(), raw_sql);
             let column_default = field
@@ -4195,7 +4194,7 @@ mod tests {
                 .expect("default must be present");
             assert_eq!(column_default.raw_sql(), raw_sql);
             assert_eq!(column_default.data_type(), &data_type);
-            assert_eq!(column_default.is_kernel_parsable(), is_kernel_parsable);
+            assert_eq!(column_default.to_scalar().unwrap().is_some(), parsable);
         }
 
         #[test]
@@ -4206,7 +4205,7 @@ mod tests {
                 .column_default()
                 .expect_err("non-NULL default on a non-primitive type must error")
                 .to_string();
-            assert!(err.contains("must be NULL"), "got: {err}");
+            assert!(err.contains("not supported"), "got: {err}");
         }
     }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -483,6 +483,31 @@ impl StructField {
         }
     }
 
+    /// Returns this field's column default, parsed from its `CURRENT_DEFAULT`
+    /// ([`ColumnMetadataKey::CurrentDefault`]) metadata, if present.
+    ///
+    /// - `Ok(None)` -- no `CURRENT_DEFAULT` metadata.
+    /// - `Ok(Some(_))` -- present as a [`MetadataValue::String`] and accepted by
+    ///   [`ColumnDefault::new`].
+    /// - `Err(_)` -- present but malformed: either not a [`MetadataValue::String`] (the protocol
+    ///   defines `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected
+    ///   by [`ColumnDefault::new`] (e.g. a non-NULL default on a non-primitive type).
+    #[cfg(feature = "column-defaults-in-dev")]
+    pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault>> {
+        let raw_sql = match self.get_config_value(&ColumnMetadataKey::CurrentDefault) {
+            None => return Ok(None),
+            Some(MetadataValue::String(s)) => s.clone(),
+            Some(other) => {
+                return Err(Error::schema(format!(
+                    "Field '{}' has a non-string `{}` annotation: {other}",
+                    self.name,
+                    ColumnMetadataKey::CurrentDefault.as_ref(),
+                )))
+            }
+        };
+        ColumnDefault::new(raw_sql, self.data_type.clone()).map(Some)
+    }
+
     /// Validates and extracts pre-existing column-mapping annotations on this field, returning
     /// the parsed `id` and `physical_name` borrowed from the field's metadata. Returning the
     /// parsed values lets the column-mapping assignment dispatch match on
@@ -4121,6 +4146,68 @@ mod tests {
             ColumnMetadataKey::CurrentDefault.as_ref(),
             "CURRENT_DEFAULT"
         );
+    }
+
+    #[cfg(feature = "column-defaults-in-dev")]
+    mod column_default_method {
+        use super::*;
+
+        /// A nullable field named `c` carrying `raw_sql` as its `CURRENT_DEFAULT`.
+        fn field_with_default(data_type: DataType, raw_sql: &str) -> StructField {
+            StructField::nullable("c", data_type).add_metadata([(
+                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+                MetadataValue::String(raw_sql.to_string()),
+            )])
+        }
+
+        #[test]
+        fn returns_none_when_no_current_default() {
+            let field = StructField::nullable("c", DataType::INTEGER);
+            assert_eq!(field.column_default().unwrap(), None);
+        }
+
+        #[test]
+        fn errors_when_current_default_is_not_a_string() {
+            let field = StructField::nullable("c", DataType::INTEGER).add_metadata([(
+                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+                MetadataValue::Number(42),
+            )]);
+            let err = field
+                .column_default()
+                .expect_err("a non-string CURRENT_DEFAULT must error")
+                .to_string();
+            assert!(err.contains("non-string"), "got: {err}");
+        }
+
+        #[rstest]
+        #[case::parsable_literal(DataType::INTEGER, "42", true)]
+        #[case::null_primitive(DataType::INTEGER, "NULL", true)]
+        #[case::unparsable_primitive(DataType::TIMESTAMP, "current_timestamp()", false)]
+        fn exposes_default_for_primitive(
+            #[case] data_type: DataType,
+            #[case] raw_sql: &str,
+            #[case] is_kernel_parsable: bool,
+        ) {
+            let field = field_with_default(data_type.clone(), raw_sql);
+            let column_default = field
+                .column_default()
+                .unwrap()
+                .expect("default must be present");
+            assert_eq!(column_default.raw_sql(), raw_sql);
+            assert_eq!(column_default.data_type(), &data_type);
+            assert_eq!(column_default.is_kernel_parsable(), is_kernel_parsable);
+        }
+
+        #[test]
+        fn non_null_default_on_non_primitive_errors() {
+            let data_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
+            let field = field_with_default(data_type, "ARRAY(1)");
+            let err = field
+                .column_default()
+                .expect_err("non-NULL default on a non-primitive type must error")
+                .to_string();
+            assert!(err.contains("must be NULL"), "got: {err}");
+        }
     }
 
     /// Schema: { a: { b: { c: double } } } — supports walks at depths 1, 2, and 3.

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -493,7 +493,7 @@ impl StructField {
     ///   defines `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected
     ///   by [`ColumnDefault::new`] (e.g. a non-NULL default on a non-primitive type).
     #[cfg(feature = "column-defaults-in-dev")]
-    pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault>> {
+    pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault<'_>>> {
         let raw_sql = match self.get_config_value(&ColumnMetadataKey::CurrentDefault) {
             None => return Ok(None),
             Some(MetadataValue::String(s)) => s.clone(),
@@ -505,7 +505,7 @@ impl StructField {
                 )))
             }
         };
-        ColumnDefault::new(raw_sql, self.data_type.clone()).map(Some)
+        ColumnDefault::new(raw_sql, &self.data_type).map(Some)
     }
 
     /// Validates and extracts pre-existing column-mapping annotations on this field, returning

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -455,6 +455,7 @@ impl TableConfiguration {
     ///
     /// Use this over [`logical_schema`](Self::logical_schema) when callers need to derive
     /// `&self`-bound borrows from the schema (e.g. `&DataType` of a field).
+    #[cfg(feature = "column-defaults-in-dev")]
     pub(crate) fn logical_schema_ref(&self) -> &SchemaRef {
         &self.logical_schema
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -451,6 +451,14 @@ impl TableConfiguration {
         self.logical_schema.clone()
     }
 
+    /// Borrows this table's logical schema, tied to `&self` (no `Arc` clone).
+    ///
+    /// Use this over [`logical_schema`](Self::logical_schema) when callers need to derive
+    /// `&self`-bound borrows from the schema (e.g. `&DataType` of a field).
+    pub(crate) fn logical_schema_ref(&self) -> &SchemaRef {
+        &self.logical_schema
+    }
+
     /// The physical schema ([`SchemaRef`]) of this table at this version.
     ///
     /// When column mapping is disabled, this is identical to

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -219,6 +219,11 @@ impl TableConfiguration {
         validate_variant_type_feature_support(&table_config)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
 
+        // TODO(#2630): Validate column-default metadata here so a table that declares a
+        // `CURRENT_DEFAULT` without the `allowColumnDefaults` feature, or with malformed default
+        // metadata, is rejected eagerly as corrupted rather than lazily in
+        // `Transaction::column_defaults`.
+
         Ok(table_config)
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -996,9 +996,9 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the column default for every top-level column in this table's logical schema that
     /// declares one, keyed by logical column name.
     ///
-    /// Connectors use this to discover which columns have defaults, then
-    /// [`ColumnDefault::evaluate`] each parsable default (or fall back to
-    /// [`ColumnDefault::raw_sql`]) to materialize the column before writing.
+    /// Connectors use this to discover which columns have defaults, then call
+    /// [`ColumnDefault::to_scalar`] on each (or fall back to [`ColumnDefault::raw_sql`] when the
+    /// kernel cannot parse the default) to materialize the column before writing.
     ///
     /// Keys are `String` rather than [`ColumnName`] because column defaults are only supported on
     /// top-level columns, consistent with partition columns.
@@ -2180,11 +2180,11 @@ mod tests {
 
             let parsable = &defaults["parsable"];
             assert_eq!(parsable.raw_sql(), "42");
-            assert!(parsable.is_kernel_parsable());
+            assert!(parsable.to_scalar().unwrap().is_some());
 
             let unparsable = &defaults["unparsable"];
             assert_eq!(unparsable.raw_sql(), "current_timestamp()");
-            assert!(!unparsable.is_kernel_parsable());
+            assert!(unparsable.to_scalar().unwrap().is_none());
         }
 
         #[test]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1012,26 +1012,24 @@ impl<S: SupportsDataFiles> Transaction<S> {
     ///   (non-string metadata, or a non-NULL default on a non-primitive type).
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
-        // The protocol honors `CURRENT_DEFAULT` only "when enabled", so reject stray defaults on a
-        // table without the feature rather than let a connector materialize values it should
-        // ignore.
         let allow_column_defaults = self
             .effective_table_config
             .is_feature_enabled(&TableFeature::AllowColumnDefaults);
-        self.effective_table_config
-            .logical_schema_ref()
-            .fields()
-            .filter_map(|field| match field.column_default() {
-                Ok(Some(_)) if !allow_column_defaults => Some(Err(Error::generic(format!(
+        let mut defaults = HashMap::new();
+        for field in self.effective_table_config.logical_schema_ref().fields() {
+            let Some(column_default) = field.column_default()? else {
+                continue;
+            };
+            if !allow_column_defaults {
+                return Err(Error::generic(format!(
                     "Field '{}' declares a `CURRENT_DEFAULT` but the table does not enable the \
                      `allowColumnDefaults` writer feature",
                     field.name()
-                )))),
-                Ok(Some(column_default)) => Some(Ok((field.name().clone(), column_default))),
-                Ok(None) => None,
-                Err(e) => Some(Err(e)),
-            })
-            .collect()
+                )));
+            }
+            defaults.insert(field.name().clone(), column_default);
+        }
+        Ok(defaults)
     }
 
     /// Validates that the table's logical schema supports data writes.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -37,6 +37,8 @@ use crate::scan::log_replay::{
 };
 use crate::scan::scan_row_schema;
 use crate::schema::void_utils::{add_void_stripping, validate_schema_for_write};
+#[cfg(feature = "column-defaults-in-dev")]
+use crate::schema::ColumnDefault;
 use crate::schema::{
     schema_ref, ArrayType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType,
 };
@@ -989,6 +991,33 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns the logical partition column names for this table.
     pub fn logical_partition_columns(&self) -> &[String] {
         self.effective_table_config.partition_columns()
+    }
+
+    /// Returns the column default for every top-level column in this table's logical schema that
+    /// declares one, keyed by logical column name.
+    ///
+    /// Connectors use this to discover which columns have defaults, then
+    /// [`ColumnDefault::evaluate`] each parsable default (or fall back to
+    /// [`ColumnDefault::raw_sql`]) to materialize the column before writing.
+    ///
+    /// Keys are `String` rather than [`ColumnName`] because column defaults are only supported on
+    /// top-level columns, consistent with partition columns.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`StructField::column_default`] -- a malformed `CURRENT_DEFAULT`
+    /// (non-string metadata, or a non-NULL default on a non-primitive type).
+    #[cfg(feature = "column-defaults-in-dev")]
+    pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault>> {
+        self.effective_table_config
+            .logical_schema()
+            .fields()
+            .filter_map(|field| match field.column_default() {
+                Ok(Some(column_default)) => Some(Ok((field.name().clone(), column_default))),
+                Ok(None) => None,
+                Err(e) => Some(Err(e)),
+            })
+            .collect()
     }
 
     /// Validates that the table's logical schema supports data writes.
@@ -2060,6 +2089,103 @@ mod tests {
             .contains("fresh_column"));
 
         Ok(())
+    }
+
+    #[cfg(feature = "column-defaults-in-dev")]
+    mod column_defaults {
+        use super::*;
+        use crate::schema::{ColumnMetadataKey, MetadataValue};
+
+        // NB: `test_utils::schema_with_column_defaults` cannot be used here. In `--lib` unit tests
+        // the crate under test and the `delta_kernel` that `test_utils` links are two distinct
+        // crate instances, so kernel schema types don't unify across the `test_utils` boundary.
+        // That helper is fine in the integration tests (which link `delta_kernel` exactly once).
+
+        /// Builds a transaction whose effective logical schema is `schema`. The schema is swapped
+        /// onto a real snapshot's table configuration so column-default discovery can be exercised
+        /// without a table that actually carries the `allowColumnDefaults` feature in its protocol.
+        fn txn_with_schema(schema: StructType) -> Transaction {
+            let (engine, snapshot) = setup_non_dv_table();
+            let mut txn = snapshot
+                .transaction(Box::new(FileSystemCommitter::new()), &engine)
+                .unwrap();
+            let schema = Arc::new(schema);
+            let metadata = txn
+                .effective_table_config
+                .metadata()
+                .clone()
+                .with_schema(schema.clone())
+                .unwrap();
+            txn.effective_table_config = TableConfiguration::try_new_with_schema(
+                &txn.effective_table_config,
+                metadata,
+                schema,
+            )
+            .unwrap();
+            txn
+        }
+
+        /// A nullable field carrying `raw_sql` as its `CURRENT_DEFAULT`.
+        fn field_with_default(name: &str, data_type: DataType, raw_sql: &str) -> StructField {
+            StructField::nullable(name, data_type).add_metadata([(
+                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+                MetadataValue::String(raw_sql.to_string()),
+            )])
+        }
+
+        #[test]
+        fn collects_present_defaults_and_skips_columns_without_one() {
+            let schema = StructType::try_new(vec![
+                field_with_default("parsable", DataType::INTEGER, "42"),
+                field_with_default("unparsable", DataType::TIMESTAMP, "current_timestamp()"),
+                StructField::nullable("no_default", DataType::STRING),
+            ])
+            .unwrap();
+            let txn = txn_with_schema(schema);
+
+            let defaults = txn.column_defaults().unwrap();
+            assert_eq!(
+                defaults.len(),
+                2,
+                "only columns with a default are returned"
+            );
+            assert!(!defaults.contains_key("no_default"));
+
+            let parsable = &defaults["parsable"];
+            assert_eq!(parsable.raw_sql(), "42");
+            assert!(parsable.is_kernel_parsable());
+
+            let unparsable = &defaults["unparsable"];
+            assert_eq!(unparsable.raw_sql(), "current_timestamp()");
+            assert!(!unparsable.is_kernel_parsable());
+        }
+
+        #[test]
+        fn returns_empty_map_when_no_column_has_a_default() {
+            let schema = StructType::try_new(vec![
+                StructField::nullable("a", DataType::INTEGER),
+                StructField::nullable("b", DataType::STRING),
+            ])
+            .unwrap();
+            let txn = txn_with_schema(schema);
+            assert!(txn.column_defaults().unwrap().is_empty());
+        }
+
+        #[test]
+        fn propagates_error_for_malformed_default() {
+            let field = StructField::nullable("c", DataType::INTEGER).add_metadata([(
+                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+                MetadataValue::Number(7),
+            )]);
+            let schema = StructType::try_new(vec![field]).unwrap();
+            let txn = txn_with_schema(schema);
+
+            let err = txn
+                .column_defaults()
+                .expect_err("non-string CURRENT_DEFAULT must error")
+                .to_string();
+            assert!(err.contains("non-string"), "got: {err}");
+        }
     }
 
     #[test]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1011,7 +1011,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// - Propagates any error from [`StructField::column_default`] -- a malformed `CURRENT_DEFAULT`
     ///   (non-string metadata, or a non-NULL default on a non-primitive type).
     #[cfg(feature = "column-defaults-in-dev")]
-    pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault>> {
+    pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
         // The protocol honors `CURRENT_DEFAULT` only "when enabled", so reject stray defaults on a
         // table without the feature rather than let a connector materialize values it should
         // ignore.
@@ -1019,7 +1019,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
             .effective_table_config
             .is_feature_enabled(&TableFeature::AllowColumnDefaults);
         self.effective_table_config
-            .logical_schema()
+            .logical_schema_ref()
             .fields()
             .filter_map(|field| match field.column_default() {
                 Ok(Some(_)) if !allow_column_defaults => Some(Err(Error::generic(format!(

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1005,14 +1005,28 @@ impl<S: SupportsDataFiles> Transaction<S> {
     ///
     /// # Errors
     ///
-    /// Propagates any error from [`StructField::column_default`] -- a malformed `CURRENT_DEFAULT`
-    /// (non-string metadata, or a non-NULL default on a non-primitive type).
+    /// - A column declares a `CURRENT_DEFAULT` but the table does not enable the
+    ///   `allowColumnDefaults` writer feature. The protocol only honors defaults "when enabled", so
+    ///   such metadata is stray and is rejected rather than returned.
+    /// - Propagates any error from [`StructField::column_default`] -- a malformed `CURRENT_DEFAULT`
+    ///   (non-string metadata, or a non-NULL default on a non-primitive type).
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault>> {
+        // The protocol honors `CURRENT_DEFAULT` only "when enabled", so reject stray defaults on a
+        // table without the feature rather than let a connector materialize values it should
+        // ignore.
+        let allow_column_defaults = self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::AllowColumnDefaults);
         self.effective_table_config
             .logical_schema()
             .fields()
             .filter_map(|field| match field.column_default() {
+                Ok(Some(_)) if !allow_column_defaults => Some(Err(Error::generic(format!(
+                    "Field '{}' declares a `CURRENT_DEFAULT` but the table does not enable the \
+                     `allowColumnDefaults` writer feature",
+                    field.name()
+                )))),
                 Ok(Some(column_default)) => Some(Ok((field.name().clone(), column_default))),
                 Ok(None) => None,
                 Err(e) => Some(Err(e)),
@@ -2101,25 +2115,38 @@ mod tests {
         // crate instances, so kernel schema types don't unify across the `test_utils` boundary.
         // That helper is fine in the integration tests (which link `delta_kernel` exactly once).
 
-        /// Builds a transaction whose effective logical schema is `schema`. The schema is swapped
-        /// onto a real snapshot's table configuration so column-default discovery can be exercised
-        /// without a table that actually carries the `allowColumnDefaults` feature in its protocol.
+        /// Builds a transaction whose effective logical schema is `schema`, with the
+        /// `allowColumnDefaults` writer feature enabled so any declared defaults are honored.
         fn txn_with_schema(schema: StructType) -> Transaction {
+            txn_with_schema_and_writer_features(schema, [TableFeature::AllowColumnDefaults])
+        }
+
+        /// Like [`txn_with_schema`] but with an explicit writer-feature list, so a test can
+        /// exercise a table that does *not* enable `allowColumnDefaults`. The schema and a
+        /// synthetic protocol are swapped onto a real snapshot's table configuration so
+        /// column-default discovery can be exercised without going through `create_table`.
+        fn txn_with_schema_and_writer_features(
+            schema: StructType,
+            writer_features: impl IntoIterator<Item = TableFeature>,
+        ) -> Transaction {
             let (engine, snapshot) = setup_non_dv_table();
             let mut txn = snapshot
                 .transaction(Box::new(FileSystemCommitter::new()), &engine)
                 .unwrap();
-            let schema = Arc::new(schema);
             let metadata = txn
                 .effective_table_config
                 .metadata()
                 .clone()
-                .with_schema(schema.clone())
+                .with_schema(Arc::new(schema))
                 .unwrap();
-            txn.effective_table_config = TableConfiguration::try_new_with_schema(
+            let protocol =
+                Protocol::try_new_modern(TableFeature::EMPTY_LIST, writer_features).unwrap();
+            let version = txn.effective_table_config.version();
+            txn.effective_table_config = TableConfiguration::try_new_from(
                 &txn.effective_table_config,
-                metadata,
-                schema,
+                Some(metadata),
+                Some(protocol),
+                version,
             )
             .unwrap();
             txn
@@ -2185,6 +2212,20 @@ mod tests {
                 .expect_err("non-string CURRENT_DEFAULT must error")
                 .to_string();
             assert!(err.contains("non-string"), "got: {err}");
+        }
+
+        #[test]
+        fn errors_when_default_present_but_feature_not_enabled() {
+            let schema =
+                StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
+                    .unwrap();
+            let txn = txn_with_schema_and_writer_features(schema, []);
+
+            let err = txn
+                .column_defaults()
+                .expect_err("a column default without the allowColumnDefaults feature must error")
+                .to_string();
+            assert!(err.contains("allowColumnDefaults"), "got: {err}");
         }
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1000,8 +1000,9 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// [`ColumnDefault::to_scalar`] on each (or fall back to [`ColumnDefault::raw_sql`] when the
     /// kernel cannot parse the default) to materialize the column before writing.
     ///
-    /// Keys are `String` rather than [`ColumnName`] because column defaults are only supported on
-    /// top-level columns, consistent with partition columns.
+    /// Keys are `String` rather than [`ColumnName`] because the kernel currently surfaces defaults
+    /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
+    /// not a protocol one.
     ///
     /// # Errors
     ///
@@ -2111,7 +2112,6 @@ mod tests {
         // NB: `test_utils::schema_with_column_defaults` cannot be used here. In `--lib` unit tests
         // the crate under test and the `delta_kernel` that `test_utils` links are two distinct
         // crate instances, so kernel schema types don't unify across the `test_utils` boundary.
-        // That helper is fine in the integration tests (which link `delta_kernel` exactly once).
 
         /// Builds a transaction whose effective logical schema is `schema`, with the
         /// `allowColumnDefaults` writer feature enabled so any declared defaults are honored.

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -120,9 +120,7 @@ mod feature_enabled {
     use delta_kernel::arrow::record_batch::RecordBatch;
     use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
     use delta_kernel::engine::arrow_data::ArrowEngineData;
-    use delta_kernel::schema::{
-        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
-    };
+    use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::table_features::TableFeature;
     use delta_kernel::Snapshot;
     use rstest::rstest;
@@ -215,12 +213,16 @@ mod feature_enabled {
             .expect("c field must exist in loaded schema");
 
         assert_eq!(field.data_type(), &data_type);
-        // TODO(#2630): replace this manual metadata read once StructField::column_default exists.
+        let column_default = field
+            .column_default()
+            .expect("column_default must not error for a valid primitive default")
+            .expect("CURRENT_DEFAULT metadata must be present in the loaded schema");
         assert_eq!(
-            field.get_config_value(&ColumnMetadataKey::CurrentDefault),
-            Some(&MetadataValue::String(default_sql.to_string())),
-            "CURRENT_DEFAULT metadata must round-trip verbatim",
+            column_default.raw_sql(),
+            default_sql,
+            "CURRENT_DEFAULT raw SQL must round-trip verbatim",
         );
+        assert_eq!(column_default.data_type(), &data_type);
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -118,9 +118,11 @@ mod feature_enabled {
 
     use delta_kernel::arrow::array::{ArrayRef, Int64Array, StringArray};
     use delta_kernel::arrow::record_batch::RecordBatch;
+    use delta_kernel::committer::FileSystemCommitter;
     use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
     use delta_kernel::engine::arrow_data::ArrowEngineData;
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::expressions::Scalar;
+    use delta_kernel::schema::{ArrayType, DataType, StructField, StructType};
     use delta_kernel::table_features::TableFeature;
     use delta_kernel::Snapshot;
     use rstest::rstest;
@@ -261,5 +263,91 @@ mod feature_enabled {
             &["timestampNtz"],
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn test_transaction_column_defaults_exposes_all_top_level_defaults(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default.
+        let base = StructType::try_new(vec![
+            StructField::nullable("a", DataType::INTEGER),
+            StructField::nullable("b", DataType::INTEGER),
+            StructField::nullable("c", DataType::TIMESTAMP),
+        ])?;
+        let schema = schema_with_column_defaults(
+            &base,
+            HashMap::from([("b", "1337"), ("c", "current_timestamp()")]),
+        )?;
+
+        let (store, engine, table_location) = engine_store_setup("test_txn_column_defaults", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],                         /* partition_columns */
+            true,                        /* use_37_protocol */
+            vec![],                      /* reader_features */
+            vec!["allowColumnDefaults"], /* writer_features */
+        )
+        .await?;
+
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+
+        let defaults = txn.column_defaults()?;
+        assert_eq!(defaults.len(), 2, "only b and c declare a default");
+        assert!(!defaults.contains_key("a"), "a has no default");
+
+        let b = &defaults["b"];
+        assert_eq!(b.raw_sql(), "1337");
+        assert!(b.is_kernel_parsable());
+        assert_eq!(b.evaluate(&engine)?, Some(Scalar::Integer(1337)));
+
+        let c = &defaults["c"];
+        assert_eq!(c.raw_sql(), "current_timestamp()");
+        assert!(!c.is_kernel_parsable());
+        assert_eq!(
+            c.evaluate(&engine)?,
+            None,
+            "a non-kernel-parsable default evaluates to None",
+        );
+
+        Ok(())
+    }
+
+    /// A non-NULL default on a non-primitive column is accepted at create time but surfaces as an
+    /// error when later discovered via `Transaction::column_defaults`.
+    #[tokio::test]
+    async fn test_transaction_column_defaults_errors_on_non_null_non_primitive_default(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable(
+            "arr",
+            ArrayType::new(DataType::INTEGER, true),
+        )])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("arr", "ARRAY(1)")]))?;
+
+        let (store, engine, table_location) =
+            engine_store_setup("test_txn_column_defaults_non_primitive", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],                         /* partition_columns */
+            true,                        /* use_37_protocol */
+            vec![],                      /* reader_features */
+            vec!["allowColumnDefaults"], /* writer_features */
+        )
+        .await?;
+
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+
+        let err = txn
+            .column_defaults()
+            .expect_err("a non-NULL default on a non-primitive column must error")
+            .to_string();
+        assert!(err.contains("must be NULL"), "got: {err}");
+
+        Ok(())
     }
 }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -300,16 +300,14 @@ mod feature_enabled {
 
         let b = &defaults["b"];
         assert_eq!(b.raw_sql(), "1337");
-        assert!(b.is_kernel_parsable());
-        assert_eq!(b.evaluate(&engine)?, Some(Scalar::Integer(1337)));
+        assert_eq!(b.to_scalar()?, Some(Scalar::Integer(1337)));
 
         let c = &defaults["c"];
         assert_eq!(c.raw_sql(), "current_timestamp()");
-        assert!(!c.is_kernel_parsable());
         assert_eq!(
-            c.evaluate(&engine)?,
+            c.to_scalar()?,
             None,
-            "a non-kernel-parsable default evaluates to None",
+            "a non-kernel-parsable default is not parsed by the kernel",
         );
 
         Ok(())
@@ -346,7 +344,7 @@ mod feature_enabled {
             .column_defaults()
             .expect_err("a non-NULL default on a non-primitive column must error")
             .to_string();
-        assert!(err.contains("must be NULL"), "got: {err}");
+        assert!(err.contains("not supported"), "got: {err}");
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -265,8 +265,12 @@ mod feature_enabled {
         .await
     }
 
+    #[rstest]
+    #[case::all_data_columns(&[])]
+    #[case::default_on_partition_column(&["b"])]
     #[tokio::test]
     async fn test_transaction_column_defaults_exposes_all_top_level_defaults(
+        #[case] partition_columns: &[&str],
     ) -> Result<(), Box<dyn std::error::Error>> {
         // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default.
         let base = StructType::try_new(vec![
@@ -284,7 +288,7 @@ mod feature_enabled {
             store,
             table_location,
             schema,
-            &[],                         /* partition_columns */
+            partition_columns,
             true,                        /* use_37_protocol */
             vec![],                      /* reader_features */
             vec!["allowColumnDefaults"], /* writer_features */


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2808/files) to review incremental changes.
- [stack/column-defaults-feature-flag](https://github.com/delta-io/delta-kernel-rs/pull/2636) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2636/files)] [MERGED]
  - [stack/column-defaults-sql-parser](https://github.com/delta-io/delta-kernel-rs/pull/2670) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2670/files)] [MERGED]
    - [stack/column-defaults-create-helper](https://github.com/delta-io/delta-kernel-rs/pull/2686) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2686/files)] [MERGED]
      - [stack/column-defaults-struct](https://github.com/delta-io/delta-kernel-rs/pull/2797) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2797/files)] [MERGED]
        - [**stack/column-defaults-schema-method**](https://github.com/delta-io/delta-kernel-rs/pull/2808) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2808/files)] ← _this PR_
          - [stack/column-defaults-ffi-support](https://github.com/delta-io/delta-kernel-rs/pull/2843) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2843/files/739167ad93b0c0e2b17c216e7619aa43e67e28da..59f9bb7582be4aeb5ca3b5209e45490ac7dcf2cc)]
          - [stack/default-columns-v3-compat](https://github.com/delta-io/delta-kernel-rs/pull/2846) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2846/files/739167ad93b0c0e2b17c216e7619aa43e67e28da..d673429bc128d5d4ad87301e4941c003cbcc67fa)]

---------
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2808/files) to review incremental changes.
- [stack/column-defaults-feature-flag](https://github.com/delta-io/delta-kernel-rs/pull/2636) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2636/files)] [MERGED]
  - [stack/column-defaults-sql-parser](https://github.com/delta-io/delta-kernel-rs/pull/2670) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2670/files)] [MERGED]
    - [stack/column-defaults-create-helper](https://github.com/delta-io/delta-kernel-rs/pull/2686) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2686/files)] [MERGED]
      - [stack/column-defaults-struct](https://github.com/delta-io/delta-kernel-rs/pull/2797) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2797/files)] [MERGED]
        - [**stack/column-defaults-schema-method**](https://github.com/delta-io/delta-kernel-rs/pull/2808) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2808/files)]
          - [stack/column-defaults-ffi-support](https://github.com/delta-io/delta-kernel-rs/pull/2843) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2843/files/739167ad93b0c0e2b17c216e7619aa43e67e28da..59f9bb7582be4aeb5ca3b5209e45490ac7dcf2cc)]
          - stack/default-columns-v3-compat

---------
## What changes are proposed in this pull request?
This PR adds two methods `StructField::column_default` and `Transaction::column_defaults` which enable users to access a single column default either from a schema or all column defaults from a transaction. 

## How was this change tested?
Added unit and integration tests.

## Resources
Tracking Issue #2630