### PR TITLE
feat: allow maintenance properties during CREATE TABLE

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -31,12 +31,13 @@ use crate::table_features::{
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
-    TableProperties, APPEND_ONLY, CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT,
-    COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS,
-    DATA_SKIPPING_STATS_COLUMNS, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
-    ENABLE_DELETION_VECTORS, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2,
+    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_WRITE_STATS_AS_JSON,
+    CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE,
+    DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS, DELETED_FILE_RETENTION_DURATION,
+    DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS,
+    ENABLE_EXPIRED_LOG_CLEANUP, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2,
     ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS, ENABLE_ROW_TRACKING,
-    ENABLE_TYPE_WIDENING, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
+    ENABLE_TYPE_WIDENING, LOG_RETENTION_DURATION, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
     MATERIALIZED_ROW_ID_COLUMN_NAME, PARQUET_FORMAT_VERSION, ROW_TRACKING_SUSPENDED,
     SET_TRANSACTION_RETENTION_DURATION,
 };
@@ -114,6 +115,14 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     ENABLE_ROW_TRACKING,
     // Set transaction retention duration: controls expiration of txn identifiers
     SET_TRANSACTION_RETENTION_DURATION,
+    // Metadata-only log/checkpoint maintenance configs. These do not enable any table feature;
+    // they are stored verbatim in the table metadata and consumed later by log cleanup /
+    // checkpoint scheduling. Allowed at CREATE so connectors (e.g. AI Gateway / payload logging)
+    // can pin retention at table-creation time.
+    LOG_RETENTION_DURATION,
+    DELETED_FILE_RETENTION_DURATION,
+    ENABLE_EXPIRED_LOG_CLEANUP,
+    CHECKPOINT_INTERVAL,
     // Parquet format version: controls the Parquet writer version for data files
     PARQUET_FORMAT_VERSION,
     // IcebergCompatV3 enablement: triggers auto-enablement of ColumnMapping,
