### PR TITLE
feat: expanding SQL Parser to support predicates

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -122,6 +122,11 @@ declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc
 # work. TODO(#2630): remove once full column-defaults support ships.
 column-defaults-in-dev = []
 
+# Experimental, temporary, test-only feature flag guarding the in-progress check-constraints
+# work. Gates the SQL predicate parser (`parse_sql_simple_predicate`) and, later, `checkConstraints`
+# write enforcement. Remove once full check-constraints support ships.
+check-constraints-in-dev = []
+
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate
 # and the SyncEngine. Keeps `reqwest` only for the gated `Error::Reqwest` variant.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -26,12 +26,19 @@ mod column_names;
 pub(crate) mod literal_expression_transform;
 pub(crate) use literal_expression_transform::literal_expression_transform;
 mod scalars;
-#[cfg(feature = "column-defaults-in-dev")]
+#[cfg(any(
+    feature = "column-defaults-in-dev",
+    feature = "check-constraints-in-dev"
+))]
 mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
 // TODO(#2630): Wire up `parse_sql` to column-defaults and remove this allow
 #[allow(unused_imports)]
 pub(crate) use self::sql::parse_sql;
+#[cfg(feature = "check-constraints-in-dev")]
+// TODO: Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this allow
+#[allow(unused_imports)]
+pub(crate) use self::sql::parse_sql_simple_predicate;
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -1,24 +1,74 @@
-//! Parse a SQL string into a kernel [`Expression`].
+//! Parse a SQL string into a kernel [`Expression`] or `Predicate`.
 //!
-//! Delta stores column defaults, check constraints, and generated column definitions as SQL
-//! strings in table metadata. This module turns those strings into kernel [`Expression`] values
-//! so the kernel can interpret them without depending on a full SQL parser.
+//! Delta stores column defaults, generated column definitions, and check constraints as SQL strings
+//! in table metadata. This module turns those strings into kernel `Expression` or `Predicate`
+//! values so the kernel can interpret them without depending on a full SQL parser.
 //!
 //! The grammar follows the Spark SQL standard: this parser implements a subset of Spark's SQL
 //! grammar rather than defining a kernel-specific dialect, so the forms it accepts match what
 //! Spark reads and writes.
 //!
-//! This is an intentionally light start: a small internal parser covering only the literal forms
-//! Delta metadata contains today. If the supported SQL surface grows, options include moving
-//! parsing behind the [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
+//! This is an intentionally light start, covering only the forms Delta metadata contains today. If
+//! the supported SQL surface grows, options include moving parsing behind the
+//! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 
 // `parse_sql` has no in-crate caller yet; it will be wired up by the column-defaults work
 // (#2630).
 #![allow(dead_code)]
 
+#[cfg(feature = "check-constraints-in-dev")]
+use crate::expressions::Predicate;
 use crate::expressions::{Expression, Scalar};
+#[cfg(feature = "check-constraints-in-dev")]
+use crate::schema::StructType;
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};
+
+// === CHECK-constraint predicate parser ===
+//
+// `parse_sql` (below) turns a single SQL *literal* of a known type into an `Expression`. A CHECK
+// constraint is instead a boolean *predicate* over columns (e.g. `amount > 0`), which the literal
+// parser cannot express. These submodules add the three layers it lacks -- a tokenizer, a
+// single-comparison parser, and a schema-aware lowering pass -- and reuse `parse_sql` to parse the
+// literal leaves.
+//
+// Only one comparison (`operand <op> operand`) is parsed today; richer grammar (`AND`/`OR`/`NOT`,
+// parentheses, `IS [NOT] NULL`) is a follow-up. Anything outside the supported grammar is rejected,
+// which the caller treats as "not kernel-parsable".
+#[cfg(feature = "check-constraints-in-dev")]
+mod lower;
+#[cfg(feature = "check-constraints-in-dev")]
+mod parser;
+#[cfg(feature = "check-constraints-in-dev")]
+mod token;
+
+/// Parse a single-comparison CHECK-constraint SQL string into a kernel [`Predicate`], resolving
+/// column references against `schema` and inferring each literal's type from the column it is
+/// compared against.
+///
+/// The supported grammar is exactly one comparison `<operand> <op> <operand>`, where each operand
+/// is a column reference (case-insensitive, dotted paths allowed), a literal, or `NULL`, and
+/// `<op>` is one of `< <= > >= = == != <>`. Literal leaves are parsed by [`parse_sql`], typed from
+/// the column on the other side of the comparison; a comparison must therefore reference at least
+/// one column.
+///
+/// Junctions (`AND`/`OR`/`NOT`), parentheses, and `IS [NOT] NULL` are intentionally out of scope
+/// and surface as errors.
+///
+/// # Errors
+///
+/// Returns an error for any input outside the supported grammar (junctions, functions, arithmetic,
+/// `IN`, `BETWEEN`, ...), for unknown columns, and for type-incompatible literals. Callers treat
+/// that error as the signal that a constraint is *not kernel-parsable*.
+#[cfg(feature = "check-constraints-in-dev")]
+pub(crate) fn parse_sql_simple_predicate(sql: &str, schema: &StructType) -> DeltaResult<Predicate> {
+    let tokens = token::tokenize(sql)?;
+    if tokens.is_empty() {
+        return Err(Error::generic("empty CHECK constraint expression"));
+    }
+    let comparison = parser::parse(tokens)?;
+    lower::lower(&comparison, schema)
+}
 
 /// Parse a SQL string into an [`Expression`] that yields a value of the given [`DataType`]
 /// (e.g. the type of the column whose default is being parsed).

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -1,7 +1,7 @@
-//! Parse a SQL string into a kernel [`Expression`] or `Predicate`.
+//! Parse a SQL string into a kernel [`Expression`] or [`Predicate`].
 //!
 //! Delta stores column defaults, generated column definitions, and check constraints as SQL strings
