### PR TITLE
feat: describe scan transform as LoadColumnSpec descriptor

### DIFF
--- a/kernel/benches/metadata_bench.rs
+++ b/kernel/benches/metadata_bench.rs
@@ -66,22 +66,32 @@ fn scan_metadata_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("scan_metadata");
     group.sample_size(SCAN_METADATA_BENCH_SAMPLE_SIZE);
-    group.bench_function("scan_metadata", |b| {
-        b.iter(|| {
-            let scan = snapshot
-                .clone() // arc
-                .scan_builder()
-                .build()
-                .expect("Failed to build scan");
-            let metadata_iter = scan
-                .scan_metadata(engine.as_ref())
-                .expect("Failed to get scan metadata");
-            // kernel scans are lazy, we must consume iterator to do the work we want to test
-            for result in metadata_iter {
-                result.expect("Failed to process scan metadata");
-            }
-        })
-    });
+    // Benchmark both the default path (kernel builds a per-file transform expression for this
+    // partitioned table) and the `without_row_transforms` opt-out (which skips that build and the
+    // per-row partition-value parse that feeds it).
+    for without_row_transforms in [false, true] {
+        let id = if without_row_transforms {
+            "scan_metadata_without_row_transforms"
+        } else {
+            "scan_metadata"
+        };
+        group.bench_function(id, |b| {
+            b.iter(|| {
+                let mut builder = snapshot.clone().scan_builder();
+                if without_row_transforms {
+                    builder = builder.without_row_transforms();
+                }
+                let scan = builder.build().expect("Failed to build scan");
+                let metadata_iter = scan
+                    .scan_metadata(engine.as_ref())
+                    .expect("Failed to get scan metadata");
+                // kernel scans are lazy, we must consume iterator to do the work we want to test
+                for result in metadata_iter {
+                    result.expect("Failed to process scan metadata");
+                }
+            })
+        });
+    }
     group.finish();
 }
 

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -319,6 +319,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: true,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -78,6 +78,7 @@ struct InternalScanState {
     physical_stats_columns: HashSet<ColumnName>,
     #[serde(default)]
     is_catalog_managed: bool,
+    skip_row_transforms: bool,
 }
 
 /// Serializable processor state for distributed processing. This can be serialized using the
@@ -344,6 +345,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
+            skip_row_transforms,
         } = self.state_info.as_ref().clone();
 
         // Extract predicate from PhysicalPredicate
@@ -364,6 +366,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed,
+            skip_row_transforms,
         };
         let internal_state_blob = serde_json::to_vec(&internal_state)
             .map_err(|e| Error::generic(format!("Failed to serialize internal state: {e}")))?;
@@ -422,6 +425,7 @@ impl ScanLogReplayProcessor {
             physical_partition_schema: internal_state.physical_partition_schema,
             physical_stats_columns: internal_state.physical_stats_columns,
             is_catalog_managed: internal_state.is_catalog_managed,
+            skip_row_transforms: internal_state.skip_row_transforms,
         });
 
         Self::new_with_seen_files(
@@ -502,7 +506,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         // Partition pruning is handled by DataSkippingFilter in the columnar data skipping phase,
         // so we only need to parse values here for the transform.
         let partition_values = match &self.state_info.transform_spec {
-            Some(transform) if is_add => {
+            Some(transform) if is_add && !self.state_info.skip_row_transforms => {
                 let partition_values = getters[ScanLogReplayProcessor::ADD_PARTITION_VALUES_INDEX]
                     .get(row, "add.partitionValues")?;
                 parse_partition_values(
@@ -519,25 +523,27 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         if self.deduplicator.check_and_record_seen(file_key) || !is_add {
             return Ok(false);
         }
-        let base_row_id: Option<i64> =
-            getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
-        let patch_expr = self
-            .state_info
-            .transform_spec
-            .as_ref()
-            .map(|transform_spec| {
-                get_transform_expr(
-                    transform_spec,
-                    partition_values,
-                    &self.state_info.physical_schema,
-                    base_row_id,
-                )
-            })
-            .transpose()?;
-        if patch_expr.is_some() {
-            // fill in any needed `None`s for previous rows
-            self.row_transform_exprs.resize_with(row, Default::default);
-            self.row_transform_exprs.push(patch_expr);
+        if !self.state_info.skip_row_transforms {
+            let base_row_id: Option<i64> =
+                getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
+            let patch_expr = self
+                .state_info
+                .transform_spec
+                .as_ref()
+                .map(|transform_spec| {
+                    get_transform_expr(
+                        transform_spec,
+                        partition_values,
+                        &self.state_info.physical_schema,
+                        base_row_id,
+                    )
+                })
+                .transpose()?;
+            if patch_expr.is_some() {
+                // fill in any needed `None`s for previous rows
+                self.row_transform_exprs.resize_with(row, Default::default);
+                self.row_transform_exprs.push(patch_expr);
+            }
         }
         self.metrics.record_active_add_file(size);
         Ok(true)
@@ -1111,6 +1117,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         });
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
@@ -1442,6 +1449,7 @@ mod tests {
                 physical_partition_schema: None,
                 physical_stats_columns: HashSet::new(),
                 is_catalog_managed: false,
+                skip_row_transforms: false,
             });
             let checkpoint_info = test_checkpoint_info();
             let processor = ScanLogReplayProcessor::new(
@@ -1480,6 +1488,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1514,6 +1523,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: true,
+            skip_row_transforms: false,
         });
         let processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1526,6 +1536,43 @@ mod tests {
         let deserialized =
             ScanLogReplayProcessor::from_serializable_state(&engine, serialized).unwrap();
         assert!(deserialized.is_catalog_managed());
+    }
+
+    #[test]
+    fn test_serialization_round_trips_skip_row_transforms() {
+        let engine = SyncEngine::new();
+        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
+            "id",
+            DataType::INTEGER,
+            true,
+        )]));
+        for skip in [false, true] {
+            let state_info = Arc::new(StateInfo {
+                logical_schema: schema.clone(),
+                physical_schema: schema.clone(),
+                physical_predicate: PhysicalPredicate::None,
+                transform_spec: None,
+                column_mapping_mode: ColumnMappingMode::None,
+                physical_stats_schema: None,
+                physical_partition_schema: None,
+                physical_stats_columns: HashSet::new(),
+                is_catalog_managed: false,
+                skip_row_transforms: skip,
+            });
+            let processor = ScanLogReplayProcessor::new(
+                &engine,
+                state_info,
+                test_checkpoint_info(),
+                ScanStatsOptions::default(),
+            )
+            .unwrap();
+            let deserialized = ScanLogReplayProcessor::from_serializable_state(
+                &engine,
+                processor.into_serializable_state().unwrap(),
+            )
+            .unwrap();
+            assert_eq!(deserialized.state_info.skip_row_transforms, skip);
+        }
     }
 
     #[test]
