### PR TITLE
feat!: make default engine read I/O concurrency configurable

### DIFF
--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -1,6 +1,7 @@
 //! Default Json handler implementation
 
 use std::io::BufReader;
+use std::num::NonZero;
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -37,10 +38,10 @@ pub struct DefaultJsonHandler<E: TaskExecutor> {
     /// The maximum number of read requests to buffer in memory at once. Note that this actually
     /// controls two things: the number of concurrent requests (done by `buffered`) and the size of
     /// the buffer (via our `sync_channel`).
-    buffer_size: usize,
+    buffer_size: NonZero<usize>,
     /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
     /// yielded by the stream will have at most N rows.
-    batch_size: usize,
+    batch_size: NonZero<usize>,
 }
 
 impl<E: TaskExecutor> DefaultJsonHandler<E> {
@@ -48,21 +49,21 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
         Self {
             store,
             task_executor,
-            buffer_size: super::DEFAULT_BUFFER_SIZE,
-            batch_size: super::DEFAULT_BATCH_SIZE,
+            buffer_size: super::DEFAULT_READ_BUFFER_SIZE,
+            batch_size: super::DEFAULT_READ_BATCH_SIZE,
         }
     }
 
     /// Set the maximum number read requests to buffer in memory at once in
     /// [Self::read_json_files()].
     ///
-    /// Defaults to 1000.
+    /// Defaults to `super::DEFAULT_READ_BUFFER_SIZE`.
     ///
     /// Memory constraints can be imposed by constraining the buffer size and batch size. Note that
     /// overall memory usage is proportional to the product of these two values.
     /// 1. Batch size governs the size of RecordBatches yielded in each iteration of the stream
     /// 2. Buffer size governs the number of concurrent tasks (which equals the size of the buffer
-    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+    pub fn with_buffer_size(mut self, buffer_size: NonZero<usize>) -> Self {
         self.buffer_size = buffer_size;
         self
     }
@@ -70,13 +71,13 @@ impl<E: TaskExecutor> DefaultJsonHandler<E> {
     /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
     /// yielded by the stream will have at most N rows.
     ///
-    /// Defaults to 1000 rows (json objects).
+    /// Defaults to `super::DEFAULT_READ_BATCH_SIZE` rows (json objects).
     ///
     /// See [Decoder::with_buffer_size] for details on constraining memory usage with buffer size
     /// and batch size.
     ///
     /// [Decoder::with_buffer_size]: delta_kernel::arrow::json::reader::Decoder
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    pub fn with_batch_size(mut self, batch_size: NonZero<usize>) -> Self {
         self.batch_size = batch_size;
         self
     }
@@ -169,8 +170,8 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
             files.to_vec(),
             physical_schema,
             predicate,
-            self.batch_size,
-            self.buffer_size,
+            self.batch_size.get(),
+            self.buffer_size.get(),
         );
         super::stream_future_to_iter(self.task_executor.clone(), future)
     }
@@ -586,7 +587,7 @@ mod tests {
         assert_eq!(data[0].num_rows(), 4);
 
         // limit batch size
-        let handler = handler.with_batch_size(2);
+        let handler = handler.with_batch_size(NonZero::new(2).unwrap());
         let data: Vec<RecordBatch> = handler
             .read_json_files(files, get_commit_schema().clone(), None)
             .unwrap()
@@ -796,7 +797,8 @@ mod tests {
                     tokio::runtime::Handle::current(),
                 )),
             );
-            let handler = handler.with_buffer_size(*buffer_size);
+            let handler = handler
+                .with_buffer_size(NonZero::new(*buffer_size).expect("buffer_size is non-zero"));
             let physical_schema = schema_ref! { nullable "val": INTEGER };
             let data: Vec<RecordBatch> = handler
                 .read_json_files(&files, physical_schema, None)

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -85,6 +85,13 @@ impl<T: Send + 'static, E: executor::TaskExecutor> Iterator for BlockingStreamIt
 const DEFAULT_BUFFER_SIZE: usize = 1000;
 const DEFAULT_BATCH_SIZE: usize = 1000;
 
+/// Default file-level readahead depth for JSON and Parquet handlers.
+pub(crate) const DEFAULT_READ_BUFFER_SIZE: NonZero<usize> =
+    NonZero::new(DEFAULT_BUFFER_SIZE).unwrap();
+/// Default row batch size for JSON and Parquet read streams.
+pub(crate) const DEFAULT_READ_BATCH_SIZE: NonZero<usize> =
+    NonZero::new(DEFAULT_BATCH_SIZE).unwrap();
+
 #[derive(Debug)]
 pub struct DefaultEngine<E: TaskExecutor> {
     object_store: Arc<DynObjectStore>,
@@ -226,16 +233,14 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             task_executor.clone(),
         ));
 
