### PR TITLE
feat: add DataType::UserDefined for Spark UDT read support

### DIFF
--- a/docs/user-guide/src/concepts/schema_and_types.md
+++ b/docs/user-guide/src/concepts/schema_and_types.md
@@ -104,6 +104,28 @@ with `metadata` and `value` fields (both binary). To create an unshredded varian
 let variant_type = DataType::unshredded_variant();
 ```
 
+#### UserDefinedType (UDT)
+
+A Spark `UserDefinedType` is a compute-engine-specific annotation over a physical type. It is not
+part of the Delta protocol type system. The compute engine (for example, Spark) serializes it in
+the schema as a `udt` object that names the engine's deserialization code and carries a `sqlType`:
+
+```json
+{
+  "type": "udt",
+  "class": "org.apache.spark.ml.linalg.VectorUDT",
+  "sqlType": {"type": "struct", "fields": [/* ... */]}
+}
+```
+
+Kernel can't run the engine code named by `class`/`pyClass`, so it reads the column as its physical
+`sqlType`, which is what's actually stored in Parquet. The logical schema keeps the column as
+`DataType::UserDefined`, and re-serializing the schema preserves the original `udt` annotation.
+
+> [!NOTE]
+> Kernel reads existing UDT columns as their `sqlType`. It does not construct UDT columns, so there
+> is no builder for `DataType::UserDefined`.
+
 ## Schemas
 
 A schema is a `StructType`, an ordered collection of named, typed fields. The type

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -340,6 +340,16 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
             &DataType::VOID => call!(visit_void),
+            // A UDT has no FFI representation of its own; present it as its physical sql_type so
+            // engines read the column without needing the (unavailable) engine UDT class.
+            DataType::UserDefined(udt) => visit_schema_item(
+                name,
+                &udt.sql_type,
+                is_nullable,
+                metadata,
+                visitor,
+                sibling_list_id,
+            ),
         }
     }
 

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -301,9 +301,11 @@ fn kernel_field_into_arrow(
                 false, /* keys_sorted */
             ))
         }
-        DataType::Struct(_) | DataType::Primitive(_) | DataType::Variant(_) => {
-            datatype.try_into_arrow()
-        }
+        // A UDT converts via its physical sql_type (delegated through `try_into_arrow`).
+        DataType::Struct(_)
+        | DataType::Primitive(_)
+        | DataType::Variant(_)
+        | DataType::UserDefined(_) => datatype.try_into_arrow(),
     }
 }
 
@@ -390,6 +392,8 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     )))
                 }
             }
+            // A UDT is physically its sql_type; convert that.
+            DataType::UserDefined(udt) => udt.sql_type.as_ref().try_into_arrow(),
         }
     }
 }

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -301,7 +301,6 @@ fn kernel_field_into_arrow(
                 false, /* keys_sorted */
             ))
         }
-        // A UDT converts via its physical sql_type (delegated through `try_into_arrow`).
         DataType::Struct(_)
         | DataType::Primitive(_)
         | DataType::Variant(_)
@@ -392,7 +391,6 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                     )))
                 }
             }
-            // A UDT is physically its sql_type; convert that.
             DataType::UserDefined(udt) => udt.sql_type.as_ref().try_into_arrow(),
         }
     }

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -208,7 +208,6 @@ impl Scalar {
                 }
             }
             DataType::VOID => append_nulls_as!(array::NullBuilder),
-            // A UDT's physical layout is its sql_type; append nulls for that.
             DataType::UserDefined(ref udt) => Self::append_null(builder, &udt.sql_type, num_rows)?,
             DataType::Variant(_) => {
                 return Err(Error::unsupported(

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -208,6 +208,8 @@ impl Scalar {
                 }
             }
             DataType::VOID => append_nulls_as!(array::NullBuilder),
+            // A UDT's physical layout is its sql_type; append nulls for that.
+            DataType::UserDefined(ref udt) => Self::append_null(builder, &udt.sql_type, num_rows)?,
             DataType::Variant(_) => {
                 return Err(Error::unsupported(
                     "Variant is not supported as scalar yet.",

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -488,10 +488,16 @@ fn get_indices(
             if requested_field.data_type == DataType::unshredded_variant() {
                 validate_parquet_variant(field)?;
             }
+            // A UDT is read as its physical `sql_type`, so resolve through it for the structural
+            // checks below. The leaf arm passes the UDT to `ensure_data_types`, which delegates.
+            let requested_data_type = match &requested_field.data_type {
+                DataType::UserDefined(udt) => udt.sql_type.as_ref(),
+                dt => dt,
+            };
             match field.data_type() {
                 ArrowDataType::Struct(fields) => {
-                    if let DataType::Struct(ref requested_schema)
-                    | DataType::Variant(ref requested_schema) = requested_field.data_type
+                    if let DataType::Struct(requested_schema)
+                    | DataType::Variant(requested_schema) = requested_data_type
                     {
                         let mask_before = mask_indices.len();
                         let (parquet_advance, children) = get_indices(
@@ -532,7 +538,7 @@ fn get_indices(
                 | ArrowDataType::ListView(list_field) => {
                     // we just want to transparently recurse into lists, need to transform the
                     // kernel list data type into a schema
-                    if let DataType::Array(array_type) = requested_field.data_type() {
+                    if let DataType::Array(array_type) = requested_data_type {
                         let requested_schema = StructType::new_unchecked([StructField::new(
                             list_field.name().clone(), // so we find it in the inner call
                             array_type.element_type.clone(),
@@ -571,7 +577,7 @@ fn get_indices(
                     }
                 }
                 ArrowDataType::Map(key_val_field, _) => {
-                    match (key_val_field.data_type(), requested_field.data_type()) {
+                    match (key_val_field.data_type(), requested_data_type) {
                         (ArrowDataType::Struct(inner_fields), DataType::Map(map_type)) => {
                             let mut key_val_names =
                                 inner_fields.iter().map(|f| f.name().to_string());

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -81,6 +81,9 @@ impl EnsureDataTypes {
             (&DataType::Variant(_), _) => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
+            // A UDT is physically stored as its `sql_type`, so validate the Arrow type against
+            // that.
+            (DataType::UserDefined(udt), _) => self.ensure_data_types(&udt.sql_type, arrow_type),
             // Arrow's `is_primitive()` covers only numeric/temporal/decimal types and
             // excludes Boolean, the string and binary variants, and Null -- even though
             // kernel models all of these as `PrimitiveType` variants. Match them

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -81,8 +81,6 @@ impl EnsureDataTypes {
             (&DataType::Variant(_), _) => {
                 check_cast_compat(kernel_type.try_into_arrow()?, arrow_type)
             }
-            // A UDT is physically stored as its `sql_type`, so validate the Arrow type against
-            // that.
             (DataType::UserDefined(udt), _) => self.ensure_data_types(&udt.sql_type, arrow_type),
             // Arrow's `is_primitive()` covers only numeric/temporal/decimal types and
             // excludes Boolean, the string and binary variants, and Null -- even though

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -620,6 +620,10 @@ impl From<&DataType> for proto_schema::DataType {
             DataType::Map(map) => Kind::Map(Box::new(map.as_ref().into())),
             // The proto `VariantType` is intentionally empty: variants are opaque on the wire.
             DataType::Variant(_) => Kind::Variant(proto_schema::VariantType {}),
+            // A UDT has no proto representation of its own. Ship it as its physical `sql_type`,
+            // which is what a plan executor reads; the engine-only annotation is not needed on the
+            // wire.
+            DataType::UserDefined(udt) => return udt.sql_type.as_ref().into(),
         };
         proto_schema::DataType { kind: Some(kind) }
     }

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -545,6 +545,40 @@ mod tests {
         assert_eq!(&expected, &stats_schema);
     }
 
+    // A UDT is excluded from min/max even when its sql_type is an orderable primitive (Spark writes
+    // no stats for UDT columns), but still appears as a nullCount leaf like Array/Map/Variant.
+    #[test]
+    fn test_stats_schema_excludes_udt_from_min_max() {
+        let properties: TableProperties = [("key", "value")].into();
+        let udt = DataType::UserDefined(UserDefinedType {
+            sql_type: Box::new(DataType::INTEGER),
+            raw: serde_json::json!({"type": "udt", "class": "X", "sqlType": "integer"}),
+        });
+        let file_schema = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("features", udt),
+        ]);
+
+        let stats_schema = expected_stats_schema(
+            &file_schema,
+            &stats_config_from_table_properties(&properties),
+            None,
+            None,
+        )
+        .unwrap();
+
+        // nullCount includes the UDT as a leaf; min/max excludes it.
+        let expected_null = StructType::new_unchecked([
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("features", DataType::LONG),
+        ]);
+        let expected_min_max =
+            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let expected = expected_stats(expected_null, expected_min_max);
+
+        assert_eq!(&expected, &stats_schema);
+    }
+
     #[test]
     fn test_stats_schema_col_names() {
         let properties: TableProperties = [(

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use column_filter::StatsConfig;
 use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::schema::{
     ArrayType, ColumnName, DataType, MapType, PrimitiveType, Schema, StructField, StructType,
+    UserDefinedType,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::DeltaResult;
@@ -339,6 +340,15 @@ impl<'a> SchemaTransform<'a> for BaseStatsTransform<'_> {
     fn transform_variant(&mut self, vtype: &'a StructType) -> Option<Cow<'a, StructType>> {
         self.include_leaf().then_some(Cow::Borrowed(vtype))
     }
+
+    // A UDT is a single opaque leaf (Spark writes no stats for its `sql_type`); do not expand
+    // into per-field stat columns.
+    fn transform_user_defined(
+        &mut self,
+        udt: &'a UserDefinedType,
+    ) -> Option<Cow<'a, UserDefinedType>> {
+        self.include_leaf().then_some(Cow::Borrowed(udt))
+    }
 }
 
 // removes all fields with non eligible data types
@@ -359,6 +369,13 @@ impl<'a> SchemaTransform<'a> for MinMaxStatsTransform {
         None
     }
     fn transform_variant(&mut self, _: &'a StructType) -> Option<Cow<'a, StructType>> {
+        None
+    }
+    // A UDT is never min/max-eligible (Spark writes no stats for it); exclude it like Array/Map.
+    fn transform_user_defined(
+        &mut self,
+        _: &'a UserDefinedType,
+    ) -> Option<Cow<'a, UserDefinedType>> {
         None
     }
 

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -213,6 +213,12 @@ pub(crate) fn parse_partition_value_raw(
     raw: Option<&String>,
     data_type: &DataType,
 ) -> DeltaResult<Scalar> {
+    // A UDT partition column is physically stored as its `sql_type`, so parse against that -- just
+    // as every other read-path site resolves a UDT through `sql_type`.
+    let data_type = match data_type {
+        DataType::UserDefined(udt) => udt.sql_type.as_ref(),
+        dt => dt,
+    };
     match (raw, data_type.as_primitive_opt()) {
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(
@@ -228,7 +234,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::BinaryExpressionOp;
-    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+    use crate::schema::{DataType, PrimitiveType, StructField, StructType, UserDefinedType};
     use crate::utils::test_utils::assert_result_error_with_message;
 
     // Tests for parse_partition_value function
@@ -351,6 +357,22 @@ mod tests {
             &DataType::Primitive(PrimitiveType::Integer),
         );
         assert_result_error_with_message(result, "Failed to parse value");
+    }
+
+    // A UDT-over-primitive partition column parses against its physical `sql_type`, not the
+    // opaque UDT wrapper (which is not primitive and would otherwise error).
+    #[test]
+    fn test_parse_partition_value_raw_user_defined() {
+        let udt = DataType::UserDefined(UserDefinedType {
+            sql_type: Box::new(DataType::INTEGER),
+            raw: serde_json::json!({"type": "udt", "class": "X", "sqlType": "integer"}),
+        });
+        let result = parse_partition_value_raw(Some(&"42".to_string()), &udt).unwrap();
+        assert_eq!(result, Scalar::Integer(42));
+
+        // A missing value still yields a physical-typed null, not a UDT-typed one.
+        let null = parse_partition_value_raw(None, &udt).unwrap();
+        assert_eq!(null, Scalar::Null(DataType::INTEGER));
     }
 
     // Tests for get_transform_expr function

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -179,7 +179,26 @@ mod tests {
     use rstest::rstest;
 
     use crate::schema::compare::{Error, SchemaComparison};
-    use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
+    use crate::schema::{
+        ArrayType, DataType, MapType, PrimitiveType, StructField, StructType, UserDefinedType,
+    };
+
+    // Two UDTs with the same physical `sql_type` but cosmetically different `raw` JSON (key order
+    // or engine class) must be read-compatible: `raw` is opaque and must not affect type
+    // comparison. Regression for equality being derived over `raw`.
+    #[test]
+    fn udt_equal_sql_type_different_raw_is_compatible() {
+        let udt = |raw: &str| {
+            DataType::UserDefined(UserDefinedType {
+                sql_type: Box::new(DataType::INTEGER),
+                raw: raw.to_string(),
+            })
+        };
+        let a = udt(r#"{"type":"udt","class":"X","sqlType":"integer"}"#);
+        let b = udt(r#"{"type":"udt","sqlType":"integer","pyClass":"x.Y"}"#);
+        assert!(a.can_read_as(&b).is_ok());
+        assert!(b.can_read_as(&a).is_ok());
+    }
 
     #[test]
     fn can_read_is_reflexive() {

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -191,7 +191,7 @@ mod tests {
         let udt = |raw: &str| {
             DataType::UserDefined(UserDefinedType {
                 sql_type: Box::new(DataType::INTEGER),
-                raw: raw.to_string(),
+                raw: serde_json::from_str(raw).unwrap(),
             })
         };
         let a = udt(r#"{"type":"udt","class":"X","sqlType":"integer"}"#);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1778,12 +1778,9 @@ fn serialize_user_defined<S: serde::Serializer>(
     udt: &UserDefinedType,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    // Re-emit the original `udt` JSON object so the annotation round-trips value-for-value. The
-    // kernel never originates a UDT (it only captures one during deserialization), so `raw` is
-    // always a conformant `udt` object the engine itself wrote.
-    let value: serde_json::Value =
-        serde_json::from_str(&udt.raw).map_err(serde::ser::Error::custom)?;
-    serde::Serialize::serialize(&value, serializer)
+    // Re-emit the original `udt` JSON object verbatim so the annotation round-trips. `raw` is
+    // captured during deserialization and never mutated, so this cannot fail.
+    serde::Serialize::serialize(&udt.raw, serializer)
 }
 
 // Custom Deserialize to provide clear error messages for unsupported types.
@@ -1884,28 +1881,30 @@ pub enum DataType {
     /// reads. The unshredded schema is `Variant(StructType<metadata: BINARY, value: BINARY>)`.
     #[serde(serialize_with = "serialize_variant")]
     Variant(Box<StructType>),
-    /// A Spark `UserDefinedType` (UDT). UDT is not part of the Delta protocol type system; it is
-    /// an engine-specific annotation over a physical `sql_type`. The `class`/`pyClass` fields
-    /// reference engine (JVM/Python) code the kernel cannot run, so the kernel reads the column as
-    /// its physical `sql_type` and preserves the original JSON for faithful re-serialization.
+    /// A Spark `UserDefinedType` (UDT) column. See [`UserDefinedType`].
     #[serde(serialize_with = "serialize_user_defined")]
     UserDefined(UserDefinedType),
 }
 
 /// A Spark `UserDefinedType` (UDT) column. Spark serializes it as
-/// `{"type":"udt", "class"/"pyClass"/"serializedClass", "sqlType": <type>}`. The kernel cannot run
-/// the engine's (de)serialization class, so it represents the column by its physical `sql_type`
-/// (what is actually stored in Parquet) while preserving the original JSON object in `raw` so the
+/// `{"type":"udt", "class"/"pyClass"/"serializedClass", "sqlType": <type>}`. UDT is not part of the
+/// Delta protocol type system; it is an engine-specific annotation over a physical type. The kernel
+/// cannot run the engine's (de)serialization class, so it represents the column by its physical
+/// `sql_type` (what is actually stored in Parquet) while preserving the original JSON object so the
 /// annotation round-trips faithfully when the schema is re-serialized.
+///
+/// The kernel only ever constructs a `UserDefinedType` by deserializing a `udt` object an engine
+/// wrote; `raw` is not publicly settable, so it always holds the conformant object serialization
+/// re-emits verbatim.
 #[derive(Debug, Clone)]
 pub struct UserDefinedType {
-    /// The physical type backing the UDT, used for all read/scan/Arrow/stats operations.
+    /// The physical type backing the UDT (what is actually stored in Parquet).
     pub sql_type: Box<DataType>,
 
-    /// The original `udt` JSON object, preserved for re-serialization. This round-trips the
-    /// annotation (`class`/`pyClass`/`sqlType`/...) value-for-value; JSON object key order is not
-    /// preserved, which is immaterial since the annotation is opaque to the kernel.
-    pub raw: String,
+    /// The original `udt` JSON object, preserved so re-serialization reproduces the annotation
+    /// (`class`/`pyClass`/`sqlType`/...) value-for-value. JSON object key order is not preserved,
+    /// which is immaterial since the annotation is opaque to the kernel.
+    pub(crate) raw: serde_json::Value,
 }
 
 // Type equality is physical: two UDTs are equal iff their `sql_type`s match. The `raw` annotation
@@ -2007,13 +2006,11 @@ impl<'de> serde::Deserialize<'de> for DataType {
                         let sql_type_value = map.get("sqlType").ok_or_else(|| {
                             Error::custom("Invalid 'udt' type: missing required 'sqlType' field")
                         })?;
-                        let sql_type = DataType::deserialize(sql_type_value.clone())
-                            .map_err(|e| Error::custom(e.to_string()))?;
-                        let raw = serde_json::to_string(&value)
+                        let sql_type = DataType::deserialize(sql_type_value)
                             .map_err(|e| Error::custom(e.to_string()))?;
                         Ok(DataType::UserDefined(UserDefinedType {
                             sql_type: Box::new(sql_type),
-                            raw,
+                            raw: value.clone(),
                         }))
                     }
                     _ => Err(Error::custom(format!("Unknown complex type: '{type_str}'"))),
@@ -2155,7 +2152,6 @@ impl Display for DataType {
             }
             DataType::Map(m) => write!(f, "map<{}, {}>", m.key_type, m.value_type),
             DataType::Variant(_) => write!(f, "variant"),
-            // A UDT renders as its physical type, which is how reads materialize the column.
             DataType::UserDefined(udt) => write!(f, "{}", udt.sql_type),
         }
     }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1148,9 +1148,9 @@ impl StructType {
                     Self::ensure_no_metadata_columns(&mut struct_type.fields())?;
                 }
             }
-            // Primitive types cannot contain nested metadata columns and variant types are
-            // validated at creation
-            DataType::Primitive(_) | DataType::Variant(_) => {}
+            // Primitive types cannot contain nested metadata columns; variant and user-defined
+            // types are validated/handled at creation and carry no nested metadata columns.
+            DataType::Primitive(_) | DataType::Variant(_) | DataType::UserDefined(_) => {}
         };
 
         Ok(())
@@ -1423,6 +1423,13 @@ impl<'a> SchemaTransform<'a> for NonNullFieldChecker {
     /// `Variant` are protocol-defined, always non-null, and not user-controlled, so they
     /// must not be treated as user-declared non-null columns.
     fn transform_variant(&mut self, _stype: &'a StructType) -> Result<(), ()> {
+        Ok(())
+    }
+
+    /// Skip recursion into UDT internals. The fields inside a UDT's `sql_type` are engine-defined,
+    /// not user-declared columns, so a non-null inner field (e.g. `VectorUDT`'s `type`) must not be
+    /// reported as a user-declared non-null column.
+    fn transform_user_defined(&mut self, _udt: &'a UserDefinedType) -> Result<(), ()> {
         Ok(())
     }
 
@@ -1767,6 +1774,18 @@ fn serialize_variant<S: serde::Serializer>(
     serializer.serialize_str("variant")
 }
 
+fn serialize_user_defined<S: serde::Serializer>(
+    udt: &UserDefinedType,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    // Re-emit the original `udt` JSON object so the annotation round-trips value-for-value. The
+    // kernel never originates a UDT (it only captures one during deserialization), so `raw` is
+    // always a conformant `udt` object the engine itself wrote.
+    let value: serde_json::Value =
+        serde_json::from_str(&udt.raw).map_err(serde::ser::Error::custom)?;
+    serde::Serialize::serialize(&value, serializer)
+}
+
 // Custom Deserialize to provide clear error messages for unsupported types.
 // The derived impl would produce: "unknown variant `interval second`, expected one of ..."
 // This impl produces: "Unsupported Delta table type: 'interval second'"
@@ -1865,7 +1884,40 @@ pub enum DataType {
     /// reads. The unshredded schema is `Variant(StructType<metadata: BINARY, value: BINARY>)`.
     #[serde(serialize_with = "serialize_variant")]
     Variant(Box<StructType>),
+    /// A Spark `UserDefinedType` (UDT). UDT is not part of the Delta protocol type system; it is
+    /// an engine-specific annotation over a physical `sql_type`. The `class`/`pyClass` fields
+    /// reference engine (JVM/Python) code the kernel cannot run, so the kernel reads the column as
+    /// its physical `sql_type` and preserves the original JSON for faithful re-serialization.
+    #[serde(serialize_with = "serialize_user_defined")]
+    UserDefined(UserDefinedType),
 }
+
+/// A Spark `UserDefinedType` (UDT) column. Spark serializes it as
+/// `{"type":"udt", "class"/"pyClass"/"serializedClass", "sqlType": <type>}`. The kernel cannot run
+/// the engine's (de)serialization class, so it represents the column by its physical `sql_type`
+/// (what is actually stored in Parquet) while preserving the original JSON object in `raw` so the
+/// annotation round-trips faithfully when the schema is re-serialized.
+#[derive(Debug, Clone)]
+pub struct UserDefinedType {
+    /// The physical type backing the UDT, used for all read/scan/Arrow/stats operations.
+    pub sql_type: Box<DataType>,
+
+    /// The original `udt` JSON object, preserved for re-serialization. This round-trips the
+    /// annotation (`class`/`pyClass`/`sqlType`/...) value-for-value; JSON object key order is not
+    /// preserved, which is immaterial since the annotation is opaque to the kernel.
+    pub raw: String,
+}
+
+// Type equality is physical: two UDTs are equal iff their `sql_type`s match. The `raw` annotation
+// (engine class names, JSON key order) does not affect how the column is read, and folding it into
+// equality would make schema-compatibility checks (`DataType::can_read_as`, which compares with
+// `==`) reject cosmetically-different-but-equivalent UDTs.
+impl PartialEq for UserDefinedType {
+    fn eq(&self, other: &Self) -> bool {
+        self.sql_type == other.sql_type
+    }
+}
+impl Eq for UserDefinedType {}
 
 impl From<DecimalType> for PrimitiveType {
     fn from(dtype: DecimalType) -> Self {
@@ -1948,6 +2000,22 @@ impl<'de> serde::Deserialize<'de> for DataType {
                     "map" => MapType::deserialize(value)
                         .map(DataType::from)
                         .map_err(|e| Error::custom(e.to_string())),
+                    "udt" => {
+                        // UDT is engine-specific and outside the Delta protocol. Read the column
+                        // as its physical `sqlType`; the `class`/`pyClass` reference engine code
+                        // the kernel cannot run. Preserve the whole object so it round-trips.
+                        let sql_type_value = map.get("sqlType").ok_or_else(|| {
+                            Error::custom("Invalid 'udt' type: missing required 'sqlType' field")
+                        })?;
+                        let sql_type = DataType::deserialize(sql_type_value.clone())
+                            .map_err(|e| Error::custom(e.to_string()))?;
+                        let raw = serde_json::to_string(&value)
+                            .map_err(|e| Error::custom(e.to_string()))?;
+                        Ok(DataType::UserDefined(UserDefinedType {
+                            sql_type: Box::new(sql_type),
+                            raw,
+                        }))
+                    }
                     _ => Err(Error::custom(format!("Unknown complex type: '{type_str}'"))),
                 };
             }
@@ -2087,6 +2155,8 @@ impl Display for DataType {
             }
             DataType::Map(m) => write!(f, "map<{}, {}>", m.key_type, m.value_type),
             DataType::Variant(_) => write!(f, "variant"),
+            // A UDT renders as its physical type, which is how reads materialize the column.
+            DataType::UserDefined(udt) => write!(f, "{}", udt.sql_type),
         }
     }
 }
@@ -2221,6 +2291,17 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
         // There is no column mapping metadata inside the struct fields of a variant, so
         // we do not recurse into the variant fields
         Ok(Cow::Borrowed(stype))
+    }
+
+    fn transform_user_defined(
+        &mut self,
+        udt: &'a UserDefinedType,
+    ) -> DeltaResult<Cow<'a, UserDefinedType>> {
+        // A UDT is a column-mapping leaf: the fields inside its `sql_type` carry no
+        // `physicalName`/`id` annotations (they are not user-controlled columns), so we must not
+        // recurse, just as for a variant. Recursing would demand annotations the fields don't have
+        // and fail to load any column-mapped table containing a struct-`sqlType` UDT.
+        Ok(Cow::Borrowed(udt))
     }
 }
 
@@ -3713,6 +3794,56 @@ mod tests {
             Some(MetadataColumnSpec::RowId)
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_udt_roundtrip_and_unwrap() -> DeltaResult<()> {
+        // Scala/Java UDT with a struct sqlType (VectorUDT-shaped).
+        let udt_json = r#"{"type":"udt","class":"org.apache.spark.ml.linalg.VectorUDT","pyClass":"pyspark.ml.linalg.VectorUDT","sqlType":{"type":"struct","fields":[{"name":"size","type":"integer","nullable":true,"metadata":{}},{"name":"values","type":{"type":"array","elementType":"double","containsNull":false},"nullable":true,"metadata":{}}]}}"#;
+
+        let dt: DataType = serde_json::from_str(udt_json)?;
+        let DataType::UserDefined(udt) = &dt else {
+            panic!("expected UserDefined, got {dt:?}");
+        };
+
+        // The physical sql_type is parsed and available for reads.
+        let expected_sql_type: DataType = serde_json::from_str(
+            r#"{"type":"struct","fields":[{"name":"size","type":"integer","nullable":true,"metadata":{}},{"name":"values","type":{"type":"array","elementType":"double","containsNull":false},"nullable":true,"metadata":{}}]}"#,
+        )?;
+        assert_eq!(*udt.sql_type, expected_sql_type);
+
+        // Non-lossy: re-serialization is JSON-equal to the input (key order may differ).
+        let got: serde_json::Value = serde_json::from_str(&serde_json::to_string(&dt)?)?;
+        let want: serde_json::Value = serde_json::from_str(udt_json)?;
+        assert_eq!(got, want, "udt did not round-trip faithfully");
+        Ok(())
+    }
+
+    #[test]
+    fn test_udt_python_flavor_and_primitive_sql_type() -> DeltaResult<()> {
+        // Python UDT (no `class`, has `serializedClass`) backed by a primitive sqlType.
+        let udt_json =
+            r#"{"type":"udt","pyClass":"x.Y","serializedClass":"AAAA","sqlType":"integer"}"#;
+        let dt: DataType = serde_json::from_str(udt_json)?;
+        let DataType::UserDefined(udt) = &dt else {
+            panic!("expected UserDefined, got {dt:?}");
+        };
+        assert_eq!(*udt.sql_type, DataType::INTEGER);
+
+        let got: serde_json::Value = serde_json::from_str(&serde_json::to_string(&dt)?)?;
+        let want: serde_json::Value = serde_json::from_str(udt_json)?;
+        assert_eq!(got, want, "python udt did not round-trip faithfully");
+        Ok(())
+    }
+
+    #[test]
+    fn test_udt_missing_sql_type_errors() {
+        let json = r#"{"type":"udt","class":"X"}"#;
+        let err = serde_json::from_str::<DataType>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("sqlType"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -555,8 +555,12 @@ fn flat_cm_info_for_nested_data_type(
                 map_type.value_contains_null(),
             )))
         }
-        // Primitive and Variant types don't contain nested struct fields - return as-is
-        DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
+        // Primitive, Variant, and UserDefined types don't contain nested struct fields - return
+        // as-is. A UDT is an opaque leaf for column mapping (like Variant); its physical sql_type
+        // is not assigned separate column-mapping ids.
+        DataType::Primitive(_) | DataType::Variant(_) | DataType::UserDefined(_) => {
+            Ok(data_type.clone())
+        }
     }
 }
 
@@ -612,7 +616,9 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
                     map_type.value_contains_null(),
                 )))
             }
-            DataType::Primitive(_) | DataType::Variant(_) => Ok(data_type.clone()),
+            DataType::Primitive(_) | DataType::Variant(_) | DataType::UserDefined(_) => {
+                Ok(data_type.clone())
+            }
         }
     }
 

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -191,7 +191,8 @@ fn column_types_for(dt: &DataType) -> DeltaResult<&'static ColumnNamesAndTypes> 
         | DataType::Struct(_)
         | DataType::Array(_)
         | DataType::Map(_)
-        | DataType::Variant(_) => Err(Error::internal_error(format!(
+        | DataType::Variant(_)
+        | DataType::UserDefined(_) => Err(Error::internal_error(format!(
             "Unsupported data type for stats validation: {dt}"
         ))),
     }
@@ -225,7 +226,8 @@ fn is_stat_present<'b>(
         | DataType::Struct(_)
         | DataType::Array(_)
         | DataType::Map(_)
-        | DataType::Variant(_) => Err(Error::internal_error(format!(
+        | DataType::Variant(_)
+        | DataType::UserDefined(_) => Err(Error::internal_error(format!(
             "Unsupported data type for stats presence check: {data_type}"
         ))),
     }

--- a/kernel/src/transforms/schema.rs
+++ b/kernel/src/transforms/schema.rs
@@ -129,6 +129,10 @@ pub trait SchemaTransform<'a> {
 
     /// Called for each user-defined type encountered. The provided implementation recurses into
     /// the physical `sql_type` and rebuilds the [`UserDefinedType`], preserving its `raw` JSON.
+    ///
+    /// A transform that rewrites `sql_type` desyncs it from `raw` (which still embeds the original
+    /// `sqlType`); such transforms must override this to treat the UDT as an opaque leaf, as the
+    /// column-mapping and stats transforms do.
     fn transform_user_defined(
         &mut self,
         udt: &'a UserDefinedType,

--- a/kernel/src/transforms/schema.rs
+++ b/kernel/src/transforms/schema.rs
@@ -1,6 +1,8 @@
 use std::borrow::{Cow, ToOwned};
 
-use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
+use crate::schema::{
+    ArrayType, DataType, MapType, PrimitiveType, StructField, StructType, UserDefinedType,
+};
 use crate::transforms::{
     map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, transform_output_type,
     Carrier,
@@ -125,6 +127,19 @@ pub trait SchemaTransform<'a> {
         self.recurse_into_struct(stype)
     }
 
+    /// Called for each user-defined type encountered. The provided implementation recurses into
+    /// the physical `sql_type` and rebuilds the [`UserDefinedType`], preserving its `raw` JSON.
+    fn transform_user_defined(
+        &mut self,
+        udt: &'a UserDefinedType,
+    ) -> Self::Output<UserDefinedType> {
+        let child = self.transform(&udt.sql_type);
+        map_owned_or_else(udt, child, |sql_type| UserDefinedType {
+            sql_type: Box::new(sql_type),
+            raw: udt.raw.clone(),
+        })
+    }
+
     /// General entry point for a recursive traversal over any data type. Also invoked internally to
     /// dispatch on nested data types encountered during the traversal.
     fn transform(&mut self, data_type: &'a DataType) -> Self::Output<DataType> {
@@ -148,6 +163,10 @@ pub trait SchemaTransform<'a> {
             DataType::Variant(stype) => {
                 let child = self.transform_variant(stype);
                 map_owned_or_else(data_type, child, |s| DataType::Variant(Box::new(s)))
+            }
+            DataType::UserDefined(udt) => {
+                let child = self.transform_user_defined(udt);
+                map_owned_or_else(data_type, child, DataType::UserDefined)
             }
         }
     }

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use std::vec;
 
 use delta_kernel::actions::deletion_vector::split_vector;
-use delta_kernel::arrow::array::{ArrayRef, AsArray as _, RecordBatch, TimestampMicrosecondArray};
+use delta_kernel::arrow::array::{
+    ArrayRef, AsArray as _, Float64Array, Int32Array, RecordBatch, StructArray,
+    TimestampMicrosecondArray,
+};
 use delta_kernel::arrow::compute::{concat_batches, filter_record_batch};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Int64Type, Schema as ArrowSchema, TimeUnit,
@@ -2554,6 +2557,319 @@ async fn read_table_with_void_column() -> Result<(), Box<dyn std::error::Error>>
         ArrowDataType::Null
     );
 
+    Ok(())
+}
+
+// === Spark UserDefinedType (UDT) ===
+// A `udt` column is an engine-specific annotation over a physical `sqlType`. The kernel keeps the
+// annotation in the logical schema (`DataType::UserDefined`), preserves the original JSON verbatim
+// for a faithful round-trip, and reads the column as its physical `sqlType`.
+
+// Scala/Java VectorUDT-shaped: struct sqlType, both `class` and `pyClass`.
+const SCALA_UDT_JSON: &str = r#"{"type":"udt","class":"org.apache.spark.ml.linalg.VectorUDT","pyClass":"pyspark.ml.linalg.VectorUDT","sqlType":{"type":"struct","fields":[{"name":"size","type":"integer","nullable":true,"metadata":{}},{"name":"values","type":{"type":"array","elementType":"double","containsNull":false},"nullable":true,"metadata":{}}]}}"#;
+// Python flavor: no `class`, has `serializedClass`, backed by a primitive sqlType.
+const PYTHON_UDT_JSON: &str =
+    r#"{"type":"udt","pyClass":"x.Y","serializedClass":"AAAA","sqlType":"integer"}"#;
+
+// Builds a `{"metaData":{...}}` commit action whose `schemaString` embeds `fields`. serde handles
+// all string-escaping of the nested schema JSON, so callers pass real JSON values, not escaped
+// text.
+fn udt_metadata_action(fields: serde_json::Value) -> String {
+    let schema_value = serde_json::json!({"type": "struct", "fields": fields});
+    let schema_string = serde_json::to_string(&schema_value).unwrap();
+    serde_json::json!({
+        "metaData": {
+            "id": "test-udt",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": [],
+            "configuration": {},
+            "createdTime": 1587968585495_u64,
+        }
+    })
+    .to_string()
+}
+
+// Loading a UDT table through the default engine keeps the `UserDefined` annotation in the logical
+// schema, and re-serializing it reproduces the original `udt` JSON verbatim (key-order agnostic) --
+// i.e. the annotation survives a full load -> re-serialize cycle through the engine's read path.
+#[rstest::rstest]
+#[case::scala_struct(SCALA_UDT_JSON)]
+#[case::python_primitive(PYTHON_UDT_JSON)]
+#[tokio::test]
+async fn udt_schema_round_trips_through_snapshot_load(
+    #[case] udt_json: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let udt_value: serde_json::Value = serde_json::from_str(udt_json)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "features", "type": udt_value, "nullable": true, "metadata": {}},
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+
+    let field = snapshot
+        .schema()
+        .field("features")
+        .cloned()
+        .expect("features field present");
+    assert!(
+        matches!(field.data_type, DataType::UserDefined(_)),
+        "expected UserDefined, got {:?}",
+        field.data_type
+    );
+
+    let got = serde_json::to_value(&field.data_type)?;
+    let want: serde_json::Value = serde_json::from_str(udt_json)?;
+    assert_eq!(got, want, "udt did not round-trip through snapshot load");
+    Ok(())
+}
+
+// A `udt` nested inside a struct column is preserved at its nested position and round-trips.
+#[tokio::test]
+async fn udt_nested_in_struct_round_trips() -> Result<(), Box<dyn std::error::Error>> {
+    let udt_value: serde_json::Value = serde_json::from_str(SCALA_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {
+            "name": "wrapper",
+            "type": {"type": "struct", "fields": [
+                {"name": "vec", "type": udt_value, "nullable": true, "metadata": {}},
+            ]},
+            "nullable": true, "metadata": {},
+        },
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+
+    let schema = snapshot.schema();
+    let DataType::Struct(wrapper) = &schema
+        .field("wrapper")
+        .expect("wrapper field present")
+        .data_type
+    else {
+        panic!("expected wrapper to be a struct");
+    };
+    let vec_field = wrapper.field("vec").expect("vec field present");
+    assert!(
+        matches!(vec_field.data_type, DataType::UserDefined(_)),
+        "expected nested UserDefined, got {:?}",
+        vec_field.data_type
+    );
+
+    let got = serde_json::to_value(&vec_field.data_type)?;
+    let want: serde_json::Value = serde_json::from_str(SCALA_UDT_JSON)?;
+    assert_eq!(got, want, "nested udt did not round-trip");
+    Ok(())
+}
+
+// A UDT column is physically stored as its `sqlType`, so the kernel reads it as that physical type
+// (here `integer`) even though the logical schema keeps the `UserDefined` annotation.
+#[tokio::test]
+async fn read_table_with_udt_column() -> Result<(), Box<dyn std::error::Error>> {
+    // The Parquet file contains an ordinary int column -- the UDT's physical sqlType.
+    let batch = generate_batch(vec![
+        ("id", vec![1, 2, 3].into_array()),
+        ("features", vec![10, 20, 30].into_array()),
+    ])?;
+
+    let udt_value: serde_json::Value = serde_json::from_str(PYTHON_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "features", "type": udt_value, "nullable": true, "metadata": {}},
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields),
+        format!(
+            r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
+        ),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    storage
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
+        .await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+
+    // Logical schema keeps the UDT annotation...
+    assert!(matches!(
+        snapshot
+            .schema()
+            .field("features")
+            .expect("features field present")
+            .data_type,
+        DataType::UserDefined(_)
+    ));
+
+    // ...but the data reads back as the physical sqlType (integer).
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine)?;
+    assert_eq!(batches.len(), 1);
+    let result = &batches[0];
+    assert_eq!(result.num_rows(), 3);
+    let features_idx = result.schema().index_of("features")?;
+    assert_eq!(
+        *result.schema().field(features_idx).data_type(),
+        ArrowDataType::Int32
+    );
+    let features = result
+        .column(features_idx)
+        .as_primitive::<delta_kernel::arrow::datatypes::Int32Type>();
+    assert_eq!(features.values(), &[10, 20, 30]);
+    Ok(())
+}
+
+// Scala UDT whose sqlType is a struct of two primitives (a simplified VectorUDT). Exercises the
+// struct-recursion path in get_indices/ensure_data_types that a primitive sqlType does not.
+const STRUCT_UDT_JSON: &str = r#"{"type":"udt","class":"com.example.PointUDT","sqlType":{"type":"struct","fields":[{"name":"size","type":"integer","nullable":true,"metadata":{}},{"name":"value","type":"double","nullable":true,"metadata":{}}]}}"#;
+
+// A UDT whose sqlType is a struct is stored physically as that struct; the kernel reads it as a
+// struct (recursing through the sqlType) even though the logical schema keeps the annotation.
+#[tokio::test]
+async fn read_table_with_struct_sqltype_udt_column() -> Result<(), Box<dyn std::error::Error>> {
+    let size: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let value: ArrayRef = Arc::new(Float64Array::from(vec![1.5, 2.5, 3.5]));
+    let features: ArrayRef = Arc::new(StructArray::from(vec![
+        (
+            Arc::new(ArrowField::new("size", ArrowDataType::Int32, true)),
+            size,
+        ),
+        (
+            Arc::new(ArrowField::new("value", ArrowDataType::Float64, true)),
+            value,
+        ),
+    ]));
+    let batch = generate_batch(vec![
+        ("id", vec![1, 2, 3].into_array()),
+        ("features", features),
+    ])?;
+
+    let udt_value: serde_json::Value = serde_json::from_str(STRUCT_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "features", "type": udt_value, "nullable": true, "metadata": {}},
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields),
+        format!(
+            r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
+        ),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    storage
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
+        .await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+    assert!(matches!(
+        snapshot
+            .schema()
+            .field("features")
+            .expect("features field present")
+            .data_type,
+        DataType::UserDefined(_)
+    ));
+
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine)?;
+    assert_eq!(batches.len(), 1);
+    let result = &batches[0];
+    assert_eq!(result.num_rows(), 3);
+    let result_schema = result.schema();
+    let idx = result_schema.index_of("features")?;
+    let ArrowDataType::Struct(inner) = result_schema.field(idx).data_type() else {
+        panic!("features should read as a struct");
+    };
+    assert_eq!(inner.len(), 2);
+    // The nested struct data materializes through the sqlType projection.
+    let features_col = result.column(idx).as_struct();
+    let size_col = features_col
+        .column(0)
+        .as_primitive::<delta_kernel::arrow::datatypes::Int32Type>();
+    assert_eq!(size_col.values(), &[1, 2, 3]);
+    Ok(())
+}
+
+// A column-mapped table with a struct-sqlType UDT column must load: the UDT is a column-mapping
+// leaf, so its sqlType's inner fields carry no physicalName annotations. Regression for
+// `MakePhysical` recursing into the UDT and demanding annotations the inner fields lack (which made
+// every column-mapped table with such a column fail to load).
+#[rstest::rstest]
+#[case::name("name")]
+#[case::id("id")]
+#[tokio::test]
+async fn column_mapped_struct_udt_table_loads(
+    #[case] mode: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let udt_value: serde_json::Value = serde_json::from_str(STRUCT_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true,
+         "metadata": {"delta.columnMapping.id": 1, "delta.columnMapping.physicalName": "col-id"}},
+        {"name": "features", "type": udt_value, "nullable": true,
+         "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "col-features"}},
+    ]);
+    let schema_value = serde_json::json!({"type": "struct", "fields": fields});
+    let schema_string = serde_json::to_string(&schema_value)?;
+    let metadata = serde_json::json!({
+        "metaData": {
+            "id": "test-udt-cm",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": [],
+            "configuration": {
+                "delta.columnMapping.mode": mode,
+                "delta.columnMapping.maxColumnId": "2",
+            },
+            "createdTime": 1587968585495_u64,
+        }
+    })
+    .to_string();
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":2,"minWriterVersion":5}}"#.to_string(),
+        metadata,
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+    assert!(matches!(
+        snapshot
+            .schema()
+            .field("features")
+            .expect("features field present")
+            .data_type,
+        DataType::UserDefined(_)
+    ));
     Ok(())
 }
 

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -4,9 +4,10 @@ use std::vec;
 
 use delta_kernel::actions::deletion_vector::split_vector;
 use delta_kernel::arrow::array::{
-    ArrayRef, AsArray as _, Float64Array, Int32Array, RecordBatch, StructArray,
+    ArrayRef, AsArray as _, Float64Array, Int32Array, ListArray, RecordBatch, StructArray,
     TimestampMicrosecondArray,
 };
+use delta_kernel::arrow::buffer::OffsetBuffer;
 use delta_kernel::arrow::compute::{concat_batches, filter_record_batch};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Int64Type, Schema as ArrowSchema, TimeUnit,
@@ -2562,8 +2563,8 @@ async fn read_table_with_void_column() -> Result<(), Box<dyn std::error::Error>>
 
 // === Spark UserDefinedType (UDT) ===
 // A `udt` column is an engine-specific annotation over a physical `sqlType`. The kernel keeps the
-// annotation in the logical schema (`DataType::UserDefined`), preserves the original JSON verbatim
-// for a faithful round-trip, and reads the column as its physical `sqlType`.
+// annotation in the logical schema (`DataType::UserDefined`), preserves the original JSON so it
+// round-trips value-for-value (key order aside), and reads the column as its physical `sqlType`.
 
 // Scala/Java VectorUDT-shaped: struct sqlType, both `class` and `pyClass`.
 const SCALA_UDT_JSON: &str = r#"{"type":"udt","class":"org.apache.spark.ml.linalg.VectorUDT","pyClass":"pyspark.ml.linalg.VectorUDT","sqlType":{"type":"struct","fields":[{"name":"size","type":"integer","nullable":true,"metadata":{}},{"name":"values","type":{"type":"array","elementType":"double","containsNull":false},"nullable":true,"metadata":{}}]}}"#;
@@ -2571,10 +2572,10 @@ const SCALA_UDT_JSON: &str = r#"{"type":"udt","class":"org.apache.spark.ml.linal
 const PYTHON_UDT_JSON: &str =
     r#"{"type":"udt","pyClass":"x.Y","serializedClass":"AAAA","sqlType":"integer"}"#;
 
-// Builds a `{"metaData":{...}}` commit action whose `schemaString` embeds `fields`. serde handles
-// all string-escaping of the nested schema JSON, so callers pass real JSON values, not escaped
-// text.
-fn udt_metadata_action(fields: serde_json::Value) -> String {
+// Builds a `{"metaData":{...}}` commit action whose `schemaString` embeds `fields`, with the given
+// table `configuration`. serde handles all string-escaping of the nested schema JSON, so callers
+// pass real JSON values, not escaped text.
+fn udt_metadata_action(fields: serde_json::Value, configuration: serde_json::Value) -> String {
     let schema_value = serde_json::json!({"type": "struct", "fields": fields});
     let schema_string = serde_json::to_string(&schema_value).unwrap();
     serde_json::json!({
@@ -2583,7 +2584,7 @@ fn udt_metadata_action(fields: serde_json::Value) -> String {
             "format": {"provider": "parquet", "options": {}},
             "schemaString": schema_string,
             "partitionColumns": [],
-            "configuration": {},
+            "configuration": configuration,
             "createdTime": 1587968585495_u64,
         }
     })
@@ -2607,7 +2608,7 @@ async fn udt_schema_round_trips_through_snapshot_load(
     ]);
     let actions = [
         r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
-        udt_metadata_action(fields),
+        udt_metadata_action(fields, serde_json::json!({})),
     ];
 
     let storage = Arc::new(InMemory::new());
@@ -2648,7 +2649,7 @@ async fn udt_nested_in_struct_round_trips() -> Result<(), Box<dyn std::error::Er
     ]);
     let actions = [
         r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
-        udt_metadata_action(fields),
+        udt_metadata_action(fields, serde_json::json!({})),
     ];
 
     let storage = Arc::new(InMemory::new());
@@ -2694,7 +2695,7 @@ async fn read_table_with_udt_column() -> Result<(), Box<dyn std::error::Error>> 
     ]);
     let actions = [
         r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
-        udt_metadata_action(fields),
+        udt_metadata_action(fields, serde_json::json!({})),
         format!(
             r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
         ),
@@ -2772,7 +2773,7 @@ async fn read_table_with_struct_sqltype_udt_column() -> Result<(), Box<dyn std::
     ]);
     let actions = [
         r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
-        udt_metadata_action(fields),
+        udt_metadata_action(fields, serde_json::json!({})),
         format!(
             r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
         ),
@@ -2818,6 +2819,150 @@ async fn read_table_with_struct_sqltype_udt_column() -> Result<(), Box<dyn std::
     Ok(())
 }
 
+// Real VectorUDT-style shape: an array<double> sqlType. Exercises the array arm of get_indices
+// reached through the UDT sql_type unwrap, which struct/primitive sqlTypes don't cover.
+const ARRAY_UDT_JSON: &str = r#"{"type":"udt","class":"com.example.VecUDT","sqlType":{"type":"array","elementType":"double","containsNull":false}}"#;
+
+// A UDT whose sqlType is an array is stored physically as that list; the kernel reads it as a list
+// (recursing through the sqlType's array arm) while the logical schema keeps the annotation.
+#[tokio::test]
+async fn read_table_with_array_sqltype_udt_column() -> Result<(), Box<dyn std::error::Error>> {
+    // features: [[1.0, 2.0], [3.0], [4.0, 5.0]]
+    let elements = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+    let offsets = OffsetBuffer::new(vec![0, 2, 3, 5].into());
+    let element_field = Arc::new(ArrowField::new("element", ArrowDataType::Float64, false));
+    let features: ArrayRef = Arc::new(ListArray::new(
+        element_field,
+        offsets,
+        Arc::new(elements),
+        None,
+    ));
+    let batch = generate_batch(vec![
+        ("id", vec![1, 2, 3].into_array()),
+        ("features", features),
+    ])?;
+
+    let udt_value: serde_json::Value = serde_json::from_str(ARRAY_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "features", "type": udt_value, "nullable": true, "metadata": {}},
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields, serde_json::json!({})),
+        format!(
+            r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
+        ),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    storage
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
+        .await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+    assert!(matches!(
+        snapshot
+            .schema()
+            .field("features")
+            .expect("features field present")
+            .data_type,
+        DataType::UserDefined(_)
+    ));
+
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine)?;
+    assert_eq!(batches.len(), 1);
+    let result = &batches[0];
+    assert_eq!(result.num_rows(), 3);
+    let idx = result.schema().index_of("features")?;
+    assert!(matches!(
+        result.schema().field(idx).data_type(),
+        ArrowDataType::List(_)
+    ));
+    // The list data materializes through the sqlType projection.
+    let lists = result.column(idx).as_list::<i32>();
+    let first = lists.value(0);
+    assert_eq!(
+        first
+            .as_primitive::<delta_kernel::arrow::datatypes::Float64Type>()
+            .values(),
+        &[1.0, 2.0]
+    );
+    Ok(())
+}
+
+// The original failure this feature fixes: a table containing a UDT column was fully unreadable,
+// so even a SELECT of unrelated columns aborted. Reading only the non-UDT `id` column from a table
+// whose UDT has a multi-leaf (struct) sqlType must succeed and return correct data -- the UDT
+// column is projected out and its physical leaves skipped without shifting the other columns.
+#[tokio::test]
+async fn read_table_projecting_out_struct_udt_column() -> Result<(), Box<dyn std::error::Error>> {
+    let size: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let value: ArrayRef = Arc::new(Float64Array::from(vec![1.5, 2.5, 3.5]));
+    let features: ArrayRef = Arc::new(StructArray::from(vec![
+        (
+            Arc::new(ArrowField::new("size", ArrowDataType::Int32, true)),
+            size,
+        ),
+        (
+            Arc::new(ArrowField::new("value", ArrowDataType::Float64, true)),
+            value,
+        ),
+    ]));
+    let batch = generate_batch(vec![
+        ("id", vec![1, 2, 3].into_array()),
+        ("features", features),
+    ])?;
+
+    let udt_value: serde_json::Value = serde_json::from_str(STRUCT_UDT_JSON)?;
+    let fields = serde_json::json!([
+        {"name": "id", "type": "integer", "nullable": true, "metadata": {}},
+        {"name": "features", "type": udt_value, "nullable": true, "metadata": {}},
+    ]);
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        udt_metadata_action(fields, serde_json::json!({})),
+        format!(
+            r#"{{"add":{{"path":"{PARQUET_FILE1}","partitionValues":{{}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#
+        ),
+    ];
+
+    let storage = Arc::new(InMemory::new());
+    add_commit("memory:///", storage.as_ref(), 0, actions.iter().join("\n")).await?;
+    storage
+        .put(
+            &Path::from(PARQUET_FILE1),
+            record_batch_to_bytes(&batch).into(),
+        )
+        .await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(Url::parse("memory:///")?).build(engine.as_ref())?;
+
+    // Select only `id`, dropping the UDT column.
+    let read_schema = Arc::new(StructType::try_new([StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+    let scan = snapshot.scan_builder().with_schema(read_schema).build()?;
+    let batches = read_scan(&scan, engine)?;
+    assert_eq!(batches.len(), 1);
+    let result = &batches[0];
+    assert_eq!(result.schema().fields().len(), 1);
+    // The skip over the UDT's physical leaves is correct: `id` is not shifted or garbled.
+    let id = result
+        .column(result.schema().index_of("id")?)
+        .as_primitive::<delta_kernel::arrow::datatypes::Int32Type>();
+    assert_eq!(id.values(), &[1, 2, 3]);
+    Ok(())
+}
+
 // A column-mapped table with a struct-sqlType UDT column must load: the UDT is a column-mapping
 // leaf, so its sqlType's inner fields carry no physicalName annotations. Regression for
 // `MakePhysical` recursing into the UDT and demanding annotations the inner fields lack (which made
@@ -2836,25 +2981,13 @@ async fn column_mapped_struct_udt_table_loads(
         {"name": "features", "type": udt_value, "nullable": true,
          "metadata": {"delta.columnMapping.id": 2, "delta.columnMapping.physicalName": "col-features"}},
     ]);
-    let schema_value = serde_json::json!({"type": "struct", "fields": fields});
-    let schema_string = serde_json::to_string(&schema_value)?;
-    let metadata = serde_json::json!({
-        "metaData": {
-            "id": "test-udt-cm",
-            "format": {"provider": "parquet", "options": {}},
-            "schemaString": schema_string,
-            "partitionColumns": [],
-            "configuration": {
-                "delta.columnMapping.mode": mode,
-                "delta.columnMapping.maxColumnId": "2",
-            },
-            "createdTime": 1587968585495_u64,
-        }
-    })
-    .to_string();
+    let configuration = serde_json::json!({
+        "delta.columnMapping.mode": mode,
+        "delta.columnMapping.maxColumnId": "2",
+    });
     let actions = [
         r#"{"protocol":{"minReaderVersion":2,"minWriterVersion":5}}"#.to_string(),
-        metadata,
+        udt_metadata_action(fields, configuration),
     ];
 
     let storage = Arc::new(InMemory::new());


### PR DESCRIPTION
## What changes are proposed in this pull request?

Spark `UserDefinedType` (`udt`) columns previously aborted the entire `schemaString` parse (`Unknown complex type: 'udt'`), making any table containing a UDT column unreadable, even for a `SELECT` of unrelated columns. A `udt` is an engine-specific annotation over a physical `sqlType`; it is not part of the Delta protocol type system, and the physical Parquet layout is always the `sqlType`.

This adds a `DataType::UserDefined` variant that carries the parsed `sqlType` (used for all physical read/Arrow/validation work) plus the original `udt` JSON for value-preserving re-serialization. The logical schema keeps the annotation; physical operations delegate to `sqlType`. No table feature and no new FFI callback are required (this mirrors how `void` is handled).

- **Read/Arrow:** `arrow_conversion`, `ensure_data_types`, `arrow_expression`, and the FFI schema visitor delegate `UserDefined -> sql_type`; `get_indices` resolves through `sql_type` so a struct/array/map `sqlType` reads correctly.
- **Column mapping:** `UserDefined` is an opaque leaf. `MakePhysical` and `NonNullFieldChecker` do not recurse into its `sql_type` (mirroring variant), so a column-mapped table with a struct-`sqlType` UDT loads.
- **Type equality** compares `sql_type` only; the opaque `raw` annotation must not affect schema-compatibility checks such as `can_read_as`.
- **Stats:** rejected by `stats_verifier` and treated as a single opaque leaf by the per-column stats transforms; excluded from data skipping and iceberg v3 by omission.

### This PR affects the following public APIs

New (non-breaking) additions:
- `DataType::UserDefined(UserDefinedType)` enum variant.
- `UserDefinedType { sql_type, raw }` struct.

This is read support only; the kernel does not construct UDT columns. A companion Delta protocol note (a `void`-style disposition for `udt` in `PROTOCOL.md`) is proposed separately in delta-io/delta.

## How was this change tested?

- Serde round-trip unit tests: Scala/Java, Python, and missing-`sqlType` error.
- Default-engine snapshot-load tests asserting the schema round-trips (schema-JSON checks) at top level and nested in a struct.
- Reads of primitive- and struct-`sqlType` UDT columns asserting the column materializes as its `sqlType`.
- A column-mapped (`name`/`id`) struct-`sqlType` UDT load test.
- A `can_read_as` regression asserting equality ignores the opaque `raw` annotation.
