### PR TITLE
feat: add java_package option to declarative-plan protos

### DIFF
--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -9,6 +9,9 @@ syntax = "proto3";
 
 package delta.kernel.expressions;
 
+// Java package for generated bindings. Ignored by prost (Rust codegen).
+option java_package = "io.delta.kernel.proto.expressions";
+
 import "schema.proto";
 
 // ============================================================================

--- a/kernel/proto/operation.proto
+++ b/kernel/proto/operation.proto
@@ -4,6 +4,9 @@ syntax = "proto3";
 
 package delta.kernel.operation;
 
+// Java package for generated bindings. Ignored by prost (Rust codegen).
+option java_package = "io.delta.kernel.proto.operation";
+
 import "plan.proto";
 
 // ============================================================================

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -8,6 +8,9 @@ syntax = "proto3";
 
 package delta.kernel.plan;
 
+// Java package for generated bindings. Ignored by prost (Rust codegen).
+option java_package = "io.delta.kernel.proto.plan";
+
 import "expressions.proto";
 import "schema.proto";
 

--- a/kernel/proto/schema.proto
+++ b/kernel/proto/schema.proto
@@ -4,6 +4,9 @@ syntax = "proto3";
 
 package delta.kernel.schema;
 
+// Java package for generated bindings. Ignored by prost (Rust codegen).
+option java_package = "io.delta.kernel.proto.schema";
+
 // ============================================================================
 // Primitive types
 // ============================================================================


### PR DESCRIPTION
## What changes are proposed in this pull request?
 Namespaces the generated Java bindings under io.delta.kernel.proto.* directly in the proto source, so the delta-kernel-rs-java jar build no longer needs a sed pass to inject it. Ignored by prost (Rust codegen).

