### PR TITLE
feat!: support iceberg compat v3 with column defaults

### DIFF
--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -1,7 +1,35 @@
-//! A typed wrapper around Delta's `CURRENT_DEFAULT` column metadata
+//! A typed wrapper around Delta's `CURRENT_DEFAULT` column metadata.
+//!
+//! # Invariants
+//!
+//! The rules kernel enforces on column defaults, and where each comes from. Each is enforced in
+//! code below (see [`ColumnDefault::new`] and
+//! [`validate_column_defaults_metadata_respects_protocol`], plus the IcebergCompatV3 check in
+//! [`crate::table_features`]).
+//!
+//! - A `CURRENT_DEFAULT` is honored only when the `allowColumnDefaults` writer feature is enabled;
+//!   metadata present without it is stray and the table is treated as corrupt. (Protocol.)
+//! - `CURRENT_DEFAULT` metadata must be a SQL string. (Protocol.)
+//! - A Variant column may default only to `NULL`. (Protocol: the Default Columns section requires
+//!   that all columns of `variant` type default to null.)
+//! - An Array, Map, or Struct column may likewise default only to `NULL`. (Delta/Spark parity: the
+//!   protocol does not explicitly restrict these, but kernel matches Spark, which does not
+//!   materialize non-`NULL` defaults on complex types.)
+//! - Defaults may appear on nested struct fields, not just top-level columns. Kernel only *writes*
+//!   top-level defaults, but supports *loading* a snapshot of a table authored elsewhere that
+//!   carries nested defaults, so validation descends into nested fields. (Protocol permits nesting;
+//!   the write-side restriction is a kernel limitation.)
+//! - Parsing is best-effort: unparseable SQL (e.g. `current_timestamp()`) is not an error; the
+//!   connector falls back to the raw SQL. (Kernel.)
+//! - On an IcebergCompatV3 table, kernel imposes two extra limitations on every default:
+//!     - It must be a literal. (Protocol requires a literal; kernel enforces this via its own SQL
+//!       parser, so a literal kernel cannot parse is rejected too.)
+//!     - Its column must be primitive. (Kernel limitation: kernel does not materialize
+//!       non-primitive defaults, so it rejects them even where the protocol would allow a `NULL`.)
 
 use crate::expressions::{parse_sql, Expression, Scalar};
-use crate::schema::{DataType, StructType};
+use crate::schema::{DataType, StructField, StructType};
+use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::{DeltaResult, Error};
 
 /// A column-level default parsed from the `CURRENT_DEFAULT` metadata key of a
