### PR TITLE
feat!: added delete functionality to StorageHandler

### DIFF
--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -168,6 +168,15 @@ async fn put_impl(
     Ok(())
 }
 
+/// Native async implementation for delete.
+async fn delete_impl(store: Arc<DynObjectStore>, path: Path) -> DeltaResult<()> {
+    match store.delete(&path).await {
+        Ok(()) => Ok(()),
+        Err(object_store::Error::NotFound { .. }) => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
 /// Native async implementation for head
 async fn head_impl(store: Arc<DynObjectStore>, url: Url) -> DeltaResult<FileMeta> {
     let meta = store.head(&Path::from_url_path(url.path())?).await?;
@@ -219,6 +228,12 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
     fn head(&self, path: &Url) -> DeltaResult<FileMeta> {
         let future = head_impl(self.inner.clone(), path.clone());
         self.task_executor.block_on(future)
+    }
+
+    fn delete(&self, path: &Url) -> DeltaResult<()> {
+        let path = Path::from_url_path(path.path())?;
+        self.task_executor
+            .block_on(delete_impl(self.inner.clone(), path))
     }
 }
 
@@ -513,5 +528,33 @@ mod tests {
             .collect();
         assert_eq!(read_back.len(), 1);
         assert_eq!(read_back[0], new_data);
+    }
+
+    #[test]
+    fn test_delete() {
+        let (tmp, _store, handler) = setup_test();
+
+        let data = Bytes::from("delete-test-data");
+        let file_url = Url::from_file_path(tmp.path().join("delete.txt")).unwrap();
+        handler.put(&file_url, data, false).unwrap();
+
+        handler.delete(&file_url).unwrap();
+
+        assert!(matches!(
+            handler.head(&file_url),
+            Err(Error::FileNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_delete_nonexistent_is_ok() {
+        let (tmp, _store, handler) = setup_test();
+
+        let missing_url = Url::from_file_path(tmp.path().join("missing.txt")).unwrap();
+        assert!(matches!(
+            handler.head(&missing_url),
+            Err(Error::FileNotFound(_))
+        ));
+        handler.delete(&missing_url).unwrap();
     }
 }

--- a/kernel/src/engine/plans/storage.rs
+++ b/kernel/src/engine/plans/storage.rs
@@ -59,6 +59,11 @@ impl StorageHandler for PlanBasedStorageHandler {
             .exactly_one()
             .map_err(|e| Error::generic(format!("Expected exactly one file meta: {e}")))?
     }
+
+    fn delete(&self, _path: &Url) -> DeltaResult<()> {
+        // TODO(#2820): implement here once supported as IoOperation.
+        unimplemented!("PlanBasedStorageHandler does not yet implement delete")
+    }
 }
 
 #[cfg(test)]

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -99,6 +99,15 @@ impl StorageHandler for SyncStorageHandler {
             size: meta.size,
         })
     }
+
+    fn delete(&self, url: &Url) -> DeltaResult<()> {
+        let (store, _, path) = resolve_scope(self.store.as_ref(), url)?;
+        match futures::executor::block_on(store.delete(&path)) {
+            Ok(()) => Ok(()),
+            Err(crate::object_store::Error::NotFound { .. }) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -313,5 +322,35 @@ mod tests {
             store.get(&path).await.unwrap().bytes().await.unwrap()
         });
         assert_eq!(bytes.as_ref(), b"third");
+    }
+
+    #[tokio::test]
+    async fn delete_store_removes_file() {
+        let store = std::sync::Arc::new(InMemory::new());
+        let storage = SyncStorageHandler::new(Some(store));
+        let url = Url::parse("memory:///file.json").unwrap();
+
+        storage
+            .put(&url, bytes::Bytes::from("hello"), false)
+            .unwrap();
+        storage.delete(&url).unwrap();
+
+        assert!(matches!(
+            storage.head(&url).unwrap_err(),
+            Error::FileNotFound(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_missing_is_ok() {
+        let store = std::sync::Arc::new(InMemory::new());
+        let storage = SyncStorageHandler::new(Some(store));
+        let url = Url::parse("memory:///missing.json").unwrap();
+
+        assert!(matches!(
+            storage.head(&url).unwrap_err(),
+            Error::FileNotFound(_)
+        ));
+        storage.delete(&url).unwrap();
     }
 }

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -324,6 +324,7 @@ mod tests {
         assert_eq!(bytes.as_ref(), b"third");
     }
 
+    // TODO(#2872): add a double-delete test to exercise idempotency on the in-memory store.
     #[tokio::test]
     async fn delete_store_removes_file() {
         let store = std::sync::Arc::new(InMemory::new());

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -630,7 +630,8 @@ pub trait StorageHandler: AsAny {
 
     /// Delete the file at the given path.
     ///
-    /// This operation is idempotent: deleting a path that does not exist returns `Ok(())`.
+    /// This operation is idempotent: deleting a path that does not exist should return `Ok(())`.
+    /// For any other error, this must propagate the corresponding error.
     fn delete(&self, path: &Url) -> DeltaResult<()>;
 }
 
@@ -890,7 +891,7 @@ pub trait ParquetHandler: AsAny {
     ///
     /// **Non-compliance produces files with incorrect `field_id`s**, which may lead to
     /// read failures when column mapping mode is `id` and to failures when converting
-    /// the table to Iceberg.   
+    /// the table to Iceberg.
     ///
     /// # Parameters
     ///

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -627,6 +627,11 @@ pub trait StorageHandler: AsAny {
     ///
     /// If the file does not exist, this must return an `Err` with [`Error::FileNotFound`].
     fn head(&self, path: &Url) -> DeltaResult<FileMeta>;
+
+    /// Delete the file at the given path.
+    ///
+    /// This operation is idempotent: deleting a path that does not exist returns `Ok(())`.
+    fn delete(&self, path: &Url) -> DeltaResult<()>;
 }
 
 /// Provides JSON handling functionality to Delta Kernel.

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -191,6 +191,10 @@ impl StorageHandler for CountingStorageHandler {
     fn head(&self, _path: &Url) -> DeltaResult<crate::FileMeta> {
         panic!("head should not be called during listing");
     }
+
+    fn delete(&self, _path: &Url) -> DeltaResult<()> {
+        panic!("delete should not be called during listing");
+    }
 }
 
 /// Helper to call `LogSegmentFiles::list()` and destructure the result for assertions.
@@ -371,6 +375,9 @@ fn test_log_tail_covers_entire_range_empty_filesystem() {
         }
         fn head(&self, _path: &Url) -> DeltaResult<crate::FileMeta> {
             panic!("head should not be called during listing");
+        }
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            panic!("delete should not be called during listing");
         }
     }
 

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -126,6 +126,9 @@ mod tests {
         fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
             unreachable!("not exercised")
         }
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            Ok(())
+        }
     }
 
     /// Engine that delegates everything to a [`SyncEngine`] except `storage_handler`, which

--- a/kernel/src/metrics/metered_storage.rs
+++ b/kernel/src/metrics/metered_storage.rs
@@ -15,8 +15,8 @@ use crate::metrics::{emit_storage_span, MetricsIterator};
 use crate::{DeltaResult, FileMeta, FileSlice, StorageHandler};
 
 /// Decorator over an engine-provided `Arc<dyn StorageHandler>` that emits the kernel's
-/// standard `"storage"` spans on operations that produce metrics. `put` and `head` are
-/// pass-through and emit nothing.
+/// standard `"storage"` spans on operations that produce metrics. `put`, `head`, and `delete`
+/// are pass-through and emit nothing.
 pub struct MeteredStorageHandler {
     inner: Arc<dyn StorageHandler>,
 }
@@ -82,6 +82,10 @@ impl StorageHandler for MeteredStorageHandler {
     fn head(&self, path: &Url) -> DeltaResult<FileMeta> {
         self.inner.head(path)
     }
+
+    fn delete(&self, path: &Url) -> DeltaResult<()> {
+        self.inner.delete(path)
+    }
 }
 
 #[cfg(test)]
@@ -126,6 +130,10 @@ mod tests {
 
         fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
             unreachable!("not exercised in these tests")
+        }
+
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            Ok(())
         }
     }
 

--- a/kernel/src/plans/ir/operation.rs
+++ b/kernel/src/plans/ir/operation.rs
@@ -71,6 +71,9 @@ pub enum IoOperation {
     /// [`PlanResult::ParquetFooter`]: crate::plans::PlanResult::ParquetFooter
     /// [`ParquetHandler::read_parquet_footer`]: crate::ParquetHandler::read_parquet_footer
     ParquetFooter { file: FileMeta },
+    // TODO(#2820): add a `Delete { url: Url }` variant (plus an `IoOperation::delete`
+    // constructor) so `PlanBasedStorageHandler::delete` can route through the plan path
+    // instead of `unimplemented!()`.
 }
 
 impl IoOperation {


### PR DESCRIPTION
## What changes are proposed in this pull request?
This is the first step towards adding functionality to support stale staged commit metadata. Essentially, in the future, there is a need to clean up any conflicted staged commits that the catalog no longer uses. Thus, this requires the `StorageHandler` to expose functionality to allow deletion of specific files, which this PR accomplishes.

1. Adds `delete` to the `StorageHandler` trait. Note: `delete` is idempotent, which means deletes to non-existing files are a no-op.
2. Defines `delete` for any necessary `StorageHandler` implementations (both default + testing impls).
3. Tests relevant functionality for main implementations: `FileStorageHandler` and `SyncStorageHandler`

Consideration
* There is ongoing work within logical plans, which involves `IoOperation`. Furthermore, `PlanBasedStorageHandler` also depends on this, so it is left as unimplemented. This is recorded with an issue (#2820) to implement this in the future.

## How was this change tested?
Ran the following commands:
*  `FileStorageHandler`: `cargo nextest run -p delta_kernel_default_engine --all-features test_delete`
* `SyncStorageHandler`: `cargo nextest run -p delta_kernel --lib --all-features engine::sync::storage::tests::delete`