### PR TITLE
fix: accept `timestampWithoutTimezone` feature alias for legacy tables

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1462,6 +1462,39 @@ mod test {
     }
 
     #[test]
+    fn test_timestamp_ntz_legacy_alias_unblocks_read_and_write() {
+        let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
+            "ts",
+            DataType::TIMESTAMP_NTZ,
+        )]));
+        let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
+
+        // Build the protocol from the legacy string alias to exercise the real read path.
+        let protocol =
+            Protocol::try_new_modern(["timestampWithoutTimezone"], ["timestampWithoutTimezone"])
+                .unwrap();
+
+        assert_eq!(
+            protocol.reader_features(),
+            Some([TableFeature::TimestampWithoutTimezone].as_slice())
+        );
+        assert_eq!(
+            protocol.writer_features(),
+            Some([TableFeature::TimestampWithoutTimezone].as_slice())
+        );
+
+        let table_root = Url::try_from("file:///").unwrap();
+        let table_config = TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap();
+
+        table_config
+            .ensure_operation_supported(Operation::Scan)
+            .unwrap();
+        table_config
+            .ensure_operation_supported(Operation::Write)
+            .unwrap();
+    }
+
+    #[test]
     fn test_variant_validation_integration() {
         // Schema with VARIANT column
         let schema = schema_ref! { nullable "v": (DataType::unshredded_variant()) };

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -144,9 +144,12 @@ pub(crate) enum TableFeature {
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
-    /// timestamps without timezone support
-    #[strum(serialize = "timestampNtz")]
-    #[serde(rename = "timestampNtz")]
+    /// Timestamps without timezone support.
+    ///
+    /// Accepts the legacy `timestampWithoutTimezone` alias on read; always writes the canonical
+    /// `timestampNtz`. See <https://github.com/delta-io/delta-kernel-rs/issues/2557>.
+    #[strum(to_string = "timestampNtz", serialize = "timestampWithoutTimezone")]
+    #[serde(rename = "timestampNtz", alias = "timestampWithoutTimezone")]
     TimestampWithoutTimezone,
     // Allow columns to change type
     TypeWidening,
@@ -1062,6 +1065,40 @@ mod tests {
                 "expected Unsupported, got: {result:?}"
             ),
         }
+    }
+
+    #[test]
+    fn test_timestamp_ntz_legacy_alias() {
+        assert_eq!(
+            TableFeature::from("timestampNtz"),
+            TableFeature::TimestampWithoutTimezone
+        );
+        assert_eq!(
+            TableFeature::from("timestampWithoutTimezone"),
+            TableFeature::TimestampWithoutTimezone
+        );
+
+        assert_eq!(
+            serde_json::from_str::<TableFeature>("\"timestampNtz\"").unwrap(),
+            TableFeature::TimestampWithoutTimezone
+        );
+        assert_eq!(
+            serde_json::from_str::<TableFeature>("\"timestampWithoutTimezone\"").unwrap(),
+            TableFeature::TimestampWithoutTimezone
+        );
+
+        assert_eq!(
+            TableFeature::TimestampWithoutTimezone.to_string(),
+            "timestampNtz"
+        );
+        assert_eq!(
+            TableFeature::TimestampWithoutTimezone.as_ref(),
+            "timestampNtz"
+        );
+        assert_eq!(
+            serde_json::to_string(&TableFeature::TimestampWithoutTimezone).unwrap(),
+            "\"timestampNtz\""
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -144,10 +144,12 @@ pub(crate) enum TableFeature {
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
-    /// Timestamps without timezone support.
+    /// Timestamps without timezone support. The canonical protocol feature name is `timestampNtz`.
     ///
-    /// Accepts the legacy `timestampWithoutTimezone` alias on read; always writes the canonical
-    /// `timestampNtz`. See <https://github.com/delta-io/delta-kernel-rs/issues/2557>.
+    /// `timestampWithoutTimezone` is not a Delta protocol feature name, but some existing tables
+    /// carry it in their reader/writer feature arrays. Kernel accepts it on read for compatibility
+    /// with those tables and always writes the canonical `timestampNtz`. See
+    /// <https://github.com/delta-io/delta-kernel-rs/issues/2557>.
     #[strum(to_string = "timestampNtz", serialize = "timestampWithoutTimezone")]
     #[serde(rename = "timestampNtz", alias = "timestampWithoutTimezone")]
     TimestampWithoutTimezone,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some existing Delta tables list the legacy `timestampWithoutTimezone` string in their `readerFeatures`/`writerFeatures` arrays instead of the canonical `timestampNtz`. Kernel parsed the unrecognized name into the catch-all `TableFeature::Unknown`, which is treated as unsupported, so it blocked both reads (unknown reader feature) and writes (unknown writer feature) on these tables. The tables are customer-owned and cannot have their logs rewritten, and protocol features cannot be removed once added.

This maps the legacy name onto the existing `TableFeature::TimestampWithoutTimezone` variant. The log-replay read path parses feature strings via strum's `FromStr`, so the strum attribute is what restores read/write support; the serde attribute is mirrored to keep `TableFeature`'s derived `Serialize`/`Deserialize` consistent with strum. Writes continue to
emit only the canonical `timestampNtz`.

```rust
// kernel/src/table_features/mod.rs
#[strum(to_string = "timestampNtz", serialize = "timestampWithoutTimezone")]
#[serde(rename = "timestampNtz", alias = "timestampWithoutTimezone")]
TimestampWithoutTimezone,
```

Closes #2557.

## How was this change tested?
Two tests added.