@@ -1118,6 +1127,43 @@ mod tests {
         let properties = HashMap::from([(key.to_string(), value.to_string())]);
         let validated = validate_extract_table_features_and_properties(properties).unwrap();
         assert_eq!(validated.properties.get(key), Some(&value.to_string()));
+        assert!(validated.reader_features.is_empty());
+        assert!(validated.writer_features.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_maintenance_properties_accepted() {
+        // Log/checkpoint maintenance configs are metadata-only: accepted at CREATE, stored
+        // verbatim, and enable no table feature.
+        let properties = HashMap::from([
+            (
+                LOG_RETENTION_DURATION.to_string(),
+                "interval 30 days".to_string(),
+            ),
+            (
+                DELETED_FILE_RETENTION_DURATION.to_string(),
+                "interval 7 days".to_string(),
+            ),
+            (ENABLE_EXPIRED_LOG_CLEANUP.to_string(), "true".to_string()),
+            (CHECKPOINT_INTERVAL.to_string(), "10".to_string()),
+        ]);
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+        assert_eq!(
+            validated.properties.get(LOG_RETENTION_DURATION),
+            Some(&"interval 30 days".to_string()),
+        );
+        assert_eq!(
+            validated.properties.get(DELETED_FILE_RETENTION_DURATION),
+            Some(&"interval 7 days".to_string()),
+        );
+        assert_eq!(
+            validated.properties.get(ENABLE_EXPIRED_LOG_CLEANUP),
+            Some(&"true".to_string()),
+        );
+        assert_eq!(
+            validated.properties.get(CHECKPOINT_INTERVAL),
+            Some(&"10".to_string()),
+        );
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());
     }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -774,9 +774,17 @@ fn validate_extract_table_features_and_properties(
         .collect();
     if !metadata_props.is_empty() {
         let parsed = TableProperties::from(metadata_props.iter().copied());
-        if let Some((key, value)) = parsed.unknown_properties.iter().next() {
+        if !parsed.unknown_properties.is_empty() {
+            // Sort for a deterministic message: `unknown_properties` is a `HashMap`.
+            let mut invalid: Vec<_> = parsed
+                .unknown_properties
+                .iter()
+                .map(|(key, value)| format!("'{value}' for table property '{key}'"))
+                .collect();
+            invalid.sort_unstable();
             return Err(Error::generic(format!(
-                "Invalid value '{value}' for table property '{key}' during CREATE TABLE"
+                "Invalid values during CREATE TABLE: {}",
+                invalid.join("; ")
             )));
         }
     }
@@ -1205,7 +1213,7 @@ mod tests {
             HashMap::from([(CHECKPOINT_INTERVAL.to_string(), "not_a_number".to_string())]);
         assert_result_error_with_message(
             validate_extract_table_features_and_properties(properties),
-            "Invalid value 'not_a_number' for table property 'delta.checkpointInterval'",
+            "'not_a_number' for table property 'delta.checkpointInterval'",
         );
 
         // A duration missing the `interval` keyword also fails to parse and is rejected.
@@ -1213,7 +1221,19 @@ mod tests {
             HashMap::from([(LOG_RETENTION_DURATION.to_string(), "30 days".to_string())]);
         assert_result_error_with_message(
             validate_extract_table_features_and_properties(properties),
-            "Invalid value '30 days' for table property 'delta.logRetentionDuration'",
+            "'30 days' for table property 'delta.logRetentionDuration'",
+        );
+
+        // Multiple malformed values are all reported (sorted), not just the first.
+        let properties = HashMap::from([
+            (CHECKPOINT_INTERVAL.to_string(), "not_a_number".to_string()),
+            (LOG_RETENTION_DURATION.to_string(), "30 days".to_string()),
+        ]);
+        assert_result_error_with_message(
+            validate_extract_table_features_and_properties(properties),
+            "Invalid values during CREATE TABLE: '30 days' for table property \
+             'delta.logRetentionDuration'; 'not_a_number' for table property \
+             'delta.checkpointInterval'",
         );
     }
 

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -90,11 +90,8 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     TableFeature::IcebergCompatV3,
 ];
 
-/// Delta properties allowed to be set during CREATE TABLE.
-///
-/// This list will expand as more features are supported.
-/// The allow list will be deprecated once auto feature enablement is implemented
-/// like the Java Kernel.
+/// The single allow-list of `delta.*` properties accepted during CREATE TABLE. Any `delta.*`
+/// key not present here is rejected.
 const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     // ColumnMapping mode property: triggers column mapping transform
     COLUMN_MAPPING_MODE,
@@ -120,19 +117,8 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     // IcebergCompatV3 enablement: triggers auto-enablement of ColumnMapping,
     // RowTracking, DomainMetadata.
     ENABLE_ICEBERG_COMPAT_V3,
-];
-
-/// Metadata-only maintenance configs allowed during CREATE TABLE.
-///
-/// Unlike [`ALLOWED_DELTA_PROPERTIES`], these enable no table feature: they are stored verbatim in
-/// the table metadata and consumed later by log cleanup / checkpoint scheduling. They live in a
-/// separate list because their lifecycle is independent of feature auto-enablement -- when the
-/// feature allow-list is eventually deprecated (see above), these must remain accepted so
-/// connectors can still pin retention at table-creation time.
-///
-/// Their values ARE validated at CREATE (see [`validate_extract_table_features_and_properties`]),
-/// because nothing downstream re-checks them.
-const ALLOWED_METADATA_PROPERTIES: &[&str] = &[
+    // Log/checkpoint maintenance configs: stored verbatim, consumed by log cleanup / checkpoint
+    // scheduling.
     LOG_RETENTION_DURATION,
     DELETED_FILE_RETENTION_DURATION,
     ENABLE_EXPIRED_LOG_CLEANUP,
@@ -750,41 +736,13 @@ fn validate_extract_table_features_and_properties(
         }
     }
 
-    // Validate remaining delta.* properties against the allow lists
+    // Validate remaining delta.* properties against the allow list
     for key in properties.keys() {
         if key.starts_with(DELTA_PROPERTY_PREFIX)
             && !ALLOWED_DELTA_PROPERTIES.contains(&key.as_str())
-            && !ALLOWED_METADATA_PROPERTIES.contains(&key.as_str())
         {
             return Err(Error::generic(format!(
                 "Setting delta property '{key}' is not supported during CREATE TABLE"
-            )));
-        }
-    }
-
-    // Value-validate metadata-only maintenance configs. Feature-enablement properties have their
-    // values checked downstream during feature auto-enablement, but these do not: a malformed value
-    // is silently dropped into `unknown_properties` by `TableProperties` parsing (losing the
-    // operator's setting) and can be rejected by other engines (e.g. delta-spark) on read. Reject
-    // it here so the committed metadata always round-trips.
-    let metadata_props: Vec<(&str, &str)> = properties
-        .iter()
-        .filter(|(k, _)| ALLOWED_METADATA_PROPERTIES.contains(&k.as_str()))
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-    if !metadata_props.is_empty() {
-        let parsed = TableProperties::from(metadata_props.iter().copied());
-        if !parsed.unknown_properties.is_empty() {
-            // Sort for a deterministic message: `unknown_properties` is a `HashMap`.
-            let mut invalid: Vec<_> = parsed
-                .unknown_properties
-                .iter()
-                .map(|(key, value)| format!("'{value}' for table property '{key}'"))
-                .collect();
-            invalid.sort_unstable();
-            return Err(Error::generic(format!(
-                "Invalid values during CREATE TABLE: {}",
-                invalid.join("; ")
             )));
         }
     }
@@ -1203,38 +1161,6 @@ mod tests {
         );
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());
-    }
-
-    #[test]
-    fn test_metadata_maintenance_property_invalid_value_rejected() {
-        // A malformed maintenance value must be rejected at CREATE, not silently dropped: a
-        // non-positive-int checkpoint interval does not parse, so it would otherwise vanish.
-        let properties =
-            HashMap::from([(CHECKPOINT_INTERVAL.to_string(), "not_a_number".to_string())]);
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "'not_a_number' for table property 'delta.checkpointInterval'",
-        );
-
-        // A duration missing the `interval` keyword also fails to parse and is rejected.
-        let properties =
-            HashMap::from([(LOG_RETENTION_DURATION.to_string(), "30 days".to_string())]);
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "'30 days' for table property 'delta.logRetentionDuration'",
-        );
-
-        // Multiple malformed values are all reported (sorted), not just the first.
-        let properties = HashMap::from([
-            (CHECKPOINT_INTERVAL.to_string(), "not_a_number".to_string()),
-            (LOG_RETENTION_DURATION.to_string(), "30 days".to_string()),
-        ]);
-        assert_result_error_with_message(
-            validate_extract_table_features_and_properties(properties),
-            "Invalid values during CREATE TABLE: '30 days' for table property \
-             'delta.logRetentionDuration'; 'not_a_number' for table property \
-             'delta.checkpointInterval'",
-        );
     }
 
     #[test]

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -115,19 +115,28 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     ENABLE_ROW_TRACKING,
     // Set transaction retention duration: controls expiration of txn identifiers
     SET_TRANSACTION_RETENTION_DURATION,
