### PR TITLE
feat!: carry scan sub-step latencies as nanoseconds

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -155,8 +155,8 @@ consumed. It provides detailed statistics about the log replay process:
 | `num_non_file_actions` | Non-file actions (protocol, metadata, etc.) seen during replay. |
 | `num_predicate_filtered` | Files eliminated by predicate evaluation (data skipping and partition pruning). |
 | `peak_hash_set_size` | Peak size of the internal deduplication set. Indicates memory pressure during log replay. |
-| `dedup_visitor_time_ms` | Milliseconds spent in the deduplication visitor. |
-| `predicate_eval_time_ms` | Milliseconds spent evaluating predicates. |
+| `dedup_visitor_time_ns` | Nanoseconds spent in the deduplication visitor. |
+| `predicate_eval_time_ns` | Nanoseconds spent evaluating predicates. |
 
 #### The ScanType enum
 

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -280,8 +280,8 @@ void print_metric(MetricEvent event) {
     PM_U64(smc, num_non_file_actions);
     PM_U64(smc, num_predicate_filtered);
     PM_U64(smc, peak_hash_set_size);
-    PM_U64(smc, dedup_visitor_time_ms);
-    PM_U64(smc, predicate_eval_time_ms);
+    PM_U64(smc, dedup_visitor_time_ns);
+    PM_U64(smc, predicate_eval_time_ns);
     PM_END;
     return;
 

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -231,8 +231,8 @@ pub struct ScanMetadataCompleted {
     pub num_non_file_actions: u64,
     pub num_predicate_filtered: u64,
     pub peak_hash_set_size: u64,
-    pub dedup_visitor_time_ms: u64,
-    pub predicate_eval_time_ms: u64,
+    pub dedup_visitor_time_ns: u64,
+    pub predicate_eval_time_ns: u64,
 }
 
 /// A storage list operation completed.
@@ -478,8 +478,8 @@ impl MetricEvent {
                 num_non_file_actions,
                 num_predicate_filtered,
                 peak_hash_set_size,
-                dedup_visitor_time_ms,
-                predicate_eval_time_ms,
+                dedup_visitor_time,
+                predicate_eval_time,
             }) => Self::ScanMetadataCompleted(ScanMetadataCompleted {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -493,8 +493,8 @@ impl MetricEvent {
                 num_non_file_actions: *num_non_file_actions,
                 num_predicate_filtered: *num_predicate_filtered,
                 peak_hash_set_size: *peak_hash_set_size as u64, // note usize -> u64 cast
-                dedup_visitor_time_ms: *dedup_visitor_time_ms,
-                predicate_eval_time_ms: *predicate_eval_time_ms,
+                dedup_visitor_time_ns: ns(*dedup_visitor_time),
+                predicate_eval_time_ns: ns(*predicate_eval_time),
             }),
             K::StorageListCompleted(kernel::StorageListCompleted {
                 duration,
@@ -650,8 +650,8 @@ mod tests {
             num_non_file_actions: 31,
             num_predicate_filtered: 37,
             peak_hash_set_size: 41,
-            dedup_visitor_time_ms: 43,
-            predicate_eval_time_ms: 47,
+            dedup_visitor_time: Duration::from_nanos(43),
+            predicate_eval_time: Duration::from_nanos(47),
         });
         with_ffi_event(&event, |ffi| {
             let MetricEvent::ScanMetadataCompleted(e) = ffi else {
@@ -674,8 +674,8 @@ mod tests {
             assert_eq!(e.num_non_file_actions, 31);
             assert_eq!(e.num_predicate_filtered, 37);
             assert_eq!(e.peak_hash_set_size, 41);
-            assert_eq!(e.dedup_visitor_time_ms, 43);
-            assert_eq!(e.predicate_eval_time_ms, 47);
+            assert_eq!(e.dedup_visitor_time_ns, 43);
+            assert_eq!(e.predicate_eval_time_ns, 47);
         });
     }
 

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1194,10 +1194,10 @@ pub struct ScanMetadataCompleted {
     pub num_predicate_filtered: u64,
     /// Peak size of the deduplication hash set.
     pub peak_hash_set_size: usize,
-    /// Time spent in the deduplication visitor (milliseconds).
-    pub dedup_visitor_time_ms: u64,
-    /// Time spent evaluating predicates (milliseconds).
-    pub predicate_eval_time_ms: u64,
+    /// Time spent in the deduplication visitor.
+    pub dedup_visitor_time: Duration,
+    /// Time spent evaluating predicates.
+    pub predicate_eval_time: Duration,
 }
 
 impl ScanMetadataCompleted {
@@ -1219,8 +1219,8 @@ impl ScanMetadataCompleted {
             num_non_file_actions: v.num_non_file_actions,
             num_predicate_filtered: v.num_predicate_filtered,
             peak_hash_set_size: v.peak_hash_set_size as usize,
-            dedup_visitor_time_ms: v.dedup_visitor_time_ms,
-            predicate_eval_time_ms: v.predicate_eval_time_ms,
+            dedup_visitor_time: Duration::from_nanos(v.dedup_visitor_time_ns),
+            predicate_eval_time: Duration::from_nanos(v.predicate_eval_time_ns),
         }
     }
 }
@@ -1240,8 +1240,8 @@ impl fmt::Display for ScanMetadataCompleted {
             num_non_file_actions,
             num_predicate_filtered,
             peak_hash_set_size,
-            dedup_visitor_time_ms,
-            predicate_eval_time_ms,
+            dedup_visitor_time,
+            predicate_eval_time,
         } = self;
         write!(
             f,
@@ -1251,7 +1251,7 @@ impl fmt::Display for ScanMetadataCompleted {
              active_add_files_bytes={active_add_files_bytes}, \
              remove_files_seen={num_remove_files_seen}, non_file_actions={num_non_file_actions}, \
              predicate_filtered={num_predicate_filtered}, peak_hash_set_size={peak_hash_set_size}, \
-             dedup_visitor_time_ms={dedup_visitor_time_ms}, predicate_eval_time_ms={predicate_eval_time_ms})"
+             dedup_visitor_time={dedup_visitor_time:?}, predicate_eval_time={predicate_eval_time:?})"
         )
     }
 }
