### PR TITLE
test: add data-skipping predicate to the cross-product sweep

### DIFF
--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{Array, Int32Array, RecordBatch};
-use delta_kernel::expressions::{lit, Expression};
+use delta_kernel::expressions::{lit, Expression, PredicateRef};
 use delta_kernel::schema::MetadataColumnSpec;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
@@ -130,12 +130,31 @@ fn test_cross_product_read_write(
     Ok(())
 }
 
+/// Counts the files surviving data skipping for `predicate`. Skipping is file-level, so this
+/// reflects effectiveness (how many files the predicate pruned), unlike the sweep's
+/// row-level soundness check.
+fn count_scan_files(
+    snap: &Arc<Snapshot>,
+    engine: &dyn Engine,
+    predicate: PredicateRef,
+) -> DeltaResult<usize> {
+    let scan = snap
+        .clone()
+        .scan_builder()
+        .with_predicate(predicate)
+        .build()?;
+    let mut files = 0usize;
+    for scan_metadata in scan.scan_metadata(engine)? {
+        files = scan_metadata?.visit_scan_files(files, |count, _| *count += 1)?;
+    }
+    Ok(files)
+}
+
 /// Effectiveness companion to the sweep's soundness assertion: with stats on the predicate
 /// column, a `>= SKIP_THRESHOLD` predicate must actually prune the version-1 file via min/max
-/// data skipping (whereas the sweep only proves skipping never drops a matching row). Counts
-/// the files surviving `scan_metadata` rather than rows, since skipping is file-level.
+/// data skipping (whereas the sweep only proves skipping never drops a matching row).
 #[test]
-fn test_data_skipping_prunes_files() -> DeltaResult<()> {
+fn test_min_max_skipping_prunes_files() -> DeltaResult<()> {
     // `num_indexed_cols_all` writes stats for every leaf column, so `int_col` is indexed.
     let table = TestTableBuilder::new()
         .with_log_state(LogState::with_latest_version(3))
@@ -147,15 +166,33 @@ fn test_data_skipping_prunes_files() -> DeltaResult<()> {
 
     // v1 = [1000, 1009], v2 = [2000, 2009], v3 = [3000, 3009]. `int_col >= 2000` excludes v1.
     let predicate = Arc::new(Expression::column(["int_col"]).ge(lit(SKIP_THRESHOLD)));
-    let scan = snap.scan_builder().with_predicate(predicate).build()?;
-    let mut files = 0usize;
-    for scan_metadata in scan.scan_metadata(engine.as_ref())? {
-        files = scan_metadata?.visit_scan_files(files, |count, _| *count += 1)?;
-    }
+    let files = count_scan_files(&snap, engine.as_ref(), predicate)?;
     assert_eq!(
         files, 2,
         "version-1 file should be pruned by min/max skipping"
     );
+
+    Ok(())
+}
+
+/// Partition pruning effectiveness: a predicate on a partition column prunes files whose
+/// partition value can't match, using the Add action's partition values rather than min/max
+/// stats. Independent of `numIndexedCols`, since partition values are always present.
+#[test]
+fn test_partition_pruning_skips_files() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(3))
+        .with_data_layout(partitioned())
+        .build()?;
+    let engine: Arc<dyn Engine> =
+        Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+    let snap = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+
+    // The `part_long` partition value is `version * 1_000_000` (v1=1M, v2=2M, v3=3M), so
+    // `part_long >= 2_000_000` prunes version 1's partition.
+    let predicate = Arc::new(Expression::column(["part_long"]).ge(lit(2_000_000i64)));
+    let files = count_scan_files(&snap, engine.as_ref(), predicate)?;
+    assert_eq!(files, 2, "version-1 partition should be pruned");
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use delta_kernel::arrow::array::{Array, Int32Array, RecordBatch};
+use delta_kernel::expressions::{lit, Expression};
 use delta_kernel::schema::MetadataColumnSpec;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
@@ -17,7 +19,8 @@ use test_utils::table_builder::{
     two_checkpoints_stale_hint_post_cleanup, unpartitioned, version_at_mid,
     version_at_timestamp_max, version_incremental_from_mid_to_latest,
     version_incremental_from_mid_to_pre_latest, version_latest, with_json_stats, with_struct_stats,
-    DataLayoutConfig, FeatureSet, LogState, TableConfig, VersionTarget,
+    DataLayoutConfig, FeatureSet, LogState, TableConfig, TestTableBuilder, VersionTarget,
+    NULL_RATE_EVERY_NTH,
 };
 use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan};
 