-    // Metadata-only log/checkpoint maintenance configs. These do not enable any table feature;
-    // they are stored verbatim in the table metadata and consumed later by log cleanup /
-    // checkpoint scheduling. Allowed at CREATE so connectors (e.g. AI Gateway / payload logging)
-    // can pin retention at table-creation time.
-    LOG_RETENTION_DURATION,
-    DELETED_FILE_RETENTION_DURATION,
-    ENABLE_EXPIRED_LOG_CLEANUP,
-    CHECKPOINT_INTERVAL,
     // Parquet format version: controls the Parquet writer version for data files
     PARQUET_FORMAT_VERSION,
     // IcebergCompatV3 enablement: triggers auto-enablement of ColumnMapping,
     // RowTracking, DomainMetadata.
     ENABLE_ICEBERG_COMPAT_V3,
+];
+
+/// Metadata-only maintenance configs allowed during CREATE TABLE.
+///
+/// Unlike [`ALLOWED_DELTA_PROPERTIES`], these enable no table feature: they are stored verbatim in
+/// the table metadata and consumed later by log cleanup / checkpoint scheduling. They live in a
+/// separate list because their lifecycle is independent of feature auto-enablement -- when the
+/// feature allow-list is eventually deprecated (see above), these must remain accepted so
+/// connectors can still pin retention at table-creation time.
+///
+/// Their values ARE validated at CREATE (see [`validate_extract_table_features_and_properties`]),
+/// because nothing downstream re-checks them.
+const ALLOWED_METADATA_PROPERTIES: &[&str] = &[
+    LOG_RETENTION_DURATION,
+    DELETED_FILE_RETENTION_DURATION,
+    ENABLE_EXPIRED_LOG_CLEANUP,
+    CHECKPOINT_INTERVAL,
 ];
 
 /// Ensures that no Delta table exists at the given path.
