### PR TITLE
fix: stop snapshot-loading spans from capturing full LogSegment

### DIFF
--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -23,7 +23,7 @@ impl LogSegment {
     /// snapshot creation where both Protocol and Metadata must exist.
     ///
     /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, crc))]
+    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip_all)]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -504,12 +504,18 @@ impl SnapshotBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use itertools::Itertools;
     use serde_json::json;
     use test_utils::{actions_to_string, add_commit, TestAction};
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Level, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer, SubscriberExt as _};
+    use tracing_subscriber::registry::LookupSpan;
 
     use super::*;
     use crate::engine::sync::SyncEngine;
@@ -519,6 +525,90 @@ mod tests {
     use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
     use crate::utils::FoldWithOption as _;
+
+    type TraceFields = BTreeMap<&'static str, String>;
+    type CapturedTraces = Vec<(&'static str, TraceFields)>;
+
+    #[derive(Clone, Default)]
+    struct ConstructorTrace {
+        span_fields: Arc<Mutex<BTreeMap<&'static str, BTreeSet<&'static str>>>>,
+        span_values: Arc<Mutex<CapturedTraces>>,
+        span_records: Arc<Mutex<CapturedTraces>>,
+        error_events: Arc<Mutex<CapturedTraces>>,
+    }
+
+    #[derive(Default)]
+    struct FieldValueVisitor(TraceFields);
+
+    impl Visit for FieldValueVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0.insert(field.name(), value.to_owned());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for ConstructorTrace
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+            let span_name = attrs.metadata().name();
+            if !matches!(span_name, "try_new_from_log_segment" | "try_new_from") {
+                return;
+            }
+
+            let fields = attrs
+                .metadata()
+                .fields()
+                .iter()
+                .map(|field| field.name())
+                .collect();
+            self.span_fields.lock().unwrap().insert(span_name, fields);
+
+            let mut values = FieldValueVisitor::default();
+            attrs.record(&mut values);
+            self.span_values.lock().unwrap().push((span_name, values.0));
+        }
+
+        fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+            let Some(span) = ctx.span(id) else {
+                return;
+            };
+            let span_name = span.name();
+            if !matches!(span_name, "try_new_from_log_segment" | "try_new_from") {
+                return;
+            }
+
+            let mut fields = FieldValueVisitor::default();
+            values.record(&mut fields);
+            self.span_records
+                .lock()
+                .unwrap()
+                .push((span_name, fields.0));
+        }
+
+        fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+            if *event.metadata().level() != Level::ERROR {
+                return;
+            }
+            let Some(span) = ctx.event_span(event) else {
+                return;
+            };
+            if !matches!(span.name(), "try_new_from_log_segment" | "try_new_from") {
+                return;
+            }
+
+            let mut fields = FieldValueVisitor::default();
+            event.record(&mut fields);
+            self.error_events
+                .lock()
+                .unwrap()
+                .push((span.name(), fields.0));
+        }
+    }
 
     fn setup_test() -> (Arc<SyncEngine>, Arc<DynObjectStore>, String) {
         let table_root = String::from("memory:///");
@@ -755,6 +845,194 @@ mod tests {
             .expect("expected SnapshotBuildSuccess event");
         assert_eq!(version, 1, "version should match the updated snapshot");
         assert!(duration > Duration::ZERO, "duration should be non-zero");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_constructor_spans_capture_compact_context_and_full_error_arguments(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+
+        let captured = ConstructorTrace::default();
+        let _guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+
+        let snapshot = SnapshotBuilder::new_for(table_root.clone())
+            .at_version(0)
+            .build(engine.as_ref())?;
+        let updated = SnapshotBuilder::new_from(snapshot).build(engine.as_ref())?;
+        assert_eq!(updated.version(), 1);
+        assert!(captured.error_events.lock().unwrap().is_empty());
+
+        {
+            let span_fields = captured.span_fields.lock().unwrap();
+            let expected_fields = BTreeSet::from([
+                "path",
+                "version",
+                "operation_id",
+                "correlation_id",
+                "incremental_replay",
+                "built_as_latest",
+            ]);
+            assert_eq!(
+                span_fields.keys().copied().collect::<BTreeSet<_>>(),
+                BTreeSet::from(["try_new_from_log_segment", "try_new_from"])
+            );
+            assert!(span_fields
+                .values()
+                .all(|fields| fields == &expected_fields));
+        }
+        {
+            let span_values = captured.span_values.lock().unwrap();
+            assert!(!span_values.is_empty());
+            assert!(span_values.iter().all(|(_, fields)| {
+                fields.values().all(|value| value.len() < 256)
+                    && fields
+                        .get("path")
+                        .is_some_and(|path| path.contains(&table_root))
+            }));
+            let fresh_values = span_values
+                .iter()
+                .find(|(span_name, _)| *span_name == "try_new_from_log_segment")
+                .map(|(_, fields)| fields)
+                .expect("expected fresh constructor span values");
+            assert_eq!(fresh_values["version"], "0");
+        }
+        {
+            let span_records = captured.span_records.lock().unwrap();
+            assert!(!span_records.is_empty());
+            assert!(span_records.iter().all(|(_, fields)| {
+                fields.keys().copied().collect::<BTreeSet<_>>() == BTreeSet::from(["version"])
+                    && fields["version"].len() < 32
+            }));
+            assert_eq!(
+                span_records
+                    .iter()
+                    .filter(|(span_name, _)| *span_name == "try_new_from")
+                    .map(|(_, fields)| fields["version"].as_str())
+                    .collect::<BTreeSet<_>>(),
+                BTreeSet::from(["0", "1"])
+            );
+        }
+
+        let same_version = SnapshotBuilder::new_from(updated.clone())
+            .at_version(1)
+            .build(engine.as_ref())?;
+        assert!(Arc::ptr_eq(&updated, &same_version));
+        let unchanged = SnapshotBuilder::new_from(updated.clone()).build(engine.as_ref())?;
+        assert!(Arc::ptr_eq(&updated, &unchanged));
+        assert!(captured.error_events.lock().unwrap().is_empty());
+
+        assert!(SnapshotBuilder::new_from(updated.clone())
+            .at_version(0)
+            .with_correlation_id("incremental-test")
+            .build(engine.as_ref())
+            .is_err());
+
+        let (invalid_engine, invalid_store, invalid_root) = setup_test();
+        add_commit(
+            &invalid_root,
+            invalid_store.as_ref(),
+            0,
+            actions_to_string(vec![TestAction::Add("part-00000-test.parquet".into())]),
+        )
+        .await?;
+        assert!(SnapshotBuilder::new_for(invalid_root)
+            .with_correlation_id("fresh-test")
+            .build(invalid_engine.as_ref())
+            .is_err());
+
+        let error_events = captured.error_events.lock().unwrap();
+        assert_eq!(error_events.len(), 2);
+        let incremental_error = error_events
+            .iter()
+            .find(|(span_name, _)| *span_name == "try_new_from")
+            .map(|(_, event)| event)
+            .expect("expected incremental constructor error event");
+        assert_eq!(
+            incremental_error.keys().copied().collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "built_as_latest",
+                "error",
+                "existing_snapshot",
+                "incremental_replay",
+                "log_tail",
+                "message",
+                "metric_context",
+            ])
+        );
+        assert!(!incremental_error["error"].is_empty());
+        assert!(incremental_error["existing_snapshot"].contains("Snapshot"));
+        assert_eq!(incremental_error["log_tail"], "[]");
+        assert!(incremental_error["metric_context"].contains("incremental-test"));
+        assert_eq!(incremental_error["incremental_replay"], "Disabled");
+        assert_eq!(incremental_error["message"], "failed to update snapshot");
+
+        let fresh_error = error_events
+            .iter()
+            .find(|(span_name, _)| *span_name == "try_new_from_log_segment")
+            .map(|(_, event)| event)
+            .expect("expected fresh constructor error event");
+        assert_eq!(
+            fresh_error.keys().copied().collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                "built_as_latest",
+                "error",
+                "incremental_replay",
+                "location",
+                "log_segment",
+                "message",
+                "metric_context",
+            ])
+        );
+        assert!(!fresh_error["error"].is_empty());
+        assert!(fresh_error["location"].contains("memory"));
+        assert!(fresh_error["log_segment"].contains("LogSegment"));
+        assert!(fresh_error["metric_context"].contains("fresh-test"));
+        assert_eq!(fresh_error["incremental_replay"], "Disabled");
+        assert_eq!(
+            fresh_error["message"],
+            "failed to construct snapshot from log segment"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn snapshot_rebuild_failure_emits_inner_and_outer_constructor_errors(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+        let snapshot = SnapshotBuilder::new_for(table_root)
+            .at_version(0)
+            .build(engine.as_ref())?;
+
+        store
+            .put(
+                &Path::from("_delta_log/00000000000000000001.checkpoint.parquet"),
+                b"not parquet".to_vec().into(),
+            )
+            .await?;
+
+        let captured = ConstructorTrace::default();
+        let _guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(captured.clone()));
+
+        assert!(SnapshotBuilder::new_from(snapshot)
+            .build(engine.as_ref())
+            .is_err());
+
+        let error_events = captured.error_events.lock().unwrap();
+        assert_eq!(error_events.len(), 2);
+        assert_eq!(
+            error_events
+                .iter()
+                .map(|(span_name, _)| *span_name)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from(["try_new_from", "try_new_from_log_segment"])
+        );
+
         Ok(())
     }
 

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -82,7 +82,7 @@ impl Snapshot {
     ///
     /// [`SnapshotBuilder::at_version`]: crate::snapshot::SnapshotBuilder::at_version
     /// [`SnapshotBuilder::with_max_catalog_version`]: crate::snapshot::SnapshotBuilder::with_max_catalog_version
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, target_version))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip_all)]
     pub(super) fn try_new_from(
         existing_snapshot: Arc<Snapshot>,
         log_tail: Vec<ParsedLogPath>,

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use tracing::instrument;
+use tracing::{error, instrument};
 
 use super::{IncrementalReplay, Snapshot};
 use crate::cancellation::CancellationTokenRef;
@@ -100,7 +100,7 @@ impl Snapshot {
     /// [`SnapshotBuilder::at_version`]: crate::snapshot::SnapshotBuilder::at_version
     /// [`SnapshotBuilder::with_max_catalog_version`]: crate::snapshot::SnapshotBuilder::with_max_catalog_version
     #[allow(clippy::too_many_arguments)]
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, target_version, cancellation_token))]
+    #[instrument(skip_all, fields(path = %existing_snapshot.table_root(), version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""), incremental_replay = ?incremental_replay, built_as_latest = built_as_latest))]
     pub(super) fn try_new_from(
         existing_snapshot: Arc<Snapshot>,
         log_tail: Vec<ParsedLogPath>,
@@ -111,9 +111,44 @@ impl Snapshot {
         built_as_latest: bool,
         cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Arc<Self>> {
-        let existing_log_segment = &existing_snapshot.log_segment;
-        let existing_snapshot_version = existing_snapshot.version();
         let requested_version = target_version.into();
+        // Full failure dumps require retaining these consumed values. The eager log-tail clone
+        // allocates with the tail size even on success; that is the cost of exact diagnostics.
+        let result = Self::try_new_from_impl(
+            existing_snapshot.clone(),
+            log_tail.clone(),
+            engine,
+            requested_version,
+            &metric_context,
+            incremental_replay,
+            built_as_latest,
+            cancellation_token,
+        );
+        result.inspect_err(|error| {
+            error!(
+                %error,
+                ?existing_snapshot,
+                ?log_tail,
+                ?metric_context,
+                ?incremental_replay,
+                built_as_latest,
+                "failed to update snapshot"
+            );
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_new_from_impl(
+        existing_snapshot: Arc<Snapshot>,
+        log_tail: Vec<ParsedLogPath>,
+        engine: &dyn Engine,
+        requested_version: Option<Version>,
+        metric_context: &SnapshotLoadMetricContext,
+        incremental_replay: IncrementalReplay,
+        built_as_latest: bool,
+        cancellation_token: Option<&CancellationTokenRef>,
+    ) -> DeltaResult<Arc<Self>> {
+        let existing_snapshot_version = existing_snapshot.version();
         if let Some(requested_version) = requested_version {
             tracing::Span::current().record("version", requested_version);
             // Case A: re-requesting the same version.
@@ -131,6 +166,8 @@ impl Snapshot {
             tracing::Span::current().record("version", existing_snapshot_version);
         }
 
+        let existing_log_segment = &existing_snapshot.log_segment;
+
         // Assemble the new segment as one fallible unit so a load failure emits exactly once, via
         // the `inspect_err` below.
         let segment_load_start = std::time::Instant::now();
@@ -142,22 +179,24 @@ impl Snapshot {
             requested_version,
             cancellation_token,
         )
-        .inspect_err(|_| emit_log_segment_load_failure(&metric_context))?
+        .inspect_err(|_| emit_log_segment_load_failure(metric_context))?
         {
             NewSegment::Unchanged => {
                 return Self::reuse_promoting_built_as_latest(&existing_snapshot, built_as_latest);
             }
             NewSegment::Rebuild(new_log_segment) => {
                 emit_log_segment_load(
-                    &metric_context,
+                    metric_context,
                     &new_log_segment,
                     segment_load_start.elapsed(),
                 );
+                // The nested constructor reports the rebuild failure; this span also reports the
+                // failed incremental operation.
                 let snapshot = Self::try_new_from_log_segment(
                     existing_snapshot.table_root().clone(),
                     new_log_segment,
                     engine,
-                    metric_context,
+                    metric_context.clone(),
                     incremental_replay,
                     built_as_latest,
                 );
@@ -165,7 +204,7 @@ impl Snapshot {
             }
             NewSegment::Combined(combined_log_segment) => {
                 emit_log_segment_load(
-                    &metric_context,
+                    metric_context,
                     &combined_log_segment,
                     segment_load_start.elapsed(),
                 );
@@ -183,7 +222,7 @@ impl Snapshot {
             combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.base_crc());
         let crc_at_version = combined_log_segment
             .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
-            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
+            .inspect_err(|_| emit_protocol_metadata_load_failure(metric_context))?;
 
         let existing_table_config = existing_snapshot.table_configuration();
         let (new_metadata, new_protocol, source) = match &crc_at_version {
@@ -207,10 +246,10 @@ impl Snapshot {
                 combined_log_segment
                     .segment_after_version(existing_snapshot_version)
                     .read_protocol_metadata_opt(engine, newer_base)
-                    .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?
+                    .inspect_err(|_| emit_protocol_metadata_load_failure(metric_context))?
             }
         };
-        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
+        emit_protocol_metadata_load(metric_context, source, pm_start.elapsed());
 
         let table_configuration = TableConfiguration::try_new_from(
             existing_table_config,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -174,7 +174,7 @@ impl Snapshot {
     /// from the latest on-disk CRC, advanced to the segment's end version when `incremental_replay`
     /// permits, or used to root Protocol and Metadata log replay otherwise. Falls back to full log
     /// replay when no CRC is present.
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine))]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip_all)]
     fn try_new_from_log_segment(
         location: Url,
         log_segment: LogSegment,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use url::Url;
 
 use crate::action_reconciliation::calculate_transaction_expiration_timestamp;
@@ -191,12 +191,43 @@ impl Snapshot {
     /// from the latest on-disk CRC, advanced to the segment's end version when `incremental_replay`
     /// permits, or used to root Protocol and Metadata log replay otherwise. Falls back to full log
     /// replay when no CRC is present.
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine))]
+    #[instrument(skip_all, fields(path = %location, version = log_segment.end_version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""), incremental_replay = ?incremental_replay, built_as_latest = built_as_latest))]
     fn try_new_from_log_segment(
         location: Url,
         log_segment: LogSegment,
         engine: &dyn Engine,
         metric_context: SnapshotLoadMetricContext,
+        incremental_replay: IncrementalReplay,
+        built_as_latest: bool,
+    ) -> DeltaResult<Self> {
+        // Full failure dumps require retaining these consumed values. The eager LogSegment clone
+        // allocates with the listing size even on success; that is the cost of exact diagnostics.
+        let result = Self::try_new_from_log_segment_impl(
+            location.clone(),
+            log_segment.clone(),
+            engine,
+            &metric_context,
+            incremental_replay,
+            built_as_latest,
+        );
+        result.inspect_err(|error| {
+            error!(
+                %error,
+                ?location,
+                ?log_segment,
+                ?metric_context,
+                ?incremental_replay,
+                built_as_latest,
+                "failed to construct snapshot from log segment"
+            );
+        })
+    }
+
+    fn try_new_from_log_segment_impl(
+        location: Url,
+        log_segment: LogSegment,
+        engine: &dyn Engine,
+        metric_context: &SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
         built_as_latest: bool,
     ) -> DeltaResult<Self> {
@@ -207,7 +238,7 @@ impl Snapshot {
         let base_crc = log_segment.read_latest_crc(engine);
         let crc_at_version = log_segment
             .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
-            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
+            .inspect_err(|_| emit_protocol_metadata_load_failure(metric_context))?;
 
         // Step 2: P&M from that CRC, else log replay rooted at the base CRC, checkpoint, or
         //         first commit. The replay reports its own source (seeded vs full).
@@ -215,14 +246,12 @@ impl Snapshot {
             Some((crc, source)) => (crc.metadata.clone(), crc.protocol.clone(), *source),
             None => log_segment
                 .read_protocol_metadata(engine, base_crc.as_ref())
-                .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?,
+                .inspect_err(|_| emit_protocol_metadata_load_failure(metric_context))?,
         };
-        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
+        emit_protocol_metadata_load(metric_context, source, pm_start.elapsed());
 
         let table_configuration =
             TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
-
-        tracing::Span::current().record("version", table_configuration.version());
 
         let crc = crc_at_version.map(|(crc, _)| crc).or(base_crc);
         Self::new_with_crc(log_segment, table_configuration, crc, built_as_latest)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Snapshot constructor spans could format hundreds of kilobytes of snapshot and log-file data on successful loads. They now use `skip_all` and record only the table path, version, metric IDs, and build flags.

Errors include the full available diagnostic context. Fresh construction logs its input segment. Incremental construction moves the tail into the new segment and logs that segment if a later step fails; failures before assembly completes log the existing segment. It does not retain or reconstruct the original tail.

Configuration and CRC validation happen before the final move into the snapshot, so these diagnostics need no large success-path clones. Tracing tests guard against heavy fields on normal spans and cover early errors, late validation errors, and nested rebuild failures.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo nextest run -p delta_kernel --lib --all-features snapshot::` (140 passed)
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`

An earlier full workspace run reached 12,924 passing tests before a benchmark registry test failed. This PR does not change `benchmarks/`.
