### PR TITLE
feat!: create Unity Catalog managed tables via the Delta Tables API

### DIFF
--- a/.github/workflows/unitycatalog_test.yml
+++ b/.github/workflows/unitycatalog_test.yml
@@ -91,7 +91,10 @@ jobs:
           UC_TEST_CATALOG: unity
           UC_TEST_SCHEMA: default
           UC_TEST_TABLE: smoke_test_table
-        run: cargo nextest run --locked -p unity-catalog-delta-client-default -p delta-kernel-unity-catalog --features integration-test -E 'test(live_)'
+        # Live tests are `#[ignore]` so a normal `cargo nextest` reports them as skipped rather than
+        # passing. `--run-ignored only -E 'test(live_)'` runs exactly the ignored live tests here,
+        # where a UC server is available.
+        run: cargo nextest run --locked -p unity-catalog-delta-client-default -p delta-kernel-unity-catalog --features integration-test --run-ignored only -E 'test(live_)'
 
       - name: Stop Unity Catalog server
         if: always()

--- a/.github/workflows/unitycatalog_test.yml
+++ b/.github/workflows/unitycatalog_test.yml
@@ -1,13 +1,15 @@
 name: unity-catalog-test
 
-# Runs the gated `unity-catalog-delta-client-default` live integration tests against a real Unity
-# Catalog server (built from a pinned commit). Exercises the read-only `get_config` handshake
-# (needs no table) and `load_table` against a table seeded via the Delta-Commits (legacy) API
-# before the test step, plus the mutating create tests (UC_CREATE) against the ephemeral server.
+# Runs the gated `unity-catalog-delta-client-default` and `delta-kernel-unity-catalog` live
+# integration tests against a real Unity Catalog server (built from a pinned commit). Exercises the
+# read-only `get_config` handshake (needs no table), `load_table` against a table seeded via the
+# Delta-Commits (legacy) API before the test step, and the mutating create tests (UC_CREATE) against
+# the ephemeral server.
 on:
   push:
     branches: [main, "release/**"]
     paths:
+      - "delta-kernel-unity-catalog/**"
       - "unity-catalog-delta-client-api/**"
       - "unity-catalog-delta-client-default/**"
       - ".github/workflows/unitycatalog_test.yml"
@@ -16,6 +18,7 @@ on:
       - ".github/scripts/seed_uc_table.sh"
   pull_request:
     paths:
+      - "delta-kernel-unity-catalog/**"
       - "unity-catalog-delta-client-api/**"
       - "unity-catalog-delta-client-default/**"
       - ".github/workflows/unitycatalog_test.yml"
@@ -89,7 +92,7 @@ jobs:
           UC_TEST_SCHEMA: default
           UC_TEST_TABLE: smoke_test_table
           UC_CREATE: "1"
-        run: cargo nextest run --locked -p unity-catalog-delta-client-default --features integration-test -E 'test(live_)'
+        run: cargo nextest run --locked -p unity-catalog-delta-client-default -p delta-kernel-unity-catalog --features integration-test -E 'test(live_)'
 
       - name: Stop Unity Catalog server
         if: always()

--- a/.github/workflows/unitycatalog_test.yml
+++ b/.github/workflows/unitycatalog_test.yml
@@ -3,8 +3,8 @@ name: unity-catalog-test
 # Runs the gated `unity-catalog-delta-client-default` and `delta-kernel-unity-catalog` live
 # integration tests against a real Unity Catalog server (built from a pinned commit). Exercises the
 # read-only `get_config` handshake (needs no table), `load_table` against a table seeded via the
-# Delta-Commits (legacy) API before the test step, and the mutating create tests (UC_CREATE) against
-# the ephemeral server.
+# Delta-Commits (legacy) API before the test step, and the mutating create tests against the
+# throwaway server.
 on:
   push:
     branches: [main, "release/**"]
@@ -91,7 +91,6 @@ jobs:
           UC_TEST_CATALOG: unity
           UC_TEST_SCHEMA: default
           UC_TEST_TABLE: smoke_test_table