@@ -25,6 +28,32 @@ use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan
 /// snapshot at version `v` has exactly `v * ROWS_PER_COMMIT` total rows. File count
 /// per commit isn't asserted because partitioned layouts may emit multiple files.
 const ROWS_PER_COMMIT: usize = 10;
+
+/// Data-skipping predicate threshold. The generator fills the skipping column with
+/// `version * 1000 + row`, so `>= 2000` keeps versions >= 2; version 1's max (well under
+/// 2000) makes its file prunable by min/max skipping.
+const SKIP_THRESHOLD: i32 = 2000;
+
+/// Counts non-null rows of the `INTEGER` column `col` whose value is `>= threshold`.
+fn count_at_least(batches: &[RecordBatch], col: &str, threshold: i32) -> usize {
+    batches
+        .iter()
+        .map(|batch| {
+            let idx = batch
+                .schema()
+                .index_of(col)
+                .expect("skipping column present in scan output");
+            let array = batch
+                .column(idx)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .expect("INTEGER column reads back as Int32Array");
+            (0..array.len())
+                .filter(|&i| array.is_valid(i) && array.value(i) >= threshold)
+                .count()
+        })
+        .sum()
+}
 
 /// `default_sweep` is the canonical `{LogState x FeatureSet x (DataLayoutConfig,
 /// TableConfig) x VersionTarget}` cross-product defined in `test_utils`. Data layout and
