### PR TITLE
refactor!: identify plan nodes by index, drop RefId and output

### DIFF
--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -1,8 +1,9 @@
 // Proto mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (the Rust IR is the source of truth).
 //
 // A plan is a DAG of plan nodes: `Plan` is a flat list of `PlanNode`s, and each node wires
-// into the DAG by referencing other nodes' `output` RefIds in its `inputs`. RefIds are opaque
-// keys. Field numbers are never reused once published, so the wire stays compatible.
+// into the DAG by referencing other nodes' positions (indices into `Plan.nodes`) in its
+// `inputs`. A node is identified by its index; the terminal node is the last entry. Field
+// numbers are never reused once published, so the wire stays compatible.
 
 syntax = "proto3";
 
@@ -13,10 +14,6 @@ option java_package = "io.delta.kernel.proto.plan";
 
 import "expressions.proto";
 import "schema.proto";
-
-message RefId {
-  uint32 id = 1;
-}
 
 message FileMeta {
   string location = 1;
@@ -156,8 +153,9 @@ message Operator {
 
 message PlanNode {
   Operator op = 1;
-  repeated RefId inputs = 2;
-  RefId output = 3;
+  // Indices into `Plan.nodes` of this node's upstream inputs. Each index is strictly less than
+  // this node's own index, so `nodes` can be evaluated in order.
+  repeated uint32 inputs = 2;
 }
 
 // The plan's terminal node is its last entry; the engine streams that node's rows.

--- a/kernel/src/plans/ir/mod.rs
+++ b/kernel/src/plans/ir/mod.rs
@@ -4,7 +4,7 @@
 //!   [`PlanExecutor`](super::PlanExecutor).
 //! - [`nodes`] -- the plan nodes: [`nodes::Operator`] and its payload structs.
 //! - [`plan`] -- plan topology: [`plan::Plan`] holds a sequence of [`plan::PlanNode`]s wired into a
-//!   DAG by their [`plan::RefId`] inputs and outputs.
+//!   DAG by their input node indices.
 pub mod nodes;
 pub mod operation;
 pub mod plan;

--- a/kernel/src/plans/ir/plan.rs
+++ b/kernel/src/plans/ir/plan.rs
@@ -1,28 +1,21 @@
-//! Plan containers ([`Plan`], [`PlanNode`]) and the [`RefId`] value handle.
+//! Plan containers ([`Plan`], [`PlanNode`]).
 
 pub use super::nodes::Operator;
 
 // ============================================================================
-// RefIds and plan nodes
+// Plan nodes
 // ============================================================================
 
-/// Plan-scoped opaque identifier for a node's output value.
+/// One node in a plan: an [`Operator`] and the indices of its input nodes.
 ///
-/// Engines must treat RefIds as opaque keys: equality and hashing are the only meaningful
-/// operations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct RefId(pub u32);
-
-/// One node in a plan: an [`Operator`], its input RefIds, and its output RefId.
-///
-/// `inputs` order is interpreted per [`Operator`] (e.g. for `Operator::SemiJoin` the
-/// convention is `[probe, build]`). `Operator::UnionAll` emits the rows of all inputs
-/// regardless of input order.
+/// A node is identified by its position in [`Plan::nodes`]; `inputs` lists those indices for
+/// the upstream nodes this operator reads from. `inputs` order is interpreted per [`Operator`]
+/// (e.g. for `Operator::SemiJoin` the convention is `[probe, build]`). `Operator::UnionAll`
+/// emits the rows of all inputs regardless of input order.
 #[derive(Debug, Clone)]
 pub struct PlanNode {
     pub op: Operator,
-    pub inputs: Vec<RefId>,
-    pub output: RefId,
+    pub inputs: Vec<usize>,
 }
 
 // ============================================================================
@@ -31,24 +24,21 @@ pub struct PlanNode {
 
 /// A plan: an ordered sequence of [`PlanNode`]s forming a dataflow DAG.
 ///
-/// A [`RefId`] is an opaque value handle naming the output of one plan node. Each
-/// [`PlanNode`] is a triple `(op, inputs, output)`:
+/// A node is identified by its index in `nodes`. Each [`PlanNode`] pairs an operator with the
+/// indices of its inputs:
 ///
 /// - `op` ([`Operator`]) is the operator: a source like `ScanParquet` or a transform like
 ///   `Project`.
-/// - `inputs` is a `Vec<RefId>` naming the upstream values the operator reads from.
-/// - `output` is the RefId the operator produces.
+/// - `inputs` is a `Vec<usize>` naming the indices of the upstream nodes the operator reads from.
 ///
-/// A node depends on another when one of its `inputs` matches that node's `output`.
-/// Each RefId is bound exactly once. These input/output cross references encode the
-/// dataflow DAG, and `nodes` is stored in topological order: every node appears after
-/// the nodes whose outputs it consumes, so an engine can evaluate `nodes` in slice
-/// order; each node's inputs are guaranteed bound by the time the node is reached.
+/// A node depends on another when one of its `inputs` is that node's index. `nodes` is stored in
+/// topological order: every node appears after the nodes it consumes (each input index is
+/// strictly less than the node's own index), so an engine can evaluate `nodes` in slice order;
+/// each node's inputs are guaranteed bound by the time the node is reached.
 ///
-/// A well-formed `Plan` has at least one node. The **terminal node** is always the
-/// last entry in `nodes`: it is the only node whose `output` no other node lists in
-/// `inputs`, and `Plan::result()` returns that node's `output` RefId, the value the
-/// engine streams to the caller.
+/// A well-formed `Plan` has at least one node. The **terminal node** is always the last entry in
+/// `nodes`: no other node lists its index in `inputs`, and its rows are the value the engine
+/// streams to the caller.
 ///
 /// # Optimization
 ///
@@ -65,11 +55,11 @@ pub struct PlanNode {
 /// ```text
 /// Plan {
 ///     nodes: vec![
-///         PlanNode { op: ScanParquet(..), inputs: vec![],                   output: RefId(0) },
-///         PlanNode { op: ScanParquet(..), inputs: vec![],                   output: RefId(1) },
-///         PlanNode { op: Filter(..),      inputs: vec![RefId(0)],           output: RefId(2) },
-///         PlanNode { op: Filter(..),      inputs: vec![RefId(1)],           output: RefId(3) },
-///         PlanNode { op: UnionAll(..),    inputs: vec![RefId(2), RefId(3)], output: RefId(4) },
+///         PlanNode { op: ScanParquet(..), inputs: vec![]     },  // node 0
+///         PlanNode { op: ScanParquet(..), inputs: vec![]     },  // node 1
+///         PlanNode { op: Filter(..),      inputs: vec![0]    },  // node 2
+///         PlanNode { op: Filter(..),      inputs: vec![1]    },  // node 3
+///         PlanNode { op: UnionAll(..),    inputs: vec![2, 3] },  // node 4
 ///     ],
 /// }
 /// ```
@@ -77,28 +67,20 @@ pub struct PlanNode {
 /// The dataflow DAG this encodes:
 ///
 /// ```text
-///    ScanParquet [RefId(0)]     ScanParquet [RefId(1)]
-///              |                          |
-///              v                          v
-///       Filter [RefId(2)]          Filter [RefId(3)]
-///              |                          |
-///              +------------+-------------+
-///                           v
-///                 UnionAll [RefId(4)]   <-- terminal: Plan::result() == Some(RefId(4))
+///    ScanParquet [0]     ScanParquet [1]
+///           |                    |
+///           v                    v
+///       Filter [2]           Filter [3]
+///           |                    |
+///           +---------+----------+
+///                     v
+///               UnionAll [4]   <-- terminal (last node)
 /// ```
 ///
-/// The engine evaluates the nodes in the order of the `nodes` vector: `RefId(0)` and `RefId(1)`
-/// first (sources), then `RefId(2)` and `RefId(3)`, then `RefId(4)`. The engine streams the
-/// rows produced at the terminal node to the caller.
+/// The engine evaluates the nodes in the order of the `nodes` vector: nodes `0` and `1` first
+/// (sources), then `2` and `3`, then `4`. The engine streams the rows produced at the terminal
+/// node to the caller.
 #[derive(Debug, Clone)]
 pub struct Plan {
     pub nodes: Vec<PlanNode>,
-}
-
-impl Plan {
-    /// Returns the last node's `output` [`RefId`], the plan terminal whose rows the
-    /// engine streams to the caller, or `None` if `nodes` is empty.
-    pub fn result(&self) -> Option<RefId> {
-        self.nodes.last().map(|node| node.output)
-    }
 }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -15,7 +15,7 @@ use crate::plans::ir::nodes::{
     Agg, AggFn, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Max, MaxNonNullBy, Min,
     MinNonNullBy, Operator, Project, ScanFile, ScanJson, ScanParquet, SemiJoin, Values,
 };
-use crate::plans::ir::plan::{Plan, PlanNode, RefId};
+use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation};
 use crate::schema::{
     ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType, StructField,
@@ -125,15 +125,8 @@ impl From<&PlanNode> for proto_plan::PlanNode {
     fn from(node: &PlanNode) -> Self {
         proto_plan::PlanNode {
             op: Some((&node.op).into()),
-            inputs: convert_vec(&node.inputs),
-            output: Some((&node.output).into()),
+            inputs: node.inputs.iter().map(|&i| i as u32).collect(),
         }
-    }
-}
-
-impl From<&RefId> for proto_plan::RefId {
-    fn from(ref_id: &RefId) -> Self {
-        proto_plan::RefId { id: ref_id.0 }
     }
 }
 
@@ -738,7 +731,7 @@ mod tests {
         Agg, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Operator, Project, ScanFile,
         ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
     };
-    use crate::plans::ir::plan::{Plan, PlanNode, RefId};
+    use crate::plans::ir::plan::{Plan, PlanNode};
     use crate::plans::proto::{
         expressions as proto_expr, operation as proto_op, plan as proto_plan,
         schema as proto_schema,
@@ -979,7 +972,6 @@ mod tests {
                         schema: schema.clone(),
                     }),
                     inputs: vec![],
-                    output: RefId(0),
                 },
                 PlanNode {
                     op: Operator::Filter(Filter {
@@ -988,8 +980,7 @@ mod tests {
                             lit(5i32),
                         )),
                     }),
-                    inputs: vec![RefId(0)],
-                    output: RefId(1),
+                    inputs: vec![0],
                 },
             ],
         };
@@ -1000,9 +991,8 @@ mod tests {
         };
         assert_eq!(plan.nodes.len(), 2);
 
-        // Source node: ScanParquet, output RefId(0), no inputs.
+        // Source node: ScanParquet at index 0, no inputs.
         let source = &plan.nodes[0];
-        assert_eq!(source.output.as_ref().unwrap().id, 0);
         assert!(source.inputs.is_empty());
         let Some(proto_plan::operator::Op::ScanParquet(scan)) = &source.op.as_ref().unwrap().op
         else {
@@ -1011,11 +1001,10 @@ mod tests {
         assert_eq!(scan.files.len(), 1);
         assert_eq!(scan.schema.as_ref().unwrap().fields.len(), 2);
 
-        // Filter node: consumes RefId(0), emits RefId(1), carries a `id > 5` binary predicate.
+        // Filter node at index 1: consumes node 0, carries a `id > 5` binary predicate.
         let filter_node = &plan.nodes[1];
-        assert_eq!(filter_node.output.as_ref().unwrap().id, 1);
         assert_eq!(filter_node.inputs.len(), 1);
-        assert_eq!(filter_node.inputs[0].id, 0);
+        assert_eq!(filter_node.inputs[0], 0);
         let Some(proto_plan::operator::Op::Filter(filter)) = &filter_node.op.as_ref().unwrap().op
         else {
             panic!("expected Filter");
@@ -1029,11 +1018,6 @@ mod tests {
             binary.left.as_ref().unwrap().kind,
             Some(proto_expr::expression::Kind::Column(_))
         ));
-    }
-
-    #[test]
-    fn from_ref_id() {
-        assert_eq!(proto_plan::RefId::from(&RefId(7)).id, 7);
     }
 
     #[rstest]

--- a/kernel/src/plans/proto/mod.rs
+++ b/kernel/src/plans/proto/mod.rs
@@ -9,7 +9,7 @@
 //! - [`expressions`] -- mirror of `kernel/src/expressions/mod.rs` and `scalars.rs` (`Expression`,
 //!   `Predicate`, `Scalar`, `ColumnName`, ...).
 //! - [`plan`] -- mirror of `kernel/src/plans/ir/{plan,nodes}.rs` (`Plan`, `PlanNode`, `Operator`,
-//!   `RefId`, per-variant payload messages).
+//!   per-variant payload messages).
 //! - [`operation`] -- mirror of `kernel/src/plans/ir/operation.rs` (`Operation`, `IoOperation`, and
 //!   the I/O payload messages).
 

--- a/kernel/src/plans/query_builder.rs
+++ b/kernel/src/plans/query_builder.rs
@@ -5,7 +5,7 @@
 //! constructed directly via [`Plan`] / [`PlanNode`].
 
 use super::ir::nodes::{Operator, ScanFile, ScanJson, ScanParquet};
-use super::ir::plan::{Plan, PlanNode, RefId};
+use super::ir::plan::{Plan, PlanNode};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, FileMeta};
 
@@ -42,7 +42,7 @@ impl QueryPlanBuilder {
         }
     }
 