-        let mut json = DefaultJsonHandler::new(object_store.clone(), task_executor.clone());
-        let mut parquet = DefaultParquetHandler::new(object_store.clone(), task_executor.clone());
-        if let Some(buffer_size) = io_config.buffer_size {
-            json = json.with_buffer_size(buffer_size.get());
-            parquet = parquet.with_buffer_size(buffer_size.get());
-        }
-        if let Some(batch_size) = io_config.batch_size {
-            json = json.with_batch_size(batch_size.get());
-            parquet = parquet.with_batch_size(batch_size.get());
-        }
+        let buffer_size = io_config.buffer_size.unwrap_or(DEFAULT_READ_BUFFER_SIZE);
+        let batch_size = io_config.batch_size.unwrap_or(DEFAULT_READ_BATCH_SIZE);
+        let json = DefaultJsonHandler::new(object_store.clone(), task_executor.clone())
+            .with_buffer_size(buffer_size)
+            .with_batch_size(batch_size);
+        let parquet = DefaultParquetHandler::new(object_store.clone(), task_executor.clone())
+            .with_buffer_size(buffer_size)
+            .with_batch_size(batch_size);
         let raw_json: Arc<dyn JsonHandler> = Arc::new(json);
         let raw_parquet = Arc::new(parquet);
         Self {

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -7,6 +7,7 @@
 //! the [executor] module.
 
 use std::future::Future;
+use std::num::NonZero;
 use std::sync::Arc;
 
 use delta_kernel::engine::arrow_conversion::TryFromArrow as _;
@@ -133,9 +134,9 @@ pub struct DefaultEngineBuilder<E> {
 struct ReadIoConfig {
     /// Maximum number of files read concurrently (file-level readahead depth). See
     /// [`DefaultEngineBuilder::with_buffer_size`].
-    buffer_size: Option<usize>,
+    buffer_size: Option<NonZero<usize>>,
     /// Maximum number of rows per yielded batch. See [`DefaultEngineBuilder::with_batch_size`].
-    batch_size: Option<usize>,
+    batch_size: Option<NonZero<usize>>,
 }
 
 /// Represents the default [`TaskExecutor`]. The executor is created lazily to avoid unnecessary
@@ -178,9 +179,9 @@ impl<E> DefaultEngineBuilder<E> {
     /// `read_*_files` paths. This is the file-level I/O readahead depth: higher values overlap more
     /// object-store requests to hide latency, at the cost of more in-flight memory.
     ///
-    /// Defaults to the handlers' built-in value (1000) when unset. Ordering of returned data is
-    /// preserved regardless of this value.
-    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+    /// Defaults to the handlers' built-in value when unset. Ordering of returned data is preserved
+    /// regardless of this value.
+    pub fn with_buffer_size(mut self, buffer_size: NonZero<usize>) -> Self {
         self.io_config.buffer_size = Some(buffer_size);
         self
     }
@@ -188,9 +189,9 @@ impl<E> DefaultEngineBuilder<E> {
     /// Set the maximum number of rows per batch yielded by the JSON and Parquet handlers in their
     /// `read_*_files` paths.
     ///
-    /// Defaults to the handlers' built-in value (1000 rows) when unset. Overall read memory usage
-    /// is roughly proportional to `buffer_size * batch_size`.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    /// Defaults to the handlers' built-in value when unset. Overall read memory usage is roughly
+    /// proportional to `buffer_size * batch_size`.
+    pub fn with_batch_size(mut self, batch_size: NonZero<usize>) -> Self {
         self.io_config.batch_size = Some(batch_size);
         self
     }
@@ -228,12 +229,12 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         let mut json = DefaultJsonHandler::new(object_store.clone(), task_executor.clone());
         let mut parquet = DefaultParquetHandler::new(object_store.clone(), task_executor.clone());
         if let Some(buffer_size) = io_config.buffer_size {
-            json = json.with_buffer_size(buffer_size);
-            parquet = parquet.with_buffer_size(buffer_size);
+            json = json.with_buffer_size(buffer_size.get());
+            parquet = parquet.with_buffer_size(buffer_size.get());
         }
         if let Some(batch_size) = io_config.batch_size {
-            json = json.with_batch_size(batch_size);
-            parquet = parquet.with_batch_size(batch_size);
+            json = json.with_batch_size(batch_size.get());
+            parquet = parquet.with_batch_size(batch_size.get());
         }
         let raw_json: Arc<dyn JsonHandler> = Arc::new(json);
         let raw_parquet = Arc::new(parquet);
@@ -433,8 +434,8 @@ mod tests {
         let executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
         let engine = DefaultEngineBuilder::new(object_store)
             .with_task_executor(executor)
-            .with_buffer_size(4)
-            .with_batch_size(8)
+            .with_buffer_size(NonZero::new(4).unwrap())
+            .with_batch_size(NonZero::new(8).unwrap())
             .build();
         test_arrow_engine(&engine, &url);
     }

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -121,6 +121,21 @@ pub struct DefaultEngineBuilder<E> {
     object_store: Arc<DynObjectStore>,
     /// The state is either [`DefaultTaskExecutor`] or `Arc<E>` with a custom task executor.
     task_executor: E,
+    /// Read-path I/O concurrency config applied to the JSON and Parquet handlers. `None` fields
+    /// fall back to the handlers' defaults.
+    io_config: ReadIoConfig,
+}
+
+/// Read-path I/O tuning for [`DefaultEngine`]'s JSON and Parquet handlers.
+///
+/// Both knobs default to the handlers' built-in defaults when left unset.
+#[derive(Debug, Default, Clone, Copy)]
+struct ReadIoConfig {
+    /// Maximum number of files read concurrently (file-level readahead depth). See
+    /// [`DefaultEngineBuilder::with_buffer_size`].
+    buffer_size: Option<usize>,
+    /// Maximum number of rows per yielded batch. See [`DefaultEngineBuilder::with_batch_size`].
+    batch_size: Option<usize>,
 }
 
 /// Represents the default [`TaskExecutor`]. The executor is created lazily to avoid unnecessary
@@ -133,13 +148,14 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
         Self {
             object_store,
             task_executor: DefaultTaskExecutor,
+            io_config: ReadIoConfig::default(),
         }
     }
 
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
         let task_executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
-        DefaultEngine::new_with_opts(self.object_store, task_executor)
+        DefaultEngine::new_with_opts(self.object_store, task_executor, self.io_config)
     }
 }
 
@@ -154,14 +170,36 @@ impl<E> DefaultEngineBuilder<E> {
         DefaultEngineBuilder {
             object_store: self.object_store,
             task_executor,
+            io_config: self.io_config,
         }
+    }
+
+    /// Set the maximum number of files read concurrently by the JSON and Parquet handlers in their
+    /// `read_*_files` paths. This is the file-level I/O readahead depth: higher values overlap more
+    /// object-store requests to hide latency, at the cost of more in-flight memory.
+    ///
+    /// Defaults to the handlers' built-in value (1000) when unset. Ordering of returned data is
+    /// preserved regardless of this value.
+    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+        self.io_config.buffer_size = Some(buffer_size);
+        self
+    }
+
+    /// Set the maximum number of rows per batch yielded by the JSON and Parquet handlers in their
+    /// `read_*_files` paths.
+    ///
+    /// Defaults to the handlers' built-in value (1000 rows) when unset. Overall read memory usage
+    /// is roughly proportional to `buffer_size * batch_size`.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.io_config.batch_size = Some(batch_size);
+        self
     }
 }
 
 impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<E> {
-        DefaultEngine::new_with_opts(self.object_store, self.task_executor)
+        DefaultEngine::new_with_opts(self.object_store, self.task_executor, self.io_config)
     }
 }
 