@@ -40,6 +69,7 @@ fn test_cross_product_read_write(
     version_target: VersionTarget,
 ) -> DeltaResult<()> {
     let (data_layout, table_config) = layout_config;
+    let skip_col = data_layout.skipping_column();
     let table = test_table(log_state.clone(), feature_set, data_layout, table_config);
     let engine: Arc<dyn Engine> =
         Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
@@ -64,6 +94,29 @@ fn test_cross_product_read_write(
     let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     assert_eq!(rows, expected_version as usize * ROWS_PER_COMMIT);
 
+    // Min/max data-skipping predicate on the integer column. Data skipping is file-level, not
+    // row-level, so the scan may return extra rows from files it kept; residual-filtering the
+    // result here asserts skipping is *sound* (no row satisfying the predicate is dropped)
+    // uniformly across stats configs. Matching rows live only in versions >= 2, whose files
+    // are never validly skippable, so the matching count is fixed regardless of whether
+    // version 1 was pruned.
+    let predicate = Arc::new(Expression::column([skip_col]).ge(lit(SKIP_THRESHOLD)));
+    let filtered_scan = snap
+        .clone()
+        .scan_builder()
+        .with_predicate(predicate)
+        .build()?;
+    let filtered_batches = read_scan(&filtered_scan, engine.clone())?;
+    let nulls_per_file = (0..ROWS_PER_COMMIT)
+        .filter(|i| i % NULL_RATE_EVERY_NTH == 0)
+        .count();
+    let matching_versions = expected_version.saturating_sub(1) as usize;
+    assert_eq!(
+        count_at_least(&filtered_batches, skip_col, SKIP_THRESHOLD),
+        matching_versions * (ROWS_PER_COMMIT - nulls_per_file),
+        "data skipping dropped rows that satisfy the predicate",
+    );
+
     if snap.table_properties().enable_row_tracking == Some(true) {
         let scan_schema = Arc::new(
             snap.schema()
@@ -73,6 +126,36 @@ fn test_cross_product_read_write(
         let batches = read_scan(&scan, engine)?;
         assert_row_ids_unique(&batches);
     }
+
+    Ok(())
+}
+
+/// Effectiveness companion to the sweep's soundness assertion: with stats on the predicate
+/// column, a `>= SKIP_THRESHOLD` predicate must actually prune the version-1 file via min/max
+/// data skipping (whereas the sweep only proves skipping never drops a matching row). Counts
+/// the files surviving `scan_metadata` rather than rows, since skipping is file-level.
+#[test]
+fn test_data_skipping_prunes_files() -> DeltaResult<()> {
+    // `num_indexed_cols_all` writes stats for every leaf column, so `int_col` is indexed.
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(3))
+        .with_table_config(num_indexed_cols_all())
+        .build()?;
+    let engine: Arc<dyn Engine> =
+        Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+    let snap = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+
+    // v1 = [1000, 1009], v2 = [2000, 2009], v3 = [3000, 3009]. `int_col >= 2000` excludes v1.
+    let predicate = Arc::new(Expression::column(["int_col"]).ge(lit(SKIP_THRESHOLD)));
+    let scan = snap.scan_builder().with_predicate(predicate).build()?;
+    let mut files = 0usize;
+    for scan_metadata in scan.scan_metadata(engine.as_ref())? {
+        files = scan_metadata?.visit_scan_files(files, |count, _| *count += 1)?;
+    }
+    assert_eq!(
+        files, 2,
+        "version-1 file should be pruned by min/max skipping"
+    );
 
     Ok(())
 }

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -20,7 +20,7 @@ use test_utils::table_builder::{
     version_at_timestamp_max, version_incremental_from_mid_to_latest,
     version_incremental_from_mid_to_pre_latest, version_latest, with_json_stats, with_struct_stats,
     DataLayoutConfig, FeatureSet, LogState, TableConfig, TestTableBuilder, VersionTarget,
-    NULL_RATE_EVERY_NTH,
+    NULL_RATE_EVERY_NTH, NULL_SKIP_COLUMN,
 };
 use test_utils::{assert_row_ids_unique, build_snapshot, default_sweep, read_scan};
 
@@ -193,6 +193,30 @@ fn test_partition_pruning_skips_files() -> DeltaResult<()> {
     let predicate = Arc::new(Expression::column(["part_long"]).ge(lit(2_000_000i64)));
     let files = count_scan_files(&snap, engine.as_ref(), predicate)?;
     assert_eq!(files, 2, "version-1 partition should be pruned");
+
+    Ok(())
+}
+
+/// Null-count skipping effectiveness: `NULL_SKIP_COLUMN` is all-null in version 1 and fully
+/// populated afterward, so `IS NOT NULL` prunes version 1's file using its null-count stat,
+/// independent of min/max bounds.
+#[test]
+fn test_null_count_skipping_prunes_files() -> DeltaResult<()> {
+    // `num_indexed_cols_all` writes stats (including null counts) for every leaf column.
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(3))
+        .with_table_config(num_indexed_cols_all())
+        .build()?;
+    let engine: Arc<dyn Engine> =
+        Arc::new(DefaultEngineBuilder::new(table.store().clone()).build());
+    let snap = Snapshot::builder_for(table.table_root()).build(engine.as_ref())?;
+
+    let predicate = Arc::new(Expression::column([NULL_SKIP_COLUMN]).is_not_null());
+    let files = count_scan_files(&snap, engine.as_ref(), predicate)?;
+    assert_eq!(
+        files, 2,
+        "version-1 all-null file should be pruned by null-count skipping"
+    );
 
     Ok(())
 }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -54,9 +54,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array, Float32Array,
-    Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch, StringArray,
-    StructArray, TimestampMicrosecondArray,
+    new_null_array, Array, ArrayRef, BinaryArray, BooleanArray, Date32Array, Decimal128Array,
+    Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, RecordBatch,
+    StringArray, StructArray, TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema, TimeUnit};
@@ -1473,15 +1473,26 @@ async fn write_data_commit<E: TaskExecutor>(
         let mut columns: Vec<ArrayRef> = Vec::new();
         for (arrow_field, kernel_field) in arrow_schema.fields().iter().zip(logical_schema.fields())
         {
-            if partition_set.contains(kernel_field.name().as_str()) {
+            let name = kernel_field.name().as_str();
+            if partition_set.contains(name) {
                 continue;
             }
             let data_type = arrow_field.data_type();
-            let values = generate_column(data_type, rows_per_file, base);
-            let values = if arrow_field.is_nullable() {
-                with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
+            let values = if name == NULL_SKIP_COLUMN {
+                // All-null in the first data version, fully populated afterward, so null-count
+                // skipping has one prunable file per predicate direction.
+                if version == 1 {
+                    new_null_array(data_type, rows_per_file)
+                } else {
+                    generate_column(data_type, rows_per_file, base)
+                }
             } else {
-                values
+                let values = generate_column(data_type, rows_per_file, base);
+                if arrow_field.is_nullable() {
+                    with_sparse_nulls(values, NULL_RATE_EVERY_NTH)
+                } else {
+                    values
+                }
             };
             columns.push(values);
             data_fields.push(arrow_field.clone());
@@ -1858,6 +1869,12 @@ fn scalar_for_type(data_type: &DataType, seed: usize) -> Scalar {
 // Helpers: schema
 // ===========================================================================
 
+/// Name of the default-schema column the generator fills as all-null in the first data
+/// version and fully populated afterward (no sparse nulls). With one all-null file and the
+/// rest fully populated, null-count data skipping can prune by version: `IS NOT NULL` prunes
+/// version 1, `IS NULL` prunes the later versions.
+pub const NULL_SKIP_COLUMN: &str = "null_skip_col";
+
 /// Default schema with all Delta primitive types including TimestampNtz
 /// and a nested column type.
 pub(crate) fn default_schema() -> SchemaRef {
@@ -1884,6 +1901,7 @@ pub(crate) fn default_schema() -> SchemaRef {
             .unwrap(),
             true,
         ),
+        StructField::nullable(NULL_SKIP_COLUMN, DataType::LONG),
     ]))
 }
 
@@ -2253,13 +2271,19 @@ mod tests {
         assert_eq!(total_rows, rows_per_file);
         let expected_nulls_per_col = rows_per_file / NULL_RATE_EVERY_NTH;
         for batch in &batches {
+            let schema = batch.schema();
             for col_idx in 0..batch.num_columns() {
+                let name = schema.field(col_idx).name();
                 let null_count = batch.column(col_idx).null_count();
+                // `NULL_SKIP_COLUMN` is all-null in version 1 rather than sparsely nulled.
+                let expected = if name == NULL_SKIP_COLUMN {
+                    batch.num_rows()
+                } else {
+                    expected_nulls_per_col
+                };
                 assert_eq!(
-                    null_count,
-                    expected_nulls_per_col,
-                    "column '{}' should have {expected_nulls_per_col} nulls, got {null_count}",
-                    batch.schema().field(col_idx).name(),
+                    null_count, expected,
+                    "column '{name}' should have {expected} nulls, got {null_count}",
                 );
             }
         }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -970,6 +970,17 @@ impl DataLayoutConfig {
     pub fn is_clustered(&self) -> bool {
         self == &DataLayoutConfig::ClusteredAllTypes
     }
+
+    /// A nullable `INTEGER` data column for data-skipping predicate tests. Its values follow
+    /// the generator's `version * 1000 + row` formula, so a `>= n * 1000` predicate prunes
+    /// files from versions below `n`. (`int_col` in the default schema; `value` in
+    /// [`partitioned_schema`] and [`clustered_schema`].)
+    pub fn skipping_column(&self) -> &'static str {
+        match self {
+            DataLayoutConfig::Unpartitioned => "int_col",
+            DataLayoutConfig::PartitionedAllTypes | DataLayoutConfig::ClusteredAllTypes => "value",
+        }
+    }
 }
 
 impl fmt::Display for DataLayoutConfig {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Wires a min/max data-skipping predicate into the default cross-product sweep, so the suite exercises read predicates rather than only full scans.

- Adds `DataLayoutConfig::skipping_column()`, returning the nullable `INTEGER` column whose generated values follow `version * 1000 + row` (`int_col` for the default schema, `value` for partitioned and clustered). A `>= 2000` predicate therefore separates version 1 from later versions.
- The sweep now runs a `>= 2000` predicate scan and residual-filters the result to assert data skipping is sound (no row satisfying the predicate is dropped) uniformly across every stats config. Skipping is file-level, so the matching-row count is fixed regardless of whether the version-1 file was pruned.
- Adds `test_data_skipping_prunes_files`, a focused effectiveness check asserting via `scan_metadata` that the version-1 file is actually pruned when stats are present (since the sweep alone proves soundness, not that skipping does anything).

Tracking issue: #2526

## How was this change tested?

New assertions in `test_cross_product_read_write` (2,805 cases) plus the new `test_data_skipping_prunes_files`.

This pull request and its description were written by Isaac.