@@ -1563,6 +1610,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
         let predicate = Arc::new(crate::expressions::Predicate::column(["id"]));
         let invalid_blob = serde_json::to_vec(&invalid_internal_state).unwrap();
@@ -1597,6 +1645,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
         let blob = serde_json::to_string(&invalid_internal_state).unwrap();
         let mut obj: serde_json::Value = serde_json::from_str(&blob).unwrap();

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1538,41 +1538,39 @@ mod tests {
         assert!(deserialized.is_catalog_managed());
     }
 
-    #[test]
-    fn test_serialization_round_trips_skip_row_transforms() {
+    #[rstest]
+    fn test_serialization_round_trips_skip_row_transforms(#[values(false, true)] skip: bool) {
         let engine = SyncEngine::new();
         let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
             "id",
             DataType::INTEGER,
             true,
         )]));
-        for skip in [false, true] {
-            let state_info = Arc::new(StateInfo {
-                logical_schema: schema.clone(),
-                physical_schema: schema.clone(),
-                physical_predicate: PhysicalPredicate::None,
-                transform_spec: None,
-                column_mapping_mode: ColumnMappingMode::None,
-                physical_stats_schema: None,
-                physical_partition_schema: None,
-                physical_stats_columns: HashSet::new(),
-                is_catalog_managed: false,
-                skip_row_transforms: skip,
-            });
-            let processor = ScanLogReplayProcessor::new(
-                &engine,
-                state_info,
-                test_checkpoint_info(),
-                ScanStatsOptions::default(),
-            )
-            .unwrap();
-            let deserialized = ScanLogReplayProcessor::from_serializable_state(
-                &engine,
-                processor.into_serializable_state().unwrap(),
-            )
-            .unwrap();
-            assert_eq!(deserialized.state_info.skip_row_transforms, skip);
-        }
+        let state_info = Arc::new(StateInfo {
+            logical_schema: schema.clone(),
+            physical_schema: schema.clone(),
+            physical_predicate: PhysicalPredicate::None,
+            transform_spec: None,
+            column_mapping_mode: ColumnMappingMode::None,
+            physical_stats_schema: None,
+            physical_partition_schema: None,
+            physical_stats_columns: HashSet::new(),
+            is_catalog_managed: false,
+            skip_row_transforms: skip,
+        });
+        let processor = ScanLogReplayProcessor::new(
+            &engine,
+            state_info,
+            test_checkpoint_info(),
+            ScanStatsOptions::default(),
+        )
+        .unwrap();
+        let deserialized = ScanLogReplayProcessor::from_serializable_state(
+            &engine,
+            processor.into_serializable_state().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(deserialized.state_info.skip_row_transforms, skip);
     }
 
     #[test]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -194,6 +194,7 @@ pub struct ScanBuilder {
     predicate: Option<PredicateRef>,
     stats: StatsOptions,
     correlation_id: Option<Arc<str>>,
+    without_row_transforms: bool,
 }
 
 impl std::fmt::Debug for ScanBuilder {
@@ -203,6 +204,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("predicate", &self.predicate)
             .field("stats", &self.stats)
             .field("correlation_id", &self.correlation_id)
+            .field("without_row_transforms", &self.without_row_transforms)
             .finish()
     }
 }
@@ -216,6 +218,7 @@ impl ScanBuilder {
             predicate: None,
             stats: StatsOptions::default(),
             correlation_id: None,
+            without_row_transforms: false,
         }
     }
 
@@ -287,6 +290,22 @@ impl ScanBuilder {
         self
     }
 
+    /// Declare that the engine will reconstruct logical rows itself and will not consume
+    /// [`ScanMetadata::scan_file_transforms`].
+    ///
+    /// The kernel then skips building the per-file transform expressions and the per-row
+    /// partition-value parse done only to build them. The returned `scan_file_transforms` is left
+    /// empty (each row's transform is `None`); use [`Scan::scan_metadata`] for listing.
+    ///
+    /// With this set the engine must itself apply every physical-to-logical fixup the transform
+    /// would normally perform: partition column injection, column-mapping renames, and generated
+    /// row ids. Deletion vectors are unaffected: they are delivered per file in the scan metadata
+    /// regardless. [`Scan::execute`] returns an error.
+    pub fn without_row_transforms(mut self) -> Self {
+        self.without_row_transforms = true;
+        self
+    }
+
     /// Build the [`Scan`].
     ///
     /// This does not scan the table at this point, but does do some work to ensure that the