@@ -177,19 +215,28 @@ impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
 }
 
 impl<E: TaskExecutor> DefaultEngine<E> {
-    fn new_with_opts(object_store: Arc<DynObjectStore>, task_executor: Arc<E>) -> Self {
+    fn new_with_opts(
+        object_store: Arc<DynObjectStore>,
+        task_executor: Arc<E>,
+        io_config: ReadIoConfig,
+    ) -> Self {
         let raw_storage: Arc<dyn StorageHandler> = Arc::new(ObjectStoreStorageHandler::new(
             object_store.clone(),
             task_executor.clone(),
         ));
-        let raw_json: Arc<dyn JsonHandler> = Arc::new(DefaultJsonHandler::new(
-            object_store.clone(),
-            task_executor.clone(),
-        ));
-        let raw_parquet = Arc::new(DefaultParquetHandler::new(
-            object_store.clone(),
-            task_executor.clone(),
-        ));
+
+        let mut json = DefaultJsonHandler::new(object_store.clone(), task_executor.clone());
+        let mut parquet = DefaultParquetHandler::new(object_store.clone(), task_executor.clone());
+        if let Some(buffer_size) = io_config.buffer_size {
+            json = json.with_buffer_size(buffer_size);
+            parquet = parquet.with_buffer_size(buffer_size);
+        }
+        if let Some(batch_size) = io_config.batch_size {
+            json = json.with_batch_size(batch_size);
+            parquet = parquet.with_batch_size(batch_size);
+        }
+        let raw_json: Arc<dyn JsonHandler> = Arc::new(json);
+        let raw_parquet = Arc::new(parquet);
         Self {
             storage: Arc::new(MeteredStorageHandler::new(raw_storage)),
             json: Arc::new(MeteredJsonHandler::new(raw_json)),
@@ -386,6 +433,8 @@ mod tests {
         let executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
         let engine = DefaultEngineBuilder::new(object_store)
             .with_task_executor(executor)
+            .with_buffer_size(4)
+            .with_batch_size(8)
             .build();
         test_arrow_engine(&engine, &url);
     }

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -48,8 +48,7 @@ pub struct DefaultParquetHandler<E: TaskExecutor> {
     /// The maximum number of files to read concurrently in [`Self::read_parquet_files()`]. This is
     /// the number of futures buffered by `buffered`, i.e. the file-level I/O readahead depth.
     buffer_size: usize,
-    /// Limit the number of rows per batch. For `batch_size = N`, each RecordBatch yielded by the
-    /// read stream will have at most N rows.
+    /// The maximum number of rows per RecordBatch yielded by the read stream.
     batch_size: usize,
 }
 
@@ -161,7 +160,7 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
 
     /// Set the maximum number of files to read concurrently in [Self::read_parquet_files()].
     ///
-    /// Defaults to 1000.
+    /// Defaults to `super::DEFAULT_BUFFER_SIZE`.
     ///
     /// Memory constraints can be imposed by constraining the buffer size and batch size. Note that
     /// overall memory usage is proportional to the product of these two values.
@@ -173,10 +172,9 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         self
     }
 
-    /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
-    /// yielded by [Self::read_parquet_files()] will have at most N rows.
+    /// Set the maximum number of rows per RecordBatch yielded by [Self::read_parquet_files()].
     ///
-    /// Defaults to 1000 rows.
+    /// Defaults to `super::DEFAULT_BATCH_SIZE` rows.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = batch_size;
         self

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -45,7 +45,12 @@ use crate::UrlExt;
 pub struct DefaultParquetHandler<E: TaskExecutor> {
     store: Arc<DynObjectStore>,
     task_executor: Arc<E>,
-    readahead: usize,
+    /// The maximum number of files to read concurrently in [`Self::read_parquet_files()`]. This is
+    /// the number of futures buffered by `buffered`, i.e. the file-level I/O readahead depth.
+    buffer_size: usize,
+    /// Limit the number of rows per batch. For `batch_size = N`, each RecordBatch yielded by the
+    /// read stream will have at most N rows.
+    batch_size: usize,
 }
 
 /// Metadata of a data file (typically a parquet file).
@@ -149,15 +154,31 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         Self {
             store,
             task_executor,
-            readahead: 10,
+            buffer_size: super::DEFAULT_BUFFER_SIZE,
+            batch_size: super::DEFAULT_BATCH_SIZE,
         }
     }
 
-    /// Max number of batches to read ahead while executing [Self::read_parquet_files()].
+    /// Set the maximum number of files to read concurrently in [Self::read_parquet_files()].
     ///
-    /// Defaults to 10.
-    pub fn with_readahead(mut self, readahead: usize) -> Self {
-        self.readahead = readahead;
+    /// Defaults to 1000.
+    ///
+    /// Memory constraints can be imposed by constraining the buffer size and batch size. Note that
+    /// overall memory usage is proportional to the product of these two values.
+    /// 1. Batch size governs the size of RecordBatches yielded in each iteration of the stream.
+    /// 2. Buffer size governs the number of concurrent file reads (which equals the size of the
+    ///    readahead buffer).
+    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+        self.buffer_size = buffer_size;
+        self
+    }
+
+    /// Limit the number of rows per batch. That is, for batch_size = N, then each RecordBatch
+    /// yielded by [Self::read_parquet_files()] will have at most N rows.
+    ///
+    /// Defaults to 1000 rows.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size;
         self
     }
 
@@ -247,6 +268,8 @@ async fn read_parquet_files_impl(
     files: Vec<FileMeta>,
     physical_schema: SchemaRef,
     predicate: Option<PredicateRef>,
+    buffer_size: usize,
+    batch_size: usize,
 ) -> DeltaResult<BoxStream<'static, DeltaResult<Box<dyn EngineData>>>> {
     if files.is_empty() {
         return Ok(Box::pin(stream::empty()));
@@ -264,7 +287,7 @@ async fn read_parquet_files_impl(
     // SAFETY: we did is_empty check above, this is ok.
     if files[0].location.is_presigned() {
         let file_opener = Box::new(PresignedUrlOpener::new(
-            1024,
+            batch_size,
             physical_schema.clone(),
             predicate,
         ));
@@ -279,21 +302,11 @@ async fn read_parquet_files_impl(
         let store = store.clone();
         let schema = physical_schema.clone();
         let predicate = predicate.clone();
-        async move {
-            open_parquet_file(
-                store,
-                schema,
-                predicate,
-                None,
-                super::DEFAULT_BATCH_SIZE,
-                file,
-            )
-            .await
-        }
+        async move { open_parquet_file(store, schema, predicate, None, batch_size, file).await }
     });
     // create a stream from that iterator which buffers up to `buffer_size` futures at a time
     let result_stream = stream::iter(file_futures)
-        .buffered(super::DEFAULT_BUFFER_SIZE)
+        .buffered(buffer_size)
         .try_flatten()
         .map_ok(|record_batch| -> Box<dyn EngineData> {
             Box::new(ArrowEngineData::new(record_batch))
@@ -314,6 +327,8 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
             files.to_vec(),
             physical_schema,
             predicate,
+            self.buffer_size,
+            self.batch_size,
         );
         super::stream_future_to_iter(self.task_executor.clone(), future)
     }
@@ -1185,6 +1200,59 @@ mod tests {
         assert_eq!(data.len(), 1);
         assert_eq!(data[0].num_rows(), 3);
         assert_eq!(data[0].num_columns(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_read_parquet_files_respects_batch_size() {
+        let store = Arc::new(InMemory::new());
+        let writer: Arc<dyn ParquetHandler> = Arc::new(DefaultParquetHandler::new(
+            store.clone(),
+            Arc::new(TokioBackgroundExecutor::new()),
+        ));
+
+        let engine_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![(
+                "x",
+                Arc::new(Int64Array::from((0..10).collect::<Vec<_>>())) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ));
+        let file_url = Url::parse("memory:///test/batch_size.parquet").unwrap();
+        writer
+            .write_parquet_file(file_url.clone(), Box::new(std::iter::once(Ok(engine_data))))
+            .unwrap();
+
+        let path = Path::from_url_path(file_url.path()).unwrap();
+        let metadata = store.head(&path).await.unwrap();
+        let reader = ParquetObjectReader::new(store.clone(), path);
+        let physical_schema = ParquetRecordBatchStreamBuilder::new(reader)
+            .await
+            .unwrap()
+            .schema()
+            .clone();
+        let file_meta = FileMeta {
+            location: file_url,
+            last_modified: 0,
+            size: metadata.size,
+        };
+
+        // With a batch size of 4, the 10-row file should be split into batches of 4, 4, 2.
+        let handler =
+            DefaultParquetHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()))
+                .with_batch_size(4);
+        let data: Vec<RecordBatch> = handler
+            .read_parquet_files(
+                slice::from_ref(&file_meta),
+                Arc::new(physical_schema.try_into_kernel().unwrap()),
+                None,
+            )
+            .unwrap()
+            .map(into_record_batch)
+            .try_collect()
+            .unwrap();
+
+        let row_counts: Vec<usize> = data.iter().map(|b| b.num_rows()).collect();
+        assert_eq!(row_counts, vec![4, 4, 2]);
     }
 
     #[tokio::test]

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -1,6 +1,7 @@
 //! Default Parquet handler implementation
 
 use std::collections::HashMap;
+use std::num::NonZero;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -47,9 +48,9 @@ pub struct DefaultParquetHandler<E: TaskExecutor> {
     task_executor: Arc<E>,
     /// The maximum number of files to read concurrently in [`Self::read_parquet_files()`]. This is
     /// the number of futures buffered by `buffered`, i.e. the file-level I/O readahead depth.
-    buffer_size: usize,
+    buffer_size: NonZero<usize>,
     /// The maximum number of rows per RecordBatch yielded by the read stream.
-    batch_size: usize,
+    batch_size: NonZero<usize>,
 }
 
 /// Metadata of a data file (typically a parquet file).
@@ -153,29 +154,33 @@ impl<E: TaskExecutor> DefaultParquetHandler<E> {
         Self {
             store,
             task_executor,
-            buffer_size: super::DEFAULT_BUFFER_SIZE,
-            batch_size: super::DEFAULT_BATCH_SIZE,
+            buffer_size: super::DEFAULT_READ_BUFFER_SIZE,
+            batch_size: super::DEFAULT_READ_BATCH_SIZE,
         }
     }
 
     /// Set the maximum number of files to read concurrently in [Self::read_parquet_files()].
     ///
-    /// Defaults to `super::DEFAULT_BUFFER_SIZE`.
+    /// Defaults to `super::DEFAULT_READ_BUFFER_SIZE`.
+    ///
+    /// This setting applies only to object-store reads. When every file in the batch uses a
+    /// presigned URL (`https://...`), reads bypass the object store and this value has no effect;
+    /// use [`Self::with_batch_size`] to tune RecordBatch chunking in that path.
     ///
     /// Memory constraints can be imposed by constraining the buffer size and batch size. Note that
     /// overall memory usage is proportional to the product of these two values.
     /// 1. Batch size governs the size of RecordBatches yielded in each iteration of the stream.
     /// 2. Buffer size governs the number of concurrent file reads (which equals the size of the
     ///    readahead buffer).
-    pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
+    pub fn with_buffer_size(mut self, buffer_size: NonZero<usize>) -> Self {
         self.buffer_size = buffer_size;
         self
     }
 
     /// Set the maximum number of rows per RecordBatch yielded by [Self::read_parquet_files()].
     ///
-    /// Defaults to `super::DEFAULT_BATCH_SIZE` rows.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    /// Defaults to `super::DEFAULT_READ_BATCH_SIZE` rows.
+    pub fn with_batch_size(mut self, batch_size: NonZero<usize>) -> Self {
         self.batch_size = batch_size;
         self
     }
@@ -325,8 +330,8 @@ impl<E: TaskExecutor> ParquetHandler for DefaultParquetHandler<E> {
             files.to_vec(),
             physical_schema,
             predicate,
-            self.buffer_size,
-            self.batch_size,
+            self.buffer_size.get(),
+            self.batch_size.get(),
         );
         super::stream_future_to_iter(self.task_executor.clone(), future)
     }
@@ -1237,7 +1242,7 @@ mod tests {
         // With a batch size of 4, the 10-row file should be split into batches of 4, 4, 2.
         let handler =
             DefaultParquetHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()))
-                .with_batch_size(4);
+                .with_batch_size(NonZero::new(4).unwrap());
         let data: Vec<RecordBatch> = handler
             .read_parquet_files(
                 slice::from_ref(&file_meta),

--- a/docs/user-guide/src/ffi/overview.md
+++ b/docs/user-guide/src/ffi/overview.md
@@ -112,6 +112,7 @@ authoritative list and signatures, consult the generated
 | `get_default_engine` | Create an engine from a table path with default options |
 | `get_engine_builder` / `set_builder_option` / `builder_build` | Create an engine with custom storage options |
 | `set_builder_with_multithreaded_executor` | Configure the builder to use a multi-threaded tokio executor |
+| `set_builder_with_io_concurrency` | Configure read-path I/O concurrency (buffer size and batch size) for the JSON and Parquet handlers |
 | `free_engine` | Release the engine handle |
 
 **Snapshots**

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -551,6 +551,19 @@ pub struct EngineBuilder {
     /// Configuration for multithreaded executor. If Some, use a multi-threaded executor
     /// If None, use the default single-threaded background executor.
     multithreaded_executor_config: Option<MultithreadedExecutorConfig>,
+    /// Read-path I/O concurrency config for the JSON and Parquet handlers. `None` fields fall back
+    /// to the engine's defaults.
+    io_config: IoConcurrencyConfig,
+}
+
+#[cfg(feature = "default-engine-base")]
+#[derive(Default)]
+struct IoConcurrencyConfig {
+    /// Maximum number of files read concurrently (file-level readahead depth). `None` uses the
+    /// engine default.
+    buffer_size: Option<usize>,
+    /// Maximum number of rows per yielded batch. `None` uses the engine default.
+    batch_size: Option<usize>,
 }
 
 #[cfg(feature = "default-engine-base")]
@@ -594,6 +607,7 @@ fn get_engine_builder_impl(
         allocate_fn,
         options: HashMap::default(),
         multithreaded_executor_config: None,
+        io_config: IoConcurrencyConfig::default(),
     });
     Ok(Box::into_raw(builder))
 }
@@ -651,6 +665,35 @@ pub unsafe extern "C" fn set_builder_with_multithreaded_executor(
     });
 }
 