@@ -1270,8 +1270,8 @@ struct ScanMetadataCompletedAttrs {
     num_non_file_actions: u64,
     num_predicate_filtered: u64,
     peak_hash_set_size: u64,
-    dedup_visitor_time_ms: u64,
-    predicate_eval_time_ms: u64,
+    dedup_visitor_time_ns: u64,
+    predicate_eval_time_ns: u64,
 }
 
 impl Visit for ScanMetadataCompletedAttrs {
@@ -1297,8 +1297,8 @@ impl Visit for ScanMetadataCompletedAttrs {
             "num_non_file_actions" => self.num_non_file_actions = value,
             "num_predicate_filtered" => self.num_predicate_filtered = value,
             "peak_hash_set_size" => self.peak_hash_set_size = value,
-            "dedup_visitor_time_ms" => self.dedup_visitor_time_ms = value,
-            "predicate_eval_time_ms" => self.predicate_eval_time_ms = value,
+            "dedup_visitor_time_ns" => self.dedup_visitor_time_ns = value,
+            "predicate_eval_time_ns" => self.predicate_eval_time_ns = value,
             _ => {}
         }
     }
@@ -1533,8 +1533,8 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         num_non_file_actions = e.num_non_file_actions,
         num_predicate_filtered = e.num_predicate_filtered,
         peak_hash_set_size = e.peak_hash_set_size as u64,
-        dedup_visitor_time_ms = e.dedup_visitor_time_ms,
-        predicate_eval_time_ms = e.predicate_eval_time_ms,
+        dedup_visitor_time_ns = e.dedup_visitor_time.as_nanos() as u64,
+        predicate_eval_time_ns = e.predicate_eval_time.as_nanos() as u64,
     );
 }
 

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -644,8 +644,8 @@ mod tests {
         );
 
         // Verify timing metrics are present and parseable (values may be 0 for fast operations)
-        let _dedup_time = extract_metric(sequential_logs, "dedup_visitor_time_ms");
-        let _predicate_eval_time = extract_metric(sequential_logs, "predicate_eval_time_ms");
+        let _dedup_time = extract_metric(sequential_logs, "dedup_visitor_time_ns");
+        let _predicate_eval_time = extract_metric(sequential_logs, "predicate_eval_time_ns");
 
         // Verify Parallel metrics if expected
         if let Some(expected) = parallel_expected {
@@ -669,8 +669,8 @@ mod tests {
                 total_predicate_filtered += extract_metric(remaining, "predicate_filtered");
 
                 // Verify timing metrics are present and parseable in parallel phase
-                let _dedup_time = extract_metric(remaining, "dedup_visitor_time_ms");
-                let _predicate_eval_time = extract_metric(remaining, "predicate_eval_time_ms");
+                let _dedup_time = extract_metric(remaining, "dedup_visitor_time_ns");
+                let _predicate_eval_time = extract_metric(remaining, "predicate_eval_time_ns");
 
                 search_start = absolute_pos + 1;
             }

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -129,8 +129,12 @@ impl ScanMetrics {
             num_non_file_actions: self.num_non_file_actions.load(Ordering::Relaxed),
             num_predicate_filtered: self.num_predicate_filtered.load(Ordering::Relaxed),
             peak_hash_set_size: self.peak_hash_set_size.load(Ordering::Relaxed),
-            dedup_visitor_time_ms: self.dedup_visitor_time_ns.load(Ordering::Relaxed) / 1_000_000,
-            predicate_eval_time_ms: self.predicate_eval_time_ns.load(Ordering::Relaxed) / 1_000_000,
+            dedup_visitor_time: Duration::from_nanos(
+                self.dedup_visitor_time_ns.load(Ordering::Relaxed),
+            ),
+            predicate_eval_time: Duration::from_nanos(
+                self.predicate_eval_time_ns.load(Ordering::Relaxed),
+            ),
         }
     }
 
@@ -143,9 +147,8 @@ impl ScanMetrics {
         let non_file_actions = self.num_non_file_actions.load(Ordering::Relaxed);
         let predicate_filtered = self.num_predicate_filtered.load(Ordering::Relaxed);
         let peak_hash_set_size = self.peak_hash_set_size.load(Ordering::Relaxed);
-        let dedup_visitor_time_ms = self.dedup_visitor_time_ns.load(Ordering::Relaxed) / 1_000_000;
-        let predicate_eval_time_ms =
-            self.predicate_eval_time_ns.load(Ordering::Relaxed) / 1_000_000;
+        let dedup_visitor_time_ns = self.dedup_visitor_time_ns.load(Ordering::Relaxed);
+        let predicate_eval_time_ns = self.predicate_eval_time_ns.load(Ordering::Relaxed);
         info!(
             add_files_seen,
             active_add_files,
@@ -154,8 +157,8 @@ impl ScanMetrics {
             non_file_actions,
             predicate_filtered,
             peak_hash_set_size,
-            dedup_visitor_time_ms,
-            predicate_eval_time_ms,
+            dedup_visitor_time_ns,
+            predicate_eval_time_ns,
             "{}",
             message.as_ref()
         );


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, scan metric sub-step latencies were floored from nanosecond to millisecond.

This PR keeps them as nanosecond and allows for better granularity for downstream consumers.

## How was this change tested?

Update existing UTs.