-//! in table metadata. This module turns those strings into kernel `Expression` or `Predicate`
+//! in table metadata. This module turns those strings into kernel [`Expression`] or [`Predicate`]
 //! values so the kernel can interpret them without depending on a full SQL parser.
 //!
 //! The grammar follows the Spark SQL standard: this parser implements a subset of Spark's SQL

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -24,17 +24,6 @@ use crate::schema::StructType;
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};
 
-// === CHECK-constraint predicate parser ===
-//
-// `parse_sql` (below) turns a single SQL *literal* of a known type into an `Expression`. A CHECK
-// constraint is instead a boolean *predicate* over columns (e.g. `amount > 0`), which the literal
-// parser cannot express. These submodules add the three layers it lacks -- a tokenizer, a
-// single-comparison parser, and a schema-aware lowering pass -- and reuse `parse_sql` to parse the
-// literal leaves.
-//
-// Only one comparison (`operand <op> operand`) is parsed today; richer grammar (`AND`/`OR`/`NOT`,
-// parentheses, `IS [NOT] NULL`) is a follow-up. Anything outside the supported grammar is rejected,
-// which the caller treats as "not kernel-parsable".
 #[cfg(feature = "check-constraints-in-dev")]
 mod lower;
 #[cfg(feature = "check-constraints-in-dev")]

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -13,15 +13,13 @@ use crate::expressions::{ColumnName, Expression, Predicate};
 use crate::schema::{DataType, StructType};
 use crate::{DeltaResult, Error};
 
-/// Lower a single parsed comparison into a kernel [`Predicate`], resolving each operand against
-/// `schema` exactly once. The comparison must reference at least one column so that a literal
+/// The comparison must reference at least one column so that a literal
 /// operand can be typed from the column on the other side.
 pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-    // A literal is typed from the column on the other side, so at least one operand must be a
-    // column.
+
     let left_type = left.column_type().cloned();
     let right_type = right.column_type().cloned();
     if left_type.is_none() && right_type.is_none() {

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -13,22 +13,56 @@ use crate::expressions::{ColumnName, Expression, Predicate};
 use crate::schema::{DataType, StructType};
 use crate::{DeltaResult, Error};
 
-/// The comparison must reference at least one column so that a literal
-/// operand can be typed from the column on the other side.
+/// Lower a parsed [`Comparison`] into a kernel [`Predicate`], resolving each operand against
+/// `schema`. A comparison relates only primitive-typed columns and must reference at least one
+/// column, so a literal operand can be typed from the column on the other side.
 pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-
-    let left_type = left.column_type().cloned();
-    let right_type = right.column_type().cloned();
-    if left_type.is_none() && right_type.is_none() {
-        return Err(Error::generic(
-            "CHECK constraint comparison must reference at least one column",
-        ));
+    // Comparison policy lives here, not in `resolve_operand`: only primitive-typed columns are
+    // comparable (struct/array/map columns have no scalar comparison semantics).
+    for operand in [&left, &right] {
+        if let ResolvedOperand::Column {
+            canonical,
+            data_type,
+        } = operand
+        {
+            if !matches!(data_type, DataType::Primitive(_)) {
+                return Err(Error::generic(format!(
+                    "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
+                    canonical.join(".")
+                )));
+            }
+        }
     }
-    let left_expr = operand_expression(left, right_type.as_ref())?;
-    let right_expr = operand_expression(right, left_type.as_ref())?;
+    // A literal is typed from the column on the other side, so at least one operand must be a
+    // column.
+    let (left_expr, right_expr) = match (left, right) {
+        (
+            ResolvedOperand::Column { canonical: l, .. },
+            ResolvedOperand::Column { canonical: r, .. },
+        ) => (Expression::column(l), Expression::column(r)),
+        (
+            ResolvedOperand::Column {
+                canonical,
+                data_type,
+            },
+            ResolvedOperand::Literal(raw),
+        ) => (Expression::column(canonical), parse_sql(&raw, &data_type)?),
+        (
+            ResolvedOperand::Literal(raw),
+            ResolvedOperand::Column {
+                canonical,
+                data_type,
+            },
+        ) => (parse_sql(&raw, &data_type)?, Expression::column(canonical)),
+        (ResolvedOperand::Literal(_), ResolvedOperand::Literal(_)) => {
+            return Err(Error::generic(
+                "CHECK constraint comparison must reference at least one column",
+            ))
+        }
+    };
     Ok(match op {
         CmpOp::Eq => Predicate::eq(left_expr, right_expr),
         CmpOp::Ne => Predicate::ne(left_expr, right_expr),
@@ -39,65 +73,30 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
     })
 }
 
-/// A comparison operand after schema resolution: a column (its [`Expression`] and resolved leaf
-/// type) or a not-yet-typed literal (typed later from the column it is compared against).
+/// A comparison operand after schema resolution: a column (its canonical schema-cased path and
+/// resolved leaf type) or a not-yet-typed literal (typed by [`lower`] from the column on the other
+/// side).
 enum ResolvedOperand {
     Column {
-        expr: Expression,
+        canonical: Vec<String>,
         data_type: DataType,
     },
     Literal(String),
 }
 
-impl ResolvedOperand {
-    /// The column's resolved leaf type, or `None` for a literal.
-    fn column_type(&self) -> Option<&DataType> {
-        match self {
-            ResolvedOperand::Column { data_type, .. } => Some(data_type),
-            ResolvedOperand::Literal(_) => None,
-        }
-    }
-}
-
-/// Resolve an operand against `schema`, walking a column path at most once. A column resolves to
-/// its canonical [`Expression`] and leaf type, which must be primitive: struct/array/map columns
-/// have no scalar comparison semantics (and a literal operand is likewise restricted to primitives
-/// by [`parse_sql`]), so a non-primitive column makes the constraint not kernel-parsable. A literal
-/// is carried as raw text and typed later by [`operand_expression`].
+/// Resolve an operand against `schema`, walking a column path at most once: a column yields its
+/// canonical (schema-cased) path and leaf type; a literal is carried as raw text and typed by
+/// [`lower`]. This is pure resolution -- comparison-specific policy (primitive-only operands) lives
+/// in [`lower`], so `resolve_operand` can also resolve non-primitive columns for other callers.
 fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
     match operand {
         Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
         Operand::Column(path) => {
             let (canonical, data_type) = resolve_column(path, schema)?;
-            if !matches!(data_type, DataType::Primitive(_)) {
-                return Err(Error::generic(format!(
-                    "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
-                    canonical.join(".")
-                )));
-            }
             Ok(ResolvedOperand::Column {
-                expr: Expression::column(canonical),
+                canonical,
                 data_type,
             })
-        }
-    }
-}
-
-/// Build the kernel [`Expression`] for a resolved operand. A literal is parsed via [`parse_sql`]
-/// against `sibling_type` -- the type of the column on the other side of the comparison.
-fn operand_expression(
-    operand: ResolvedOperand,
-    sibling_type: Option<&DataType>,
-) -> DeltaResult<Expression> {
-    match operand {
-        ResolvedOperand::Column { expr, .. } => Ok(expr),
-        ResolvedOperand::Literal(raw) => {
-            let data_type = sibling_type.ok_or_else(|| {
-                Error::generic(format!(
-                    "cannot type literal '{raw}': a CHECK constraint comparison must reference a column"
-                ))
-            })?;
-            parse_sql(&raw, data_type)
         }
     }
 }