@@ -36,7 +64,7 @@ impl<'a> ColumnDefault<'a> {
     /// `raw_sql` is not `NULL` (case-insensitive).
     pub(crate) fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
-        // Spark only allows a non-primitive column default when it is NULL; match that behavior.
+        // Enforces the "non-primitive columns default only to NULL" invariant (see module docs).
         if data_type.as_primitive_opt().is_none() && !is_null {
             return Err(Error::generic(format!(
                 "non-null column default for non-primitive type {data_type:?} is not \
@@ -89,11 +117,89 @@ impl<'a> ColumnDefault<'a> {
     }
 }
 
-/// Validates the column-default metadata on a table's logical schema, treating an ill-formed
-/// default as table corruption.
+/// Walks a schema and returns the parsed [`ColumnDefault`] of every field carrying
+/// a `CURRENT_DEFAULT`, descending through nested structs, arrays, and maps (see the nesting
+/// invariant in the module docs).
+///
+/// A `CURRENT_DEFAULT` lives on a [`StructField`], so container slots contribute a synthetic path
+/// segment on the way to any struct nested inside them: `element` for an array, `key`/`value` for a
+/// map. `path` is collected for clarity in error reporting.
+///
+/// # Errors
+///
+/// Propagates any error from
+/// [`StructField::column_default`](crate::schema::StructField::column_default): a `CURRENT_DEFAULT`
+/// whose value is not a SQL string, or a non-`NULL` default on a non-primitive column.
+pub(crate) fn collect_column_defaults(
+    schema: &StructType,
+) -> DeltaResult<Vec<(String, ColumnDefault<'_>)>> {
+    let mut collector = ColumnDefaultCollector {
+        path: Vec::new(),
+        defaults: Vec::new(),
+    };
+    collector.transform_struct(schema)?;
+    Ok(collector.defaults)
+}
+
+/// Recursive [`SchemaTransform`] that gathers every field's column default with its dotted path.
+///
+/// Uses the `DeltaResult<()>` carrier so [`StructField::column_default`]'s error propagates with
+/// `?` and short-circuits the traversal. Container element types have no metadata of their own, so
+/// the array/map hooks only push a synthetic path segment before recursing toward any nested
+/// struct.
+///
+/// [`StructField::column_default`]: crate::schema::StructField::column_default
+struct ColumnDefaultCollector<'a> {
+    path: Vec<String>,
+    defaults: Vec<(String, ColumnDefault<'a>)>,
+}
+
+impl<'a> ColumnDefaultCollector<'a> {
+    /// Recurse into a container element type under a synthetic path `segment`
+    /// (`element` for arrays, `key`/`value` for maps).
+    fn descend(&mut self, segment: &str, element: &'a DataType) -> DeltaResult<()> {
+        self.path.push(segment.to_string());
+        let result = self.transform(element);
+        self.path.pop();
+        result
+    }
+}
+
+impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
+    transform_output_type!(|'a, T| DeltaResult<()>);
+
+    fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
+        self.path.push(field.name().clone());
+        if let Some(column_default) = field.column_default()? {
+            self.defaults.push((self.path.join("."), column_default));
+        }
+        let result = self.recurse_into_struct_field(field);
+        self.path.pop();
+        result
+    }
+
+    fn transform_array_element(&mut self, etype: &'a DataType) -> DeltaResult<()> {
+        self.descend("element", etype)
+    }
+
+    fn transform_map_key(&mut self, ktype: &'a DataType) -> DeltaResult<()> {
+        self.descend("key", ktype)
+    }
+
+    fn transform_map_value(&mut self, vtype: &'a DataType) -> DeltaResult<()> {
+        self.descend("value", vtype)
+    }
+
+    fn transform_variant(&mut self, _stype: &'a StructType) -> DeltaResult<()> {
+        Ok(())
+    }
+}
+
+/// Validates the column-default metadata on a table's logical schema, treating metadata the
+/// protocol forbids as table corruption (see [Errors](#errors)).
 ///
 /// Run eagerly at [`TableConfiguration`] construction so a corrupt table is rejected at load.
-/// Inspects top-level columns only, consistent with the rest of kernel's column-default handling.
+/// Inspects nested fields as well as top-level columns; see [`collect_column_defaults`].
 ///
 /// [`TableConfiguration`]: crate::table_configuration::TableConfiguration
 ///
@@ -101,19 +207,17 @@ impl<'a> ColumnDefault<'a> {
 ///
 /// - A column declares a `CURRENT_DEFAULT` but `allow_column_defaults` is `false`. The protocol
 ///   only honors defaults "when enabled", so such metadata is stray and the table is corrupt.
-/// - Propagates any error from
-///   [`StructField::column_default`](crate::schema::StructField::column_default)
+/// - Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
+///   a SQL string, or a non-`NULL` default on a non-primitive column.
 pub(crate) fn validate_column_defaults_metadata_respects_protocol(
     schema: &StructType,
     allow_column_defaults: bool,
 ) -> DeltaResult<()> {
-    for field in schema.fields() {
-        // `column_default` validates the metadata is well-formed; we discard the parsed default.
-        if field.column_default()?.is_some() && !allow_column_defaults {
+    for (path, _) in collect_column_defaults(schema)? {
+        if !allow_column_defaults {
             return Err(Error::generic(format!(
-                "Field '{}' declares a `CURRENT_DEFAULT` but the table does not enable the \
-                 `allowColumnDefaults` writer feature",
-                field.name()
+                "Field '{path}' declares a `CURRENT_DEFAULT` but the table does not enable the \
+                 `allowColumnDefaults` writer feature"
             )));
         }
     }
@@ -272,6 +376,45 @@ mod tests {
         vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
         true,
         Some("not supported")
+    )]
+    #[case::nested_default_when_enabled(
+        vec![StructField::nullable(
+            "s",
+            DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
+        )],
+        true,
+        None
+    )]
+    #[case::nested_stray_default_when_disabled(
+        vec![StructField::nullable(
+            "s",
+            DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
+        )],
+        false,
+        Some("s.inner")
+    )]
+    #[case::array_nested_stray_default_when_disabled(
+        vec![StructField::nullable(
+            "arr",
+            ArrayType::new(
+                DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
+                true,
+            ),
+        )],
+        false,
+        Some("arr.element.inner")
+    )]
+    #[case::map_value_nested_stray_default_when_disabled(
+        vec![StructField::nullable(
+            "m",
+            MapType::new(
+                DataType::STRING,
+                DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
+                true,
+            ),
+        )],
+        false,
+        Some("m.value.inner")
     )]
     fn validate_column_defaults_cases(
         #[case] fields: Vec<StructField>,

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -2,20 +2,17 @@
 //!
 //! # Invariants
 //!
-//! The rules kernel enforces on column defaults, and where each comes from. Each is enforced in
-//! code below (see [`ColumnDefault`]'s constructor and [`validate_column_defaults_metadata`],
-//! plus the IcebergCompatV3 check in [`crate::table_features`]).
+//! The rules kernel applies to column defaults, and where each comes from (enforced, or tolerated
+//! as noted), in [`ColumnDefault`]'s constructor, [`validate_column_defaults_metadata`], and the
+//! IcebergCompatV3 check in [`crate::table_features`].
 //!
 //! - `CURRENT_DEFAULT` metadata present without the `allowColumnDefaults` writer feature is
-//!   orphaned metadata, which kernel tolerates on both read and write. Most Delta features tolerate
-//!   metadata whose owning feature is absent, and this matches DBR, which reads and writes such
-//!   tables. (Protocol.)
+//!   orphaned metadata, which kernel tolerates on both read and write. (Protocol.)
 //! - `CURRENT_DEFAULT` metadata must be a SQL string. (Protocol.)
-//! - A Variant column may default only to `NULL`. (Protocol: the Default Columns section requires
-//!   that all columns of `variant` type default to null.)
-//! - An Array, Map, or Struct column may likewise default only to `NULL`. (Delta/Spark parity: the
-//!   protocol does not explicitly restrict these, but kernel matches Spark, which does not
-//!   materialize non-`NULL` defaults on complex types.)
+//! - A Variant column must default to `NULL`; a non-`NULL` variant default is rejected. (Protocol.)
+//! - A non-`NULL` default on an Array, Map, or Struct column is protocol-legal but kernel cannot
+//!   materialize it, so it is tolerated and surfaced via raw SQL (`to_scalar` returns `None`).
+//!   (Kernel.)
 //! - Defaults may appear on nested struct fields, not just top-level columns. Kernel only *writes*
 //!   top-level defaults, but supports *loading* a snapshot of a table authored elsewhere that
 //!   carries nested defaults, so validation descends into nested fields. (Protocol permits nesting;
@@ -61,21 +58,15 @@ impl<'a> ColumnDefault<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an [`Error::unsupported`] when `data_type` is non-primitive (Array, Map, Struct, or
-    /// Variant) and `raw_sql` is not `NULL` (case-insensitive). The protocol permits such a
-    /// default, but kernel does not materialize it (matching Spark), so it is unsupported
-    /// rather than corrupt.
+    /// Returns an [`Error::schema`] when `data_type` is a Variant and `raw_sql` is not `NULL`
+    /// (case-insensitive). A non-`NULL` default on an Array, Map, or Struct column is accepted;
+    /// the kernel cannot parse it, so [`to_scalar`](Self::to_scalar) returns `None`.
     pub(crate) fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
-        // Enforces the "non-primitive columns default only to NULL" invariant (see module docs).
-        // This is a kernel limitation, not table corruption: the protocol permits a non-`NULL`
-        // default on an Array/Map/Struct column, but kernel does not materialize one (matching
-        // Spark), so it reports the value as unsupported rather than rejecting the table as
-        // corrupt.
-        if data_type.as_primitive_opt().is_none() && !is_null {
-            return Err(Error::unsupported(format!(
-                "non-null column default for non-primitive type {data_type:?} is not \
-                 supported, got {raw_sql:?}"
+
+        if matches!(data_type, DataType::Variant(_)) && !is_null {
+            return Err(Error::schema(format!(
+                "a Variant column's default must be NULL, got {raw_sql:?}"
             )));
         }
         let parsed_sql = parse_sql(&raw_sql, data_type).ok();
@@ -136,7 +127,7 @@ impl<'a> ColumnDefault<'a> {
 ///
 /// Propagates any error from
 /// [`StructField::column_default`](crate::schema::StructField::column_default): a `CURRENT_DEFAULT`
-/// whose value is not a SQL string, or a non-`NULL` default on a non-primitive column.
+/// whose value is not a SQL string, or a non-`NULL` default on a Variant column.
 pub(crate) fn collect_column_defaults(
     schema: &StructType,
 ) -> DeltaResult<Vec<(String, ColumnDefault<'_>)>> {
@@ -216,7 +207,7 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
 ///
 /// Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
 /// a SQL string (corrupt, since the protocol defines it as a SQL string), or a non-`NULL` default
-/// on a non-primitive column (unsupported by kernel, though the protocol permits it).
+/// on a Variant column (which the protocol forbids).
 pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<()> {
     collect_column_defaults(schema)?;
     Ok(())
@@ -311,19 +302,15 @@ mod tests {
     #[case::non_primitive_array(
         "ARRAY(1)",
         DataType::from(ArrayType::new(DataType::INTEGER, true)),
-        Expect::NewErr("not supported")
+        Expect::Unparsable
     )]
     #[case::non_primitive_map(
         "MAP('k', 1)",
         DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
-        Expect::NewErr("not supported")
+        Expect::Unparsable
     )]
-    #[case::non_primitive_struct("STRUCT(1)", struct_ty(), Expect::NewErr("not supported"))]
-    #[case::non_primitive_variant(
-        "1",
-        DataType::unshredded_variant(),
-        Expect::NewErr("not supported")
-    )]
+    #[case::non_primitive_struct("STRUCT(1)", struct_ty(), Expect::Unparsable)]
+    #[case::non_null_variant("1", DataType::unshredded_variant(), Expect::NewErr("Variant"))]
     fn column_default_from_new(
         #[case] raw_sql: &str,
         #[case] data_type: DataType,
@@ -368,9 +355,13 @@ mod tests {
     )]
     #[case::no_defaults(vec![StructField::nullable("c", DataType::INTEGER)], None)]
     #[case::non_string_metadata(vec![field_with_invalid_default("c")], Some("non-string"))]
-    #[case::non_null_default_on_non_primitive(
+    #[case::non_null_default_on_array_tolerated(
         vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
-        Some("not supported")
+        None
+    )]
+    #[case::non_null_default_on_variant_rejected(
+        vec![field_with_default("v", DataType::unshredded_variant(), "1")],
+        Some("Variant")
     )]
     #[case::nested_default(
         vec![StructField::nullable(

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -2,30 +2,29 @@
 //!
 //! # Invariants
 //!
-//! The rules kernel applies to column defaults, and where each comes from (enforced, or tolerated
-//! as noted), in [`ColumnDefault`]'s constructor, [`validate_column_defaults_metadata`], and the
-//! IcebergCompatV3 check in [`crate::table_features`].
+//! The rules Kernel applies to column defaults, and where each comes from. This applies to
+//! [`ColumnDefault::new`], [`validate_column_defaults_metadata`], and the IcebergCompatV3 check in
+//! [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
+//! divergences are called out as such.
 //!
-//! - `CURRENT_DEFAULT` metadata present without the `allowColumnDefaults` writer feature is
-//!   orphaned metadata, which kernel tolerates on both read and write. (Protocol.)
-//! - `CURRENT_DEFAULT` metadata must be a SQL string. (Protocol.)
-//! - A Variant column must default to `NULL`; a non-`NULL` variant default is rejected. (Protocol.)
-//! - A non-`NULL` default on an Array, Map, or Struct column is protocol-legal but kernel cannot
+//! - Kernel tolerates orphaned metadata on both read and write. Orphaned metadata is a
+//!   `CURRENT_DEFAULT` present without the `allowColumnDefaults` writer feature.
+//! - `CURRENT_DEFAULT` metadata must be a SQL string.
+//! - A Variant column must default to NULL; a non-NULL variant default is rejected.
+//! - A non-NULL default on an Array, Map, or Struct column is protocol-legal but kernel cannot
 //!   materialize it, so it is tolerated and surfaced via raw SQL (`to_scalar` returns `None`).
-//!   (Kernel.)
-//! - Defaults may appear on nested struct fields, not just top-level columns. Kernel only *writes*
-//!   top-level defaults, but supports *loading* a snapshot of a table authored elsewhere that
-//!   carries nested defaults, so validation descends into nested fields. (Protocol permits nesting;
-//!   the write-side restriction is a kernel limitation.)
+//! - Defaults may appear on nested struct fields, not just top-level columns, so validation
+//!   descends into nested fields. Kernel only *writes* top-level defaults (a kernel limitation),
+//!   but *loads* a snapshot of a table authored elsewhere that carries nested defaults.
 //! - Parsing is best-effort: unparseable SQL (e.g. `current_timestamp()`) is not an error; the
-//!   connector falls back to the raw SQL. (Kernel.)
+//!   connector falls back to the raw SQL.
 //! - On an IcebergCompatV3 table, kernel imposes two extra limitations on every default:
-//!     - It must be a literal. (Protocol requires a literal; kernel enforces this via its own SQL
-//!       parser, so a literal kernel cannot parse is rejected too.)
-//!     - Its column must be primitive. (Kernel limitation: kernel does not materialize
-//!       non-primitive defaults, so it rejects them even where the protocol would allow a `NULL`.)
+//!     - It must be a kernel-parsable literal. The protocol requires a literal; kernel enforces
+//!       this with its own SQL parser, so a literal kernel cannot parse is rejected too.
+//!     - Its column must be primitive. Kernel cannot materialize non-primitive defaults, so it
+//!       rejects them even where the protocol would allow a NULL (a kernel limitation).
 
-use crate::expressions::{parse_sql, Expression, Scalar};
+use crate::expressions::{parse_sql, ColumnName, Expression, Scalar};
 use crate::schema::{DataType, StructField, StructType};
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::{DeltaResult, Error};
@@ -107,8 +106,8 @@ impl<'a> ColumnDefault<'a> {
 
     /// Returns `true` iff the default parsed to a literal expression.
     ///
-    /// SQL the kernel could not parse (e.g. arithmetic or function calls) returns `false`. Note
-    /// that `NULL` parses to a literal, so this is `true` for a `NULL` default regardless of the
+    /// Returns `false` for SQL the kernel could not parse (e.g. arithmetic or function calls). Note
+    /// that NULL parses to a literal, so this is `true` for a NULL default regardless of the
     /// column type.
     pub(crate) fn is_literal(&self) -> bool {
         matches!(self.parsed_sql, Some(Expression::Literal(_)))
@@ -119,10 +118,6 @@ impl<'a> ColumnDefault<'a> {
 /// a `CURRENT_DEFAULT`, descending through nested structs, arrays, and maps (see the nesting
 /// invariant in the module docs).
 ///
-/// A `CURRENT_DEFAULT` lives on a [`StructField`], so container slots contribute a synthetic path
-/// segment on the way to any struct nested inside them: `element` for an array, `key`/`value` for a
-/// map. `path` is collected for clarity in error reporting.
-///
 /// # Errors
 ///
 /// Propagates any error from
@@ -130,7 +125,7 @@ impl<'a> ColumnDefault<'a> {
 /// whose value is not a SQL string, or a non-`NULL` default on a Variant column.
 pub(crate) fn collect_column_defaults(
     schema: &StructType,
-) -> DeltaResult<Vec<(String, ColumnDefault<'_>)>> {
+) -> DeltaResult<Vec<(ColumnName, ColumnDefault<'_>)>> {
     let mut collector = ColumnDefaultCollector {
         path: Vec::new(),
         defaults: Vec::new(),
@@ -139,17 +134,13 @@ pub(crate) fn collect_column_defaults(
     Ok(collector.defaults)
 }
 
-/// Recursive [`SchemaTransform`] that gathers every field's column default with its dotted path.
+/// Recursive [`SchemaTransform`] that gathers every field's column default with its column name.
 ///
-/// Uses the `DeltaResult<()>` carrier so [`StructField::column_default`]'s error propagates with
-/// `?` and short-circuits the traversal. Container element types have no metadata of their own, so
-/// the array/map hooks only push a synthetic path segment before recursing toward any nested
-/// struct.
-///
-/// [`StructField::column_default`]: crate::schema::StructField::column_default
+/// Container element types have no metadata of their own, so the array/map hooks only push a
+/// synthetic path segment before recursing toward any nested struct.
 struct ColumnDefaultCollector<'a> {
     path: Vec<String>,
-    defaults: Vec<(String, ColumnDefault<'a>)>,
+    defaults: Vec<(ColumnName, ColumnDefault<'a>)>,
 }
 
 impl<'a> ColumnDefaultCollector<'a> {
@@ -169,7 +160,8 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
     fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
         self.path.push(field.name().clone());
         if let Some(column_default) = field.column_default()? {
-            self.defaults.push((self.path.join("."), column_default));
+            self.defaults
+                .push((ColumnName::new(&self.path), column_default));
         }
         let result = self.recurse_into_struct_field(field);
         self.path.pop();
@@ -199,15 +191,14 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
 /// Inspects nested fields as well as top-level columns; see [`collect_column_defaults`].
 ///
 /// This does not couple defaults to the `allowColumnDefaults` feature: a `CURRENT_DEFAULT`
-/// present without the feature is orphaned metadata, which kernel tolerates (see the module docs).
+/// present without the feature is orphaned metadata, which is allowed (see the module docs).
 ///
 /// [`TableConfiguration`]: crate::table_configuration::TableConfiguration
 ///
 /// # Errors
 ///
 /// Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
-/// a SQL string (corrupt, since the protocol defines it as a SQL string), or a non-`NULL` default
-/// on a Variant column (which the protocol forbids).
+/// a SQL string, or a non-NULL default on a Variant column.
 pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<()> {
     collect_column_defaults(schema)?;
     Ok(())
@@ -249,6 +240,11 @@ mod tests {
 
     fn struct_ty() -> DataType {
         DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
+    }
+
+    /// A struct type whose single field `inner` carries an integer default.
+    fn struct_with_inner_default() -> DataType {
+        DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap()
     }
 
     fn date_days(year: i32, month: u32, day: u32) -> i32 {
@@ -380,6 +376,29 @@ mod tests {
             (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
             (result, expected) => panic!("unexpected outcome: {result:?} vs {expected:?}"),
         }
+    }
+
+    #[rstest]
+    #[case::array_element(
+        DataType::from(ArrayType::new(struct_with_inner_default(), true)),
+        ["arr", "element", "inner"]
+    )]
+    #[case::map_value(
+        DataType::from(MapType::new(DataType::STRING, struct_with_inner_default(), true)),
+        ["arr", "value", "inner"]
+    )]
+    #[case::map_key(
+        DataType::from(MapType::new(struct_with_inner_default(), DataType::INTEGER, true)),
+        ["arr", "key", "inner"]
+    )]
+    fn collect_nested_container_default_path(
+        #[case] container: DataType,
+        #[case] expected_path: [&str; 3],
+    ) {
+        let schema = StructType::try_new([StructField::nullable("arr", container)]).unwrap();
+        let defaults = collect_column_defaults(&schema).unwrap();
+        let [(path, _)] = defaults.try_into().expect("exactly one default");
+        assert_eq!(path, ColumnName::new(expected_path));
     }
 
     #[test]

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -1,7 +1,7 @@
 //! A typed wrapper around Delta's `CURRENT_DEFAULT` column metadata
 
 use crate::expressions::{parse_sql, Expression, Scalar};
-use crate::schema::DataType;
+use crate::schema::{DataType, StructType};
 use crate::{DeltaResult, Error};
 
 /// A column-level default parsed from the `CURRENT_DEFAULT` metadata key of a
@@ -89,13 +89,44 @@ impl<'a> ColumnDefault<'a> {
     }
 }
 
+/// Validates the column-default metadata on a table's logical schema, treating an ill-formed
+/// default as table corruption.
+///
+/// Run eagerly at [`TableConfiguration`] construction so a corrupt table is rejected at load.
+/// Inspects top-level columns only, consistent with the rest of kernel's column-default handling.
+///
+/// [`TableConfiguration`]: crate::table_configuration::TableConfiguration
+///
+/// # Errors
+///
+/// - A column declares a `CURRENT_DEFAULT` but `allow_column_defaults` is `false`. The protocol
+///   only honors defaults "when enabled", so such metadata is stray and the table is corrupt.
+/// - Propagates any error from
+///   [`StructField::column_default`](crate::schema::StructField::column_default)
+pub(crate) fn validate_column_defaults(
+    schema: &StructType,
+    allow_column_defaults: bool,
+) -> DeltaResult<()> {
+    for field in schema.fields() {
+        // `column_default` validates the metadata is well-formed; we discard the parsed default.
+        if field.column_default()?.is_some() && !allow_column_defaults {
+            return Err(Error::generic(format!(
+                "Field '{}' declares a `CURRENT_DEFAULT` but the table does not enable the \
+                 `allowColumnDefaults` writer feature",
+                field.name()
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, NaiveDate, TimeZone, Utc};
     use rstest::rstest;
 
     use super::*;
-    use crate::schema::{ArrayType, MapType, StructField};
+    use crate::schema::{ArrayType, ColumnMetadataKey, MapType, MetadataValue, StructField};
 
     fn struct_ty() -> DataType {
         DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
@@ -193,6 +224,68 @@ mod tests {
             (result, expect) => {
                 panic!("unexpected outcome for {raw_sql:?}: {result:?} vs {expect:?}")
             }
+        }
+    }
+
+    /// A field carrying `raw_sql` as its `CURRENT_DEFAULT`.
+    fn field_with_default(
+        name: &str,
+        data_type: impl Into<DataType>,
+        raw_sql: &str,
+    ) -> StructField {
+        StructField::nullable(name, data_type).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::String(raw_sql.to_string()),
+        )])
+    }
+
+    /// A field whose `CURRENT_DEFAULT` metadata is a non-string value (malformed).
+    fn field_with_non_string_default(name: &str) -> StructField {
+        StructField::nullable(name, DataType::INTEGER).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::Number(7),
+        )])
+    }
+
+    /// `None` expects `Ok`; `Some(needle)` expects an error containing `needle`.
+    #[rstest]
+    #[case::well_formed_default_when_enabled(
+        vec![
+            field_with_default("c", DataType::INTEGER, "42"),
+            StructField::nullable("no_default", DataType::STRING),
+        ],
+        true,
+        None
+    )]
+    #[case::no_defaults_when_disabled(
+        vec![StructField::nullable("c", DataType::INTEGER)],
+        false,
+        None
+    )]
+    #[case::stray_default_when_disabled(
+        vec![field_with_default("c", DataType::INTEGER, "42")],
+        false,
+        Some("allowColumnDefaults")
+    )]
+    #[case::non_string_metadata(vec![field_with_non_string_default("c")], true, Some("non-string"))]
+    #[case::non_null_default_on_non_primitive(
+        vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
+        true,
+        Some("not supported")
+    )]
+    fn validate_column_defaults_cases(
+        #[case] fields: Vec<StructField>,
+        #[case] allow_column_defaults: bool,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let schema = StructType::try_new(fields).unwrap();
+        match (
+            validate_column_defaults(&schema, allow_column_defaults),
+            expected_error,
+        ) {
+            (Ok(()), None) => {}
+            (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
+            (result, expected) => panic!("unexpected outcome: {result:?} vs {expected:?}"),
         }
     }
 

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -3,12 +3,13 @@
 //! # Invariants
 //!
 //! The rules kernel enforces on column defaults, and where each comes from. Each is enforced in
-//! code below (see [`ColumnDefault::new`] and
-//! [`validate_column_defaults_metadata_respects_protocol`], plus the IcebergCompatV3 check in
-//! [`crate::table_features`]).
+//! code below (see [`ColumnDefault`]'s constructor and [`validate_column_defaults_metadata`],
+//! plus the IcebergCompatV3 check in [`crate::table_features`]).
 //!
-//! - A `CURRENT_DEFAULT` is honored only when the `allowColumnDefaults` writer feature is enabled;
-//!   metadata present without it is stray and the table is treated as corrupt. (Protocol.)
+//! - `CURRENT_DEFAULT` metadata present without the `allowColumnDefaults` writer feature is
+//!   orphaned metadata, which kernel tolerates on both read and write. Most Delta features tolerate
+//!   metadata whose owning feature is absent, and this matches DBR, which reads and writes such
+//!   tables. (Protocol.)
 //! - `CURRENT_DEFAULT` metadata must be a SQL string. (Protocol.)
 //! - A Variant column may default only to `NULL`. (Protocol: the Default Columns section requires
 //!   that all columns of `variant` type default to null.)
@@ -60,13 +61,19 @@ impl<'a> ColumnDefault<'a> {
     ///
     /// # Errors
     ///
-    /// Returns an error when `data_type` is non-primitive (Array, Map, Struct, or Variant) and
-    /// `raw_sql` is not `NULL` (case-insensitive).
+    /// Returns an [`Error::unsupported`] when `data_type` is non-primitive (Array, Map, Struct, or
+    /// Variant) and `raw_sql` is not `NULL` (case-insensitive). The protocol permits such a
+    /// default, but kernel does not materialize it (matching Spark), so it is unsupported
+    /// rather than corrupt.
     pub(crate) fn new(raw_sql: String, data_type: &'a DataType) -> DeltaResult<Self> {
         let is_null = raw_sql.trim().eq_ignore_ascii_case("null");
         // Enforces the "non-primitive columns default only to NULL" invariant (see module docs).
+        // This is a kernel limitation, not table corruption: the protocol permits a non-`NULL`
+        // default on an Array/Map/Struct column, but kernel does not materialize one (matching
+        // Spark), so it reports the value as unsupported rather than rejecting the table as
+        // corrupt.
         if data_type.as_primitive_opt().is_none() && !is_null {
-            return Err(Error::generic(format!(
+            return Err(Error::unsupported(format!(
                 "non-null column default for non-primitive type {data_type:?} is not \
                  supported, got {raw_sql:?}"
             )));
@@ -195,33 +202,50 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
     }
 }
 
-/// Validates the column-default metadata on a table's logical schema, treating metadata the
-/// protocol forbids as table corruption (see [Errors](#errors)).
+/// Validates the column-default metadata on a table's logical schema (see [Errors](#errors)).
 ///
-/// Run eagerly at [`TableConfiguration`] construction so a corrupt table is rejected at load.
+/// Run eagerly at [`TableConfiguration`] construction so an invalid table is rejected at load.
 /// Inspects nested fields as well as top-level columns; see [`collect_column_defaults`].
+///
+/// This does not couple defaults to the `allowColumnDefaults` feature: a `CURRENT_DEFAULT`
+/// present without the feature is orphaned metadata, which kernel tolerates (see the module docs).
 ///
 /// [`TableConfiguration`]: crate::table_configuration::TableConfiguration
 ///
 /// # Errors
 ///
-/// - A column declares a `CURRENT_DEFAULT` but `allow_column_defaults` is `false`. The protocol
-///   only honors defaults "when enabled", so such metadata is stray and the table is corrupt.
-/// - Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
-///   a SQL string, or a non-`NULL` default on a non-primitive column.
-pub(crate) fn validate_column_defaults_metadata_respects_protocol(
-    schema: &StructType,
-    allow_column_defaults: bool,
-) -> DeltaResult<()> {
-    for (path, _) in collect_column_defaults(schema)? {
-        if !allow_column_defaults {
-            return Err(Error::generic(format!(
-                "Field '{path}' declares a `CURRENT_DEFAULT` but the table does not enable the \
-                 `allowColumnDefaults` writer feature"
-            )));
-        }
-    }
+/// Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
+/// a SQL string (corrupt, since the protocol defines it as a SQL string), or a non-`NULL` default
+/// on a non-primitive column (unsupported by kernel, though the protocol permits it).
+pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<()> {
+    collect_column_defaults(schema)?;
     Ok(())
+}
+
+/// A nullable field named `name` carrying `raw_sql` as its `CURRENT_DEFAULT` metadata.
+///
+/// Shared across the crate's column-default unit tests (here, `schema`, and `transaction`).
+#[cfg(test)]
+pub(crate) fn field_with_default(
+    name: &str,
+    data_type: impl Into<DataType>,
+    raw_sql: &str,
+) -> StructField {
+    use crate::schema::{ColumnMetadataKey, MetadataValue};
+    StructField::nullable(name, data_type).add_metadata([(
+        ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+        MetadataValue::String(raw_sql.to_string()),
+    )])
+}
+
+/// A nullable field named `name` whose `CURRENT_DEFAULT` metadata is a non-string value (corrupt).
+#[cfg(test)]
+pub(crate) fn field_with_invalid_default(name: &str) -> StructField {
+    use crate::schema::{ColumnMetadataKey, MetadataValue};
+    StructField::nullable(name, DataType::INTEGER).add_metadata([(
+        ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+        MetadataValue::Number(7),
+    )])
 }
 
 #[cfg(test)]
@@ -230,7 +254,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::schema::{ArrayType, ColumnMetadataKey, MapType, MetadataValue, StructField};
+    use crate::schema::{ArrayType, MapType, StructField};
 
     fn struct_ty() -> DataType {
         DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
@@ -331,101 +355,36 @@ mod tests {
         }
     }
 
-    /// A field carrying `raw_sql` as its `CURRENT_DEFAULT`.
-    fn field_with_default(
-        name: &str,
-        data_type: impl Into<DataType>,
-        raw_sql: &str,
-    ) -> StructField {
-        StructField::nullable(name, data_type).add_metadata([(
-            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-            MetadataValue::String(raw_sql.to_string()),
-        )])
-    }
-
-    /// A field with an invalid `CURRENT_DEFAULT`: the metadata is a non-string value (malformed).
-    fn field_with_invalid_default(name: &str) -> StructField {
-        StructField::nullable(name, DataType::INTEGER).add_metadata([(
-            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-            MetadataValue::Number(7),
-        )])
-    }
-
-    /// `None` expects `Ok`; `Some(needle)` expects an error containing `needle`.
+    /// Validation is independent of the `allowColumnDefaults` feature: it checks only that the
+    /// metadata is well-formed (string-typed, primitive-or-NULL), never whether the feature is
+    /// enabled. `None` expects `Ok`; `Some(needle)` expects an error containing `needle`.
     #[rstest]
-    #[case::well_formed_default_when_enabled(
+    #[case::well_formed_default(
         vec![
             field_with_default("c", DataType::INTEGER, "42"),
             StructField::nullable("no_default", DataType::STRING),
         ],
-        true,
         None
     )]
-    #[case::no_defaults_when_disabled(
-        vec![StructField::nullable("c", DataType::INTEGER)],
-        false,
-        None
-    )]
-    #[case::stray_default_when_disabled(
-        vec![field_with_default("c", DataType::INTEGER, "42")],
-        false,
-        Some("allowColumnDefaults")
-    )]
-    #[case::non_string_metadata(vec![field_with_invalid_default("c")], true, Some("non-string"))]
+    #[case::no_defaults(vec![StructField::nullable("c", DataType::INTEGER)], None)]
+    #[case::non_string_metadata(vec![field_with_invalid_default("c")], Some("non-string"))]
     #[case::non_null_default_on_non_primitive(
         vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
