### PR TITLE
fix: pair struct fields by name instead of by position

### DIFF
--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -145,14 +145,14 @@ impl EnsureDataTypes {
                         }
                     }
                     ValidationMode::TypesAndNames | ValidationMode::Full => {
-                        // Name-based matching: look up kernel fields by arrow field name.
-                        // Full mode additionally checks nullability and metadata.
-                        let mapped_fields = arrow_fields
-                            .iter()
-                            .filter_map(|f| kernel_fields.field(f.name()));
-
+                        // Name-based matching: look up the kernel field for each arrow field by
+                        // name. Arrow fields with no kernel counterpart are ignored. Full mode
+                        // additionally checks nullability and metadata.
                         let mut found_fields = 0;
-                        for (kernel_field, arrow_field) in mapped_fields.zip(arrow_fields) {
+                        for arrow_field in arrow_fields {
+                            let Some(kernel_field) = kernel_fields.field(arrow_field.name()) else {
+                                continue;
+                            };
                             self.ensure_nullability_and_metadata(kernel_field, arrow_field)?;
                             self.ensure_data_types(
                                 &kernel_field.data_type,
@@ -568,6 +568,43 @@ mod tests {
                 ValidationMode::Full,
             ),
             "Generic delta kernel error: w has nullablily true in kernel and false in arrow",
+        );
+    }
+
+    #[test]
+    fn name_based_matching_pairs_fields_by_name_with_interleaved_extra() {
+        // The arrow struct has an unselected `extra` field between the matched ones. `x` must be
+        // paired with the arrow `x`, not positionally with `extra`.
+        let kernel = DataType::struct_type_unchecked([
+            StructField::nullable("w", DataType::LONG),
+            StructField::nullable("x", DataType::STRING),
+        ]);
+        let arrow = ArrowDataType::Struct(Fields::from(vec![
+            ArrowField::new("w", ArrowDataType::Int64, true),
+            ArrowField::new("extra", ArrowDataType::Int64, true),
+            ArrowField::new("x", ArrowDataType::Utf8, true),
+        ]));
+        assert_eq!(
+            ensure_data_types(&kernel, &arrow, ValidationMode::Full).unwrap(),
+            DataTypeCompat::Nested
+        );
+    }
+
+    #[test]
+    fn name_based_matching_rejects_wrong_type_behind_interleaved_extra() {
+        // An unselected `extra` field must not mask a type mismatch on the real `x` field.
+        let kernel = DataType::struct_type_unchecked([
+            StructField::nullable("w", DataType::LONG),
+            StructField::nullable("x", DataType::LONG),
+        ]);
+        let arrow = ArrowDataType::Struct(Fields::from(vec![
+            ArrowField::new("w", ArrowDataType::Int64, true),
+            ArrowField::new("extra", ArrowDataType::Int64, true),
+            ArrowField::new("x", ArrowDataType::Utf8, true),
+        ]));
+        assert_result_error_with_message(
+            ensure_data_types(&kernel, &arrow, ValidationMode::Full),
+            "Incorrect datatype",
         );
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In name-based struct validation (`TypesAndNames` and `Full` modes), `ensure_data_types` filtered the arrow fields down to those with a kernel counterpart and then zipped that filtered sequence back against the full, unfiltered arrow field list. When an unmatched arrow field appears before a matched one, the pairing drifts and a kernel field is compared against the wrong arrow field, producing either a spurious type error on valid data or a missed type error on invalid data.

This pairs each arrow field with its own kernel field by name, so the comparison is always between a field and its actual counterpart. Unmatched arrow fields are skipped, matching the documented "un-selected fields are ignored" behavior.

## How was this change tested?

Two regression tests where an unselected field is interleaved between matched fields: one asserts valid data is accepted (previously rejected) and one asserts a wrong type on the real field is still rejected (previously accepted).