@@ -207,6 +206,20 @@ mod tests {
         "ratio < 1e3",
         Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1000.0)))
     )]
+    // Signed numbers: a leading sign, and a signed exponent, each stay part of one numeric literal.
+    #[case::negative_literal(
+        "amount = -5",
+        Predicate::eq(col("amount"), Expression::literal(-5i64))
+    )]
+    #[case::signed_exponent(
+        "ratio >= -2e+1",
+        Predicate::ge(col("ratio"), Expression::literal(Scalar::Double(-20.0)))
+    )]
+    // A leading sign immediately followed by a leading-dot decimal stays one numeric literal.
+    #[case::negative_leading_dot_decimal(
+        "ratio > -.5",
+        Predicate::gt(col("ratio"), Expression::literal(Scalar::Double(-0.5)))
+    )]
     // Timestamp typed literals: LTZ (bare `TIMESTAMP` or explicit `TIMESTAMP_LTZ`, both requiring a
     // `Z` suffix) and zoneless `TIMESTAMP_NTZ`.
     #[case::typed_timestamp(
@@ -290,6 +303,8 @@ mod tests {
     #[case::literal_out_of_range_for_column("price = 9999999999")]
     // Malformed input.
     #[case::unterminated_string("name = 'oops")]
+    #[case::bang_without_eq("amount ! 0")]
+    #[case::malformed_dotted_path("nested..inner > 0")]
     #[case::missing_operator("amount price")]
     #[case::trailing_tokens("amount > 0 extra")]
     #[case::operator_only(">")]

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -1,0 +1,305 @@
+//! Lowering: resolve a parsed [`Comparison`] against the table schema into a kernel [`Predicate`].
+//!
+//! Column references resolve case-insensitively (matching Delta/Spark and kernel's other
+//! column-resolution paths). A literal's type is inferred from the column on the other side of the
+//! comparison, and the literal itself is parsed by reusing [`super::parse_sql`].
+
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+#![allow(dead_code)]
+
+use super::parse_sql;
+use super::parser::{CmpOp, Comparison, Operand};
+use crate::expressions::{ColumnName, Expression, Predicate};
+use crate::schema::{DataType, StructType};
+use crate::{DeltaResult, Error};
+
+/// Lower a single parsed comparison into a kernel [`Predicate`], resolving each operand against
+/// `schema` exactly once. The comparison must reference at least one column so that a literal
+/// operand can be typed from the column on the other side.
+pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
+    let Comparison { op, left, right } = comparison;
+    let left = resolve_operand(left, schema)?;
+    let right = resolve_operand(right, schema)?;
+    // A literal is typed from the column on the other side, so at least one operand must be a
+    // column.
+    let left_type = left.column_type().cloned();
+    let right_type = right.column_type().cloned();
+    if left_type.is_none() && right_type.is_none() {
+        return Err(Error::generic(
+            "CHECK constraint comparison must reference at least one column",
+        ));
+    }
+    let left_expr = operand_expression(left, right_type.as_ref())?;
+    let right_expr = operand_expression(right, left_type.as_ref())?;
+    Ok(match op {
+        CmpOp::Eq => Predicate::eq(left_expr, right_expr),
+        CmpOp::Ne => Predicate::ne(left_expr, right_expr),
+        CmpOp::Lt => Predicate::lt(left_expr, right_expr),
+        CmpOp::Le => Predicate::le(left_expr, right_expr),
+        CmpOp::Gt => Predicate::gt(left_expr, right_expr),
+        CmpOp::Ge => Predicate::ge(left_expr, right_expr),
+    })
+}
+
+/// A comparison operand after schema resolution: a column (its [`Expression`] and resolved leaf
+/// type) or a not-yet-typed literal (typed later from the column it is compared against).
+enum ResolvedOperand {
+    Column {
+        expr: Expression,
+        data_type: DataType,
+    },
+    Literal(String),
+}
+
+impl ResolvedOperand {
+    /// The column's resolved leaf type, or `None` for a literal.
+    fn column_type(&self) -> Option<&DataType> {
+        match self {
+            ResolvedOperand::Column { data_type, .. } => Some(data_type),
+            ResolvedOperand::Literal(_) => None,
+        }
+    }
+}
+
+/// Resolve an operand against `schema`, walking a column path at most once. A column resolves to
+/// its canonical [`Expression`] and leaf type, which must be primitive: struct/array/map columns
+/// have no scalar comparison semantics (and a literal operand is likewise restricted to primitives
+/// by [`parse_sql`]), so a non-primitive column makes the constraint not kernel-parsable. A literal
+/// is carried as raw text and typed later by [`operand_expression`].
+fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
+    match operand {
+        Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
+        Operand::Column(path) => {
+            let (canonical, data_type) = resolve_column(path, schema)?;
+            if !matches!(data_type, DataType::Primitive(_)) {
+                return Err(Error::generic(format!(
+                    "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
+                    canonical.join(".")
+                )));
+            }
+            Ok(ResolvedOperand::Column {
+                expr: Expression::column(canonical),
+                data_type,
+            })
+        }
+    }
+}
+
+/// Build the kernel [`Expression`] for a resolved operand. A literal is parsed via [`parse_sql`]
+/// against `sibling_type` -- the type of the column on the other side of the comparison.
+fn operand_expression(
+    operand: ResolvedOperand,
+    sibling_type: Option<&DataType>,
+) -> DeltaResult<Expression> {
+    match operand {
+        ResolvedOperand::Column { expr, .. } => Ok(expr),
+        ResolvedOperand::Literal(raw) => {
+            let data_type = sibling_type.ok_or_else(|| {
+                Error::generic(format!(
+                    "cannot type literal '{raw}': a CHECK constraint comparison must reference a column"
+                ))
+            })?;
+            parse_sql(&raw, data_type)
+        }
+    }
+}
+
+/// Resolve a (case-insensitive) column path against `schema`, returning the *canonical* path (the
+/// schema's stored field names) and the leaf field's type. The canonical names are what the engine
+/// sees in the logical batch, so the emitted column reference must use them rather than the
+/// as-written casing.
+fn resolve_column(path: &[String], schema: &StructType) -> DeltaResult<(Vec<String>, DataType)> {
+    let column = ColumnName::new(path.iter().cloned());
+    let mut fields = Vec::with_capacity(path.len());
+    schema.visit_fields_of_path_by(
+        &column,
+        |parent, name| {
+            parent
+                .fields()
+                .find(|f| f.name().eq_ignore_ascii_case(name))
+        },
+        |field| fields.push(field),
+    )?;
+    let canonical: Vec<String> = fields.iter().map(|f| f.name().to_string()).collect();
+    let leaf = fields
+        .last()
+        .ok_or_else(|| Error::generic("CHECK constraint references an empty column path"))?;
+    Ok((canonical, leaf.data_type().clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::super::parse_sql_simple_predicate;
+    use crate::expressions::{Expression, Predicate, Scalar};
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn schema() -> StructType {
+        StructType::new_unchecked([
+            StructField::nullable("amount", DataType::LONG),
+            StructField::nullable("price", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+            StructField::nullable("active", DataType::BOOLEAN),
+            StructField::nullable("ratio", DataType::DOUBLE),
+            StructField::nullable("created", DataType::DATE),
+            StructField::nullable("data", DataType::BINARY),
+            StructField::nullable("ts", DataType::TIMESTAMP),
+            StructField::nullable("tsn", DataType::TIMESTAMP_NTZ),
+            StructField::nullable(
+                "nested",
+                DataType::try_struct_type([StructField::nullable("inner", DataType::LONG)])
+                    .unwrap(),
+            ),
+        ])
+    }
+
+    fn col(name: &str) -> Expression {
+        Expression::column([name])
+    }
+
+    /// Kernel-parsable inputs: exactly one `operand <op> operand` comparison between a column and a
+    /// column, a literal, or `NULL`, for every comparison operator and across the primitive literal
+    /// types. Each literal is typed from the column it is compared against (via `parse_sql`), and
+    /// column names resolve case-insensitively to their canonical casing. All of these lower to a
+    /// `Predicate`.
+    #[rstest]
+    // Every comparison operator (`=`, `==`, `!=`, `<>`, `<`, `<=`, `>`, `>=`).
+    #[case::gt("amount > 0", Predicate::gt(col("amount"), Expression::literal(0i64)))]
+    #[case::lt("amount < 0", Predicate::lt(col("amount"), Expression::literal(0i64)))]
+    #[case::ge("amount >= 0", Predicate::ge(col("amount"), Expression::literal(0i64)))]
+    #[case::le("amount <= 0", Predicate::le(col("amount"), Expression::literal(0i64)))]
+    #[case::eq("amount = 0", Predicate::eq(col("amount"), Expression::literal(0i64)))]
+    #[case::eq_double("amount == 0", Predicate::eq(col("amount"), Expression::literal(0i64)))]
+    #[case::ne_bang("amount != 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
+    #[case::ne_angle("amount <> 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
+    // Whitespace between tokens is optional.
+    #[case::no_whitespace("amount>0", Predicate::gt(col("amount"), Expression::literal(0i64)))]
+    // A literal is typed from the column on the other side: `price` is INTEGER, not the default
+    // Long.
+    #[case::literal_typed_from_column(
+        "price <= 10",
+        Predicate::le(col("price"), Expression::literal(10i32))
+    )]
+    // Literal forms across the primitive type matrix, each typed from its column. Exercises the
+    // tokenizer's bareword (`TRUE`), fractional-number, typed-literal (`DATE '...'`), and binary
+    // (`X'..'`) paths.
+    #[case::boolean_literal(
+        "active = TRUE",
+        Predicate::eq(col("active"), Expression::literal(Scalar::Boolean(true)))
+    )]
+    #[case::double_literal(
+        "ratio < 1.5",
+        Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1.5)))
+    )]
+    #[case::typed_date_literal(
+        "created = DATE '1970-01-02'",
+        Predicate::eq(col("created"), Expression::literal(Scalar::Date(1)))
+    )]
+    #[case::binary_literal(
+        "data = X'01ff'",
+        Predicate::eq(col("data"), Expression::literal(Scalar::Binary(vec![0x01, 0xff])))
+    )]
+    // Leading-dot and exponent numeric forms each tokenize as a single numeric literal.
+    #[case::leading_dot_decimal(
+        "ratio > .5",
+        Predicate::gt(col("ratio"), Expression::literal(Scalar::Double(0.5)))
+    )]
+    #[case::exponent_number(
+        "ratio < 1e3",
+        Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1000.0)))
+    )]
+    // Timestamp typed literals: LTZ (bare `TIMESTAMP` or explicit `TIMESTAMP_LTZ`, both requiring a
+    // `Z` suffix) and zoneless `TIMESTAMP_NTZ`.
+    #[case::typed_timestamp(
+        "ts = TIMESTAMP '1970-01-01T00:00:00Z'",
+        Predicate::eq(col("ts"), Expression::literal(Scalar::Timestamp(0)))
+    )]
+    #[case::typed_timestamp_ltz(
+        "ts = TIMESTAMP_LTZ '1970-01-01T00:00:00Z'",
+        Predicate::eq(col("ts"), Expression::literal(Scalar::Timestamp(0)))
+    )]
+    #[case::typed_timestamp_ntz(
+        "tsn = TIMESTAMP_NTZ '1970-01-01 00:00:00'",
+        Predicate::eq(col("tsn"), Expression::literal(Scalar::TimestampNtz(0)))
+    )]
+    // Column casing in the source is normalized to the schema's stored casing.
+    #[case::case_insensitive_column(
+        "AMOUNT >= 0",
+        Predicate::ge(col("amount"), Expression::literal(0i64))
+    )]
+    #[case::string_with_doubled_quote(
+        "name = 'O''Brien'",
+        Predicate::eq(col("name"), Expression::literal("O'Brien"))
+    )]
+    #[case::column_vs_column("price < amount", Predicate::lt(col("price"), col("amount")))]
+    #[case::literal_on_left("0 < amount", Predicate::lt(Expression::literal(0i64), col("amount")))]
+    // `NULL` is an operand, typed from the column it is compared against.
+    #[case::null_operand(
+        "name = NULL",
+        Predicate::eq(col("name"), Expression::literal(Scalar::Null(DataType::STRING)))
+    )]
+    // Dotted paths resolve into nested structs.
+    #[case::nested_column(
+        "nested.inner > 0",
+        Predicate::gt(Expression::column(["nested", "inner"]), Expression::literal(0i64))
+    )]
+    fn kernel_parsable_comparison_lowers_to_expected_predicate(
+        #[case] sql: &str,
+        #[case] expected: Predicate,
+    ) {
+        assert_eq!(
+            parse_sql_simple_predicate(sql, &schema()).unwrap(),
+            expected
+        );
+    }
+
+    /// Not-kernel-parsable inputs: everything outside the single-comparison grammar must error, so
+    /// the caller treats the constraint as not-kernel-parsable (connector-enforced / fail-closed).
+    /// Covers boolean junctions, parentheses, `IS [NOT] NULL`, multi-operand predicates
+    /// (`IN`/`BETWEEN`/`LIKE`), functions, arithmetic, comparisons with no column,
+    /// type-incompatible literals (kernel applies no implicit casts), and malformed input.
+    #[rstest]
+    // Boolean structure beyond a single comparison.
+    #[case::and_junction("amount > 0 AND price < 10")]
+    #[case::or_junction("amount > 0 OR price < 10")]
+    #[case::not_prefix("NOT active")]
+    #[case::parentheses("(amount > 0)")]
+    #[case::is_null("name IS NULL")]
+    #[case::is_not_null("name IS NOT NULL")]
+    // Multi-operand predicate forms are not comparisons.
+    #[case::in_list("amount IN (1, 2)")]
+    #[case::between("amount BETWEEN 0 AND 10")]
+    #[case::like("name LIKE 'a%'")]
+    // A bare operand is not a comparison (no `<op>`), even when boolean-typed.
+    #[case::bare_boolean_column("active")]
+    // Operands richer than a column/literal/NULL.
+    #[case::function_call("length(name) > 0")]
+    #[case::arithmetic("amount + 1 > 0")]
+    // A comparison must reference at least one column (so a literal can be typed).
+    #[case::two_literals("1 > 0")]
+    #[case::two_nulls("NULL = NULL")]
+    #[case::unknown_column("nope > 0")]
+    // Non-primitive (struct/array/map) columns have no scalar comparison and are rejected on either
+    // side of the operator -- symmetric with the literal path, which rejects non-primitive targets.
+    #[case::struct_column_vs_struct_column("nested = nested")]
+    #[case::struct_column_vs_null("nested = NULL")]
+    #[case::struct_column_vs_literal("nested = 0")]
+    // No implicit casts: a literal whose SQL form does not match the compared column's type is
+    // rejected -- including a quoted number for a numeric column, which Spark would coerce.
+    #[case::string_literal_for_numeric_column("amount = 'foo'")]
+    #[case::quoted_number_for_numeric_column("amount = '10'")]
+    #[case::literal_out_of_range_for_column("price = 9999999999")]
+    // Malformed input.
+    #[case::unterminated_string("name = 'oops")]
+    #[case::missing_operator("amount price")]
+    #[case::trailing_tokens("amount > 0 extra")]
+    #[case::operator_only(">")]
+    #[case::empty("")]
+    fn not_kernel_parsable_input_is_rejected(#[case] sql: &str) {
+        assert!(
+            parse_sql_simple_predicate(sql, &schema()).is_err(),
+            "expected {sql:?} to be rejected as not kernel-parsable"
+        );
+    }
+}