+/// Configure read-path I/O concurrency for the engine's JSON and Parquet handlers.
+///
+/// These control the `read_*_files` paths used during log replay and scans. Returned data ordering
+/// is preserved regardless of these values.
+///
+/// # Parameters
+/// - `builder`: The engine builder to configure.
+/// - `buffer_size`: Maximum number of files read concurrently (file-level readahead depth). Higher
+///   values overlap more object-store requests to hide latency, at the cost of more in-flight
+///   memory. Pass 0 to use the engine default.
+/// - `batch_size`: Maximum number of rows per yielded batch. Pass 0 to use the engine default.
+///   Overall read memory usage is roughly proportional to `buffer_size * batch_size`.
+///
+/// # Safety
+///
+/// Caller must pass a valid EngineBuilder pointer.
+#[cfg(feature = "default-engine-base")]
+#[no_mangle]
+pub unsafe extern "C" fn set_builder_with_io_concurrency(
+    builder: &mut EngineBuilder,
+    buffer_size: usize,
+    batch_size: usize,
+) {
+    builder.io_config = IoConcurrencyConfig {
+        buffer_size: (buffer_size != 0).then_some(buffer_size),
+        batch_size: (batch_size != 0).then_some(batch_size),
+    };
+}
+
 /// Consume the builder and return a `default` engine. After calling, the passed pointer is _no
 /// longer valid_. Note that this _consumes_ and frees the builder, so there is no need to
 /// drop/free it afterwards.
