### PR TITLE
docs: add per-crate CLAUDE.md guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,87 +132,11 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
   merged into it as a new `#[case]`. A common pattern is toggling a feature (e.g.
   column mapping on/off) and asserting success vs. error.
 - Reuse helpers from `test_utils` and the integration-test fixtures instead of writing
-  custom ones when possible. See **Common test helpers** below for a curated starter list.
-- **Committing in tests:** Use `txn.commit(engine)?.unwrap_committed()` to assert a
-  successful commit and get the `CommittedTransaction`. When you only need the resulting
-  snapshot, use `txn.commit(engine)?.unwrap_post_commit_snapshot()` to get the
-  `SnapshotRef` directly. Do NOT use `match` + `panic!` for either -- they provide a clear
-  error message on failure. Available under `#[cfg(test)]` and the `test-utils` feature.
-- **Prefer snapshot/public API assertions over reading raw commit JSON.** Only read raw
-  commit JSON when the data is inaccessible via public API (e.g., system domain metadata
-  is blocked by `get_domain_metadata`). For commit JSON reads, use `read_actions_from_commit`
-  from `test_utils` -- do NOT write local helpers that duplicate this.
-- **`add_commit` and table setup in tests:** `add_commit` takes a `table_root` string and
-  resolves it to an absolute object-store path. The `table_root` must be a proper URL string
-  with a trailing slash (e.g. `"memory:///"`, `"file:///tmp/my_table/"`). Avoid using the
-  `Url` type directly -- most test helpers and kernel APIs accept `impl AsRef<str>`, so pass
-  URL strings instead. When using local storage, use an un-prefixed store
-  (`LocalFileSystem::new()`) with a `file:///` URL string. Do NOT use
-  `LocalFileSystem::new_with_prefix()` with `add_commit` -- the prefix causes double-nesting
-  because `add_commit` already resolves the full path from the URL. For in-memory tests, use
-  `InMemory::new()` with `"memory:///"`. ALWAYS use the same `table_root` URL string for
-  both `add_commit` (writing log files) and `snapshot`/`Snapshot::try_new` (reading the
-  table). ALWAYS include a trailing slash in directory URLs to ensure correct path joining.
+  custom ones when possible.
 
-### Common test helpers
-
-Before writing a custom helper, check this curated list and the locations below.
-This list is non-exhaustive -- when in doubt, browse the source files directly
-(`test-utils/src/lib.rs`, `kernel/tests/integration/common/`,
-`kernel/tests/integration/<topic>/mod.rs`).
-
-**Arrow construction (from `delta_kernel::arrow`)**
-
-- `arrow::array::new_null_array(&arrow_type, n)` -- Arrow array of `n` nulls of any Arrow
-  type. Prefer this over per-type `Int32Array::from(vec![None as Option<i32>])` builders.
-- `engine::arrow_conversion::TryIntoArrow`:
-  `(&kernel_data_type).try_into_arrow()` for `DataType`,
-  `(&kernel_struct_type).try_into_arrow()` for `StructType` -> Arrow `Schema`.
-
-**Engine + table setup (from `test_utils`)**
-
-- `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
-  variant under `#[tokio::test(flavor = "multi_thread")]`. Required whenever a test calls
-  `snapshot.checkpoint()`: it issues nested `block_on` calls that deadlock on a single-threaded
-  runtime / `TokioBackgroundExecutor`.
-- `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
-  needs direct object-store access.
-- `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.
-
-**Table creation in tests**
-
-- Prefer the kernel `create_table` builder
-  (`delta_kernel::transaction::create_table::create_table`). It exercises the same path
-  connectors use and auto-derives the protocol from the schema and feature flags.
-- `test_utils::create_table` (a JSON helper that hand-rolls protocol + metadata) is older
-  but still needed when the kernel builder cannot enable a particular feature combination.
-
-**Schema fixtures**
-
-- `test_utils`: `nested_schema`, `schema_with_type`, `nested_schema_with_type`,
-  `multi_schema_with_type`, `top_level_ntz_schema` / `nested_ntz_schema` /
-  `multiple_ntz_schema`, `top_level_variant_schema` / `nested_variant_schema` /
-  `multiple_variant_schema`.
-- `kernel/tests/integration/create_table/mod.rs`: `simple_schema`, `partition_test_schema`.
-
-**Commit + read helpers (from `test_utils`)**
-
-- `add_commit`, `add_staged_commit` -- write a JSON commit at a given version.
-- `read_actions_from_commit` -- read raw JSON actions from a specific commit. Use this
-  instead of hand-rolled `serde_json` parsing.
-- `test_read` -- full-scan read of a table; use for round-trip assertions.
-- `into_record_batch` -- convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
-
-**Assertion helpers (from `test_utils`)**
-
-- `assert_schema_has_field(schema, &["a", "b"])` -- assert a (possibly nested) field path.
-- `assert_result_error_with_message(result, "needle")` -- assert an error contains a
-  substring.
-
-**If a name here doesn't match what's in code:** the list may have drifted from a rename.
-Run `rg '^pub (fn|async fn)' test-utils/src/lib.rs` to discover the current public surface,
-and update this section in your PR. The same pattern works for
-`kernel/tests/integration/common/write_utils.rs`.
+For integration-test mechanics -- table setup, the `add_commit` URL rules, commit/read
+helpers, schema fixtures, and the full curated helper catalog -- see
+`kernel/tests/CLAUDE.md`.
 
 ## Protocol TLDR
 
@@ -351,5 +275,6 @@ Read these when relevant to the task at hand:
 **Keeping docs current:** If you notice anything inaccurate in these docs -- renamed
 structs, traits, functions, modules, crates, APIs, stale data flows, wrong file paths --
 inform the user so they can be updated. After major changes, update this file,