--- a/kernel/src/expressions/sql/parser.rs
+++ b/kernel/src/expressions/sql/parser.rs
@@ -1,0 +1,123 @@
+//! Parser for a single CHECK-constraint comparison.
+//!
+//! Consumes the [`Token`] stream from [`super::token`] and produces a [`Comparison`] -- exactly one
+//! `operand <op> operand`. Junctions (`AND`/`OR`/`NOT`), parentheses, and `IS [NOT] NULL` are out
+//! of this grammar and surface as errors, which the caller treats as "not kernel-parsable".
+//! Lowering ([`super::lower`]) resolves the operands against the table schema.
+
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+#![allow(dead_code)]
+
+use super::token::Token;
+use crate::{DeltaResult, Error};
+
+/// An operand of a comparison: a column reference (raw path segments, as written) or a literal
+/// (raw source text, e.g. `42`, `'foo'`, `NULL`). Both are resolved/typed during lowering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Operand {
+    Column(Vec<String>),
+    Literal(String),
+}
+
+/// A comparison operator. Kernel has no native `<=`/`>=`/`!=`; lowering maps these to the
+/// corresponding `Predicate` constructors (`le`/`ge`/`ne`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+/// A single parsed comparison `left <op> right`. Operands are resolved against the table schema
+/// during lowering ([`super::lower`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Comparison {
+    pub(super) op: CmpOp,
+    pub(super) left: Operand,
+    pub(super) right: Operand,
+}
+
+/// Parse a token stream into a single [`Comparison`]. The grammar has no junctions, so any tokens
+/// left over after one comparison are an error.
+pub(super) fn parse(tokens: Vec<Token>) -> DeltaResult<Comparison> {
+    let mut parser = Parser { tokens, pos: 0 };
+    let comparison = parser.parse_comparison()?;
+    if parser.pos != parser.tokens.len() {
+        return Err(Error::generic(
+            "unexpected trailing input in CHECK constraint: only a single comparison is supported",
+        ));
+    }
+    Ok(comparison)
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn advance(&mut self) -> Option<Token> {
+        let token = self.tokens.get(self.pos).cloned();
+        if token.is_some() {
+            self.pos += 1;
+        }
+        token
+    }
+
+    // comparison := operand cmp operand
+    fn parse_comparison(&mut self) -> DeltaResult<Comparison> {
+        let left = self.parse_operand()?;
+        let op = self.cmp_op()?;
+        let right = self.parse_operand()?;
+        Ok(Comparison { op, left, right })
+    }
+
+    fn cmp_op(&mut self) -> DeltaResult<CmpOp> {
+        let op = match self.advance() {
+            Some(Token::Lt) => CmpOp::Lt,
+            Some(Token::Le) => CmpOp::Le,
+            Some(Token::Gt) => CmpOp::Gt,
+            Some(Token::Ge) => CmpOp::Ge,
+            Some(Token::Eq) => CmpOp::Eq,
+            Some(Token::Ne) => CmpOp::Ne,
+            other => {
+                return Err(Error::generic(format!(
+                    "expected a comparison operator in CHECK constraint, found {other:?}"
+                )))
+            }
+        };
+        Ok(op)
+    }
+
+    // operand := Literal | Ident ( '.' Ident )*
+    fn parse_operand(&mut self) -> DeltaResult<Operand> {
+        match self.advance() {
+            Some(Token::Literal(raw)) => Ok(Operand::Literal(raw)),
+            Some(Token::Ident(first)) => {
+                let mut path = vec![first];
+                while self.peek() == Some(&Token::Dot) {
+                    self.advance();
+                    match self.advance() {
+                        Some(Token::Ident(segment)) => path.push(segment),
+                        other => {
+                            return Err(Error::generic(format!(
+                            "expected an identifier after '.' in CHECK constraint, found {other:?}"
+                        )))
+                        }
+                    }
+                }
+                Ok(Operand::Column(path))
+            }
+            other => Err(Error::generic(format!(
+                "expected a column or literal in CHECK constraint, found {other:?}"
+            ))),
+        }
+    }
+}

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -49,7 +49,8 @@ pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
                 chars.next();
             }
             // A `.` starts a number when a digit follows (a leading-dot decimal like `.5`);