@@ -317,7 +336,7 @@ impl ScanBuilder {
             .table_configuration()
             .ensure_operation_supported(Operation::Scan)?;
 
-        let state_info = StateInfo::try_new(
+        let mut state_info = StateInfo::try_new(
             logical_read_schema,
             table_schema,
             self.snapshot.table_configuration(),
@@ -325,6 +344,10 @@ impl ScanBuilder {
             &self.stats,
             (), // No classifier, default is for scans
         )?;
+
+        // Retain the transform spec but skip building per-file expressions, which also skips the
+        // per-row partition-value parse done only to build them.
+        state_info.skip_row_transforms = self.without_row_transforms;
 
         Ok(Scan {
             snapshot: self.snapshot,
@@ -1053,12 +1076,23 @@ impl Scan {
     /// the data for the query. Each [`EngineData`] in the resultant iterator is a portion of the
     /// final table data. Generally connectors/engines will want to use [`Scan::scan_metadata`] so
     /// they can have more control over the execution of the scan.
+    ///
+    /// Returns an error if the scan was built with [`ScanBuilder::without_row_transforms`]; use
+    /// [`Scan::scan_metadata`] instead.
     // This calls [`Scan::scan_metadata`] to get an iterator of `ScanMetadata` actions for the scan,
     // and then uses the `engine`'s [`crate::ParquetHandler`] to read the actual table data.
     pub fn execute(
         &self,
         engine: Arc<dyn Engine>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<Box<dyn EngineData>>>> {
+        if self.state_info.skip_row_transforms {
+            return Err(Error::unsupported(
+                "Scan::execute is not supported when the scan was built with \
+                 without_row_transforms; use scan_metadata for listing and read data with your \
+                 own reader",
+            ));
+        }
+
         fn scan_metadata_callback(batches: &mut Vec<state::ScanFile>, file: state::ScanFile) {
             batches.push(file);
         }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -33,9 +33,10 @@ use crate::scan::log_replay::{
 };
 use crate::scan::metrics::ScanMetrics;
 use crate::scan::state_info::StateInfo;
+use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::schema::{
-    ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField, StructType,
-    ToSchema as _,
+    ArrayType, DataType, MapType, MetadataColumnSpec, PrimitiveType, Schema, SchemaRef,
+    StructField, StructType, ToSchema as _,
 };
 use crate::table_features::{ColumnMappingMode, Operation};
 use crate::transforms::{transform_output_type, ExpressionTransform, SchemaTransform};
@@ -299,8 +300,10 @@ impl ScanBuilder {
     ///
     /// With this set the engine must itself apply every physical-to-logical fixup the transform
     /// would normally perform: partition column injection, column-mapping renames, and generated
-    /// row ids. Deletion vectors are unaffected: they are delivered per file in the scan metadata
-    /// regardless. [`Scan::execute`] returns an error.
+    /// row ids. [`Scan::scan_transform`] describes those fixups structurally so the engine can
+    /// reproduce them without re-deriving Delta read semantics. Deletion vectors are unaffected:
+    /// they are delivered per file in the scan metadata regardless. [`Scan::execute`] returns an
+    /// error.
     pub fn without_row_transforms(mut self) -> Self {
         self.without_row_transforms = true;
         self
@@ -607,6 +610,171 @@ impl HasSelectionVector for ScanMetadata {
     }
 }
 
+/// An engine-agnostic, logical-schema-keyed description of the physical-to-logical scan transform:
+/// one entry per logical output column, in output order. This is the structural counterpart to the
+/// per-file expression in [`ScanMetadata::scan_file_transforms`]. Engines that drive a configured
+/// scan node (rather than evaluating an expression) map each variant directly to their own column
+/// layout. Obtain it via [`Scan::scan_transform`].
+///
+/// The variants mirror the column roles of a declarative-plan `Load` node (data column, file
+/// constant, generated value), describing the same structure over today's [`Scan::scan_metadata`]
+/// output. It is the precursor to serving the transform as a `Load` node directly.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum LoadColumnSpec {
+    /// A column read directly from the data file. `physical_name` is the Parquet column name to
+    /// read; it is the column-mapping physical name in both modes, and equals `logical_name` when
+    /// the table has no column mapping. `field_id` is the field's `delta.columnMapping.id` when
+    /// the table uses column mapping (in either mode), and `None` otherwise. `children`
+    /// carries the nested fields of a struct column (or of the struct reached through an array
+    /// element or map value), each a `Physical` with its own physical name; it is empty for
+    /// leaf columns.
+    #[non_exhaustive]
+    Physical {
+        logical_name: String,
+        physical_name: String,
+        field_id: Option<i64>,
+        children: Vec<LoadColumnSpec>,
+    },
+    /// A partition column, whose value is not stored in the file. `physical_name` is the key the
+    /// per-file partition value is delivered under (`ScanFile.partition_values`); it equals
+    /// `logical_name` when the table has no column mapping. `values_index` is the column's
+    /// position in the table's partition-column order (`partition_columns()`).
+    #[non_exhaustive]
+    Partition {
+        logical_name: String,
+        physical_name: String,
+        values_index: usize,
+    },
+    /// The row-tracking row id: `COALESCE(materialized_column, base_row_id + row_index)`. The
+    /// engine reads `materialized_column` from the data file, takes `base_row_id` from the
+    /// per-file scan metadata, and supplies the row's physical ordinal position within the file
+    /// (before any deletion-vector filtering) as `row_index`.
+    #[non_exhaustive]
+    RowId {
+        logical_name: String,
+        /// Physical column in the data file holding explicitly materialized row ids. It is null
+        /// for rows whose id must be computed as `base_row_id + row_index`.
+        materialized_column: String,
+    },
+    /// A column the engine produces itself rather than reading from the data file (it is not
+    /// stored there). `kind` says which value to materialize.
+    #[non_exhaustive]
+    ReaderGenerated {
+        logical_name: String,
+        kind: ReaderGeneratedColumn,
+    },
+}
+
+/// Which value a [`LoadColumnSpec::ReaderGenerated`] column carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ReaderGeneratedColumn {
+    /// The row's physical ordinal position within the file, before deletion-vector filtering.
+    RowIndex,
+    /// The path of the file the row was read from.
+    FilePath,
+}
+
+/// Builds the [`LoadColumnSpec`] descriptor for a scan. Walks `logical_schema` in output order,
+/// classifying each field as a partition value, a row id, or a physical column. Returns `None` for
+/// transforms and columns that have no structural description; see [`Scan::scan_transform`] for the
+/// exact conditions.
+fn describe_scan_transform(
+    transform_spec: Option<&TransformSpec>,
+    logical_schema: &Schema,
+    partition_columns: &[String],
+    column_mapping_mode: ColumnMappingMode,
+) -> Option<Vec<LoadColumnSpec>> {
+    // The materialized row-id column comes only from the spec; the logical schema doesn't carry it.
+    let mut materialized_row_id_column = None;
+    if let Some(transform_spec) = transform_spec {
+        for field_transform in transform_spec {
+            match field_transform {
+                FieldTransformSpec::GenerateRowId { field_name, .. } => {
+                    materialized_row_id_column = Some(field_name.clone());
+                }
+                FieldTransformSpec::MetadataDerivedColumn { .. }
+                | FieldTransformSpec::StaticDrop { .. } => {}
+                FieldTransformSpec::DynamicColumn { .. }
+                | FieldTransformSpec::StaticInsert { .. } => return None,
+            }
+        }
+    }
+
+    let mut columns = Vec::with_capacity(logical_schema.num_fields());
+    for field in logical_schema.fields() {
+        let logical_name = field.name().to_string();
+        let column = if let Some(values_index) = partition_columns
+            .iter()
+            .position(|name| name == field.name())
+        {
+            LoadColumnSpec::Partition {
+                logical_name,
+                physical_name: field.physical_name(column_mapping_mode).to_string(),
+                values_index,
+            }
+        } else {
+            match field.get_metadata_column_spec() {
+                None => describe_physical_column(field, column_mapping_mode),
+                Some(MetadataColumnSpec::RowId) => LoadColumnSpec::RowId {
+                    logical_name,
+                    materialized_column: materialized_row_id_column.clone()?,
+                },
+                Some(MetadataColumnSpec::RowIndex) => LoadColumnSpec::ReaderGenerated {
+                    logical_name,
+                    kind: ReaderGeneratedColumn::RowIndex,
+                },
+                Some(MetadataColumnSpec::FilePath) => LoadColumnSpec::ReaderGenerated {
+                    logical_name,
+                    kind: ReaderGeneratedColumn::FilePath,
+                },
+                // Row commit versions aren't supported by scans (build errors first); guard
+                // defensively since they have no structural description.
+                Some(MetadataColumnSpec::RowCommitVersion) => return None,
+            }
+        };
+        columns.push(column);
+    }
+    Some(columns)
+}
+
+/// Describes a data column as a [`LoadColumnSpec::Physical`], recursing into nested struct fields
+/// (including the struct reached through an array element or map value) so every nested physical
+/// name is carried.
+fn describe_physical_column(
+    field: &StructField,
+    column_mapping_mode: ColumnMappingMode,
+) -> LoadColumnSpec {
+    LoadColumnSpec::Physical {
+        logical_name: field.name().to_string(),
+        physical_name: field.physical_name(column_mapping_mode).to_string(),
+        field_id: (column_mapping_mode != ColumnMappingMode::None)
+            .then(|| field.column_mapping_id())
+            .flatten(),
+        children: physical_children(field.data_type(), column_mapping_mode),
+    }
+}
+
+/// The nested physical columns of `data_type`: a struct's fields, or the fields of the struct
+/// reached through an array element or map value. Empty for primitive and variant leaves.
+fn physical_children(
+    data_type: &DataType,
+    column_mapping_mode: ColumnMappingMode,
+) -> Vec<LoadColumnSpec> {
+    match data_type {
+        DataType::Struct(struct_type) => struct_type
+            .fields()
+            .map(|field| describe_physical_column(field, column_mapping_mode))
+            .collect(),
+        DataType::Array(array_type) => {
+            physical_children(array_type.element_type(), column_mapping_mode)
+        }
+        DataType::Map(map_type) => physical_children(map_type.value_type(), column_mapping_mode),
+        DataType::Primitive(_) | DataType::Variant(_) => Vec::new(),
+    }
+}
+
 /// The result of building a scan over a table. This can be used to get the actual data from
 /// scanning the table.
 pub struct Scan {
@@ -682,6 +850,27 @@ impl Scan {
         } else {
             None
         }
+    }
+
+    /// The physical-to-logical transform as an engine-agnostic, logical-schema-keyed descriptor:
+    /// one [`LoadColumnSpec`] per logical output column, in output order. Engines that assemble
+    /// logical rows from a configured scan node (rather than evaluating the per-file
+    /// [`ScanMetadata::scan_file_transforms`] expression) map this directly to their own column
+    /// layout. Pairs with [`ScanBuilder::without_row_transforms`], which skips building that
+    /// expression.
+    ///
+    /// Returns `None` only when the transform cannot be described structurally, in which case the
+    /// scan must consume the per-file expression instead: a column whose physical-vs-metadata
+    /// nature varies per file (CDF's `_change_type`), an opaque inserted expression, or a
+    /// row-commit-version column (unsupported by scans). Column-mapped (nested included),
+    /// partitioned, row-tracking, and reader-generated metadata columns are all described.
+    pub fn scan_transform(&self) -> Option<Vec<LoadColumnSpec>> {
+        describe_scan_transform(
+            self.state_info.transform_spec.as_deref(),
+            self.logical_schema(),
+            self.snapshot.table_configuration().partition_columns(),
+            self.state_info.column_mapping_mode,
+        )
     }
 
     /// Get an iterator of [`ScanMetadata`]s that should be used to facilitate a scan. This handles

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -47,6 +47,12 @@ pub(crate) struct StateInfo {
     /// Whether the table is catalog-managed, used to label scan metric events. Converted to a
     /// [`TableType`](crate::metrics::TableType) at event construction.
     pub(crate) is_catalog_managed: bool,
+    /// When set, log replay does not build per-file transform expressions:
+    /// `parse_partition_values` and `get_transform_expr` are skipped and every
+    /// `ScanMetadata::scan_file_transforms` entry is left `None`. `transform_spec` is retained
+    /// so the scan can still describe the transform structurally. Set by
+    /// [`ScanBuilder::without_row_transforms`](crate::scan::ScanBuilder::without_row_transforms).
+    pub(crate) skip_row_transforms: bool,
 }
 
 /// Validating the metadata columns also extracts information needed to properly construct the full
@@ -425,6 +431,7 @@ impl StateInfo {
             physical_partition_schema,
             physical_stats_columns,
             is_catalog_managed: table_configuration.is_catalog_managed(),
+            skip_row_transforms: false,
         })
     }
 

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -168,6 +168,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
         physical_partition_schema: None,
         physical_stats_columns: HashSet::new(),
         is_catalog_managed: false,
+        skip_row_transforms: false,
     });
     let checkpoint_info = CheckpointReadInfo::without_stats_parsed();
     let (iter, _metrics) = scan_action_iter(

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -410,6 +410,144 @@ fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     );
 }
 
+/// Loads `table`'s v0 snapshot with a [`SyncEngine`], for the `without_row_transforms` tests.
+fn without_transforms_snapshot(table: &str) -> (Arc<SyncEngine>, Arc<Snapshot>) {
+    let path = std::fs::canonicalize(PathBuf::from(table)).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = Arc::new(SyncEngine::new());
+    let snapshot = Snapshot::builder_for(url)
+        .at_version(0)
+        .build(engine.as_ref())
+        .unwrap();
+    (engine, snapshot)
+}
+
+/// A partitioned table and a column-mapped table both build a transform spec.
+/// `without_row_transforms` retains the spec but sets `skip_row_transforms`, so log replay
+/// builds no per-file expressions while the structural transform stays describable.
+#[rstest]
+#[case::partitioned("./tests/data/basic_partitioned/")]
+#[case::column_mapping("./tests/data/partition_cm/name/")]
+fn test_without_row_transforms_retains_spec_and_sets_skip(#[case] table: &str) {
+    let (_engine, snapshot) = without_transforms_snapshot(table);
+
+    let scan = snapshot.clone().scan_builder().build().unwrap();
+    assert!(scan.state_info.transform_spec.is_some());
+    assert!(!scan.state_info.skip_row_transforms);
+
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+    assert!(scan.state_info.transform_spec.is_some());
+    assert!(scan.state_info.skip_row_transforms);
+}
+
+/// `scan_metadata` still lists files, and every emitted per-file transform is `None`.
+#[test]
+fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
+    let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    let mut saw_file = false;
+    for metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let metadata = metadata.unwrap();
+        assert!(
+            metadata.scan_file_transforms.iter().all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        saw_file = true;
+    }
+    assert!(
+        saw_file,
+        "scan_metadata should still list files under without_row_transforms"
+    );
+}
+
+#[test]
+fn test_without_row_transforms_rejects_execute() {
+    let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+    let err = scan
+        .execute(engine)
+        .err()
+        .expect("execute must error when row transforms are skipped");
+    assert!(
+        err.to_string().contains("without_row_transforms"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Row commit version metadata columns are unsupported by scans, so requesting one errors at
+/// build time regardless of `without_row_transforms`.
+#[rstest]
+fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_transforms: bool) {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let schema = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("rcv", MetadataColumnSpec::RowCommitVersion)
+            .unwrap(),
+    );
+    let mut builder = snapshot.scan_builder().with_schema(schema);
+    if without_row_transforms {
+        builder = builder.without_row_transforms();
+    }
+    let err = builder
+        .build()
+        .expect_err("row commit version columns are unsupported by scans");
+    assert!(
+        err.to_string()
+            .contains("Row commit versions not supported"),
+        "unexpected error: {err}"
+    );
+}
+
+/// Deletion vectors flow through scan metadata independently of the row transform, so they are
+/// still surfaced under `without_row_transforms` while every per-file transform is `None`.
+#[test]
+fn test_without_row_transforms_scan_metadata_surfaces_deletion_vectors() {
+    // The deletion vector is added at the latest version, so load the full table (not v0).
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    fn dv_callback(seen: &mut bool, scan_file: ScanFile) {
+        *seen |= scan_file.dv_info.deletion_vector.is_some();
+    }
+    let mut saw_dv = false;
+    for res in scan.scan_metadata(&engine).unwrap() {
+        let scan_metadata = res.unwrap();
+        assert!(
+            scan_metadata
+                .scan_file_transforms
+                .iter()
+                .all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        saw_dv = scan_metadata.visit_scan_files(saw_dv, dv_callback).unwrap();
+    }
+    assert!(
+        saw_dv,
+        "deletion vector info should still be surfaced under without_row_transforms"
+    );
+}
+
 fn get_files_for_scan(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<String>> {
     let scan_metadata_iter = scan.scan_metadata(engine)?;
     fn scan_metadata_callback(paths: &mut Vec<String>, scan_file: ScanFile) {

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use ::test_utils::get_column;
+use ::test_utils::{get_column, load_test_data};
 use bytes::Bytes;
 use rstest::rstest;
 
@@ -444,9 +444,11 @@ fn test_without_row_transforms_retains_spec_and_sets_skip(#[case] table: &str) {
     assert!(scan.state_info.skip_row_transforms);
 }
 
-/// `scan_metadata` still lists files, and every emitted per-file transform is `None`.
+/// Under `without_row_transforms`, `scan_metadata` still lists files and surfaces the partition
+/// values a connector needs to reconstruct rows itself, while every per-file transform is `None`.
+/// Deletion vectors are covered by the sibling test.
 #[test]
-fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
+fn test_without_row_transforms_scan_metadata_lists_files_with_partition_values() {
     let (engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
     let scan = snapshot
         .scan_builder()
@@ -454,8 +456,51 @@ fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
         .build()
         .unwrap();
 
-    let mut saw_file = false;
+    // (saw a file, saw non-empty partition values)
+    fn collect(acc: &mut (bool, bool), scan_file: ScanFile) {
+        acc.0 = true;
+        acc.1 |= !scan_file.partition_values.is_empty();
+    }
+    let mut acc = (false, false);
     for metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let metadata = metadata.unwrap();
+        assert!(
+            metadata.scan_file_transforms.iter().all(Option::is_none),
+            "every per-file transform must be None under without_row_transforms"
+        );
+        acc = metadata.visit_scan_files(acc, collect).unwrap();
+    }
+    let (saw_file, saw_partition_values) = acc;
+    assert!(
+        saw_file,
+        "scan_metadata should still list files under without_row_transforms"
+    );
+    assert!(
+        saw_partition_values,
+        "partition values must still be surfaced so the connector can inject them itself"
+    );
+}
+
+/// Column mapping also builds a per-file transform (the physical-to-logical rename). Under
+/// `without_row_transforms`, `scan_metadata` still lists a column-mapped table's files with every
+/// per-file transform `None`, leaving the rename to the connector.
+#[test]
+fn test_without_row_transforms_scan_metadata_lists_files_column_mapping() {
+    let table = "table-with-columnmapping-mode-name";
+    let tempdir = load_test_data("tests/golden_data", table).unwrap();
+    // Golden tables extract to `<name>/delta/` (with a sibling `expected/`).
+    let table_path = tempdir.path().join(table).join("delta");
+    let url = url::Url::from_directory_path(table_path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+
+    let mut saw_file = false;
+    for metadata in scan.scan_metadata(&engine).unwrap() {
         let metadata = metadata.unwrap();
         assert!(
             metadata.scan_file_transforms.iter().all(Option::is_none),
@@ -465,7 +510,7 @@ fn test_without_row_transforms_scan_metadata_emits_no_transforms() {
     }
     assert!(
         saw_file,
-        "scan_metadata should still list files under without_row_transforms"
+        "scan_metadata should list the column-mapped table's files under without_row_transforms"
     );
 }
 

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -532,8 +532,20 @@ fn test_without_row_transforms_rejects_execute() {
     );
 }
 
-/// Row commit version metadata columns are unsupported by scans, so requesting one errors at
-/// build time regardless of `without_row_transforms`.
+/// `without_row_transforms` still exposes the structural descriptor.
+#[test]
+fn test_without_row_transforms_exposes_scan_transform() {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let scan = snapshot
+        .scan_builder()
+        .without_row_transforms()
+        .build()
+        .unwrap();
+    assert!(scan.scan_transform().is_some());
+}
+
+/// Row commit version metadata columns are unsupported by scans (the descriptor has no recipe for
+/// them), so requesting one errors at build time regardless of `without_row_transforms`.
 #[rstest]
 fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_transforms: bool) {
     let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
@@ -554,6 +566,387 @@ fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_trans
         err.to_string()
             .contains("Row commit versions not supported"),
         "unexpected error: {err}"
+    );
+}
+
+// === scan_transform descriptor: describe_scan_transform classification ===
+
+/// Without column mapping, `physical_name` equals `logical_name` and `field_id` is `None`.
+#[test]
+fn test_describe_scan_transform_plain_all_physical() {
+    let schema = StructType::new_unchecked([
+        StructField::nullable("a", DataType::INTEGER),
+        StructField::nullable("b", DataType::STRING),
+    ]);
+    let cols = describe_scan_transform(None, &schema, &[], ColumnMappingMode::None).unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Physical {
+                logical_name: "a".into(),
+                physical_name: "a".into(),
+                field_id: None,
+                children: vec![],
+            },
+            LoadColumnSpec::Physical {
+                logical_name: "b".into(),
+                physical_name: "b".into(),
+                field_id: None,
+                children: vec![],
+            },
+        ]
+    );
+}
+
+/// `values_index` is the column's position in `partition_columns`, not its position in the schema.
+#[test]
+fn test_describe_scan_transform_partition_values_index_follows_partition_order() {
+    let schema = StructType::new_unchecked([
+        StructField::nullable("year", DataType::INTEGER),
+        StructField::nullable("region", DataType::STRING),
+        StructField::nullable("value", DataType::INTEGER),
+    ]);
+    let partition_columns = ["region".to_string(), "year".to_string()];
+    let cols = describe_scan_transform(None, &schema, &partition_columns, ColumnMappingMode::None)
+        .unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Partition {
+                logical_name: "year".into(),
+                physical_name: "year".into(),
+                values_index: 1
+            },
+            LoadColumnSpec::Partition {
+                logical_name: "region".into(),
+                physical_name: "region".into(),
+                values_index: 0
+            },
+            LoadColumnSpec::Physical {
+                logical_name: "value".into(),
+                physical_name: "value".into(),
+                field_id: None,
+                children: vec![],
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_describe_scan_transform_row_id_carries_materialized_column() {
+    let schema = StructType::new_unchecked([
+        StructField::nullable("id", DataType::LONG),
+        StructField::create_metadata_column("row_id", MetadataColumnSpec::RowId),
+    ]);
+    let spec: TransformSpec = vec![
+        FieldTransformSpec::GenerateRowId {
+            field_name: "_mat_row_id".to_string(),
+            row_index_field_name: "_row_index".to_string(),
+        },
+        FieldTransformSpec::StaticDrop {
+            field_name: "_row_index".to_string(),
+        },
+    ];
+    let cols = describe_scan_transform(Some(&spec), &schema, &[], ColumnMappingMode::None).unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Physical {
+                logical_name: "id".into(),
+                physical_name: "id".into(),
+                field_id: None,
+                children: vec![],
+            },
+            LoadColumnSpec::RowId {
+                logical_name: "row_id".into(),
+                materialized_column: "_mat_row_id".into()
+            },
+        ]
+    );
+}
+
+/// CDF's per-file dynamic column and opaque inserted expressions have no structural description.
+#[rstest]
+#[case::dynamic_column(FieldTransformSpec::DynamicColumn {
+    field_index: 0,
+    physical_name: "a".to_string(),
+    insert_after: None,
+})]
+#[case::static_insert(FieldTransformSpec::StaticInsert {
+    insert_after: None,
+    expr: Arc::new(Expr::literal(42)),
+})]
+fn test_describe_scan_transform_fails_closed(#[case] field_transform: FieldTransformSpec) {
+    let schema = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
+    let spec: TransformSpec = vec![field_transform];
+    assert!(describe_scan_transform(Some(&spec), &schema, &[], ColumnMappingMode::None).is_none());
+}
+
+/// Row commit versions have no structural description, so the descriptor fails closed.
+#[test]
+fn test_describe_scan_transform_fails_closed_on_row_commit_version_metadata() {
+    let schema = StructType::new_unchecked([StructField::create_metadata_column(
+        "rcv",
+        MetadataColumnSpec::RowCommitVersion,
+    )]);
+    assert!(describe_scan_transform(None, &schema, &[], ColumnMappingMode::None).is_none());
+}
+
+/// Reader-generated columns are classified as `ReaderGenerated` so the engine knows to produce
+/// them itself rather than reading a non-existent file column.
+#[rstest]
+#[case::row_index(MetadataColumnSpec::RowIndex, ReaderGeneratedColumn::RowIndex)]
+#[case::file_path(MetadataColumnSpec::FilePath, ReaderGeneratedColumn::FilePath)]
+fn test_describe_scan_transform_reader_generated_column(
+    #[case] spec: MetadataColumnSpec,
+    #[case] kind: ReaderGeneratedColumn,
+) {
+    let schema = StructType::new_unchecked([StructField::create_metadata_column("meta", spec)]);
+    let cols = describe_scan_transform(None, &schema, &[], ColumnMappingMode::None).unwrap();
+    assert_eq!(
+        cols,
+        vec![LoadColumnSpec::ReaderGenerated {
+            logical_name: "meta".into(),
+            kind
+        }]
+    );
+}
+
+/// A schema of only partition columns yields all-`Partition` entries.
+#[test]
+fn test_describe_scan_transform_partition_only_schema() {
+    let schema = StructType::new_unchecked([
+        StructField::nullable("a", DataType::INTEGER),
+        StructField::nullable("b", DataType::STRING),
+    ]);
+    let partition_columns = ["a".to_string(), "b".to_string()];
+    let cols = describe_scan_transform(None, &schema, &partition_columns, ColumnMappingMode::None)
+        .unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Partition {
+                logical_name: "a".into(),
+                physical_name: "a".into(),
+                values_index: 0
+            },
+            LoadColumnSpec::Partition {
+                logical_name: "b".into(),
+                physical_name: "b".into(),
+                values_index: 1
+            },
+        ]
+    );
+}
+
+// === scan_transform descriptor: end-to-end over real tables ===
+
+#[test]
+fn test_scan_transform_partitioned() {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let cols = snapshot
+        .scan_builder()
+        .build()
+        .unwrap()
+        .scan_transform()
+        .unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Partition {
+                logical_name: "letter".into(),
+                physical_name: "letter".into(),
+                values_index: 0
+            },
+            LoadColumnSpec::Physical {
+                logical_name: "number".into(),
+                physical_name: "number".into(),
+                field_id: None,
+                children: vec![],
+            },
+            LoadColumnSpec::Physical {
+                logical_name: "a_float".into(),
+                physical_name: "a_float".into(),
+                field_id: None,
+                children: vec![],
+            },
+        ]
+    );
+}
+
+/// Under column mapping (both modes), physical columns carry their physical name and
+/// `delta.columnMapping.id`; the partition column is classified as a partition but still carries
+/// its physical name (the key its per-file value is delivered under).
+#[rstest]
+#[case::id_mode("./tests/data/partition_cm/id/", ColumnMappingMode::Id)]
+#[case::name_mode("./tests/data/partition_cm/name/", ColumnMappingMode::Name)]
+fn test_scan_transform_column_mapping(#[case] table: &str, #[case] mode: ColumnMappingMode) {
+    let (_engine, snapshot) = without_transforms_snapshot(table);
+    let schema = snapshot.schema();
+    let value_physical = schema
+        .field("value")
+        .unwrap()
+        .physical_name(mode)
+        .to_string();
+    let category_physical = schema
+        .field("category")
+        .unwrap()
+        .physical_name(mode)
+        .to_string();
+    // Column mapping resolves a distinct, non-logical physical name (the `col-<uuid>` form),
+    // independent of the accessor used to build the expected values above.
+    assert_ne!(value_physical, "value");
+    assert!(value_physical.starts_with("col-"));
+    assert!(category_physical.starts_with("col-"));
+
+    let cols = snapshot
+        .scan_builder()
+        .build()
+        .unwrap()
+        .scan_transform()
+        .unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Physical {
+                logical_name: "value".into(),
+                physical_name: value_physical,
+                field_id: Some(1),
+                children: vec![],
+            },
+            LoadColumnSpec::Partition {
+                logical_name: "category".into(),
+                physical_name: category_physical,
+                values_index: 0
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_scan_transform_row_tracking() {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/crc-full/");
+    let schema = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("row_id", MetadataColumnSpec::RowId)
+            .unwrap(),
+    );
+    let materialized = snapshot
+        .table_configuration()
+        .metadata()
+        .configuration()
+        .get("delta.rowTracking.materializedRowIdColumnName")
+        .unwrap()
+        .clone();
+    let cols = snapshot
+        .scan_builder()
+        .with_schema(schema)
+        .without_row_transforms()
+        .build()
+        .unwrap()
+        .scan_transform()
+        .unwrap();
+    assert_eq!(
+        cols,
+        vec![
+            LoadColumnSpec::Physical {
+                logical_name: "id".into(),
+                physical_name: "id".into(),
+                field_id: None,
+                children: vec![],
+            },
+            LoadColumnSpec::RowId {
+                logical_name: "row_id".into(),
+                materialized_column: materialized
+            },
+        ]
+    );
+}
+
+/// The descriptor lists exactly the logical output columns, in output order.
+#[rstest]
+#[case("./tests/data/basic_partitioned/")]
+#[case("./tests/data/partition_cm/none/")]
+#[case("./tests/data/partition_cm/id/")]
+#[case("./tests/data/partition_cm/name/")]
+fn test_scan_transform_matches_logical_schema_order(#[case] table: &str) {
+    let (_engine, snapshot) = without_transforms_snapshot(table);
+    let scan = snapshot.scan_builder().build().unwrap();
+    let cols = scan.scan_transform().unwrap();
+    let descriptor_names: Vec<&str> = cols
+        .iter()
+        .map(|c| match c {
+            LoadColumnSpec::Physical { logical_name, .. }
+            | LoadColumnSpec::Partition { logical_name, .. }
+            | LoadColumnSpec::RowId { logical_name, .. }
+            | LoadColumnSpec::ReaderGenerated { logical_name, .. } => logical_name.as_str(),
+        })
+        .collect();
+    let logical_names: Vec<&str> = scan
+        .logical_schema()
+        .fields()
+        .map(|f| f.name().as_str())
+        .collect();
+    assert_eq!(descriptor_names, logical_names);
+}
+
+/// A nested struct column is described recursively: each nested field carries its own physical
+/// name (here forced to differ from the logical name via a column-mapping annotation).
+#[test]
+fn test_describe_scan_transform_nested_struct_carries_child_physical_names() {
+    let phys_key = ColumnMetadataKey::ColumnMappingPhysicalName.as_ref();
+    let nested = StructField::nullable("a", DataType::INTEGER).add_metadata([(phys_key, "col-a")]);
+    let outer = StructField::nullable("s", StructType::new_unchecked([nested]))
+        .add_metadata([(phys_key, "col-s")]);
+    let schema = StructType::new_unchecked([outer]);
+    let cols = describe_scan_transform(None, &schema, &[], ColumnMappingMode::Name).unwrap();
+    assert_eq!(
+        cols,
+        vec![LoadColumnSpec::Physical {
+            logical_name: "s".into(),
+            physical_name: "col-s".into(),
+            field_id: None,
+            children: vec![LoadColumnSpec::Physical {
+                logical_name: "a".into(),
+                physical_name: "col-a".into(),
+                field_id: None,
+                children: vec![],
+            }],
+        }]
+    );
+}
+
+/// A row-id column with no `GenerateRowId` in the spec has no materialized column to describe.
+#[test]
+fn test_describe_scan_transform_row_id_without_generate_spec_fails_closed() {
+    let schema = StructType::new_unchecked([StructField::create_metadata_column(
+        "row_id",
+        MetadataColumnSpec::RowId,
+    )]);
+    let spec: TransformSpec = vec![];
+    assert!(describe_scan_transform(Some(&spec), &schema, &[], ColumnMappingMode::None).is_none());
+}
+
+/// A reader-generated metadata column is classified as `ReaderGenerated` end-to-end through the
+/// public `scan_transform()` (not just the free function).
+#[rstest]
+#[case::row_index(MetadataColumnSpec::RowIndex, ReaderGeneratedColumn::RowIndex)]
+#[case::file_path(MetadataColumnSpec::FilePath, ReaderGeneratedColumn::FilePath)]
+fn test_scan_transform_classifies_reader_generated_metadata_column(
+    #[case] spec: MetadataColumnSpec,
+    #[case] kind: ReaderGeneratedColumn,
+) {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
+    let schema = Arc::new(snapshot.schema().add_metadata_column("m", spec).unwrap());
+    let scan = snapshot.scan_builder().with_schema(schema).build().unwrap();
+    let cols = scan.scan_transform().unwrap();
+    assert_eq!(
+        cols.last(),
+        Some(&LoadColumnSpec::ReaderGenerated {
+            logical_name: "m".into(),
+            kind
+        })
     );
 }
 

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -190,6 +190,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         }
     }
 