-`CLAUDE/architecture.md`, `ffi/CLAUDE.md`, `.github/CLAUDE.md`, and any relevant
-`<crate>/CLAUDE.md` files.
+`CLAUDE/architecture.md`, `kernel/tests/CLAUDE.md`, and the per-crate `<crate>/CLAUDE.md`
+guidelines (e.g. `ffi/`, `default-engine/`, the `*unity-catalog*` crates, `derive-macros/`,
+`test-utils/`, `acceptance/`, `workloads/`) and `.github/CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,8 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
 - Reuse helpers from `test_utils` and the integration-test fixtures instead of writing
   custom ones when possible.
 
-For integration-test mechanics -- table setup, the `add_commit` URL rules, commit/read
-helpers, schema fixtures, and the full curated helper catalog -- see
-`kernel/tests/CLAUDE.md`.
+See `kernel/tests/CLAUDE.md` for integration-test mechanics: table setup, the `add_commit` URL
+rules, commit and read helpers, schema fixtures, and where to find the shared test helpers.
 
 ## Protocol TLDR
 

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -35,7 +35,7 @@ Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 1. **LogSegment** (`kernel/src/log_segment/`) -- discovers commits + checkpoints for the
    requested version, replays Protocol and Metadata (`protocol_metadata_replay.rs`), and
    replays domain metadata (`domain_metadata_replay.rs`)
-2. **Log replay** (`kernel/src/log_replay.rs`) -- file-action deduplication via
+2. **Log replay** (`kernel/src/log_replay/`) -- file-action deduplication via
    `FileActionDeduplicator` and `LogReplayProcessor` trait (distinct from Protocol/Metadata
    replay above)
 
@@ -57,8 +57,8 @@ set), `data_skipping.rs` (rewrite predicates against min/max/nullCount stats and
 - `scan.execute(engine)` -- kernel handles everything end-to-end, returns `EngineData`
 - `scan.scan_metadata(engine)` -- returns file list + transforms; connector reads files and
   calls `transform_to_logical` / `DvInfo::get_selection_vector`
-- `scan.parallel_scan_metadata(engine)` -- two-phase distributed log replay (`pub(crate)`,
-  requires `internal-api` feature)
+- `scan.parallel_scan_metadata(engine)` -- two-phase distributed log replay (the method is
+  `pub`; its supporting types and the `parallel` module are gated behind `internal-api`)
 
 **Incremental read:** `Snapshot::incremental_scan_builder(base_version)` streams the file-action
 diff over `(base_version, target_version]` -- live Adds as a `FilteredEngineData` iterator
@@ -130,7 +130,7 @@ all returned batches -- the engine may split a single file across multiple batch
    encoding, URI encoding for `add.path`
 - `kernel/src/committer/` -- `Committer` trait, `FileSystemCommitter`
 - `kernel/src/log_segment/` -- log file discovery, Protocol/Metadata replay
-- `kernel/src/log_replay.rs` -- file-action deduplication, `LogReplayProcessor` trait
+- `kernel/src/log_replay/` -- file-action deduplication, `LogReplayProcessor` trait
 - `kernel/src/log_reader/` -- I/O layer for reading commit and checkpoint files
 - `kernel/src/actions/` -- Delta action types (Protocol, Metadata, CommitInfo, Add, Remove, Cdc,
    SetTransaction, DomainMetadata, Sidecar, CheckpointMetadata)

--- a/acceptance/CLAUDE.md
+++ b/acceptance/CLAUDE.md
@@ -1,21 +1,20 @@
 # Acceptance test guidelines
 
-Scope: `acceptance/**`. Cross-cutting conventions live in the root `CLAUDE.md`. For writing
-kernel's own integration tests (table setup, helpers), see `kernel/tests/CLAUDE.md` -- this crate
-is different: it runs the cross-implementation conformance suite.
+The `acceptance` crate runs the Delta Acceptance Tests (DAT): a cross-implementation conformance
+suite. "Conformance" here means every Delta implementation (kernel, Spark, delta-rs, ...) is held
+to the same externally generated golden cases, so the suite checks kernel against a shared spec
+rather than against itself. Each case is a table plus a JSON description of the expected results;
+the harness loads a case, builds a snapshot, and asserts kernel's reported metadata and data match
+that description.
 
-## What this crate is
-
-The `acceptance` crate runs the Delta Acceptance Tests (DAT): externally generated test cases,
-each a table plus a JSON spec of expected metadata and scan results. It loads a case, builds a
-snapshot, and asserts kernel's snapshot metadata and full scan output match the golden spec. This
-is the suite that proves kernel agrees with the protocol across implementations.
+Kernel's own integration tests (table setup, helpers) are a separate thing under `kernel/tests/`
+-- see `kernel/tests/CLAUDE.md`.
 
 ## Invariants to uphold
 
 - **Golden expectations are the source of truth; don't loosen an assertion to make a case pass.**
   A failing DAT case is signal that kernel diverged from the spec. Fix kernel (or escalate a
-  genuine spec/case bug) -- never weaken the metadata/scan comparison to get green.
+  genuine spec/case bug) -- never weaken the comparison against the golden case to get green.
 - **Cases come from generated DAT resources.** The data is downloaded/generated, not committed.
   If the resource tree is absent the harness has nothing to run; a "passing" empty run is not
   coverage.

--- a/acceptance/CLAUDE.md
+++ b/acceptance/CLAUDE.md
@@ -1,0 +1,23 @@
+# Acceptance test guidelines
+
+Scope: `acceptance/**`. Cross-cutting conventions live in the root `CLAUDE.md`. For writing
+kernel's own integration tests (table setup, helpers), see `kernel/tests/CLAUDE.md` -- this crate
+is different: it runs the cross-implementation conformance suite.
+
+## What this crate is
+
+The `acceptance` crate runs the Delta Acceptance Tests (DAT): externally generated test cases,
+each a table plus a JSON spec of expected metadata and scan results. It loads a case, builds a
+snapshot, and asserts kernel's snapshot metadata and full scan output match the golden spec. This
+is the suite that proves kernel agrees with the protocol across implementations.
+
+## Invariants to uphold
+
+- **Golden expectations are the source of truth; don't loosen an assertion to make a case pass.**
+  A failing DAT case is signal that kernel diverged from the spec. Fix kernel (or escalate a
+  genuine spec/case bug) -- never weaken the metadata/scan comparison to get green.
+- **Cases come from generated DAT resources.** The data is downloaded/generated, not committed.
+  If the resource tree is absent the harness has nothing to run; a "passing" empty run is not
+  coverage.
+- **Cover the protocol versions the suite spans** -- both legacy (reader/writer 1/2) and
+  table-features (3/7) cases -- when adding or adjusting validation logic.

--- a/default-engine/CLAUDE.md
+++ b/default-engine/CLAUDE.md
@@ -1,20 +1,19 @@
 # Default engine guidelines
 
-Scope: `default-engine/**`. Cross-cutting Rust/comment/protocol conventions live in the root
-`CLAUDE.md`; this file is the default-engine context. Kernel architecture (the `Engine` trait
-and its handlers) is in `CLAUDE/architecture.md`.
-
-## What this crate is
-
 `delta_kernel_default_engine` is the reference `Engine` implementation: an Arrow + Tokio +
 `object_store` backing for the five kernel handlers (storage, JSON, Parquet, evaluation, and
-the optional metrics reporter). It is what most connectors use out of the box, and the bar for
-"how an engine is supposed to behave". Kernel itself does no I/O and does not depend on Arrow --
-that all lives here.
+the optional metrics reporter). Most connectors use it out of the box.
+
+Keep the kernel-core vs engine distinction straight. "Kernel" (the `delta_kernel` crate) is the
+protocol core: synchronous APIs that do no I/O and carry no Arrow dependency. `Engine` is the
+trait that supplies I/O and compute, and this crate is one Arrow-based implementation of it.
+Kernel core must never assume an engine uses Arrow -- Arrow lives on this side of the trait.
 
 `DefaultEngine<E: TaskExecutor>` wraps the handlers; build it via `DefaultEngineBuilder`. The
 crate is organized by handler concern (storage/filesystem, json, parquet, plus stats and the
 file-stream adapters that feed them).
+
+The `Engine` trait and its handlers are described in `CLAUDE/architecture.md`.
 
 ## Async execution
 
@@ -22,9 +21,10 @@ All I/O is async and runs through a `TaskExecutor` (`executor.rs`). Two Tokio ex
 `TokioBackgroundExecutor` (single background runtime) and `TokioMultiThreadExecutor`. Kernel's
 public API is synchronous, so the engine bridges sync->async with `block_on`.
 
-- **Operations that re-enter the engine (notably `checkpoint()`) issue nested `block_on` calls
-  and deadlock on a single-threaded runtime.** Such paths require the multi-thread executor.
-  This is the same hazard the test helper `test_table_setup_mt` exists to avoid.
+- **Any kernel operation that re-enters the engine issues nested `block_on` calls and deadlocks
+  on a single-threaded runtime** (`checkpoint()` is one such path). These require the multi-thread
+  executor. This is the canonical description of the nested-`block_on` hazard that the rest of the
+  docs point back to.
 - A custom `TaskExecutor` is a valid extension point, but it must uphold this same nested-blocking
   contract.
 

--- a/default-engine/CLAUDE.md
+++ b/default-engine/CLAUDE.md
@@ -1,0 +1,40 @@
+# Default engine guidelines
+
+Scope: `default-engine/**`. Cross-cutting Rust/comment/protocol conventions live in the root
+`CLAUDE.md`; this file is the default-engine context. Kernel architecture (the `Engine` trait
+and its handlers) is in `CLAUDE/architecture.md`.
+
+## What this crate is
+
+`delta_kernel_default_engine` is the reference `Engine` implementation: an Arrow + Tokio +
+`object_store` backing for the five kernel handlers (storage, JSON, Parquet, evaluation, and
+the optional metrics reporter). It is what most connectors use out of the box, and the bar for
+"how an engine is supposed to behave". Kernel itself does no I/O and does not depend on Arrow --
+that all lives here.
+
+`DefaultEngine<E: TaskExecutor>` wraps the handlers; build it via `DefaultEngineBuilder`. The
+crate is organized by handler concern (storage/filesystem, json, parquet, plus stats and the
+file-stream adapters that feed them).
+
+## Async execution
+
+All I/O is async and runs through a `TaskExecutor` (`executor.rs`). Two Tokio executors ship:
+`TokioBackgroundExecutor` (single background runtime) and `TokioMultiThreadExecutor`. Kernel's
+public API is synchronous, so the engine bridges sync->async with `block_on`.
+
+- **Operations that re-enter the engine (notably `checkpoint()`) issue nested `block_on` calls
+  and deadlock on a single-threaded runtime.** Such paths require the multi-thread executor.
+  This is the same hazard the test helper `test_table_setup_mt` exists to avoid.
+- A custom `TaskExecutor` is a valid extension point, but it must uphold this same nested-blocking
+  contract.
+
+## Invariants to uphold
+
+- **`EngineData` produced here is still opaque to kernel.** It is concretely `ArrowEngineData`,
+  but the engine must not assume kernel will downcast it, and must never assume one batch per
+  file -- always stream batches.
+- **TLS and Arrow version are feature-selected.** TLS backend (`rustls` vs `native-tls`) lives
+  on this crate, not on kernel. Arrow version features are mutually exclusive; code must build
+  under each supported version, not just the default.
+- **Honor presigned/direct URLs.** The filesystem layer detects presigned object-store URLs and
+  reads them directly; don't route those through credentialed object-store clients.

--- a/delta-kernel-unity-catalog/CLAUDE.md
+++ b/delta-kernel-unity-catalog/CLAUDE.md
@@ -1,0 +1,34 @@
+# Unity Catalog integration guidelines
+
+Scope: `delta-kernel-unity-catalog/**`. Cross-cutting Rust/comment/protocol conventions live in
+the root `CLAUDE.md`; catalog-managed table background is in `CLAUDE/architecture.md`.
+
+## Where this sits in the UC stack
+
+Three crates layer cleanly; lower layers know nothing of higher ones:
+
+1. `unity-catalog-delta-client-api` -- transport-agnostic traits (`GetCommitsClient`,
+   `CommitClient`) and request/response + credential models. No HTTP.
+2. `unity-catalog-delta-rest-client` -- concrete HTTP implementation of those traits.
+3. `delta-kernel-unity-catalog` (this crate) -- the kernel-facing glue: `UCKernelClient` loads a
+   snapshot from UC-reported commits, and `UCCommitter` implements kernel's `Committer` for
+   catalog-managed tables.
+
+When changing the trait surface, edit `*-client-api` and let the REST client and this crate
+follow; do not duplicate models downstream.
+
+## Invariants to uphold
+
+- **Catalog-managed tables must commit through `UCCommitter`**, never `FileSystemCommitter`. The
+  committer is the only thing that knows the stage/ratify/publish protocol.
+- **Version 0 publishes directly; version >= 1 stages then ratifies.** v0 (table creation) writes
+  the commit file to the published log path. v>=1 writes a staged commit and calls the UC commit
+  API to ratify it. Preserve this split -- it is the catalog-managed write protocol.
+- **The commit log tail from UC must be contiguous** (no version gaps), and bounded by the
+  max-ratified version UC reports. Validate, don't assume.
+- **Required protocol properties are enforced centrally** (the `get_*_required_properties_*`
+  helpers). A catalog-managed table's feature set (e.g. `catalogManaged`, `inCommitTimestamp`,
+  `vacuumProtocolCheck`) must be consistent; route checks through these helpers rather than
+  hand-listing features at call sites.
+- **Commit runs in async context** and assumes a multi-threaded Tokio runtime (it drives kernel
+  operations that block); don't call it from a single-threaded runtime.

--- a/delta-kernel-unity-catalog/CLAUDE.md
+++ b/delta-kernel-unity-catalog/CLAUDE.md
@@ -1,11 +1,8 @@
 # Unity Catalog integration guidelines
 
-Scope: `delta-kernel-unity-catalog/**`. Cross-cutting Rust/comment/protocol conventions live in
-the root `CLAUDE.md`; catalog-managed table background is in `CLAUDE/architecture.md`.
-
 ## Where this sits in the UC stack
 
-Three crates layer cleanly; lower layers know nothing of higher ones:
+Three crates layer, and lower layers know nothing of higher ones:
 
 1. `unity-catalog-delta-client-api` -- transport-agnostic traits (`GetCommitsClient`,
    `CommitClient`) and request/response + credential models. No HTTP.
@@ -15,7 +12,8 @@ Three crates layer cleanly; lower layers know nothing of higher ones:
    catalog-managed tables.
 
 When changing the trait surface, edit `*-client-api` and let the REST client and this crate
-follow; do not duplicate models downstream.
+follow; do not duplicate models downstream. Catalog-managed table background is in
+`CLAUDE/architecture.md`.
 
 ## Invariants to uphold
 

--- a/derive-macros/CLAUDE.md
+++ b/derive-macros/CLAUDE.md
@@ -1,8 +1,5 @@
 # Derive macros guidelines
 
-Scope: `derive-macros/**`. Cross-cutting Rust/comment conventions live in the root `CLAUDE.md`;
-this file is the proc-macro context.
-
 ## What this crate is
 
 `delta_kernel_derive` is the proc-macro crate backing kernel ergonomics. It provides the

--- a/derive-macros/CLAUDE.md
+++ b/derive-macros/CLAUDE.md
@@ -1,0 +1,25 @@
+# Derive macros guidelines
+
+Scope: `derive-macros/**`. Cross-cutting Rust/comment conventions live in the root `CLAUDE.md`;
+this file is the proc-macro context.
+
+## What this crate is
+
+`delta_kernel_derive` is the proc-macro crate backing kernel ergonomics. It provides the
+`ToSchema` and `IntoEngineData` derives, the `#[internal_api]` attribute (feature-gates the
+visibility of unstable APIs), and a column-name parsing macro. It is a compile-time dependency
+of kernel; it has no runtime surface of its own.
+
+## Invariants to uphold
+
+- **`ToSchema` encodes the Delta naming convention.** It maps Rust `snake_case` fields to the
+  protocol's `camelCase` schema names. Changing that mapping changes the on-disk/action schema
+  for every deriving type -- treat it as protocol-affecting, not cosmetic.
+- **Generated code must obey the no-panic-in-production rule.** A macro that can emit
+  `unwrap`/`panic!` into kernel violates the root guideline at every expansion site; surface
+  errors through the generated code's `Result` paths instead.
+- **Attributes must validate their target.** `#[internal_api]` is meaningful only on items whose
+  visibility is below `pub`; the container-null attribute is meaningful only on map-shaped
+  fields. Emit a clear `compile_error!` on misuse rather than silently miscompiling.
+- **A macro is the wrong tool for a one-off.** Proc macros are hard to read and debug; add or
+  extend one only when several call sites share the generated shape. Prefer plain code otherwise.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -1,14 +1,31 @@
 # FFI Layer
 
+Scope: `ffi/**`. Cross-cutting Rust/comment/protocol conventions live in the root
+`CLAUDE.md`; this file is the FFI-boundary context.
+
 The `delta_kernel_ffi` crate exposes the kernel to C/C++ via a stable FFI boundary using
 cbindgen-generated headers (`.h` and `.hpp`).
+
+## Terminology
+
+- **Kernel vs engine** -- "kernel" is the native Rust side; "engine" is the foreign runtime
+  on the other side of the boundary. This is the lens for "which side allocated/owns this".
+- **Downcall vs upcall** -- a downcall is the engine invoking an exported Rust function; an
+  upcall is Rust invoking an engine-provided function pointer.
+- **Allocator vs owner** -- the allocator initialized the memory and knows *how* to free it;
+  the owner decides *when*. Ownership can transfer across the boundary (e.g. a handle returned
+  from a builder), so track both independently.
 
 ## Handle System
 
 Objects crossing the FFI boundary may be wrapped in **handles** -- opaque pointers with
 ownership semantics:
-- **Mutable handles** (`Box`-like) -- exclusive ownership, neither `Copy` nor `Clone`
+- **Exclusive handles** (`Box`-like) -- exclusive ownership, neither `Copy` nor `Clone`
 - **Shared handles** (`Arc`-like) -- shared ownership via reference counting
+
+Declare them with the `#[handle_descriptor]` macro and prefix the type name with `Exclusive`
+or `Shared` so the ownership model is visible at the use site (e.g. `SharedSnapshot`,
+`ExclusiveTransaction`).
 
 A handle is needed when a value might outlive the function call that passes it across the
 FFI boundary, or when the type is not representable in C/C++ (dyn trait references, slices,
@@ -16,6 +33,30 @@ options, etc.). Short-lived "plain old data" types like `ExternResult`, `KernelE
 `KernelStringSlice`, and `EngineIterator` do not need handles.
 
 Every handle has a corresponding `free_*` function (e.g. `free_engine`, `free_snapshot`).
+
+## Memory Ownership
+
+Default to **kernel-allocated** data whose ownership transfers via a handle: it keeps freeing
+explicit (the engine calls `free_*`) and avoids upcalls just to release memory. Reach for
+**engine-allocated** data only where it genuinely pays off:
+- Arrow `EngineData` (Arrow's C Data Interface already carries ownership-transfer semantics),
+- error strings (the callee allocates them in the caller's space; see Error Handling), and
+- engine-owned iterators, where kernel must re-enter engine state across upcalls.
+
+For engine-allocated state, the engine supplies the data plus a `free` callback. Mirror its
+layout with a `repr(C)` struct prefixed `C` (e.g. `CEngineDataIterator`), and wrap it in a
+Rust adapter prefixed `Ffi` (e.g. `FfiEngineDataIter`) whose `Drop` invokes that `free`
+callback -- so the engine resource is released deterministically by Rust's ownership rules.
+
+## repr(C) structs & out-pointers
+
+Small `repr(C)` structs cross the boundary by value (inputs, grouped primitive returns,
+tagged unions like `ExternResult`/`OptionalValue`). Prefix the transparent type with `C`.
+
+Upcalls that return a struct use an **out-pointer**: Rust passes `*mut T` and the engine
+writes into it. Before invoking the upcall, always initialize `*out` to a well-defined
+sentinel (e.g. `EngineExecResult::Uninit`) so a callback that fails to write cannot leave
+Rust reading uninitialized memory -- treat a still-sentinel value after the call as failure.
 
 ## Error Handling
 

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -1,15 +1,13 @@
 # FFI Layer
 
-Scope: `ffi/**`. Cross-cutting Rust/comment/protocol conventions live in the root
-`CLAUDE.md`; this file is the FFI-boundary context.
-
 The `delta_kernel_ffi` crate exposes the kernel to C/C++ via a stable FFI boundary using
 cbindgen-generated headers (`.h` and `.hpp`).
 
 ## Terminology
 
 - **Kernel vs engine** -- "kernel" is the native Rust side; "engine" is the foreign runtime
-  on the other side of the boundary. This is the lens for "which side allocated/owns this".
+  on the other side of the boundary. Use this split to reason about which side allocated and owns
+  a value.
 - **Downcall vs upcall** -- a downcall is the engine invoking an exported Rust function; an
   upcall is Rust invoking an engine-provided function pointer.
 - **Allocator vs owner** -- the allocator initialized the memory and knows *how* to free it;
@@ -25,7 +23,9 @@ ownership semantics:
 
 Declare them with the `#[handle_descriptor]` macro and prefix the type name with `Exclusive`
 or `Shared` so the ownership model is visible at the use site (e.g. `SharedSnapshot`,
-`ExclusiveTransaction`).
+`ExclusiveTransaction`). The public type convention is `Exclusive`/`Shared`, but the
+macro-internal vocabulary is still "mutable" -- the `#[handle_descriptor(mutable = ...)]` argument
+and `HandleDescriptor::Mutable` -- so don't be surprised by the mismatch when editing the macro.
 
 A handle is needed when a value might outlive the function call that passes it across the
 FFI boundary, or when the type is not representable in C/C++ (dyn trait references, slices,

--- a/kernel/tests/CLAUDE.md
+++ b/kernel/tests/CLAUDE.md
@@ -1,9 +1,9 @@
 # Integration test guidelines
 
-Scope: `kernel/tests/**`. This file holds the mechanics for writing kernel integration
-tests -- table setup, helper catalog, and commit/read patterns. The universal testing
-philosophy (unit vs integration, rstest consolidation, naming) lives in the root
-`CLAUDE.md`; this file is the source of truth for *how* to set up and assert against tables.
+This file is the source of truth for *how* to set up and assert against tables in kernel
+integration tests: table setup, commit/read patterns, and where the shared helpers live. (The
+universal testing philosophy -- unit vs integration, rstest consolidation, naming -- is in the
+root `CLAUDE.md`.)
 
 Integration tests exercise only public APIs end-to-end. See `kernel/tests/README.md` for a
 catalog of available test tables (schema, protocol, features, and which tests use them).
@@ -31,65 +31,35 @@ Consult it before creating new test data to avoid duplication.
   use `match` + `panic!` for either -- they provide a clear error message on failure. Available
   under `#[cfg(test)]` and the `test-utils` feature.
 - **Prefer snapshot/public API assertions over reading raw commit JSON.** Only read raw commit
-  JSON when the data is inaccessible via public API (e.g., system domain metadata is blocked by
-  `get_domain_metadata`). For commit JSON reads, use `read_actions_from_commit` from
-  `test_utils` -- do NOT write local helpers that duplicate this.
+  JSON when the data is genuinely inaccessible otherwise (e.g. the public `get_domain_metadata`
+  rejects system `delta.*` domains; `get_domain_metadata_internal` can read them but is gated
+  behind `internal-api`). For commit JSON reads, use `read_actions_from_commit` from `test_utils`
+  -- do NOT write local helpers that duplicate this.
 
 ## Common test helpers
 
-Before writing a custom helper, check this curated list and the locations below. This list is
-non-exhaustive -- when in doubt, browse the source files directly (`test-utils/src/lib.rs`,
-`kernel/tests/integration/common/`, `kernel/tests/integration/<topic>/mod.rs`).
+Before writing a custom helper, look for an existing one -- the shared utilities already cover
+most setup, commit, read, and assertion needs, and re-rolling them is one of the most common
+review comments on test PRs. Read the source rather than relying on a name list here, which would
+drift as helpers are added or renamed:
 
-**Arrow construction (from `delta_kernel::arrow`)**
+- `test-utils/src/lib.rs` -- engine/table setup (`test_table_setup` and its `_mt` variant),
+  commit and read helpers (`add_commit`, `read_actions_from_commit`, `test_read`,
+  `into_record_batch`), schema fixtures, and assertion helpers. Run
+  `rg '^pub (fn|async fn)' test-utils/src/lib.rs` for the current surface.
+- `kernel/tests/integration/common/` (notably `write_utils.rs`) -- integration-test fixtures and
+  write helpers.
+- `kernel/tests/integration/<topic>/mod.rs` -- topic-local fixtures (e.g. `simple_schema`,
+  `partition_test_schema` in `create_table/mod.rs`).
+- `delta_kernel::arrow` -- Arrow construction helpers such as `new_null_array`; prefer these over
+  hand-rolled per-type array builders. (The `TryIntoArrow` conversions live separately, in
+  `delta_kernel::engine::arrow_conversion`.)
 
-- `arrow::array::new_null_array(&arrow_type, n)` -- Arrow array of `n` nulls of any Arrow
-  type. Prefer this over per-type `Int32Array::from(vec![None as Option<i32>])` builders.
-- `engine::arrow_conversion::TryIntoArrow`:
-  `(&kernel_data_type).try_into_arrow()` for `DataType`,
-  `(&kernel_struct_type).try_into_arrow()` for `StructType` -> Arrow `Schema`.
+Two judgment calls worth stating outright, since grep won't tell you which to pick:
 
-**Engine + table setup (from `test_utils`)**
-
-- `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
-  variant under `#[tokio::test(flavor = "multi_thread")]`. Required whenever a test calls
-  `snapshot.checkpoint()`: it issues nested `block_on` calls that deadlock on a single-threaded
-  runtime / `TokioBackgroundExecutor`.
-- `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
-  needs direct object-store access.
-- `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.
-
-**Table creation in tests**
-
-- Prefer the kernel `create_table` builder
-  (`delta_kernel::transaction::create_table::create_table`). It exercises the same path
-  connectors use and auto-derives the protocol from the schema and feature flags.
-- `test_utils::create_table` (a JSON helper that hand-rolls protocol + metadata) is older
-  but still needed when the kernel builder cannot enable a particular feature combination.
-
-**Schema fixtures**
-
-- `test_utils`: `nested_schema`, `schema_with_type`, `nested_schema_with_type`,
-  `multi_schema_with_type`, `top_level_ntz_schema` / `nested_ntz_schema` /
-  `multiple_ntz_schema`, `top_level_variant_schema` / `nested_variant_schema` /
-  `multiple_variant_schema`.
-- `kernel/tests/integration/create_table/mod.rs`: `simple_schema`, `partition_test_schema`.
-
-**Commit + read helpers (from `test_utils`)**
-
-- `add_commit`, `add_staged_commit` -- write a JSON commit at a given version.
-- `read_actions_from_commit` -- read raw JSON actions from a specific commit. Use this
-  instead of hand-rolled `serde_json` parsing.
-- `test_read` -- full-scan read of a table; use for round-trip assertions.
-- `into_record_batch` -- convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
-
-**Assertion helpers (from `test_utils`)**
-
-- `assert_schema_has_field(schema, &["a", "b"])` -- assert a (possibly nested) field path.
-- `assert_result_error_with_message(result, "needle")` -- assert an error contains a
-  substring.
-
-**If a name here doesn't match what's in code:** the list may have drifted from a rename.
-Run `rg '^pub (fn|async fn)' test-utils/src/lib.rs` to discover the current public surface,
-and update this section in your PR. The same pattern works for
-`kernel/tests/integration/common/write_utils.rs`.
+- Prefer the kernel `create_table` builder (`delta_kernel::transaction::create_table::create_table`)
+  over the older hand-rolled `test_utils::create_table` JSON helper -- reach for the JSON helper
+  only when the builder can't express the feature combination you need.
+- Use the `_mt` setup variant under `#[tokio::test(flavor = "multi_thread")]` whenever a test hits
+  a nested-`block_on` path such as `snapshot.checkpoint()` (see `default-engine/CLAUDE.md` for why
+  a single-threaded runtime deadlocks there).

--- a/kernel/tests/CLAUDE.md
+++ b/kernel/tests/CLAUDE.md
@@ -1,0 +1,95 @@
+# Integration test guidelines
+
+Scope: `kernel/tests/**`. This file holds the mechanics for writing kernel integration
+tests -- table setup, helper catalog, and commit/read patterns. The universal testing
+philosophy (unit vs integration, rstest consolidation, naming) lives in the root
+`CLAUDE.md`; this file is the source of truth for *how* to set up and assert against tables.
+
+Integration tests exercise only public APIs end-to-end. See `kernel/tests/README.md` for a
+catalog of available test tables (schema, protocol, features, and which tests use them).
+Consult it before creating new test data to avoid duplication.
+
+## Table setup
+
+- **`add_commit` and table setup:** `add_commit` takes a `table_root` string and resolves it
+  to an absolute object-store path. The `table_root` must be a proper URL string with a
+  trailing slash (e.g. `"memory:///"`, `"file:///tmp/my_table/"`). Avoid using the `Url` type
+  directly -- most test helpers and kernel APIs accept `impl AsRef<str>`, so pass URL strings
+  instead. When using local storage, use an un-prefixed store (`LocalFileSystem::new()`) with
+  a `file:///` URL string. Do NOT use `LocalFileSystem::new_with_prefix()` with `add_commit`
+  -- the prefix causes double-nesting because `add_commit` already resolves the full path from
+  the URL. For in-memory tests, use `InMemory::new()` with `"memory:///"`. ALWAYS use the same
+  `table_root` URL string for both `add_commit` (writing log files) and
+  `snapshot`/`Snapshot::try_new` (reading the table). ALWAYS include a trailing slash in
+  directory URLs to ensure correct path joining.
+
+## Asserting against commits
+
+- **Committing in tests:** Use `txn.commit(engine)?.unwrap_committed()` to assert a successful
+  commit and get the `CommittedTransaction`. When you only need the resulting snapshot, use
+  `txn.commit(engine)?.unwrap_post_commit_snapshot()` to get the `SnapshotRef` directly. Do NOT
+  use `match` + `panic!` for either -- they provide a clear error message on failure. Available
+  under `#[cfg(test)]` and the `test-utils` feature.
+- **Prefer snapshot/public API assertions over reading raw commit JSON.** Only read raw commit
+  JSON when the data is inaccessible via public API (e.g., system domain metadata is blocked by
+  `get_domain_metadata`). For commit JSON reads, use `read_actions_from_commit` from
+  `test_utils` -- do NOT write local helpers that duplicate this.
+
+## Common test helpers
+
+Before writing a custom helper, check this curated list and the locations below. This list is
+non-exhaustive -- when in doubt, browse the source files directly (`test-utils/src/lib.rs`,
+`kernel/tests/integration/common/`, `kernel/tests/integration/<topic>/mod.rs`).
+
+**Arrow construction (from `delta_kernel::arrow`)**
+
+- `arrow::array::new_null_array(&arrow_type, n)` -- Arrow array of `n` nulls of any Arrow
+  type. Prefer this over per-type `Int32Array::from(vec![None as Option<i32>])` builders.
+- `engine::arrow_conversion::TryIntoArrow`:
+  `(&kernel_data_type).try_into_arrow()` for `DataType`,
+  `(&kernel_struct_type).try_into_arrow()` for `StructType` -> Arrow `Schema`.
+
+**Engine + table setup (from `test_utils`)**
+
+- `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
+  variant under `#[tokio::test(flavor = "multi_thread")]`. Required whenever a test calls
+  `snapshot.checkpoint()`: it issues nested `block_on` calls that deadlock on a single-threaded
+  runtime / `TokioBackgroundExecutor`.
+- `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
+  needs direct object-store access.
+- `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.
+
+**Table creation in tests**
+
+- Prefer the kernel `create_table` builder
+  (`delta_kernel::transaction::create_table::create_table`). It exercises the same path
+  connectors use and auto-derives the protocol from the schema and feature flags.
+- `test_utils::create_table` (a JSON helper that hand-rolls protocol + metadata) is older
+  but still needed when the kernel builder cannot enable a particular feature combination.
+
+**Schema fixtures**
+
+- `test_utils`: `nested_schema`, `schema_with_type`, `nested_schema_with_type`,
+  `multi_schema_with_type`, `top_level_ntz_schema` / `nested_ntz_schema` /
+  `multiple_ntz_schema`, `top_level_variant_schema` / `nested_variant_schema` /
+  `multiple_variant_schema`.
+- `kernel/tests/integration/create_table/mod.rs`: `simple_schema`, `partition_test_schema`.
+
+**Commit + read helpers (from `test_utils`)**
+
+- `add_commit`, `add_staged_commit` -- write a JSON commit at a given version.
+- `read_actions_from_commit` -- read raw JSON actions from a specific commit. Use this
+  instead of hand-rolled `serde_json` parsing.
+- `test_read` -- full-scan read of a table; use for round-trip assertions.
+- `into_record_batch` -- convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
+
+**Assertion helpers (from `test_utils`)**
+
+- `assert_schema_has_field(schema, &["a", "b"])` -- assert a (possibly nested) field path.
+- `assert_result_error_with_message(result, "needle")` -- assert an error contains a
+  substring.
+
+**If a name here doesn't match what's in code:** the list may have drifted from a rename.
+Run `rg '^pub (fn|async fn)' test-utils/src/lib.rs` to discover the current public surface,
+and update this section in your PR. The same pattern works for
+`kernel/tests/integration/common/write_utils.rs`.

--- a/test-utils/CLAUDE.md
+++ b/test-utils/CLAUDE.md
@@ -1,9 +1,7 @@
 # Test utilities guidelines
 
-Scope: `test-utils/**`. Cross-cutting conventions live in the root `CLAUDE.md`; the universal
-testing philosophy is there too, and the curated catalog of what these helpers are and when to
-reach for them lives in `kernel/tests/CLAUDE.md`. This file is about *maintaining* the shared
-helper crate.
+This file is about *maintaining* the shared helper crate. How to *use* these helpers from tests
+is in `kernel/tests/CLAUDE.md`.
 
 ## What this crate is
 
@@ -16,12 +14,13 @@ its public items are effectively an internal API.
 
 - **Add the helper here, not a private copy in a test.** The reason this crate exists is to stop
   every test file from hand-rolling table setup or commit-JSON parsing. Before adding a helper,
-  check whether one already exists (and is catalogued in `kernel/tests/CLAUDE.md`); when you add
-  or rename one, update that catalog so it doesn't drift.
+  check whether one already exists; give every new public helper a doc comment so callers can
+  discover it from the source.
 - **Keep helpers reusable and engine-agnostic where they can be.** A helper baked to one test's
   specifics defeats the purpose; prefer parameters and the existing sweep templates over forking.
 - **Exported sweep templates are a shared macro surface.** Templates are reachable from other
   crates; renaming or repurposing one ripples across consumers -- treat it like an API change.
 - **Honor the multi-thread runtime requirement.** Setup helpers come in single- and multi-thread
-  variants because checkpoint-style operations deadlock on a single-threaded runtime; keep both
-  paths working and point callers at the `_mt` variant when nested blocking is possible.
+  variants because some kernel operations need the multi-thread runtime (see
+  `default-engine/CLAUDE.md` for the nested-`block_on` reason); keep both paths working and point
+  callers at the `_mt` variant when nested blocking is possible.

--- a/test-utils/CLAUDE.md
+++ b/test-utils/CLAUDE.md
@@ -1,0 +1,27 @@
+# Test utilities guidelines
+
+Scope: `test-utils/**`. Cross-cutting conventions live in the root `CLAUDE.md`; the universal
+testing philosophy is there too, and the curated catalog of what these helpers are and when to
+reach for them lives in `kernel/tests/CLAUDE.md`. This file is about *maintaining* the shared
+helper crate.
+
+## What this crate is
+
+`test_utils` is the shared test-support surface for the whole workspace: engine/table setup,
+table builders and parameterized sweep templates, commit/read helpers, schema fixtures, a
+counting metrics reporter, and a mock catalog committer. Other crates depend on it for tests, so
+its public items are effectively an internal API.
+
+## Invariants to uphold
+
+- **Add the helper here, not a private copy in a test.** The reason this crate exists is to stop
+  every test file from hand-rolling table setup or commit-JSON parsing. Before adding a helper,
+  check whether one already exists (and is catalogued in `kernel/tests/CLAUDE.md`); when you add
+  or rename one, update that catalog so it doesn't drift.
+- **Keep helpers reusable and engine-agnostic where they can be.** A helper baked to one test's
+  specifics defeats the purpose; prefer parameters and the existing sweep templates over forking.
+- **Exported sweep templates are a shared macro surface.** Templates are reachable from other
+  crates; renaming or repurposing one ripples across consumers -- treat it like an API change.
+- **Honor the multi-thread runtime requirement.** Setup helpers come in single- and multi-thread
+  variants because checkpoint-style operations deadlock on a single-threaded runtime; keep both
+  paths working and point callers at the `_mt` variant when nested blocking is possible.

--- a/unity-catalog-delta-client-api/CLAUDE.md
+++ b/unity-catalog-delta-client-api/CLAUDE.md
@@ -1,0 +1,23 @@
+# Unity Catalog client API guidelines
+
+Scope: `unity-catalog-delta-client-api/**`. Cross-cutting conventions live in the root
+`CLAUDE.md`. The UC crate stack and how this layer fits is described in
+`delta-kernel-unity-catalog/CLAUDE.md`.
+
+## What this crate is
+
+The transport-agnostic contract for talking to Unity Catalog's Delta APIs: the `GetCommitsClient`
+and `CommitClient` traits plus the request/response and credential-vending models they exchange.
+It contains **no HTTP and no concrete client** -- the REST implementation lives in
+`unity-catalog-delta-rest-client`, and an in-memory mock (behind `test-utils`) backs unit tests.
+
+## Invariants to uphold
+
+- **This is the seam; keep it implementation-free.** No reqwest, no wire details, no kernel
+  dependency. Anything HTTP-specific belongs in the REST client.
+- **Retries are the implementor's responsibility, not the caller's.** The trait contract assumes
+  a client handles transient failures internally; document and honor that when adding methods.
+- **Clients are `Send + Sync`** so they can be shared across threads -- preserve those bounds on
+  any new trait or method.
+- **Models are shared across all UC crates.** Add or change a type here and let the REST client
+  and `delta-kernel-unity-catalog` consume it; do not redefine UC models downstream.

--- a/unity-catalog-delta-client-api/CLAUDE.md
+++ b/unity-catalog-delta-client-api/CLAUDE.md
@@ -1,15 +1,13 @@
 # Unity Catalog client API guidelines
 
-Scope: `unity-catalog-delta-client-api/**`. Cross-cutting conventions live in the root
-`CLAUDE.md`. The UC crate stack and how this layer fits is described in
-`delta-kernel-unity-catalog/CLAUDE.md`.
-
 ## What this crate is
 
 The transport-agnostic contract for talking to Unity Catalog's Delta APIs: the `GetCommitsClient`
 and `CommitClient` traits plus the request/response and credential-vending models they exchange.
 It contains **no HTTP and no concrete client** -- the REST implementation lives in
 `unity-catalog-delta-rest-client`, and an in-memory mock (behind `test-utils`) backs unit tests.
+Where this layer sits in the three-crate UC stack is described in
+`delta-kernel-unity-catalog/CLAUDE.md`.
 
 ## Invariants to uphold
 

--- a/unity-catalog-delta-rest-client/CLAUDE.md
+++ b/unity-catalog-delta-rest-client/CLAUDE.md
@@ -1,13 +1,12 @@
 # Unity Catalog REST client guidelines
 
-Scope: `unity-catalog-delta-rest-client/**`. Cross-cutting conventions live in the root
-`CLAUDE.md`. The UC crate stack is described in `delta-kernel-unity-catalog/CLAUDE.md`.
-
 ## What this crate is
 
 The concrete HTTP implementation of the traits defined in `unity-catalog-delta-client-api`,
 built on `reqwest`. It provides the commits client (`GetCommitsClient` + `CommitClient`) and a
 higher-level client for table/credential endpoints, configured through a `ClientConfig` builder.
+Where this layer sits in the three-crate UC stack is described in
+`delta-kernel-unity-catalog/CLAUDE.md`.
 
 ## Invariants to uphold
 

--- a/unity-catalog-delta-rest-client/CLAUDE.md
+++ b/unity-catalog-delta-rest-client/CLAUDE.md
@@ -1,0 +1,21 @@
+# Unity Catalog REST client guidelines
+
+Scope: `unity-catalog-delta-rest-client/**`. Cross-cutting conventions live in the root
+`CLAUDE.md`. The UC crate stack is described in `delta-kernel-unity-catalog/CLAUDE.md`.
+
+## What this crate is
+
+The concrete HTTP implementation of the traits defined in `unity-catalog-delta-client-api`,
+built on `reqwest`. It provides the commits client (`GetCommitsClient` + `CommitClient`) and a
+higher-level client for table/credential endpoints, configured through a `ClientConfig` builder.
+
+## Invariants to uphold
+
+- **Implement the upstream traits; don't reinvent their models.** This crate's job is wire
+  transport. The trait shapes and exchanged types are owned by `unity-catalog-delta-client-api`.
+- **Own retry and HTTP error mapping here.** The trait contract says clients absorb transient
+  failures, so retry/backoff and translation of HTTP status into the shared error type live in
+  this layer, not in callers.
+- **The API is async** (Tokio/reqwest); every public method is async. Don't add blocking calls.
+- **Configuration is explicit.** Endpoint and auth must come through `ClientConfig`; never read
+  ambient credentials or hard-code endpoints.

--- a/workloads/CLAUDE.md
+++ b/workloads/CLAUDE.md
@@ -1,0 +1,25 @@
+# Workloads guidelines
+
+Scope: `workloads/**`. Cross-cutting conventions live in the root `CLAUDE.md`; this file is the
+workload-spec context.
+
+## What this crate is
+
+`delta_kernel_workloads` holds the shared description of a benchmark/acceptance workload --
+table identity and layout, read configuration (serial vs parallel scan), and a SQL predicate
+parser that turns a WHERE clause into a kernel expression. It is the common vocabulary the
+benchmark and remote-table suites build on; aside from loading its own spec JSON it drives no
+engine and runs no workload itself.
+
+## Invariants to uphold
+
+- **A workload points at a table one way or the other** -- a filesystem/object-store path or UC
+  catalog identity, not both. Today these are two optional fields with the exclusivity checked at
+  parse time (there is a TODO to make it a single enum); preserve the invariant however it is
+  modeled, and don't let both fields be populated.
+- **The predicate parser must emit the same expression kernel would evaluate.** It is a thin SQL
+  front-end over kernel's expression types; when extending it, mirror kernel's operator and
+  literal semantics exactly -- a parser that subtly diverges produces benchmarks that don't
+  measure the real predicate.
+- **Specs must round-trip and stay engine-neutral.** These types are serialized and shared across
+  suites; keep them serde-stable and free of engine- or backend-specific assumptions.

--- a/workloads/CLAUDE.md
+++ b/workloads/CLAUDE.md
@@ -1,8 +1,5 @@
 # Workloads guidelines
 
-Scope: `workloads/**`. Cross-cutting conventions live in the root `CLAUDE.md`; this file is the
-workload-spec context.
-
 ## What this crate is
 
 `delta_kernel_workloads` holds the shared description of a benchmark/acceptance workload --
@@ -14,9 +11,8 @@ engine and runs no workload itself.
 ## Invariants to uphold
 
 - **A workload points at a table one way or the other** -- a filesystem/object-store path or UC
-  catalog identity, not both. Today these are two optional fields with the exclusivity checked at
-  parse time (there is a TODO to make it a single enum); preserve the invariant however it is
-  modeled, and don't let both fields be populated.
+  catalog identity, not both. The two are modeled as separate optional fields with the exclusivity
+  checked at parse time; preserve that invariant and never let both fields be populated.
 - **The predicate parser must emit the same expression kernel would evaluate.** It is a thin SQL
   front-end over kernel's expression types; when extending it, mirror kernel's operator and
   literal semantics exactly -- a parser that subtly diverges produces benchmarks that don't


### PR DESCRIPTION
## What changes are proposed in this pull request?

Restructure the kernel docs such that each directory is more contained and has a `CLAUDE.md` next to each meaningful crate, instead of one root file that applies to every PR in the workspace.

- Move the integration-test mechanics and helper catalog out of the root `CLAUDE.md` into `kernel/tests/CLAUDE.md`.
- Add per-crate guidelines for `default-engine`, the three unity-catalog crates, `derive-macros`, `test-utils`, `acceptance`, and `workloads`.
- Fold the FFI memory-ownership, handle-naming, and common conventions into `ffi/CLAUDE.md`.
- Fix a stale `log_replay.rs` -> `log_replay/` path in `architecture.md`.

## How was this change tested?

Docs-only change. Every factual claim (module and symbol names, crate dependency direction, the catalog committer protocol, FFI conventions) was verified against the current source.