@@ -741,13 +750,33 @@ fn validate_extract_table_features_and_properties(
         }
     }
 
-    // Validate remaining delta.* properties against allow list
+    // Validate remaining delta.* properties against the allow lists
     for key in properties.keys() {
         if key.starts_with(DELTA_PROPERTY_PREFIX)
             && !ALLOWED_DELTA_PROPERTIES.contains(&key.as_str())
+            && !ALLOWED_METADATA_PROPERTIES.contains(&key.as_str())
         {
             return Err(Error::generic(format!(
                 "Setting delta property '{key}' is not supported during CREATE TABLE"
+            )));
+        }
+    }
+
+    // Value-validate metadata-only maintenance configs. Feature-enablement properties have their
+    // values checked downstream during feature auto-enablement, but these do not: a malformed value
+    // is silently dropped into `unknown_properties` by `TableProperties` parsing (losing the
+    // operator's setting) and can be rejected by other engines (e.g. delta-spark) on read. Reject
+    // it here so the committed metadata always round-trips.
+    let metadata_props: Vec<(&str, &str)> = properties
+        .iter()
+        .filter(|(k, _)| ALLOWED_METADATA_PROPERTIES.contains(&k.as_str()))
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    if !metadata_props.is_empty() {
+        let parsed = TableProperties::from(metadata_props.iter().copied());
+        if let Some((key, value)) = parsed.unknown_properties.iter().next() {
+            return Err(Error::generic(format!(
+                "Invalid value '{value}' for table property '{key}' during CREATE TABLE"
             )));
         }
     }
@@ -1166,6 +1195,26 @@ mod tests {
         );
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());
+    }
+
+    #[test]
+    fn test_metadata_maintenance_property_invalid_value_rejected() {
+        // A malformed maintenance value must be rejected at CREATE, not silently dropped: a
+        // non-positive-int checkpoint interval does not parse, so it would otherwise vanish.
+        let properties =
+            HashMap::from([(CHECKPOINT_INTERVAL.to_string(), "not_a_number".to_string())]);
+        assert_result_error_with_message(
+            validate_extract_table_features_and_properties(properties),
+            "Invalid value 'not_a_number' for table property 'delta.checkpointInterval'",
+        );
+
+        // A duration missing the `interval` keyword also fails to parse and is rejected.
+        let properties =
+            HashMap::from([(LOG_RETENTION_DURATION.to_string(), "30 days".to_string())]);
+        assert_result_error_with_message(
+            validate_extract_table_features_and_properties(properties),
+            "Invalid value '30 days' for table property 'delta.logRetentionDuration'",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2816/files) to review incremental changes.
- [**stack/ffi/create-table-data-layout-and-props**](https://github.com/delta-io/delta-kernel-rs/pull/2816) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2816/files)]
  - [stack/ffi/partitioned-write-context](https://github.com/delta-io/delta-kernel-rs/pull/2774) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2774/files/f54f48f61fd0f1d5d22a84780a2fd3b0fdd71f91..825081e13724e3ba043001bf976412c2bbfb8fce)]

---------
## What changes are proposed in this pull request?

Permit the metadata-only log/checkpoint maintenance configs to be set during `CREATE TABLE`: `delta.logRetentionDuration`, `delta.deletedFileRetentionDuration`, `delta.enableExpiredLogCleanup`, and `delta.checkpointInterval`. Unlike the existing CREATE-time properties, these enable no table feature -- they are stored verbatim in the table metadata and consumed later by log cleanup and checkpoint scheduling. Allowing them at creation lets connectors pin retention and checkpoint cadence at table-creation time.

They live in a separate `ALLOWED_METADATA_PROPERTIES` allow-list so their lifecycle stays independent of feature auto-enablement: when the feature-enablement allow-list is eventually deprecated, these must remain accepted. Their values are validated at CREATE, because nothing downstream re-checks them -- a malformed value (e.g. a non-integer `checkpointInterval`, or a retention duration missing the `interval` keyword) is rejected up front rather than being silently dropped into `unknown_properties`, where the operator's setting would be lost and could be rejected by other engines on read.

## How was this change tested?

Unit tests covering acceptance of the maintenance configs at CREATE and rejection of malformed values (non-integer checkpoint interval and malformed retention duration).