-        true,
         Some("not supported")
     )]
-    #[case::nested_default_when_enabled(
+    #[case::nested_default(
         vec![StructField::nullable(
             "s",
             DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
         )],
-        true,
         None
-    )]
-    #[case::nested_stray_default_when_disabled(
-        vec![StructField::nullable(
-            "s",
-            DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
-        )],
-        false,
-        Some("s.inner")
-    )]
-    #[case::array_nested_stray_default_when_disabled(
-        vec![StructField::nullable(
-            "arr",
-            ArrayType::new(
-                DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
-                true,
-            ),
-        )],
-        false,
-        Some("arr.element.inner")
-    )]
-    #[case::map_value_nested_stray_default_when_disabled(
-        vec![StructField::nullable(
-            "m",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
-                true,
-            ),
-        )],
-        false,
-        Some("m.value.inner")
     )]
     fn validate_column_defaults_cases(
         #[case] fields: Vec<StructField>,
-        #[case] allow_column_defaults: bool,
         #[case] expected_error: Option<&str>,
     ) {
         let schema = StructType::try_new(fields).unwrap();
-        match (
-            validate_column_defaults_metadata_respects_protocol(&schema, allow_column_defaults),
-            expected_error,
-        ) {
+        match (validate_column_defaults_metadata(&schema), expected_error) {
             (Ok(()), None) => {}
             (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
             (result, expected) => panic!("unexpected outcome: {result:?} vs {expected:?}"),

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -113,6 +113,8 @@ impl<'a> ColumnDefault<'a> {
 /// a `CURRENT_DEFAULT`, descending through nested structs, arrays, and maps (see the nesting
 /// invariant in the module docs). Each default is paired with a human-readable path.
 ///
+/// The path is a dot-joined string intended only for error messages.
+///
 /// # Errors
 ///
 /// Propagates any error from

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -3,8 +3,8 @@
 //! # Invariants
 //!
 //! The rules Kernel applies to column defaults, and where each comes from. This applies to
-//! [`ColumnDefault::new`], [`validate_column_defaults_metadata`], and the IcebergCompatV3 check in
-//! [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
+//! [`ColumnDefault::new`], [`validate_column_defaults_metadata`], and the IcebergCompatV3 warnings
+//! in [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
 //! divergences are called out as such.
 //!
 //! - Kernel tolerates orphaned metadata on both read and write. Orphaned metadata is a
@@ -18,11 +18,10 @@
 //!   but *loads* a snapshot of a table authored elsewhere that carries nested defaults.
 //! - Parsing is best-effort: unparseable SQL (e.g. `current_timestamp()`) is not an error; the
 //!   connector falls back to the raw SQL.
-//! - On an IcebergCompatV3 table, kernel imposes two extra limitations on every default:
-//!     - It must be a kernel-parsable literal. The protocol requires a literal; kernel enforces
-//!       this with its own SQL parser, so a literal kernel cannot parse is rejected too.
-//!     - Its column must be primitive. Kernel cannot materialize non-primitive defaults, so it
-//!       rejects them even where the protocol would allow a NULL (a kernel limitation).
+//! - On an IcebergCompatV3 table, kernel warns on two kinds of default it cannot materialize into
+//!   the Iceberg metadata:
+//!     - A default that is not a kernel-parsable literal
+//!     - A default on a non-primitive column
 
 use crate::expressions::{parse_sql, ColumnName, Expression, Scalar};
 use crate::schema::{DataType, StructField, StructType};

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -81,9 +81,9 @@ impl<'a> ColumnDefault<'a> {
 
     /// Returns `true` iff the default parsed to a literal expression.
     ///
-    /// SQL the kernel could not parse (e.g. arithmetic or function calls) returns `false`, as does
-    /// the defensive case of a parsed-but-non-literal expression. Note that `NULL` parses to a
-    /// literal, so this is `true` for a `NULL` default regardless of the column type.
+    /// SQL the kernel could not parse (e.g. arithmetic or function calls) returns `false`. Note
+    /// that `NULL` parses to a literal, so this is `true` for a `NULL` default regardless of the
+    /// column type.
     pub(crate) fn is_literal(&self) -> bool {
         matches!(self.parsed_sql, Some(Expression::Literal(_)))
     }
@@ -103,7 +103,7 @@ impl<'a> ColumnDefault<'a> {
 ///   only honors defaults "when enabled", so such metadata is stray and the table is corrupt.
 /// - Propagates any error from
 ///   [`StructField::column_default`](crate::schema::StructField::column_default)
-pub(crate) fn validate_column_defaults(
+pub(crate) fn validate_column_defaults_metadata_respects_protocol(
     schema: &StructType,
     allow_column_defaults: bool,
 ) -> DeltaResult<()> {
@@ -239,8 +239,8 @@ mod tests {
         )])
     }
 
-    /// A field whose `CURRENT_DEFAULT` metadata is a non-string value (malformed).
-    fn field_with_non_string_default(name: &str) -> StructField {
+    /// A field with an invalid `CURRENT_DEFAULT`: the metadata is a non-string value (malformed).
+    fn field_with_invalid_default(name: &str) -> StructField {
         StructField::nullable(name, DataType::INTEGER).add_metadata([(
             ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
             MetadataValue::Number(7),
@@ -267,7 +267,7 @@ mod tests {
         false,
         Some("allowColumnDefaults")
     )]
-    #[case::non_string_metadata(vec![field_with_non_string_default("c")], true, Some("non-string"))]
+    #[case::non_string_metadata(vec![field_with_invalid_default("c")], true, Some("non-string"))]
     #[case::non_null_default_on_non_primitive(
         vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
         true,
@@ -280,7 +280,7 @@ mod tests {
     ) {
         let schema = StructType::try_new(fields).unwrap();
         match (
-            validate_column_defaults(&schema, allow_column_defaults),
+            validate_column_defaults_metadata_respects_protocol(&schema, allow_column_defaults),
             expected_error,
         ) {
             (Ok(()), None) => {}

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -78,6 +78,15 @@ impl<'a> ColumnDefault<'a> {
             ))),
         }
     }
+
+    /// Returns `true` iff the default parsed to a literal expression.
+    ///
+    /// SQL the kernel could not parse (e.g. arithmetic or function calls) returns `false`, as does
+    /// the defensive case of a parsed-but-non-literal expression. Note that `NULL` parses to a
+    /// literal, so this is `true` for a `NULL` default regardless of the column type.
+    pub(crate) fn is_literal(&self) -> bool {
+        matches!(self.parsed_sql, Some(Expression::Literal(_)))
+    }
 }
 
 #[cfg(test)]

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -7,9 +7,7 @@
 //! in [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
 //! divergences are called out as such.
 //!
-//! - Kernel tolerates orphaned metadata on both read and write. Orphaned metadata is a
-//!   `CURRENT_DEFAULT` present without the `allowColumnDefaults` writer feature.
-//! - `CURRENT_DEFAULT` metadata must be a SQL string.
+//! - `CURRENT_DEFAULT` metadata must be a string.
 //! - A Variant column must default to NULL; a non-NULL variant default is rejected.
 //! - A non-NULL default on an Array, Map, or Struct column is protocol-legal but kernel cannot
 //!   materialize it, so it is tolerated and surfaced via raw SQL (`to_scalar` returns `None`).
@@ -18,12 +16,10 @@
 //!   but *loads* a snapshot of a table authored elsewhere that carries nested defaults.
 //! - Parsing is best-effort: unparseable SQL (e.g. `current_timestamp()`) is not an error; the
 //!   connector falls back to the raw SQL.
-//! - On an IcebergCompatV3 table, kernel warns on two kinds of default it cannot materialize into
-//!   the Iceberg metadata:
-//!     - A default that is not a kernel-parsable literal
-//!     - A default on a non-primitive column
+//! - On an IcebergCompatV3 table, kernel warns when its parser cannot verify that a default is a
+//!   literal.
 
-use crate::expressions::{parse_sql, ColumnName, Expression, Scalar};
+use crate::expressions::{parse_sql, Expression, Scalar};
 use crate::schema::{DataType, StructField, StructType};
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::{DeltaResult, Error};
@@ -108,23 +104,23 @@ impl<'a> ColumnDefault<'a> {
     /// Returns `false` for SQL the kernel could not parse (e.g. arithmetic or function calls). Note
     /// that NULL parses to a literal, so this is `true` for a NULL default regardless of the
     /// column type.
-    pub(crate) fn is_literal(&self) -> bool {
+    pub(crate) fn is_kernel_parsable_literal(&self) -> bool {
         matches!(self.parsed_sql, Some(Expression::Literal(_)))
     }
 }
 
 /// Walks a schema and returns the parsed [`ColumnDefault`] of every field carrying
 /// a `CURRENT_DEFAULT`, descending through nested structs, arrays, and maps (see the nesting
-/// invariant in the module docs).
+/// invariant in the module docs). Each default is paired with a human-readable path.
 ///
 /// # Errors
 ///
 /// Propagates any error from
 /// [`StructField::column_default`](crate::schema::StructField::column_default): a `CURRENT_DEFAULT`
-/// whose value is not a SQL string, or a non-`NULL` default on a Variant column.
-pub(crate) fn collect_column_defaults(
+/// whose value is not a string, or a non-`NULL` default on a Variant column.
+pub(crate) fn try_collect_column_defaults(
     schema: &StructType,
-) -> DeltaResult<Vec<(ColumnName, ColumnDefault<'_>)>> {
+) -> DeltaResult<Vec<(String, ColumnDefault<'_>)>> {
     let mut collector = ColumnDefaultCollector {
         path: Vec::new(),
         defaults: Vec::new(),
@@ -133,13 +129,13 @@ pub(crate) fn collect_column_defaults(
     Ok(collector.defaults)
 }
 
-/// Recursive [`SchemaTransform`] that gathers every field's column default with its column name.
+/// Recursive [`SchemaTransform`] that gathers every field's column default with its display path.
 ///
 /// Container element types have no metadata of their own, so the array/map hooks only push a
 /// synthetic path segment before recursing toward any nested struct.
 struct ColumnDefaultCollector<'a> {
     path: Vec<String>,
-    defaults: Vec<(ColumnName, ColumnDefault<'a>)>,
+    defaults: Vec<(String, ColumnDefault<'a>)>,
 }
 
 impl<'a> ColumnDefaultCollector<'a> {
@@ -159,8 +155,7 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
     fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
         self.path.push(field.name().clone());
         if let Some(column_default) = field.column_default()? {
-            self.defaults
-                .push((ColumnName::new(&self.path), column_default));
+            self.defaults.push((self.path.join("."), column_default));
         }
         let result = self.recurse_into_struct_field(field);
         self.path.pop();
@@ -187,7 +182,7 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
 /// Validates the column-default metadata on a table's logical schema (see [Errors](#errors)).
 ///
 /// Run eagerly at [`TableConfiguration`] construction so an invalid table is rejected at load.
-/// Inspects nested fields as well as top-level columns; see [`collect_column_defaults`].
+/// Inspects nested fields as well as top-level columns; see [`try_collect_column_defaults`].
 ///
 /// This does not couple defaults to the `allowColumnDefaults` feature: a `CURRENT_DEFAULT`
 /// present without the feature is orphaned metadata, which is allowed (see the module docs).
@@ -196,10 +191,10 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
 ///
 /// # Errors
 ///
-/// Propagates any error from [`collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is not
-/// a SQL string, or a non-NULL default on a Variant column.
+/// Propagates any error from [`try_collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is
+/// not a string, or a non-NULL default on a Variant column.
 pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<()> {
-    collect_column_defaults(schema)?;
+    try_collect_column_defaults(schema)?;
     Ok(())
 }
 
@@ -395,9 +390,9 @@ mod tests {
         #[case] expected_path: [&str; 3],
     ) {
         let schema = StructType::try_new([StructField::nullable("arr", container)]).unwrap();
-        let defaults = collect_column_defaults(&schema).unwrap();
+        let defaults = try_collect_column_defaults(&schema).unwrap();
         let [(path, _)] = defaults.try_into().expect("exactly one default");
-        assert_eq!(path, ColumnName::new(expected_path));
+        assert_eq!(path, expected_path.join("."));
     }
 
     #[test]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -526,8 +526,7 @@ impl StructField {
     /// - `Ok(Some(_))` -- present as a [`MetadataValue::String`] and accepted by [`ColumnDefault`].
     /// - `Err(_)` -- either not a [`MetadataValue::String`] (corrupt: the protocol defines
     ///   `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected by
-    ///   [`ColumnDefault`] as unsupported (a non-NULL default on a non-primitive type, which the
-    ///   protocol permits but kernel does not materialize).
+    ///   [`ColumnDefault`] (a non-NULL default on a Variant column, which the protocol forbids).
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault<'_>>> {
         let raw_sql = match self.get_config_value(&ColumnMetadataKey::CurrentDefault) {
@@ -4287,14 +4286,27 @@ mod tests {
         }
 
         #[test]
-        fn non_null_default_on_non_primitive_errors() {
+        fn non_null_default_on_array_is_tolerated() {
             let data_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
-            let field = field_with_default("c", data_type, "ARRAY(1)");
+            let field = field_with_default("c", data_type.clone(), "ARRAY(1)");
+            let column_default = field
+                .column_default()
+                .unwrap()
+                .expect("default must be present");
+            // Kernel cannot parse a non-primitive default, so it surfaces via raw SQL.
+            assert_eq!(column_default.raw_sql(), "ARRAY(1)");
+            assert_eq!(column_default.data_type(), &data_type);
+            assert_eq!(column_default.to_scalar().unwrap(), None);
+        }
+
+        #[test]
+        fn non_null_default_on_variant_errors() {
+            let field = field_with_default("v", DataType::unshredded_variant(), "1");
             let err = field
                 .column_default()
-                .expect_err("non-NULL default on a non-primitive type must error")
+                .expect_err("a non-NULL default on a Variant column must error")
                 .to_string();
-            assert!(err.contains("not supported"), "got: {err}");
+            assert!(err.contains("Variant"), "got: {err}");
         }
     }
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -28,9 +28,11 @@ use crate::{DeltaResult, Error};
 #[cfg(feature = "column-defaults-in-dev")]
 mod column_default;
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) use column_default::validate_column_defaults_metadata_respects_protocol;
-#[cfg(feature = "column-defaults-in-dev")]
 pub use column_default::ColumnDefault;
+#[cfg(feature = "column-defaults-in-dev")]
+pub(crate) use column_default::{
+    collect_column_defaults, validate_column_defaults_metadata_respects_protocol,
+};
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -28,6 +28,8 @@ use crate::{DeltaResult, Error};
 #[cfg(feature = "column-defaults-in-dev")]
 mod column_default;
 #[cfg(feature = "column-defaults-in-dev")]
+pub(crate) use column_default::validate_column_defaults;
+#[cfg(feature = "column-defaults-in-dev")]
 pub use column_default::ColumnDefault;
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod column_default;
 #[cfg(feature = "column-defaults-in-dev")]
 pub use column_default::ColumnDefault;
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) use column_default::{collect_column_defaults, validate_column_defaults_metadata};
+pub(crate) use column_default::{try_collect_column_defaults, validate_column_defaults_metadata};
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;
@@ -4285,16 +4285,23 @@ mod tests {
             assert_eq!(column_default.to_scalar().unwrap().is_some(), parsable);
         }
 
-        #[test]
-        fn non_null_default_on_array_is_tolerated() {
-            let data_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
-            let field = field_with_default("c", data_type.clone(), "ARRAY(1)");
+        #[rstest]
+        #[case::array(DataType::from(ArrayType::new(DataType::INTEGER, true)), "ARRAY(1)")]
+        #[case::map(
+            DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true)),
+            "MAP('a', 1)"
+        )]
+        fn non_null_default_on_container_is_tolerated(
+            #[case] data_type: DataType,
+            #[case] raw_sql: &str,
+        ) {
+            let field = field_with_default("c", data_type.clone(), raw_sql);
             let column_default = field
                 .column_default()
                 .unwrap()
                 .expect("default must be present");
             // Kernel cannot parse a non-primitive default, so it surfaces via raw SQL.
-            assert_eq!(column_default.raw_sql(), "ARRAY(1)");
+            assert_eq!(column_default.raw_sql(), raw_sql);
             assert_eq!(column_default.data_type(), &data_type);
             assert_eq!(column_default.to_scalar().unwrap(), None);
         }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -28,7 +28,7 @@ use crate::{DeltaResult, Error};
 #[cfg(feature = "column-defaults-in-dev")]
 mod column_default;
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) use column_default::validate_column_defaults;
+pub(crate) use column_default::validate_column_defaults_metadata_respects_protocol;
 #[cfg(feature = "column-defaults-in-dev")]
 pub use column_default::ColumnDefault;
 pub(crate) mod compare;

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -26,13 +26,11 @@ use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 #[cfg(feature = "column-defaults-in-dev")]
-mod column_default;
+pub(crate) mod column_default;
 #[cfg(feature = "column-defaults-in-dev")]
 pub use column_default::ColumnDefault;
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) use column_default::{
-    collect_column_defaults, validate_column_defaults_metadata_respects_protocol,
-};
+pub(crate) use column_default::{collect_column_defaults, validate_column_defaults_metadata};
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;
@@ -526,9 +524,10 @@ impl StructField {
     ///
     /// - `Ok(None)` -- no `CURRENT_DEFAULT` metadata.
     /// - `Ok(Some(_))` -- present as a [`MetadataValue::String`] and accepted by [`ColumnDefault`].
-    /// - `Err(_)` -- present but malformed: either not a [`MetadataValue::String`] (the protocol
-    ///   defines `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected
-    ///   by [`ColumnDefault`] (e.g. a non-NULL default on a non-primitive type).
+    /// - `Err(_)` -- either not a [`MetadataValue::String`] (corrupt: the protocol defines
+    ///   `CURRENT_DEFAULT` as a SQL string, the only form the kernel writes), or rejected by
+    ///   [`ColumnDefault`] as unsupported (a non-NULL default on a non-primitive type, which the
+    ///   protocol permits but kernel does not materialize).
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_default(&self) -> DeltaResult<Option<ColumnDefault<'_>>> {
         let raw_sql = match self.get_config_value(&ColumnMetadataKey::CurrentDefault) {
@@ -4246,14 +4245,7 @@ mod tests {
     #[cfg(feature = "column-defaults-in-dev")]
     mod column_default_method {
         use super::*;
-
-        /// A nullable field named `c` carrying `raw_sql` as its `CURRENT_DEFAULT`.
-        fn field_with_default(data_type: DataType, raw_sql: &str) -> StructField {
-            StructField::nullable("c", data_type).add_metadata([(
-                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-                MetadataValue::String(raw_sql.to_string()),
-            )])
-        }
+        use crate::schema::column_default::field_with_default;
 
         #[test]
         fn returns_none_when_no_current_default() {
@@ -4284,7 +4276,7 @@ mod tests {
             #[case] raw_sql: &str,
             #[case] parsable: bool,
         ) {
-            let field = field_with_default(data_type.clone(), raw_sql);
+            let field = field_with_default("c", data_type.clone(), raw_sql);
             let column_default = field
                 .column_default()
                 .unwrap()
@@ -4297,7 +4289,7 @@ mod tests {
         #[test]
         fn non_null_default_on_non_primitive_errors() {
             let data_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
-            let field = field_with_default(data_type, "ARRAY(1)");
+            let field = field_with_default("c", data_type, "ARRAY(1)");
             let err = field
                 .column_default()
                 .expect_err("non-NULL default on a non-primitive type must error")

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -22,7 +22,7 @@ use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
 #[cfg(feature = "column-defaults-in-dev")]
-use crate::schema::validate_column_defaults_metadata_respects_protocol;
+use crate::schema::validate_column_defaults_metadata;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
@@ -219,13 +219,13 @@ impl TableConfiguration {
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
-        // Reject stray/malformed column-default metadata as table corruption before the
-        // IcebergCompatV3 check applies its narrower (literal, primitive-column) rules.
+        // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a
+        // kernel-unsupported non-primitive default). Orphaned metadata (present without the
+        // `allowColumnDefaults` feature) is tolerated. Independent of the IcebergCompatV3 check
+        // below, which applies its own narrower (literal, primitive-column) rules; order is
+        // arbitrary since either failing rejects the table.
         #[cfg(feature = "column-defaults-in-dev")]
-        validate_column_defaults_metadata_respects_protocol(
-            &table_config.logical_schema,
-            table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
-        )?;
+        validate_column_defaults_metadata(&table_config.logical_schema)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
 
         Ok(table_config)

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -220,8 +220,7 @@ impl TableConfiguration {
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
         // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a non-`NULL`
-        // default on a Variant column). Independent of the IcebergCompatV3 check below, which
-        // applies its own narrower (literal, primitive-column) rules.
+        // default on a Variant column).
         #[cfg(feature = "column-defaults-in-dev")]
         validate_column_defaults_metadata(&table_config.logical_schema)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -219,11 +219,9 @@ impl TableConfiguration {
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
-        // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a
-        // kernel-unsupported non-primitive default). Orphaned metadata (present without the
-        // `allowColumnDefaults` feature) is tolerated. Independent of the IcebergCompatV3 check
-        // below, which applies its own narrower (literal, primitive-column) rules; order is
-        // arbitrary since either failing rejects the table.
+        // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a non-`NULL`
+        // default on a Variant column). Independent of the IcebergCompatV3 check below, which
+        // applies its own narrower (literal, primitive-column) rules.
         #[cfg(feature = "column-defaults-in-dev")]
         validate_column_defaults_metadata(&table_config.logical_schema)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -21,6 +21,8 @@ use crate::expressions::ColumnName;
 use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
+#[cfg(feature = "column-defaults-in-dev")]
+use crate::schema::validate_column_defaults;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
@@ -217,12 +219,14 @@ impl TableConfiguration {
         // Validate schema against protocol features now that we have a TC instance.
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
+        // Reject stray/malformed column-default metadata as table corruption before the
+        // IcebergCompatV3 check applies its narrower (literal, primitive-column) rules.
+        #[cfg(feature = "column-defaults-in-dev")]
+        validate_column_defaults(
+            &table_config.logical_schema,
+            table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
+        )?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
-
-        // TODO(#2630): Validate column-default metadata here so a table that declares a
-        // `CURRENT_DEFAULT` without the `allowColumnDefaults` feature, or with malformed default
-        // metadata, is rejected eagerly as corrupted rather than lazily in
-        // `Transaction::column_defaults`.
 
         Ok(table_config)
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -22,7 +22,7 @@ use crate::scan::data_skipping::stats_schema::{
     expected_stats_schema, stats_column_names, StatsConfig, StripFieldMetadataTransform,
 };
 #[cfg(feature = "column-defaults-in-dev")]
-use crate::schema::validate_column_defaults;
+use crate::schema::validate_column_defaults_metadata_respects_protocol;
 pub(crate) use crate::schema::variant_utils::validate_variant_type_feature_support;
 use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{schema_has_invariants, SchemaRef, StructField, StructType};
@@ -222,7 +222,7 @@ impl TableConfiguration {
         // Reject stray/malformed column-default metadata as table corruption before the
         // IcebergCompatV3 check applies its narrower (literal, primitive-column) rules.
         #[cfg(feature = "column-defaults-in-dev")]
-        validate_column_defaults(
+        validate_column_defaults_metadata_respects_protocol(
             &table_config.logical_schema,
             table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
         )?;

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -57,8 +57,8 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
 /// Validates IcebergCompatV3 column defaults and logs warnings kernel cannot verify.
 ///
 /// The IcebergCompatV3 spec requires column defaults to be literals. Kernel warns when its parser
-/// cannot verify that requirement. This warning can be a false positive because a connector's
-/// parser may be able to parse the corresponding expression.
+/// cannot verify that requirement. This warning can be a false positive when the expression is a
+/// literal that kernel's parser cannot parse.
 ///
 /// This condition remains a warning because the table has already passed metadata validation and
 /// rejecting a DML transaction could block valid tables based on kernel parser limitations. The

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -1,9 +1,14 @@
 //! IcebergCompatV3 checks.
 
+#[cfg(feature = "column-defaults-in-dev")]
+use tracing::warn;
+
 use super::{
     check_no_legacy_nested_ids, check_only_supported_types, IcebergCompatCheck,
     IcebergCompatValidator, IcebergCompatVersion,
 };
+#[cfg(feature = "column-defaults-in-dev")]
+use crate::schema::try_collect_column_defaults;
 use crate::schema::DataType;
 use crate::schema::PrimitiveType::*;
 use crate::table_configuration::TableConfiguration;
@@ -49,45 +54,36 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
     )
 }
 
-/// Returns a warning for every column default that violates an IcebergCompatV3 rule, empty when
-/// all defaults are V3-clean.
+/// Validates IcebergCompatV3 column defaults and logs warnings kernel cannot verify.
 ///
-/// The IcebergCompatV3 spec requires only that a column default be a literal. Kernel additionally
-/// warns on two cases it cannot materialize into the Iceberg metadata:
-/// - The default is not a *kernel-parsable* literal (so [`ColumnDefault::is_literal`] is `false`,
-///   e.g. `current_timestamp()`). The table may still be valid: a connector that does not use
-///   kernel's parser can materialize such a default itself.
-/// - The default is on a non-primitive column. Spark does not emit non-primitive defaults for
-///   IcebergCompatV3.
+/// The IcebergCompatV3 spec requires column defaults to be literals. Kernel warns when its parser
+/// cannot verify that requirement. This warning can be a false positive because a connector's
+/// parser may be able to parse the corresponding expression.
 ///
-/// Never an error: this runs on DML transaction construction (see
-/// [`Transaction::try_new_existing_table`]) to surface, not reject, defaults that kernel can't
-/// materialize. Propagates only the corruption error from [`collect_column_defaults`], which is
-/// already surfaced at snapshot load.
+/// This condition remains a warning because the table has already passed metadata validation and
+/// rejecting a DML transaction could block valid tables based on kernel parser limitations. The
+/// check provides defense in depth without treating an interoperability risk as definite
+/// corruption.
 ///
-/// [`ColumnDefault::is_literal`]: crate::schema::ColumnDefault::is_literal
-/// [`collect_column_defaults`]: crate::schema::collect_column_defaults
-/// [`Transaction::try_new_existing_table`]: crate::transaction::Transaction::try_new_existing_table
+/// # Errors
+///
+/// Propagates malformed column-default metadata errors from [`try_collect_column_defaults`].
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) fn iceberg_compat_v3_column_default_warnings(
-    tc: &TableConfiguration,
-) -> DeltaResult<Vec<std::string::String>> {
-    let mut warnings = Vec::new();
-    for (path, column_default) in crate::schema::collect_column_defaults(tc.logical_schema_ref())? {
-        if column_default.data_type().as_primitive_opt().is_none() {
-            warnings.push(format!(
-                "kernel does not support a column default on non-primitive column '{path}' on \
-                 icebergCompatV3 tables"
-            ));
-        } else if !column_default.is_literal() {
-            warnings.push(format!(
-                "icebergCompatV3 requires the column default for '{path}' to be a literal kernel \
-                 can parse, got: {}",
+pub(crate) fn iceberg_compat_v3_column_defaults_validation(
+    table_configuration: &TableConfiguration,
+) -> DeltaResult<()> {
+    for (path, column_default) in
+        try_collect_column_defaults(table_configuration.logical_schema_ref())?
+    {
+        if !column_default.is_kernel_parsable_literal() {
+            warn!(
+                "kernel could not verify that the icebergCompatV3 column default for '{path}' is a \
+                 literal, got: {}",
                 column_default.raw_sql()
-            ));
+            );
         }
     }
-    Ok(warnings)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -145,20 +141,20 @@ mod column_default_tests {
     use std::collections::HashMap;
 
     use rstest::rstest;
+    use test_utils::LoggingTest;
     use url::Url;
 
-    use super::iceberg_compat_v3_column_default_warnings;
+    use super::iceberg_compat_v3_column_defaults_validation;
     use crate::actions::{Metadata, Protocol};
-    use crate::schema::{
-        ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
-    };
+    use crate::schema::ColumnMetadataKey::CurrentDefault;
+    use crate::schema::{ArrayType, DataType, MetadataValue, StructField, StructType};
     use crate::table_configuration::TableConfiguration;
     use crate::table_features::TableFeature;
 
     /// Builds a `TableConfiguration` carrying `schema` with `allowColumnDefaults` enabled, so
-    /// `iceberg_compat_v3_column_default_warnings` can be driven directly. The config does not
+    /// the IcebergCompatV3 column-default validation can be driven directly. The config does not
     /// enable IcebergCompatV3 itself (whose required dependencies are heavy to assemble here); the
-    /// warnings helper is invoked directly instead, and the end-to-end V3 path is covered by the
+    /// validation is invoked directly instead, and the end-to-end V3 path is covered by the
     /// integration tests.
     fn table_config_with_schema(schema: StructType) -> TableConfiguration {
         let metadata = Metadata::try_new(
@@ -179,68 +175,86 @@ mod column_default_tests {
             .unwrap()
     }
 
-    #[rstest]
-    #[case::primitive_literal(DataType::INTEGER, "42", None)]
-    #[case::primitive_null(DataType::INTEGER, "NULL", None)]
-    #[case::non_literal_primitive(DataType::TIMESTAMP, "current_timestamp()", Some("literal"))]
-    #[case::null_on_non_primitive(
-        ArrayType::new(DataType::INTEGER, true).into(),
-        "NULL",
-        Some("non-primitive")
-    )]
-    #[case::non_null_on_non_primitive(
-        ArrayType::new(DataType::INTEGER, true).into(),
-        "ARRAY(1)",
-        Some("non-primitive")
-    )]
-    fn v3_column_default_warning(
-        #[case] data_type: DataType,
-        #[case] default_sql: &str,
-        #[case] expected_warning: Option<&str>,
-    ) {
-        let field = StructField::nullable("a", data_type).add_metadata([(
-            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+    fn field_with_default(
+        name: &str,
+        data_type: impl Into<DataType>,
+        default_sql: &str,
+    ) -> StructField {
+        StructField::nullable(name, data_type).add_metadata([(
+            CurrentDefault.as_ref().to_string(),
             MetadataValue::String(default_sql.to_string()),
-        )]);
-        let tc = table_config_with_schema(StructType::try_new([field]).unwrap());
-
-        let warnings = iceberg_compat_v3_column_default_warnings(&tc).unwrap();
-        match expected_warning {
-            None => assert!(
-                warnings.is_empty(),
-                "expected no warnings, got: {warnings:?}"
-            ),
-            Some(needle) => {
-                let [warning] = warnings.as_slice() else {
-                    panic!("expected exactly one warning, got: {warnings:?}");
-                };
-                assert!(warning.contains(needle), "got: {warning}");
-            }
-        }
+        )])
     }
 
-    #[test]
-    fn v3_column_default_warns_on_nested_non_literal() {
-        let inner = StructField::nullable("inner", DataType::TIMESTAMP).add_metadata([(
-            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-            MetadataValue::String("current_timestamp()".to_string()),
-        )]);
-        let schema = StructType::try_new([StructField::nullable(
+    #[rstest]
+    #[case::primitive_literal(
+        StructType::try_new([field_with_default("a", DataType::INTEGER, "42")]).unwrap(),
+        "a",
+        None
+    )]
+    #[case::primitive_null(
+        StructType::try_new([field_with_default("a", DataType::INTEGER, "NULL")]).unwrap(),
+        "a",
+        None
+    )]
+    #[case::non_literal_primitive(
+        StructType::try_new([field_with_default(
+            "a",
+            DataType::TIMESTAMP,
+            "current_timestamp()"
+        )]).unwrap(),
+        "a",
+        Some("could not verify")
+    )]
+    #[case::null_on_non_primitive(
+        StructType::try_new([field_with_default(
+            "a",
+            ArrayType::new(DataType::INTEGER, true),
+            "NULL"
+        )]).unwrap(),
+        "a",
+        None
+    )]
+    #[case::non_null_on_non_primitive(
+        StructType::try_new([field_with_default(
+            "a",
+            ArrayType::new(DataType::INTEGER, true),
+            "ARRAY(1)"
+        )]).unwrap(),
+        "a",
+        Some("could not verify")
+    )]
+    #[case::nested_non_literal(
+        StructType::try_new([StructField::nullable(
             "s",
-            DataType::try_struct_type([inner]).unwrap(),
-        )])
-        .unwrap();
-        let tc = table_config_with_schema(schema);
+            DataType::try_struct_type([field_with_default(
+                "inner",
+                DataType::TIMESTAMP,
+                "current_timestamp()"
+            )]).unwrap(),
+        )]).unwrap(),
+        "s.inner",
+        Some("could not verify")
+    )]
+    fn v3_column_default_validation(
+        #[case] schema: StructType,
+        #[case] expected_path: &str,
+        #[case] expected_warning: Option<&str>,
+    ) {
+        let table_configuration = table_config_with_schema(schema);
+        let logging = LoggingTest::new();
+        iceberg_compat_v3_column_defaults_validation(&table_configuration).unwrap();
+        let logs = logging.logs();
 
-        let warnings = iceberg_compat_v3_column_default_warnings(&tc).unwrap();
-        let [warning] = warnings.as_slice() else {
-            panic!(
-                "non-literal default on a nested field must warn exactly once, got: {warnings:?}"
-            );
-        };
-        assert!(
-            warning.contains("s.inner"),
-            "expected nested path in warning: {warning}"
-        );
+        match expected_warning {
+            None => assert!(
+                !logs.contains("icebergCompatV3 column default"),
+                "logs: {logs}"
+            ),
+            Some(needle) => {
+                assert!(logs.contains(expected_path), "logs: {logs}");
+                assert!(logs.contains(needle), "logs: {logs}");
+            }
+        }
     }
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -71,21 +71,16 @@ fn check_column_defaults(tc: &TableConfiguration) -> DeltaResult<()> {
 
 #[cfg(feature = "column-defaults-in-dev")]
 fn validate_v3_column_defaults(schema: &crate::schema::StructType) -> DeltaResult<()> {
-    for field in schema.fields() {
-        let Some(column_default) = field.column_default()? else {
-            continue;
-        };
+    for (path, column_default) in crate::schema::collect_column_defaults(schema)? {
         if column_default.data_type().as_primitive_opt().is_none() {
             return Err(Error::generic(format!(
-                "kernel does not support a column default on non-primitive column '{}' on \
-                 icebergCompatV3 tables",
-                field.name()
+                "kernel does not support a column default on non-primitive column '{path}' on \
+                 icebergCompatV3 tables"
             )));
         }
         if !column_default.is_literal() {
             return Err(Error::generic(format!(
-                "icebergCompatV3 requires the column default for '{}' to be a literal, got: {}",
-                field.name(),
+                "icebergCompatV3 requires the column default for '{path}' to be a literal, got: {}",
                 column_default.raw_sql()
             )));
         }
@@ -179,5 +174,26 @@ mod column_default_tests {
                 panic!("unexpected outcome for {default_sql:?}: {result:?} vs {expected:?}")
             }
         }
+    }
+
+    #[test]
+    fn validate_v3_column_default_rejects_nested_non_literal() {
+        let inner = StructField::nullable("inner", DataType::TIMESTAMP).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::String("current_timestamp()".to_string()),
+        )]);
+        let schema = StructType::try_new([StructField::nullable(
+            "s",
+            DataType::try_struct_type([inner]).unwrap(),
+        )])
+        .unwrap();
+
+        let err = validate_v3_column_defaults(&schema)
+            .expect_err("non-literal default on a nested field must be rejected")
+            .to_string();
+        assert!(
+            err.contains("s.inner"),
+            "expected nested path in error: {err}"
+        );
     }
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -8,8 +8,6 @@ use crate::schema::DataType;
 use crate::schema::PrimitiveType::*;
 use crate::table_configuration::TableConfiguration;
 use crate::DeltaResult;
-#[cfg(feature = "column-defaults-in-dev")]
-use crate::Error;
 
 /// V3 invariants paired with the version constant. Fed to
 /// [`super::validate_iceberg_compat_if_needed`].
@@ -18,12 +16,7 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
     checks: V3_CHECKS,
 };
 
-const V3_CHECKS: &[IcebergCompatCheck] = &[
-    check_v3_supported_types,
-    check_no_legacy_nested_ids,
-    #[cfg(feature = "column-defaults-in-dev")]
-    check_column_defaults,
-];
+const V3_CHECKS: &[IcebergCompatCheck] = &[check_v3_supported_types, check_no_legacy_nested_ids];
 
 fn is_v3_supported_type(dt: &DataType) -> bool {
     matches!(
@@ -56,36 +49,45 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
     )
 }
 
-/// Validates column defaults on an IcebergCompatV3 table.
+/// Returns a warning for every column default that violates an IcebergCompatV3 rule, empty when
+/// all defaults are V3-clean.
 ///
-/// The IcebergCompatV3 spec requires only that a column default be a literal. Kernel imposes two
-/// tighter limitations here:
-/// - The default must be a *kernel-parsable* literal. A literal kernel's SQL parser cannot parse
-///   (so [`ColumnDefault::is_literal`] is `false`, e.g. `current_timestamp()`) is rejected, since
-///   kernel cannot materialize it into the Iceberg metadata.
-/// - The column must be primitive. A non-primitive column's default -- `NULL` (allowed on a normal
-///   table) or non-`NULL` (tolerated on a normal table but unmaterializable) -- is rejected here,
-///   matching Spark, which does not emit non-primitive defaults for IcebergCompatV3.
+/// The IcebergCompatV3 spec requires only that a column default be a literal. Kernel additionally
+/// warns on two cases it cannot materialize into the Iceberg metadata:
+/// - The default is not a *kernel-parsable* literal (so [`ColumnDefault::is_literal`] is `false`,
+///   e.g. `current_timestamp()`). The table may still be valid: a connector that does not use
+///   kernel's parser can materialize such a default itself.
+/// - The default is on a non-primitive column. Spark does not emit non-primitive defaults for
+///   IcebergCompatV3.
+///
+/// Never an error: this runs on DML transaction construction (see
+/// [`Transaction::try_new_existing_table`]) to surface, not reject, defaults that kernel can't
+/// materialize. Propagates only the corruption error from [`collect_column_defaults`], which is
+/// already surfaced at snapshot load.
 ///
 /// [`ColumnDefault::is_literal`]: crate::schema::ColumnDefault::is_literal
+/// [`collect_column_defaults`]: crate::schema::collect_column_defaults
+/// [`Transaction::try_new_existing_table`]: crate::transaction::Transaction::try_new_existing_table
 #[cfg(feature = "column-defaults-in-dev")]
-fn check_column_defaults(tc: &TableConfiguration) -> DeltaResult<()> {
+pub(crate) fn iceberg_compat_v3_column_default_warnings(
+    tc: &TableConfiguration,
+) -> DeltaResult<Vec<std::string::String>> {
+    let mut warnings = Vec::new();
     for (path, column_default) in crate::schema::collect_column_defaults(tc.logical_schema_ref())? {
         if column_default.data_type().as_primitive_opt().is_none() {
-            return Err(Error::generic(format!(
+            warnings.push(format!(
                 "kernel does not support a column default on non-primitive column '{path}' on \
                  icebergCompatV3 tables"
-            )));
-        }
-        if !column_default.is_literal() {
-            return Err(Error::generic(format!(
+            ));
+        } else if !column_default.is_literal() {
+            warnings.push(format!(
                 "icebergCompatV3 requires the column default for '{path}' to be a literal kernel \
                  can parse, got: {}",
                 column_default.raw_sql()
-            )));
+            ));
         }
     }
-    Ok(())
+    Ok(warnings)
 }
 
 #[cfg(test)]
@@ -145,7 +147,7 @@ mod column_default_tests {
     use rstest::rstest;
     use url::Url;
 
-    use super::check_column_defaults;
+    use super::iceberg_compat_v3_column_default_warnings;
     use crate::actions::{Metadata, Protocol};
     use crate::schema::{
         ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
@@ -154,9 +156,10 @@ mod column_default_tests {
     use crate::table_features::TableFeature;
 
     /// Builds a `TableConfiguration` carrying `schema` with `allowColumnDefaults` enabled, so
-    /// `check_column_defaults` can be driven directly. The config does not enable IcebergCompatV3
-    /// itself (whose required dependencies are heavy to assemble here); the V3 check is invoked
-    /// directly instead, and the end-to-end V3 path is covered by the integration tests.
+    /// `iceberg_compat_v3_column_default_warnings` can be driven directly. The config does not
+    /// enable IcebergCompatV3 itself (whose required dependencies are heavy to assemble here); the
+    /// warnings helper is invoked directly instead, and the end-to-end V3 path is covered by the
+    /// integration tests.
     fn table_config_with_schema(schema: StructType) -> TableConfiguration {
         let metadata = Metadata::try_new(
             None,
@@ -190,10 +193,10 @@ mod column_default_tests {
         "ARRAY(1)",
         Some("non-primitive")
     )]
-    fn check_v3_column_default(
+    fn v3_column_default_warning(
         #[case] data_type: DataType,
         #[case] default_sql: &str,
-        #[case] expected_error: Option<&str>,
+        #[case] expected_warning: Option<&str>,
     ) {
         let field = StructField::nullable("a", data_type).add_metadata([(
             ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
@@ -201,17 +204,23 @@ mod column_default_tests {
         )]);
         let tc = table_config_with_schema(StructType::try_new([field]).unwrap());
 
-        match (check_column_defaults(&tc), expected_error) {
-            (Ok(()), None) => {}
-            (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
-            (result, expected) => {
-                panic!("unexpected outcome for {default_sql:?}: {result:?} vs {expected:?}")
+        let warnings = iceberg_compat_v3_column_default_warnings(&tc).unwrap();
+        match expected_warning {
+            None => assert!(
+                warnings.is_empty(),
+                "expected no warnings, got: {warnings:?}"
+            ),
+            Some(needle) => {
+                let [warning] = warnings.as_slice() else {
+                    panic!("expected exactly one warning, got: {warnings:?}");
+                };
+                assert!(warning.contains(needle), "got: {warning}");
             }
         }
     }
 
     #[test]
-    fn check_v3_column_default_rejects_nested_non_literal() {
+    fn v3_column_default_warns_on_nested_non_literal() {
         let inner = StructField::nullable("inner", DataType::TIMESTAMP).add_metadata([(
             ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
             MetadataValue::String("current_timestamp()".to_string()),
@@ -223,12 +232,15 @@ mod column_default_tests {
         .unwrap();
         let tc = table_config_with_schema(schema);
 
-        let err = check_column_defaults(&tc)
-            .expect_err("non-literal default on a nested field must be rejected")
-            .to_string();
+        let warnings = iceberg_compat_v3_column_default_warnings(&tc).unwrap();
+        let [warning] = warnings.as_slice() else {
+            panic!(
+                "non-literal default on a nested field must warn exactly once, got: {warnings:?}"
+            );
+        };
         assert!(
-            err.contains("s.inner"),
-            "expected nested path in error: {err}"
+            warning.contains("s.inner"),
+            "expected nested path in warning: {warning}"
         );
     }
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -60,18 +60,19 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
 
 /// Validates column defaults on an IcebergCompatV3 table.
 ///
-/// The IcebergCompatV3 spec requires only that a column default be a literal, so non-literal
-/// defaults (e.g. `current_timestamp()`) are rejected. The kernel additionally restricts defaults
-/// to primitive columns: a `NULL` default on a non-primitive column is allowed on a normal table
-/// but rejected here.
+/// The IcebergCompatV3 spec requires only that a column default be a literal. Kernel imposes two
+/// tighter limitations here:
+/// - The default must be a *kernel-parsable* literal. A literal kernel's SQL parser cannot parse
+///   (so [`ColumnDefault::is_literal`] is `false`, e.g. `current_timestamp()`) is rejected, since
+///   kernel cannot materialize it into the Iceberg metadata.
+/// - The column must be primitive. A `NULL` default on a non-primitive column is allowed on a
+///   normal table but rejected here, matching Spark, which does not emit non-primitive defaults for
+///   IcebergCompatV3.
+///
+/// [`ColumnDefault::is_literal`]: crate::schema::ColumnDefault::is_literal
 #[cfg(feature = "column-defaults-in-dev")]
 fn check_column_defaults(tc: &TableConfiguration) -> DeltaResult<()> {
-    validate_v3_column_defaults(tc.logical_schema_ref())
-}
-
-#[cfg(feature = "column-defaults-in-dev")]
-fn validate_v3_column_defaults(schema: &crate::schema::StructType) -> DeltaResult<()> {
-    for (path, column_default) in crate::schema::collect_column_defaults(schema)? {
+    for (path, column_default) in crate::schema::collect_column_defaults(tc.logical_schema_ref())? {
         if column_default.data_type().as_primitive_opt().is_none() {
             return Err(Error::generic(format!(
                 "kernel does not support a column default on non-primitive column '{path}' on \
@@ -80,7 +81,8 @@ fn validate_v3_column_defaults(schema: &crate::schema::StructType) -> DeltaResul
         }
         if !column_default.is_literal() {
             return Err(Error::generic(format!(
-                "icebergCompatV3 requires the column default for '{path}' to be a literal, got: {}",
+                "icebergCompatV3 requires the column default for '{path}' to be a literal kernel \
+                 can parse, got: {}",
                 column_default.raw_sql()
             )));
         }
@@ -140,12 +142,41 @@ mod tests {
 
 #[cfg(all(test, feature = "column-defaults-in-dev"))]
 mod column_default_tests {
-    use rstest::rstest;
+    use std::collections::HashMap;
 
-    use super::validate_v3_column_defaults;
+    use rstest::rstest;
+    use url::Url;
+
+    use super::check_column_defaults;
+    use crate::actions::{Metadata, Protocol};
     use crate::schema::{
         ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
     };
+    use crate::table_configuration::TableConfiguration;
+    use crate::table_features::TableFeature;
+
+    /// Builds a `TableConfiguration` carrying `schema` with `allowColumnDefaults` enabled, so
+    /// `check_column_defaults` can be driven directly. The config does not enable IcebergCompatV3
+    /// itself (whose required dependencies are heavy to assemble here); the V3 check is invoked
+    /// directly instead, and the end-to-end V3 path is covered by the integration tests.
+    fn table_config_with_schema(schema: StructType) -> TableConfiguration {
+        let metadata = Metadata::try_new(
+            None,
+            None,
+            std::sync::Arc::new(schema),
+            vec![],
+            0,
+            HashMap::new(),
+        )
+        .unwrap();
+        let protocol = Protocol::try_new_modern(
+            TableFeature::EMPTY_LIST,
+            [TableFeature::AllowColumnDefaults],
+        )
+        .unwrap();
+        TableConfiguration::try_new(metadata, protocol, Url::parse("file:///t/").unwrap(), 0)
+            .unwrap()
+    }
 
     #[rstest]
     #[case::primitive_literal(DataType::INTEGER, "42", None)]
@@ -156,7 +187,7 @@ mod column_default_tests {
         "NULL",
         Some("non-primitive")
     )]
-    fn validate_v3_column_default(
+    fn check_v3_column_default(
         #[case] data_type: DataType,
         #[case] default_sql: &str,
         #[case] expected_error: Option<&str>,
@@ -165,9 +196,9 @@ mod column_default_tests {
             ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
             MetadataValue::String(default_sql.to_string()),
         )]);
-        let schema = StructType::try_new([field]).unwrap();
+        let tc = table_config_with_schema(StructType::try_new([field]).unwrap());
 
-        match (validate_v3_column_defaults(&schema), expected_error) {
+        match (check_column_defaults(&tc), expected_error) {
             (Ok(()), None) => {}
             (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
             (result, expected) => {
@@ -177,7 +208,7 @@ mod column_default_tests {
     }
 
     #[test]
-    fn validate_v3_column_default_rejects_nested_non_literal() {
+    fn check_v3_column_default_rejects_nested_non_literal() {
         let inner = StructField::nullable("inner", DataType::TIMESTAMP).add_metadata([(
             ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
             MetadataValue::String("current_timestamp()".to_string()),
@@ -187,8 +218,9 @@ mod column_default_tests {
             DataType::try_struct_type([inner]).unwrap(),
         )])
         .unwrap();
+        let tc = table_config_with_schema(schema);
 
-        let err = validate_v3_column_defaults(&schema)
+        let err = check_column_defaults(&tc)
             .expect_err("non-literal default on a nested field must be rejected")
             .to_string();
         assert!(

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -65,9 +65,9 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
 /// - The default must be a *kernel-parsable* literal. A literal kernel's SQL parser cannot parse
 ///   (so [`ColumnDefault::is_literal`] is `false`, e.g. `current_timestamp()`) is rejected, since
 ///   kernel cannot materialize it into the Iceberg metadata.
-/// - The column must be primitive. A `NULL` default on a non-primitive column is allowed on a
-///   normal table but rejected here, matching Spark, which does not emit non-primitive defaults for
-///   IcebergCompatV3.
+/// - The column must be primitive. A non-primitive column's default -- `NULL` (allowed on a normal
+///   table) or non-`NULL` (tolerated on a normal table but unmaterializable) -- is rejected here,
+///   matching Spark, which does not emit non-primitive defaults for IcebergCompatV3.
 ///
 /// [`ColumnDefault::is_literal`]: crate::schema::ColumnDefault::is_literal
 #[cfg(feature = "column-defaults-in-dev")]
@@ -185,6 +185,11 @@ mod column_default_tests {
     #[case::null_on_non_primitive(
         ArrayType::new(DataType::INTEGER, true).into(),
         "NULL",
+        Some("non-primitive")
+    )]
+    #[case::non_null_on_non_primitive(
+        ArrayType::new(DataType::INTEGER, true).into(),
+        "ARRAY(1)",
         Some("non-primitive")
     )]
     fn check_v3_column_default(

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -1,20 +1,31 @@
 //! IcebergCompatV3 checks.
 
 use super::{
-    check_no_legacy_nested_ids, check_only_supported_types, IcebergCompatValidator,
-    IcebergCompatVersion,
+    check_no_legacy_nested_ids, check_only_supported_types, IcebergCompatCheck,
+    IcebergCompatValidator, IcebergCompatVersion,
 };
 use crate::schema::DataType;
 use crate::schema::PrimitiveType::*;
 use crate::table_configuration::TableConfiguration;
 use crate::DeltaResult;
+#[cfg(feature = "column-defaults-in-dev")]
+use crate::Error;
 
 /// V3 invariants paired with the version constant. Fed to
 /// [`super::validate_iceberg_compat_if_needed`].
 pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
     version: IcebergCompatVersion::V3,
-    checks: &[check_v3_supported_types, check_no_legacy_nested_ids],
+    checks: V3_CHECKS,
 };
+
+// `check_column_defaults` only exists under `column-defaults-in-dev`, so it is gated as an
+// individual slice element rather than duplicating the whole list per cfg.
+const V3_CHECKS: &[IcebergCompatCheck] = &[
+    check_v3_supported_types,
+    check_no_legacy_nested_ids,
+    #[cfg(feature = "column-defaults-in-dev")]
+    check_column_defaults,
+];
 
 fn is_v3_supported_type(dt: &DataType) -> bool {
     matches!(
@@ -45,6 +56,41 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
         is_v3_supported_type,
         IcebergCompatVersion::V3.as_table_feature().as_ref(),
     )
+}
+
+/// Validates column defaults on an IcebergCompatV3 table.
+///
+/// The IcebergCompatV3 spec requires only that a column default be a literal, so non-literal
+/// defaults (e.g. `current_timestamp()`) are rejected. The kernel additionally restricts defaults
+/// to primitive columns: a `NULL` default on a non-primitive column is allowed on a normal table
+/// but rejected here.
+#[cfg(feature = "column-defaults-in-dev")]
+fn check_column_defaults(tc: &TableConfiguration) -> DeltaResult<()> {
+    validate_v3_column_defaults(tc.logical_schema_ref())
+}
+
+#[cfg(feature = "column-defaults-in-dev")]
+fn validate_v3_column_defaults(schema: &crate::schema::StructType) -> DeltaResult<()> {
+    for field in schema.fields() {
+        let Some(column_default) = field.column_default()? else {
+            continue;
+        };
+        if column_default.data_type().as_primitive_opt().is_none() {
+            return Err(Error::generic(format!(
+                "kernel does not support a column default on non-primitive column '{}' on \
+                 icebergCompatV3 tables",
+                field.name()
+            )));
+        }
+        if !column_default.is_literal() {
+            return Err(Error::generic(format!(
+                "icebergCompatV3 requires the column default for '{}' to be a literal, got: {}",
+                field.name(),
+                column_default.raw_sql()
+            )));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -94,5 +140,44 @@ mod tests {
         // Void is excluded from the V3 allowlist (by omission) to match delta-spark, which
         // cannot consume an icebergCompatV3 table containing a void column.
         assert!(!is_v3_supported_type(&DataType::VOID));
+    }
+}
+
+#[cfg(all(test, feature = "column-defaults-in-dev"))]
+mod column_default_tests {
+    use rstest::rstest;
+
+    use super::validate_v3_column_defaults;
+    use crate::schema::{
+        ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
+
+    #[rstest]
+    #[case::primitive_literal(DataType::INTEGER, "42", None)]
+    #[case::primitive_null(DataType::INTEGER, "NULL", None)]
+    #[case::non_literal_primitive(DataType::TIMESTAMP, "current_timestamp()", Some("literal"))]
+    #[case::null_on_non_primitive(
+        ArrayType::new(DataType::INTEGER, true).into(),
+        "NULL",
+        Some("non-primitive")
+    )]
+    fn validate_v3_column_default(
+        #[case] data_type: DataType,
+        #[case] default_sql: &str,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let field = StructField::nullable("a", data_type).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::String(default_sql.to_string()),
+        )]);
+        let schema = StructType::try_new([field]).unwrap();
+
+        match (validate_v3_column_defaults(&schema), expected_error) {
+            (Ok(()), None) => {}
+            (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
+            (result, expected) => {
+                panic!("unexpected outcome for {default_sql:?}: {result:?} vs {expected:?}")
+            }
+        }
     }
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -21,8 +21,6 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
 const V3_CHECKS: &[IcebergCompatCheck] = &[
     check_v3_supported_types,
     check_no_legacy_nested_ids,
-    // `check_column_defaults` only exists under `column-defaults-in-dev`, so it is gated as an
-    // individual slice element rather than duplicating the whole list per cfg.
     #[cfg(feature = "column-defaults-in-dev")]
     check_column_defaults,
 ];

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -18,11 +18,11 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
     checks: V3_CHECKS,
 };
 
-// `check_column_defaults` only exists under `column-defaults-in-dev`, so it is gated as an
-// individual slice element rather than duplicating the whole list per cfg.
 const V3_CHECKS: &[IcebergCompatCheck] = &[
     check_v3_supported_types,
     check_no_legacy_nested_ids,
+    // `check_column_defaults` only exists under `column-defaults-in-dev`, so it is gated as an
+    // individual slice element rather than duplicating the whole list per cfg.
     #[cfg(feature = "column-defaults-in-dev")]
     check_column_defaults,
 ];

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -439,10 +439,13 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 /// TODO: Implement the write-side requirements for IcebergCompatV3.
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
 ///
+/// Column defaults are enforced (gated by `column-defaults-in-dev`) in `iceberg_compat::v3`'s
+/// `check_column_defaults`: the spec requires literal defaults, and kernel additionally restricts
+/// them to primitive columns.
+///
 /// Attention in the future:
 /// - Geo types: when supported, they must not be usable as partition columns on IcebergCompatV3
 ///   tables.
-/// - Column defaults: when supported, only literal expressions are allowed.
 /// - REPLACE TABLE: when supported, partition columns must not change across the replace.
 /// - Timestamp parquet encoding: when kernel can write INT96 or INT64, IcebergCompatV3 tables must
 ///   always use INT64; INT96 is forbidden.

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use column_mapping::{
     validate_column_mapping_id, StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
+#[cfg(feature = "column-defaults-in-dev")]
+pub(crate) use iceberg_compat::v3::iceberg_compat_v3_column_default_warnings;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;
 pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
@@ -438,11 +440,6 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///
 /// TODO: Implement the write-side requirements for IcebergCompatV3.
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
-///
-/// Column defaults are enforced (gated by `column-defaults-in-dev`) in `iceberg_compat::v3`'s
-/// `check_column_defaults`: the spec requires literal defaults, and kernel additionally restricts
-/// them to primitive columns for parity with Spark, which does not emit non-primitive defaults on
-/// IcebergCompatV3 tables.
 ///
 /// Attention in the future:
 /// - Geo types: when supported, they must not be usable as partition columns on IcebergCompatV3

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -441,7 +441,8 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///
 /// Column defaults are enforced (gated by `column-defaults-in-dev`) in `iceberg_compat::v3`'s
 /// `check_column_defaults`: the spec requires literal defaults, and kernel additionally restricts
-/// them to primitive columns.
+/// them to primitive columns for parity with Spark, which does not emit non-primitive defaults on
+/// IcebergCompatV3 tables.
 ///
 /// Attention in the future:
 /// - Geo types: when supported, they must not be usable as partition columns on IcebergCompatV3

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use column_mapping::{
 };
 use delta_kernel_derive::internal_api;
 #[cfg(feature = "column-defaults-in-dev")]
-pub(crate) use iceberg_compat::v3::iceberg_compat_v3_column_default_warnings;
+pub(crate) use iceberg_compat::v3::iceberg_compat_v3_column_defaults_validation;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;
 pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1005,13 +1005,22 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// column) are rejected eagerly at snapshot load (when constructing the
     /// [`TableConfiguration`]), so by the time this runs the metadata is already validated.
     /// Orphaned metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults` writer feature)
-    /// is tolerated and surfaced here like any other default.
+    /// is tolerated at table load but is not surfaced through this method.
     ///
     /// # Errors
     ///
     /// Propagates any error from [`StructField::column_default`].
     #[cfg(feature = "column-defaults-in-dev")]
-    pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
+    pub fn top_level_column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
+        if !self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::AllowColumnDefaults)
+        {
+            info!(
+                "allowColumnDefaults is not enabled; the schema may contain orphaned column-default metadata"
+            );
+            return Ok(HashMap::new());
+        }
         let mut defaults = HashMap::new();
         for field in self.effective_table_config.logical_schema_ref().fields() {
             if let Some(column_default) = field.column_default()? {
@@ -2168,7 +2177,7 @@ mod tests {
             .unwrap();
             let txn = txn_with_schema(schema);
 
-            let defaults = txn.column_defaults().unwrap();
+            let defaults = txn.top_level_column_defaults().unwrap();
             assert_eq!(
                 defaults.len(),
                 2,
@@ -2193,7 +2202,7 @@ mod tests {
             ])
             .unwrap();
             let txn = txn_with_schema(schema);
-            assert!(txn.column_defaults().unwrap().is_empty());
+            assert!(txn.top_level_column_defaults().unwrap().is_empty());
         }
 
         #[test]
@@ -2213,8 +2222,8 @@ mod tests {
                     .unwrap();
 
             // Orphaned column-default metadata (no `allowColumnDefaults` feature) is tolerated.
-            try_table_config(&base_txn(), schema, [])
-                .expect("orphaned column-default metadata must be tolerated at load");
+            let txn = txn_with_schema_and_writer_features(schema, []);
+            assert!(txn.top_level_column_defaults().unwrap().is_empty());
         }
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1001,31 +1001,21 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
     /// not a protocol one.
     ///
+    /// Stray column-default metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults` writer
+    /// feature) and malformed defaults are rejected eagerly at snapshot load (when constructing the
+    /// [`TableConfiguration`]), so by the time this runs the metadata is already validated.
+    ///
     /// # Errors
     ///
-    /// - A column declares a `CURRENT_DEFAULT` but the table does not enable the
-    ///   `allowColumnDefaults` writer feature. The protocol only honors defaults "when enabled", so
-    ///   such metadata is stray and is rejected rather than returned.
-    /// - Propagates any error from [`StructField::column_default`] -- a malformed `CURRENT_DEFAULT`
-    ///   (non-string metadata, or a non-NULL default on a non-primitive type).
+    /// Returns an error only in the structurally-unreachable case that a `CURRENT_DEFAULT` became
+    /// malformed after load; propagated from [`StructField::column_default`].
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
-        let allow_column_defaults = self
-            .effective_table_config
-            .is_feature_enabled(&TableFeature::AllowColumnDefaults);
         let mut defaults = HashMap::new();
         for field in self.effective_table_config.logical_schema_ref().fields() {
-            let Some(column_default) = field.column_default()? else {
-                continue;
-            };
-            if !allow_column_defaults {
-                return Err(Error::generic(format!(
-                    "Field '{}' declares a `CURRENT_DEFAULT` but the table does not enable the \
-                     `allowColumnDefaults` writer feature",
-                    field.name()
-                )));
+            if let Some(column_default) = field.column_default()? {
+                defaults.insert(field.name().clone(), column_default);
             }
-            defaults.insert(field.name().clone(), column_default);
         }
         Ok(defaults)
     }
@@ -2117,9 +2107,8 @@ mod tests {
         }
 
         /// Like [`txn_with_schema`] but with an explicit writer-feature list, so a test can
-        /// exercise a table that does *not* enable `allowColumnDefaults`. The schema and a
-        /// synthetic protocol are swapped onto a real snapshot's table configuration so
-        /// column-default discovery can be exercised without going through `create_table`.
+        /// exercise a table that does *not* enable `allowColumnDefaults`. Panics if the table
+        /// configuration fails to construct; use [`try_table_config`] to assert that error.
         fn txn_with_schema_and_writer_features(
             schema: StructType,
             writer_features: impl IntoIterator<Item = TableFeature>,
@@ -2128,7 +2117,20 @@ mod tests {
             let mut txn = snapshot
                 .transaction(Box::new(FileSystemCommitter::new()), &engine)
                 .unwrap();
-            let metadata = txn
+            txn.effective_table_config = try_table_config(&txn, schema, writer_features).unwrap();
+            txn
+        }
+
+        /// Builds the [`TableConfiguration`] a transaction would carry for `schema` and
+        /// `writer_features`, swapping a synthetic schema/protocol onto a real snapshot's config so
+        /// column-default validation (run at construction) can be exercised without `create_table`.
+        /// Returns the construction result so a test can assert eager-validation errors.
+        fn try_table_config(
+            base: &Transaction,
+            schema: StructType,
+            writer_features: impl IntoIterator<Item = TableFeature>,
+        ) -> DeltaResult<TableConfiguration> {
+            let metadata = base
                 .effective_table_config
                 .metadata()
                 .clone()
@@ -2136,15 +2138,22 @@ mod tests {
                 .unwrap();
             let protocol =
                 Protocol::try_new_modern(TableFeature::EMPTY_LIST, writer_features).unwrap();
-            let version = txn.effective_table_config.version();
-            txn.effective_table_config = TableConfiguration::try_new_from(
-                &txn.effective_table_config,
+            let version = base.effective_table_config.version();
+            TableConfiguration::try_new_from(
+                &base.effective_table_config,
                 Some(metadata),
                 Some(protocol),
                 version,
             )
-            .unwrap();
-            txn
+        }
+
+        /// A transaction over a real (non-DV) table, to use as the base config in
+        /// [`try_table_config`].
+        fn base_txn() -> Transaction {
+            let (engine, snapshot) = setup_non_dv_table();
+            snapshot
+                .transaction(Box::new(FileSystemCommitter::new()), &engine)
+                .unwrap()
         }
 
         /// A nullable field carrying `raw_sql` as its `CURRENT_DEFAULT`.
@@ -2194,30 +2203,26 @@ mod tests {
         }
 
         #[test]
-        fn propagates_error_for_malformed_default() {
+        fn load_rejects_malformed_default() {
             let field = StructField::nullable("c", DataType::INTEGER).add_metadata([(
                 ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
                 MetadataValue::Number(7),
             )]);
             let schema = StructType::try_new(vec![field]).unwrap();
-            let txn = txn_with_schema(schema);
 
-            let err = txn
-                .column_defaults()
-                .expect_err("non-string CURRENT_DEFAULT must error")
+            let err = try_table_config(&base_txn(), schema, [TableFeature::AllowColumnDefaults])
+                .expect_err("non-string CURRENT_DEFAULT must error at load")
                 .to_string();
             assert!(err.contains("non-string"), "got: {err}");
         }
 
         #[test]
-        fn errors_when_default_present_but_feature_not_enabled() {
+        fn load_rejects_default_present_but_feature_not_enabled() {
             let schema =
                 StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
                     .unwrap();
-            let txn = txn_with_schema_and_writer_features(schema, []);
 
-            let err = txn
-                .column_defaults()
+            let err = try_table_config(&base_txn(), schema, [])
                 .expect_err("a column default without the allowColumnDefaults feature must error")
                 .to_string();
             assert!(err.contains("allowColumnDefaults"), "got: {err}");

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1001,9 +1001,11 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
     /// not a protocol one.
     ///
-    /// Stray column-default metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults` writer
-    /// feature) and malformed defaults are rejected eagerly at snapshot load (when constructing the
+    /// Malformed defaults (a non-string `CURRENT_DEFAULT`, or a non-`NULL` default on a
+    /// non-primitive column) are rejected eagerly at snapshot load (when constructing the
     /// [`TableConfiguration`]), so by the time this runs the metadata is already validated.
+    /// Orphaned metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults` writer feature)
+    /// is tolerated and surfaced here like any other default.
     ///
     /// # Errors
     ///
@@ -2094,11 +2096,12 @@ mod tests {
     #[cfg(feature = "column-defaults-in-dev")]
     mod column_defaults {
         use super::*;
-        use crate::schema::{ColumnMetadataKey, MetadataValue};
+        use crate::schema::column_default::{field_with_default, field_with_invalid_default};
 
         // NB: `test_utils::schema_with_column_defaults` cannot be used here. In `--lib` unit tests
         // the crate under test and the `delta_kernel` that `test_utils` links are two distinct
         // crate instances, so kernel schema types don't unify across the `test_utils` boundary.
+        // The `field_with_*` helpers live in-crate (`schema::column_default`) for the same reason.
 
         /// Builds a transaction whose effective logical schema is `schema`, with the
         /// `allowColumnDefaults` writer feature enabled so any declared defaults are honored.
@@ -2123,7 +2126,7 @@ mod tests {
 
         /// Builds the [`TableConfiguration`] a transaction would carry for `schema` and
         /// `writer_features`, swapping a synthetic schema/protocol onto a real snapshot's config so
-        /// column-default validation (run at construction) can be exercised without `create_table`.
+        /// the validation `try_new` runs at construction can be exercised without `create_table`.
         /// Returns the construction result so a test can assert eager-validation errors.
         fn try_table_config(
             base: &Transaction,
@@ -2154,14 +2157,6 @@ mod tests {
             snapshot
                 .transaction(Box::new(FileSystemCommitter::new()), &engine)
                 .unwrap()
-        }
-
-        /// A nullable field carrying `raw_sql` as its `CURRENT_DEFAULT`.
-        fn field_with_default(name: &str, data_type: DataType, raw_sql: &str) -> StructField {
-            StructField::nullable(name, data_type).add_metadata([(
-                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-                MetadataValue::String(raw_sql.to_string()),
-            )])
         }
 
         #[test]
@@ -2204,11 +2199,7 @@ mod tests {
 
         #[test]
         fn load_rejects_malformed_default() {
-            let field = StructField::nullable("c", DataType::INTEGER).add_metadata([(
-                ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
-                MetadataValue::Number(7),
-            )]);
-            let schema = StructType::try_new(vec![field]).unwrap();
+            let schema = StructType::try_new(vec![field_with_invalid_default("c")]).unwrap();
 
             let err = try_table_config(&base_txn(), schema, [TableFeature::AllowColumnDefaults])
                 .expect_err("non-string CURRENT_DEFAULT must error at load")
@@ -2217,15 +2208,14 @@ mod tests {
         }
 
         #[test]
-        fn load_rejects_default_present_but_feature_not_enabled() {
+        fn load_tolerates_default_present_but_feature_not_enabled() {
             let schema =
                 StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
                     .unwrap();
 
-            let err = try_table_config(&base_txn(), schema, [])
-                .expect_err("a column default without the allowColumnDefaults feature must error")
-                .to_string();
-            assert!(err.contains("allowColumnDefaults"), "got: {err}");
+            // Orphaned column-default metadata (no `allowColumnDefaults` feature) is tolerated.
+            try_table_config(&base_txn(), schema, [])
+                .expect("orphaned column-default metadata must be tolerated at load");
         }
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1001,16 +1001,15 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
     /// not a protocol one.
     ///
-    /// Malformed defaults (a non-string `CURRENT_DEFAULT`, or a non-`NULL` default on a
-    /// non-primitive column) are rejected eagerly at snapshot load (when constructing the
+    /// Malformed defaults (a non-string `CURRENT_DEFAULT`, or a non-`NULL` default on a Variant
+    /// column) are rejected eagerly at snapshot load (when constructing the
     /// [`TableConfiguration`]), so by the time this runs the metadata is already validated.
     /// Orphaned metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults` writer feature)
     /// is tolerated and surfaced here like any other default.
     ///
     /// # Errors
     ///
-    /// Returns an error only in the structurally-unreachable case that a `CURRENT_DEFAULT` became
-    /// malformed after load; propagated from [`StructField::column_default`].
+    /// Propagates any error from [`StructField::column_default`].
     #[cfg(feature = "column-defaults-in-dev")]
     pub fn column_defaults(&self) -> DeltaResult<HashMap<String, ColumnDefault<'_>>> {
         let mut defaults = HashMap::new();

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -33,6 +33,8 @@ use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
 use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
+#[cfg(feature = "column-defaults-in-dev")]
+use crate::table_features::iceberg_compat_v3_column_default_warnings;
 use crate::table_features::{Operation, TableFeature};
 use crate::utils::current_time_ms;
 use crate::{DataType, DeltaResult, Engine, Expression};
@@ -75,6 +77,16 @@ impl Transaction {
         );
 
         let effective_table_config = read_snapshot.table_configuration().clone();
+
+        // IcebergCompatV3 restricts column defaults to kernel-materializable literals on primitive
+        // columns. This is surfaced as a warning on the DML/write path so a valid
+        // table carrying a default that kernel cannot materialize still loads and writes.
+        #[cfg(feature = "column-defaults-in-dev")]
+        if effective_table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+            for warning in iceberg_compat_v3_column_default_warnings(&effective_table_config)? {
+                tracing::warn!("{warning}");
+            }
+        }
 
         Ok(Transaction {
             span,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -34,7 +34,7 @@ use crate::scan::{restored_add_schema, scan_row_schema};
 use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
 #[cfg(feature = "column-defaults-in-dev")]
-use crate::table_features::iceberg_compat_v3_column_default_warnings;
+use crate::table_features::iceberg_compat_v3_column_defaults_validation;
 use crate::table_features::{Operation, TableFeature};
 use crate::utils::current_time_ms;
 use crate::{DataType, DeltaResult, Engine, Expression};
@@ -78,14 +78,11 @@ impl Transaction {
 
         let effective_table_config = read_snapshot.table_configuration().clone();
 
-        // IcebergCompatV3 restricts column defaults to kernel-materializable literals on primitive
-        // columns. This is surfaced as a warning on the DML/write path so a valid
-        // table carrying a default that kernel cannot materialize still loads and writes.
+        // Surface IcebergCompatV3 interoperability risks without rejecting tables based on
+        // kernel parser limitations.
         #[cfg(feature = "column-defaults-in-dev")]
         if effective_table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            for warning in iceberg_compat_v3_column_default_warnings(&effective_table_config)? {
-                tracing::warn!("{warning}");
-            }
+            iceberg_compat_v3_column_defaults_validation(&effective_table_config)?;
         }
 
         Ok(Transaction {

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -349,33 +349,29 @@ mod feature_enabled {
         Ok(())
     }
 
-    /// Snapshot load rejects a non-literal default on an `icebergCompatV3` table. The V3
-    /// accept/reject matrix itself lives in the `check_v3_column_default` unit test in
-    /// `iceberg_compat::v3`; this only asserts the check is wired into snapshot load. A non-NULL
-    /// default on a non-primitive column is NOT rejected -- see
-    /// `test_load_tolerates_non_primitive_non_null_default`. Orphaned metadata is NOT rejected --
-    /// see `test_load_and_write_allow_orphan_default`.
+    /// On an `icebergCompatV3` table, a column default kernel cannot materialize (a non-literal
+    /// default, or a default on a non-primitive column) is a warning, not an error: the snapshot
+    /// loads and a DML transaction constructs without error. The V3 warning accept/reject matrix
+    /// itself lives in the `v3_column_default_warning` unit test in `iceberg_compat::v3`; this only
+    /// asserts kernel does not reject such a table on the read/write path.
     #[rstest]
-    #[case::v3_non_literal_default(
-        "v3_non_literal",
-        DataType::TIMESTAMP,
-        "current_timestamp()",
-        vec!["allowColumnDefaults", "icebergCompatV3"],
-        "literal"
+    #[case::non_literal("non_literal", DataType::TIMESTAMP, "current_timestamp()")]
+    #[case::non_primitive(
+        "non_primitive",
+        DataType::from(ArrayType::new(DataType::INTEGER, true)),
+        "ARRAY(1)"
     )]
     #[tokio::test]
-    async fn test_load_rejects_invalid_column_default(
+    async fn test_load_and_write_tolerate_v3_unmaterializable_default(
         #[case] label: &str,
         #[case] field_type: DataType,
         #[case] default_sql: &str,
-        #[case] writer_features: Vec<&str>,
-        #[case] error_needle: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
         let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
         let (store, engine, table_location) =
-            engine_store_setup(&format!("test_load_rejects_{label}"), None);
+            engine_store_setup(&format!("test_v3_tolerates_{label}"), None);
         let table_url = create_table(
             store,
             table_location,
@@ -383,15 +379,15 @@ mod feature_enabled {
             &[],    /* partition_columns */
             true,   /* use_37_protocol */
             vec![], /* reader_features */
-            writer_features,
+            vec!["allowColumnDefaults", "icebergCompatV3"],
         )
         .await?;
 
-        let err = Snapshot::builder_for(table_url)
-            .build(&engine)
-            .expect_err("invalid column default must be rejected at load")
-            .to_string();
-        assert!(err.contains(error_needle), "got: {err}");
+        // Read: the snapshot loads despite the unmaterializable default.
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+        // Write: a DML transaction constructs without error (a warning is logged, not returned).
+        snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -349,20 +349,13 @@ mod feature_enabled {
         Ok(())
     }
 
-    /// Snapshot load rejects corrupt column-default metadata: a non-NULL default on a
-    /// non-primitive column (unsupported by kernel) and a non-literal default on an
-    /// `icebergCompatV3` table. The V3 accept/reject matrix itself lives in the
-    /// `check_v3_column_default` unit test in `iceberg_compat::v3`; this only asserts the checks
-    /// are wired into snapshot load. Orphaned metadata is NOT rejected -- see
-    /// `test_load_and_write_allow_orphan_default`.
+    /// Snapshot load rejects a non-literal default on an `icebergCompatV3` table. The V3
+    /// accept/reject matrix itself lives in the `check_v3_column_default` unit test in
+    /// `iceberg_compat::v3`; this only asserts the check is wired into snapshot load. A non-NULL
+    /// default on a non-primitive column is NOT rejected -- see
+    /// `test_load_tolerates_non_primitive_non_null_default`. Orphaned metadata is NOT rejected --
+    /// see `test_load_and_write_allow_orphan_default`.
     #[rstest]
-    #[case::non_primitive_default(
-        "non_primitive",
-        DataType::from(ArrayType::new(DataType::INTEGER, true)),
-        "ARRAY(1)",
-        vec!["allowColumnDefaults"],
-        "not supported"
-    )]
     #[case::v3_non_literal_default(
         "v3_non_literal",
         DataType::TIMESTAMP,
@@ -461,6 +454,47 @@ mod feature_enabled {
         // Write: a write context builds without error.
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
         txn.unpartitioned_write_context()?;
+
+        Ok(())
+    }
+
+    /// A non-`NULL` default on a non-primitive (Array) column is protocol-legal but
+    /// unmaterializable by kernel: the snapshot loads, and the default surfaces via raw SQL
+    /// (`to_scalar` returns `None`) so the connector can evaluate it itself. Contrast a
+    /// non-`NULL` Variant default, which the protocol forbids and kernel rejects at load.
+    #[tokio::test]
+    async fn test_load_tolerates_non_primitive_non_null_default(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable(
+            "c",
+            ArrayType::new(DataType::INTEGER, true),
+        )])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("c", "ARRAY(1)")]))?;
+
+        let (store, engine, table_location) =
+            engine_store_setup("test_load_non_primitive_default", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            vec!["allowColumnDefaults"],
+        )
+        .await?;
+
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let defaults = txn.column_defaults()?;
+
+        let c = &defaults["c"];
+        assert_eq!(c.raw_sql(), "ARRAY(1)");
+        assert_eq!(
+            c.to_scalar()?,
+            None,
+            "kernel cannot parse a non-primitive default"
+        );
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -347,10 +347,8 @@ mod feature_enabled {
         Ok(())
     }
 
-    /// A non-NULL default on a non-primitive column is accepted at create time but surfaces as an
-    /// error when later discovered via `Transaction::column_defaults`.
     #[tokio::test]
-    async fn test_transaction_column_defaults_errors_on_non_null_non_primitive_default(
+    async fn test_load_rejects_non_null_non_primitive_default(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let base = StructType::try_new(vec![StructField::nullable(
             "arr",
@@ -359,7 +357,7 @@ mod feature_enabled {
         let schema = schema_with_column_defaults(&base, HashMap::from([("arr", "ARRAY(1)")]))?;
 
         let (store, engine, table_location) =
-            engine_store_setup("test_txn_column_defaults_non_primitive", None);
+            engine_store_setup("test_load_non_primitive_default", None);
         let table_url = create_table(
             store,
             table_location,
@@ -371,14 +369,38 @@ mod feature_enabled {
         )
         .await?;
 
-        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-
-        let err = txn
-            .column_defaults()
-            .expect_err("a non-NULL default on a non-primitive column must error")
+        let err = Snapshot::builder_for(table_url)
+            .build(&engine)
+            .expect_err("a non-NULL default on a non-primitive column must error at load")
             .to_string();
         assert!(err.contains("not supported"), "got: {err}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_rejects_default_without_allow_column_defaults_feature(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
+
+        let (store, engine, table_location) = engine_store_setup("test_load_stray_default", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            vec![], /* writer_features: no allowColumnDefaults */
+        )
+        .await?;
+
+        let err = Snapshot::builder_for(table_url)
+            .build(&engine)
+            .expect_err("a CURRENT_DEFAULT without the allowColumnDefaults feature must error")
+            .to_string();
+        assert!(err.contains("allowColumnDefaults"), "got: {err}");
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -4,11 +4,33 @@ use std::collections::HashMap;
 
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::schema::{
-    schema_ref, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    schema_ref, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
 };
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::DeltaResult;
-use test_utils::{schema_with_column_defaults, test_table_setup};
+use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
+use test_utils::delta_kernel_default_engine::DefaultEngine;
+use test_utils::{create_table, engine_store_setup, schema_with_column_defaults, test_table_setup};
+use url::Url;
+
+async fn setup_unpartitioned_table(
+    name: &str,
+    schema: SchemaRef,
+    writer_features: Vec<&str>,
+) -> Result<(DefaultEngine<TokioBackgroundExecutor>, Url), Box<dyn std::error::Error>> {
+    let (store, engine, table_location) = engine_store_setup(name, None);
+    let table_url = create_table(
+        store,
+        table_location,
+        schema,
+        &[],
+        true,
+        vec![],
+        writer_features,
+    )
+    .await?;
+    Ok((engine, table_url))
+}
 
 // TODO(#2630): Allow create table to support column defaults
 #[test]
@@ -76,7 +98,9 @@ mod feature_disabled {
     use delta_kernel::committer::FileSystemCommitter;
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::Snapshot;
-    use test_utils::{create_table, engine_store_setup, schema_with_column_defaults};
+    use test_utils::schema_with_column_defaults;
+
+    use super::setup_unpartitioned_table;
 
     #[tokio::test]
     async fn test_col_defaults_blocked_when_cargo_feature_off(
@@ -86,17 +110,9 @@ mod feature_disabled {
             StructField::nullable("name", DataType::STRING),
         ])?);
 
-        let (store, engine, table_location) = engine_store_setup("test_col_defaults_off", None);
-        let table_url = create_table(
-            store.clone(),
-            table_location,
-            schema,
-            &[],                         /* partition_columns */
-            true,                        /* use_37_protocol */
-            vec![],                      /* reader_features */
-            vec!["allowColumnDefaults"], /* writer_features */
-        )
-        .await?;
+        let (engine, table_url) =
+            setup_unpartitioned_table("test_col_defaults_off", schema, vec!["allowColumnDefaults"])
+                .await?;
 
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let err = snapshot
@@ -111,9 +127,9 @@ mod feature_disabled {
         Ok(())
     }
 
-    /// With the cargo feature off, `V3_CHECKS` omits `check_column_defaults`, so a V3 table whose
-    /// default would be rejected with the feature on (here a non-literal primitive default) still
-    /// loads. `allowColumnDefaults` is a writer feature, so it does not block snapshot load.
+    /// With the cargo feature off, the IcebergCompatV3 column-default validation is not compiled,
+    /// so a V3 table with a non-literal primitive default still loads. `allowColumnDefaults` is a
+    /// writer feature, so it does not block snapshot load.
     #[tokio::test]
     async fn test_v3_column_default_check_absent_when_cargo_feature_off(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -121,14 +137,9 @@ mod feature_disabled {
         let schema =
             schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
 
-        let (store, engine, table_location) = engine_store_setup("test_v3_default_off", None);
-        let table_url = create_table(
-            store,
-            table_location,
+        let (engine, table_url) = setup_unpartitioned_table(
+            "test_v3_default_off",
             schema,
-            &[],    /* partition_columns */
-            true,   /* use_37_protocol */
-            vec![], /* reader_features */
             vec!["allowColumnDefaults", "icebergCompatV3"],
         )
         .await?;
@@ -160,7 +171,10 @@ mod feature_enabled {
     use rstest::rstest;
     use test_utils::{
         create_table, engine_store_setup, insert_data, schema_with_column_defaults, test_read,
+        LoggingTest,
     };
+
+    use super::setup_unpartitioned_table;
 
     #[tokio::test]
     async fn test_blind_append_to_col_defaults_table_supported_when_cargo_feature_on(
@@ -301,14 +315,21 @@ mod feature_enabled {
     #[case::all_data_columns(&[])]
     #[case::default_on_partition_column(&["b"])]
     #[tokio::test]
-    async fn test_transaction_column_defaults_exposes_all_top_level_defaults(
+    async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
         #[case] partition_columns: &[&str],
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default.
+        let nested_default = StructField::nullable("inner", DataType::INTEGER).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::String("7".to_string()),
+        )]);
+
+        // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default,
+        // `s.inner`: nested default that the top-level API must not return.
         let base = StructType::try_new(vec![
             StructField::nullable("a", DataType::INTEGER),
             StructField::nullable("b", DataType::INTEGER),
             StructField::nullable("c", DataType::TIMESTAMP),
+            StructField::nullable("s", DataType::try_struct_type([nested_default])?),
         ])?;
         let schema = schema_with_column_defaults(
             &base,
@@ -330,9 +351,13 @@ mod feature_enabled {
         let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
 
-        let defaults = txn.column_defaults()?;
+        let defaults = txn.top_level_column_defaults()?;
         assert_eq!(defaults.len(), 2, "only b and c declare a default");
         assert!(!defaults.contains_key("a"), "a has no default");
+        assert!(
+            !defaults.contains_key("s") && !defaults.contains_key("s.inner"),
+            "nested defaults must not be returned by the top-level API"
+        );
 
         let b = &defaults["b"];
         assert_eq!(b.raw_sql(), "1337");
@@ -349,45 +374,48 @@ mod feature_enabled {
         Ok(())
     }
 
-    /// On an `icebergCompatV3` table, a column default kernel cannot materialize (a non-literal
-    /// default, or a default on a non-primitive column) is a warning, not an error: the snapshot
-    /// loads and a DML transaction constructs without error. The V3 warning accept/reject matrix
-    /// itself lives in the `v3_column_default_warning` unit test in `iceberg_compat::v3`; this only
-    /// asserts kernel does not reject such a table on the read/write path.
+    /// On an `icebergCompatV3` table, a default kernel cannot verify as a literal produces a
+    /// warning rather than an error, so the snapshot loads and a DML transaction constructs.
     #[rstest]
-    #[case::non_literal("non_literal", DataType::TIMESTAMP, "current_timestamp()")]
-    #[case::non_primitive(
+    #[case::non_literal(
+        "non_literal",
+        DataType::TIMESTAMP,
+        "current_timestamp()",
+        "could not verify"
+    )]
+    #[case::unparsable_non_primitive(
         "non_primitive",
         DataType::from(ArrayType::new(DataType::INTEGER, true)),
-        "ARRAY(1)"
+        "ARRAY(1)",
+        "could not verify"
     )]
     #[tokio::test]
-    async fn test_load_and_write_tolerate_v3_unmaterializable_default(
+    async fn test_load_and_write_tolerate_v3_unverifiable_default(
         #[case] label: &str,
         #[case] field_type: DataType,
         #[case] default_sql: &str,
+        #[case] warning_text: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
         let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
-        let (store, engine, table_location) =
-            engine_store_setup(&format!("test_v3_tolerates_{label}"), None);
-        let table_url = create_table(
-            store,
-            table_location,
+        let (engine, table_url) = setup_unpartitioned_table(
+            &format!("test_v3_tolerates_{label}"),
             schema,
-            &[],    /* partition_columns */
-            true,   /* use_37_protocol */
-            vec![], /* reader_features */
             vec!["allowColumnDefaults", "icebergCompatV3"],
         )
         .await?;
 
-        // Read: the snapshot loads despite the unmaterializable default.
+        // Read: the snapshot loads despite the unverifiable default.
         let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
 
-        // Write: a DML transaction constructs without error (a warning is logged, not returned).
+        let logging = LoggingTest::new();
         snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        assert!(
+            logging.logs().contains(warning_text),
+            "logs: {}",
+            logging.logs()
+        );
 
         Ok(())
     }
@@ -403,16 +431,10 @@ mod feature_enabled {
         )]);
         let schema = Arc::new(StructType::try_new(vec![field])?);
 
-        let (store, engine, table_location) =
-            engine_store_setup("test_load_rejects_non_string_default", None);
-        let table_url = create_table(
-            store,
-            table_location,
+        let (engine, table_url) = setup_unpartitioned_table(
+            "test_load_rejects_non_string_default",
             schema,
-            &[],                         /* partition_columns */
-            true,                        /* use_37_protocol */
-            vec![],                      /* reader_features */
-            vec!["allowColumnDefaults"], /* writer_features */
+            vec!["allowColumnDefaults"],
         )
         .await?;
 
@@ -432,17 +454,8 @@ mod feature_enabled {
         let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)])?;
         let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
 
-        let (store, engine, table_location) = engine_store_setup("test_load_orphan_default", None);
-        let table_url = create_table(
-            store,
-            table_location,
-            schema,
-            &[],    /* partition_columns */
-            true,   /* use_37_protocol */
-            vec![], /* reader_features */
-            vec![], /* writer_features: no allowColumnDefaults */
-        )
-        .await?;
+        let (engine, table_url) =
+            setup_unpartitioned_table("test_load_orphan_default", schema, vec![]).await?;
 
         // Read: snapshot loads despite the orphaned metadata.
         let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
@@ -467,22 +480,16 @@ mod feature_enabled {
         )])?;
         let schema = schema_with_column_defaults(&base, HashMap::from([("c", "ARRAY(1)")]))?;
 
-        let (store, engine, table_location) =
-            engine_store_setup("test_load_non_primitive_default", None);
-        let table_url = create_table(
-            store,
-            table_location,
+        let (engine, table_url) = setup_unpartitioned_table(
+            "test_load_non_primitive_default",
             schema,
-            &[],    /* partition_columns */
-            true,   /* use_37_protocol */
-            vec![], /* reader_features */
             vec!["allowColumnDefaults"],
         )
         .await?;
 
         let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-        let defaults = txn.column_defaults()?;
+        let defaults = txn.top_level_column_defaults()?;
 
         let c = &defaults["c"];
         assert_eq!(c.raw_sql(), "ARRAY(1)");
@@ -544,7 +551,7 @@ mod feature_enabled {
         let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
-        let defaults = txn.column_defaults()?;
+        let defaults = txn.top_level_column_defaults()?;
         assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
         drop(defaults);
         drop(txn);

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -70,12 +70,13 @@ fn test_schema_with_column_defaults_overwrites_existing_default() {
 
 #[cfg(not(feature = "column-defaults-in-dev"))]
 mod feature_disabled {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use delta_kernel::committer::FileSystemCommitter;
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::Snapshot;
-    use test_utils::{create_table, engine_store_setup};
+    use test_utils::{create_table, engine_store_setup, schema_with_column_defaults};
 
     #[tokio::test]
     async fn test_col_defaults_blocked_when_cargo_feature_off(
@@ -109,6 +110,35 @@ mod feature_disabled {
 
         Ok(())
     }
+
+    /// With the cargo feature off, `V3_CHECKS` omits `check_column_defaults`, so a V3 table whose
+    /// default would be rejected with the feature on (here a non-literal primitive default) still
+    /// loads. `allowColumnDefaults` is a writer feature, so it does not block snapshot load.
+    #[tokio::test]
+    async fn test_v3_column_default_check_absent_when_cargo_feature_off(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable("c", DataType::TIMESTAMP)])?;
+        let schema =
+            schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
+
+        let (store, engine, table_location) = engine_store_setup("test_v3_default_off", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            vec!["allowColumnDefaults", "icebergCompatV3"],
+        )
+        .await?;
+
+        Snapshot::builder_for(table_url)
+            .build(&engine)
+            .expect("V3 table must load when the column-defaults check is not compiled in");
+
+        Ok(())
+    }
 }
 
 #[cfg(feature = "column-defaults-in-dev")]
@@ -116,7 +146,7 @@ mod feature_enabled {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use delta_kernel::arrow::array::{ArrayRef, Int64Array, StringArray};
+    use delta_kernel::arrow::array::{ArrayRef, Int32Array, Int64Array, StringArray};
     use delta_kernel::arrow::record_batch::RecordBatch;
     use delta_kernel::committer::FileSystemCommitter;
     use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
@@ -349,6 +379,108 @@ mod feature_enabled {
             .expect_err("a non-NULL default on a non-primitive column must error")
             .to_string();
         assert!(err.contains("not supported"), "got: {err}");
+
+        Ok(())
+    }
+
+    /// End-to-end: a literal column default composes with `icebergCompatV3`. The default survives
+    /// the column-mapping transform (so it is still discoverable by its logical name), and a write
+    /// that materializes the default round-trips on read.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_column_default_with_iceberg_compat_v3_e2e(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![
+            StructField::nullable("id", DataType::LONG),
+            StructField::nullable("c", DataType::INTEGER),
+        ])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
+
+        let (store, engine, table_location) = engine_store_setup("test_v3_col_default_e2e", None);
+        // The helper auto-enables V3's dependencies (columnMapping, rowTracking, domainMetadata)
+        // and assigns the per-field column-mapping metadata a valid V3 table requires.
+        let table_url = create_table(
+            store,
+            table_location,
+            schema.clone(),
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            vec!["allowColumnDefaults", "icebergCompatV3"],
+        )
+        .await?;
+        let engine = Arc::new(engine);
+
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+        let writer_features = snapshot
+            .table_configuration()
+            .protocol()
+            .writer_features()
+            .expect("writer_features must be present on a writer v7 table");
+        for feature in [
+            TableFeature::IcebergCompatV3,
+            TableFeature::RowTracking,
+            TableFeature::ColumnMapping,
+            TableFeature::AllowColumnDefaults,
+        ] {
+            assert!(
+                writer_features.contains(&feature),
+                "writer_features must include {feature:?}; got {writer_features:?}",
+            );
+        }
+
+        // The default is still keyed by the logical name `c` and parses to its literal.
+        let txn = snapshot
+            .clone()
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+        let defaults = txn.column_defaults()?;
+        assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
+        drop(defaults);
+        drop(txn);
+
+        // The connector materializes the default (42) into the batch, then writes.
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(Int32Array::from(vec![42, 42, 42])),
+        ];
+        assert!(insert_data(snapshot, &engine, columns.clone())
+            .await?
+            .is_committed());
+
+        let data = RecordBatch::try_new(Arc::new(schema.as_ref().try_into_arrow()?), columns)?;
+        test_read(&ArrowEngineData::new(data), &table_url, engine)?;
+
+        Ok(())
+    }
+
+    /// `icebergCompatV3` requires column defaults to be literals, so a non-literal primitive
+    /// default fails snapshot load. This asserts the check is wired into snapshot load; the
+    /// full reject/accept matrix (including the NULL-on-non-primitive kernel limitation) lives
+    /// in the `validate_v3_column_default` unit test in `iceberg_compat::v3`.
+    #[tokio::test]
+    async fn test_iceberg_compat_v3_rejects_non_literal_column_default(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let base = StructType::try_new(vec![StructField::nullable("c", DataType::TIMESTAMP)])?;
+        let schema =
+            schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
+
+        let (store, engine, table_location) =
+            engine_store_setup("test_v3_invalid_col_default", None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            vec!["allowColumnDefaults", "icebergCompatV3"],
+        )
+        .await?;
+
+        let err = Snapshot::builder_for(table_url)
+            .build(&engine)
+            .expect_err("icebergCompatV3 must reject a non-literal column default")
+            .to_string();
+        assert!(err.contains("literal"), "got: {err}");
 
         Ok(())
     }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -152,7 +152,9 @@ mod feature_enabled {
     use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
     use delta_kernel::engine::arrow_data::ArrowEngineData;
     use delta_kernel::expressions::Scalar;
-    use delta_kernel::schema::{ArrayType, DataType, StructField, StructType};
+    use delta_kernel::schema::{
+        ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
     use delta_kernel::table_features::TableFeature;
     use delta_kernel::Snapshot;
     use rstest::rstest;
@@ -347,17 +349,73 @@ mod feature_enabled {
         Ok(())
     }
 
+    /// Snapshot load rejects corrupt column-default metadata: a non-NULL default on a
+    /// non-primitive column (unsupported by kernel) and a non-literal default on an
+    /// `icebergCompatV3` table. The V3 accept/reject matrix itself lives in the
+    /// `check_v3_column_default` unit test in `iceberg_compat::v3`; this only asserts the checks
+    /// are wired into snapshot load. Orphaned metadata is NOT rejected -- see
+    /// `test_load_and_write_allow_orphan_default`.
+    #[rstest]
+    #[case::non_primitive_default(
+        "non_primitive",
+        DataType::from(ArrayType::new(DataType::INTEGER, true)),
+        "ARRAY(1)",
+        vec!["allowColumnDefaults"],
+        "not supported"
+    )]
+    #[case::v3_non_literal_default(
+        "v3_non_literal",
+        DataType::TIMESTAMP,
+        "current_timestamp()",
+        vec!["allowColumnDefaults", "icebergCompatV3"],
+        "literal"
+    )]
     #[tokio::test]
-    async fn test_load_rejects_non_null_non_primitive_default(
+    async fn test_load_rejects_invalid_column_default(
+        #[case] label: &str,
+        #[case] field_type: DataType,
+        #[case] default_sql: &str,
+        #[case] writer_features: Vec<&str>,
+        #[case] error_needle: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let base = StructType::try_new(vec![StructField::nullable(
-            "arr",
-            ArrayType::new(DataType::INTEGER, true),
-        )])?;
-        let schema = schema_with_column_defaults(&base, HashMap::from([("arr", "ARRAY(1)")]))?;
+        let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
+        let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
         let (store, engine, table_location) =
-            engine_store_setup("test_load_non_primitive_default", None);
+            engine_store_setup(&format!("test_load_rejects_{label}"), None);
+        let table_url = create_table(
+            store,
+            table_location,
+            schema,
+            &[],    /* partition_columns */
+            true,   /* use_37_protocol */
+            vec![], /* reader_features */
+            writer_features,
+        )
+        .await?;
+
+        let err = Snapshot::builder_for(table_url)
+            .build(&engine)
+            .expect_err("invalid column default must be rejected at load")
+            .to_string();
+        assert!(err.contains(error_needle), "got: {err}");
+
+        Ok(())
+    }
+
+    /// A non-string `CURRENT_DEFAULT` value is corrupt and rejected at snapshot load. Built by
+    /// hand because `schema_with_column_defaults` only writes string values.
+    #[tokio::test]
+    async fn test_load_rejects_non_string_column_default() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let field = StructField::nullable("c", DataType::INTEGER).add_metadata([(
+            ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
+            MetadataValue::Number(7),
+        )]);
+        let schema = Arc::new(StructType::try_new(vec![field])?);
+
+        let (store, engine, table_location) =
+            engine_store_setup("test_load_rejects_non_string_default", None);
         let table_url = create_table(
             store,
             table_location,
@@ -371,20 +429,21 @@ mod feature_enabled {
 
         let err = Snapshot::builder_for(table_url)
             .build(&engine)
-            .expect_err("a non-NULL default on a non-primitive column must error at load")
+            .expect_err("a non-string CURRENT_DEFAULT must be rejected at load")
             .to_string();
-        assert!(err.contains("not supported"), "got: {err}");
+        assert!(err.contains("non-string"), "got: {err}");
 
         Ok(())
     }
 
+    /// Orphaned column-default metadata (a `CURRENT_DEFAULT` without the `allowColumnDefaults`
+    /// feature) is tolerated: the snapshot loads and a write context builds without error.
     #[tokio::test]
-    async fn test_load_rejects_default_without_allow_column_defaults_feature(
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_load_and_write_allow_orphan_default() -> Result<(), Box<dyn std::error::Error>> {
         let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)])?;
         let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
 
-        let (store, engine, table_location) = engine_store_setup("test_load_stray_default", None);
+        let (store, engine, table_location) = engine_store_setup("test_load_orphan_default", None);
         let table_url = create_table(
             store,
             table_location,
@@ -396,11 +455,12 @@ mod feature_enabled {
         )
         .await?;
 
-        let err = Snapshot::builder_for(table_url)
-            .build(&engine)
-            .expect_err("a CURRENT_DEFAULT without the allowColumnDefaults feature must error")
-            .to_string();
-        assert!(err.contains("allowColumnDefaults"), "got: {err}");
+        // Read: snapshot loads despite the orphaned metadata.
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+        // Write: a write context builds without error.
+        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        txn.unpartitioned_write_context()?;
 
         Ok(())
     }
@@ -470,39 +530,6 @@ mod feature_enabled {
 
         let data = RecordBatch::try_new(Arc::new(schema.as_ref().try_into_arrow()?), columns)?;
         test_read(&ArrowEngineData::new(data), &table_url, engine)?;
-
-        Ok(())
-    }
-
-    /// `icebergCompatV3` requires column defaults to be literals, so a non-literal primitive
-    /// default fails snapshot load. This asserts the check is wired into snapshot load; the
-    /// full reject/accept matrix (including the NULL-on-non-primitive kernel limitation) lives
-    /// in the `validate_v3_column_default` unit test in `iceberg_compat::v3`.
-    #[tokio::test]
-    async fn test_iceberg_compat_v3_rejects_non_literal_column_default(
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let base = StructType::try_new(vec![StructField::nullable("c", DataType::TIMESTAMP)])?;
-        let schema =
-            schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
-
-        let (store, engine, table_location) =
-            engine_store_setup("test_v3_invalid_col_default", None);
-        let table_url = create_table(
-            store,
-            table_location,
-            schema,
-            &[],    /* partition_columns */
-            true,   /* use_37_protocol */
-            vec![], /* reader_features */
-            vec!["allowColumnDefaults", "icebergCompatV3"],
-        )
-        .await?;
-
-        let err = Snapshot::builder_for(table_url)
-            .build(&engine)
-            .expect_err("icebergCompatV3 must reject a non-literal column default")
-            .to_string();
-        assert!(err.contains("literal"), "got: {err}");
 
         Ok(())
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -196,6 +196,7 @@ use delta_kernel::scan::Scan;
 use delta_kernel::schema::{
     ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
 };
+use delta_kernel::table_features::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 use delta_kernel::transaction::{CommitResult, Transaction};
 use delta_kernel::{
     try_parse_uri, DeltaResult, DeltaResultIterator, Engine, EngineData, Error, FileMeta,
@@ -627,10 +628,36 @@ pub async fn create_table(
     schema: SchemaRef,
     partition_columns: &[&str],
     use_37_protocol: bool,
-    reader_features: Vec<&str>,
-    writer_features: Vec<&str>,
+    mut reader_features: Vec<&str>,
+    mut writer_features: Vec<&str>,
 ) -> Result<Url, Box<dyn std::error::Error>> {
     let table_id = "test_id";
+
+    // IcebergCompatV3 requires ColumnMapping, RowTracking, and DomainMetadata. Add them so callers
+    // can pass just `icebergCompatV3` (plus e.g. `allowColumnDefaults`) and get a loadable table.
+    let enable_iceberg_compat_v3 = writer_features.contains(&"icebergCompatV3");
+    if enable_iceberg_compat_v3 {
+        if !reader_features.contains(&"columnMapping") {
+            reader_features.push("columnMapping");
+        }
+        for f in ["columnMapping", "rowTracking", "domainMetadata"] {
+            if !writer_features.contains(&f) {
+                writer_features.push(f);
+            }
+        }
+    }
+
+    // Column mapping requires per-field `id`/`physicalName` metadata, without which snapshot load
+    // fails. Assign it here (with nested ids for iceberg v3); `max_column_id` feeds
+    // `delta.columnMapping.maxColumnId` below.
+    let (schema, max_column_id) = if reader_features.contains(&"columnMapping") {
+        let mut max_id = find_max_column_id_in_schema(&schema).unwrap_or(0);
+        let schema =
+            assign_column_mapping_metadata(&schema, &mut max_id, enable_iceberg_compat_v3)?;
+        (Arc::new(schema), max_id)
+    } else {
+        (schema, 0i64)
+    };
     let schema = serde_json::to_string(&schema)?;
 
     let protocol = if use_37_protocol {
@@ -656,6 +683,13 @@ pub async fn create_table(
 
         if reader_features.contains(&"columnMapping") {
             config.insert("delta.columnMapping.mode".to_string(), json!("name"));
+            config.insert(
+                "delta.columnMapping.maxColumnId".to_string(),
+                json!(max_column_id.to_string()),
+            );
+        }
+        if writer_features.contains(&"icebergCompatV3") {
+            config.insert("delta.enableIcebergCompatV3".to_string(), json!("true"));
         }
         if writer_features.contains(&"rowTracking") {
             config.insert("delta.enableRowTracking".to_string(), json!("true"));


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2846/files) to review incremental changes.
- [**stack/column-defaults-v3-compat**](https://github.com/delta-io/delta-kernel-rs/pull/2846) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2846/files)]
  - [stack/column-defaults-ffi-support](https://github.com/delta-io/delta-kernel-rs/pull/2843) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2843/files/9a75abc1762fa8f6a5351fd8ee4ffc8e1afd51ce..e5a973763cf0c8a412d83eb332f6d3d2cae1f2ed)]

---------
## What changes are proposed in this pull request?
This PR adds IcebergCompatV3 enforcement of column-default rules. When `icebergCompatV3` is enabled, transaction load now
validates every column default and warns on:
- non-literal defaults
- defaults on non-primitive columns

Additionally we move column default validation up to table configuration so if a table has `CURRENT_DEFAULT` metadata that is non-string or the column is variant type but non-null we throw an error.

## How was this change tested?
Unit and Integration Testing

## Resources
[Tracking Issue](https://github.com/delta-io/delta-kernel-rs/issues/2630)