@@ -413,6 +414,7 @@ mod tests {
             physical_partition_schema: None,
             physical_stats_columns: HashSet::new(),
             is_catalog_managed: false,
+            skip_row_transforms: false,
         };
 
         let result = get_cdf_transform_expr(&scan_file, &state_info, &physical_schema);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2821/files/ed7b687231886835f9e926a12119da75af4ceb1e..8a262151eec8516fcd089787982017c4368869c1) to review incremental changes.
- [stack/without-row-transforms](https://github.com/delta-io/delta-kernel-rs/pull/2756) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2756/files)]
  - [**stack/scan-transform-load**](https://github.com/delta-io/delta-kernel-rs/pull/2821) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2821/files/ed7b687231886835f9e926a12119da75af4ceb1e..8a262151eec8516fcd089787982017c4368869c1)] ← _this PR_

---------
## What changes are proposed in this pull request?

Stacked on #2756.

Adds `Scan::scan_transform()`, which serves the physical-to-logical scan transform as an engine-agnostic descriptor: one `LoadColumnSpec` per logical output column, in output order. Each variant says where that output column comes from:

- `Physical { physical_name, field_id, children }`: read from the data file (physical name and field id resolve column mapping; `children` carries nested struct / array / map fields),
- `Partition { physical_name, values_index }`: injected from the file's partition values,
- `RowId { materialized_column }`: the row-tracking id, `COALESCE(materialized_column, base_row_id + row_index)`,
- `ReaderGenerated { kind }`: produced by the engine itself (row index or file path).

A connector that drives its own scan node maps each variant to its column layout instead of evaluating the per-file `scan_file_transforms` expression; it pairs with `without_row_transforms()` from the parent PR. The enum is `#[non_exhaustive]` and `scan_transform()` returns `None` for transforms it can't describe structurally (CDF `_change_type`, opaque inserts, row commit versions), so the connector falls back to the expression path.

The variants mirror the column roles of a declarative-plan `Load` node, describing the same structure over today's `scan_metadata()` output. It is the precursor to serving the transform as a `Load` node directly, once the plan-based scan source that feeds such a node lands.

## How was this change tested?

`cargo test -p delta_kernel`: descriptor classification (plain, partitioned, column mapping id and name modes, row tracking, nested struct physical names, reader-generated columns, fail-closed cases), end-to-end `scan_transform()` over real tables, and schema-order parity with the logical output schema.