-    /// Consume the builder and produce a [`Plan`] with a single node whose output is `RefId(0)`.
+    /// Consume the builder and produce a [`Plan`] with a single node (at index 0).
     ///
     /// # Errors
     ///
@@ -53,7 +53,6 @@ impl QueryPlanBuilder {
             nodes: vec![PlanNode {
                 op: self.op,
                 inputs: vec![],
-                output: RefId(0),
             }],
         })
     }
@@ -104,9 +103,7 @@ mod tests {
         .build()
         .unwrap();
 
-        let result = plan.result();
         let [node] = <[_; 1]>::try_from(plan.nodes).expect("single-node plan");
-        assert_eq!(Some(node.output), result);
         let (Operator::ScanJson(ScanJson {
             files: scan_files,
             schema: node_schema,


### PR DESCRIPTION
## What changes are proposed in this pull request?

In the experimental `declarative-plans` IR, plan nodes are now identified by their index in `Plan.nodes` instead of an opaque `RefId`:

- `PlanNode` drops its `output` field; `inputs` becomes `Vec<usize>` (indices into `nodes`).
- The terminal node is implicitly the last entry, so `Plan::result()` and the `RefId` newtype are both removed.
- The proto mirror (`plan.proto`) drops the `RefId` message and the `output` field; `PlanNode.inputs` is `repeated uint32`.

### This PR affects the following public APIs

Breaking change to the experimental `declarative-plans` IR: `RefId` removed, `PlanNode.output` removed, `Plan::result()` removed, and `PlanNode.inputs` retyped to `Vec<usize>`.

## How was this change tested?

