### PR TITLE
feat: support more cases for `snap.write_checksum`

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -39,41 +39,51 @@ pub(crate) struct CrcDelta {
 }
 
 impl CrcDelta {
-    /// Convert this delta into a fresh [`Crc`]. Used when the delta represents the entire table
-    /// state (e.g. CREATE TABLE or the first commit in a forward replay from version zero).
+    /// Convert this delta into a fresh [`Crc`] at `version`. Used when the delta represents the
+    /// entire table state: CREATE TABLE (version 0), or a full-history reverse replay over all
+    /// commits when no CRC or checkpoint is available.
+    ///
+    /// Because the delta covers the whole table, the resulting domain-metadata and
+    /// set-transaction states are [`Complete`](DomainMetadataState::Complete) (authoritative).
+    /// If the file-stats portion is not incremental-safe, file stats are
+    /// [`Indeterminate`](FileStatsState::Indeterminate).
     ///
     /// Returns `None` if protocol or metadata are missing (both are required for a valid CRC).
-    pub(crate) fn into_crc_for_version_zero(self) -> Option<Crc> {
+    pub(crate) fn into_complete_crc(self, version: Version) -> Option<Crc> {
         let protocol = self.protocol?;
         let metadata = self.metadata?;
-        // For CREATE TABLE we know the full domain metadata state: the transaction either
-        // included domain metadata actions or it didn't. Always Complete. Drop tombstones
-        // (a fresh table has no domains to remove).
+        // The delta covers the full table, so the domain metadata state is authoritative.
+        // Drop tombstones (a from-scratch state has no prior domains to remove).
         let domain_metadata_state = DomainMetadataState::Complete(
             self.domain_metadata
                 .into_iter()
                 .filter(|(_, dm)| !dm.is_removed())
                 .collect(),
         );
-        // CREATE TABLE starts with a known-complete set of transactions (possibly empty).
+        // The delta covers the full table, so the set-transaction state is authoritative.
         let set_transaction_state = SetTransactionState::Complete(self.set_transactions);
-        Some(Crc {
-            version: 0,
-            file_stats_state: FileStatsState::Complete(FileStats {
+        let file_stats_state = if self.is_incremental_safe {
+            FileStatsState::Complete(FileStats {
                 num_files: self.file_stats.net_files(),
                 table_size_bytes: self.file_stats.net_bytes(),
-                // For version zero the delta IS the full table histogram. Validate that all bins
-                // are non-negative (a real table can't have negative file counts). If validation
-                // fails, drop the histogram.
+                // The delta IS the full table histogram. Validate that all bins are non-negative
+                // (a real table can't have negative file counts). If validation fails, drop the
+                // histogram.
                 file_size_histogram: self.file_stats.net_histogram.and_then(|delta| {
                     delta
                         .check_non_negative()
                         .inspect_err(|e| {
-                            warn!("Non-negative file count check failed, dropping file size histogram for version zero: {e}");
+                            warn!("Non-negative file count check failed, dropping file size histogram: {e}");
                         })
                         .ok()
                 }),
-            }),
+            })
+        } else {
+            FileStatsState::Indeterminate
+        };
+        Some(Crc {
+            version,
+            file_stats_state,
             protocol,
             metadata,
             domain_metadata_state,
@@ -435,7 +445,7 @@ mod tests {
         assert_eq!(crc.in_commit_timestamp_opt, None);
     }
 
-    // ===== CrcDelta::into_crc_for_version_zero tests =====
+    // ===== CrcDelta::into_complete_crc tests =====
 
     fn test_protocol() -> Protocol {
         Protocol::try_new(
@@ -448,7 +458,7 @@ mod tests {
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_with_protocol_and_metadata() {
+    fn test_into_complete_crc_with_protocol_and_metadata() {
         let protocol = test_protocol();
         let metadata = Metadata::default();
         let delta = CrcDelta {
@@ -456,7 +466,7 @@ mod tests {
             metadata: Some(metadata.clone()),
             ..add_files_delta(5, 1000)
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         let stats = crc.file_stats().unwrap();
         assert_eq!(crc.version, 0);
         assert_eq!(crc.protocol, protocol);
@@ -476,25 +486,25 @@ mod tests {
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_returns_none_without_protocol() {
+    fn test_into_complete_crc_returns_none_without_protocol() {
         let delta = CrcDelta {
             metadata: Some(Metadata::default()),
             ..add_files_delta(5, 1000)
         };
-        assert!(delta.into_crc_for_version_zero().is_none());
+        assert!(delta.into_complete_crc(0).is_none());
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_returns_none_without_metadata() {
+    fn test_into_complete_crc_returns_none_without_metadata() {
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             ..add_files_delta(5, 1000)
         };
-        assert!(delta.into_crc_for_version_zero().is_none());
+        assert!(delta.into_complete_crc(0).is_none());
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_with_domain_metadata() {
+    fn test_into_complete_crc_with_domain_metadata() {
         let dm = DomainMetadata::new("my.domain".to_string(), "config1".to_string());
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
@@ -502,22 +512,47 @@ mod tests {
             domain_metadata: HashMap::from([("my.domain".to_string(), dm)]),
             ..add_files_delta(0, 0)
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         let map = crc.domain_metadata_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my.domain"].configuration(), "config1");
     }
 
     #[test]
-    fn test_into_crc_for_version_zero_with_in_commit_timestamp() {
+    fn test_into_complete_crc_with_in_commit_timestamp() {
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             in_commit_timestamp: Some(12345),
             ..add_files_delta(0, 0)
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         assert_eq!(crc.in_commit_timestamp_opt, Some(12345));
+    }
+
+    #[test]
+    fn into_complete_crc_at_nonzero_version_keeps_complete_stats() {
+        let delta = CrcDelta {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            ..add_files_delta(5, 1000)
+        };
+        let crc = delta.into_complete_crc(7).unwrap();
+        assert_eq!(crc.version, 7);
+        assert_eq!(crc.file_stats().unwrap().num_files(), 5);
+    }
+
+    #[test]
+    fn into_complete_crc_with_unsafe_delta_is_indeterminate() {
+        let delta = CrcDelta {
+            protocol: Some(test_protocol()),
+            metadata: Some(Metadata::default()),
+            is_incremental_safe: false,
+            ..add_files_delta(5, 1000)
+        };
+        let crc = delta.into_complete_crc(7).unwrap();
+        assert_eq!(crc.version, 7);
+        assert!(crc.file_stats_state.is_indeterminate());
     }
 
     // ===== apply: set transaction tests =====
@@ -558,10 +593,10 @@ mod tests {
         assert_eq!(map["new"].version, 1);
     }
 
-    // ===== into_crc_for_version_zero: set transaction tests =====
+    // ===== into_complete_crc: set transaction tests =====
 
     #[test]
-    fn test_into_crc_for_version_zero_with_set_transactions() {
+    fn test_into_complete_crc_with_set_transactions() {
         let txn = SetTransaction::new("my-app".to_string(), 5, Some(3000));
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
@@ -569,7 +604,7 @@ mod tests {
             set_transactions: HashMap::from([("my-app".to_string(), txn)]),
             ..add_files_delta(0, 0)
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         let map = crc.set_transaction_state.expect_complete();
         assert_eq!(map.len(), 1);
         assert_eq!(map["my-app"].version, 5);
@@ -700,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn into_crc_for_version_zero_includes_histogram() {
+    fn into_complete_crc_includes_histogram() {
         let delta_hist = histogram_from_sizes(&[500, 1000]);
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
@@ -714,7 +749,7 @@ mod tests {
             is_incremental_safe: true,
             ..Default::default()
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         let stats = crc.file_stats().unwrap();
         let hist = stats.file_size_histogram().unwrap();
         assert_eq!(hist.file_counts[0], 2);
@@ -722,15 +757,15 @@ mod tests {
     }
 
     #[test]
-    fn into_crc_for_version_zero_without_histogram() {
+    fn into_complete_crc_without_histogram() {
         // add_files_delta() produces a CrcDelta with no histogram delta, so
-        // into_crc_for_version_zero cannot construct a file size histogram.
+        // into_complete_crc cannot construct a file size histogram.
         let delta = CrcDelta {
             protocol: Some(test_protocol()),
             metadata: Some(Metadata::default()),
             ..add_files_delta(0, 0)
         };
-        let crc = delta.into_crc_for_version_zero().unwrap();
+        let crc = delta.into_complete_crc(0).unwrap();
         let stats = crc.file_stats().unwrap();
         assert!(stats.file_size_histogram().is_none());
     }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -52,7 +52,6 @@ impl CrcDelta {
     pub(crate) fn into_complete_crc(self, version: Version) -> Option<Crc> {
         let protocol = self.protocol?;
         let metadata = self.metadata?;
-        // The delta covers the full table, so the domain metadata state is authoritative.
         // Drop tombstones (a from-scratch state has no prior domains to remove).
         let domain_metadata_state = DomainMetadataState::Complete(
             self.domain_metadata
@@ -60,7 +59,6 @@ impl CrcDelta {
                 .filter(|(_, dm)| !dm.is_removed())
                 .collect(),
         );
-        // The delta covers the full table, so the set-transaction state is authoritative.
         let set_transaction_state = SetTransactionState::Complete(self.set_transactions);
         let file_stats_state = if self.is_incremental_safe {
             FileStatsState::Complete(FileStats {

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -28,6 +28,7 @@ use crate::crc::{
     FileSizeHistogram, FileStatsDelta,
 };
 use crate::engine_data::{GetData, TypedGetData as _};
+use crate::path::ParsedLogPath;
 use crate::schema::{
     column_name, schema, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
 };
@@ -173,8 +174,7 @@ impl LogSegment {
             ))
         );
 
-        let locations = deltas.iter().rev().map(|c| c.location.clone()).collect();
-        self.replay_commits_into_crc_delta(engine, locations, seed_histogram)
+        self.replay_commits_into_crc_delta(engine, deltas.into_iter(), seed_histogram)
     }
 
     /// Build a Complete [`Crc`] at `checkpoint_version` by reading this segment's checkpoint
@@ -228,45 +228,46 @@ impl LogSegment {
         let Some(first) = self.listed.ascending_commit_files.first() else {
             return Ok(None);
         };
+        // A log with no checkpoint must start at version 0; a higher first version means the log
+        // was truncated without a checkpoint. That is a corrupt table, not a kernel-invariant
+        // breach, so it is a generic error rather than an internal one.
         require!(
             first.version == 0,
-            Error::internal_error(format!(
-                "build_crc_from_version_zero expects commits from version 0, but the first commit \
-                 is at version {}",
+            Error::generic(format!(
+                "Cannot build CRC: log has no checkpoint but its first commit is at version {} \
+                 (expected 0); the log appears truncated without a checkpoint",
                 first.version
             ))
         );
-        let locations = self
-            .listed
-            .ascending_commit_files
-            .iter()
-            .rev()
-            .map(|c| c.location.clone())
-            .collect();
         let delta = self.replay_commits_into_crc_delta(
             engine,
-            locations,
+            self.listed.ascending_commit_files.iter(),
             Some(FileSizeHistogram::create_default()),
         )?;
         Ok(delta.into_complete_crc(self.end_version))
     }
 
-    /// Reverse-replay the given commit files (passed newest-first) into a [`CrcDelta`]. The shared
-    /// core of [`Self::build_incremental_crc_delta_from_base`] and
-    /// [`Self::build_crc_from_version_zero`]. `seed_histogram` is an empty histogram with the
-    /// downstream base's bin boundaries, or `None` to skip histogram tracking.
-    fn replay_commits_into_crc_delta(
+    /// Reverse-replay the given commits into a [`CrcDelta`]. The shared core of
+    /// [`Self::build_incremental_crc_delta_from_base`] and
+    /// [`Self::build_crc_from_version_zero`]. Takes the commits in ascending order and reverses
+    /// them internally, since reverse replay (newest-first) is load-bearing for ICT capture.
+    /// `seed_histogram` is an empty histogram with the downstream base's bin boundaries, or
+    /// `None` to skip histogram tracking.
+    fn replay_commits_into_crc_delta<'a>(
         &self,
         engine: &dyn Engine,
-        locations_newest_first: Vec<FileMeta>,
+        ascending_commits: impl DoubleEndedIterator<Item = &'a ParsedLogPath>,
         seed_histogram: Option<FileSizeHistogram>,
     ) -> DeltaResult<CrcDelta> {
+        let locations: Vec<FileMeta> = ascending_commits
+            .rev()
+            .map(|c| c.location.clone())
+            .collect();
         let mut acc = CrcReplayAccumulator::new(seed_histogram);
-        let batches = engine.json_handler().read_json_files(
-            &locations_newest_first,
-            REPLAY_SCHEMA.clone(),
-            None,
-        )?;
+        let batches =
+            engine
+                .json_handler()
+                .read_json_files(&locations, REPLAY_SCHEMA.clone(), None)?;
 
         for batch_result in batches {
             // Transient visitor borrows the shared accumulator for the duration of the
@@ -520,6 +521,27 @@ fn append_protocol_metadata_leaves(
     (names, types)
 }
 
+/// Validate that `getters` carries exactly the columns a replay visitor projects: `n_fixed`
+/// fixed columns plus the protocol and metadata leaves. Returns the protocol-leaf count, which
+/// the caller needs to split the trailing protocol/metadata leaf slices. `visitor_name` names
+/// the visitor in the error.
+fn check_visitor_getters(
+    getters: &[&dyn GetData<'_>],
+    n_fixed: usize,
+    visitor_name: &str,
+) -> DeltaResult<usize> {
+    let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
+    let n_metadata_leaves = METADATA_LEAVES.as_ref().0.len();
+    require!(
+        getters.len() == n_fixed + n_protocol_leaves + n_metadata_leaves,
+        Error::internal_error(format!(
+            "Wrong number of {visitor_name} getters: {}",
+            getters.len()
+        ))
+    );
+    Ok(n_protocol_leaves)
+}
+
 // ============================================================================
 // Visitor
 // ============================================================================
@@ -572,15 +594,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
-        let n_metadata_leaves = METADATA_LEAVES.as_ref().0.len();
-        require!(
-            getters.len() == N_FIXED_COLS + n_protocol_leaves + n_metadata_leaves,
-            Error::internal_error(format!(
-                "Wrong number of CrcReplayVisitor getters: {}",
-                getters.len()
-            ))
-        );
+        let n_protocol_leaves = check_visitor_getters(getters, N_FIXED_COLS, "CrcReplayVisitor")?;
         if row_count == 0 {
             return Ok(());
         }
@@ -690,15 +704,8 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
-        let n_metadata_leaves = METADATA_LEAVES.as_ref().0.len();
-        require!(
-            getters.len() == N_CP_FIXED_COLS + n_protocol_leaves + n_metadata_leaves,
-            Error::internal_error(format!(
-                "Wrong number of CheckpointCrcVisitor getters: {}",
-                getters.len()
-            ))
-        );
+        let n_protocol_leaves =
+            check_visitor_getters(getters, N_CP_FIXED_COLS, "CheckpointCrcVisitor")?;
         let common = CommonColumns {
             dm_domain: COL_CP_DM_DOMAIN,
             dm_config: COL_CP_DM_CONFIG,

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -85,7 +85,7 @@ impl LogSegment {
         if !incremental_replay.should_advance(base.version, self.end_version)? {
             return Ok(None);
         }
-        let advanced = self.build_incremental_crc_from_base(engine, base)?;
+        let advanced = self.build_crc_from_base(engine, base)?;
         Ok(Some(Arc::new(advanced)))
     }
 
@@ -117,8 +117,8 @@ impl LogSegment {
     /// Produce a fresh `Crc` at `self.end_version` by reverse-replaying the commits in
     /// `(base_crc.version, self.end_version]` and applying the resulting delta to
     /// `base_crc` via [`Crc::apply`].
-    #[instrument(name = "log_seg.build_incremental_crc_from_base", skip_all, err)]
-    pub(crate) fn build_incremental_crc_from_base(
+    #[instrument(name = "log_seg.build_crc_from_base", skip_all, err)]
+    pub(crate) fn build_crc_from_base(
         &self,
         engine: &dyn Engine,
         base_crc: &Crc,
@@ -130,63 +130,20 @@ impl LogSegment {
                 FileSizeHistogram::create_empty_with_boundaries(h.sorted_bin_boundaries().to_vec())
             })
             .transpose()?;
-        let delta =
-            self.build_incremental_crc_delta_from_base(engine, base_crc.version, seed_histogram)?;
+        let delta = self.build_crc_delta_from_base(engine, base_crc.version, seed_histogram)?;
         Ok(base_crc.clone().apply(delta, self.end_version))
     }
 
-    /// Build a `CrcDelta` covering commits `(base_version, self.end_version]` via reverse
-    /// log replay. `seed_histogram` is an empty histogram with the same bin boundaries as
-    /// the downstream base CRC, or `None` to skip histogram tracking on the delta.
+    /// Build a Complete base [`Crc`] at `checkpoint_version` from this segment's checkpoint files.
+    /// The tail commits are folded in separately by the caller as a [`CrcDelta`], so this reads
+    /// only the checkpoint. Returns `None` when the segment has no checkpoint, or if protocol or
+    /// metadata could not be recovered from it.
     ///
-    /// Errors if `base_version >= self.end_version` or if the segment is missing the
-    /// commit at `base_version + 1` (i.e. has a gap above `base_version`).
-    pub(crate) fn build_incremental_crc_delta_from_base(
-        &self,
-        engine: &dyn Engine,
-        base_version: Version,
-        seed_histogram: Option<FileSizeHistogram>,
-    ) -> DeltaResult<CrcDelta> {
-        require!(
-            base_version < self.end_version,
-            Error::internal_error(format!(
-                "build_incremental_crc_delta_from_base: base_version ({}) must be strictly less \
-                 than end_version ({})",
-                base_version, self.end_version,
-            ))
-        );
-
-        let deltas: Vec<_> = self
-            .listed
-            .ascending_commit_files
-            .iter()
-            .filter(|c| c.version > base_version)
-            .collect();
-
-        let first_above = deltas.first().map(|c| c.version);
-        require!(
-            first_above == Some(base_version + 1),
-            Error::internal_error(format!(
-                "build_incremental_crc_delta_from_base: segment is missing commit {} \
-                 (lowest commit above base_version is {:?})",
-                base_version + 1,
-                first_above,
-            ))
-        );
-
-        self.replay_commits_into_crc_delta(engine, deltas.into_iter(), seed_histogram)
-    }
-
-    /// Build a Complete [`Crc`] at `checkpoint_version` by reading this segment's checkpoint
-    /// files only (not the tail commits). Returns `None` when the segment has no checkpoint, or
-    /// if protocol or metadata could not be recovered from it.
-    ///
-    /// File stats sum live [`Add`](crate::actions::Add) actions (remove tombstones are skipped);
-    /// a missing Add `size` yields [`FileStatsState::Indeterminate`]. Domain metadata and set
-    /// transactions are [`Complete`](DomainMetadataState::Complete) since a checkpoint is
-    /// authoritative. `in_commit_timestamp_opt` is left `None`: a checkpoint carries no
-    /// `commitInfo`, so the caller supplies the ICT (from a tail commit, or read directly when
-    /// the checkpoint is at the target version).
+    /// File stats sum the checkpoint's AddFile actions (a reconciled checkpoint holds only live
+    /// files). Domain metadata and set transactions are
+    /// [`Complete`](DomainMetadataState::Complete) since a checkpoint is authoritative.
+    /// `in_commit_timestamp_opt` is left `None`: a checkpoint carries no `commitInfo`, so the
+    /// caller sets the ICT on the returned CRC afterward.
     pub(crate) fn build_crc_from_checkpoint(
         &self,
         engine: &dyn Engine,
@@ -194,11 +151,10 @@ impl LogSegment {
         let Some(version) = self.checkpoint_version else {
             return Ok(None);
         };
-        // No commit boundaries here, so the delta stays incremental-safe unless an Add is missing
-        // its size. It covers the full table, which `into_complete_crc` turns into a Complete CRC.
+        // No commit boundaries here, so the delta stays incremental-safe. It covers the full
+        // table, which `into_complete_crc` turns into a Complete CRC.
         let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
-        // Read the checkpoint files only (parquet plus any V2 sidecars), skipping the commit
-        // files: `create_checkpoint_stream` without the commit chain that `read_actions` adds.
+        // Read only the checkpoint parquet plus any V2 sidecars via `create_checkpoint_stream`.
         let batches = self
             .create_checkpoint_stream(engine, CHECKPOINT_CRC_SCHEMA.clone(), None, None, None)?
             .actions;
@@ -210,9 +166,9 @@ impl LogSegment {
         Ok(acc.into_crc_delta().into_complete_crc(version))
     }
 
-    /// Build a Complete [`Crc`] at `end_version` by reverse-replaying every commit in the
-    /// segment, for the case where there is neither a CRC nor a checkpoint to root at. Only
-    /// valid when the segment has no checkpoint, so its commits run contiguously from version 0.
+    /// Build a Complete [`Crc`] at `end_version` by reverse-replaying every commit in the segment,
+    /// for a segment with no CRC and no checkpoint to root at. The commits must run contiguously
+    /// from version 0.
     ///
     /// Returns `None` if protocol or metadata could not be recovered. File stats degrade to
     /// [`Indeterminate`](FileStatsState::Indeterminate) if the replay is not incremental-safe.
@@ -227,9 +183,8 @@ impl LogSegment {
         let Some(first) = self.listed.ascending_commit_files.first() else {
             return Ok(None);
         };
-        // A log with no checkpoint must start at version 0; a higher first version means the log
-        // was truncated without a checkpoint. That is a corrupt table, not a kernel-invariant
-        // breach, so it is a generic error rather than an internal one.
+        // A log with no checkpoint must start at version 0; a higher first version means a table
+        // truncated without a checkpoint.
         require!(
             first.version == 0,
             Error::generic(format!(
@@ -246,18 +201,59 @@ impl LogSegment {
         Ok(delta.into_complete_crc(self.end_version))
     }
 
-    /// Reverse-replay the given commits into a [`CrcDelta`]. The shared core of
-    /// [`Self::build_incremental_crc_delta_from_base`] and
-    /// [`Self::build_crc_from_version_zero`]. Takes the commits in ascending order and reverses
-    /// them internally, since reverse replay (newest-first) is load-bearing for ICT capture.
-    /// `seed_histogram` is an empty histogram with the downstream base's bin boundaries, or
-    /// `None` to skip histogram tracking.
+    /// Build a `CrcDelta` covering commits `(base_version, self.end_version]` via reverse
+    /// log replay. `seed_histogram` is an empty histogram with the same bin boundaries as
+    /// the downstream base CRC, or `None` to skip histogram tracking on the delta.
+    ///
+    /// Errors if `base_version >= self.end_version` or if the segment is missing the
+    /// commit at `base_version + 1` (i.e. has a gap above `base_version`).
+    pub(crate) fn build_crc_delta_from_base(
+        &self,
+        engine: &dyn Engine,
+        base_version: Version,
+        seed_histogram: Option<FileSizeHistogram>,
+    ) -> DeltaResult<CrcDelta> {
+        require!(
+            base_version < self.end_version,
+            Error::internal_error(format!(
+                "build_crc_delta_from_base: base_version ({}) must be strictly less \
+                 than end_version ({})",
+                base_version, self.end_version,
+            ))
+        );
+
+        let deltas: Vec<_> = self
+            .listed
+            .ascending_commit_files
+            .iter()
+            .filter(|c| c.version > base_version)
+            .collect();
+
+        let first_above = deltas.first().map(|c| c.version);
+        require!(
+            first_above == Some(base_version + 1),
+            Error::internal_error(format!(
+                "build_crc_delta_from_base: segment is missing commit {} \
+                 (lowest commit above base_version is {:?})",
+                base_version + 1,
+                first_above,
+            ))
+        );
+
+        self.replay_commits_into_crc_delta(engine, deltas.into_iter(), seed_histogram)
+    }
+
+    /// Replay the given commits into a [`CrcDelta`]. The shared core of
+    /// [`Self::build_crc_delta_from_base`] and [`Self::build_crc_from_version_zero`].
+    /// `ascending_commits` are taken oldest-first; `seed_histogram` is an empty histogram with the
+    /// downstream base's bin boundaries, or `None` to skip histogram tracking.
     fn replay_commits_into_crc_delta<'a>(
         &self,
         engine: &dyn Engine,
         ascending_commits: impl DoubleEndedIterator<Item = &'a ParsedLogPath>,
         seed_histogram: Option<FileSizeHistogram>,
     ) -> DeltaResult<CrcDelta> {
+        // Replay newest-first: ICT capture reads from the newest commit only.
         let locations: Vec<FileMeta> = ascending_commits
             .rev()
             .map(|c| c.location.clone())
@@ -365,12 +361,6 @@ impl CrcReplayAccumulator {
 
     // ===== Row-level updates (also the seams used by `on_*` unit tests) =====
 
-    /// Mark file stats as non-incremental-safe so they degrade to `Indeterminate`. Used when a
-    /// size needed for accounting is absent (e.g. a checkpoint Add with no `size`).
-    fn mark_file_stats_unsafe(&mut self) {
-        self.delta.is_incremental_safe = false;
-    }
-
     /// Called by the visitor once per commitInfo row (gated on operation or ict being
     /// present). Handles both pieces: `operation` drives per-commit safety classification,
     /// `ict` is captured into the delta from the newest commit only.
@@ -453,10 +443,10 @@ impl CrcReplayAccumulator {
         }
     }
 
-    /// Fold the columns common to commit and checkpoint replay (domain metadata, set
-    /// transactions, protocol, metadata) from row `i`. Each visitor handles its source-specific
-    /// columns (commit: `_file`/commitInfo/add/remove; checkpoint: add) and delegates the rest
-    /// here so the shared leaves live in one place.
+    /// Apply the columns common to commit and checkpoint replay (domain metadata, set
+    /// transactions, protocol, metadata) from row `i` to the delta. Each visitor handles its
+    /// source-specific columns (commit: `_file`/commitInfo/add/remove; checkpoint: add) and
+    /// delegates the rest here so the shared leaves live in one place.
     fn visit_common_columns<'a>(
         &mut self,
         i: usize,
@@ -490,9 +480,11 @@ impl CrcReplayAccumulator {
     }
 }
 
-/// Number of columns shared by both replay visitors: domain metadata (domain, configuration,
-/// removed) then set transaction (appId, version, lastUpdated). They sit contiguously at the end
-/// of each visitor's fixed columns, immediately before the protocol and metadata leaves.
+/// Number of columns shared by [`CrcReplayVisitor`] and [`CheckpointCrcVisitor`]: domain metadata
+/// (domain, configuration, removed) then set transaction (appId, version, lastUpdated). Each
+/// visitor's column list is {source-specific} then {shared} then {protocol leaves, metadata
+/// leaves}. Protocol and metadata are appended last because each expands to many leaf columns,
+/// while every column before them is a single leaf.
 const N_SHARED_COLS: usize = 6;
 
 /// Getter indices for the columns shared by commit and checkpoint replay, plus the count of
@@ -657,19 +649,14 @@ impl RowVisitor for CrcReplayVisitor<'_> {
 // Checkpoint base construction
 // ============================================================================
 
-/// Action schema for reading a checkpoint into a base [`Crc`]. Mirrors the on-disk action
-/// layout but projects only the leaves the accumulator needs. `add.path` (required) marks an
-/// Add row; `add.size` is read as optional so a malformed Add with no size degrades file stats
-/// rather than erroring. Unlike [`REPLAY_SCHEMA`], there is no `_file`, `remove`, or
-/// `commitInfo`: a checkpoint is a single reconciled view with no commit boundaries, removes
-/// are tombstones excluded from live file stats, and ICT is supplied by the caller.
+/// Action schema for reading a checkpoint into a base [`Crc`], projecting only the leaves the
+/// accumulator needs. `add.size` is the only Add leaf read, and it is required, so its presence
+/// marks an Add row (a checkpoint Add missing `size` errors at read time). A checkpoint has no
+/// `remove` or `commitInfo` to project.
 #[allow(clippy::expect_used)]
 static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(schema! {
-        nullable ADD_NAME: {
-            not_null "path": STRING,
-            nullable "size": LONG,
-        },
+        nullable ADD_NAME: { not_null "size": LONG },
         nullable PROTOCOL_NAME: (Protocol::to_schema()),
         nullable METADATA_NAME: (Metadata::to_schema()),
         nullable SET_TRANSACTION_NAME: (SetTransaction::to_schema()),
@@ -678,14 +665,12 @@ static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 // ===== Checkpoint visitor column indices =====
-const COL_CP_ADD_PATH: usize = 0;
-const COL_CP_ADD_SIZE: usize = 1;
+const COL_CP_ADD_SIZE: usize = 0;
 /// Source-specific columns end here; the shared columns follow.
 const N_CP_SPECIFIC_COLS: usize = COL_CP_ADD_SIZE + 1;
 const N_CP_FIXED_COLS: usize = N_CP_SPECIFIC_COLS + N_SHARED_COLS;
 
-/// Pulls leaf values from a checkpoint batch into the shared [`CrcReplayAccumulator`]. An Add
-/// with no `size` degrades file stats to `Indeterminate`.
+/// Pulls leaf values from a checkpoint batch into the shared [`CrcReplayAccumulator`].
 struct CheckpointCrcVisitor<'a> {
     acc: &'a mut CrcReplayAccumulator,
 }
@@ -693,10 +678,7 @@ struct CheckpointCrcVisitor<'a> {
 impl RowVisitor for CheckpointCrcVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-            let mut fixed = vec![
-                (DataType::STRING, column_name!("add.path")),
-                (DataType::LONG, column_name!("add.size")),
-            ];
+            let mut fixed = vec![(DataType::LONG, column_name!("add.size"))];
             fixed.extend(shared_dm_txn_columns());
             append_protocol_metadata_leaves(fixed).into()
         });
@@ -708,14 +690,9 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
             check_visitor_getters(getters, N_CP_FIXED_COLS, "CheckpointCrcVisitor")?;
         let common = CommonColumns::new(N_CP_SPECIFIC_COLS, n_protocol_leaves);
         for i in 0..row_count {
-            // `add.path` (required) marks an Add row; a present Add with no `size` cannot be
-            // accounted for, so file stats degrade to `Indeterminate`.
-            let add_path: Option<String> = getters[COL_CP_ADD_PATH].get_opt(i, "add.path")?;
-            if add_path.is_some() {
-                match getters[COL_CP_ADD_SIZE].get_opt(i, "add.size")? {
-                    Some(size) => self.acc.on_add(size)?,
-                    None => self.acc.mark_file_stats_unsafe(),
-                }
+            // `add.size` (required) marks an Add row.
+            if let Some(size) = getters[COL_CP_ADD_SIZE].get_opt(i, "add.size")? {
+                self.acc.on_add(size)?;
             }
 
             self.acc.visit_common_columns(i, getters, &common)?;
@@ -1009,9 +986,7 @@ mod tests {
             set_transaction_state: SetTransactionState::Complete(HashMap::new()),
             ..Default::default()
         };
-        let crc = segment
-            .build_incremental_crc_from_base(&engine, &base)
-            .unwrap();
+        let crc = segment.build_crc_from_base(&engine, &base).unwrap();
 
         // Newest-wins: v2's upgraded protocol (now carries `rowTracking` on top of v0's
         // features), v2's metadata, v2's ICT.
@@ -1055,7 +1030,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_incremental_crc_delta_from_base_errors_when_base_version_geq_end_version() {
+    async fn build_crc_delta_from_base_errors_when_base_version_geq_end_version() {
         let store = Arc::new(InMemory::new());
         let engine = SyncEngine::new_with_store(store.clone());
         let root = "memory:///t/";
@@ -1078,7 +1053,7 @@ mod tests {
         .unwrap();
         for base in [0, 5] {
             assert_result_error_with_message(
-                segment.build_incremental_crc_delta_from_base(&engine, base, None),
+                segment.build_crc_delta_from_base(&engine, base, None),
                 "must be strictly less than end_version",
             );
         }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -178,7 +178,8 @@ impl LogSegment {
     }
 
     /// Build a Complete [`Crc`] at `checkpoint_version` by reading this segment's checkpoint
-    /// files only (not the tail commits). Returns `None` when the segment has no checkpoint.
+    /// files only (not the tail commits). Returns `None` when the segment has no checkpoint, or
+    /// if protocol or metadata could not be recovered from it.
     ///
     /// File stats sum live [`Add`](crate::actions::Add) actions (remove tombstones are skipped);
     /// a missing Add `size` yields [`FileStatsState::Indeterminate`]. Domain metadata and set
@@ -193,10 +194,8 @@ impl LogSegment {
         let Some(version) = self.checkpoint_version else {
             return Ok(None);
         };
-        // A checkpoint is reconciled absolute state: there is no per-commit safety boundary, so
-        // we never call `process_batch_start` / `process_commit_file_end` and the delta stays
-        // incremental-safe unless an Add is missing its size. The resulting "delta" is the full
-        // table state, which `into_complete_crc` turns into a Complete CRC.
+        // No commit boundaries here, so the delta stays incremental-safe unless an Add is missing
+        // its size. It covers the full table, which `into_complete_crc` turns into a Complete CRC.
         let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
         // Read the checkpoint files only (parquet plus any V2 sidecars), skipping the commit
         // files: `create_checkpoint_stream` without the commit chain that `read_actions` adds.
@@ -491,10 +490,14 @@ impl CrcReplayAccumulator {
     }
 }
 
+/// Number of columns shared by both replay visitors: domain metadata (domain, configuration,
+/// removed) then set transaction (appId, version, lastUpdated). They sit contiguously at the end
+/// of each visitor's fixed columns, immediately before the protocol and metadata leaves.
+const N_SHARED_COLS: usize = 6;
+
 /// Getter indices for the columns shared by commit and checkpoint replay, plus the count of
-/// protocol leaves so the trailing protocol/metadata leaf slices can be split. Each visitor
-/// fills this from its own column layout and hands it to
-/// [`CrcReplayAccumulator::visit_common_columns`].
+/// protocol leaves so the trailing protocol/metadata leaf slices can be split. Built via
+/// [`CommonColumns::new`] and handed to [`CrcReplayAccumulator::visit_common_columns`].
 struct CommonColumns {
     dm_domain: usize,
     dm_config: usize,
@@ -505,6 +508,39 @@ struct CommonColumns {
     /// Index of the first protocol leaf; metadata leaves follow the protocol leaves.
     proto_meta_base: usize,
     n_protocol_leaves: usize,
+}
+
+impl CommonColumns {
+    /// The shared columns are contiguous starting at `base`, in the order laid out by
+    /// [`shared_dm_txn_columns`], followed by the protocol leaves and then the metadata leaves.
+    fn new(base: usize, n_protocol_leaves: usize) -> Self {
+        Self {
+            dm_domain: base,
+            dm_config: base + 1,
+            dm_removed: base + 2,
+            txn_app_id: base + 3,
+            txn_version: base + 4,
+            txn_last_updated: base + 5,
+            proto_meta_base: base + N_SHARED_COLS,
+            n_protocol_leaves,
+        }
+    }
+}
+
+/// The domain-metadata and set-transaction columns shared by both replay visitors, in the order
+/// [`CommonColumns::new`] assumes. Each visitor appends these to its source-specific columns.
+fn shared_dm_txn_columns() -> Vec<(DataType, ColumnName)> {
+    vec![
+        (DataType::STRING, column_name!("domainMetadata.domain")),
+        (
+            DataType::STRING,
+            column_name!("domainMetadata.configuration"),
+        ),
+        (DataType::BOOLEAN, column_name!("domainMetadata.removed")),
+        (DataType::STRING, column_name!("txn.appId")),
+        (DataType::LONG, column_name!("txn.version")),
+        (DataType::LONG, column_name!("txn.lastUpdated")),
+    ]
 }
 
 /// Append the protocol and metadata leaf columns (in that order) to a visitor's fixed columns,
@@ -554,13 +590,9 @@ const COL_ICT: usize = 2;
 const COL_ADD_SIZE: usize = 3;
 const COL_REMOVE_PATH: usize = 4;
 const COL_REMOVE_SIZE: usize = 5;
-const COL_DM_DOMAIN: usize = 6;
-const COL_DM_CONFIG: usize = 7;
-const COL_DM_REMOVED: usize = 8;
-const COL_TXN_APP_ID: usize = 9;
-const COL_TXN_VERSION: usize = 10;
-const COL_TXN_LAST_UPDATED: usize = 11;
-const N_FIXED_COLS: usize = COL_TXN_LAST_UPDATED + 1;
+/// Source-specific columns end here; the shared columns follow.
+const N_CRC_SPECIFIC_COLS: usize = COL_REMOVE_SIZE + 1;
+const N_FIXED_COLS: usize = N_CRC_SPECIFIC_COLS + N_SHARED_COLS;
 
 /// Thin shim that pulls leaf values from `getters` and forwards them to the accumulator's
 /// `on_*` methods. All behavior lives in [`CrcReplayAccumulator`].
@@ -571,23 +603,15 @@ struct CrcReplayVisitor<'a> {
 impl RowVisitor for CrcReplayVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-            const STRING: DataType = DataType::STRING;
-            const LONG: DataType = DataType::LONG;
-            const BOOLEAN: DataType = DataType::BOOLEAN;
-            let fixed = vec![
-                (STRING, column_name!("_file")),
-                (STRING, column_name!("commitInfo.operation")),
-                (LONG, column_name!("commitInfo.inCommitTimestamp")),
-                (LONG, column_name!("add.size")),
-                (STRING, column_name!("remove.path")),
-                (LONG, column_name!("remove.size")),
-                (STRING, column_name!("domainMetadata.domain")),
-                (STRING, column_name!("domainMetadata.configuration")),
-                (BOOLEAN, column_name!("domainMetadata.removed")),
-                (STRING, column_name!("txn.appId")),
-                (LONG, column_name!("txn.version")),
-                (LONG, column_name!("txn.lastUpdated")),
+            let mut fixed = vec![
+                (DataType::STRING, column_name!("_file")),
+                (DataType::STRING, column_name!("commitInfo.operation")),
+                (DataType::LONG, column_name!("commitInfo.inCommitTimestamp")),
+                (DataType::LONG, column_name!("add.size")),
+                (DataType::STRING, column_name!("remove.path")),
+                (DataType::LONG, column_name!("remove.size")),
             ];
+            fixed.extend(shared_dm_txn_columns());
             append_protocol_metadata_leaves(fixed).into()
         });
         NAMES_AND_TYPES.as_ref()
@@ -603,16 +627,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
         let file_url: String = getters[COL_FILE].get(0, "_file")?;
         self.acc.process_batch_start(&file_url);
 
-        let common = CommonColumns {
-            dm_domain: COL_DM_DOMAIN,
-            dm_config: COL_DM_CONFIG,
-            dm_removed: COL_DM_REMOVED,
-            txn_app_id: COL_TXN_APP_ID,
-            txn_version: COL_TXN_VERSION,
-            txn_last_updated: COL_TXN_LAST_UPDATED,
-            proto_meta_base: N_FIXED_COLS,
-            n_protocol_leaves,
-        };
+        let common = CommonColumns::new(N_CRC_SPECIFIC_COLS, n_protocol_leaves);
 
         for i in 0..row_count {
             let operation: Option<String> = getters[COL_OP].get_opt(i, "commitInfo.operation")?;
@@ -665,19 +680,12 @@ static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 // ===== Checkpoint visitor column indices =====
 const COL_CP_ADD_PATH: usize = 0;
 const COL_CP_ADD_SIZE: usize = 1;
-const COL_CP_DM_DOMAIN: usize = 2;
-const COL_CP_DM_CONFIG: usize = 3;
-const COL_CP_DM_REMOVED: usize = 4;
-const COL_CP_TXN_APP_ID: usize = 5;
-const COL_CP_TXN_VERSION: usize = 6;
-const COL_CP_TXN_LAST_UPDATED: usize = 7;
-const N_CP_FIXED_COLS: usize = COL_CP_TXN_LAST_UPDATED + 1;
+/// Source-specific columns end here; the shared columns follow.
+const N_CP_SPECIFIC_COLS: usize = COL_CP_ADD_SIZE + 1;
+const N_CP_FIXED_COLS: usize = N_CP_SPECIFIC_COLS + N_SHARED_COLS;
 
-/// Pulls leaf values from a checkpoint batch and forwards them to the shared
-/// [`CrcReplayAccumulator`]. Unlike [`CrcReplayVisitor`] it reads no `_file`, `commitInfo`, or
-/// `remove`: a checkpoint is one reconciled view (no commit boundaries or operations), and its
-/// removes are tombstones excluded from live file stats. An Add with no `size` degrades file
-/// stats to `Indeterminate`.
+/// Pulls leaf values from a checkpoint batch into the shared [`CrcReplayAccumulator`]. An Add
+/// with no `size` degrades file stats to `Indeterminate`.
 struct CheckpointCrcVisitor<'a> {
     acc: &'a mut CrcReplayAccumulator,
 }
@@ -685,19 +693,11 @@ struct CheckpointCrcVisitor<'a> {
 impl RowVisitor for CheckpointCrcVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-            const STRING: DataType = DataType::STRING;
-            const LONG: DataType = DataType::LONG;
-            const BOOLEAN: DataType = DataType::BOOLEAN;
-            let fixed = vec![
-                (STRING, column_name!("add.path")),
-                (LONG, column_name!("add.size")),
-                (STRING, column_name!("domainMetadata.domain")),
-                (STRING, column_name!("domainMetadata.configuration")),
-                (BOOLEAN, column_name!("domainMetadata.removed")),
-                (STRING, column_name!("txn.appId")),
-                (LONG, column_name!("txn.version")),
-                (LONG, column_name!("txn.lastUpdated")),
+            let mut fixed = vec![
+                (DataType::STRING, column_name!("add.path")),
+                (DataType::LONG, column_name!("add.size")),
             ];
+            fixed.extend(shared_dm_txn_columns());
             append_protocol_metadata_leaves(fixed).into()
         });
         NAMES_AND_TYPES.as_ref()
@@ -706,16 +706,7 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let n_protocol_leaves =
             check_visitor_getters(getters, N_CP_FIXED_COLS, "CheckpointCrcVisitor")?;
-        let common = CommonColumns {
-            dm_domain: COL_CP_DM_DOMAIN,
-            dm_config: COL_CP_DM_CONFIG,
-            dm_removed: COL_CP_DM_REMOVED,
-            txn_app_id: COL_CP_TXN_APP_ID,
-            txn_version: COL_CP_TXN_VERSION,
-            txn_last_updated: COL_CP_TXN_LAST_UPDATED,
-            proto_meta_base: N_CP_FIXED_COLS,
-            n_protocol_leaves,
-        };
+        let common = CommonColumns::new(N_CP_SPECIFIC_COLS, n_protocol_leaves);
         for i in 0..row_count {
             // `add.path` (required) marks an Add row; a present Add with no `size` cannot be
             // accounted for, so file stats degrade to `Indeterminate`.
@@ -1091,5 +1082,33 @@ mod tests {
                 "must be strictly less than end_version",
             );
         }
+    }
+
+    #[tokio::test]
+    async fn build_crc_from_version_zero_no_checkpoint_first_commit_nonzero_errors() {
+        let store = Arc::new(InMemory::new());
+        let engine = SyncEngine::new_with_store(store.clone());
+        let root = "memory:///t/";
+        add_commit(
+            root,
+            store.as_ref(),
+            1,
+            r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":1}}"#.to_string(),
+        )
+        .await
+        .unwrap();
+        let log_root = url::Url::parse(root).unwrap().join("_delta_log/").unwrap();
+        let segment = LogSegment::for_snapshot_impl(
+            engine.storage_handler().as_ref(),
+            log_root,
+            vec![],
+            None,
+            Some(1),
+        )
+        .unwrap();
+        assert_result_error_with_message(
+            segment.build_crc_from_version_zero(&engine),
+            "log appears truncated without a checkpoint",
+        );
     }
 }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -453,9 +453,71 @@ impl CrcReplayAccumulator {
         }
     }
 
+    /// Fold the columns common to commit and checkpoint replay (domain metadata, set
+    /// transactions, protocol, metadata) from row `i`. Each visitor handles its source-specific
+    /// columns (commit: `_file`/commitInfo/add/remove; checkpoint: add) and delegates the rest
+    /// here so the shared leaves live in one place.
+    fn visit_common_columns<'a>(
+        &mut self,
+        i: usize,
+        getters: &[&'a dyn GetData<'a>],
+        cols: &CommonColumns,
+    ) -> DeltaResult<()> {
+        if let Some(domain) = getters[cols.dm_domain].get_opt(i, "domainMetadata.domain")? {
+            let configuration: String =
+                getters[cols.dm_config].get(i, "domainMetadata.configuration")?;
+            let removed: bool = getters[cols.dm_removed].get(i, "domainMetadata.removed")?;
+            self.on_domain_metadata(domain, configuration, removed);
+        }
+        if let Some(app_id) = getters[cols.txn_app_id].get_opt(i, "txn.appId")? {
+            let version: i64 = getters[cols.txn_version].get(i, "txn.version")?;
+            let last_updated: Option<i64> =
+                getters[cols.txn_last_updated].get_opt(i, "txn.lastUpdated")?;
+            self.on_set_transaction(app_id, version, last_updated);
+        }
+        let pm = &getters[cols.proto_meta_base..];
+        if self.delta.protocol.is_none() {
+            self.delta.protocol = visit_protocol_at(i, &pm[..cols.n_protocol_leaves])?;
+        }
+        if self.delta.metadata.is_none() {
+            self.delta.metadata = visit_metadata_at(i, &pm[cols.n_protocol_leaves..])?;
+        }
+        Ok(())
+    }
+
     fn into_crc_delta(self) -> CrcDelta {
         self.delta
     }
+}
+
+/// Getter indices for the columns shared by commit and checkpoint replay, plus the count of
+/// protocol leaves so the trailing protocol/metadata leaf slices can be split. Each visitor
+/// fills this from its own column layout and hands it to
+/// [`CrcReplayAccumulator::visit_common_columns`].
+struct CommonColumns {
+    dm_domain: usize,
+    dm_config: usize,
+    dm_removed: usize,
+    txn_app_id: usize,
+    txn_version: usize,
+    txn_last_updated: usize,
+    /// Index of the first protocol leaf; metadata leaves follow the protocol leaves.
+    proto_meta_base: usize,
+    n_protocol_leaves: usize,
+}
+
+/// Append the protocol and metadata leaf columns (in that order) to a visitor's fixed columns,
+/// shared by both replay visitors' `selected_column_names_and_types`.
+fn append_protocol_metadata_leaves(
+    fixed: Vec<(DataType, ColumnName)>,
+) -> (Vec<ColumnName>, Vec<DataType>) {
+    let (mut types, mut names): (Vec<_>, Vec<_>) = fixed.into_iter().unzip();
+    for leaves in [&*PROTOCOL_LEAVES, &*METADATA_LEAVES] {
+        let (leaf_names, leaf_types) = leaves.as_ref();
+        names.extend_from_slice(leaf_names);
+        types.extend_from_slice(leaf_types);
+    }
+    (names, types)
 }
 
 // ============================================================================
@@ -504,13 +566,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 (LONG, column_name!("txn.version")),
                 (LONG, column_name!("txn.lastUpdated")),
             ];
-            let (mut types, mut names): (Vec<_>, Vec<_>) = fixed.into_iter().unzip();
-            for leaves in [&*PROTOCOL_LEAVES, &*METADATA_LEAVES] {
-                let (leaf_names, leaf_types) = leaves.as_ref();
-                names.extend_from_slice(leaf_names);
-                types.extend_from_slice(leaf_types);
-            }
-            (names, types).into()
+            append_protocol_metadata_leaves(fixed).into()
         });
         NAMES_AND_TYPES.as_ref()
     }
@@ -533,6 +589,17 @@ impl RowVisitor for CrcReplayVisitor<'_> {
         let file_url: String = getters[COL_FILE].get(0, "_file")?;
         self.acc.process_batch_start(&file_url);
 
+        let common = CommonColumns {
+            dm_domain: COL_DM_DOMAIN,
+            dm_config: COL_DM_CONFIG,
+            dm_removed: COL_DM_REMOVED,
+            txn_app_id: COL_TXN_APP_ID,
+            txn_version: COL_TXN_VERSION,
+            txn_last_updated: COL_TXN_LAST_UPDATED,
+            proto_meta_base: N_FIXED_COLS,
+            n_protocol_leaves,
+        };
+
         for i in 0..row_count {
             let operation: Option<String> = getters[COL_OP].get_opt(i, "commitInfo.operation")?;
             let ict: Option<i64> = getters[COL_ICT].get_opt(i, "commitInfo.inCommitTimestamp")?;
@@ -551,31 +618,7 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 self.acc.on_remove(&path, remove_size)?;
             }
 
-            let dm_domain: Option<String> =
-                getters[COL_DM_DOMAIN].get_opt(i, "domainMetadata.domain")?;
-            if let Some(domain) = dm_domain {
-                let configuration: String =
-                    getters[COL_DM_CONFIG].get(i, "domainMetadata.configuration")?;
-                let removed: bool = getters[COL_DM_REMOVED].get(i, "domainMetadata.removed")?;
-                self.acc.on_domain_metadata(domain, configuration, removed);
-            }
-
-            let txn_app_id: Option<String> = getters[COL_TXN_APP_ID].get_opt(i, "txn.appId")?;
-            if let Some(app_id) = txn_app_id {
-                let version: i64 = getters[COL_TXN_VERSION].get(i, "txn.version")?;
-                let last_updated: Option<i64> =
-                    getters[COL_TXN_LAST_UPDATED].get_opt(i, "txn.lastUpdated")?;
-                self.acc.on_set_transaction(app_id, version, last_updated);
-            }
-
-            if self.acc.delta.protocol.is_none() {
-                self.acc.delta.protocol =
-                    visit_protocol_at(i, &getters[N_FIXED_COLS..N_FIXED_COLS + n_protocol_leaves])?;
-            }
-            if self.acc.delta.metadata.is_none() {
-                self.acc.delta.metadata =
-                    visit_metadata_at(i, &getters[N_FIXED_COLS + n_protocol_leaves..])?;
-            }
+            self.acc.visit_common_columns(i, getters, &common)?;
         }
         Ok(())
     }
@@ -641,13 +684,7 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
                 (LONG, column_name!("txn.version")),
                 (LONG, column_name!("txn.lastUpdated")),
             ];
-            let (mut types, mut names): (Vec<_>, Vec<_>) = fixed.into_iter().unzip();
-            for leaves in [&*PROTOCOL_LEAVES, &*METADATA_LEAVES] {
-                let (leaf_names, leaf_types) = leaves.as_ref();
-                names.extend_from_slice(leaf_names);
-                types.extend_from_slice(leaf_types);
-            }
-            (names, types).into()
+            append_protocol_metadata_leaves(fixed).into()
         });
         NAMES_AND_TYPES.as_ref()
     }
@@ -662,6 +699,16 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
                 getters.len()
             ))
         );
+        let common = CommonColumns {
+            dm_domain: COL_CP_DM_DOMAIN,
+            dm_config: COL_CP_DM_CONFIG,
+            dm_removed: COL_CP_DM_REMOVED,
+            txn_app_id: COL_CP_TXN_APP_ID,
+            txn_version: COL_CP_TXN_VERSION,
+            txn_last_updated: COL_CP_TXN_LAST_UPDATED,
+            proto_meta_base: N_CP_FIXED_COLS,
+            n_protocol_leaves,
+        };
         for i in 0..row_count {
             // `add.path` (required) marks an Add row; a present Add with no `size` cannot be
             // accounted for, so file stats degrade to `Indeterminate`.
@@ -673,33 +720,7 @@ impl RowVisitor for CheckpointCrcVisitor<'_> {
                 }
             }
 
-            let dm_domain: Option<String> =
-                getters[COL_CP_DM_DOMAIN].get_opt(i, "domainMetadata.domain")?;
-            if let Some(domain) = dm_domain {
-                let configuration: String =
-                    getters[COL_CP_DM_CONFIG].get(i, "domainMetadata.configuration")?;
-                let removed: bool = getters[COL_CP_DM_REMOVED].get(i, "domainMetadata.removed")?;
-                self.acc.on_domain_metadata(domain, configuration, removed);
-            }
-
-            let txn_app_id: Option<String> = getters[COL_CP_TXN_APP_ID].get_opt(i, "txn.appId")?;
-            if let Some(app_id) = txn_app_id {
-                let version: i64 = getters[COL_CP_TXN_VERSION].get(i, "txn.version")?;
-                let last_updated: Option<i64> =
-                    getters[COL_CP_TXN_LAST_UPDATED].get_opt(i, "txn.lastUpdated")?;
-                self.acc.on_set_transaction(app_id, version, last_updated);
-            }
-
-            if self.acc.delta.protocol.is_none() {
-                self.acc.delta.protocol = visit_protocol_at(
-                    i,
-                    &getters[N_CP_FIXED_COLS..N_CP_FIXED_COLS + n_protocol_leaves],
-                )?;
-            }
-            if self.acc.delta.metadata.is_none() {
-                self.acc.delta.metadata =
-                    visit_metadata_at(i, &getters[N_CP_FIXED_COLS + n_protocol_leaves..])?;
-            }
+            self.acc.visit_common_columns(i, getters, &common)?;
         }
         Ok(())
     }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -267,7 +267,7 @@ impl LogSegment {
         for batch_result in batches {
             // Transient visitor borrows the shared accumulator for the duration of the
             // batch; same pattern as `ActionReconciliationVisitor`.
-            let mut visitor = CrcReplayVisitor { acc: &mut acc };
+            let mut visitor = CommitCrcVisitor { acc: &mut acc };
             visitor.visit_rows_of(batch_result?.as_ref())?;
         }
 
@@ -443,34 +443,39 @@ impl CrcReplayAccumulator {
         }
     }
 
-    /// Apply the columns common to commit and checkpoint replay (domain metadata, set
-    /// transactions, protocol, metadata) from row `i` to the delta. Each visitor handles its
-    /// source-specific columns (commit: `_file`/commitInfo/add/remove; checkpoint: add) and
-    /// delegates the rest here so the shared leaves live in one place.
-    fn visit_common_columns<'a>(
+    /// Apply the columns every source carries (add file, domain metadata, set transactions,
+    /// protocol, metadata) from row `i` to the delta. Each visitor handles its source-specific
+    /// columns (commit: `_file`/commitInfo/remove) and passes the trailing shared slice here so
+    /// the shared leaves live in one place. `shared` starts at the first shared column, laid out
+    /// as [`shared_columns`] then the protocol and metadata leaves.
+    fn apply_shared_columns<'a>(
         &mut self,
         i: usize,
-        getters: &[&'a dyn GetData<'a>],
-        cols: &CommonColumns,
+        shared: &[&'a dyn GetData<'a>],
     ) -> DeltaResult<()> {
-        if let Some(domain) = getters[cols.dm_domain].get_opt(i, "domainMetadata.domain")? {
+        // `add.size` (required) marks an Add row.
+        if let Some(size) = shared[SHARED_COL_ADD_SIZE].get_opt(i, "add.size")? {
+            self.on_add(size)?;
+        }
+        if let Some(domain) = shared[SHARED_COL_DM_DOMAIN].get_opt(i, "domainMetadata.domain")? {
             let configuration: String =
-                getters[cols.dm_config].get(i, "domainMetadata.configuration")?;
-            let removed: bool = getters[cols.dm_removed].get(i, "domainMetadata.removed")?;
+                shared[SHARED_COL_DM_CONFIG].get(i, "domainMetadata.configuration")?;
+            let removed: bool = shared[SHARED_COL_DM_REMOVED].get(i, "domainMetadata.removed")?;
             self.on_domain_metadata(domain, configuration, removed);
         }
-        if let Some(app_id) = getters[cols.txn_app_id].get_opt(i, "txn.appId")? {
-            let version: i64 = getters[cols.txn_version].get(i, "txn.version")?;
+        if let Some(app_id) = shared[SHARED_COL_TXN_APP_ID].get_opt(i, "txn.appId")? {
+            let version: i64 = shared[SHARED_COL_TXN_VERSION].get(i, "txn.version")?;
             let last_updated: Option<i64> =
-                getters[cols.txn_last_updated].get_opt(i, "txn.lastUpdated")?;
+                shared[SHARED_COL_TXN_LAST_UPDATED].get_opt(i, "txn.lastUpdated")?;
             self.on_set_transaction(app_id, version, last_updated);
         }
-        let pm = &getters[cols.proto_meta_base..];
+        let leaves = &shared[N_SHARED_SINGLE_LEAF_COLS..];
+        let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
         if self.delta.protocol.is_none() {
-            self.delta.protocol = visit_protocol_at(i, &pm[..cols.n_protocol_leaves])?;
+            self.delta.protocol = visit_protocol_at(i, &leaves[..n_protocol_leaves])?;
         }
         if self.delta.metadata.is_none() {
-            self.delta.metadata = visit_metadata_at(i, &pm[cols.n_protocol_leaves..])?;
+            self.delta.metadata = visit_metadata_at(i, &leaves[n_protocol_leaves..])?;
         }
         Ok(())
     }
@@ -480,49 +485,27 @@ impl CrcReplayAccumulator {
     }
 }
 
-/// Number of columns shared by [`CrcReplayVisitor`] and [`CheckpointCrcVisitor`]: domain metadata
-/// (domain, configuration, removed) then set transaction (appId, version, lastUpdated). Each
-/// visitor's column list is {source-specific} then {shared} then {protocol leaves, metadata
-/// leaves}. Protocol and metadata are appended last because each expands to many leaf columns,
-/// while every column before them is a single leaf.
-const N_SHARED_COLS: usize = 6;
+// ===== Shared column indices =====
+// Indices into the shared slice each visitor passes to
+// [`CrcReplayAccumulator::apply_shared_columns`], laid out by [`shared_columns`].
+// Zero-based: the slice starts at the first shared column.
+const SHARED_COL_ADD_SIZE: usize = 0;
+const SHARED_COL_DM_DOMAIN: usize = 1;
+const SHARED_COL_DM_CONFIG: usize = 2;
+const SHARED_COL_DM_REMOVED: usize = 3;
+const SHARED_COL_TXN_APP_ID: usize = 4;
+const SHARED_COL_TXN_VERSION: usize = 5;
+const SHARED_COL_TXN_LAST_UPDATED: usize = 6;
+/// The single-leaf shared columns end here; the protocol and metadata leaves follow them in the
+/// shared slice.
+const N_SHARED_SINGLE_LEAF_COLS: usize = SHARED_COL_TXN_LAST_UPDATED + 1;
 
-/// Getter indices for the columns shared by commit and checkpoint replay, plus the count of
-/// protocol leaves so the trailing protocol/metadata leaf slices can be split. Built via
-/// [`CommonColumns::new`] and handed to [`CrcReplayAccumulator::visit_common_columns`].
-struct CommonColumns {
-    dm_domain: usize,
-    dm_config: usize,
-    dm_removed: usize,
-    txn_app_id: usize,
-    txn_version: usize,
-    txn_last_updated: usize,
-    /// Index of the first protocol leaf; metadata leaves follow the protocol leaves.
-    proto_meta_base: usize,
-    n_protocol_leaves: usize,
-}
-
-impl CommonColumns {
-    /// The shared columns are contiguous starting at `base`, in the order laid out by
-    /// [`shared_dm_txn_columns`], followed by the protocol leaves and then the metadata leaves.
-    fn new(base: usize, n_protocol_leaves: usize) -> Self {
-        Self {
-            dm_domain: base,
-            dm_config: base + 1,
-            dm_removed: base + 2,
-            txn_app_id: base + 3,
-            txn_version: base + 4,
-            txn_last_updated: base + 5,
-            proto_meta_base: base + N_SHARED_COLS,
-            n_protocol_leaves,
-        }
-    }
-}
-
-/// The domain-metadata and set-transaction columns shared by both replay visitors, in the order
-/// [`CommonColumns::new`] assumes. Each visitor appends these to its source-specific columns.
-fn shared_dm_txn_columns() -> Vec<(DataType, ColumnName)> {
+/// The columns every source carries (add file, domain metadata, set transaction), in the order
+/// [`CrcReplayAccumulator::apply_shared_columns`] assumes. Each visitor appends these to its
+/// source-specific columns.
+fn shared_columns() -> Vec<(DataType, ColumnName)> {
     vec![
+        (DataType::LONG, column_name!("add.size")),
         (DataType::STRING, column_name!("domainMetadata.domain")),
         (
             DataType::STRING,
@@ -550,14 +533,13 @@ fn append_protocol_metadata_leaves(
 }
 
 /// Validate that `getters` carries exactly the columns a replay visitor projects: `n_fixed`
-/// fixed columns plus the protocol and metadata leaves. Returns the protocol-leaf count, which
-/// the caller needs to split the trailing protocol/metadata leaf slices. `visitor_name` names
-/// the visitor in the error.
+/// fixed columns plus the protocol and metadata leaves. `visitor_name` names the visitor in the
+/// error.
 fn check_visitor_getters(
     getters: &[&dyn GetData<'_>],
     n_fixed: usize,
     visitor_name: &str,
-) -> DeltaResult<usize> {
+) -> DeltaResult<()> {
     let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
     let n_metadata_leaves = METADATA_LEAVES.as_ref().0.len();
     require!(
@@ -567,7 +549,7 @@ fn check_visitor_getters(
             getters.len()
         ))
     );
-    Ok(n_protocol_leaves)
+    Ok(())
 }
 
 // ============================================================================
@@ -575,42 +557,40 @@ fn check_visitor_getters(
 // ============================================================================
 
 // ===== Visitor column indices =====
-// Indices into the column list returned by [`CrcReplayVisitor::selected_column_names_and_types`].
+// Indices into the column list returned by [`CommitCrcVisitor::selected_column_names_and_types`].
 const COL_FILE: usize = 0;
 const COL_OP: usize = 1;
 const COL_ICT: usize = 2;
-const COL_ADD_SIZE: usize = 3;
-const COL_REMOVE_PATH: usize = 4;
-const COL_REMOVE_SIZE: usize = 5;
+const COL_REMOVE_PATH: usize = 3;
+const COL_REMOVE_SIZE: usize = 4;
 /// Source-specific columns end here; the shared columns follow.
 const N_CRC_SPECIFIC_COLS: usize = COL_REMOVE_SIZE + 1;
-const N_FIXED_COLS: usize = N_CRC_SPECIFIC_COLS + N_SHARED_COLS;
+const N_FIXED_COLS: usize = N_CRC_SPECIFIC_COLS + N_SHARED_SINGLE_LEAF_COLS;
 
 /// Thin shim that pulls leaf values from `getters` and forwards them to the accumulator's
 /// `on_*` methods. All behavior lives in [`CrcReplayAccumulator`].
-struct CrcReplayVisitor<'a> {
+struct CommitCrcVisitor<'a> {
     acc: &'a mut CrcReplayAccumulator,
 }
 
-impl RowVisitor for CrcReplayVisitor<'_> {
+impl RowVisitor for CommitCrcVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
             let mut fixed = vec![
                 (DataType::STRING, column_name!("_file")),
                 (DataType::STRING, column_name!("commitInfo.operation")),
                 (DataType::LONG, column_name!("commitInfo.inCommitTimestamp")),
-                (DataType::LONG, column_name!("add.size")),
                 (DataType::STRING, column_name!("remove.path")),
                 (DataType::LONG, column_name!("remove.size")),
             ];
-            fixed.extend(shared_dm_txn_columns());
+            fixed.extend(shared_columns());
             append_protocol_metadata_leaves(fixed).into()
         });
         NAMES_AND_TYPES.as_ref()
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        let n_protocol_leaves = check_visitor_getters(getters, N_FIXED_COLS, "CrcReplayVisitor")?;
+        check_visitor_getters(getters, N_FIXED_COLS, "CommitCrcVisitor")?;
         if row_count == 0 {
             return Ok(());
         }
@@ -619,17 +599,11 @@ impl RowVisitor for CrcReplayVisitor<'_> {
         let file_url: String = getters[COL_FILE].get(0, "_file")?;
         self.acc.process_batch_start(&file_url);
 
-        let common = CommonColumns::new(N_CRC_SPECIFIC_COLS, n_protocol_leaves);
-
         for i in 0..row_count {
             let operation: Option<String> = getters[COL_OP].get_opt(i, "commitInfo.operation")?;
             let ict: Option<i64> = getters[COL_ICT].get_opt(i, "commitInfo.inCommitTimestamp")?;
             if operation.is_some() || ict.is_some() {
                 self.acc.on_commit_info(operation.as_deref(), ict);
-            }
-
-            if let Some(size) = getters[COL_ADD_SIZE].get_opt(i, "add.size")? {
-                self.acc.on_add(size)?;
             }
 
             let remove_path: Option<String> = getters[COL_REMOVE_PATH].get_opt(i, "remove.path")?;
@@ -639,7 +613,8 @@ impl RowVisitor for CrcReplayVisitor<'_> {
                 self.acc.on_remove(&path, remove_size)?;
             }
 
-            self.acc.visit_common_columns(i, getters, &common)?;
+            self.acc
+                .apply_shared_columns(i, &getters[N_CRC_SPECIFIC_COLS..])?;
         }
         Ok(())
     }
@@ -664,11 +639,9 @@ static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     })
 });
 
-// ===== Checkpoint visitor column indices =====
-const COL_CP_ADD_SIZE: usize = 0;
-/// Source-specific columns end here; the shared columns follow.
-const N_CP_SPECIFIC_COLS: usize = COL_CP_ADD_SIZE + 1;
-const N_CP_FIXED_COLS: usize = N_CP_SPECIFIC_COLS + N_SHARED_COLS;
+// A checkpoint carries no `_file`, `commitInfo`, or `remove`, so its entire projection is the
+// shared columns: the visitor has no source-specific columns and hands the full getter slice to
+// [`CrcReplayAccumulator::apply_shared_columns`].
 
 /// Pulls leaf values from a checkpoint batch into the shared [`CrcReplayAccumulator`].
 struct CheckpointCrcVisitor<'a> {
@@ -677,25 +650,15 @@ struct CheckpointCrcVisitor<'a> {
 
 impl RowVisitor for CheckpointCrcVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
-        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-            let mut fixed = vec![(DataType::LONG, column_name!("add.size"))];
-            fixed.extend(shared_dm_txn_columns());
-            append_protocol_metadata_leaves(fixed).into()
-        });
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| append_protocol_metadata_leaves(shared_columns()).into());
         NAMES_AND_TYPES.as_ref()
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        let n_protocol_leaves =
-            check_visitor_getters(getters, N_CP_FIXED_COLS, "CheckpointCrcVisitor")?;
-        let common = CommonColumns::new(N_CP_SPECIFIC_COLS, n_protocol_leaves);
+        check_visitor_getters(getters, N_SHARED_SINGLE_LEAF_COLS, "CheckpointCrcVisitor")?;
         for i in 0..row_count {
-            // `add.size` (required) marks an Add row.
-            if let Some(size) = getters[COL_CP_ADD_SIZE].get_opt(i, "add.size")? {
-                self.acc.on_add(size)?;
-            }
-
-            self.acc.visit_common_columns(i, getters, &common)?;
+            self.acc.apply_shared_columns(i, getters)?;
         }
         Ok(())
     }
@@ -854,7 +817,7 @@ mod tests {
     #[test]
     fn visitor_schema_length_matches_column_indices() {
         let mut acc = CrcReplayAccumulator::new(None);
-        let visitor = CrcReplayVisitor { acc: &mut acc };
+        let visitor = CommitCrcVisitor { acc: &mut acc };
         let (names, types) = visitor.selected_column_names_and_types();
         let expected =
             N_FIXED_COLS + PROTOCOL_LEAVES.as_ref().0.len() + METADATA_LEAVES.as_ref().0.len();

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -3,6 +3,10 @@
 //! Reverse-replays a log segment's commit files to produce a [`CrcDelta`] covering
 //! commits `(X, Y]`. Per the incremental equation `Crc[X] + CrcDelta = Crc[Y]`, that
 //! delta is applied to a stale base via [`Crc::apply`].
+//!
+//! The base `Crc[X]` itself can also be built here: [`LogSegment::build_crc_from_checkpoint`]
+//! reads a checkpoint into a Complete CRC, and [`LogSegment::build_crc_from_version_zero`] builds
+//! one from a full reverse replay when there is neither a CRC nor a checkpoint to root at.
 //
 // TODO(#2615): support log compaction files.
 
@@ -29,7 +33,7 @@ use crate::schema::{
 };
 use crate::snapshot::IncrementalReplay;
 use crate::utils::require;
-use crate::{DeltaResult, Engine, Error, RowVisitor, Version};
+use crate::{DeltaResult, Engine, Error, FileMeta, RowVisitor, Version};
 
 #[allow(clippy::expect_used)]
 static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
@@ -125,7 +129,8 @@ impl LogSegment {
                 FileSizeHistogram::create_empty_with_boundaries(h.sorted_bin_boundaries().to_vec())
             })
             .transpose()?;
-        let delta = self.build_incremental_crc_delta(engine, base_crc.version, seed_histogram)?;
+        let delta =
+            self.build_incremental_crc_delta_from_base(engine, base_crc.version, seed_histogram)?;
         Ok(base_crc.clone().apply(delta, self.end_version))
     }
 
@@ -135,7 +140,7 @@ impl LogSegment {
     ///
     /// Errors if `base_version >= self.end_version` or if the segment is missing the
     /// commit at `base_version + 1` (i.e. has a gap above `base_version`).
-    pub(crate) fn build_incremental_crc_delta(
+    pub(crate) fn build_incremental_crc_delta_from_base(
         &self,
         engine: &dyn Engine,
         base_version: Version,
@@ -144,8 +149,8 @@ impl LogSegment {
         require!(
             base_version < self.end_version,
             Error::internal_error(format!(
-                "build_incremental_crc_delta: base_version ({}) must be strictly less than \
-                 end_version ({})",
+                "build_incremental_crc_delta_from_base: base_version ({}) must be strictly less \
+                 than end_version ({})",
                 base_version, self.end_version,
             ))
         );
@@ -161,18 +166,107 @@ impl LogSegment {
         require!(
             first_above == Some(base_version + 1),
             Error::internal_error(format!(
-                "build_incremental_crc_delta: segment is missing commit {} \
+                "build_incremental_crc_delta_from_base: segment is missing commit {} \
                  (lowest commit above base_version is {:?})",
                 base_version + 1,
                 first_above,
             ))
         );
 
+        let locations = deltas.iter().rev().map(|c| c.location.clone()).collect();
+        self.replay_commits_into_crc_delta(engine, locations, seed_histogram)
+    }
+
+    /// Build a Complete [`Crc`] at `checkpoint_version` by reading this segment's checkpoint
+    /// files only (not the tail commits). Returns `None` when the segment has no checkpoint.
+    ///
+    /// File stats sum live [`Add`](crate::actions::Add) actions (remove tombstones are skipped);
+    /// a missing Add `size` yields [`FileStatsState::Indeterminate`]. Domain metadata and set
+    /// transactions are [`Complete`](DomainMetadataState::Complete) since a checkpoint is
+    /// authoritative. `in_commit_timestamp_opt` is left `None`: a checkpoint carries no
+    /// `commitInfo`, so the caller supplies the ICT (from a tail commit, or read directly when
+    /// the checkpoint is at the target version).
+    pub(crate) fn build_crc_from_checkpoint(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<Crc>> {
+        let Some(version) = self.checkpoint_version else {
+            return Ok(None);
+        };
+        // A checkpoint is reconciled absolute state: there is no per-commit safety boundary, so
+        // we never call `process_batch_start` / `process_commit_file_end` and the delta stays
+        // incremental-safe unless an Add is missing its size. The resulting "delta" is the full
+        // table state, which `into_complete_crc` turns into a Complete CRC.
+        let mut acc = CrcReplayAccumulator::new(Some(FileSizeHistogram::create_default()));
+        // Read the checkpoint files only (parquet plus any V2 sidecars), skipping the commit
+        // files: `create_checkpoint_stream` without the commit chain that `read_actions` adds.
+        let batches = self
+            .create_checkpoint_stream(engine, CHECKPOINT_CRC_SCHEMA.clone(), None, None, None)?
+            .actions;
+        for batch in batches {
+            let batch = batch?;
+            let mut visitor = CheckpointCrcVisitor { acc: &mut acc };
+            visitor.visit_rows_of(batch.actions())?;
+        }
+        Ok(acc.into_crc_delta().into_complete_crc(version))
+    }
+
+    /// Build a Complete [`Crc`] at `end_version` by reverse-replaying every commit in the
+    /// segment, for the case where there is neither a CRC nor a checkpoint to root at. Only
+    /// valid when the segment has no checkpoint, so its commits run contiguously from version 0.
+    ///
+    /// Returns `None` if protocol or metadata could not be recovered. File stats degrade to
+    /// [`Indeterminate`](FileStatsState::Indeterminate) if the replay is not incremental-safe.
+    pub(crate) fn build_crc_from_version_zero(
+        &self,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<Crc>> {
+        require!(
+            self.checkpoint_version.is_none(),
+            Error::internal_error("build_crc_from_version_zero called with a checkpoint present")
+        );
+        let Some(first) = self.listed.ascending_commit_files.first() else {
+            return Ok(None);
+        };
+        require!(
+            first.version == 0,
+            Error::internal_error(format!(
+                "build_crc_from_version_zero expects commits from version 0, but the first commit \
+                 is at version {}",
+                first.version
+            ))
+        );
+        let locations = self
+            .listed
+            .ascending_commit_files
+            .iter()
+            .rev()
+            .map(|c| c.location.clone())
+            .collect();
+        let delta = self.replay_commits_into_crc_delta(
+            engine,
+            locations,
+            Some(FileSizeHistogram::create_default()),
+        )?;
+        Ok(delta.into_complete_crc(self.end_version))
+    }
+
+    /// Reverse-replay the given commit files (passed newest-first) into a [`CrcDelta`]. The shared
+    /// core of [`Self::build_incremental_crc_delta_from_base`] and
+    /// [`Self::build_crc_from_version_zero`]. `seed_histogram` is an empty histogram with the
+    /// downstream base's bin boundaries, or `None` to skip histogram tracking.
+    fn replay_commits_into_crc_delta(
+        &self,
+        engine: &dyn Engine,
+        locations_newest_first: Vec<FileMeta>,
+        seed_histogram: Option<FileSizeHistogram>,
+    ) -> DeltaResult<CrcDelta> {
         let mut acc = CrcReplayAccumulator::new(seed_histogram);
-        let files: Vec<_> = deltas.iter().rev().map(|c| c.location.clone()).collect();
-        let batches = engine
-            .json_handler()
-            .read_json_files(&files, REPLAY_SCHEMA.clone(), None)?;
+        let batches = engine.json_handler().read_json_files(
+            &locations_newest_first,
+            REPLAY_SCHEMA.clone(),
+            None,
+        )?;
 
         for batch_result in batches {
             // Transient visitor borrows the shared accumulator for the duration of the
@@ -270,6 +364,12 @@ impl CrcReplayAccumulator {
     }
 
     // ===== Row-level updates (also the seams used by `on_*` unit tests) =====
+
+    /// Mark file stats as non-incremental-safe so they degrade to `Indeterminate`. Used when a
+    /// size needed for accounting is absent (e.g. a checkpoint Add with no `size`).
+    fn mark_file_stats_unsafe(&mut self) {
+        self.delta.is_incremental_safe = false;
+    }
 
     /// Called by the visitor once per commitInfo row (gated on operation or ict being
     /// present). Handles both pieces: `operation` drives per-commit safety classification,
@@ -475,6 +575,130 @@ impl RowVisitor for CrcReplayVisitor<'_> {
             if self.acc.delta.metadata.is_none() {
                 self.acc.delta.metadata =
                     visit_metadata_at(i, &getters[N_FIXED_COLS + n_protocol_leaves..])?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Checkpoint base construction
+// ============================================================================
+
+/// Action schema for reading a checkpoint into a base [`Crc`]. Mirrors the on-disk action
+/// layout but projects only the leaves the accumulator needs. `add.path` (required) marks an
+/// Add row; `add.size` is read as optional so a malformed Add with no size degrades file stats
+/// rather than erroring. Unlike [`REPLAY_SCHEMA`], there is no `_file`, `remove`, or
+/// `commitInfo`: a checkpoint is a single reconciled view with no commit boundaries, removes
+/// are tombstones excluded from live file stats, and ICT is supplied by the caller.
+#[allow(clippy::expect_used)]
+static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(schema! {
+        nullable ADD_NAME: {
+            not_null "path": STRING,
+            nullable "size": LONG,
+        },
+        nullable PROTOCOL_NAME: (Protocol::to_schema()),
+        nullable METADATA_NAME: (Metadata::to_schema()),
+        nullable SET_TRANSACTION_NAME: (SetTransaction::to_schema()),
+        nullable DOMAIN_METADATA_NAME: (DomainMetadata::to_schema()),
+    })
+});
+
+// ===== Checkpoint visitor column indices =====
+const COL_CP_ADD_PATH: usize = 0;
+const COL_CP_ADD_SIZE: usize = 1;
+const COL_CP_DM_DOMAIN: usize = 2;
+const COL_CP_DM_CONFIG: usize = 3;
+const COL_CP_DM_REMOVED: usize = 4;
+const COL_CP_TXN_APP_ID: usize = 5;
+const COL_CP_TXN_VERSION: usize = 6;
+const COL_CP_TXN_LAST_UPDATED: usize = 7;
+const N_CP_FIXED_COLS: usize = COL_CP_TXN_LAST_UPDATED + 1;
+
+/// Pulls leaf values from a checkpoint batch and forwards them to the shared
+/// [`CrcReplayAccumulator`]. Unlike [`CrcReplayVisitor`] it reads no `_file`, `commitInfo`, or
+/// `remove`: a checkpoint is one reconciled view (no commit boundaries or operations), and its
+/// removes are tombstones excluded from live file stats. An Add with no `size` degrades file
+/// stats to `Indeterminate`.
+struct CheckpointCrcVisitor<'a> {
+    acc: &'a mut CrcReplayAccumulator,
+}
+
+impl RowVisitor for CheckpointCrcVisitor<'_> {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+            const STRING: DataType = DataType::STRING;
+            const LONG: DataType = DataType::LONG;
+            const BOOLEAN: DataType = DataType::BOOLEAN;
+            let fixed = vec![
+                (STRING, column_name!("add.path")),
+                (LONG, column_name!("add.size")),
+                (STRING, column_name!("domainMetadata.domain")),
+                (STRING, column_name!("domainMetadata.configuration")),
+                (BOOLEAN, column_name!("domainMetadata.removed")),
+                (STRING, column_name!("txn.appId")),
+                (LONG, column_name!("txn.version")),
+                (LONG, column_name!("txn.lastUpdated")),
+            ];
+            let (mut types, mut names): (Vec<_>, Vec<_>) = fixed.into_iter().unzip();
+            for leaves in [&*PROTOCOL_LEAVES, &*METADATA_LEAVES] {
+                let (leaf_names, leaf_types) = leaves.as_ref();
+                names.extend_from_slice(leaf_names);
+                types.extend_from_slice(leaf_types);
+            }
+            (names, types).into()
+        });
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        let n_protocol_leaves = PROTOCOL_LEAVES.as_ref().0.len();
+        let n_metadata_leaves = METADATA_LEAVES.as_ref().0.len();
+        require!(
+            getters.len() == N_CP_FIXED_COLS + n_protocol_leaves + n_metadata_leaves,
+            Error::internal_error(format!(
+                "Wrong number of CheckpointCrcVisitor getters: {}",
+                getters.len()
+            ))
+        );
+        for i in 0..row_count {
+            // `add.path` (required) marks an Add row; a present Add with no `size` cannot be
+            // accounted for, so file stats degrade to `Indeterminate`.
+            let add_path: Option<String> = getters[COL_CP_ADD_PATH].get_opt(i, "add.path")?;
+            if add_path.is_some() {
+                match getters[COL_CP_ADD_SIZE].get_opt(i, "add.size")? {
+                    Some(size) => self.acc.on_add(size)?,
+                    None => self.acc.mark_file_stats_unsafe(),
+                }
+            }
+
+            let dm_domain: Option<String> =
+                getters[COL_CP_DM_DOMAIN].get_opt(i, "domainMetadata.domain")?;
+            if let Some(domain) = dm_domain {
+                let configuration: String =
+                    getters[COL_CP_DM_CONFIG].get(i, "domainMetadata.configuration")?;
+                let removed: bool = getters[COL_CP_DM_REMOVED].get(i, "domainMetadata.removed")?;
+                self.acc.on_domain_metadata(domain, configuration, removed);
+            }
+
+            let txn_app_id: Option<String> = getters[COL_CP_TXN_APP_ID].get_opt(i, "txn.appId")?;
+            if let Some(app_id) = txn_app_id {
+                let version: i64 = getters[COL_CP_TXN_VERSION].get(i, "txn.version")?;
+                let last_updated: Option<i64> =
+                    getters[COL_CP_TXN_LAST_UPDATED].get_opt(i, "txn.lastUpdated")?;
+                self.acc.on_set_transaction(app_id, version, last_updated);
+            }
+
+            if self.acc.delta.protocol.is_none() {
+                self.acc.delta.protocol = visit_protocol_at(
+                    i,
+                    &getters[N_CP_FIXED_COLS..N_CP_FIXED_COLS + n_protocol_leaves],
+                )?;
+            }
+            if self.acc.delta.metadata.is_none() {
+                self.acc.delta.metadata =
+                    visit_metadata_at(i, &getters[N_CP_FIXED_COLS + n_protocol_leaves..])?;
             }
         }
         Ok(())
@@ -812,7 +1036,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_incremental_crc_delta_errors_when_base_version_geq_end_version() {
+    async fn build_incremental_crc_delta_from_base_errors_when_base_version_geq_end_version() {
         let store = Arc::new(InMemory::new());
         let engine = SyncEngine::new_with_store(store.clone());
         let root = "memory:///t/";
@@ -835,7 +1059,7 @@ mod tests {
         .unwrap();
         for base in [0, 5] {
             assert_result_error_with_message(
-                segment.build_incremental_crc_delta(&engine, base, None),
+                segment.build_incremental_crc_delta_from_base(&engine, base, None),
                 "must be strictly less than end_version",
             );
         }

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -631,10 +631,10 @@ impl RowVisitor for CommitCrcVisitor<'_> {
 static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(schema! {
         nullable ADD_NAME: { not_null "size": LONG },
-        nullable PROTOCOL_NAME: (Protocol::to_schema()),
-        nullable METADATA_NAME: (Metadata::to_schema()),
-        nullable SET_TRANSACTION_NAME: (SetTransaction::to_schema()),
-        nullable DOMAIN_METADATA_NAME: (DomainMetadata::to_schema()),
+        (&PROTOCOL_FIELD),
+        (&METADATA_FIELD),
+        (&SET_TRANSACTION_FIELD),
+        (&DOMAIN_METADATA_FIELD),
     })
 });
 

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -443,11 +443,10 @@ impl CrcReplayAccumulator {
         }
     }
 
-    /// Apply the columns every source carries (add file, domain metadata, set transactions,
-    /// protocol, metadata) from row `i` to the delta. Each visitor handles its source-specific
-    /// columns (commit: `_file`/commitInfo/remove) and passes the trailing shared slice here so
-    /// the shared leaves live in one place. `shared` starts at the first shared column, laid out
-    /// as [`shared_columns`] then the protocol and metadata leaves.
+    /// Apply the shared columns (`shared`, laid out by [`shared_columns`] then the protocol and
+    /// metadata leaves) from row `i` to the delta. Each visitor reads its source-specific columns
+    /// (commit: `_file`/commitInfo/remove) and passes the trailing shared slice here so the shared
+    /// leaves live in one place.
     fn apply_shared_columns<'a>(
         &mut self,
         i: usize,
@@ -488,7 +487,7 @@ impl CrcReplayAccumulator {
 // ===== Shared column indices =====
 // Indices into the shared slice each visitor passes to
 // [`CrcReplayAccumulator::apply_shared_columns`], laid out by [`shared_columns`].
-// Zero-based: the slice starts at the first shared column.
+// The slice starts at the first shared column.
 const SHARED_COL_ADD_SIZE: usize = 0;
 const SHARED_COL_DM_DOMAIN: usize = 1;
 const SHARED_COL_DM_CONFIG: usize = 2;
@@ -639,9 +638,7 @@ static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     })
 });
 
-// A checkpoint carries no `_file`, `commitInfo`, or `remove`, so its entire projection is the
-// shared columns: the visitor has no source-specific columns and hands the full getter slice to
-// [`CrcReplayAccumulator::apply_shared_columns`].
+// A checkpoint has no source-specific columns, so its projection is the shared columns.
 
 /// Pulls leaf values from a checkpoint batch into the shared [`CrcReplayAccumulator`].
 struct CheckpointCrcVisitor<'a> {
@@ -821,6 +818,18 @@ mod tests {
         let (names, types) = visitor.selected_column_names_and_types();
         let expected =
             N_FIXED_COLS + PROTOCOL_LEAVES.as_ref().0.len() + METADATA_LEAVES.as_ref().0.len();
+        assert_eq!(names.len(), expected);
+        assert_eq!(types.len(), expected);
+    }
+
+    #[test]
+    fn checkpoint_visitor_schema_length_matches_column_indices() {
+        let mut acc = CrcReplayAccumulator::new(None);
+        let visitor = CheckpointCrcVisitor { acc: &mut acc };
+        let (names, types) = visitor.selected_column_names_and_types();
+        let expected = N_SHARED_SINGLE_LEAF_COLS
+            + PROTOCOL_LEAVES.as_ref().0.len()
+            + METADATA_LEAVES.as_ref().0.len();
         assert_eq!(names.len(), expected);
         assert_eq!(types.len(), expected);
     }

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -390,13 +390,13 @@ struct BuiltCrcTest {
 
 impl BuiltCrcTest {
     /// Construct a `LogSegment` directly from the store state (no `Snapshot`) and run
-    /// `build_incremental_crc_from_base` against `base`.
+    /// `build_crc_from_base` against `base`.
     fn incrementally_build_crc(&self, base: &Crc) -> DeltaResult<Crc> {
         let storage = self.engine.storage_handler();
         let log_root = self.url.join("_delta_log/").unwrap();
         let log_segment =
             LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
-        log_segment.build_incremental_crc_from_base(&self.engine, base)
+        log_segment.build_crc_from_base(&self.engine, base)
     }
 
     /// Read the on-disk CRC at `version` from this test's log.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -861,8 +861,8 @@ impl Snapshot {
     ///   ANALYZE STATS, or a file action with a missing size; recoverable with a full state
     ///   reconstruction in the future), or if `delta.enableInCommitTimestamps` is `true` but
     ///   `inCommitTimestampOpt` is absent.
-    /// - The underlying read error if in-commit timestamps are enabled but the timestamp cannot
-    ///   be read from the commit file.
+    /// - The underlying read error if in-commit timestamps are enabled but the timestamp cannot be
+    ///   read from the commit file.
     /// - I/O errors from the engine's storage handler if the write fails.
     #[instrument(parent = &self.span, name = "snap.write_checksum", skip_all, err)]
     pub fn write_checksum(

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -103,6 +103,12 @@ impl std::fmt::Debug for Snapshot {
     }
 }
 
+/// Build a [`Error::ChecksumWriteUnsupported`] for a resolution root that could not yield a
+/// writable CRC. `reason` completes the sentence "Cannot resolve a CRC to write: ...".
+fn unresolved_crc(reason: &str) -> Error {
+    Error::ChecksumWriteUnsupported(format!("Cannot resolve a CRC to write: {reason}"))
+}
+
 impl Snapshot {
     // ============================================================================
     // Construction entry points
@@ -855,6 +861,8 @@ impl Snapshot {
     ///   ANALYZE STATS, or a file action with a missing size; recoverable with a full state
     ///   reconstruction in the future), or if `delta.enableInCommitTimestamps` is `true` but
     ///   `inCommitTimestampOpt` is absent.
+    /// - The underlying read error if in-commit timestamps are enabled but the timestamp cannot
+    ///   be read from the commit file.
     /// - I/O errors from the engine's storage handler if the write fails.
     #[instrument(parent = &self.span, name = "snap.write_checksum", skip_all, err)]
     pub fn write_checksum(
@@ -876,11 +884,7 @@ impl Snapshot {
             return Ok((ChecksumWriteResult::AlreadyExists, Arc::clone(self)));
         }
 
-        let crc = self.resolve_crc_for_write(engine)?.ok_or_else(|| {
-            Error::ChecksumWriteUnsupported(
-                "No CRC could be resolved for this snapshot version.".to_string(),
-            )
-        })?;
+        let crc = self.resolve_crc_for_write(engine)?;
 
         let crc_path = ParsedLogPath::new_crc(self.table_root(), self.version())?;
 
@@ -906,7 +910,7 @@ impl Snapshot {
         }
     }
 
-    /// Resolve the CRC to write for this snapshot's version, or `None` when none can be produced.
+    /// Resolve the CRC to write for this snapshot's version.
     ///
     /// Tries the newest available root, stopping at the first that applies:
     /// 1. The in-memory CRC, used as-is. E.g. a snapshot at N that did incremental CRC replay from
@@ -915,35 +919,42 @@ impl Snapshot {
     /// 2. A stale on-disk CRC, advanced over the tail commits via reverse replay.
     /// 3. A checkpoint, advanced over the tail commits via reverse replay.
     /// 4. A full reverse replay of the commit history.
-    fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Option<Arc<Crc>>> {
+    ///
+    /// Returns [`Error::ChecksumWriteUnsupported`] when a root is reached but cannot yield a
+    /// writable CRC (missing protocol or metadata, or a non-incremental tail that dooms file
+    /// stats).
+    fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Arc<Crc>> {
         // Case 1: an in-memory CRC at this version is ready to write as-is.
         if let Some(crc) = &self.crc {
-            return Ok(Some(crc.clone()));
+            return Ok(crc.clone());
         }
 
         let end = self.version();
         let log_segment = &self.log_segment;
 
-        // Case 2: a stale on-disk CRC (older than this version, since an equal one would have
-        // short-circuited to `AlreadyExists`). Advance it over the tail commits.
+        // Case 2: a stale on-disk CRC, older than this version. An on-disk CRC at exactly this
+        // version would have short-circuited to `AlreadyExists` in `write_checksum`. Advance it
+        // over the tail commits.
         // TODO: `read_latest_crc` re-reads the CRC from disk. `LazyCrc` was deleted in the pivot
         //       to incremental CRC being optional; reintroduce something like it so a CRC already
         //       read during snapshot load is reused here instead of re-read.
         if let Some(base) = log_segment.read_latest_crc(engine) {
             let crc = log_segment.build_crc_from_base(engine, &base)?;
-            return Ok(Some(Arc::new(crc)));
+            return Ok(Arc::new(crc));
         }
 
         // Case 3: no CRC, but a checkpoint to root at.
         if let Some(checkpoint_version) = log_segment.checkpoint_version {
             if checkpoint_version == end {
-                // No tail commits, so read v_end's ICT from its commit file. A failed read leaves
-                // it absent, and `try_write_crc_file`'s ICT guard fails the write closed.
-                let Some(mut crc) = log_segment.build_crc_from_checkpoint(engine)? else {
-                    return Ok(None);
-                };
-                crc.in_commit_timestamp_opt = self.get_in_commit_timestamp(engine).ok().flatten();
-                return Ok(Some(Arc::new(crc)));
+                // A checkpoint carries no ICT (it has no commitInfo). Since there's no tail delta
+                // to carry it either, we defer to `get_in_commit_timestamp`, which reads the commit
+                // at the checkpoint version and returns None when ICT is disabled, or errors when
+                // it is enabled but unreadable.
+                let mut crc = log_segment
+                    .build_crc_from_checkpoint(engine)?
+                    .ok_or_else(|| unresolved_crc("checkpoint is missing protocol or metadata"))?;
+                crc.in_commit_timestamp_opt = self.get_in_commit_timestamp(engine)?;
+                return Ok(Arc::new(crc));
             }
             // Replay the tail commits first: a non-incremental tail dooms file stats no matter
             // what the checkpoint holds, so skip the larger checkpoint read in that case.
@@ -952,20 +963,22 @@ impl Snapshot {
                 checkpoint_version,
                 Some(FileSizeHistogram::create_default()),
             )?;
-            if !delta.is_incremental_safe {
-                return Ok(None);
-            }
-            let Some(base) = log_segment.build_crc_from_checkpoint(engine)? else {
-                return Ok(None);
-            };
+            require!(
+                delta.is_incremental_safe,
+                unresolved_crc("commits after the checkpoint are not incremental-safe")
+            );
+            let base = log_segment
+                .build_crc_from_checkpoint(engine)?
+                .ok_or_else(|| unresolved_crc("checkpoint is missing protocol or metadata"))?;
             // The tail delta carries v_end's ICT, which `apply` sets on the result.
-            return Ok(Some(Arc::new(base.apply(delta, end))));
+            return Ok(Arc::new(base.apply(delta, end)));
         }
 
         // Case 4: neither CRC nor checkpoint, so reverse-replay the full commit history.
-        Ok(log_segment
+        let crc = log_segment
             .build_crc_from_version_zero(engine)?
-            .map(Arc::new))
+            .ok_or_else(|| unresolved_crc("commit history is missing protocol or metadata"))?;
+        Ok(Arc::new(crc))
     }
 
     /// Performs a complete checkpoint of this snapshot using the provided engine.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -915,9 +915,6 @@ impl Snapshot {
     /// 2. A stale on-disk CRC, advanced over the tail commits via reverse replay.
     /// 3. A checkpoint, advanced over the tail commits via reverse replay.
     /// 4. A full reverse replay of the commit history.
-    ///
-    /// An on-disk CRC always sits at or after the checkpoint (a log-segment invariant) and is
-    /// cheap to read, so 2 is preferred over 3 whenever a CRC exists.
     fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Option<Arc<Crc>>> {
         // Case 1: an in-memory CRC at this version is ready to write as-is.
         if let Some(crc) = &self.crc {
@@ -929,18 +926,19 @@ impl Snapshot {
 
         // Case 2: a stale on-disk CRC (older than this version, since an equal one would have
         // short-circuited to `AlreadyExists`). Advance it over the tail commits.
+        // TODO: `read_latest_crc` re-reads the CRC from disk. `LazyCrc` was deleted in the pivot
+        //       to incremental CRC being optional; reintroduce something like it so a CRC already
+        //       read during snapshot load is reused here instead of re-read.
         if let Some(base) = log_segment.read_latest_crc(engine) {
-            let crc = log_segment.build_incremental_crc_from_base(engine, &base)?;
+            let crc = log_segment.build_crc_from_base(engine, &base)?;
             return Ok(Some(Arc::new(crc)));
         }
 
         // Case 3: no CRC, but a checkpoint to root at.
         if let Some(checkpoint_version) = log_segment.checkpoint_version {
             if checkpoint_version == end {
-                // No tail commits: the checkpoint carries no ICT, so read v_end's ICT from its
-                // commit file. A failed read (e.g. the commit file was log-cleaned on an
-                // ICT-enabled table) leaves it absent; the write then fails closed via
-                // `try_write_crc_file`'s ICT guard rather than erroring here.
+                // No tail commits, so read v_end's ICT from its commit file. A failed read leaves
+                // it absent, and `try_write_crc_file`'s ICT guard fails the write closed.
                 let Some(mut crc) = log_segment.build_crc_from_checkpoint(engine)? else {
                     return Ok(None);
                 };
@@ -949,7 +947,7 @@ impl Snapshot {
             }
             // Replay the tail commits first: a non-incremental tail dooms file stats no matter
             // what the checkpoint holds, so skip the larger checkpoint read in that case.
-            let delta = log_segment.build_incremental_crc_delta_from_base(
+            let delta = log_segment.build_crc_delta_from_base(
                 engine,
                 checkpoint_version,
                 Some(FileSizeHistogram::create_default()),

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -17,7 +17,8 @@ use crate::checkpoint::{
 use crate::clustering::{parse_clustering_columns, CLUSTERING_DOMAIN_NAME};
 use crate::committer::{Committer, PublishMetadata};
 use crate::crc::{
-    try_write_crc_file, Crc, CrcDelta, DomainMetadataState, FileStats, SetTransactionState,
+    try_write_crc_file, Crc, CrcDelta, DomainMetadataState, FileSizeHistogram, FileStats,
+    SetTransactionState,
 };
 use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
@@ -838,9 +839,9 @@ impl Snapshot {
     /// Writes a version checksum (CRC) file for this snapshot. Writers should call this after
     /// every commit because checksums enable faster snapshot loading and table state validation.
     ///
-    /// Currently only supports writing from a post-commit snapshot that has pre-computed CRC
-    /// information in memory (i.e. the snapshot returned by
-    /// [`CommittedTransaction::post_commit_snapshot`]).
+    /// The CRC is resolved best-effort from the newest available root: an in-memory CRC at this
+    /// version, a stale on-disk CRC advanced to this version, a checkpoint advanced to this
+    /// version, or the full commit history.
     ///
     /// Returns a tuple of [`ChecksumWriteResult`] and a [`SnapshotRef`]. On
     /// [`ChecksumWriteResult::Written`], the returned snapshot has the CRC file recorded in
@@ -849,15 +850,12 @@ impl Snapshot {
     ///
     /// # Errors
     ///
-    /// - [`Error::ChecksumWriteUnsupported`] if no in-memory CRC is available at this snapshot's
-    ///   version (e.g. a snapshot loaded from disk that has no CRC file), if the CRC's
-    ///   `file_stats_state` is `Indeterminate` (a non-incremental operation like ANALYZE STATS was
-    ///   encountered, or a file action had a missing size; recoverable with a full state
+    /// - [`Error::ChecksumWriteUnsupported`] if no CRC can be resolved for this version, if the
+    ///   resolved CRC's `file_stats_state` is `Indeterminate` (a non-incremental operation like
+    ///   ANALYZE STATS, or a file action with a missing size; recoverable with a full state
     ///   reconstruction in the future), or if `delta.enableInCommitTimestamps` is `true` but
     ///   `inCommitTimestampOpt` is absent.
     /// - I/O errors from the engine's storage handler if the write fails.
-    ///
-    /// [`CommittedTransaction::post_commit_snapshot`]: crate::transaction::CommittedTransaction::post_commit_snapshot
     #[instrument(parent = &self.span, name = "snap.write_checksum", skip_all, err)]
     pub fn write_checksum(
         self: &SnapshotRef,
@@ -878,22 +876,22 @@ impl Snapshot {
             return Ok((ChecksumWriteResult::AlreadyExists, Arc::clone(self)));
         }
 
-        let crc = self.crc.as_deref().ok_or_else(|| {
+        let crc = self.resolve_crc_for_write(engine)?.ok_or_else(|| {
             Error::ChecksumWriteUnsupported(
-                "No in-memory CRC available at this snapshot version.".to_string(),
+                "No CRC could be resolved for this snapshot version.".to_string(),
             )
         })?;
 
         let crc_path = ParsedLogPath::new_crc(self.table_root(), self.version())?;
 
-        match try_write_crc_file(engine, &crc_path.location, crc) {
+        match try_write_crc_file(engine, &crc_path.location, &crc) {
             Ok(()) => {
                 info!("Wrote CRC file at {}", crc_path.location);
                 let new_log_segment = self.log_segment.try_new_with_crc_file(crc_path)?;
                 let new_snapshot = Arc::new(Snapshot::new_with_crc(
                     new_log_segment,
                     self.table_configuration().clone(),
-                    self.crc.clone(),
+                    Some(crc),
                 )?);
                 Ok((ChecksumWriteResult::Written, new_snapshot))
             }
@@ -906,6 +904,68 @@ impl Snapshot {
             }
             Err(e) => Err(e),
         }
+    }
+
+    /// Resolve the CRC to write for this snapshot's version, or `None` when none can be produced.
+    ///
+    /// Tries the newest available root, stopping at the first that applies:
+    /// 1. The in-memory CRC, used as-is. E.g. a snapshot at N that did incremental CRC replay from
+    ///    a CRC at N-5, or a post-commit snapshot at N+1 built from a CRC at N (on disk or
+    ///    computed).
+    /// 2. A stale on-disk CRC, advanced over the tail commits via reverse replay.
+    /// 3. A checkpoint, advanced over the tail commits via reverse replay.
+    /// 4. A full reverse replay of the commit history.
+    ///
+    /// An on-disk CRC always sits at or after the checkpoint (a log-segment invariant) and is
+    /// cheap to read, so 2 is preferred over 3 whenever a CRC exists.
+    fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Option<Arc<Crc>>> {
+        // Case 1: an in-memory CRC at this version is ready to write as-is.
+        if let Some(crc) = &self.crc {
+            return Ok(Some(crc.clone()));
+        }
+
+        let end = self.version();
+        let log_segment = &self.log_segment;
+
+        // Case 2: a stale on-disk CRC (older than this version, since an equal one would have
+        // short-circuited to `AlreadyExists`). Advance it over the tail commits.
+        if let Some(base) = log_segment.read_latest_crc(engine) {
+            let crc = log_segment.build_incremental_crc_from_base(engine, &base)?;
+            return Ok(Some(Arc::new(crc)));
+        }
+
+        // Case 3: no CRC, but a checkpoint to root at.
+        if let Some(checkpoint_version) = log_segment.checkpoint_version {
+            if checkpoint_version == end {
+                // No tail commits: the checkpoint carries no ICT, so read v_end's ICT from its
+                // commit file (`None` when ICT is disabled).
+                let Some(mut crc) = log_segment.build_crc_from_checkpoint(engine)? else {
+                    return Ok(None);
+                };
+                crc.in_commit_timestamp_opt = self.get_in_commit_timestamp(engine)?;
+                return Ok(Some(Arc::new(crc)));
+            }
+            // Replay the tail commits first: a non-incremental tail dooms file stats no matter
+            // what the checkpoint holds, so skip the larger checkpoint read in that case.
+            let delta = log_segment.build_incremental_crc_delta_from_base(
+                engine,
+                checkpoint_version,
+                Some(FileSizeHistogram::create_default()),
+            )?;
+            if !delta.is_incremental_safe {
+                return Ok(None);
+            }
+            let Some(base) = log_segment.build_crc_from_checkpoint(engine)? else {
+                return Ok(None);
+            };
+            // The tail delta carries v_end's ICT, which `apply` sets on the result.
+            return Ok(Some(Arc::new(base.apply(delta, end))));
+        }
+
+        // Case 4: neither CRC nor checkpoint -- reverse-replay the full commit history.
+        Ok(log_segment
+            .build_crc_from_version_zero(engine)?
+            .map(Arc::new))
     }
 
     /// Performs a complete checkpoint of this snapshot using the provided engine.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -938,11 +938,13 @@ impl Snapshot {
         if let Some(checkpoint_version) = log_segment.checkpoint_version {
             if checkpoint_version == end {
                 // No tail commits: the checkpoint carries no ICT, so read v_end's ICT from its
-                // commit file (`None` when ICT is disabled).
+                // commit file. A failed read (e.g. the commit file was log-cleaned on an
+                // ICT-enabled table) leaves it absent; the write then fails closed via
+                // `try_write_crc_file`'s ICT guard rather than erroring here.
                 let Some(mut crc) = log_segment.build_crc_from_checkpoint(engine)? else {
                     return Ok(None);
                 };
-                crc.in_commit_timestamp_opt = self.get_in_commit_timestamp(engine)?;
+                crc.in_commit_timestamp_opt = self.get_in_commit_timestamp(engine).ok().flatten();
                 return Ok(Some(Arc::new(crc)));
             }
             // Replay the tail commits first: a non-incremental tail dooms file stats no matter
@@ -962,7 +964,7 @@ impl Snapshot {
             return Ok(Some(Arc::new(base.apply(delta, end))));
         }
 
-        // Case 4: neither CRC nor checkpoint -- reverse-replay the full commit history.
+        // Case 4: neither CRC nor checkpoint, so reverse-replay the full commit history.
         Ok(log_segment
             .build_crc_from_version_zero(engine)?
             .map(Arc::new))

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -923,9 +923,14 @@ impl Snapshot {
     /// Returns [`Error::ChecksumWriteUnsupported`] when a root is reached but cannot yield a
     /// writable CRC (missing protocol or metadata, or a non-incremental tail that dooms file
     /// stats).
+    ///
+    /// The `root` span field records which root resolved the CRC.
+    #[instrument(parent = &self.span, name = "snap.resolve_crc_for_write", skip_all, err, fields(root))]
     fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Arc<Crc>> {
+        let span = tracing::Span::current();
         // Case 1: an in-memory CRC at this version is ready to write as-is.
         if let Some(crc) = &self.crc {
+            span.record("root", "in_memory");
             return Ok(crc.clone());
         }
 
@@ -935,16 +940,18 @@ impl Snapshot {
         // Case 2: a stale on-disk CRC, older than this version. An on-disk CRC at exactly this
         // version would have short-circuited to `AlreadyExists` in `write_checksum`. Advance it
         // over the tail commits.
-        // TODO: `read_latest_crc` re-reads the CRC from disk. `LazyCrc` was deleted in the pivot
-        //       to incremental CRC being optional; reintroduce something like it so a CRC already
-        //       read during snapshot load is reused here instead of re-read.
+        // TODO(#2889): `read_latest_crc` re-reads the CRC from disk. `LazyCrc` was deleted in the
+        //              pivot to incremental CRC being optional; reintroduce something like it so a
+        //              CRC already read during snapshot load is reused here instead of re-read.
         if let Some(base) = log_segment.read_latest_crc(engine) {
+            span.record("root", "stale_crc");
             let crc = log_segment.build_crc_from_base(engine, &base)?;
             return Ok(Arc::new(crc));
         }
 
         // Case 3: no CRC, but a checkpoint to root at.
         if let Some(checkpoint_version) = log_segment.checkpoint_version {
+            span.record("root", "checkpoint");
             if checkpoint_version == end {
                 // A checkpoint carries no ICT (it has no commitInfo). Since there's no tail delta
                 // to carry it either, we defer to `get_in_commit_timestamp`, which reads the commit
@@ -975,6 +982,7 @@ impl Snapshot {
         }
 
         // Case 4: neither CRC nor checkpoint, so reverse-replay the full commit history.
+        span.record("root", "version_zero");
         let crc = log_segment
             .build_crc_from_version_zero(engine)?
             .ok_or_else(|| unresolved_crc("commit history is missing protocol or metadata"))?;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1370,7 +1370,7 @@ impl<S> Transaction<S> {
                     .table_root()
                     .join("_delta_log/")?;
                 let log_segment = LogSegment::new_for_version_zero(log_root, parsed_commit)?;
-                let crc = crc_delta.into_crc_for_version_zero().ok_or_else(|| {
+                let crc = crc_delta.into_complete_crc(0).ok_or_else(|| {
                     Error::internal_error("CREATE TABLE CRC delta is missing protocol or metadata")
                 })?;
                 let stats = PostCommitStats {

--- a/kernel/tests/integration/cross_product/mod.rs
+++ b/kernel/tests/integration/cross_product/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use delta_kernel::schema::MetadataColumnSpec;
+use delta_kernel::snapshot::ChecksumWriteResult;
 use delta_kernel::{DeltaResult, Engine, Snapshot};
 use rstest::rstest;
 use rstest_reuse::apply;
@@ -69,10 +70,37 @@ fn test_cross_product_read_write(
             snap.schema()
                 .add_metadata_column("row_id", MetadataColumnSpec::RowId)?,
         );
-        let scan = snap.scan_builder().with_schema(scan_schema).build()?;
-        let batches = read_scan(&scan, engine)?;
+        let scan = snap
+            .clone()
+            .scan_builder()
+            .with_schema(scan_schema)
+            .build()?;
+        let batches = read_scan(&scan, engine.clone())?;
         assert_row_ids_unique(&batches);
     }
 
+    write_and_assert_checksum(&snap, &log_state, expected_version, engine.as_ref())?;
+
+    Ok(())
+}
+
+/// Write a CRC for `snap` and assert the exact outcome. A CRC can be written for virtually any
+/// table state; the only cases that block it are a missing remove `size` or a non-incremental
+/// operation (e.g. ANALYZE STATS) in the replayed commits, which force `Indeterminate` file
+/// stats. The sweep exercises neither, so the write succeeds unless a CRC already exists at this
+/// version, which is exactly known from the sweep.
+fn write_and_assert_checksum(
+    snap: &delta_kernel::snapshot::SnapshotRef,
+    log_state: &LogState,
+    version: u64,
+    engine: &dyn Engine,
+) -> DeltaResult<()> {
+    let expected_result = if log_state.crcs_at().contains(&version) {
+        ChecksumWriteResult::AlreadyExists
+    } else {
+        ChecksumWriteResult::Written
+    };
+    let (result, _) = snap.write_checksum(engine)?;
+    assert_eq!(result, expected_result);
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -585,17 +585,27 @@ async fn test_write_checksum_resolves_crc_with_no_in_memory_crc(
     Ok(())
 }
 
+/// Checkpoint at the current version with no tail commits and no CRC: `write_checksum` builds
+/// the CRC from the checkpoint and fills ICT from v_end's commit file. With ICT enabled the
+/// written CRC carries an ICT; with ICT disabled it carries `None` and the write still succeeds.
+#[rstest]
+#[case::ict_enabled(true)]
+#[case::ict_disabled(false)]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_checksum_from_checkpoint_at_current_version_reads_ict() -> DeltaResult<()> {
+async fn test_write_checksum_from_checkpoint_at_current_version(
+    #[case] ict_enabled: bool,
+) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
 
-    // ICT-enabled table; insert data, then checkpoint at the latest version (no tail, no CRC).
     let schema = schema_ref! { nullable "id": INTEGER };
-    let snap = create_table(&table_path, schema, "test_engine")
-        .with_table_properties([
+    let mut builder = create_table(&table_path, schema, "test_engine");
+    if ict_enabled {
+        builder = builder.with_table_properties([
             ("delta.feature.inCommitTimestamp", "supported"),
             ("delta.enableInCommitTimestamps", "true"),
-        ])
+        ]);
+    }
+    let snap = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
@@ -621,9 +631,12 @@ async fn test_write_checksum_from_checkpoint_at_current_version_reads_ict() -> D
     let (result, _updated) = fresh.write_checksum(engine.as_ref())?;
     assert_eq!(result, ChecksumWriteResult::Written);
 
-    // The written CRC carries the ICT read from v_end's commit file.
+    // ICT is present iff the table enabled it; either way the CRC round-trips.
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(reloaded.crc().unwrap().in_commit_timestamp_opt.is_some());
+    assert_eq!(
+        reloaded.crc().unwrap().in_commit_timestamp_opt.is_some(),
+        ict_enabled
+    );
 
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -1935,6 +1935,32 @@ async fn test_stale_crc_fresh_build_advance_matrix(
         ChecksumWriteResult::Written
     );
 
+    // For the Absent case, the CRC just written was rooted at the checkpoint (no prior CRC).
+    // Reload and read domain metadata and set transactions back through `FailingEngine`: every
+    // value must come from the written CRC's `Complete` state, so a mis-wired checkpoint visitor
+    // (e.g. a swapped `CommonColumns` index) surfaces as a wrong value or a panic, not a silent
+    // fallthrough to log replay.
+    if crc_staleness == CrcStaleness::Absent {
+        let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+        assert!(reloaded.crc().is_some());
+        // Carried from the checkpoint base.
+        assert!(reloaded
+            .get_domain_metadata_internal("domain_at_create", &FailingEngine)?
+            .is_some());
+        assert_eq!(
+            reloaded.get_app_id_version("app_at_create", &FailingEngine)?,
+            Some(0)
+        );
+        // Carried from the advanced tail.
+        assert!(reloaded
+            .get_domain_metadata_internal("domain", &FailingEngine)?
+            .is_some());
+        assert_eq!(
+            reloaded.get_app_id_version("app", &FailingEngine)?,
+            Some(LATEST_VERSION)
+        );
+    }
+
     Ok(())
 }
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -705,9 +705,9 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
 }
 
 /// ICT enabled, checkpoint at the current version, but v_end's commit file is unreadable: the
-/// ICT read fails, and rather than persist a CRC with a missing ICT the write fails closed.
+/// ICT read error propagates instead of being laundered into a generic "CRC unresolved" error.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_returns_unsupported(
+async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_propagates_read_error(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
 
@@ -739,9 +739,10 @@ async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_r
 
     let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(fresh.crc().is_none());
+    // The failure is the propagated ICT read error, not a laundered `ChecksumWriteUnsupported`.
     assert!(matches!(
         fresh.write_checksum(engine.as_ref()),
-        Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+        Err(e) if !matches!(e, delta_kernel::Error::ChecksumWriteUnsupported(_))
     ));
 
     Ok(())

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -544,9 +544,7 @@ async fn test_write_checksum_double_write_returns_already_exists(
     Ok(())
 }
 
-/// With no in-memory CRC at load, `write_checksum` resolves one from disk: a stale on-disk CRC
-/// at v0 is advanced (case 2), and with no CRC at all the full history from version zero is
-/// replayed (case 4). Neither table has a checkpoint.
+/// No checkpoint: `write_checksum` resolves from a stale on-disk CRC or from version zero.
 #[rstest]
 #[case::stale_on_disk_crc(true)]
 #[case::version_zero(false)]
@@ -585,9 +583,8 @@ async fn test_write_checksum_resolves_crc_with_no_in_memory_crc(
     Ok(())
 }
 
-/// Checkpoint at the current version with no tail commits and no CRC: `write_checksum` builds
-/// the CRC from the checkpoint and fills ICT from v_end's commit file. With ICT enabled the
-/// written CRC carries an ICT; with ICT disabled it carries `None` and the write still succeeds.
+/// Checkpoint at the current version, no tail commits, no CRC: `write_checksum` builds the CRC
+/// from the checkpoint and fills ICT (present iff enabled) from v_end's commit file.
 #[rstest]
 #[case::ict_enabled(true)]
 #[case::ict_disabled(false)]
@@ -637,6 +634,49 @@ async fn test_write_checksum_from_checkpoint_at_current_version(
         reloaded.crc().unwrap().in_commit_timestamp_opt.is_some(),
         ict_enabled
     );
+
+    Ok(())
+}
+
+/// ICT enabled, checkpoint at the current version, but v_end's commit file is unreadable: the
+/// ICT read fails, and rather than persist a CRC with a missing ICT the write fails closed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_returns_unsupported(
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let snap = create_table(&table_path, schema, "test_engine")
+        .with_table_properties([
+            ("delta.feature.inCommitTimestamp", "supported"),
+            ("delta.enableInCommitTimestamps", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    let snap = insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+    let (_, snap) = snap.checkpoint(engine.as_ref(), None)?;
+    let checkpoint_version = snap.version();
+
+    // Corrupt v_end's commit file so its ICT can't be read (the snapshot still loads from the
+    // checkpoint at the same version).
+    let commit = _temp_dir
+        .path()
+        .join(format!("_delta_log/{checkpoint_version:020}.json"));
+    std::fs::write(&commit, b"}}} not valid commit json").unwrap();
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(fresh.crc().is_none());
+    assert!(matches!(
+        fresh.write_checksum(engine.as_ref()),
+        Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+    ));
 
     Ok(())
 }
@@ -1935,14 +1975,17 @@ async fn test_stale_crc_fresh_build_advance_matrix(
         ChecksumWriteResult::Written
     );
 
-    // For the Absent case, the CRC just written was rooted at the checkpoint (no prior CRC).
-    // Reload and read domain metadata and set transactions back through `FailingEngine`: every
-    // value must come from the written CRC's `Complete` state, so a mis-wired checkpoint visitor
-    // (e.g. a swapped `CommonColumns` index) surfaces as a wrong value or a panic, not a silent
-    // fallthrough to log replay.
+    // For the Absent case the CRC was rooted at the checkpoint. Reload and read domain metadata,
+    // set transactions, and file stats through `FailingEngine`: with I/O impossible, every value
+    // must come from the written CRC's `Complete` state.
     if crc_staleness == CrcStaleness::Absent {
         let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
         assert!(reloaded.crc().is_some());
+        // File stats: checkpoint base summed with the advanced tail, checked against disk.
+        let stats = reloaded.get_file_stats_if_present().unwrap();
+        let disk = parquet_file_sizes_on_disk(&table_path);
+        assert_eq!(stats.num_files() as usize, disk.len());
+        assert_eq!(stats.table_size_bytes(), disk.iter().sum::<i64>());
         // Carried from the checkpoint base.
         assert!(reloaded
             .get_domain_metadata_internal("domain_at_create", &FailingEngine)?

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -544,16 +544,120 @@ async fn test_write_checksum_double_write_returns_already_exists(
     Ok(())
 }
 
+/// With no in-memory CRC at load, `write_checksum` resolves one from disk: a stale on-disk CRC
+/// at v0 is advanced (case 2), and with no CRC at all the full history from version zero is
+/// replayed (case 4). Neither table has a checkpoint.
+#[rstest]
+#[case::stale_on_disk_crc(true)]
+#[case::version_zero(false)]
 #[tokio::test]
-async fn test_write_checksum_with_no_in_memory_crc_returns_error() -> DeltaResult<()> {
+async fn test_write_checksum_resolves_crc_with_no_in_memory_crc(
+    #[case] write_crc_at_v0: bool,
+) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let _ = create_table_and_commit(&table_path, engine.as_ref())?;
+    let snap = create_table_and_commit(&table_path, engine.as_ref())?
+        .post_commit_snapshot()
+        .unwrap()
+        .clone();
+    if write_crc_at_v0 {
+        snap.write_checksum(engine.as_ref())?;
+    }
+    let snap = insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![1]))])
+        .await?
+        .unwrap_post_commit_snapshot();
+    insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![2]))])
+        .await?
+        .unwrap_committed();
 
-    // Load from disk -- no CRC file on disk, so no in-memory CRC
-    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    // Default load (no incremental replay), so no in-memory CRC.
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 2);
+    assert!(fresh.crc().is_none());
 
-    let result = snapshot.write_checksum(engine.as_ref());
-    assert!(result.is_err());
+    let (result, _updated) = fresh.write_checksum(engine.as_ref())?;
+    assert_eq!(result, ChecksumWriteResult::Written);
+
+    // The written CRC round-trips with file stats covering both inserted files.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let stats = reloaded.get_file_stats_if_present().unwrap();
+    assert_eq!(stats.num_files(), 2);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_checksum_from_checkpoint_at_current_version_reads_ict() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    // ICT-enabled table; insert data, then checkpoint at the latest version (no tail, no CRC).
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let snap = create_table(&table_path, schema, "test_engine")
+        .with_table_properties([
+            ("delta.feature.inCommitTimestamp", "supported"),
+            ("delta.enableInCommitTimestamps", "true"),
+        ])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    let snap = insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+    let (_, snap) = snap.checkpoint(engine.as_ref(), None)?;
+    let checkpoint_version = snap.version();
+
+    // Default load: checkpoint at the current version, no tail commits, no CRC.
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), checkpoint_version);
+    assert!(fresh.crc().is_none());
+    assert_eq!(
+        fresh.log_segment().checkpoint_version,
+        Some(checkpoint_version)
+    );
+
+    let (result, _updated) = fresh.write_checksum(engine.as_ref())?;
+    assert_eq!(result, ChecksumWriteResult::Written);
+
+    // The written CRC carries the ICT read from v_end's commit file.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(reloaded.crc().unwrap().in_commit_timestamp_opt.is_some());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_checksum_no_crc_with_non_incremental_tail_returns_unsupported(
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let snap = create_table(&table_path, schema, "test_engine")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    let snap = insert_data(
+        snap,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+    let (_, snap) = snap.checkpoint(engine.as_ref(), None)?;
+    // Non-incremental operation in the tail dooms file stats regardless of the checkpoint.
+    begin_transaction(snap, engine.as_ref())?
+        .with_operation("ANALYZE STATS".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert!(fresh.crc().is_none());
+    assert!(matches!(
+        fresh.write_checksum(engine.as_ref()),
+        Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
+    ));
 
     Ok(())
 }
@@ -1811,17 +1915,12 @@ async fn test_stale_crc_fresh_build_advance_matrix(
     );
 
     // === Check: write_checksum ===
-    if expect_crc_present {
-        assert_eq!(
-            fresh.write_checksum(engine.as_ref())?.0,
-            ChecksumWriteResult::Written
-        );
-    } else {
-        assert!(matches!(
-            fresh.write_checksum(engine.as_ref()),
-            Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
-        ));
-    }
+    // Succeeds whether or not an in-memory CRC was present: with no CRC, write_checksum resolves
+    // one from the checkpoint root and advances it over the tail commits.
+    assert_eq!(
+        fresh.write_checksum(engine.as_ref())?.0,
+        ChecksumWriteResult::Written
+    );
 
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -544,96 +544,162 @@ async fn test_write_checksum_double_write_returns_already_exists(
     Ok(())
 }
 
-/// No checkpoint: `write_checksum` resolves from a stale on-disk CRC or from version zero.
-#[rstest]
-#[case::stale_on_disk_crc(true)]
-#[case::version_zero(false)]
-#[tokio::test]
-async fn test_write_checksum_resolves_crc_with_no_in_memory_crc(
-    #[case] write_crc_at_v0: bool,
-) -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let snap = create_table_and_commit(&table_path, engine.as_ref())?
-        .post_commit_snapshot()
-        .unwrap()
-        .clone();
-    if write_crc_at_v0 {
-        snap.write_checksum(engine.as_ref())?;
-    }
-    let snap = insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![1]))])
-        .await?
-        .unwrap_post_commit_snapshot();
-    insert_data(snap, &engine, vec![Arc::new(Int32Array::from(vec![2]))])
-        .await?
-        .unwrap_committed();
-
-    // Default load (no incremental replay), so no in-memory CRC.
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(fresh.version(), 2);
-    assert!(fresh.crc().is_none());
-
-    let (result, _updated) = fresh.write_checksum(engine.as_ref())?;
-    assert_eq!(result, ChecksumWriteResult::Written);
-
-    // The written CRC round-trips with file stats covering both inserted files.
-    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    let stats = reloaded.get_file_stats_if_present().unwrap();
-    assert_eq!(stats.num_files(), 2);
-
-    Ok(())
+/// The root that `resolve_crc_for_write` resolves the CRC from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WriteRoot {
+    /// No checkpoint and no CRC.
+    VersionZero,
+    /// A checkpoint at the snapshot's version with no tail commits.
+    CheckpointNoTail,
+    /// A checkpoint below the snapshot's version with tail commits.
+    CheckpointWithTail,
+    /// A stale on-disk CRC, loaded with [`IncrementalReplay::Unlimited`].
+    StaleCrcIncrementalBuild,
+    /// A stale on-disk CRC, loaded with [`IncrementalReplay::Disabled`].
+    StaleCrcNonIncrementalBuild,
 }
 
-/// Checkpoint at the current version, no tail commits, no CRC: `write_checksum` builds the CRC
-/// from the checkpoint and fills ICT (present iff enabled) from v_end's commit file.
+/// For each resolution root: build a table, load a snapshot, write the CRC, and validate its
+/// contents (file stats, active domains, set transactions).
 #[rstest]
-#[case::ict_enabled(true)]
-#[case::ict_disabled(false)]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_write_checksum_from_checkpoint_at_current_version(
-    #[case] ict_enabled: bool,
+async fn test_write_checksum_resolves_correct_crc_from_each_root(
+    #[values(
+        WriteRoot::VersionZero,
+        WriteRoot::CheckpointNoTail,
+        WriteRoot::CheckpointWithTail,
+        WriteRoot::StaleCrcIncrementalBuild,
+        WriteRoot::StaleCrcNonIncrementalBuild
+    )]
+    root: WriteRoot,
+    #[values(false, true)] ict_enabled: bool,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
 
+    // === Create the table with domain metadata (and optionally ICT) enabled ===
     let schema = schema_ref! { nullable "id": INTEGER };
-    let mut builder = create_table(&table_path, schema, "test_engine");
+    let mut builder = create_table(&table_path, schema, "test_engine")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")]);
     if ict_enabled {
-        builder = builder.with_table_properties([
-            ("delta.feature.inCommitTimestamp", "supported"),
-            ("delta.enableInCommitTimestamps", "true"),
-        ]);
+        builder = builder.with_table_properties([("delta.enableInCommitTimestamps", "true")]);
     }
-    let snap = builder
+    let mut snap = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
-    let snap = insert_data(
-        snap,
-        &engine,
-        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-    )
-    .await?
-    .unwrap_post_commit_snapshot();
-    let (_, snap) = snap.checkpoint(engine.as_ref(), None)?;
-    let checkpoint_version = snap.version();
 
-    // Default load: checkpoint at the current version, no tail commits, no CRC.
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(fresh.version(), checkpoint_version);
-    assert!(fresh.crc().is_none());
+    const CHECKPOINT_OR_CRC_VERSION: i64 = 4;
+    let (checkpoint_or_crc_version, latest): (Option<i64>, i64) = match root {
+        WriteRoot::VersionZero => (None, CHECKPOINT_OR_CRC_VERSION),
+        WriteRoot::CheckpointNoTail => (Some(CHECKPOINT_OR_CRC_VERSION), CHECKPOINT_OR_CRC_VERSION),
+        WriteRoot::CheckpointWithTail
+        | WriteRoot::StaleCrcIncrementalBuild
+        | WriteRoot::StaleCrcNonIncrementalBuild => (
+            Some(CHECKPOINT_OR_CRC_VERSION),
+            CHECKPOINT_OR_CRC_VERSION + 2,
+        ),
+    };
+    let removed_domain = "d1";
+
+    // === Commit loop: accumulate domain metadata and set transactions ===
+    // Each commit v adds one file, sets domain "d{v}"->"cfg{v}" and set-txn "app{v}"->v. At v=3 we
+    // also remove "d1", so the final CRC must reflect the removal.
+    for v in 1..=latest {
+        let arrow_schema = TryFromKernel::try_from_kernel(snap.schema().as_ref())?;
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![Arc::new(Int32Array::from(vec![v as i32]))],
+        )
+        .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
+        let mut txn = snap
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("WRITE".to_string())
+            .with_data_change(true)
+            .with_domain_metadata(format!("d{v}"), format!("cfg{v}"))
+            .with_transaction_id(format!("app{v}"), v);
+        if v == 3 {
+            txn = txn.with_domain_metadata_removed(removed_domain.to_string());
+        }
+        let write_context = txn.unpartitioned_write_context()?;
+        let adds = engine
+            .write_parquet(&ArrowEngineData::new(batch), &write_context)
+            .await?;
+        txn.add_files(adds);
+        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+
+        if checkpoint_or_crc_version == Some(v) {
+            match root {
+                WriteRoot::CheckpointNoTail | WriteRoot::CheckpointWithTail => {
+                    snap = snap.checkpoint(engine.as_ref(), None)?.1;
+                }
+                WriteRoot::StaleCrcIncrementalBuild | WriteRoot::StaleCrcNonIncrementalBuild => {
+                    snap.write_checksum(engine.as_ref())?;
+                }
+                WriteRoot::VersionZero => unreachable!("VersionZero has no seed version"),
+            }
+        }
+    }
+
+    // === Load from disk, write the checksum, reload, assert the persisted CRC ===
+    let incremental_build = root == WriteRoot::StaleCrcIncrementalBuild;
+    let replay = if incremental_build {
+        IncrementalReplay::Unlimited
+    } else {
+        IncrementalReplay::Disabled
+    };
+    let fresh = Snapshot::builder_for(&table_path)
+        .with_incremental_crc_replay(replay)
+        .build(engine.as_ref())?;
+    assert_eq!(fresh.crc().is_some(), incremental_build);
+
+    // Confirm the load actually reached the intended resolution root, so a mis-resolution that
+    // still produced correct contents cannot pass silently.
+    match root {
+        WriteRoot::CheckpointNoTail | WriteRoot::CheckpointWithTail => assert_eq!(
+            fresh.log_segment().checkpoint_version,
+            Some(CHECKPOINT_OR_CRC_VERSION as u64)
+        ),
+        WriteRoot::VersionZero => assert!(fresh.log_segment().checkpoint_version.is_none()),
+        WriteRoot::StaleCrcIncrementalBuild | WriteRoot::StaleCrcNonIncrementalBuild => {
+            assert!(crc_file_path(&table_path, CHECKPOINT_OR_CRC_VERSION as u64).exists())
+        }
+    }
+
     assert_eq!(
-        fresh.log_segment().checkpoint_version,
-        Some(checkpoint_version)
+        fresh.write_checksum(engine.as_ref())?.0,
+        ChecksumWriteResult::Written
     );
 
-    let (result, _updated) = fresh.write_checksum(engine.as_ref())?;
-    assert_eq!(result, ChecksumWriteResult::Written);
-
-    // ICT is present iff the table enabled it; either way the CRC round-trips.
+    // Reload from disk so the assertions below run against the persisted CRC.
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(
-        reloaded.crc().unwrap().in_commit_timestamp_opt.is_some(),
-        ict_enabled
-    );
+    let crc = reloaded.crc().unwrap();
+
+    assert_eq!(crc.version as i64, latest);
+    assert_eq!(crc.in_commit_timestamp_opt.is_some(), ict_enabled);
+
+    // File stats cover every live file (one per commit), checked against disk ground truth.
+    let disk = parquet_file_sizes_on_disk(&table_path);
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files() as usize, disk.len());
+    assert_eq!(stats.table_size_bytes(), disk.iter().sum::<i64>());
+
+    // Domain metadata: every set domain is present with its config, except the removed one.
+    let dms = crc.domain_metadata_state.expect_complete();
+    assert!(!dms.contains_key(removed_domain));
+    for v in 1..=latest {
+        let domain = format!("d{v}");
+        if domain == removed_domain {
+            continue;
+        }
+        assert_eq!(dms[&domain].configuration(), format!("cfg{v}"));
+    }
+
+    // Set transactions: every committed app id is present.
+    let txns = crc.set_transaction_state.expect_complete();
+    assert_eq!(txns.len() as i64, latest);
+    for v in 1..=latest {
+        assert!(txns.contains_key(&format!("app{v}")));
+    }
 
     Ok(())
 }
@@ -1966,43 +2032,6 @@ async fn test_stale_crc_fresh_build_advance_matrix(
         fresh.get_app_id_version("app", real_engine_iff_crc_missing)?,
         Some(LATEST_VERSION)
     );
-
-    // === Check: write_checksum ===
-    // Succeeds whether or not an in-memory CRC was present: with no CRC, write_checksum resolves
-    // one from the checkpoint root and advances it over the tail commits.
-    assert_eq!(
-        fresh.write_checksum(engine.as_ref())?.0,
-        ChecksumWriteResult::Written
-    );
-
-    // For the Absent case the CRC was rooted at the checkpoint. Reload and read domain metadata,
-    // set transactions, and file stats through `FailingEngine`: with I/O impossible, every value
-    // must come from the written CRC's `Complete` state.
-    if crc_staleness == CrcStaleness::Absent {
-        let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-        assert!(reloaded.crc().is_some());
-        // File stats: checkpoint base summed with the advanced tail, checked against disk.
-        let stats = reloaded.get_file_stats_if_present().unwrap();
-        let disk = parquet_file_sizes_on_disk(&table_path);
-        assert_eq!(stats.num_files() as usize, disk.len());
-        assert_eq!(stats.table_size_bytes(), disk.iter().sum::<i64>());
-        // Carried from the checkpoint base.
-        assert!(reloaded
-            .get_domain_metadata_internal("domain_at_create", &FailingEngine)?
-            .is_some());
-        assert_eq!(
-            reloaded.get_app_id_version("app_at_create", &FailingEngine)?,
-            Some(0)
-        );
-        // Carried from the advanced tail.
-        assert!(reloaded
-            .get_domain_metadata_internal("domain", &FailingEngine)?
-            .is_some());
-        assert_eq!(
-            reloaded.get_app_id_version("app", &FailingEngine)?,
-            Some(LATEST_VERSION)
-        );
-    }
 
     Ok(())
 }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -325,7 +325,7 @@ impl LogState {
     }
 
     /// Versions at which CRC files are written, in ascending order.
-    pub(crate) fn crcs_at(&self) -> &[u64] {
+    pub fn crcs_at(&self) -> &[u64] {
         &self.crcs_at
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, `snap.write_checksum` only worked if:
- there is a CRC on disk at N, you write `N+1.json`, and then we can write `N+1.crc`
- there is a CRC on disk at N - 5, you load a Snapshot with incremental replay turned on, then we have an in-memory CRC at N. Now we can write a CRC at N, or at N+1 if we perform a commit, too

Now, this PR enables writing CRC for the cases of:
- checkpoint-rooted snapshot [10.checkpoint, 11.json, 12.json]
- checkpoint-versioned snapshot [10.checkpoint]
- v0 rooted snasphot [0.json, 1.json, 2.json]
- stale CRC with incremental replay disabled [10.checkpoint, 11.json, 12.json, 12.crc, 13.json, 14.json]

## How was this change tested?

New UTs for these specific cases + error cases. Also added write-checksum to the cross-product suite (2800+ tests) which already covers lots of stale CRC, only checkpoint, no checkpoint, etc cases.