@@ -669,6 +712,7 @@ pub unsafe extern "C" fn builder_build(
         builder_box.url,
         builder_box.options,
         builder_box.multithreaded_executor_config,
+        builder_box.io_config,
         builder_box.allocate_fn,
     )
     .into_extern_result(&builder_box.allocate_fn)
@@ -693,7 +737,13 @@ fn get_default_default_engine_impl(
     url: DeltaResult<Url>,
     allocate_error: AllocateErrorFn,
 ) -> DeltaResult<Handle<SharedExternEngine>> {
-    get_default_engine_impl(url?, Default::default(), None, allocate_error)
+    get_default_engine_impl(
+        url?,
+        Default::default(),
+        None,
+        IoConcurrencyConfig::default(),
+        allocate_error,
+    )
 }
 
 /// Safety
@@ -720,6 +770,7 @@ fn get_default_engine_impl(
     url: Url,
     options: HashMap<String, String>,
     executor_config: Option<MultithreadedExecutorConfig>,
+    io_config: IoConcurrencyConfig,
     allocate_error: AllocateErrorFn,
 ) -> DeltaResult<Handle<SharedExternEngine>> {
     use delta_kernel_default_engine::storage::store_from_url_opts;
@@ -727,18 +778,32 @@ fn get_default_engine_impl(
 
     let store = store_from_url_opts(&url, options)?;
 
+    // The builder is generic over the executor type, so apply the shared I/O config via a generic
+    // helper to both branches without naming the concrete builder type.
+    fn apply_io_config<E>(
+        builder: DefaultEngineBuilder<E>,
+        io_config: &IoConcurrencyConfig,
+    ) -> DefaultEngineBuilder<E> {
+        let builder = match io_config.buffer_size {
+            Some(buffer_size) => builder.with_buffer_size(buffer_size),
+            None => builder,
+        };
+        match io_config.batch_size {
+            Some(batch_size) => builder.with_batch_size(batch_size),
+            None => builder,
+        }
+    }
+
     let engine: Arc<dyn Engine> = if let Some(config) = executor_config {
         let executor = TokioMultiThreadExecutor::new_owned_runtime(
             config.worker_threads,
             config.max_blocking_threads,
         )?;
-        Arc::new(
-            DefaultEngineBuilder::new(store)
-                .with_task_executor(Arc::new(executor))
-                .build(),
-        )
+        let builder = DefaultEngineBuilder::new(store).with_task_executor(Arc::new(executor));
+        Arc::new(apply_io_config(builder, &io_config).build())
     } else {
-        Arc::new(DefaultEngineBuilder::new(store).build())
+        let builder = apply_io_config(DefaultEngineBuilder::new(store), &io_config);
+        Arc::new(builder.build())
     };
 
     Ok(engine_to_handle(engine, allocate_error))
@@ -2471,6 +2536,65 @@ mod tests {
             }
         };
         assert!(did_checkpoint);
+
+        unsafe { free_snapshot(snapshot) }
+        unsafe { free_engine(engine) }
+        Ok(())
+    }
+
+    // Test building an engine via the FFI builder with custom read-path I/O concurrency, then
+    // exercising the read path (snapshot + checkpoint) to confirm the configured engine works.
+    #[cfg(feature = "default-engine-base")]
+    #[test]
+    fn test_setting_io_concurrency() -> Result<(), Box<dyn std::error::Error>> {
+        use delta_kernel::object_store::local::LocalFileSystem;
+        use tempfile::tempdir;
+
+        let tmp_dir = tempdir()?;
+        let tmp_path = tmp_dir.path();
+        let table_root = tmp_path
+            .to_str()
+            .ok_or_else(|| delta_kernel::Error::generic("Invalid path"))?;
+        let storage = Arc::new(LocalFileSystem::new());
+
+        let protocol_and_metadata = METADATA
+            .lines()
+            .skip(1) // skip commitInfo
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        {
+            let rt = tokio::runtime::Runtime::new()?;
+            rt.block_on(async {
+                add_commit(&table_root, storage.as_ref(), 0, protocol_and_metadata).await?;
+                add_commit(
+                    &table_root,
+                    storage.as_ref(),
+                    1,
+                    actions_to_string(vec![
+                        TestAction::Add("file1.parquet".into()),
+                        TestAction::Add("file2.parquet".into()),
+                    ]),
+                )
+                .await?;
+                Ok::<_, Box<dyn std::error::Error>>(())
+            })?;
+        }
+
+        let builder = unsafe {
+            ok_or_panic(get_engine_builder(
+                kernel_string_slice!(table_root),
+                allocate_err,
+            ))
+        };
+        // Non-zero values configure the JSON and Parquet handlers; 0 would mean "use default".
+        unsafe { set_builder_with_io_concurrency(builder.as_mut().unwrap(), 4, 8) };
+        let engine = unsafe { ok_or_panic(builder_build(builder)) };
+
+        let snapshot =
+            unsafe { build_snapshot(kernel_string_slice!(table_root), engine.shallow_copy()) };
+        let version = unsafe { version(snapshot.shallow_copy()) };
+        assert_eq!(version, 1);
 
         unsafe { free_snapshot(snapshot) }
         unsafe { free_engine(engine) }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2544,10 +2544,15 @@ mod tests {
     }
 
     // Test building an engine via the FFI builder with custom read-path I/O concurrency, then
-    // exercising the read path (snapshot + checkpoint) to confirm the configured engine works.
+    // exercising the read path (snapshot) to confirm the configured engine works.
     #[cfg(feature = "default-engine-base")]
-    #[test]
-    fn test_setting_io_concurrency() -> Result<(), Box<dyn std::error::Error>> {
+    #[rstest]
+    #[case(4, 8)]
+    #[case(0, 0)]
+    fn test_setting_io_concurrency(
+        #[case] buffer_size: usize,
+        #[case] batch_size: usize,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         use delta_kernel::object_store::local::LocalFileSystem;
         use tempfile::tempdir;
 
@@ -2588,8 +2593,9 @@ mod tests {
                 allocate_err,
             ))
         };
-        // Non-zero values configure the JSON and Parquet handlers; 0 would mean "use default".
-        unsafe { set_builder_with_io_concurrency(builder.as_mut().unwrap(), 4, 8) };
+        unsafe {
+            set_builder_with_io_concurrency(builder.as_mut().unwrap(), buffer_size, batch_size)
+        };
         let engine = unsafe { ok_or_panic(builder_build(builder)) };
 
         let snapshot =

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -27,7 +27,7 @@ use url::Url;
 #[cfg(feature = "default-engine-base")]
 use {
     delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor,
-    std::collections::HashMap,
+    std::collections::HashMap, std::num::NonZero,
 };
 
 // cbindgen doesn't understand our use of feature flags here, and by default it parses `mod handle`
@@ -561,9 +561,9 @@ pub struct EngineBuilder {
 struct IoConcurrencyConfig {
     /// Maximum number of files read concurrently (file-level readahead depth). `None` uses the
     /// engine default.
-    buffer_size: Option<usize>,
+    buffer_size: Option<NonZero<usize>>,
     /// Maximum number of rows per yielded batch. `None` uses the engine default.
-    batch_size: Option<usize>,
+    batch_size: Option<NonZero<usize>>,
 }
 
 #[cfg(feature = "default-engine-base")]
@@ -688,9 +688,10 @@ pub unsafe extern "C" fn set_builder_with_io_concurrency(
     buffer_size: usize,
     batch_size: usize,
 ) {
+    // `NonZero::new` maps 0 -> `None`, which the engine reads as "use the default".
     builder.io_config = IoConcurrencyConfig {
-        buffer_size: (buffer_size != 0).then_some(buffer_size),
-        batch_size: (batch_size != 0).then_some(batch_size),
+        buffer_size: NonZero::new(buffer_size),
+        batch_size: NonZero::new(batch_size),
     };
 }
 

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -5,6 +5,7 @@
 //! compaction interactions, catalog-managed staged commits, and vacuum races.
 
 use std::collections::HashSet;
+use std::num::NonZero;
 use std::sync::Arc;
 
 use delta_kernel::incremental_scan::{
@@ -793,7 +794,7 @@ impl CustomBatchSizeEngine {
         let task_executor = Arc::new(TokioBackgroundExecutor::new());
         let json = Arc::new(
             DefaultJsonHandler::new(storage.clone(), task_executor.clone())
-                .with_batch_size(batch_size),
+                .with_batch_size(NonZero::new(batch_size).expect("batch_size is non-zero")),
         );
         let inner = Arc::new(
             DefaultEngineBuilder::new(storage)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make the `DefaultEngine` read-path I/O concurrency configurable along two dimensions, and fix the Parquet read path that previously ignored its configured values.

- **Parquet handler:** replace the dead `readahead` knob (it was never applied on the read path, which hardcoded the buffer size) with `buffer_size` and `batch_size` (both default 1000). `read_parquet_files` now actually applies them to the `buffered(...)` file concurrency, the per-batch row limit, and the presigned opener.
- **`DefaultEngineBuilder`:** add `with_buffer_size` / `with_batch_size`, threaded through to **both** the JSON and Parquet handlers. Unset preserves the prior effective defaults.
- **FFI:** add `set_builder_with_io_concurrency(builder, buffer_size, batch_size)` (0 means "use default"), mirroring the existing `set_builder_with_multithreaded_executor`.

Thread-pool sizing (the other concurrency dimension) was already configurable via `set_builder_with_multithreaded_executor` / `with_task_executor`; this PR completes the picture by exposing I/O concurrency. Returned data ordering is unaffected (still `buffered`, not `buffered_unordered`).

### This PR affects the following public APIs

- **Breaking:** `DefaultParquetHandler::with_readahead` is removed, replaced by `DefaultParquetHandler::with_buffer_size` and `with_batch_size` (consistent with the JSON handler, mirroring the prior `with_readahead` -> `with_buffer_size` rename in #711).
- **New:** `DefaultEngineBuilder::with_buffer_size` / `with_batch_size`; FFI `set_builder_with_io_concurrency`.

Note: the presigned-URL Parquet read path's default batch size changes from a hardcoded 1024 to the configurable default of 1000. This only affects RecordBatch row chunking, not correctness or ordering.

## How was this change tested?

- New `default-engine` test `test_read_parquet_files_respects_batch_size` verifies the Parquet read path now honors `batch_size` (10 rows @ batch_size 4 -> batches of [4, 4, 2]).
- Extended `test_default_engine_builder_all_options` to set both knobs through the builder.
- New FFI test `test_setting_io_concurrency` builds an engine via `set_builder_with_io_concurrency` and reads back a snapshot.
- `cargo +nightly fmt`, `cargo clippy --all-features --tests -D warnings`, and `cargo doc` all clean for the affected crates; `delta_kernel_default_engine` and `delta_kernel_ffi` test suites pass.