### PR TITLE
chore: upgrade to strum-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tempfile",
  "test-log",
  "test_utils",
@@ -4153,11 +4153,11 @@ checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -4175,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -50,7 +50,7 @@ rand = "0.9"
 roaring = "0.11.2"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-strum = { version = "0.27", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 thiserror = "2"
 prost = { version = "0.13", optional = true }
 tracing = { version = "0.1", features = ["log"] }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -13,8 +13,8 @@ use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
 use crate::schema::{DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::table_features::{
-    FeatureType, IntoTableFeature, TableFeature, MIN_VALID_RW_VERSION,
-    TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
+    FeatureType, TableFeature, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
+    TABLE_FEATURES_MIN_WRITER_VERSION,
 };
 use crate::table_properties::TableProperties;
 use crate::utils::require;
@@ -471,17 +471,17 @@ pub(crate) struct Protocol {
 /// Parse a list of feature identifiers into TableFeatures. Returns `None` for `None` input;
 /// otherwise infallible (unrecognized names become `TableFeature::Unknown`).
 fn parse_features(
-    features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
+    features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
 ) -> Option<Vec<TableFeature>> {
-    let features = features?.into_iter().map(|f| f.into_table_feature());
+    let features = features?.into_iter().map(Into::into);
     Some(features.collect())
 }
 
 impl Protocol {
     /// Try to create a new modern Protocol instance with the given table feature lists
     pub(crate) fn try_new_modern(
-        reader_features: impl IntoIterator<Item = impl IntoTableFeature>,
-        writer_features: impl IntoIterator<Item = impl IntoTableFeature>,
+        reader_features: impl IntoIterator<Item = impl Into<TableFeature>>,
+        writer_features: impl IntoIterator<Item = impl Into<TableFeature>>,
     ) -> DeltaResult<Self> {
         Self::try_new(
             TABLE_FEATURES_MIN_READER_VERSION,
@@ -509,8 +509,8 @@ impl Protocol {
     pub(crate) fn try_new(
         min_reader_version: i32,
         min_writer_version: i32,
-        reader_features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
-        writer_features: Option<impl IntoIterator<Item = impl IntoTableFeature>>,
+        reader_features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
+        writer_features: Option<impl IntoIterator<Item = impl Into<TableFeature>>>,
     ) -> DeltaResult<Self> {
         require!(
             min_reader_version >= MIN_VALID_RW_VERSION,

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -82,11 +82,7 @@ pub const SET_TABLE_FEATURE_SUPPORTED_VALUE: &str = "supported";
     EnumCount,
     Hash,
 )]
-#[strum(
-    serialize_all = "camelCase",
-    parse_err_fn = xxx__not_needed__default_variant_means_parsing_is_infallible__xxx,
-    parse_err_ty = Infallible // ignored, sadly: https://github.com/Peternator7/strum/issues/430
-)]
+#[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 #[internal_api]
 #[derive(EnumIter)]
@@ -761,38 +757,15 @@ impl TableFeature {
     }
 }
 
-/// Like `Into<TableFeature>`, but avoids collisions between strum's derived `EnumString` and the
-/// blanket impl `TryFrom<&str>` that `From<&str> for TableFeature` would trigger.
-///
-/// Parsing is infallible: the `Unknown` default variant catches any unrecognized feature name. If
-/// https://github.com/Peternator7/strum/pull/432 merges, use impl From for TableFeature instead.
-pub(crate) trait IntoTableFeature {
-    fn into_table_feature(self) -> TableFeature;
-}
-
-impl IntoTableFeature for TableFeature {
-    fn into_table_feature(self) -> TableFeature {
-        self
+impl From<String> for TableFeature {
+    fn from(value: String) -> Self {
+        value.as_str().into()
     }
 }
 
-impl IntoTableFeature for &TableFeature {
-    fn into_table_feature(self) -> TableFeature {
-        self.clone()
-    }
-}
-
-/// Parsing is infallible thanks to `TableFeature::Unknown` default variant
-impl IntoTableFeature for &str {
-    fn into_table_feature(self) -> TableFeature {
-        #[allow(clippy::unwrap_used)] // infallible, see strum parse_err_fn
-        self.parse().unwrap()
-    }
-}
-
-impl IntoTableFeature for String {
-    fn into_table_feature(self) -> TableFeature {
-        self.as_str().into_table_feature()
+impl From<&TableFeature> for TableFeature {
+    fn from(value: &TableFeature) -> Self {
+        value.clone()
     }
 }
 
@@ -1002,7 +975,7 @@ mod tests {
 
             // strum
             assert_eq!(feature.to_string(), expected);
-            assert_eq!(feature, expected.into_table_feature());
+            assert_eq!(feature, TableFeature::from(expected));
 
             // json
             let serialized = serde_json::to_string(&feature).unwrap();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Upgrade to strum-28 and delete hacky workarounds that are no longer needed.

## How was this change tested?

Compilation and unit tests suffice.