### PR TITLE
feat: add with_correlation_id to create-table and alter-table builders

### DIFF
--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -7,6 +7,7 @@
 #![allow(unreachable_pub)]
 
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use crate::committer::Committer;
 use crate::metrics::MetricId;
@@ -38,6 +39,7 @@ impl AlterTableTransaction {
         read_snapshot: SnapshotRef,
         effective_table_config: TableConfiguration,
         committer: Box<dyn Committer>,
+        correlation_id: Option<Arc<str>>,
     ) -> DeltaResult<Self> {
         let span = tracing::info_span!(
             "txn",
@@ -49,7 +51,7 @@ impl AlterTableTransaction {
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
-            correlation_id: None,
+            correlation_id,
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
             should_emit_protocol: false,

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -67,11 +67,12 @@ mod sealed {
 ///
 /// Uses a type-state pattern (`S`) to enforce at compile time:
 /// - At least one schema operation must be queued before `build()` is callable.
-/// - Only operations valid for the current state can be chained. This will disallow incompatibel
+/// - Only operations valid for the current state can be chained. This will disallow incompatible
 ///   chaining.
 pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
     operations: Vec<SchemaOperation>,
+    correlation_id: Option<Arc<str>>,
     // PhantomData marker for builder state (Ready or Modifying).
     // Zero-sized; only affects which methods are available at compile time.
     _state: PhantomData<S>,
@@ -88,8 +89,16 @@ impl<S> AlterTableTransactionBuilder<S> {
         AlterTableTransactionBuilder {
             snapshot: self.snapshot,
             operations: self.operations,
+            correlation_id: self.correlation_id,
             _state: PhantomData,
         }
+    }
+
+    /// Attach an opaque, caller-supplied correlation id for joining the alter-table commit's metric
+    /// events to the caller's own request or operation id. An empty id is treated as unset.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
     }
 }
 
@@ -99,6 +108,7 @@ impl AlterTableTransactionBuilder<Ready> {
         AlterTableTransactionBuilder {
             snapshot,
             operations: Vec::new(),
+            correlation_id: None,
             _state: PhantomData,
         }
     }
@@ -193,6 +203,11 @@ impl AlterTableTransactionBuilder<Modifying> {
             evolved_schema,
         )?;
 
-        AlterTableTransaction::try_new_alter_table(self.snapshot, evolved_table_config, committer)
+        AlterTableTransaction::try_new_alter_table(
+            self.snapshot,
+            evolved_table_config,
+            committer,
+            self.correlation_id,
+        )
     }
 }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -766,6 +766,7 @@ pub struct CreateTableTransactionBuilder {
     engine_info: String,
     table_properties: HashMap<String, String>,
     data_layout: DataLayout,
+    correlation_id: Option<Arc<str>>,
 }
 
 impl CreateTableTransactionBuilder {
@@ -780,6 +781,7 @@ impl CreateTableTransactionBuilder {
             engine_info: engine_info.into(),
             table_properties: HashMap::new(),
             data_layout: DataLayout::None,
+            correlation_id: None,
         }
     }
 
@@ -864,6 +866,13 @@ impl CreateTableTransactionBuilder {
     /// ```
     pub fn with_data_layout(mut self, layout: DataLayout) -> Self {
         self.data_layout = layout;
+        self
+    }
+
+    /// Attach an opaque, caller-supplied correlation id for joining the create-table commit's
+    /// metric events to the caller's own request or operation id. An empty id is treated as unset.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
         self
     }
 
@@ -985,6 +994,7 @@ impl CreateTableTransactionBuilder {
             committer,
             data_layout_result.system_domain_metadata,
             data_layout_result.clustering_columns,
+            self.correlation_id,
         )
     }
 }

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -32,6 +32,7 @@
 #![allow(unreachable_pub, dead_code)]
 
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 // Re-export the builder so callers can still access it from this module path.
 pub use super::builder::create_table::CreateTableTransactionBuilder;