-            // otherwise it is a column-path separator. Mirrors the sign arm's lookahead below.
+            // otherwise it is a column-path separator. (The `+`/`-` arm below uses a similar
+            // lookahead, though it also admits a following `.`.)
             '.' => {
                 let mut lookahead = chars.clone();
                 lookahead.next();
@@ -132,11 +133,9 @@ fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Stri
             "unterminated string literal in CHECK constraint: {sql}"
         ))
     };
-    let mut out = String::new();
-    match chars.next() {
-        Some('\'') => out.push('\''),
-        _ => return Err(unterminated()),
-    }
+    // The caller guarantees the stream starts with the opening `'`; consume it.
+    chars.next();
+    let mut out = String::from('\'');
     loop {
         match chars.next() {
             Some('\'') => {

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -1,0 +1,221 @@
+//! Tokenizer for the CHECK-constraint predicate parser.
+//!
+//! Splits a constraint SQL string into [`Token`]s. Literal tokens keep their *raw* source text
+//! (quotes and typed-literal keyword included) so lowering can hand them to the existing literal
+//! parser [`super::parse_sql`] rather than re-implementing scalar parsing here.
+
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+#![allow(dead_code)]
+
+use std::iter::Peekable;
+use std::str::Chars;
+
+use crate::{DeltaResult, Error};
+
+/// A peekable character stream over the constraint source string.
+type CharStream<'a> = Peekable<Chars<'a>>;
+
+/// A lexical token in a single CHECK-constraint comparison.
+///
+/// The grammar is intentionally minimal -- only what a single `operand <op> operand` comparison
+/// needs. Junction keywords (`AND`/`OR`/`NOT`/`IS`) and parentheses are not recognized; they fall
+/// through to either an [`Token::Ident`] or a tokenizer error, both of which the parser rejects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Token {
+    /// A single identifier segment (one component of a column path). Dotted paths are assembled by
+    /// the parser from `Ident (Dot Ident)*`.
+    Ident(String),
+    /// The raw source text of a literal -- a number, a `'string'` (quotes retained), an `X'..'`
+    /// binary, `TRUE`/`FALSE`, `NULL`, or a typed `DATE '...'` / `TIMESTAMP '...'` /
+    /// `TIMESTAMP_LTZ '...'` / `TIMESTAMP_NTZ '...'` literal. Decoding is deferred to
+    /// [`super::parse_sql`].
+    Literal(String),
+    Dot,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    /// `<>` or `!=` (both lower to the same not-equal predicate).
+    Ne,
+}
+
+/// Tokenize a single-comparison constraint expression, or return an error for any character/run the
+/// grammar does not recognize (e.g. arithmetic operators, parentheses, an unterminated string).
+pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
+    let mut chars = sql.chars().peekable();
+    let mut tokens = Vec::new();
+    while let Some(&c) = chars.peek() {
+        match c {
+            c if c.is_whitespace() => {
+                chars.next();
+            }
+            // A `.` starts a number when a digit follows (a leading-dot decimal like `.5`);
+            // otherwise it is a column-path separator. Mirrors the sign arm's lookahead below.
+            '.' => {
+                let mut lookahead = chars.clone();
+                lookahead.next();
+                if matches!(lookahead.peek(), Some(d) if d.is_ascii_digit()) {
+                    tokens.push(Token::Literal(take_number(&mut chars)));
+                } else {
+                    chars.next();
+                    tokens.push(Token::Dot);
+                }
+            }
+            '=' => {
+                chars.next();
+                // Accept `==` as an alias for `=` (Spark SQL allows both); consume the optional
+                // second `=`.
+                chars.next_if_eq(&'=');
+                tokens.push(Token::Eq);
+            }
+            '<' => {
+                chars.next();
+                let tok = if chars.next_if_eq(&'=').is_some() {
+                    Token::Le
+                } else if chars.next_if_eq(&'>').is_some() {
+                    Token::Ne
+                } else {
+                    Token::Lt
+                };
+                tokens.push(tok);
+            }
+            '>' => {
+                chars.next();
+                let tok = if chars.next_if_eq(&'=').is_some() {
+                    Token::Ge
+                } else {
+                    Token::Gt
+                };
+                tokens.push(tok);
+            }
+            '!' => {
+                chars.next();
+                match chars.next_if_eq(&'=') {
+                    Some(_) => tokens.push(Token::Ne),
+                    None => return Err(unexpected('!', sql)),
+                }
+            }
+            '\'' => tokens.push(Token::Literal(take_quoted_string(&mut chars, sql)?)),
+            // A sign is only valid as the start of a numeric literal -- the grammar has no
+            // arithmetic, so `a - b` is intentionally rejected.
+            '+' | '-' => {
+                let mut lookahead = chars.clone();
+                lookahead.next();
+                match lookahead.peek() {
+                    Some(d) if d.is_ascii_digit() || *d == '.' => {
+                        tokens.push(Token::Literal(take_number(&mut chars)))
+                    }
+                    _ => return Err(unexpected(c, sql)),
+                }
+            }
+            c if c.is_ascii_digit() => tokens.push(Token::Literal(take_number(&mut chars))),
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                tokens.push(classify_word(&mut chars, sql)?)
+            }
+            _ => return Err(unexpected(c, sql)),
+        }
+    }
+    Ok(tokens)
+}
+
+fn unexpected(c: char, sql: &str) -> Error {
+    Error::generic(format!(
+        "unexpected character '{c}' in CHECK constraint: {sql}"
+    ))
+}
+
+/// Consume a `'...'` string literal, returning its raw text *including* the surrounding quotes and
+/// any doubled `''` escapes. Decoding (un-escaping) is left to [`super::parse_sql`]. The caller
+/// guarantees a leading `'`.
+fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<String> {
+    let unterminated = || {
+        Error::generic(format!(
+            "unterminated string literal in CHECK constraint: {sql}"
+        ))
+    };
+    let mut out = String::new();
+    match chars.next() {
+        Some('\'') => out.push('\''),
+        _ => return Err(unterminated()),
+    }
+    loop {
+        match chars.next() {
+            Some('\'') => {
+                out.push('\'');
+                // A doubled quote is an embedded single quote; keep scanning. Otherwise this was
+                // the closing quote.
+                match chars.next_if_eq(&'\'') {
+                    Some(q) => out.push(q),
+                    None => return Ok(out),
+                }
+            }
+            Some(c) => out.push(c),
+            None => return Err(unterminated()),
+        }
+    }
+}
+
+/// Consume a numeric literal: optional leading sign, integer/fraction digits, optional exponent.
+/// Stops before a second operator so `1+1` is not swallowed as one number.
+fn take_number(chars: &mut CharStream<'_>) -> String {
+    let mut out = String::new();
+    if let Some(sign) = chars.next_if(|c| *c == '+' || *c == '-') {
+        out.push(sign);
+    }
+    while let Some(c) = chars.next_if(|c| c.is_ascii_digit() || *c == '.') {
+        out.push(c);
+    }
+    if let Some(e) = chars.next_if(|c| *c == 'e' || *c == 'E') {
+        out.push(e);
+        if let Some(sign) = chars.next_if(|c| *c == '+' || *c == '-') {
+            out.push(sign);
+        }
+        while let Some(c) = chars.next_if(|c| c.is_ascii_digit()) {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Scan a bare word, then classify it as a boolean/null/typed/binary literal or an identifier.
+/// Typed (`DATE '...'`) and binary (`X'..'`) literals are recognized here so their raw text reaches
+/// [`super::parse_sql`] as a single token.
+fn classify_word(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Token> {
+    let mut word = String::new();
+    while let Some(c) = chars.next_if(|c| c.is_ascii_alphanumeric() || *c == '_') {
+        word.push(c);
+    }
+    let token = match word.to_ascii_uppercase().as_str() {
+        // `NULL`, `TRUE`, and `FALSE` are literals; `parse_sql` decodes them against the compared
+        // column's type during lowering. (Junction keywords like `AND`/`IS` are deliberately not
+        // recognized -- they become `Ident`s and the parser rejects them.)
+        "NULL" | "TRUE" | "FALSE" => Token::Literal(word),
+        // `X'deadbeef'` binary literal: only when a quote immediately follows (no whitespace),
+        // otherwise `x` is a column named `x`.
+        "X" if chars.peek() == Some(&'\'') => {
+            let quoted = take_quoted_string(chars, sql)?;
+            Token::Literal(format!("{word}{quoted}"))
+        }
+        // Typed literal: the keyword followed (whitespace allowed) by a quoted string. Without the
+        // quote it is just a column named `date`/`timestamp`/etc. This set must cover every
+        // typed-literal keyword `super::parse_sql` accepts (incl. `TIMESTAMP_LTZ`); a missing one
+        // is mis-lexed as an identifier and the constraint is wrongly rejected.
+        "DATE" | "TIMESTAMP" | "TIMESTAMP_LTZ" | "TIMESTAMP_NTZ" if quote_follows(chars) => {
+            while chars.next_if(|c| c.is_whitespace()).is_some() {}
+            let quoted = take_quoted_string(chars, sql)?;
+            Token::Literal(format!("{word} {quoted}"))
+        }
+        _ => Token::Ident(word),
+    };
+    Ok(token)
+}
+
+/// Peek (without consuming) past any whitespace to see whether the next character is a `'`.
+fn quote_follows(chars: &CharStream<'_>) -> bool {
+    let mut lookahead = chars.clone();
+    while matches!(lookahead.peek(), Some(c) if c.is_whitespace()) {
+        lookahead.next();
+    }
+    lookahead.peek() == Some(&'\'')
+}

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -22,8 +22,6 @@ type CharStream<'a> = Peekable<Chars<'a>>;
 /// through to either an [`Token::Ident`] or a tokenizer error, both of which the parser rejects.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum Token {
-    /// A single identifier segment (one component of a column path). Dotted paths are assembled by
-    /// the parser from `Ident (Dot Ident)*`.
     Ident(String),
     /// The raw source text of a literal -- a number, a `'string'` (quotes retained), an `X'..'`
     /// binary, `TRUE`/`FALSE`, `NULL`, or a typed `DATE '...'` / `TIMESTAMP '...'` /


### PR DESCRIPTION
## What changes are proposed in this pull request?

We expand Kernel's existing SQL parser to parse predicates in support of the eventual integration of check constraints. It is currently gated behind a cargo feature. 

The current scope is intentionally narrow - we support predicates of the form '<operand> <op> <operand>', where an <operand> is either a column, literal, or null, and <op> is one of `< <= > >= = == != <>`. This is to avoid bloating kernel and also to focus on the majority use case for DBR constraints. 

We introduce 3 new files - {token,parser,lower}.rs (tokenizer -> single-comparison
parser -> schema-aware lowering).

## How was this change tested?

new UTs