-          UC_CREATE: "1"
         run: cargo nextest run --locked -p unity-catalog-delta-client-default -p delta-kernel-unity-catalog --features integration-test -E 'test(live_)'
 
       - name: Stop Unity Catalog server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -857,7 +857,7 @@
 2. Add create many API to engine ([#2070])
    - Adds `create_many` method to `ParquetHandler` trait. Implementors must add this method. See the trait rustdocs for details.
 3. Rename uc-catalog and uc-client crates ([#2136])
-   - `delta-kernel-uc-catalog` renamed to `delta-kernel-unity-catalog`. `delta-kernel-uc-client` renamed to `unity-catalog-delta-client-default`. Update `Cargo.toml` dependencies accordingly.
+   - `delta-kernel-uc-catalog` renamed to `delta-kernel-unity-catalog`. `delta-kernel-uc-client` renamed to `unity-catalog-delta-rest-client`. Update `Cargo.toml` dependencies accordingly.
 4. Checksum and checkpoint APIs return updated Snapshot ([#2182])
    - `Snapshot::checkpoint()` and checksum APIs now return the updated `Snapshot`. Callers must handle the returned value.
 5. Add P&M to CommitMetadata and enforce committer/table type matching ([#2250])

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,19 +48,19 @@ cargo +nightly fmt \
 
 ### Crate Names for `-p` Flag
 
-| Crate                             | Directory                          | Description                                               |
-|-----------------------------------|------------------------------------|-----------------------------------------------------------|
-| `delta_kernel`                    | `kernel/`                          | Core library                                              |
-| `delta_kernel_default_engine`     | `default-engine/`                  | Default Arrow/Tokio `Engine` implementation               |
-| `delta_kernel_ffi`                | `ffi/`                             | C/C++ FFI bindings                                        |
-| `delta_kernel_derive`             | `derive-macros/`                   | Proc macros                                               |
-| `acceptance`                      | `acceptance/`                      | Acceptance tests (DAT)                                    |
-| `test_utils`                      | `test-utils/`                      | Shared test utilities                                     |
-| `delta_kernel_workloads`          | `workloads/`                       | Shared workload spec types + SQL predicate parser         |
-| `feature_tests`                   | `feature-tests/`                   | Feature flag tests                                        |
-| `delta-kernel-unity-catalog`      | `delta-kernel-unity-catalog/`      | Unity Catalog integration (UCCommitter, snapshot helpers) |
-| `unity-catalog-delta-client-api`  | `unity-catalog-delta-client-api/`  | Unity Catalog client traits and shared models             |
-| `unity-catalog-delta-client-default` | `unity-catalog-delta-client-default/` | Unity Catalog REST client                                 |
+| Crate                                | Directory                             | Description                                                              |
+|--------------------------------------|---------------------------------------|--------------------------------------------------------------------------|
+| `delta_kernel`                       | `kernel/`                             | Core library                                                             |
+| `delta_kernel_default_engine`        | `default-engine/`                     | Default Arrow/Tokio `Engine` implementation                              |
+| `delta_kernel_ffi`                   | `ffi/`                                | C/C++ FFI bindings                                                       |
+| `delta_kernel_derive`                | `derive-macros/`                      | Proc macros                                                              |
+| `acceptance`                         | `acceptance/`                         | Acceptance tests (DAT)                                                   |
+| `test_utils`                         | `test-utils/`                         | Shared test utilities                                                    |
+| `delta_kernel_workloads`             | `workloads/`                          | Shared workload spec types + SQL predicate parser                        |
+| `feature_tests`                      | `feature-tests/`                      | Feature flag tests                                                       |
+| `delta-kernel-unity-catalog`         | `delta-kernel-unity-catalog/`         | Unity Catalog integration (UCCommitter, snapshot + create-table helpers) |
+| `unity-catalog-delta-client-api`     | `unity-catalog-delta-client-api/`     | Unity Catalog client traits and shared models                            |
+| `unity-catalog-delta-client-default` | `unity-catalog-delta-client-default/` | Unity Catalog REST client                                                |
 
 ### Feature Flags
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ cargo +nightly fmt \
 | `feature_tests`                      | `feature-tests/`                      | Feature flag tests                                                       |
 | `delta-kernel-unity-catalog`         | `delta-kernel-unity-catalog/`         | Unity Catalog integration (UCCommitter, snapshot + create-table helpers) |
 | `unity-catalog-delta-client-api`     | `unity-catalog-delta-client-api/`     | Unity Catalog client traits and shared models                            |
-| `unity-catalog-delta-client-default` | `unity-catalog-delta-client-default/` | Unity Catalog REST client                                                |
+| `unity-catalog-delta-client-default` | `unity-catalog-delta-client-default/` | Default Unity Catalog REST/HTTP client implementation                    |
 
 ### Feature Flags
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,9 +333,10 @@ Keep this list updated when new protocol features are added to kernel.
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 - Order a file so the most important APIs and impls come first; put private helper functions
-  toward the bottom. A reader scanning top to bottom should hit the public surface before the
-  private plumbing. (Order-sensitive items like `macro_rules!` used within the file are exempt --
-  they must precede their use.)
+  toward the bottom. Within that, order by visibility: `pub` first, then `pub(crate)`, then
+  private. A reader scanning top to bottom should hit the public surface before the private
+  plumbing. (Order-sensitive items like `macro_rules!` used within the file are exempt -- they
+  must precede their use.)
 
 ## Comment & Doc Style
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ version = "0.26.0"
 dependencies = [
  "delta_kernel",
  "delta_kernel_default_engine",
+ "reqwest 0.13.2",
  "rstest",
  "serde_json",
  "tempfile",
@@ -1319,6 +1320,7 @@ dependencies = [
  "unity-catalog-delta-client-api",
  "unity-catalog-delta-client-default",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/delta-kernel-unity-catalog/Cargo.toml
+++ b/delta-kernel-unity-catalog/Cargo.toml
@@ -18,6 +18,9 @@ default = ["arrow"]
 arrow = ["arrow-59"]
 arrow-59 = ["delta_kernel/arrow-59"]
 arrow-58 = ["delta_kernel/arrow-58"]
+# Live-server E2E tests. Gated so normal `cargo nextest` never compiles or runs them.
+# Tests additionally skip at runtime when UC_SERVER_URL is unset.
+integration-test = []
 
 [dependencies]
 delta_kernel = { path = "../kernel", features = ["internal-api"] }
@@ -33,5 +36,9 @@ delta_kernel_default_engine = { path = "../default-engine", features = ["rustls"
 unity-catalog-delta-client-default = { path = "../unity-catalog-delta-client-default", features = ["test-utils"] }
 unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
 test_utils = { path = "../test-utils" }
-tempfile = "3"
 rstest = "0.23"
+tempfile = "3"
+uuid = { version = "1", features = ["v4"] }
+# Only used by the gated live-server CREATE test, which hand-rolls the staging-tables/tables POSTs.
+# Mirrors the rest-client's reqwest config.
+reqwest = { version = "0.13", default-features = false, features = ["charset", "http2", "json", "rustls", "system-proxy"] }

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -255,9 +255,10 @@ impl<C: UpdateTableClient> UCCommitter<C> {
 impl<C: UpdateTableClient + 'static> Committer for UCCommitter<C> {
     /// Commit the given `actions` to the delta table in UC.
     ///
-    /// For version 0, the caller finalizes the table in UC separately. For version >= 1, connectors
-    /// should publish staged commits to the delta log immediately after writing; UC expects to be
-    /// informed of the last known published version during commit.
+    /// For version 0 (table creation), the committer writes `000.json` directly to the published
+    /// commit path; the caller finalizes the table in UC via the create-table API. For version >=
+    /// 1, connectors should publish staged commits to the delta log immediately after writing;
+    /// UC expects to be informed of the last known published version during commit.
     fn commit(
         &self,
         engine: &dyn Engine,

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -5,7 +5,7 @@ use delta_kernel::committer::{
     CommitMetadata, CommitResponse, CommitType, Committer, PublishMetadata,
 };
 use delta_kernel::{
-    DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FilteredEngineData,
+    DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FileMeta, FilteredEngineData,
 };
 use tracing::{debug, info};
 use unity_catalog_delta_client_api::{
@@ -31,7 +31,7 @@ macro_rules! require {
 /// A [UCCommitter] is a Unity Catalog [`Committer`] implementation for committing to a specific
 /// delta table in UC.
 ///
-/// Version 0 (table creation) is not yet supported and returns an error (#2826).
+/// Version 0 (table creation) writes the published commit directly to the delta log.
 ///
 /// For version >= 1, the committer writes a staged commit and calls the UC `update_table` API
 /// to ratify it.
@@ -132,8 +132,6 @@ impl<C: UpdateTableClient> UCCommitter<C> {
 
     /// Commit version 0 (table creation). Validates that all required UC properties are present,
     /// then writes the version 0 commit file directly to the published commit path.
-    // TODO(#2826): wire into `commit` dispatch once CREATE is exposed by this committer.
-    #[allow(dead_code)]
     fn commit_version_0(
         &self,
         engine: &dyn Engine,
@@ -154,7 +152,11 @@ impl<C: UpdateTableClient> UCCommitter<C> {
         ) {
             Ok(()) => {
                 info!("wrote version 0 commit file for UC table creation");
-                let file_meta = engine.storage_handler().head(&published_commit_path)?;
+                let file_meta = FileMeta::new(
+                    published_commit_path,
+                    commit_metadata.in_commit_timestamp(),
+                    0,
+                );
                 Ok(CommitResponse::Committed { file_meta })
             }
             Err(DeltaError::FileAlreadyExists(_)) => {
@@ -216,6 +218,10 @@ impl<C: UpdateTableClient> UCCommitter<C> {
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             DeltaError::generic("UCCommitter may only be used within a tokio runtime")
         })?;
+        // `block_in_place` panics if the current runtime isn't multi-threaded. We can't check for
+        // that up front: `runtime_flavor()` can't tell a real single-threaded runtime (where this
+        // panics) apart from the FFI case (single-threaded on top of multi-threaded, where it's
+        // fine). So we let it run and catch the panic.
         let result = catch_unwind(AssertUnwindSafe(|| {
             tokio::task::block_in_place(|| {
                 handle.block_on(async move {
@@ -249,22 +255,17 @@ impl<C: UpdateTableClient> UCCommitter<C> {
 impl<C: UpdateTableClient + 'static> Committer for UCCommitter<C> {
     /// Commit the given `actions` to the delta table in UC.
     ///
-    /// Version 0 (table creation) is not yet supported and returns an error (#2826).
-    ///
-    /// For version >= 1, writes a staged commit then calls the UC update_table API to ratify it.
-    /// Connectors should publish staged commits to the delta log immediately after writing.
-    /// UC expects to be informed of the last known published version during commit.
+    /// For version 0, the caller finalizes the table in UC separately. For version >= 1, connectors
+    /// should publish staged commits to the delta log immediately after writing; UC expects to be
+    /// informed of the last known published version during commit.
     fn commit(
         &self,
         engine: &dyn Engine,
         actions: DeltaResultIterator<'_, FilteredEngineData>,
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
-        // TODO(#2826): dispatch v0 to `commit_version_0` once CREATE is wired end-to-end.
         if commit_metadata.version() == 0 {
-            return Err(DeltaError::unsupported(
-                "CREATE (version 0) is not yet supported by UCCommitter",
-            ));
+            return self.commit_version_0(engine, actions, &commit_metadata);
         }
         self.commit_version_non_zero(engine, actions, commit_metadata)
     }
@@ -357,26 +358,7 @@ mod tests {
         .unwrap()
     }
 
-    // TODO(#2826): remove once CREATE is wired; the ignored v0 tests below take over.
     #[test]
-    fn commit_rejects_version_0() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
-        let commit_metadata = catalog_managed_commit_metadata(table_root, 0);
-        let engine = DefaultEngine::builder(Arc::new(LocalFileSystem::new())).build();
-
-        let err = test_committer()
-            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("version 0"),
-            "expected a version-0-unsupported error, got: {err}"
-        );
-    }
-
-    // TODO(#2826): un-ignore once CREATE is wired into `commit` dispatch.
-    #[test]
-    #[ignore = "v0 CREATE not yet wired into commit dispatch"]
     fn commit_version_0_writes_published_commit() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
@@ -400,6 +382,7 @@ mod tests {
                     "expected published path for version 0, got: {}",
                     file_meta.location
                 );
+                assert_eq!(file_meta.size, 0);
                 // Verify the file was written to disk
                 let commit_path = tmp_dir.path().join("_delta_log/00000000000000000000.json");
                 assert!(commit_path.exists(), "000.json should exist on disk");
@@ -411,7 +394,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "v0 CREATE not yet wired into commit dispatch"]
     fn commit_version_0_conflict_when_file_exists() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
@@ -434,7 +416,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "v0 CREATE not yet wired into commit dispatch"]
     fn commit_version_0_rejects_missing_catalog_managed_feature() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
@@ -453,7 +434,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "v0 CREATE not yet wired into commit dispatch"]
     fn commit_version_0_rejects_missing_table_id() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
@@ -483,7 +463,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "v0 CREATE not yet wired into commit dispatch"]
     fn commit_version_0_rejects_missing_ict_enablement() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();

--- a/delta-kernel-unity-catalog/src/constants.rs
+++ b/delta-kernel-unity-catalog/src/constants.rs
@@ -10,10 +10,6 @@ pub(crate) const FEATURE_SUPPORTED: &str = "supported";
 pub(crate) const CATALOG_MANAGED_FEATURE_KEY: &str = "delta.feature.catalogManaged";
 /// Feature signal key for vacuum protocol check.
 pub(crate) const VACUUM_PROTOCOL_CHECK_FEATURE_KEY: &str = "delta.feature.vacuumProtocolCheck";
-/// UC property for the last committed version.
-pub(crate) const METASTORE_LAST_UPDATE_VERSION: &str = "delta.lastUpdateVersion";
-/// UC property for the last commit timestamp.
-pub(crate) const METASTORE_LAST_COMMIT_TIMESTAMP: &str = "delta.lastCommitTimestamp";
 /// Feature name for catalog-managed tables (wire format).
 pub(crate) const CATALOG_MANAGED_FEATURE: &str = "catalogManaged";
 /// Feature name for vacuum protocol check (wire format).
@@ -22,3 +18,5 @@ pub(crate) const VACUUM_PROTOCOL_CHECK_FEATURE: &str = "vacuumProtocolCheck";
 pub(crate) const IN_COMMIT_TIMESTAMP_FEATURE: &str = "inCommitTimestamp";
 /// Domain name for clustering metadata.
 pub(crate) const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
+/// Domain name for row-tracking metadata.
+pub(crate) const ROW_TRACKING_DOMAIN_NAME: &str = "delta.rowTracking";

--- a/delta-kernel-unity-catalog/src/constants.rs
+++ b/delta-kernel-unity-catalog/src/constants.rs
@@ -10,6 +10,22 @@ pub(crate) const FEATURE_SUPPORTED: &str = "supported";
 pub(crate) const CATALOG_MANAGED_FEATURE_KEY: &str = "delta.feature.catalogManaged";
 /// Feature signal key for vacuum protocol check.
 pub(crate) const VACUUM_PROTOCOL_CHECK_FEATURE_KEY: &str = "delta.feature.vacuumProtocolCheck";
+/// Feature signal key for v2 checkpoints.
+pub(crate) const V2_CHECKPOINT_FEATURE_KEY: &str = "delta.feature.v2Checkpoint";
+/// Feature signal key for deletion vectors.
+pub(crate) const DELETION_VECTORS_FEATURE_KEY: &str = "delta.feature.deletionVectors";
+/// Config property enabling deletion vectors.
+pub(crate) const ENABLE_DELETION_VECTORS_KEY: &str = "delta.enableDeletionVectors";
+/// Config property selecting the checkpoint policy.
+pub(crate) const CHECKPOINT_POLICY_KEY: &str = "delta.checkpointPolicy";
+/// Config property value selecting the v2 checkpoint policy.
+pub(crate) const CHECKPOINT_POLICY_V2: &str = "v2";
+/// Config property writing checkpoint stats as a struct.
+pub(crate) const CHECKPOINT_WRITE_STATS_AS_STRUCT_KEY: &str = "delta.checkpoint.writeStatsAsStruct";
+/// Config property writing checkpoint stats as JSON.
+pub(crate) const CHECKPOINT_WRITE_STATS_AS_JSON_KEY: &str = "delta.checkpoint.writeStatsAsJson";
+/// Boolean-true config property value.
+pub(crate) const CONFIG_TRUE: &str = "true";
 /// Feature name for catalog-managed tables (wire format).
 pub(crate) const CATALOG_MANAGED_FEATURE: &str = "catalogManaged";
 /// Feature name for vacuum protocol check (wire format).

--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -10,7 +10,7 @@ use delta_kernel::snapshot::SnapshotBuilder;
 use delta_kernel::{DeltaResult, Error, LogPath, Snapshot};
 use unity_catalog_delta_client_api::{Commit, LoadTableResponse};
 use url::Url;
-pub use utils::{get_final_required_properties_for_uc, get_required_properties_for_disk};
+pub use utils::{build_uc_create_table_request, get_required_properties_for_disk};
 
 /// Convert the inline `Commit`s returned by a UC `load_table` response into
 /// kernel `LogPath`s suitable for `Snapshot::builder_for(...).with_log_tail(...)`.

--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -10,7 +10,9 @@ use delta_kernel::snapshot::SnapshotBuilder;
 use delta_kernel::{DeltaResult, Error, LogPath, Snapshot};
 use unity_catalog_delta_client_api::{Commit, LoadTableResponse};
 use url::Url;
-pub use utils::{build_uc_create_table_request, get_required_properties_for_disk};
+pub use utils::{
+    aws_object_store_options, build_uc_create_table_request, get_required_properties_for_disk,
+};
 
 /// Convert the inline `Commit`s returned by a UC `load_table` response into
 /// kernel `LogPath`s suitable for `Snapshot::builder_for(...).with_log_tail(...)`.

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -7,29 +7,51 @@
 //!
 //! ```ignore
 //! // Step 1: Get staging info from UC
-//! let staging_info = my_uc_client.get_staging_table(..);
+//! let staging_info: CreateStagingTableResponse = my_uc_client.post_staging_table(..).await?;
 //!
-//! // Step 2: Build and commit the create-table transaction
-//! let disk_props = get_required_properties_for_disk(staging_info.table_id);
+//! // Step 2: Build and commit the create-table transaction.
+//! let disk_props = get_required_properties_for_disk(&staging_info.table_id);
 //! let create_table_txn = kernel::create_table(path, schema, "MyApp/1.0")
 //!     .with_table_properties(disk_props)
 //!     .build(engine, committer);
-//! let result = create_table_txn.commit(engine);
+//! create_table_txn.commit(engine)?;
 //!
 //! // Step 3: Finalize table in UC
 //! let snapshot = /* load post-commit snapshot at version 0 */;
-//! let uc_props = get_final_required_properties_for_uc(&snapshot, engine)?;
-//! my_uc_client.create_table(.., uc_props);
+//! let create_req = build_uc_create_table_request(&snapshot, engine, table_name)?;
+//! my_uc_client.post_create_table(create_req).await?;
 //! ```
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use delta_kernel::actions::Protocol;
 use delta_kernel::{Engine, Snapshot};
+use unity_catalog_delta_client_api::{CreateTableRequest, Protocol as WireProtocol};
 
 use crate::constants::{
-    CATALOG_MANAGED_FEATURE_KEY, FEATURE_SUPPORTED, METASTORE_LAST_COMMIT_TIMESTAMP,
-    METASTORE_LAST_UPDATE_VERSION, UC_TABLE_ID_KEY, VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
+    CATALOG_MANAGED_FEATURE_KEY, CLUSTERING_DOMAIN_NAME, FEATURE_SUPPORTED,
+    ROW_TRACKING_DOMAIN_NAME, UC_TABLE_ID_KEY, VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
 };
+
+/// Convert a kernel `Protocol` into the api crate's wire `Protocol`.
+fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
+    WireProtocol {
+        min_reader_version: protocol.min_reader_version(),
+        min_writer_version: protocol.min_writer_version(),
+        reader_features: protocol
+            .reader_features()
+            .into_iter()
+            .flatten()
+            .map(|f| f.as_ref().to_string())
+            .collect(),
+        writer_features: protocol
+            .writer_features()
+            .into_iter()
+            .flatten()
+            .map(|f| f.as_ref().to_string())
+            .collect(),
+    }
+}
 
 /// Returns the table properties that must be written to disk (in `000.json`) for a UC
 /// catalog-managed table creation.
@@ -48,86 +70,110 @@ pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, St
     .collect()
 }
 
-/// Extracts the properties that must be sent to the UC server when finalizing a table creation.
+/// Build the typed `CreateTableRequest` body the connector sends to the UC `tables` endpoint after
+/// the v0 commit succeeds, driving off the post-commit v0 snapshot.
 ///
-/// These properties are derived from the post-commit snapshot (after `000.json` has
-/// been written). The connector should pass these to the UC `create_table` API.
+/// User properties set via `create_table`'s `with_table_properties` flow through automatically
+/// (they land in `metaData.configuration`). To add or override properties afterward, mutate
+/// `req.properties` on the returned request before sending.
 ///
-/// # Properties returned
+/// # Errors
 ///
-/// - All entries from `Metadata.configuration` (includes `io.unitycatalog.tableId`, user props)
-/// - `delta.minReaderVersion` and `delta.minWriterVersion`
-/// - `delta.feature.<name> = "supported"` for every reader and writer table feature
-/// - `delta.lastUpdateVersion` -- the snapshot version
-/// - `delta.lastCommitTimestamp` -- the snapshot's in-commit timestamp (requires ICT enabled)
-/// - `clusteringColumns` -- JSON-serialized clustering columns (if clustering is enabled)
-///
-/// # Clustering columns
-///
-/// Clustering columns are returned as logical column names. When column mapping is enabled,
-/// the physical names stored in domain metadata are converted to logical names using the
-/// table schema.
-pub fn get_final_required_properties_for_uc(
+/// Returns an error if `snapshot` is not at version 0, if the schema can't be serialized, or if the
+/// engine fails to read clustering metadata or the commit timestamp.
+pub fn build_uc_create_table_request(
     snapshot: &Snapshot,
     engine: &dyn Engine,
-) -> delta_kernel::DeltaResult<HashMap<String, String>> {
+    table_name: impl Into<String>,
+) -> delta_kernel::DeltaResult<CreateTableRequest> {
     if snapshot.version() != 0 {
         return Err(delta_kernel::Error::generic(format!(
-            "get_final_required_properties_for_uc is only valid for version 0 (table creation) \
+            "build_uc_create_table_request is only valid for version 0 (table creation) \
              snapshots, but snapshot is at version {}",
             snapshot.version()
         )));
     }
 
-    // Start with metadata configuration (user + delta properties)
-    let mut properties = snapshot.metadata_configuration().clone();
-
-    // Protocol-derived properties (versions + feature signals)
-    properties.extend(snapshot.get_protocol_derived_properties());
-
-    // UC-specific properties
-    properties.insert(
-        METASTORE_LAST_UPDATE_VERSION.to_string(),
-        snapshot.version().to_string(),
-    );
-    let timestamp = snapshot.get_in_commit_timestamp(engine)?.ok_or_else(|| {
-        delta_kernel::Error::generic(
-            "In-commit timestamp is required for UC catalog-managed tables but was not found",
-        )
+    let columns = serde_json::to_value(snapshot.schema().as_ref()).map_err(|e| {
+        delta_kernel::Error::generic(format!("Failed to serialize table schema: {e}"))
     })?;
-    properties.insert(
-        METASTORE_LAST_COMMIT_TIMESTAMP.to_string(),
-        timestamp.to_string(),
-    );
 
-    // Clustering columns as logical names (if present)
-    if let Some(columns) = snapshot.get_logical_clustering_columns(engine)? {
-        let column_arrays: Vec<Vec<&str>> = columns
-            .iter()
-            .map(|c| c.path().iter().map(|s| s.as_str()).collect())
-            .collect();
-        let json = serde_json::to_string(&column_arrays).map_err(|e| {
-            delta_kernel::Error::generic(format!("Failed to serialize clustering columns: {e}"))
+    let table_config = snapshot.table_configuration();
+    let metadata = table_config.metadata();
+    let protocol = table_config.protocol();
+
+    let partition_columns = metadata.partition_columns().to_vec();
+    let properties = metadata.configuration().clone();
+    let typed_protocol = to_wire_protocol(protocol);
+
+    // UC only recognizes the `delta.clustering` and `delta.rowTracking` domain metadatas.
+    let uc_recognized_domains = HashSet::from([CLUSTERING_DOMAIN_NAME, ROW_TRACKING_DOMAIN_NAME]);
+    let mut domain_metadata: HashMap<String, serde_json::Value> = HashMap::new();
+    for (domain, dm) in
+        snapshot.get_domain_metadatas_internal(engine, Some(&uc_recognized_domains))?
+    {
+        let value = serde_json::from_str(dm.configuration()).map_err(|e| {
+            delta_kernel::Error::generic(format!("malformed {domain} domain metadata: {e}"))
         })?;
-        properties.insert("clusteringColumns".to_string(), json);
+        domain_metadata.insert(domain, value);
     }
 
-    Ok(properties)
+    let in_commit_timestamp_ms = snapshot.get_timestamp(engine)?;
+
+    Ok(CreateTableRequest {
+        name: table_name.into(),
+        location: snapshot.table_root().to_string(),
+        table_type: "MANAGED".to_string(),
+        comment: None,
+        columns,
+        partition_columns,
+        protocol: typed_protocol,
+        properties,
+        domain_metadata,
+        last_commit_timestamp_ms: in_commit_timestamp_ms,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
+    use delta_kernel::expressions::ColumnName;
     use delta_kernel::object_store::memory::InMemory;
-    use delta_kernel::schema::schema_ref;
+    use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
     use delta_kernel::snapshot::Snapshot;
     use delta_kernel::transaction::create_table::create_table;
     use delta_kernel::transaction::data_layout::DataLayout;
     use delta_kernel_default_engine::DefaultEngineBuilder;
+    use rstest::rstest;
     use test_utils::TestCatalogCommitter;
 
     use super::*;
+
+    /// Create a table at version 0 (optionally clustered), then build the UC create request from
+    /// its post-commit snapshot. Shared setup for the version-0 request tests.
+    fn create_v0_and_build_request(
+        engine: &dyn Engine,
+        table_path: &str,
+        schema: SchemaRef,
+        disk_props: HashMap<String, String>,
+        data_layout: DataLayout,
+    ) -> CreateTableRequest {
+        create_table(table_path, schema, "Test/1.0")
+            .with_table_properties(disk_props)
+            .with_data_layout(data_layout)
+            .build(engine, Box::new(TestCatalogCommitter))
+            .unwrap()
+            .commit(engine)
+            .unwrap()
+            .unwrap_committed();
+        let snapshot = Snapshot::builder_for(table_path)
+            .with_max_catalog_version(0)
+            .build(engine)
+            .unwrap();
+        assert_eq!(snapshot.version(), 0);
+        build_uc_create_table_request(&snapshot, engine, "my_table").unwrap()
+    }
 
     #[test]
     fn test_get_required_properties_for_disk() {
@@ -139,64 +185,136 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_final_required_properties_for_uc() {
+    async fn test_build_uc_create_table_request() {
         let storage = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(storage).build();
-        let table_path = "memory:///test_table/";
-        let schema = schema_ref! {
-            nullable "id": INTEGER,
-            nullable "region": STRING,
-        };
+        let table_path = "memory:///test_create_req/";
+        let schema = Arc::new(
+            StructType::try_new(vec![
+                StructField::new("id", DataType::INTEGER, true),
+                StructField::new("region", DataType::STRING, true),
+            ])
+            .unwrap(),
+        );
 
-        // Create a UC catalog-managed table with clustering
         let disk_props = get_required_properties_for_disk("test-table-id-456");
-        let _ = create_table(table_path, schema, "Test/1.0")
+        let req = create_v0_and_build_request(
+            &engine,
+            table_path,
+            schema,
+            disk_props,
+            DataLayout::clustered(["region"]),
+        );
+
+        assert_eq!(req.protocol.min_reader_version, 3);
+        assert_eq!(req.protocol.min_writer_version, 7);
+        assert!(req
+            .protocol
+            .reader_features
+            .iter()
+            .any(|f| f == "catalogManaged"));
+        assert!(req
+            .protocol
+            .writer_features
+            .iter()
+            .any(|f| f == "inCommitTimestamp"));
+
+        assert_eq!(
+            req.properties["io.unitycatalog.tableId"],
+            "test-table-id-456"
+        );
+        assert!(!req.properties.contains_key("delta.feature.catalogManaged"));
+        assert!(!req.properties.contains_key("delta.minReaderVersion"));
+        assert!(!req.properties.contains_key("delta.lastUpdateVersion"));
+
+        // Clustering surfaces under domain_metadata in typed JSON form.
+        let clustering = req
+            .domain_metadata
+            .get("delta.clustering")
+            .expect("clustering domain metadata should be present");
+        let cols = clustering
+            .get("clusteringColumns")
+            .and_then(|v| v.as_array())
+            .expect("clusteringColumns should be a JSON array");
+        assert_eq!(cols.len(), 1);
+
+        assert_eq!(
+            req.columns.get("type").and_then(|v| v.as_str()),
+            Some("struct")
+        );
+        assert_eq!(req.name, "my_table");
+        assert!(req.location.contains("test_create_req"));
+
+        assert!(
+            req.last_commit_timestamp_ms > 0,
+            "expected positive in-commit timestamp, got {}",
+            req.last_commit_timestamp_ms
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_uc_create_table_request_forwards_row_tracking() {
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage).build();
+        let table_path = "memory:///test_row_tracking/";
+        let schema = schema_ref! { nullable "id": INTEGER };
+
+        let mut disk_props = get_required_properties_for_disk("test-table-id");
+        disk_props.insert("delta.enableRowTracking".to_string(), "true".to_string());
+        let req =
+            create_v0_and_build_request(&engine, table_path, schema, disk_props, DataLayout::None);
+
+        let hwm = req.domain_metadata[ROW_TRACKING_DOMAIN_NAME]["rowIdHighWaterMark"].as_i64();
+        assert_eq!(
+            hwm,
+            Some(-1),
+            "empty create should forward the initial watermark"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_uc_create_table_request_silently_drops_user_domain_metadata() {
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage).build();
+        let table_path = "memory:///test_user_domain/";
+        let schema = schema_ref! { nullable "id": INTEGER };
+
+        let mut disk_props = get_required_properties_for_disk("test-table-id");
+        disk_props.insert(
+            "delta.feature.domainMetadata".to_string(),
+            "supported".to_string(),
+        );
+        create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
-            .with_data_layout(DataLayout::clustered(["region"]))
             .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
+            .with_domain_metadata("myApp.retention".to_string(), r#"{"days":30}"#.to_string())
             .commit(&engine)
-            .unwrap();
+            .unwrap()
+            .unwrap_committed();
 
         let snapshot = Snapshot::builder_for(table_path)
             .with_max_catalog_version(0)
             .build(&engine)
             .unwrap();
-        assert_eq!(snapshot.version(), 0);
-        let uc_props = get_final_required_properties_for_uc(&snapshot, &engine).unwrap();
-
-        // Protocol-derived properties
-        assert_eq!(uc_props["delta.minReaderVersion"], "3");
-        assert_eq!(uc_props["delta.minWriterVersion"], "7");
-        assert_eq!(uc_props["delta.feature.catalogManaged"], "supported");
-        assert_eq!(uc_props["delta.feature.vacuumProtocolCheck"], "supported");
-        assert_eq!(uc_props["delta.feature.inCommitTimestamp"], "supported");
-        assert_eq!(uc_props["delta.feature.clustering"], "supported");
-
-        // Metadata configuration
-        assert_eq!(uc_props["io.unitycatalog.tableId"], "test-table-id-456");
-
-        // UC-specific properties
-        assert_eq!(uc_props["delta.lastUpdateVersion"], "0");
-        let timestamp: i64 = uc_props["delta.lastCommitTimestamp"]
-            .parse()
-            .expect("timestamp should be a valid i64");
+        let req = build_uc_create_table_request(&snapshot, &engine, "test_user_domain").unwrap();
         assert!(
-            timestamp > 0,
-            "ICT timestamp should be non-zero, got {timestamp}"
+            !req.domain_metadata.contains_key("myApp.retention"),
+            "user domain should be dropped, not forwarded"
         );
-
-        // Clustering columns: serialized as [[col1], [col2]] (array of path arrays)
-        let parsed: Vec<Vec<String>> =
-            serde_json::from_str(&uc_props["clusteringColumns"]).unwrap();
-        assert_eq!(parsed, vec![vec!["region"]]);
     }
 
+    // Clustering columns are forwarded verbatim from the committed `delta.clustering` domain. Under
+    // column mapping the committed paths are physical names, so the request must carry those, not
+    // the logical names.
+    #[rstest]
+    #[case::logical_names_without_column_mapping(false)]
+    #[case::physical_names_under_column_mapping(true)]
     #[tokio::test]
-    async fn test_clustering_columns_serialization_multiple_and_nested() {
+    async fn test_clustering_columns_forwarded(#[case] column_mapping: bool) {
         let storage = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(storage).build();
-        let table_path = "memory:///test_clustering_ser/";
+        let table_path = "memory:///test_clustering/";
         let schema = schema_ref! {
             nullable "id": INTEGER,
             nullable "region": STRING,
@@ -206,47 +324,44 @@ mod tests {
             },
         };
 
-        use delta_kernel::expressions::ColumnName;
-
-        let disk_props = get_required_properties_for_disk("test-table-id");
-        let _ = create_table(table_path, schema, "Test/1.0")
-            .with_table_properties(disk_props)
-            .with_data_layout(DataLayout::Clustered {
+        let mut disk_props = get_required_properties_for_disk("test-table-id");
+        if column_mapping {
+            disk_props.insert("delta.columnMapping.mode".to_string(), "name".to_string());
+        }
+        let req = create_v0_and_build_request(
+            &engine,
+            table_path,
+            schema,
+            disk_props,
+            DataLayout::Clustered {
                 columns: vec![
                     ColumnName::new(["region"]),
                     ColumnName::new(["address", "city"]),
                 ],
-            })
-            .build(&engine, Box::new(TestCatalogCommitter))
-            .unwrap()
-            .commit(&engine)
-            .unwrap();
-
-        let snapshot = Snapshot::builder_for(table_path)
-            .with_max_catalog_version(0)
-            .build(&engine)
-            .unwrap();
-        let uc_props = get_final_required_properties_for_uc(&snapshot, &engine).unwrap();
-
-        // Clustering columns serialized as array of path arrays:
-        // [["region"], ["address", "city"]]
-        let raw_json = &uc_props["clusteringColumns"];
-        let parsed: Vec<Vec<String>> = serde_json::from_str(raw_json).unwrap();
-        assert_eq!(
-            parsed,
-            vec![vec!["region"], vec!["address", "city"]],
-            "Raw JSON: {raw_json}"
+            },
         );
+
+        let cols = req.domain_metadata[CLUSTERING_DOMAIN_NAME]["clusteringColumns"].clone();
+        let parsed: Vec<Vec<String>> = serde_json::from_value(cols).unwrap();
+        if column_mapping {
+            assert_eq!(parsed.len(), 2);
+            let flat: Vec<&str> = parsed.iter().flatten().map(String::as_str).collect();
+            assert!(!flat.contains(&"region") && !flat.contains(&"city"));
+        } else {
+            assert_eq!(parsed, vec![vec!["region"], vec!["address", "city"]]);
+        }
     }
 
     #[tokio::test]
-    async fn test_get_final_required_properties_for_uc_rejects_non_zero_version() {
+    async fn test_build_uc_create_table_request_rejects_non_zero_version() {
         let storage = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(storage).build();
-        let table_path = "memory:///test_version_check/";
-        let schema = schema_ref! { nullable "id": INTEGER };
+        let table_path = "memory:///test_create_req_version/";
+        let schema = Arc::new(
+            StructType::try_new(vec![StructField::new("id", DataType::INTEGER, true)]).unwrap(),
+        );
 
-        // Create a table (version 0) and append (version 1)
+        // Create a table (version 0) and append (version 1).
         let disk_props = get_required_properties_for_disk("test-table-id");
         let _ = create_table(table_path, schema, "Test/1.0")
             .with_table_properties(disk_props)
@@ -265,15 +380,15 @@ mod tests {
             .unwrap();
         assert!(result.is_committed());
 
-        // Load snapshot at version 1
+        // Load snapshot at version 1.
         let snapshot = Snapshot::builder_for(table_path)
             .with_max_catalog_version(1)
             .build(&engine)
             .unwrap();
         assert_eq!(snapshot.version(), 1);
 
-        // Should fail because version != 0
-        let err = get_final_required_properties_for_uc(&snapshot, &engine).unwrap_err();
+        // Should fail because version != 0.
+        let err = build_uc_create_table_request(&snapshot, &engine, "x").unwrap_err();
         assert!(
             err.to_string().contains("version 0"),
             "expected version 0 error, got: {err}"

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -26,11 +26,16 @@ use std::collections::{HashMap, HashSet};
 
 use delta_kernel::actions::Protocol;
 use delta_kernel::{Engine, Snapshot};
-use unity_catalog_delta_client_api::{CreateTableRequest, Protocol as WireProtocol};
+use unity_catalog_delta_client_api::{
+    CreateTableRequest, Protocol as WireProtocol, StorageCredential,
+};
 
 use crate::constants::{
-    CATALOG_MANAGED_FEATURE_KEY, CLUSTERING_DOMAIN_NAME, FEATURE_SUPPORTED,
-    ROW_TRACKING_DOMAIN_NAME, UC_TABLE_ID_KEY, VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
+    CATALOG_MANAGED_FEATURE_KEY, CHECKPOINT_POLICY_KEY, CHECKPOINT_POLICY_V2,
+    CHECKPOINT_WRITE_STATS_AS_JSON_KEY, CHECKPOINT_WRITE_STATS_AS_STRUCT_KEY,
+    CLUSTERING_DOMAIN_NAME, CONFIG_TRUE, DELETION_VECTORS_FEATURE_KEY, ENABLE_DELETION_VECTORS_KEY,
+    FEATURE_SUPPORTED, ROW_TRACKING_DOMAIN_NAME, UC_TABLE_ID_KEY, V2_CHECKPOINT_FEATURE_KEY,
+    VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
 };
 
 /// Convert a kernel `Protocol` into the api crate's wire `Protocol`.
@@ -59,10 +64,19 @@ fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
 /// These properties must be persisted in the Delta log so that the table is recognized as
 /// catalog-managed. Note: ICT enablement is handled automatically by kernel's CREATE TABLE
 /// when the `catalogManaged` feature is present.
+///
+/// TODO: this hardcodes the required table features and properties. The create table flow should
+/// instead derive them from the `createStagingTable` response's advertised `required_protocol` and
+/// `required_properties`, so it stays correct if UC changes what it requires.
 pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, String> {
     [
         (CATALOG_MANAGED_FEATURE_KEY, FEATURE_SUPPORTED),
         (VACUUM_PROTOCOL_CHECK_FEATURE_KEY, FEATURE_SUPPORTED),
+        (V2_CHECKPOINT_FEATURE_KEY, FEATURE_SUPPORTED),
+        (DELETION_VECTORS_FEATURE_KEY, FEATURE_SUPPORTED),
+        (ENABLE_DELETION_VECTORS_KEY, CONFIG_TRUE),
+        (CHECKPOINT_WRITE_STATS_AS_STRUCT_KEY, CONFIG_TRUE),
+        (CHECKPOINT_WRITE_STATS_AS_JSON_KEY, CONFIG_TRUE),
         (UC_TABLE_ID_KEY, uc_table_id),
     ]
     .into_iter()
@@ -70,12 +84,42 @@ pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, St
     .collect()
 }
 
+/// Map AWS S3 credentials vended by UC (`CreateStagingTableResponse.storage_credentials` or
+/// `get_table_credentials`) into `object_store` option keys, for building an engine over the
+/// table's storage.
+///
+/// TODO: only AWS S3 is handled today. Generalize to GCS (`gcs.*`) and Azure (`azure.*`), which
+/// need their own `object_store` key mappings.
+pub fn aws_object_store_options(
+    creds: &[StorageCredential],
+    region: &str,
+) -> HashMap<String, String> {
+    let mut opts = HashMap::new();
+    for cred in creds {
+        for (key, value) in &cred.config {
+            let mapped = match key.as_str() {
+                "s3.access-key-id" => "access_key_id",
+                "s3.secret-access-key" => "secret_access_key",
+                "s3.session-token" => "session_token",
+                other => other,
+            };
+            opts.insert(mapped.to_string(), value.clone());
+        }
+    }
+    opts.insert("region".to_string(), region.to_string());
+    opts
+}
+
 /// Build the typed `CreateTableRequest` body the connector sends to the UC `tables` endpoint after
-/// the v0 commit succeeds, driving off the post-commit v0 snapshot.
+/// the v0 commit succeeds, built from the post-commit v0 snapshot.
 ///
 /// User properties set via `create_table`'s `with_table_properties` flow through automatically
 /// (they land in `metaData.configuration`). To add or override properties afterward, mutate
 /// `req.properties` on the returned request before sending.
+///
+/// UC requires `delta.checkpointPolicy=v2` in the request body, but kernel's CREATE TABLE rejects
+/// it as a table property, so it never lands in the committed metadata. This function adds it to
+/// the request body so callers get a complete, contract-valid request.
 ///
 /// # Errors
 ///
@@ -103,8 +147,12 @@ pub fn build_uc_create_table_request(
     let protocol = table_config.protocol();
 
     let partition_columns = metadata.partition_columns().to_vec();
-    let properties = metadata.configuration().clone();
-    let typed_protocol = to_wire_protocol(protocol);
+    let mut properties = metadata.configuration().clone();
+    properties.insert(
+        CHECKPOINT_POLICY_KEY.to_string(),
+        CHECKPOINT_POLICY_V2.to_string(),
+    );
+    let wire_protocol = to_wire_protocol(protocol);
 
     // UC only recognizes the `delta.clustering` and `delta.rowTracking` domain metadatas.
     let uc_recognized_domains = HashSet::from([CLUSTERING_DOMAIN_NAME, ROW_TRACKING_DOMAIN_NAME]);
@@ -127,7 +175,7 @@ pub fn build_uc_create_table_request(
         comment: None,
         columns,
         partition_columns,
-        protocol: typed_protocol,
+        protocol: wire_protocol,
         properties,
         domain_metadata,
         last_commit_timestamp_ms: in_commit_timestamp_ms,
@@ -178,9 +226,14 @@ mod tests {
     #[test]
     fn test_get_required_properties_for_disk() {
         let props = get_required_properties_for_disk("my-uc-table-123");
-        assert_eq!(props.len(), 3);
+        assert_eq!(props.len(), 8);
         assert_eq!(props["delta.feature.catalogManaged"], "supported");
         assert_eq!(props["delta.feature.vacuumProtocolCheck"], "supported");
+        assert_eq!(props["delta.feature.v2Checkpoint"], "supported");
+        assert_eq!(props["delta.feature.deletionVectors"], "supported");
+        assert_eq!(props["delta.enableDeletionVectors"], "true");
+        assert_eq!(props["delta.checkpoint.writeStatsAsStruct"], "true");
+        assert_eq!(props["delta.checkpoint.writeStatsAsJson"], "true");
         assert_eq!(props["io.unitycatalog.tableId"], "my-uc-table-123");
     }
 
@@ -223,6 +276,7 @@ mod tests {
             req.properties["io.unitycatalog.tableId"],
             "test-table-id-456"
         );
+        assert_eq!(req.properties["delta.checkpointPolicy"], "v2");
         assert!(!req.properties.contains_key("delta.feature.catalogManaged"));
         assert!(!req.properties.contains_key("delta.minReaderVersion"));
         assert!(!req.properties.contains_key("delta.lastUpdateVersion"));

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -25,7 +25,7 @@
 use std::collections::{HashMap, HashSet};
 
 use delta_kernel::actions::Protocol;
-use delta_kernel::{Engine, Snapshot};
+use delta_kernel::{DeltaResult, Engine, Error, Snapshot};
 use unity_catalog_delta_client_api::{
     CreateTableRequest, Protocol as WireProtocol, StorageCredential,
 };
@@ -134,18 +134,17 @@ pub fn build_uc_create_table_request(
     snapshot: &Snapshot,
     engine: &dyn Engine,
     table_name: impl Into<String>,
-) -> delta_kernel::DeltaResult<CreateTableRequest> {
+) -> DeltaResult<CreateTableRequest> {
     if snapshot.version() != 0 {
-        return Err(delta_kernel::Error::generic(format!(
+        return Err(Error::generic(format!(
             "build_uc_create_table_request is only valid for version 0 (table creation) \
              snapshots, but snapshot is at version {}",
             snapshot.version()
         )));
     }
 
-    let columns = serde_json::to_value(snapshot.schema().as_ref()).map_err(|e| {
-        delta_kernel::Error::generic(format!("Failed to serialize table schema: {e}"))
-    })?;
+    let columns = serde_json::to_value(snapshot.schema().as_ref())
+        .map_err(|e| Error::generic(format!("Failed to serialize table schema: {e}")))?;
 
     let table_config = snapshot.table_configuration();
     let metadata = table_config.metadata();
@@ -165,9 +164,8 @@ pub fn build_uc_create_table_request(
     for (domain, dm) in
         snapshot.get_domain_metadatas_internal(engine, Some(&uc_recognized_domains))?
     {
-        let value = serde_json::from_str(dm.configuration()).map_err(|e| {
-            delta_kernel::Error::generic(format!("malformed {domain} domain metadata: {e}"))
-        })?;
+        let value = serde_json::from_str(dm.configuration())
+            .map_err(|e| Error::generic(format!("malformed {domain} domain metadata: {e}")))?;
         domain_metadata.insert(domain, value);
     }
 

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -7,9 +7,9 @@
 //!
 //! ```ignore
 //! // Step 1: Get staging info from UC
-//! let staging_info: CreateStagingTableResponse = my_uc_client.post_staging_table(..).await?;
+//! let staging_info = my_uc_client.post_staging_table(..).await?;
 //!
-//! // Step 2: Build and commit the create-table transaction.
+//! // Step 2: Build and commit the create-table transaction
 //! let disk_props = get_required_properties_for_disk(&staging_info.table_id);
 //! let create_table_txn = kernel::create_table(path, schema, "MyApp/1.0")
 //!     .with_table_properties(disk_props)
@@ -38,7 +38,8 @@ use crate::constants::{
     VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
 };
 
-/// Convert a kernel `Protocol` into the api crate's wire `Protocol`.
+/// Convert a kernel `Protocol` into the api crate's wire `Protocol`. The api crate is kernel-free,
+/// so it defines its own serializable transport type rather than reusing `delta_kernel::Protocol`.
 fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
     WireProtocol {
         min_reader_version: protocol.min_reader_version(),
@@ -65,9 +66,10 @@ fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
 /// catalog-managed. Note: ICT enablement is handled automatically by kernel's CREATE TABLE
 /// when the `catalogManaged` feature is present.
 ///
-/// TODO: this hardcodes the required table features and properties. The create table flow should
-/// instead derive them from the `createStagingTable` response's advertised `required_protocol` and
-/// `required_properties`, so it stays correct if UC changes what it requires.
+/// TODO(delta-io/delta#7179): this hardcodes the required table features and properties. The create
+/// table flow should instead derive them from the `createStagingTable` response's advertised
+/// `required_protocol` and `required_properties`, so it stays correct if UC changes what it
+/// requires.
 pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, String> {
     [
         (CATALOG_MANAGED_FEATURE_KEY, FEATURE_SUPPORTED),
@@ -88,8 +90,11 @@ pub fn get_required_properties_for_disk(uc_table_id: &str) -> HashMap<String, St
 /// `get_table_credentials`) into `object_store` option keys, for building an engine over the
 /// table's storage.
 ///
-/// TODO: only AWS S3 is handled today. Generalize to GCS (`gcs.*`) and Azure (`azure.*`), which
-/// need their own `object_store` key mappings.
+/// This is a convenience over the public `store_from_url_opts`: connectors can build a store
+/// themselves by passing option keys directly. It only translates S3's key names today.
+///
+/// TODO(#3016): also translate GCS (`gcs.*`) and Azure (`azure.*`) credential keys so connectors
+/// don't each re-derive the mapping.
 pub fn aws_object_store_options(
     creds: &[StorageCredential],
     region: &str,

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -3,6 +3,9 @@
 //! These utilities help connectors create UC-managed tables by providing the required properties
 //! for both the Delta log (disk) and the UC server registration.
 //!
+//! TODO(#3032): add a high-level helper that runs the whole flow (reserve staging table, vend
+//! credentials, kernel v0 commit, register with UC) in one call.
+//!
 //! # Usage
 //!
 //! ```ignore
@@ -37,27 +40,6 @@ use crate::constants::{
     FEATURE_SUPPORTED, ROW_TRACKING_DOMAIN_NAME, UC_TABLE_ID_KEY, V2_CHECKPOINT_FEATURE_KEY,
     VACUUM_PROTOCOL_CHECK_FEATURE_KEY,
 };
-
-/// Convert a kernel `Protocol` into the api crate's wire `Protocol`. The api crate is kernel-free,
-/// so it defines its own serializable transport type rather than reusing `delta_kernel::Protocol`.
-fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
-    WireProtocol {
-        min_reader_version: protocol.min_reader_version(),
-        min_writer_version: protocol.min_writer_version(),
-        reader_features: protocol
-            .reader_features()
-            .into_iter()
-            .flatten()
-            .map(|f| f.as_ref().to_string())
-            .collect(),
-        writer_features: protocol
-            .writer_features()
-            .into_iter()
-            .flatten()
-            .map(|f| f.as_ref().to_string())
-            .collect(),
-    }
-}
 
 /// Returns the table properties that must be written to disk (in `000.json`) for a UC
 /// catalog-managed table creation.
@@ -183,6 +165,27 @@ pub fn build_uc_create_table_request(
         domain_metadata,
         last_commit_timestamp_ms: in_commit_timestamp_ms,
     })
+}
+
+/// Convert a kernel `Protocol` into the api crate's wire `Protocol`. The api crate is kernel-free,
+/// so it defines its own serializable transport type rather than reusing `delta_kernel::Protocol`.
+fn to_wire_protocol(protocol: &Protocol) -> WireProtocol {
+    WireProtocol {
+        min_reader_version: protocol.min_reader_version(),
+        min_writer_version: protocol.min_writer_version(),
+        reader_features: protocol
+            .reader_features()
+            .into_iter()
+            .flatten()
+            .map(|f| f.as_ref().to_string())
+            .collect(),
+        writer_features: protocol
+            .writer_features()
+            .into_iter()
+            .flatten()
+            .map(|f| f.as_ref().to_string())
+            .collect(),
+    }
 }
 
 #[cfg(test)]

--- a/delta-kernel-unity-catalog/src/utils/mod.rs
+++ b/delta-kernel-unity-catalog/src/utils/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod create_table;
 
-pub use create_table::{get_final_required_properties_for_uc, get_required_properties_for_disk};
+pub use create_table::{build_uc_create_table_request, get_required_properties_for_disk};

--- a/delta-kernel-unity-catalog/src/utils/mod.rs
+++ b/delta-kernel-unity-catalog/src/utils/mod.rs
@@ -1,3 +1,5 @@
 pub(crate) mod create_table;
 
-pub use create_table::{build_uc_create_table_request, get_required_properties_for_disk};
+pub use create_table::{
+    aws_object_store_options, build_uc_create_table_request, get_required_properties_for_disk,
+};

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -1,12 +1,17 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{Engine, Snapshot};
 use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel_default_engine::DefaultEngine;
-use delta_kernel_unity_catalog::{snapshot_builder_from_load_table, UCCommitter};
-use test_utils::read_scan;
+use delta_kernel_unity_catalog::{
+    get_required_properties_for_disk, snapshot_builder_from_load_table, UCCommitter,
+};
+use test_utils::{insert_data_with, read_scan};
 use unity_catalog_delta_client_api::{
     Commit, InMemoryUpdateTableClient, TableData, TableIdentifier,
 };
@@ -123,6 +128,16 @@ fn commit(
         .unwrap_post_commit_snapshot())
 }
 
+/// Loads a snapshot via the connector read path: `load_table` response -> snapshot builder.
+fn build_snapshot(
+    client: &Arc<InMemoryUpdateTableClient>,
+    engine: &DefaultEngine<TokioMultiThreadExecutor>,
+    table_uri: &url::Url,
+) -> Result<Arc<Snapshot>, TestError> {
+    let resp = client.load_table_response(TABLE_ID, table_uri.as_str())?;
+    Ok(snapshot_builder_from_load_table(&resp)?.build(engine)?)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -220,5 +235,116 @@ async fn test_cannot_checkpoint_unpublished_snapshot() -> Result<(), TestError> 
     let snapshot = commit(&snapshot, &update_table_client, &engine)?;
     let err = snapshot.checkpoint(&engine, None).unwrap_err();
     assert!(matches!(err, delta_kernel::Error::Generic(msg) if msg.contains("not published")));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_append_scan_back_and_incremental_read() -> Result<(), TestError> {
+    let tmp = tempfile::tempdir()?;
+    let table_uri = url::Url::from_directory_path(tmp.path()).map_err(|_| "invalid path")?;
+
+    let store = Arc::new(LocalFileSystem::new());
+    let executor = Arc::new(TokioMultiThreadExecutor::new(
+        tokio::runtime::Handle::current(),
+    ));
+    let engine = Arc::new(
+        delta_kernel_default_engine::DefaultEngineBuilder::new(store)
+            .with_task_executor(executor)
+            .build(),
+    );
+
+    let client = Arc::new(InMemoryUpdateTableClient::new());
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("val", DataType::STRING),
+    ])?);
+
+    // v0 create: writes 000.json directly to storage, does not call the catalog.
+    create_table(table_uri.as_str(), schema, "delta-kernel-uc-test")
+        .with_table_properties(get_required_properties_for_disk(TABLE_ID))
+        .build(engine.as_ref(), Box::new(uc_committer(&client)))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+    client.create_table(TABLE_ID)?;
+
+    let snap_v0 = build_snapshot(&client, &engine, &table_uri)?;
+    assert_eq!(snap_v0.version(), 0);
+    let scan = snap_v0.clone().scan_builder().build()?;
+    let v0_rows: usize = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(v0_rows, 0);
+
+    // v1 append: 3 rows.
+    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let val_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "b", "c"]));
+    insert_data_with(
+        snap_v0,
+        &engine,
+        vec![id_col, val_col],
+        Box::new(uc_committer(&client)),
+        "WRITE",
+        true,
+        false,
+    )
+    .await?
+    .unwrap_committed();
+
+    let snap_v1 = build_snapshot(&client, &engine, &table_uri)?;
+    assert_eq!(snap_v1.version(), 1);
+    let scan = snap_v1.clone().scan_builder().build()?;
+    let v1_batches = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?;
+    let v1_rows: usize = v1_batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(v1_rows, 3);
+    let mut ids: Vec<i32> = v1_batches
+        .iter()
+        .flat_map(|b| {
+            let col = b
+                .column_by_name("id")
+                .expect("id column")
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("id is int32");
+            col.values().to_vec()
+        })
+        .collect();
+    // Scan row order is not guaranteed, so sort before comparing.
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2, 3]);
+
+    // v2 append: 2 more rows -> incremental read sees v1 + v2.
+    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![4, 5]));
+    let val_col: ArrayRef = Arc::new(StringArray::from(vec!["d", "e"]));
+    insert_data_with(
+        snap_v1,
+        &engine,
+        vec![id_col, val_col],
+        Box::new(uc_committer(&client)),
+        "WRITE",
+        true,
+        false,
+    )
+    .await?
+    .unwrap_committed();
+
+    let snap_v2 = build_snapshot(&client, &engine, &table_uri)?;
+    assert_eq!(snap_v2.version(), 2);
+    let scan = snap_v2.clone().scan_builder().build()?;
+    let v2_rows: usize = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(v2_rows, 5);
+
+    // Publish, then confirm reads still return all rows.
+    let published = snap_v2.publish(engine.as_ref(), &uc_committer(&client))?;
+    let scan = published.scan_builder().build()?;
+    let pub_rows: usize = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(pub_rows, 5);
     Ok(())
 }

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -314,7 +314,7 @@ async fn test_append_scan_back_and_incremental_read() -> Result<(), TestError> {
     ids.sort_unstable();
     assert_eq!(ids, vec![1, 2, 3]);
 
-    // v2 append: 2 more rows -> incremental read sees v1 + v2.
+    // Append 2 rows. A scan at v2 should see 5 rows.
     let id_col: ArrayRef = Arc::new(Int32Array::from(vec![4, 5]));
     let val_col: ArrayRef = Arc::new(StringArray::from(vec!["d", "e"]));
     insert_data_with(

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -1,0 +1,472 @@
+//! Live end-to-end tests against a running Unity Catalog server.
+//!
+//! These are gated behind the `integration-test` feature so they are never compiled or run by a
+//! normal `cargo nextest`. Even with the feature enabled, each test skips (passes as a no-op) when
+//! `UC_SERVER_URL` is unset, so a developer can build the suite without a server on hand.
+//!
+//! Run against a local UC OSS server:
+//! ```bash
+//! UC_SERVER_URL=http://localhost:8080 UC_TOKEN=not-used \
+//!   cargo nextest run -p delta-kernel-unity-catalog --features integration-test
+//! ```
+//!
+//! Optional overrides for the read-path test: `UC_TEST_CATALOG`, `UC_TEST_SCHEMA`,
+//! `UC_TEST_TABLE` (the read test skips unless `UC_TEST_TABLE` is set).
+//!
+//! The mutating CREATE test (`live_create_table`) is double-gated: it requires `UC_CREATE=1` (and
+//! also skips with an eprintln otherwise). Point it only at throwaway tables/schemas.
+//!
+//! UC does no validation of the createTable payload against the committed log. These tests prove
+//! the RPCs round-trip, not that the values we send are correct.
+#![cfg(feature = "integration-test")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray, StructArray};
+use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
+use delta_kernel::expressions::ColumnName;
+use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::{Engine, Snapshot};
+use delta_kernel_default_engine::storage::store_from_url_opts;
+use delta_kernel_default_engine::DefaultEngineBuilder;
+use delta_kernel_unity_catalog::{
+    build_uc_create_table_request, log_tail_from_commits, UCCommitter,
+};
+use test_utils::{insert_data_with, read_scan};
+use unity_catalog_delta_client_api::{
+    CreateStagingTableRequest, CreateStagingTableResponse, LoadTableResponse, StorageCredential,
+    TableName,
+};
+use unity_catalog_delta_rest_client::{ClientConfig, UCClient, UCUpdateTableRestClient};
+use url::Url;
+
+/// Returns `(server_url, token)` from the environment, or `None` to signal the caller to skip.
+/// `UC_TOKEN` defaults to a dummy value since a dev-mode server runs with auth disabled.
+fn server_env() -> Option<(String, String)> {
+    let url = std::env::var("UC_SERVER_URL").ok()?;
+    let token = std::env::var("UC_TOKEN").unwrap_or_else(|_| "not-used".to_string());
+    Some((url, token))
+}
+
+/// Builds a `ClientConfig`, applying `UC_USER_AGENT` when set. Some catalogs require a specific
+/// `User-Agent` value and reject others; others ignore the header entirely.
+fn client_config(url: &str, token: &str) -> ClientConfig {
+    let mut builder = ClientConfig::build(url, token);
+    if let Ok(user_agent) = std::env::var("UC_USER_AGENT") {
+        builder = builder.with_user_agent(user_agent);
+    }
+    builder.build().expect("failed to build ClientConfig")
+}
+
+fn client(url: &str, token: &str) -> UCClient {
+    UCClient::new(client_config(url, token)).expect("failed to build UCClient")
+}
+
+/// Default `User-Agent` when `UC_USER_AGENT` is unset. Derived from the crate version to match the
+/// production default.
+const DEFAULT_USER_AGENT: &str = concat!(
+    "Delta/",
+    env!("CARGO_PKG_VERSION"),
+    " delta-kernel-rs/",
+    env!("CARGO_PKG_VERSION")
+);
+
+/// Returns the base URL (`<workspace>/api/2.1/unity-catalog/delta/v1/`) plus an authed
+/// `reqwest::Client` for the hand-rolled staging-tables/tables POSTs.
+fn raw_delta_rest_client(url: &str, token: &str) -> (Url, reqwest::Client) {
+    let base = ClientConfig::build(url, token)
+        .build()
+        .expect("failed to build ClientConfig")
+        .workspace_url
+        .join("delta/v1/")
+        .expect("failed to join delta/v1/ onto workspace URL");
+    let user_agent =
+        std::env::var("UC_USER_AGENT").unwrap_or_else(|_| DEFAULT_USER_AGENT.to_string());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::AUTHORIZATION,
+        reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+            .expect("invalid bearer token"),
+    );
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        reqwest::header::USER_AGENT,
+        reqwest::header::HeaderValue::from_str(&user_agent).expect("invalid user agent"),
+    );
+    let http = reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .expect("failed to build reqwest client");
+    (base, http)
+}
+
+/// Maps vended storage credentials into `object_store` option keys so the table's cloud store can
+/// be constructed. Currently handles the AWS S3 credential keys; pass-through for anything else
+/// (e.g. region), plus a `UC_AWS_REGION` fallback since vended creds may omit the region. Used by
+/// the CREATE path (`CreateStagingTableResponse.storage_credentials`).
+fn object_store_options(creds: &[StorageCredential]) -> HashMap<String, String> {
+    let mut opts = HashMap::new();
+    for cred in creds {
+        for (key, value) in &cred.config {
+            let mapped = match key.as_str() {
+                "s3.access-key-id" => "access_key_id",
+                "s3.secret-access-key" => "secret_access_key",
+                "s3.session-token" => "session_token",
+                // Pass keys we don't remap (e.g. region) through unchanged; intentional, test-only.
+                other => other,
+            };
+            opts.insert(mapped.to_string(), value.clone());
+        }
+    }
+    if let Ok(region) = std::env::var("UC_AWS_REGION") {
+        opts.insert("region".to_string(), region);
+    }
+    opts
+}
+
+/// Normalize a UC table location to a root URL ending in `/`. UC returns the location without a
+/// trailing slash, but staged-commit path resolution and snapshot building require one.
+fn normalize_table_root(table_url: &Url) -> Url {
+    let mut root = table_url.clone();
+    if !root.path().ends_with('/') {
+        root.set_path(&format!("{}/", root.path()));
+    }
+    root
+}
+
+/// Builds a `Snapshot` from a `load_table` response: normalize the location, build the log tail
+/// from the inline commits, and pin the snapshot to the catalog's max version. Returns the
+/// normalized table root alongside the snapshot.
+fn snapshot_from_load_table(resp: &LoadTableResponse, engine: &dyn Engine) -> (Url, Arc<Snapshot>) {
+    let root = normalize_table_root(
+        &Url::parse(&resp.metadata.location).expect("location is not a valid URL"),
+    );
+    let max_version: u64 = resp
+        .latest_table_version
+        .unwrap_or(0)
+        .try_into()
+        .expect("latest_table_version does not fit u64");
+    let log_tail = log_tail_from_commits(&resp.commits, root.clone()).expect("log tail");
+    let snapshot = Snapshot::builder_for(root.clone())
+        .with_log_tail(log_tail)
+        .with_max_catalog_version(max_version)
+        .build(engine)
+        .expect("failed to build snapshot from load_table response");
+    (root, snapshot)
+}
+
+/// `load_table` returns parseable metadata + commits, and the commits convert to a kernel log tail.
+/// Skips unless `UC_TEST_TABLE` names an existing managed delta table. This validates the read-path
+/// wire types without requiring storage credentials (it does not read data files).
+#[tokio::test(flavor = "multi_thread")]
+async fn live_load_table_builds_log_tail() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_load_table_builds_log_tail");
+        return;
+    };
+    let Some(table) = std::env::var("UC_TEST_TABLE").ok() else {
+        eprintln!("UC_TEST_TABLE unset; skipping live_load_table_builds_log_tail");
+        return;
+    };
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+    let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
+
+    let resp = client(&url, &token)
+        .load_table(&catalog, &schema, &table)
+        .await
+        .expect("load_table failed");
+
+    assert!(
+        !resp.metadata.table_uuid.is_empty(),
+        "expected a table_uuid in the load_table response"
+    );
+    let table_url = Url::parse(&resp.metadata.location).expect("location is not a valid URL");
+
+    // Pure transform (no I/O): proves the commit wire shape maps onto kernel log paths.
+    let log_tail = log_tail_from_commits(&resp.commits, table_url)
+        .expect("log_tail_from_commits failed on the server's commit list");
+    assert_eq!(
+        log_tail.len(),
+        resp.commits.len(),
+        "every returned commit should map to a log path"
+    );
+}
+
+/// Translate the staging response's required protocol + properties into the table properties the v0
+/// create commit must carry. Each required protocol feature becomes
+/// `delta.feature.<name>=supported` so kernel enables it; required raw properties with concrete
+/// values pass through (a null value means "any value is acceptable").
+fn disk_properties_from_staging(resp: &CreateStagingTableResponse) -> HashMap<String, String> {
+    let mut props: HashMap<String, String> = resp
+        .required_protocol
+        .reader_features
+        .iter()
+        .chain(resp.required_protocol.writer_features.iter())
+        .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
+        .collect();
+    for (k, v) in &resp.required_properties {
+        // Skip properties kernel derives from the enabled features and forbids setting at CREATE
+        // (e.g. `delta.checkpointPolicy` is implied by `delta.feature.v2Checkpoint`).
+        if k == "delta.checkpointPolicy" {
+            continue;
+        }
+        if let Some(v) = v {
+            props.insert(k.clone(), v.clone());
+        }
+    }
+    props.insert("io.unitycatalog.tableId".to_string(), resp.table_id.clone());
+    props
+}
+
+/// Live CREATE through the full connector flow. The two CREATE endpoints (`staging-tables`,
+/// `tables`) are deliberately not in the REST client, so this test hand-rolls those POSTs with raw
+/// `reqwest` while using kernel for the v0 commit and the typed `tables` body. The inline
+/// `(a)`-`(n)` markers walk the flow.
+///
+/// The table enables row tracking and clustering so the create body and the write path exercise the
+/// `delta.rowTracking` and `delta.clustering` domains in one round trip: the initial watermark (-1)
+/// is forwarded at create and advances to 2 after the append (the CTAS concern), and the clustering
+/// columns are forwarded under `delta.clustering`.
+///
+/// This mutates the catalog, so it is double-gated: requires `UC_CREATE=1`. Uses a unique table
+/// name and best-effort DELETEs before and after to keep reruns idempotent.
+#[tokio::test(flavor = "multi_thread")]
+async fn live_create_table() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_create_table");
+        return;
+    };
+    if std::env::var("UC_CREATE").is_err() {
+        eprintln!("UC_CREATE unset; skipping mutating live_create_table");
+        return;
+    }
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+    let schema_name = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
+    // Unique per run: a leftover table/staging-table from a prior run (best-effort cleanup can
+    // fail) otherwise 409s the staging-tables POST. Suffix keeps reruns collision-free.
+    let name = format!("kernel_rs_create_test_{}", uuid::Uuid::new_v4().simple());
+    let name = name.as_str();
+
+    let (base, http) = raw_delta_rest_client(&url, &token);
+    let tables_base = base
+        .join(&format!("catalogs/{catalog}/schemas/{schema_name}/"))
+        .expect("tables base URL");
+
+    // (a) Best-effort cleanup of a prior run; ignore non-2xx/404.
+    let table_url = tables_base
+        .join(&format!("tables/{name}"))
+        .expect("table URL");
+    let _ = http.delete(table_url.clone()).send().await;
+
+    // (b) POST staging-tables -> allocate uuid + storage + staging credentials.
+    let staging_url = tables_base
+        .join("staging-tables")
+        .expect("staging-tables URL");
+    let staging_req = CreateStagingTableRequest {
+        name: name.to_string(),
+    };
+    let staging_req_json =
+        serde_json::to_string_pretty(&staging_req).expect("serialize CreateStagingTableRequest");
+    let staging_resp = http
+        .post(staging_url)
+        .json(&staging_req)
+        .send()
+        .await
+        .expect("staging-tables POST failed");
+    let staging_status = staging_resp.status();
+    if !staging_status.is_success() {
+        let body = staging_resp.text().await.unwrap_or_default();
+        panic!(
+            "staging-tables POST returned {staging_status}\nrequest body:\n{staging_req_json}\nresponse body:\n{body}"
+        );
+    }
+    let resp: CreateStagingTableResponse = staging_resp
+        .json()
+        .await
+        .expect("failed to deserialize CreateStagingTableResponse");
+
+    // (c)/(d) Build the engine over the staging storage location.
+    let table_root =
+        normalize_table_root(&Url::parse(&resp.location).expect("location is not a valid URL"));
+    let store = store_from_url_opts(&table_root, object_store_options(&resp.storage_credentials))
+        .expect("failed to build object store from staging credentials");
+    let engine = Arc::new(DefaultEngineBuilder::new(store).build());
+
+    // A server backed by local-FS storage (e.g. the OSS server in CI) allocates the table location
+    // logically without creating the directory; kernel lists the table root during create-table and
+    // `LocalFileSystem` errors on a missing path (a cloud object store returns empty). Create it
+    // for file:// locations so the create-table build can proceed.
+    if table_root.scheme() == "file" {
+        if let Ok(path) = table_root.to_file_path() {
+            std::fs::create_dir_all(&path).expect("failed to create local table directory");
+        }
+    }
+
+    // (e) Schema with a nested struct so clustering can target both a top-level and a nested
+    // column.
+    let schema: SchemaRef = Arc::new(
+        StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+            StructField::nullable(
+                "address",
+                StructType::try_new(vec![
+                    StructField::nullable("city", DataType::STRING),
+                    StructField::nullable("zip", DataType::STRING),
+                ])
+                .expect("failed to build nested schema"),
+            ),
+        ])
+        .expect("failed to build schema"),
+    );
+
+    // (f)/(g) Commit v0 directly to storage via the UC committer (v0 path does not call the
+    // catalog). Enable row tracking so the create body carries `delta.rowTracking`, and cluster on
+    // `name` and the nested `address.city` so it carries `delta.clustering`.
+    let mut disk_props = disk_properties_from_staging(&resp);
+    disk_props.insert("delta.enableRowTracking".to_string(), "true".to_string());
+    let committer = Box::new(UCCommitter::new(
+        Arc::new(UCUpdateTableRestClient::new(client_config(&url, &token)).expect("update client")),
+        resp.table_id.clone(),
+        TableName::new(catalog.clone(), schema_name.clone(), name.to_string()),
+    ));
+    create_table(table_root.as_str(), schema, "delta-kernel-rs-live-test")
+        .with_table_properties(disk_props)
+        .with_data_layout(DataLayout::Clustered {
+            columns: vec![
+                ColumnName::new(["name"]),
+                ColumnName::new(["address", "city"]),
+            ],
+        })
+        .build(engine.as_ref(), committer)
+        .expect("failed to build create-table transaction")
+        .commit(engine.as_ref())
+        .expect("failed to commit create-table transaction")
+        .unwrap_committed();
+
+    // (h) Load the post-commit v0 snapshot. The table is catalog-managed, so the snapshot build
+    // requires the catalog's max version; the just-created table is at v0.
+    let snapshot = Snapshot::builder_for(table_root.clone())
+        .with_max_catalog_version(0)
+        .build(engine.as_ref())
+        .expect("failed to build post-commit snapshot");
+    assert_eq!(
+        snapshot.version(),
+        0,
+        "post-create snapshot should be at version 0"
+    );
+
+    // (i)/(j) Build the typed create body and register the table.
+    let mut req = build_uc_create_table_request(&snapshot, engine.as_ref(), name)
+        .expect("failed to build CreateTableRequest");
+    // Empty create forwards the initial row-tracking watermark and the clustering columns.
+    assert_eq!(
+        req.domain_metadata["delta.rowTracking"]["rowIdHighWaterMark"].as_i64(),
+        Some(-1),
+        "empty create should forward the initial watermark"
+    );
+    let clustering: Vec<Vec<String>> = serde_json::from_value(
+        req.domain_metadata["delta.clustering"]["clusteringColumns"].clone(),
+    )
+    .expect("clusteringColumns should deserialize");
+    assert_eq!(clustering, vec![vec!["name"], vec!["address", "city"]]);
+    // The server requires `delta.checkpointPolicy=v2` in the create body for v2Checkpoint tables.
+    // The kernel does not write the companion `delta.checkpointPolicy` property when enabling the
+    // `v2Checkpoint` feature, so it is absent from the committed metadata. The connector supplies
+    // it here to satisfy the server contract.
+    req.properties
+        .insert("delta.checkpointPolicy".to_string(), "v2".to_string());
+    let req_json = serde_json::to_string_pretty(&req).expect("serialize CreateTableRequest");
+    let create_resp = http
+        .post(tables_base.join("tables").expect("tables URL"))
+        .json(&req)
+        .send()
+        .await
+        .expect("tables POST failed");
+    let create_status = create_resp.status();
+    if !create_status.is_success() {
+        let body = create_resp.text().await.unwrap_or_default();
+        panic!(
+            "tables POST returned {create_status}\nrequest body:\n{req_json}\nresponse body:\n{body}"
+        );
+    }
+
+    // (k) Verify registration: the table loads and its uuid matches the staging table id.
+    let loaded = client(&url, &token)
+        .load_table(&catalog, &schema_name, name)
+        .await
+        .expect("load_table after create failed");
+    assert_eq!(
+        loaded.metadata.table_uuid, resp.table_id,
+        "loaded table uuid should match the staging table id"
+    );
+
+    // (m) Append 3 rows through the connector write path, then scan them back.
+    let uc = client(&url, &token);
+    let pre = uc
+        .load_table(&catalog, &schema_name, name)
+        .await
+        .expect("load_table before append failed");
+    let (_, snapshot) = snapshot_from_load_table(&pre, engine.as_ref());
+
+    let id_col: ArrayRef = Arc::new(Int32Array::from(vec![10, 20, 30]));
+    let name_col: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "z"]));
+    let address_col: ArrayRef = Arc::new(StructArray::from(vec![
+        (
+            Arc::new(Field::new("city", ArrowDataType::Utf8, true)),
+            Arc::new(StringArray::from(vec!["nyc", "sf", "la"])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new("zip", ArrowDataType::Utf8, true)),
+            Arc::new(StringArray::from(vec!["10001", "94103", "90001"])) as ArrayRef,
+        ),
+    ]));
+    let append_committer = Box::new(UCCommitter::new(
+        Arc::new(UCUpdateTableRestClient::new(client_config(&url, &token)).expect("update client")),
+        resp.table_id.clone(),
+        TableName::new(catalog.clone(), schema_name.clone(), name.to_string()),
+    ));
+    insert_data_with(
+        snapshot,
+        &engine,
+        vec![id_col, name_col, address_col],
+        append_committer,
+        "WRITE",
+        true,
+        false,
+    )
+    .await
+    .expect("append failed")
+    .unwrap_committed();
+
+    let post = uc
+        .load_table(&catalog, &schema_name, name)
+        .await
+        .expect("load_table after append failed");
+    let (_, snapshot) = snapshot_from_load_table(&post, engine.as_ref());
+
+    // Appending 3 rows to a row-tracking table assigns IDs 0..=2, advancing the mark from -1 to 2.
+    let row_tracking = snapshot
+        .get_domain_metadata_internal("delta.rowTracking", engine.as_ref())
+        .expect("failed to read delta.rowTracking domain metadata");
+    assert_eq!(
+        row_tracking.as_deref(),
+        Some(r#"{"rowIdHighWaterMark":2}"#),
+        "after appending 3 rows the high water mark should advance from -1 to 2"
+    );
+
+    let scan = snapshot.scan_builder().build().expect("scan build failed");
+    let batches = read_scan(&scan, engine.clone() as Arc<dyn Engine>).expect("read_scan failed");
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(rows, 3, "appended rows should be returned by the scan");
+
+    // (n) Best-effort cleanup.
+    let _ = http.delete(table_url).send().await;
+}

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -4,7 +4,7 @@
 //! normal `cargo nextest`. Even with the feature enabled, each test skips (passes as a no-op) when
 //! `UC_SERVER_URL` is unset, so a developer can build the suite without a server on hand.
 //!
-//! Run against a local UC OSS server:
+//! Run against a local UC server:
 //! ```bash
 //! UC_SERVER_URL=http://localhost:8080 UC_TOKEN=not-used \
 //!   cargo nextest run -p delta-kernel-unity-catalog --features integration-test
@@ -13,14 +13,12 @@
 //! Optional overrides for the read-path test: `UC_TEST_CATALOG`, `UC_TEST_SCHEMA`,
 //! `UC_TEST_TABLE` (the read test skips unless `UC_TEST_TABLE` is set).
 //!
-//! The mutating CREATE test (`live_create_table`) is double-gated: it requires `UC_CREATE=1` (and
-//! also skips with an eprintln otherwise). Point it only at throwaway tables/schemas.
+//! The CREATE test (`live_create_table`) mutates the catalog, so point `UC_SERVER_URL` only at a
+//! throwaway server or schema.
 //!
-//! UC does no validation of the createTable payload against the committed log. These tests prove
-//! the RPCs round-trip, not that the values we send are correct.
+//! These tests prove the RPCs round-trip, not that the payloads are semantically correct.
 #![cfg(feature = "integration-test")]
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray, StructArray};
@@ -33,14 +31,14 @@ use delta_kernel::{Engine, Snapshot};
 use delta_kernel_default_engine::storage::store_from_url_opts;
 use delta_kernel_default_engine::DefaultEngineBuilder;
 use delta_kernel_unity_catalog::{
-    build_uc_create_table_request, log_tail_from_commits, UCCommitter,
+    aws_object_store_options, build_uc_create_table_request, get_required_properties_for_disk,
+    log_tail_from_commits, snapshot_builder_from_load_table, UCCommitter,
 };
 use test_utils::{insert_data_with, read_scan};
 use unity_catalog_delta_client_api::{
-    CreateStagingTableRequest, CreateStagingTableResponse, LoadTableResponse, StorageCredential,
-    TableName,
+    CreateStagingTableRequest, CreateStagingTableResponse, LoadTableResponse, TableIdentifier,
 };
-use unity_catalog_delta_rest_client::{ClientConfig, UCClient, UCUpdateTableRestClient};
+use unity_catalog_delta_client_default::{ClientConfig, UCClient, UCUpdateTableRestClient};
 use url::Url;
 
 /// Returns `(server_url, token)` from the environment, or `None` to signal the caller to skip.
@@ -107,30 +105,6 @@ fn raw_delta_rest_client(url: &str, token: &str) -> (Url, reqwest::Client) {
     (base, http)
 }
 
-/// Maps vended storage credentials into `object_store` option keys so the table's cloud store can
-/// be constructed. Currently handles the AWS S3 credential keys; pass-through for anything else
-/// (e.g. region), plus a `UC_AWS_REGION` fallback since vended creds may omit the region. Used by
-/// the CREATE path (`CreateStagingTableResponse.storage_credentials`).
-fn object_store_options(creds: &[StorageCredential]) -> HashMap<String, String> {
-    let mut opts = HashMap::new();
-    for cred in creds {
-        for (key, value) in &cred.config {
-            let mapped = match key.as_str() {
-                "s3.access-key-id" => "access_key_id",
-                "s3.secret-access-key" => "secret_access_key",
-                "s3.session-token" => "session_token",
-                // Pass keys we don't remap (e.g. region) through unchanged; intentional, test-only.
-                other => other,
-            };
-            opts.insert(mapped.to_string(), value.clone());
-        }
-    }
-    if let Ok(region) = std::env::var("UC_AWS_REGION") {
-        opts.insert("region".to_string(), region);
-    }
-    opts
-}
-
 /// Normalize a UC table location to a root URL ending in `/`. UC returns the location without a
 /// trailing slash, but staged-commit path resolution and snapshot building require one.
 fn normalize_table_root(table_url: &Url) -> Url {
@@ -141,25 +115,11 @@ fn normalize_table_root(table_url: &Url) -> Url {
     root
 }
 
-/// Builds a `Snapshot` from a `load_table` response: normalize the location, build the log tail
-/// from the inline commits, and pin the snapshot to the catalog's max version. Returns the
-/// normalized table root alongside the snapshot.
-fn snapshot_from_load_table(resp: &LoadTableResponse, engine: &dyn Engine) -> (Url, Arc<Snapshot>) {
-    let root = normalize_table_root(
-        &Url::parse(&resp.metadata.location).expect("location is not a valid URL"),
-    );
-    let max_version: u64 = resp
-        .latest_table_version
-        .unwrap_or(0)
-        .try_into()
-        .expect("latest_table_version does not fit u64");
-    let log_tail = log_tail_from_commits(&resp.commits, root.clone()).expect("log tail");
-    let snapshot = Snapshot::builder_for(root.clone())
-        .with_log_tail(log_tail)
-        .with_max_catalog_version(max_version)
+fn snapshot_from_load_table(resp: &LoadTableResponse, engine: &dyn Engine) -> Arc<Snapshot> {
+    snapshot_builder_from_load_table(resp)
+        .expect("build snapshot builder from load_table response")
         .build(engine)
-        .expect("failed to build snapshot from load_table response");
-    (root, snapshot)
+        .expect("build snapshot from load_table response")
 }
 
 /// `load_table` returns parseable metadata + commits, and the commits convert to a kernel log tail.
@@ -199,32 +159,6 @@ async fn live_load_table_builds_log_tail() {
     );
 }
 
-/// Translate the staging response's required protocol + properties into the table properties the v0
-/// create commit must carry. Each required protocol feature becomes
-/// `delta.feature.<name>=supported` so kernel enables it; required raw properties with concrete
-/// values pass through (a null value means "any value is acceptable").
-fn disk_properties_from_staging(resp: &CreateStagingTableResponse) -> HashMap<String, String> {
-    let mut props: HashMap<String, String> = resp
-        .required_protocol
-        .reader_features
-        .iter()
-        .chain(resp.required_protocol.writer_features.iter())
-        .map(|f| (format!("delta.feature.{f}"), "supported".to_string()))
-        .collect();
-    for (k, v) in &resp.required_properties {
-        // Skip properties kernel derives from the enabled features and forbids setting at CREATE
-        // (e.g. `delta.checkpointPolicy` is implied by `delta.feature.v2Checkpoint`).
-        if k == "delta.checkpointPolicy" {
-            continue;
-        }
-        if let Some(v) = v {
-            props.insert(k.clone(), v.clone());
-        }
-    }
-    props.insert("io.unitycatalog.tableId".to_string(), resp.table_id.clone());
-    props
-}
-
 /// Live CREATE through the full connector flow. The two CREATE endpoints (`staging-tables`,
 /// `tables`) are deliberately not in the REST client, so this test hand-rolls those POSTs with raw
 /// `reqwest` while using kernel for the v0 commit and the typed `tables` body. The inline
@@ -235,7 +169,7 @@ fn disk_properties_from_staging(resp: &CreateStagingTableResponse) -> HashMap<St
 /// is forwarded at create and advances to 2 after the append (the CTAS concern), and the clustering
 /// columns are forwarded under `delta.clustering`.
 ///
-/// This mutates the catalog, so it is double-gated: requires `UC_CREATE=1`. Uses a unique table
+/// This mutates the catalog, so point it only at a throwaway server or schema. Uses a unique table
 /// name and best-effort DELETEs before and after to keep reruns idempotent.
 #[tokio::test(flavor = "multi_thread")]
 async fn live_create_table() {
@@ -243,10 +177,6 @@ async fn live_create_table() {
         eprintln!("UC_SERVER_URL unset; skipping live_create_table");
         return;
     };
-    if std::env::var("UC_CREATE").is_err() {
-        eprintln!("UC_CREATE unset; skipping mutating live_create_table");
-        return;
-    }
     let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
     let schema_name = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
     // Unique per run: a leftover table/staging-table from a prior run (best-effort cleanup can
@@ -295,11 +225,14 @@ async fn live_create_table() {
     // (c)/(d) Build the engine over the staging storage location.
     let table_root =
         normalize_table_root(&Url::parse(&resp.location).expect("location is not a valid URL"));
-    let store = store_from_url_opts(&table_root, object_store_options(&resp.storage_credentials))
-        .expect("failed to build object store from staging credentials");
+    let store = store_from_url_opts(
+        &table_root,
+        aws_object_store_options(&resp.storage_credentials, "us-east-1"),
+    )
+    .expect("failed to build object store from staging credentials");
     let engine = Arc::new(DefaultEngineBuilder::new(store).build());
 
-    // A server backed by local-FS storage (e.g. the OSS server in CI) allocates the table location
+    // A server backed by local-FS storage (e.g. the server in CI) allocates the table location
     // logically without creating the directory; kernel lists the table root during create-table and
     // `LocalFileSystem` errors on a missing path (a cloud object store returns empty). Create it
     // for file:// locations so the create-table build can proceed.
@@ -330,12 +263,12 @@ async fn live_create_table() {
     // (f)/(g) Commit v0 directly to storage via the UC committer (v0 path does not call the
     // catalog). Enable row tracking so the create body carries `delta.rowTracking`, and cluster on
     // `name` and the nested `address.city` so it carries `delta.clustering`.
-    let mut disk_props = disk_properties_from_staging(&resp);
+    let mut disk_props = get_required_properties_for_disk(&resp.table_id);
     disk_props.insert("delta.enableRowTracking".to_string(), "true".to_string());
     let committer = Box::new(UCCommitter::new(
         Arc::new(UCUpdateTableRestClient::new(client_config(&url, &token)).expect("update client")),
         resp.table_id.clone(),
-        TableName::new(catalog.clone(), schema_name.clone(), name.to_string()),
+        TableIdentifier::new(catalog.clone(), schema_name.clone(), name.to_string()),
     ));
     create_table(table_root.as_str(), schema, "delta-kernel-rs-live-test")
         .with_table_properties(disk_props)
@@ -364,7 +297,7 @@ async fn live_create_table() {
     );
 
     // (i)/(j) Build the typed create body and register the table.
-    let mut req = build_uc_create_table_request(&snapshot, engine.as_ref(), name)
+    let req = build_uc_create_table_request(&snapshot, engine.as_ref(), name)
         .expect("failed to build CreateTableRequest");
     // Empty create forwards the initial row-tracking watermark and the clustering columns.
     assert_eq!(
@@ -377,12 +310,18 @@ async fn live_create_table() {
     )
     .expect("clusteringColumns should deserialize");
     assert_eq!(clustering, vec![vec!["name"], vec!["address", "city"]]);
-    // The server requires `delta.checkpointPolicy=v2` in the create body for v2Checkpoint tables.
-    // The kernel does not write the companion `delta.checkpointPolicy` property when enabling the
-    // `v2Checkpoint` feature, so it is absent from the committed metadata. The connector supplies
-    // it here to satisfy the server contract.
-    req.properties
-        .insert("delta.checkpointPolicy".to_string(), "v2".to_string());
+    for (key, value) in [
+        ("delta.checkpoint.writeStatsAsStruct", "true"),
+        ("delta.checkpoint.writeStatsAsJson", "true"),
+        ("delta.enableDeletionVectors", "true"),
+        ("delta.checkpointPolicy", "v2"),
+    ] {
+        assert_eq!(
+            req.properties.get(key).map(String::as_str),
+            Some(value),
+            "{key} should be present in the create body"
+        );
+    }
     let req_json = serde_json::to_string_pretty(&req).expect("serialize CreateTableRequest");
     let create_resp = http
         .post(tables_base.join("tables").expect("tables URL"))
@@ -414,7 +353,7 @@ async fn live_create_table() {
         .load_table(&catalog, &schema_name, name)
         .await
         .expect("load_table before append failed");
-    let (_, snapshot) = snapshot_from_load_table(&pre, engine.as_ref());
+    let snapshot = snapshot_from_load_table(&pre, engine.as_ref());
 
     let id_col: ArrayRef = Arc::new(Int32Array::from(vec![10, 20, 30]));
     let name_col: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "z"]));
@@ -431,7 +370,7 @@ async fn live_create_table() {
     let append_committer = Box::new(UCCommitter::new(
         Arc::new(UCUpdateTableRestClient::new(client_config(&url, &token)).expect("update client")),
         resp.table_id.clone(),
-        TableName::new(catalog.clone(), schema_name.clone(), name.to_string()),
+        TableIdentifier::new(catalog.clone(), schema_name.clone(), name.to_string()),
     ));
     insert_data_with(
         snapshot,
@@ -450,7 +389,7 @@ async fn live_create_table() {
         .load_table(&catalog, &schema_name, name)
         .await
         .expect("load_table after append failed");
-    let (_, snapshot) = snapshot_from_load_table(&post, engine.as_ref());
+    let snapshot = snapshot_from_load_table(&post, engine.as_ref());
 
     // Appending 3 rows to a row-tracking table assigns IDs 0..=2, advancing the mark from -1 to 2.
     let row_tracking = snapshot

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -1,8 +1,10 @@
 //! Live end-to-end tests against a running Unity Catalog server.
 //!
-//! These are gated behind the `integration-test` feature so they are never compiled or run by a
-//! normal `cargo nextest`. Even with the feature enabled, each test skips (passes as a no-op) when
-//! `UC_SERVER_URL` is unset, so a developer can build the suite without a server on hand.
+//! These are gated behind the `integration-test` feature so they are never compiled by a normal
+//! `cargo nextest`, and marked `#[ignore]` so that even with the feature enabled they report as
+//! skipped rather than passing. Run them against a UC server with
+//! `--run-ignored only -E 'test(live_)'` (see the UC CI job). Each also returns early if
+//! `UC_SERVER_URL` is unset.
 //!
 //! Run against a local UC server:
 //! ```bash
@@ -126,6 +128,7 @@ fn snapshot_from_load_table(resp: &LoadTableResponse, engine: &dyn Engine) -> Ar
 /// Skips unless `UC_TEST_TABLE` names an existing managed delta table. This validates the read-path
 /// wire types without requiring storage credentials (it does not read data files).
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_load_table_builds_log_tail() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_load_table_builds_log_tail");
@@ -160,18 +163,17 @@ async fn live_load_table_builds_log_tail() {
 }
 
 /// Live CREATE through the full connector flow. The two CREATE endpoints (`staging-tables`,
-/// `tables`) are deliberately not in the REST client, so this test hand-rolls those POSTs with raw
-/// `reqwest` while using kernel for the v0 commit and the typed `tables` body. The inline
-/// `(a)`-`(n)` markers walk the flow.
+/// `tables`) are not yet on the REST client (tracked by #3032), so this test hand-rolls those POSTs
+/// with raw `reqwest` while using kernel for the v0 commit and the typed `tables` body.
 ///
 /// The table enables row tracking and clustering so the create body and the write path exercise the
 /// `delta.rowTracking` and `delta.clustering` domains in one round trip: the initial watermark (-1)
 /// is forwarded at create and advances to 2 after the append (the CTAS concern), and the clustering
 /// columns are forwarded under `delta.clustering`.
 ///
-/// This mutates the catalog, so point it only at a throwaway server or schema. Uses a unique table
-/// name and best-effort DELETEs before and after to keep reruns idempotent.
+/// This mutates the catalog, so point it only at a throwaway server or schema.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_create_table() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_create_table");
@@ -179,8 +181,8 @@ async fn live_create_table() {
     };
     let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
     let schema_name = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
-    // Unique per run: a leftover table/staging-table from a prior run (best-effort cleanup can
-    // fail) otherwise 409s the staging-tables POST. Suffix keeps reruns collision-free.
+    // Unique per run so reruns never collide on the staging-tables POST (which 409s on a name
+    // already present).
     let name = format!("kernel_rs_create_test_{}", uuid::Uuid::new_v4().simple());
     let name = name.as_str();
 
@@ -189,13 +191,7 @@ async fn live_create_table() {
         .join(&format!("catalogs/{catalog}/schemas/{schema_name}/"))
         .expect("tables base URL");
 
-    // (a) Best-effort cleanup of a prior run; ignore non-2xx/404.
-    let table_url = tables_base
-        .join(&format!("tables/{name}"))
-        .expect("table URL");
-    let _ = http.delete(table_url.clone()).send().await;
-
-    // (b) POST staging-tables -> allocate uuid + storage + staging credentials.
+    // ===== Step 1: POST staging-tables -> allocate uuid + storage + staging credentials =====
     let staging_url = tables_base
         .join("staging-tables")
         .expect("staging-tables URL");
@@ -222,7 +218,7 @@ async fn live_create_table() {
         .await
         .expect("failed to deserialize CreateStagingTableResponse");
 
-    // (c)/(d) Build the engine over the staging storage location.
+    // ===== Step 2: Build the engine over the staging storage location =====
     let table_root =
         normalize_table_root(&Url::parse(&resp.location).expect("location is not a valid URL"));
     let store = store_from_url_opts(
@@ -242,7 +238,8 @@ async fn live_create_table() {
         }
     }
 
-    // (e) Schema with a nested struct so clustering can target both a top-level and a nested
+    // ===== Step 3: Define the schema =====
+    // A nested struct so clustering can target both a top-level and a nested
     // column.
     let schema: SchemaRef = Arc::new(
         StructType::try_new(vec![
@@ -260,9 +257,10 @@ async fn live_create_table() {
         .expect("failed to build schema"),
     );
 
-    // (f)/(g) Commit v0 directly to storage via the UC committer (v0 path does not call the
-    // catalog). Enable row tracking so the create body carries `delta.rowTracking`, and cluster on
-    // `name` and the nested `address.city` so it carries `delta.clustering`.
+    // ===== Step 4: Invoke kernel to write the v0 commit (00.json) via the UC committer =====
+    // The v0 path writes directly to storage and does not call the catalog. Enable row tracking so
+    // the create body carries `delta.rowTracking`, and cluster on `name` and the nested
+    // `address.city` so it carries `delta.clustering`.
     let mut disk_props = get_required_properties_for_disk(&resp.table_id);
     disk_props.insert("delta.enableRowTracking".to_string(), "true".to_string());
     let committer = Box::new(UCCommitter::new(
@@ -284,8 +282,9 @@ async fn live_create_table() {
         .expect("failed to commit create-table transaction")
         .unwrap_committed();
 
-    // (h) Load the post-commit v0 snapshot. The table is catalog-managed, so the snapshot build
-    // requires the catalog's max version; the just-created table is at v0.
+    // ===== Step 5: Load the post-commit v0 snapshot =====
+    // The table is catalog-managed, so the snapshot build requires the catalog's max version; the
+    // just-created table is at v0.
     let snapshot = Snapshot::builder_for(table_root.clone())
         .with_max_catalog_version(0)
         .build(engine.as_ref())
@@ -296,7 +295,7 @@ async fn live_create_table() {
         "post-create snapshot should be at version 0"
     );
 
-    // (i)/(j) Build the typed create body and register the table.
+    // ===== Step 6: Build the typed create body and register the table with UC (POST tables) =====
     let req = build_uc_create_table_request(&snapshot, engine.as_ref(), name)
         .expect("failed to build CreateTableRequest");
     // Empty create forwards the initial row-tracking watermark and the clustering columns.
@@ -337,7 +336,7 @@ async fn live_create_table() {
         );
     }
 
-    // (k) Verify registration: the table loads and its uuid matches the staging table id.
+    // ===== Step 7: Verify registration: the table loads and its uuid matches the staging id =====
     let loaded = client(&url, &token)
         .load_table(&catalog, &schema_name, name)
         .await
@@ -347,7 +346,7 @@ async fn live_create_table() {
         "loaded table uuid should match the staging table id"
     );
 
-    // (m) Append 3 rows through the connector write path, then scan them back.
+    // ===== Step 8: Append 3 rows through the connector write path, then scan them back =====
     let uc = client(&url, &token);
     let pre = uc
         .load_table(&catalog, &schema_name, name)
@@ -405,7 +404,4 @@ async fn live_create_table() {
     let batches = read_scan(&scan, engine.clone() as Arc<dyn Engine>).expect("read_scan failed");
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, 3, "appended rows should be returned by the scan");
-
-    // (n) Best-effort cleanup.
-    let _ = http.delete(table_url).send().await;
 }

--- a/docs/user-guide/src/unity_catalog/creating_tables.md
+++ b/docs/user-guide/src/unity_catalog/creating_tables.md
@@ -48,12 +48,19 @@ use delta_kernel_unity_catalog::get_required_properties_for_disk;
 let disk_props = get_required_properties_for_disk(&table_id);
 ```
 
-The returned map has exactly three entries:
+The returned map has exactly eight entries: four `delta.feature.*` signals that enable the required
+table features, three companion config properties that kernel does not write itself, and the UC
+table ID.
 
 | Key | Value |
 |-----|-------|
 | `delta.feature.catalogManaged` | `supported` |
 | `delta.feature.vacuumProtocolCheck` | `supported` |
+| `delta.feature.v2Checkpoint` | `supported` |
+| `delta.feature.deletionVectors` | `supported` |
+| `delta.enableDeletionVectors` | `true` |
+| `delta.checkpoint.writeStatsAsStruct` | `true` |
+| `delta.checkpoint.writeStatsAsJson` | `true` |
 | `io.unitycatalog.tableId` | the UC-assigned table ID |
 
 > [!NOTE]
@@ -135,9 +142,11 @@ let create_req = build_uc_create_table_request(&post_commit_snapshot, &engine, "
 > `build_uc_create_table_request` requires a version 0 snapshot with an in-commit timestamp. The
 > `post_commit_snapshot` from Step 3 satisfies both.
 >
-> If your UC server requires `delta.checkpointPolicy=v2` for `v2Checkpoint` tables, insert it into
-> `create_req.properties` before sending: kernel enables the `v2Checkpoint` feature without writing
-> the companion property.
+> The companion config properties from `get_required_properties_for_disk`
+> (`delta.enableDeletionVectors`, `delta.checkpoint.writeStatsAsStruct`,
+> `delta.checkpoint.writeStatsAsJson`) round-trip from the committed metadata into `properties`
+> automatically. `build_uc_create_table_request` also sets `delta.checkpointPolicy=v2` in the request
+> body, which kernel's CREATE TABLE rejects as a table property and so cannot round-trip from disk.
 
 ## Step 5: Finalize the table in Unity Catalog
 

--- a/docs/user-guide/src/unity_catalog/creating_tables.md
+++ b/docs/user-guide/src/unity_catalog/creating_tables.md
@@ -12,12 +12,10 @@ Before reading this page, make sure you understand
 [Creating a Table](../writing/create_table.md) and the
 [Unity Catalog Integration overview](./overview.md).
 
-> [!WARNING]
-> The create flow is not yet wired end-to-end. `UCCommitter::commit` currently
-> rejects version 0 (see #2826), so Step 3 does not work yet. This page
-> documents the intended flow. In addition, Steps 1 and 5 call UC endpoints that
-> the Rust `unity-catalog-delta-client-default` crate does not yet expose. Route
-> those through your connector's own UC client.
+> [!NOTE]
+> Steps 1 and 5 call UC endpoints that the Rust `unity-catalog-delta-client-default`
+> crate does not yet expose. Route those through your connector's own UC client;
+> the request and response wire types live in `unity-catalog-delta-client-api`.
 
 ## Prerequisites
 
@@ -27,15 +25,19 @@ Before reading this page, make sure you understand
 
 ## Step 1: Reserve the table in Unity Catalog
 
+POST a `CreateStagingTableRequest` to the UC `staging-tables` endpoint. UC allocates a table ID
+and storage location and returns temporary credentials for the initial commit.
+
 ```rust,ignore
-// TODO: not yet exposed by `unity-catalog-delta-client-default`. Call through
-// your connector's own UC client.
-let staging_info = my_uc_client.get_staging_table(
-    "main.default.my_table",
-    &schema,
-).await?;
+use unity_catalog_delta_client_api::{CreateStagingTableRequest, CreateStagingTableResponse};
+
+// The `staging-tables` POST is not yet exposed as a method on `UCClient`. Send the request
+// through your connector's own UC HTTP client; the request and response wire types live in
+// `unity-catalog-delta-client-api`.
+let staging_req = CreateStagingTableRequest { name: "my_table".to_string() };
+let staging_info: CreateStagingTableResponse = my_uc_client.post_staging_table(staging_req).await?;
 let table_id = staging_info.table_id;
-let table_uri = staging_info.storage_location;
+let table_uri = staging_info.location;
 ```
 
 ## Step 2: Collect the disk-bound properties
@@ -70,16 +72,15 @@ use unity_catalog_delta_client_api::{Operation, TableIdentifier};
 use unity_catalog_delta_client_default::{ClientConfig, UCClient, UCUpdateTableRestClient};
 
 let config = ClientConfig::build(&endpoint, &token).build()?;
-let uc_client = UCClient::new(config.clone())?;
 let update_client = Arc::new(UCUpdateTableRestClient::new(config)?);
 
-// Credentials. Use ReadWrite so the engine can write 000.json into storage.
-let creds = uc_client
-    .get_table_credentials("main", "default", "my_table", Operation::ReadWrite)
-    .await?;
-let engine = build_engine_with_credentials(&table_uri, &creds)?;
+// Build the engine over the staging storage location using the staging credentials
+// (`staging_info.storage_credentials`). `build_engine_with_credentials` is a connector-owned
+// helper; see Step 4 of [Reading UC Tables](./reading.md#step-4-build-an-engine-with-vended-credentials).
+let engine = build_engine_with_credentials(&table_uri, &staging_info.storage_credentials)?;
 
-// Build the create-table transaction with the disk-bound properties.
+// Build the create-table transaction with the disk-bound properties. `UCCommitter::new` takes the
+// commit client plus the table's UC-assigned id and its three-part name.
 let committer = Box::new(UCCommitter::new(
     update_client.clone(),
     table_id.clone(),
@@ -105,45 +106,47 @@ let post_commit_snapshot = match create_txn.commit(&engine)? {
 };
 ```
 
-Once wired (#2826), version 0 has `UCCommitter` write
-`_delta_log/00000000000000000000.json` directly and skip the UC commits API.
+On version 0, `UCCommitter` writes `_delta_log/00000000000000000000.json`
+directly and skips the `update_table` API.
 
-See `build_engine_with_credentials` in
-[Step 4 of Reading UC Tables](./reading.md#step-4-build-an-engine-with-vended-credentials)
-for the engine construction details.
+## Step 4: Build the create-table request for UC
 
-## Step 4: Collect the final UC-bound properties
+`build_uc_create_table_request` reads the post-commit version 0 snapshot and produces a typed
+`CreateTableRequest` to send to UC's create-table endpoint. Each part of the request maps to a
+distinct typed field, so the same information is never duplicated across fields:
 
 ```rust,ignore
-use delta_kernel_unity_catalog::get_final_required_properties_for_uc;
+use delta_kernel_unity_catalog::build_uc_create_table_request;
 
-let uc_props = get_final_required_properties_for_uc(&post_commit_snapshot, &engine)?;
+let create_req = build_uc_create_table_request(&post_commit_snapshot, &engine, "my_table")?;
 ```
 
-The returned map contains:
-
-- Every entry from the table's metadata configuration, including
-  `io.unitycatalog.tableId`, `delta.enableInCommitTimestamps=true`, and any
-  user-supplied custom properties.
-- `delta.minReaderVersion` and `delta.minWriterVersion`.
-- `delta.feature.<name>=supported` for every reader and writer feature on the
-  protocol (for a freshly created UC table this is at least `catalogManaged`,
-  `vacuumProtocolCheck`, and `inCommitTimestamp`).
-- `delta.lastUpdateVersion=0`.
-- `delta.lastCommitTimestamp` set to the in-commit timestamp of version 0.
-- `clusteringColumns` as a JSON array of logical column paths, if the table is
-  clustered.
+- `columns` carries the serialized table schema, and `partition_columns` the partition column names.
+- `protocol` is a typed field holding the min reader and writer versions and the reader and writer
+  feature names (for a freshly created UC table this is at least `catalogManaged`,
+  `vacuumProtocolCheck`, and `inCommitTimestamp`). Features are not flattened into `properties`.
+- `domain_metadata` carries the `delta.clustering` and `delta.rowTracking` domains verbatim when
+  present. UC ignores any other domain.
+- `properties` is the table's metadata configuration as-is, such as `io.unitycatalog.tableId`,
+  `delta.enableInCommitTimestamps`, and any user-supplied custom properties. Protocol and clustering
+  data live in their own fields above, not here.
 
 > [!NOTE]
-> `get_final_required_properties_for_uc` requires a version 0 snapshot with an
-> in-commit timestamp. The `post_commit_snapshot` from Step 3 satisfies both.
+> `build_uc_create_table_request` requires a version 0 snapshot with an in-commit timestamp. The
+> `post_commit_snapshot` from Step 3 satisfies both.
+>
+> If your UC server requires `delta.checkpointPolicy=v2` for `v2Checkpoint` tables, insert it into
+> `create_req.properties` before sending: kernel enables the `v2Checkpoint` feature without writing
+> the companion property.
 
 ## Step 5: Finalize the table in Unity Catalog
 
+POST the `CreateTableRequest` to UC's create-table (`tables`) endpoint to register the table.
+
 ```rust,ignore
-// TODO: not yet exposed by `unity-catalog-delta-client-default`. Call through
-// your connector's own UC client.
-my_uc_client.create_table(&table_id, uc_props).await?;
+// The create-table POST is not yet exposed as a method on `UCClient`. Send the typed
+// `CreateTableRequest` through your connector's own UC HTTP client.
+my_uc_client.post_create_table(create_req).await?;
 ```
 
 ## Clustered tables
@@ -159,8 +162,9 @@ let create_txn = create_table(table_uri.as_str(), Arc::new(schema), "MyApp/1.0")
     .build(&engine, committer)?;
 ```
 
-`get_final_required_properties_for_uc` adds a `clusteringColumns` entry (a
-JSON array of logical column paths) to its output when clustering is enabled.
+`build_uc_create_table_request` forwards the committed `delta.clustering` domain verbatim into the
+request's domain metadata. Its `clusteringColumns` paths are physical column names when column
+mapping is enabled, matching what the table committed.
 
 ## What's next
 

--- a/docs/user-guide/src/unity_catalog/overview.md
+++ b/docs/user-guide/src/unity_catalog/overview.md
@@ -82,19 +82,21 @@ This crate connects the UC client layer to Kernel's APIs. It depends on both
   response into a `Vec<LogPath>` log tail. Use it directly when you need to assemble
   the `SnapshotBuilder` yourself.
 - **`UCCommitter<C: UpdateTableClient>`**: implements Kernel's `Committer` trait
-  for UC tables. Version 0 (table creation) is not yet supported (#2826). For
-  version >= 1, it writes a staged commit to `_delta_log/_staged_commits/`, then
-  calls the UC `update_table` API to ratify it. The `publish()` method copies
-  ratified staged commits to `_delta_log/` as published commits.
+  for UC tables. Version 0 (table creation) writes `00000000000000000000.json`
+  directly and skips `update_table`. For version >= 1, it writes a staged commit
+  to `_delta_log/_staged_commits/`, then calls the UC `update_table` API to ratify
+  it. The `publish()` method copies ratified staged commits to `_delta_log/` as
+  published commits.
 - **`get_required_properties_for_disk()`**: returns the table properties you
   must include when creating a UC-managed table (the `catalogManaged` and
   `vacuumProtocolCheck` feature signals, plus the `io.unitycatalog.tableId`).
   Kernel's `create_table()` consumes these as table properties on the version 0
   commit.
-- **`get_final_required_properties_for_uc()`**: extracts the full set of
-  properties from the post-creation Snapshot (feature signals, protocol
-  versions, in-commit timestamp, optional clustering columns) that you send to
-  your UC server's table-registration endpoint to finalize the table.
+- **`build_uc_create_table_request()`**: reads the post-creation version 0
+  Snapshot and produces a typed `CreateTableRequest` whose schema, partition
+  columns, protocol, domain metadata, and metadata-config properties are separate
+  typed fields. You send it to your UC server's table-registration endpoint to
+  finalize the table.
 
 See [Creating UC Tables](./creating_tables.md) for the end-to-end creation
 flow and how these two utilities fit together.
@@ -163,8 +165,9 @@ connector reads or writes a UC-managed table.
 ```
 
 The diagram shows the steady-state commit flow for an existing table. Version 0
-(table creation) is not yet supported by `UCCommitter` (#2826). See
-[Creating UC Tables](./creating_tables.md) for the intended creation flow.
+(table creation) takes a different path: `UCCommitter` writes the published commit
+directly and skips `update_table`. See [Creating UC Tables](./creating_tables.md)
+for the creation flow.
 
 ## Dependencies and feature flags
 
@@ -249,7 +252,7 @@ extension points.
 
 - [Creating UC Tables](./creating_tables.md): how to create a new UC-managed
   table using `get_required_properties_for_disk` and
-  `get_final_required_properties_for_uc`.
+  `build_uc_create_table_request`.
 - [Reading UC Tables](./reading.md): how to load a Snapshot and read data from
   a UC-managed table.
 - [Writing to UC Tables](./writing.md): how to commit and publish writes through

--- a/docs/user-guide/src/unity_catalog/overview.md
+++ b/docs/user-guide/src/unity_catalog/overview.md
@@ -88,10 +88,11 @@ This crate connects the UC client layer to Kernel's APIs. It depends on both
   it. The `publish()` method copies ratified staged commits to `_delta_log/` as
   published commits.
 - **`get_required_properties_for_disk()`**: returns the table properties you
-  must include when creating a UC-managed table (the `catalogManaged` and
-  `vacuumProtocolCheck` feature signals, plus the `io.unitycatalog.tableId`).
-  Kernel's `create_table()` consumes these as table properties on the version 0
-  commit.
+  must include when creating a UC-managed table (the `catalogManaged`,
+  `vacuumProtocolCheck`, `v2Checkpoint`, and `deletionVectors` feature signals,
+  the companion config properties kernel does not write itself, plus the
+  `io.unitycatalog.tableId`). Kernel's `create_table()` consumes these as table
+  properties on the version 0 commit.
 - **`build_uc_create_table_request()`**: reads the post-creation version 0
   Snapshot and produces a typed `CreateTableRequest` whose schema, partition
   columns, protocol, domain metadata, and metadata-config properties are separate

--- a/docs/user-guide/src/unity_catalog/writing.md
+++ b/docs/user-guide/src/unity_catalog/writing.md
@@ -151,8 +151,9 @@ Under the hood, `UCCommitter::commit` does two things for versions >= 1:
 2. Submits the staged commit to the UC `update_table` API, where Unity Catalog
    ratifies it
 
-Version 0 (table creation) is not yet supported by `UCCommitter` (#2826).
-See [Creating UC Tables](./creating_tables.md) for the intended creation flow and
+Version 0 (table creation) takes a different path: `UCCommitter` writes
+`_delta_log/00000000000000000000.json` directly and skips the `update_table` API.
+See [Creating UC Tables](./creating_tables.md) for the creation flow and
 [the catalog-managed write lifecycle](../catalog_managed/writing.md) for the
 generic ratification flow.
 

--- a/unity-catalog-delta-client-default/tests/integration_live_server.rs
+++ b/unity-catalog-delta-client-default/tests/integration_live_server.rs
@@ -47,6 +47,7 @@ fn raw_delta_client(url: &str, token: &str, catalog: &str, schema: &str) -> (Url
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_get_config_round_trips() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_get_config_round_trips");
@@ -70,6 +71,7 @@ async fn live_get_config_round_trips() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_load_table_reads_metadata() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_load_table_reads_metadata");
@@ -117,6 +119,7 @@ async fn live_load_table_reads_metadata() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_get_table_credentials() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_get_table_credentials");
@@ -172,6 +175,7 @@ async fn live_get_table_credentials() {
 /// Validates the `CreateStagingTableRequest` / `CreateStagingTableResponse` wire types against a
 /// real server.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a running UC server; run with --run-ignored (UC CI job or manual)"]
 async fn live_create_staging_table() {
     let Some((url, token)) = server_env() else {
         eprintln!("UC_SERVER_URL unset; skipping live_create_staging_table");

--- a/unity-catalog-delta-client-default/tests/integration_live_server.rs
+++ b/unity-catalog-delta-client-default/tests/integration_live_server.rs
@@ -177,10 +177,6 @@ async fn live_create_staging_table() {
         eprintln!("UC_SERVER_URL unset; skipping live_create_staging_table");
         return;
     };
-    if std::env::var("UC_CREATE").is_err() {
-        eprintln!("UC_CREATE unset; skipping mutating live_create_staging_table");
-        return;
-    }
     let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
     let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
     let table = "delta_rest_client_staging_test";


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2826/files) to review incremental changes.
- [**stack/uc-api-v2**](https://github.com/delta-io/delta-kernel-rs/pull/2826) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2826/files)] ← _this PR_
  - [stack/uc-metrics](https://github.com/delta-io/delta-kernel-rs/pull/2956) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2956/files/8ec7e4ae2e4d6d140a05d1d082f9f401dc03029f..3a4fba36110308f1c908ad9964bc9e0d204f7c55)]
    - [stack/uc-client-user-agent](https://github.com/delta-io/delta-kernel-rs/pull/3033) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3033/files/3a4fba36110308f1c908ad9964bc9e0d204f7c55..36e0a060bf1a6ffe536aad4ce03cf445fb8bf2ab)]
      - [stack/uc-create-table](https://github.com/delta-io/delta-kernel-rs/pull/3034) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3034/files/36e0a060bf1a6ffe536aad4ce03cf445fb8bf2ab..2f7fb9a4716b42b73faf3f3ff42ed1eff0a9d28c)]

---------
## What changes are proposed in this pull request?

This change wires the UC crates onto the UC Delta-Tables API for catalog-managed CREATE TABLE. This change also adds the FFI bindings, CI wiring for the UC server, and an end-to-end live-server test. Lastly, this change updates the CREATE TABLE documentation for the new `build_uc_create_table_request` API.

## How was this change tested?

1. new create table, UC Committer UTs.
2. in memory E2E tests.
3. live UC server integration tests.