@@ -143,6 +144,7 @@ impl CreateTableTransaction {
         committer: Box<dyn Committer>,
         system_domain_metadata: Vec<DomainMetadata>,
         clustering_columns: Option<Vec<ColumnName>>,
+        correlation_id: Option<Arc<str>>,
     ) -> DeltaResult<Self> {
         let span = tracing::info_span!(
             "txn",
@@ -152,7 +154,7 @@ impl CreateTableTransaction {
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
-            correlation_id: None,
+            correlation_id,
             read_snapshot_opt: None,
             effective_table_config,
             should_emit_protocol: true,

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -9,6 +9,7 @@ use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::metrics::{MetricEvent, MetricsReporter, TableType, TransactionCommitSuccess};
 use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::schema::{DataType, StructField};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Snapshot};
@@ -91,6 +92,8 @@ async fn commit_append_emits_success_metrics(
     Ok(())
 }
 
+/// Sets the correlation id on the `Transaction` returned by `build()` and checks it reaches the
+/// commit metric event. The two tests below instead set it on the builder.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
     let (_temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
@@ -111,6 +114,89 @@ async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
         .expect("commit success event");
     assert_eq!(success.commit_version, 0);
     assert_eq!(success.correlation_id.as_deref(), Some("commit-req-1"));
+    Ok(())
+}
+
+/// A correlation id set on the create-table *builder* (rather than on the `Transaction` it
+/// produces) reaches the commit metric event, and an empty id is treated as unset. This is the
+/// builder-level setter added in issue #2833.
+#[rstest]
+#[case::with_id(Some("create-req-1"), Some("create-req-1"))]
+#[case::without_id(None, None)]
+#[case::empty_id_is_unset(Some(""), None)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_table_builder_carries_correlation_id(
+    #[case] correlation_id: Option<&str>,
+    #[case] expected: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let mut builder = create_table(&table_path, simple_schema(), "Test/1.0");
+    if let Some(id) = correlation_id {
+        builder = builder.with_correlation_id(id);
+    }
+    builder
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(success.commit_version, 0);
+    assert_eq!(success.correlation_id.as_deref(), expected);
+    Ok(())
+}
+
+/// A correlation id set on the alter-table *builder* reaches the commit metric event. The id is
+/// set before any schema operation (in the `Ready` state), so this also verifies it survives the
+/// builder's `Ready -> Modifying` transition. An empty id is treated as unset. Builder-level
+/// setter added in issue #2833.
+#[rstest]
+#[case::with_id(Some("alter-req-1"), Some("alter-req-1"))]
+#[case::without_id(None, None)]
+#[case::empty_id_is_unset(Some(""), None)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn alter_table_builder_carries_correlation_id(
+    #[case] correlation_id: Option<&str>,
+    #[case] expected: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    create_table(&table_path, simple_schema(), "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Install the reporter after the create commit so the captured event is the alter commit.
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    // Set the id in the `Ready` state (before `add_column`) to exercise the carry-through.
+    let mut builder = snapshot.alter_table();
+    if let Some(id) = correlation_id {
+        builder = builder.with_correlation_id(id);
+    }
+    builder
+        .add_column(StructField::nullable("extra", DataType::STRING))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let success = reporter
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("commit success event");
+    assert_eq!(success.commit_version, 1);
+    assert_eq!(success.correlation_id.as_deref(), expected);
     Ok(())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #2734, closes #2833.

#2734 added an opaque, caller-supplied `correlation_id` that rides alongside kernel's own
`operation_id` on metric events, so a connector can tie those events back to its own request. It
wired a `with_correlation_id` setter onto `SnapshotBuilder`, `ScanBuilder`, and `Transaction` — but
the create-table and alter-table builders never got one. They just default `correlation_id` to
`None`, so unless you knew to reach for the setter on the `Transaction` that `build()` hands back,
create and alter commits went out with no correlation id at all.

This gives both builders their own `with_correlation_id`, matching how the other three already
work: it stores an `Option<Arc<str>>`, treats an empty string as unset, and threads the value into
the same field that ends up on the `txn.commit` metric event. The alter builder is a type-state
builder, so its setter lives on `impl<S>` and the id is carried across the `Ready -> Modifying`
transition — you can set it before or after queuing a schema op.

I left the FFI alone, same as #2734 did: that PR exposed `correlation_id` on the FFI metric structs
but didn't add FFI setters either.

### This PR affects the following public APIs

Two new methods. Both are additive, so nothing breaks:

- `CreateTableTransactionBuilder::with_correlation_id`
- `AlterTableTransactionBuilder::with_correlation_id`

## How was this change tested?

New integration tests in `kernel/tests/integration/metrics/commit.rs` cover both builders,
parameterized over a set id, no id, and an empty id (which should come through as unset). Each one
commits and checks the `correlation_id` that lands on `TransactionCommitSuccess`. The alter test
sets the id before `add_column` on purpose, so it also exercises the id surviving the
`Ready -> Modifying` transition.

Also ran the usual `cargo +nightly fmt`, `cargo clippy --all-features -- -D warnings`,
`cargo doc --all-features --no-deps`, and the transaction unit tests plus the create/alter/metrics
integration tests.
