### PR TITLE
feat: validation for required addFile fields at commit time

### DIFF
--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -78,6 +78,7 @@ pub mod stats_verifier;
 mod stats_verifier;
 mod update;
 mod write_context;
+mod write_validation;
 
 use stats_verifier::StatsColumnVerifier;
 use write_context::SharedWriteState;
@@ -99,7 +100,7 @@ pub(crate) static MANDATORY_ADD_FILE_SCHEMA: LazyLock<SchemaRef> = lazy_schema_r
 /// Returns a reference to the mandatory fields in an add action.
 ///
 /// Note this does not include "dataChange" which is a required field but
-/// but should be set on the transactoin level. Getting the full schema
+/// should be set on the transaction level. Getting the full schema
 /// can be done with [`Transaction::add_files_schema`].
 pub(crate) fn mandatory_add_file_schema() -> &'static SchemaRef {
     &MANDATORY_ADD_FILE_SCHEMA
@@ -417,6 +418,9 @@ impl<S> Transaction<S> {
 
         // Validate clustering column stats if ClusteredTable feature is enabled
         self.validate_add_files_stats(&self.add_files_metadata)?;
+
+        // Validate required fields for addFile.
+        write_validation::ActionValidator::staged_add_file().validate(&self.add_files_metadata)?;
 
         // Step 1: Generate SetTransaction actions
         let set_transaction_actions = self
@@ -1733,7 +1737,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    use ::test_utils::get_column;
+    use ::test_utils::{copy_directory, get_column};
     use rstest::rstest;
     use url::Url;
 
@@ -1764,7 +1768,7 @@ mod tests {
     use crate::utils::test_utils::{
         install_thread_local_metrics_reporter, load_test_table, string_array_to_engine_data,
         test_schema_flat, test_schema_nested, test_schema_with_array, test_schema_with_map,
-        CapturingReporter,
+        valid_add_file_batch, CapturingReporter,
     };
     use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
@@ -2670,15 +2674,28 @@ mod tests {
     // validate_blind_append tests
     // ============================================================================
     fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
-        let data = string_array_to_engine_data(StringArray::from(vec!["dummy"]));
-        txn.add_files(data);
+        let batch = valid_add_file_batch(false /* all_nullable */);
+        txn.add_files(Box::new(ArrowEngineData::new(batch)));
     }
 
+    /// Build a transaction on a writable copy of the `table-without-dv-small` fixture.
     fn create_existing_table_txn(
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction, Option<tempfile::TempDir>)> {
-        let (engine, snapshot, tempdir) = load_test_table("table-without-dv-small")?;
+        let (_, source_snapshot, _source_dir) = load_test_table("table-without-dv-small")?;
+        let source = source_snapshot
+            .table_root()
+            .to_file_path()
+            .expect("fixture is a local path");
+
+        let tempdir = tempfile::tempdir().expect("temp dir");
+        let table_path = tempdir.path().join("table-without-dv-small");
+        copy_directory(&source, &table_path).expect("copy fixture");
+
+        let url = Url::from_directory_path(&table_path).expect("table url");
+        let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new());
+        let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
-        Ok((engine, txn, tempdir))
+        Ok((engine, txn, Some(tempdir)))
     }
 
     #[test]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -416,7 +416,11 @@ impl<S> Transaction<S> {
             );
         }
 
-        // Validate clustering column stats if ClusteredTable feature is enabled
+        // Validate protocol-required add-file statistics.
+        // Note: Stats validation cannot use `StagedDataValidator` because its columns and types
+        // are determined at runtime, whereas `RowVisitor::selected_column_names_and_types` must
+        // return a static projection. Consequently, stats validation makes a separate pass for
+        // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
         // Validate required fields for addFile.

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1742,7 +1742,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    use ::test_utils::{copy_directory, get_column};
+    use ::test_utils::get_column;
     use rstest::rstest;
     use url::Url;
 
@@ -1771,9 +1771,9 @@ mod tests {
     use crate::transaction::create_table::create_table;
     use crate::transaction::data_layout::DataLayout;
     use crate::utils::test_utils::{
-        create_valid_add_file_batch, install_thread_local_metrics_reporter, load_test_table,
-        string_array_to_engine_data, test_schema_flat, test_schema_nested, test_schema_with_array,
-        test_schema_with_map, CapturingReporter,
+        copy_test_table, create_valid_add_file_batch, install_thread_local_metrics_reporter,
+        load_test_table, string_array_to_engine_data, test_schema_flat, test_schema_nested,
+        test_schema_with_array, test_schema_with_map, CapturingReporter,
     };
     use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
@@ -2684,23 +2684,13 @@ mod tests {
     }
 
     /// Build a transaction on a writable copy of the `table-without-dv-small` fixture.
-    fn create_existing_table_txn(
-    ) -> DeltaResult<(Arc<dyn Engine>, Transaction, Option<tempfile::TempDir>)> {
-        let (_, source_snapshot, _source_dir) = load_test_table("table-without-dv-small")?;
-        let source = source_snapshot
-            .table_root()
-            .to_file_path()
-            .expect("fixture is a local path");
-
-        let tempdir = tempfile::tempdir().expect("temp dir");
-        let table_path = tempdir.path().join("table-without-dv-small");
-        copy_directory(&source, &table_path).expect("copy fixture");
-
-        let url = Url::from_directory_path(&table_path).expect("table url");
+    fn create_existing_table_txn() -> DeltaResult<(Arc<dyn Engine>, Transaction, tempfile::TempDir)>
+    {
+        let (url, tempdir) = copy_test_table("table-without-dv-small")?;
         let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new());
         let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
-        Ok((engine, txn, Some(tempdir)))
+        Ok((engine, txn, tempdir))
     }
 
     #[test]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1771,9 +1771,9 @@ mod tests {
     use crate::transaction::create_table::create_table;
     use crate::transaction::data_layout::DataLayout;
     use crate::utils::test_utils::{
-        install_thread_local_metrics_reporter, load_test_table, string_array_to_engine_data,
-        test_schema_flat, test_schema_nested, test_schema_with_array, test_schema_with_map,
-        valid_add_file_batch, CapturingReporter,
+        create_valid_add_file_batch, install_thread_local_metrics_reporter, load_test_table,
+        string_array_to_engine_data, test_schema_flat, test_schema_nested, test_schema_with_array,
+        test_schema_with_map, CapturingReporter,
     };
     use crate::{DeltaResultIterator, EvaluationHandler, Snapshot};
 
@@ -2679,7 +2679,7 @@ mod tests {
     // validate_blind_append tests
     // ============================================================================
     fn add_dummy_file<S: SupportsDataFiles>(txn: &mut Transaction<S>) {
-        let batch = valid_add_file_batch(false /* all_nullable */);
+        let batch = create_valid_add_file_batch(false /* all_nullable */);
         txn.add_files(Box::new(ArrowEngineData::new(batch)));
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -420,7 +420,8 @@ impl<S> Transaction<S> {
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
         // Validate required fields for addFile.
-        write_validation::ActionValidator::staged_add_file().validate(&self.add_files_metadata)?;
+        write_validation::StagedDataValidator::staged_add_file()
+            .validate(&self.add_files_metadata)?;
 
         // Step 1: Generate SetTransaction actions
         let set_transaction_actions = self

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -28,7 +28,7 @@ impl StagedDataValidator {
 }
 
 /// Validates that every staged add-file row has its protocol-required fields (`path`,
-/// `partitionValues`, `size`, `modificationTime`) present and non-null.
+/// `partitionValues`, `size`, `modificationTime`) present.
 pub(crate) struct AddFileRequiredFields;
 
 impl Validation for AddFileRequiredFields {
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn present_required_fields_ok() {
+    fn required_fields_present_ok() {
         let adds = [Box::new(ArrowEngineData::new(nullable_add_file())) as Box<dyn EngineData>];
         add_validator().validate(&adds).unwrap();
     }
@@ -124,7 +124,7 @@ mod tests {
     #[case::partition_values("partitionValues")]
     #[case::size("size")]
     #[case::modification_time("modificationTime")]
-    fn null_required_field_rejected(#[case] field: &str) {
+    fn required_field_missing_rejected(#[case] field: &str) {
         let batch = set_field_as_null(&nullable_add_file(), field);
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
         assert_result_error_with_message(

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -42,7 +42,7 @@ impl Validation for AddFileRequiredFields {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
-            .ok_or_else(|| Error::missing_data("Add action is missing required field 'path'"))?;
+            .ok_or_else(|| Error::missing_data("AddFile is missing required field 'path'"))?;
 
         require_add_file_field(
             getters[PARTITION_VALUES].get_map(row, "partitionValues")?,

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -1,0 +1,124 @@
+//! Add-file validations.
+
+use std::sync::LazyLock;
+
+use super::{ActionValidator, Validation};
+use crate::engine_data::{GetData, TypedGetData as _};
+use crate::schema::ColumnNamesAndTypes;
+use crate::transaction::mandatory_add_file_schema;
+use crate::utils::require;
+use crate::{DeltaResult, Error};
+
+/// Column indices, matching the order in [`MANDATORY_ADD_FILE_COLUMNS`].
+const PATH: usize = 0;
+const PARTITION_VALUES: usize = 1;
+const SIZE: usize = 2;
+const MODIFICATION_TIME: usize = 3;
+
+static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
+    LazyLock::new(|| mandatory_add_file_schema().leaves(None));
+
+impl ActionValidator {
+    pub(crate) fn staged_add_file() -> Self {
+        ActionValidator::new(
+            &MANDATORY_ADD_FILE_COLUMNS,
+            vec![Box::new(AddFileRequiredFields)],
+        )
+    }
+}
+
+/// Validates that every staged add-file row has its protocol-required fields (`path`,
+/// `partitionValues`, `size`, `modificationTime`) present and non-null.
+pub(crate) struct AddFileRequiredFields;
+
+impl Validation for AddFileRequiredFields {
+    fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        let path: &str = getters[PATH]
+            .get_opt(row, "path")?
+            .ok_or_else(|| Error::missing_data("Add action is missing required field 'path'"))?;
+
+        require!(
+            getters[PARTITION_VALUES]
+                .get_map(row, "partitionValues")?
+                .is_some(),
+            Error::missing_data(format!(
+                "Add action for '{path}' is missing required field 'partitionValues'"
+            ))
+        );
+
+        let size: Option<i64> = getters[SIZE].get_opt(row, "size")?;
+        require!(
+            size.is_some(),
+            Error::missing_data(format!(
+                "Add action for '{path}' is missing required field 'size'"
+            ))
+        );
+
+        let modification_time: Option<i64> =
+            getters[MODIFICATION_TIME].get_opt(row, "modificationTime")?;
+        require!(
+            modification_time.is_some(),
+            Error::missing_data(format!(
+                "Add action for '{path}' is missing required field 'modificationTime'"
+            ))
+        );
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::arrow::array::new_null_array;
+    use crate::arrow::record_batch::RecordBatch;
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::utils::test_utils::valid_add_file_batch;
+    use crate::{DeltaResult, EngineData};
+
+    fn nullable_add_file() -> RecordBatch {
+        valid_add_file_batch(true /* all_nullable */)
+    }
+
+    /// Return `batch` with `field`'s column replaced by an all-null array of the same type.
+    fn set_field_as_null(batch: &RecordBatch, field: &str) -> RecordBatch {
+        let schema = batch.schema();
+        let index = schema.index_of(field).expect("field in schema");
+        let mut columns = batch.columns().to_vec();
+        columns[index] = new_null_array(schema.field(index).data_type(), batch.num_rows());
+        RecordBatch::try_new(schema, columns).expect("record batch with nulled field")
+    }
+
+    fn add_validator() -> ActionValidator {
+        ActionValidator::staged_add_file()
+    }
+
+    fn assert_err_contains(result: DeltaResult<()>, needle: &str) {
+        let err = result.expect_err("expected validation error").to_string();
+        assert!(
+            err.contains(needle),
+            "error {err:?} should contain {needle:?}"
+        );
+    }
+
+    #[test]
+    fn present_required_fields_ok() {
+        let adds = [Box::new(ArrowEngineData::new(nullable_add_file())) as Box<dyn EngineData>];
+        add_validator().validate(&adds).unwrap();
+    }
+
+    #[rstest]
+    #[case::path("path")]
+    #[case::partition_values("partitionValues")]
+    #[case::size("size")]
+    #[case::modification_time("modificationTime")]
+    fn null_required_field_rejected(#[case] field: &str) {
+        let batch = set_field_as_null(&nullable_add_file(), field);
+        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
+        assert_err_contains(
+            add_validator().validate(&adds),
+            &format!("missing required field '{field}'"),
+        );
+    }
+}

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -6,7 +6,6 @@ use super::{StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
-use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 /// Column indices, matching the order in [`MANDATORY_ADD_FILE_COLUMNS`].
@@ -31,37 +30,31 @@ impl StagedDataValidator {
 /// `partitionValues`, `size`, `modificationTime`) present.
 pub(crate) struct AddFileRequiredFields;
 
+fn require_add_file_field<T>(value: Option<T>, path: &str, field: &str) -> DeltaResult<T> {
+    value.ok_or_else(|| {
+        Error::missing_data(format!(
+            "AddFile for '{path}' is missing required field '{field}'"
+        ))
+    })
+}
+
 impl Validation for AddFileRequiredFields {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
             .ok_or_else(|| Error::missing_data("Add action is missing required field 'path'"))?;
 
-        require!(
-            getters[PARTITION_VALUES]
-                .get_map(row, "partitionValues")?
-                .is_some(),
-            Error::missing_data(format!(
-                "Add action for '{path}' is missing required field 'partitionValues'"
-            ))
-        );
-
-        let size: Option<i64> = getters[SIZE].get_opt(row, "size")?;
-        require!(
-            size.is_some(),
-            Error::missing_data(format!(
-                "Add action for '{path}' is missing required field 'size'"
-            ))
-        );
-
-        let modification_time: Option<i64> =
-            getters[MODIFICATION_TIME].get_opt(row, "modificationTime")?;
-        require!(
-            modification_time.is_some(),
-            Error::missing_data(format!(
-                "Add action for '{path}' is missing required field 'modificationTime'"
-            ))
-        );
+        require_add_file_field(
+            getters[PARTITION_VALUES].get_map(row, "partitionValues")?,
+            path,
+            "partitionValues",
+        )?;
+        require_add_file_field::<i64>(getters[SIZE].get_opt(row, "size")?, path, "size")?;
+        require_add_file_field::<i64>(
+            getters[MODIFICATION_TIME].get_opt(row, "modificationTime")?,
+            path,
+            "modificationTime",
+        )?;
         Ok(())
     }
 }
@@ -71,7 +64,8 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::new_null_array;
+    use crate::arrow::array::{new_null_array, Array};
+    use crate::arrow::compute::{concat, concat_batches};
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::expressions::ColumnName;
@@ -82,13 +76,29 @@ mod tests {
         valid_add_file_batch(true /* all_nullable */)
     }
 
-    /// Return `batch` with `field`'s column replaced by an all-null array of the same type.
-    fn set_field_as_null(batch: &RecordBatch, field: &str) -> RecordBatch {
+    fn nullable_add_files(row_count: usize) -> RecordBatch {
+        let batch = nullable_add_file();
+        concat_batches(&batch.schema(), &vec![batch; row_count])
+            .expect("failed to concatenate rows into a multi-row add-file batch")
+    }
+
+    /// Return `batch` with `field` set to null at `row`.
+    fn set_field_as_null(batch: &RecordBatch, field: &str, row: usize) -> RecordBatch {
         let schema = batch.schema();
         let index = schema.index_of(field).expect("field in schema");
         let mut columns = batch.columns().to_vec();
-        columns[index] = new_null_array(schema.field(index).data_type(), batch.num_rows());
-        RecordBatch::try_new(schema, columns).expect("record batch with nulled field")
+        let column = &columns[index];
+        let null = new_null_array(schema.field(index).data_type(), 1);
+        let slices = [
+            column.slice(0, row),
+            null,
+            column.slice(row + 1, batch.num_rows() - row - 1),
+        ];
+        let arrays: Vec<&dyn Array> = slices.iter().map(|array| array.as_ref()).collect();
+        columns[index] = concat(&arrays)
+            .expect("failed to replace the selected add-file field with a null value");
+        RecordBatch::try_new(schema, columns)
+            .expect("failed to rebuild add-file batch after replacing a field value with null")
     }
 
     fn add_validator() -> StagedDataValidator {
@@ -124,8 +134,11 @@ mod tests {
     #[case::partition_values("partitionValues")]
     #[case::size("size")]
     #[case::modification_time("modificationTime")]
-    fn required_field_missing_rejected(#[case] field: &str) {
-        let batch = set_field_as_null(&nullable_add_file(), field);
+    fn required_field_missing_at_any_row_rejected(
+        #[case] field: &str,
+        #[values(0, 1, 2)] invalid_row: usize,
+    ) {
+        let batch = set_field_as_null(&nullable_add_files(3), field, invalid_row);
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
         assert_result_error_with_message(
             add_validator().validate(&adds),

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -178,11 +178,36 @@ mod tests {
     }
 
     #[rstest]
-    #[case::valid("dummy", 1, 1, None)]
-    #[case::empty_path("", 1, 1, Some("path must not be empty"))]
-    #[case::negative_size("dummy", -1, 1, Some("size must be non-negative"))]
-    #[case::zero_size("dummy", 0, 1, None)]
-    #[case::negative_modification_time("dummy", 1, -1, None)]
+    #[case::valid(
+        "dummy" /* path */,
+        1 /* size */,
+        1 /* modification_time */,
+        None /* expected_error */,
+    )]
+    #[case::empty_path(
+        "" /* path */,
+        1 /* size */,
+        1 /* modification_time */,
+        Some("path must not be empty") /* expected_error */,
+    )]
+    #[case::negative_size(
+        "dummy" /* path */,
+        -1 /* size */,
+        1 /* modification_time */,
+        Some("size must be non-negative") /* expected_error */,
+    )]
+    #[case::zero_size(
+        "dummy" /* path */,
+        0 /* size */,
+        1 /* modification_time */,
+        None /* expected_error */,
+    )]
+    #[case::negative_modification_time(
+        "dummy" /* path */,
+        1 /* size */,
+        -1 /* modification_time */,
+        None /* expected_error */,
+    )]
     fn add_file_values_accepted_or_rejected(
         #[case] path: &str,
         #[case] size: i64,

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -2,7 +2,7 @@
 
 use std::sync::LazyLock;
 
-use super::{ActionValidator, Validation};
+use super::{StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
@@ -18,9 +18,9 @@ const MODIFICATION_TIME: usize = 3;
 static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
-impl ActionValidator {
+impl StagedDataValidator {
     pub(crate) fn staged_add_file() -> Self {
-        ActionValidator::new(
+        StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
             vec![Box::new(AddFileRequiredFields)],
         )
@@ -74,8 +74,9 @@ mod tests {
     use crate::arrow::array::new_null_array;
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
-    use crate::utils::test_utils::valid_add_file_batch;
-    use crate::{DeltaResult, EngineData};
+    use crate::expressions::ColumnName;
+    use crate::utils::test_utils::{assert_result_error_with_message, valid_add_file_batch};
+    use crate::EngineData;
 
     fn nullable_add_file() -> RecordBatch {
         valid_add_file_batch(true /* all_nullable */)
@@ -90,16 +91,26 @@ mod tests {
         RecordBatch::try_new(schema, columns).expect("record batch with nulled field")
     }
 
-    fn add_validator() -> ActionValidator {
-        ActionValidator::staged_add_file()
+    fn add_validator() -> StagedDataValidator {
+        StagedDataValidator::staged_add_file()
     }
 
-    fn assert_err_contains(result: DeltaResult<()>, needle: &str) {
-        let err = result.expect_err("expected validation error").to_string();
-        assert!(
-            err.contains(needle),
-            "error {err:?} should contain {needle:?}"
+    /// Guards the invariant that the column-index consts match the leaf order of
+    /// `MANDATORY_ADD_FILE_COLUMNS`.
+    #[test]
+    fn column_indices_match_schema_order() {
+        let (names, _) = MANDATORY_ADD_FILE_COLUMNS.as_ref();
+        assert_eq!(names[PATH], ColumnName::new(["path"]));
+        assert_eq!(
+            names[PARTITION_VALUES],
+            ColumnName::new(["partitionValues"])
         );
+        assert_eq!(names[SIZE], ColumnName::new(["size"]));
+        assert_eq!(
+            names[MODIFICATION_TIME],
+            ColumnName::new(["modificationTime"])
+        );
+        assert_eq!(names.len(), 4);
     }
 
     #[test]
@@ -116,7 +127,7 @@ mod tests {
     fn null_required_field_rejected(#[case] field: &str) {
         let batch = set_field_as_null(&nullable_add_file(), field);
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        assert_err_contains(
+        assert_result_error_with_message(
             add_validator().validate(&adds),
             &format!("missing required field '{field}'"),
         );

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -141,13 +141,10 @@ mod tests {
             names[MODIFICATION_TIME],
             ColumnName::new(["modificationTime"])
         );
-        assert_eq!(names.len(), 4);
-    }
-
-    #[test]
-    fn required_fields_present_ok() {
-        let adds = [Box::new(ArrowEngineData::new(nullable_add_file())) as Box<dyn EngineData>];
-        add_validator().validate(&adds).unwrap();
+        assert_eq!(
+            names.len(),
+            [PATH, PARTITION_VALUES, SIZE, MODIFICATION_TIME].len()
+        );
     }
 
     #[rstest]
@@ -155,56 +152,61 @@ mod tests {
     #[case::partition_values("partitionValues")]
     #[case::size("size")]
     #[case::modification_time("modificationTime")]
-    fn required_field_missing_at_any_row_rejected(
+    fn required_field_missing_at_any_batch_and_row_rejected(
         #[case] field: &str,
+        #[values(0, 1, 2)] invalid_batch: usize,
         #[values(0, 1, 2)] invalid_row: usize,
     ) {
-        let batch = set_field_as_null(&nullable_add_files(3), field, invalid_row);
-        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
+        const BATCH_COUNT: usize = 3;
+        const ROW_COUNT: usize = 3;
+
+        let adds: Vec<Box<dyn EngineData>> = (0..BATCH_COUNT)
+            .map(|batch_index| {
+                let batch = nullable_add_files(ROW_COUNT);
+                let batch = if batch_index == invalid_batch {
+                    set_field_as_null(&batch, field, invalid_row)
+                } else {
+                    batch
+                };
+                Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>
+            })
+            .collect();
         assert_result_error_with_message(
             add_validator().validate(&adds),
             &format!("missing required field '{field}'"),
         );
     }
 
-    #[test]
-    fn empty_path_rejected() {
+    #[rstest]
+    #[case::valid("dummy", 1, 1, None)]
+    #[case::empty_path("", 1, 1, Some("path must not be empty"))]
+    #[case::negative_size("dummy", -1, 1, Some("size must be non-negative"))]
+    #[case::zero_size("dummy", 0, 1, None)]
+    #[case::negative_modification_time("dummy", 1, -1, None)]
+    fn add_file_values_accepted_or_rejected(
+        #[case] path: &str,
+        #[case] size: i64,
+        #[case] modification_time: i64,
+        #[case] expected_error: Option<&str>,
+    ) {
         let batch = replace_column(
             &nullable_add_file(),
             "path",
-            Arc::new(StringArray::from(vec![""])),
+            Arc::new(StringArray::from(vec![path])),
         );
-        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        assert_result_error_with_message(add_validator().validate(&adds), "path must not be empty");
-    }
-
-    #[test]
-    fn negative_size_rejected() {
-        let batch = replace_column(
-            &nullable_add_file(),
-            "size",
-            Arc::new(Int64Array::from(vec![-1])),
-        );
-        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        assert_result_error_with_message(
-            add_validator().validate(&adds),
-            "size must be non-negative",
-        );
-    }
-
-    #[test]
-    fn zero_size_and_negative_modification_time_accepted() {
-        let batch = replace_column(
-            &nullable_add_file(),
-            "size",
-            Arc::new(Int64Array::from(vec![0])),
-        );
+        let batch = replace_column(&batch, "size", Arc::new(Int64Array::from(vec![size])));
         let batch = replace_column(
             &batch,
             "modificationTime",
-            Arc::new(Int64Array::from(vec![-1])),
+            Arc::new(Int64Array::from(vec![modification_time])),
         );
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        add_validator().validate(&adds).unwrap();
+        let result = add_validator().validate(&adds);
+
+        if let Some(expected_error) = expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            result.unwrap();
+        }
     }
 }

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -18,6 +18,7 @@ static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
 impl StagedDataValidator {
+    /// Creates a validator that validates every staged add-file row.
     pub(crate) fn staged_add_file() -> Self {
         StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
@@ -43,13 +44,22 @@ impl Validation for AddFileRequiredFields {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
             .ok_or_else(|| Error::missing_data("AddFile is missing required field 'path'"))?;
+        if path.is_empty() {
+            return Err(Error::generic("AddFile path must not be empty"));
+        }
 
         require_add_file_field(
             getters[PARTITION_VALUES].get_map(row, "partitionValues")?,
             path,
             "partitionValues",
         )?;
-        require_add_file_field::<i64>(getters[SIZE].get_opt(row, "size")?, path, "size")?;
+        let size =
+            require_add_file_field::<i64>(getters[SIZE].get_opt(row, "size")?, path, "size")?;
+        if size < 0 {
+            return Err(Error::generic(format!(
+                "AddFile for '{path}' has negative size {size}; size must be non-negative"
+            )));
+        }
         require_add_file_field::<i64>(
             getters[MODIFICATION_TIME].get_opt(row, "modificationTime")?,
             path,
@@ -61,19 +71,21 @@ impl Validation for AddFileRequiredFields {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{new_null_array, Array};
+    use crate::arrow::array::{new_null_array, Array, ArrayRef, Int64Array, StringArray};
     use crate::arrow::compute::{concat, concat_batches};
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::expressions::ColumnName;
-    use crate::utils::test_utils::{assert_result_error_with_message, valid_add_file_batch};
+    use crate::utils::test_utils::{assert_result_error_with_message, create_valid_add_file_batch};
     use crate::EngineData;
 
     fn nullable_add_file() -> RecordBatch {
-        valid_add_file_batch(true /* all_nullable */)
+        create_valid_add_file_batch(true /* all_nullable */)
     }
 
     fn nullable_add_files(row_count: usize) -> RecordBatch {
@@ -99,6 +111,15 @@ mod tests {
             .expect("failed to replace the selected add-file field with a null value");
         RecordBatch::try_new(schema, columns)
             .expect("failed to rebuild add-file batch after replacing a field value with null")
+    }
+
+    fn replace_column(batch: &RecordBatch, field: &str, column: ArrayRef) -> RecordBatch {
+        let schema = batch.schema();
+        let index = schema.index_of(field).expect("field not found in schema");
+        let mut columns = batch.columns().to_vec();
+        columns[index] = column;
+        RecordBatch::try_new(schema, columns)
+            .expect("failed to rebuild add-file batch after replacing a column")
     }
 
     fn add_validator() -> StagedDataValidator {
@@ -144,5 +165,46 @@ mod tests {
             add_validator().validate(&adds),
             &format!("missing required field '{field}'"),
         );
+    }
+
+    #[test]
+    fn empty_path_rejected() {
+        let batch = replace_column(
+            &nullable_add_file(),
+            "path",
+            Arc::new(StringArray::from(vec![""])),
+        );
+        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
+        assert_result_error_with_message(add_validator().validate(&adds), "path must not be empty");
+    }
+
+    #[test]
+    fn negative_size_rejected() {
+        let batch = replace_column(
+            &nullable_add_file(),
+            "size",
+            Arc::new(Int64Array::from(vec![-1])),
+        );
+        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
+        assert_result_error_with_message(
+            add_validator().validate(&adds),
+            "size must be non-negative",
+        );
+    }
+
+    #[test]
+    fn zero_size_and_negative_modification_time_accepted() {
+        let batch = replace_column(
+            &nullable_add_file(),
+            "size",
+            Arc::new(Int64Array::from(vec![0])),
+        );
+        let batch = replace_column(
+            &batch,
+            "modificationTime",
+            Arc::new(Int64Array::from(vec![-1])),
+        );
+        let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
+        add_validator().validate(&adds).unwrap();
     }
 }

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -27,11 +27,18 @@ impl StagedDataValidator {
     }
 }
 
-/// Validates that every staged add-file row has its protocol-required fields (`path`,
-/// `partitionValues`, `size`, `modificationTime`) present.
+/// Validates that every staged add-file row has its protocol-required fields.
+///
+/// Required fields: `path`, `partitionValues`, `size`, `modificationTime`, and `dataChange`.
+/// Optional fields: `stats`, `tags`, `deletionVector`, `baseRowId`,
+/// `defaultRowCommitVersion`, and `clusteringProvider`.
 pub(crate) struct AddFileRequiredFields;
 
-fn require_add_file_field<T>(value: Option<T>, path: &str, field: &str) -> DeltaResult<T> {
+fn validate_required_add_file_field_exist<T>(
+    value: Option<T>,
+    path: &str,
+    field: &str,
+) -> DeltaResult<T> {
     value.ok_or_else(|| {
         Error::missing_data(format!(
             "AddFile for '{path}' is missing required field '{field}'"
@@ -48,19 +55,22 @@ impl Validation for AddFileRequiredFields {
             return Err(Error::generic("AddFile path must not be empty"));
         }
 
-        require_add_file_field(
+        validate_required_add_file_field_exist(
             getters[PARTITION_VALUES].get_map(row, "partitionValues")?,
             path,
             "partitionValues",
         )?;
-        let size =
-            require_add_file_field::<i64>(getters[SIZE].get_opt(row, "size")?, path, "size")?;
+        let size = validate_required_add_file_field_exist::<i64>(
+            getters[SIZE].get_opt(row, "size")?,
+            path,
+            "size",
+        )?;
         if size < 0 {
             return Err(Error::generic(format!(
                 "AddFile for '{path}' has negative size {size}; size must be non-negative"
             )));
         }
-        require_add_file_field::<i64>(
+        validate_required_add_file_field_exist::<i64>(
             getters[MODIFICATION_TIME].get_opt(row, "modificationTime")?,
             path,
             "modificationTime",
@@ -84,10 +94,16 @@ mod tests {
     use crate::utils::test_utils::{assert_result_error_with_message, create_valid_add_file_batch};
     use crate::EngineData;
 
+    /// Builds one valid add-file row with a fully nullable schema.
+    ///
+    /// The nullable schema lets tests inject nulls to protocol-required fields.
     fn nullable_add_file() -> RecordBatch {
         create_valid_add_file_batch(true /* all_nullable */)
     }
 
+    /// Builds `row_count` valid add-file rows with a fully nullable schema.
+    ///
+    /// The nullable schema lets tests inject nulls to protocol-required fields.
     fn nullable_add_files(row_count: usize) -> RecordBatch {
         let batch = nullable_add_file();
         concat_batches(&batch.schema(), &vec![batch; row_count])

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -32,6 +32,9 @@ impl StagedDataValidator {
 /// Required fields: `path`, `partitionValues`, `size`, `modificationTime`, and `dataChange`.
 /// Optional fields: `stats`, `tags`, `deletionVector`, `baseRowId`,
 /// `defaultRowCommitVersion`, and `clusteringProvider`.
+///
+/// NOTE: Currently, Kernel doesn't require connectors to set dataChange for staged addFile.
+/// TODO(2869): Add intent-based validation for dataChange.
 pub(crate) struct AddFileRequiredFields;
 
 fn validate_required_add_file_field_exist<T>(

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -14,10 +14,11 @@ pub(crate) trait Validation {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()>;
 }
 
-/// Runs a set of [`Validation`]s over staged action batches in a single `visit_rows` pass.
+/// Runs a set of [`Validation`]s over staged-data batches. One [`StagedDataValidator`] per staged-data 
+/// schema(e.g. staged add files, staged remove files, staged dv-matched files).
 ///
-/// `columns_types` is the shared column set for all validations; every [`Validation`] sees
-/// the full getter list and reads the columns it needs.
+/// `column_types` is the shared set of column names and types for one staged-data schema; every
+/// [`Validation`] sees the full getter list and reads the columns it needs.
 // TODO(#2869): Add the remaining write-side validations:
 // - No missing partition columns in `txn.add_files_metadata`
 // - Required fields for `txn.remove_files_metadata`
@@ -26,22 +27,23 @@ pub(crate) trait Validation {
 // - No duplicate (path, DvId) in `txn.add_files_metadata`, `txn.remove_files_metadata`,
 //   `txn.dv_matched_files`
 // - AppendOnly table can not have `removeFile` with dataChange = true
-pub(crate) struct ActionValidator {
-    columns_types: &'static ColumnNamesAndTypes,
+pub(crate) struct StagedDataValidator {
+    column_types: &'static ColumnNamesAndTypes,
     validations: Vec<Box<dyn Validation>>,
 }
 
-impl ActionValidator {
+impl StagedDataValidator {
     pub(crate) fn new(
-        columns_types: &'static ColumnNamesAndTypes,
+        column_types: &'static ColumnNamesAndTypes,
         validations: Vec<Box<dyn Validation>>,
     ) -> Self {
         Self {
-            columns_types,
+            column_types,
             validations,
         }
     }
 
+    /// Run every validation against each batch. Returns the first validation error encountered.
     pub(crate) fn validate(mut self, batches: &[Box<dyn EngineData>]) -> DeltaResult<()> {
         for batch in batches {
             self.visit_rows_of(batch.as_ref())?;
@@ -50,9 +52,9 @@ impl ActionValidator {
     }
 }
 
-impl RowVisitor for ActionValidator {
+impl RowVisitor for StagedDataValidator {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
-        self.columns_types.as_ref()
+        self.column_types.as_ref()
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -1,0 +1,66 @@
+//! Pre-commit validation of delta actions staged on a [`Transaction`].
+//!
+//! [`Transaction`]: super::Transaction
+
+mod addfile;
+
+use crate::engine_data::{GetData, RowVisitor};
+use crate::expressions::ColumnName;
+use crate::schema::{ColumnNamesAndTypes, DataType};
+use crate::{DeltaResult, EngineData};
+
+/// A single row-level validation.
+pub(crate) trait Validation {
+    fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()>;
+}
+
+/// Runs a set of [`Validation`]s over staged action batches in a single `visit_rows` pass.
+///
+/// `columns_types` is the shared column set for all validations; every [`Validation`] sees
+/// the full getter list and reads the columns it needs.
+// TODO(#2869): Add the remaining write-side validations:
+// - No missing partition columns in `txn.add_files_metadata`
+// - Required fields for `txn.remove_files_metadata`
+// - Required fields for `txn.dv_matched_files`
+// - No missing partition columns in `txn.dv_matched_files`
+// - No duplicate (path, DvId) in `txn.add_files_metadata`, `txn.remove_files_metadata`,
+//   `txn.dv_matched_files`
+// - AppendOnly table can not have `removeFile` with dataChange = true
+pub(crate) struct ActionValidator {
+    columns_types: &'static ColumnNamesAndTypes,
+    validations: Vec<Box<dyn Validation>>,
+}
+
+impl ActionValidator {
+    pub(crate) fn new(
+        columns_types: &'static ColumnNamesAndTypes,
+        validations: Vec<Box<dyn Validation>>,
+    ) -> Self {
+        Self {
+            columns_types,
+            validations,
+        }
+    }
+
+    pub(crate) fn validate(mut self, batches: &[Box<dyn EngineData>]) -> DeltaResult<()> {
+        for batch in batches {
+            self.visit_rows_of(batch.as_ref())?;
+        }
+        Ok(())
+    }
+}
+
+impl RowVisitor for ActionValidator {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        self.columns_types.as_ref()
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for row in 0..row_count {
+            for validation in &mut self.validations {
+                validation.validate_row(row, getters)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -1,4 +1,4 @@
-//! Pre-commit validation of delta actions staged on a [`Transaction`].
+//! Pre-commit validation of data staged on a [`Transaction`].
 //!
 //! [`Transaction`]: super::Transaction
 
@@ -14,11 +14,12 @@ pub(crate) trait Validation {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()>;
 }
 
-/// Runs a set of [`Validation`]s over staged-data batches. One [`StagedDataValidator`] per staged-data 
-/// schema(e.g. staged add files, staged remove files, staged dv-matched files).
+/// Runs a set of [`Validation`]s over staged-data batches. One [`StagedDataValidator`] per
+/// staged-data schema, i.e. one each for the `Transaction`'s `add_files_metadata`,
+/// `remove_files_metadata`, and `dv_matched_files`.
 ///
-/// `column_types` is the shared set of column names and types for one staged-data schema; every
-/// [`Validation`] sees the full getter list and reads the columns it needs.
+/// `columns_and_types` is the shared set of column names and types for one staged-data schema;
+/// every [`Validation`] sees the full getter list and reads the columns it needs.
 // TODO(#2869): Add the remaining write-side validations:
 // - No missing partition columns in `txn.add_files_metadata`
 // - Required fields for `txn.remove_files_metadata`
@@ -28,17 +29,17 @@ pub(crate) trait Validation {
 //   `txn.dv_matched_files`
 // - AppendOnly table can not have `removeFile` with dataChange = true
 pub(crate) struct StagedDataValidator {
-    column_types: &'static ColumnNamesAndTypes,
+    columns_and_types: &'static ColumnNamesAndTypes,
     validations: Vec<Box<dyn Validation>>,
 }
 
 impl StagedDataValidator {
     pub(crate) fn new(
-        column_types: &'static ColumnNamesAndTypes,
+        columns_and_types: &'static ColumnNamesAndTypes,
         validations: Vec<Box<dyn Validation>>,
     ) -> Self {
         Self {
-            column_types,
+            columns_and_types,
             validations,
         }
     }
@@ -54,7 +55,7 @@ impl StagedDataValidator {
 
 impl RowVisitor for StagedDataValidator {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
-        self.column_types.as_ref()
+        self.columns_and_types.as_ref()
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -2,6 +2,15 @@
 //!
 //! [`Transaction`]: super::Transaction
 
+// TODO(#2869): Add the remaining write-side validations:
+// - No missing partition columns in `txn.add_files_metadata`
+// - Required fields for `txn.remove_files_metadata`
+// - Required fields for `txn.dv_matched_files`
+// - No missing partition columns in `txn.dv_matched_files`
+// - No duplicate (path, DvId) in `txn.add_files_metadata`, `txn.remove_files_metadata`,
+//   `txn.dv_matched_files`
+// - AppendOnly table can not have `removeFile` with dataChange = true
+
 mod addfile;
 
 use crate::engine_data::{GetData, RowVisitor};
@@ -20,14 +29,6 @@ pub(crate) trait Validation {
 ///
 /// `columns_and_types` is the shared set of column names and types for one staged-data schema;
 /// every [`Validation`] sees the full getter list and reads the columns it needs.
-// TODO(#2869): Add the remaining write-side validations:
-// - No missing partition columns in `txn.add_files_metadata`
-// - Required fields for `txn.remove_files_metadata`
-// - Required fields for `txn.dv_matched_files`
-// - No missing partition columns in `txn.dv_matched_files`
-// - No duplicate (path, DvId) in `txn.add_files_metadata`, `txn.remove_files_metadata`,
-//   `txn.dv_matched_files`
-// - AppendOnly table can not have `removeFile` with dataChange = true
 pub(crate) struct StagedDataValidator {
     columns_and_types: &'static ColumnNamesAndTypes,
     validations: Vec<Box<dyn Validation>>,

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -236,7 +236,11 @@ pub(crate) mod test_utils {
     use crate::actions::{
         get_all_actions_schema, Add, Cdc, CommitInfo, Metadata, Protocol, Remove,
     };
-    use crate::arrow::array::{RecordBatch, StringArray, StructArray};
+    use crate::arrow::array::{
+        new_empty_array, new_null_array, ArrayRef, Int64Array, MapArray, RecordBatch, StringArray,
+        StructArray,
+    };
+    use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use crate::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
     use crate::committer::FileSystemCommitter;
     use crate::engine::arrow_conversion::{parquet_field_id_metadata, TryIntoArrow as _};
@@ -250,7 +254,7 @@ pub(crate) mod test_utils {
     use crate::path::ParsedLogPath;
     use crate::table_features::ColumnMappingMode;
     use crate::transaction::create_table::create_table;
-    use crate::transaction::{CreateTable, Transaction};
+    use crate::transaction::{CreateTable, Transaction, BASE_ADD_FILES_SCHEMA};
     use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, Snapshot, SnapshotRef};
 
     /// Parses `path` (a full URL string) into a [`ParsedLogPath`] with zero size, for building
@@ -379,6 +383,48 @@ pub(crate) mod test_utils {
     /// comparing
     pub(crate) fn assert_batch_matches(actual: Box<dyn EngineData>, expected: Box<dyn EngineData>) {
         assert_eq!(into_record_batch(actual), into_record_batch(expected));
+    }
+
+    /// Build an addFile with all required fields populated.
+    ///
+    /// When `all_nullable` is true, every field is marked nullable.
+    pub(crate) fn valid_add_file_batch(all_nullable: bool) -> RecordBatch {
+        let schema = if all_nullable {
+            let fields = BASE_ADD_FILES_SCHEMA
+                .fields()
+                .map(|f| StructField::nullable(f.name().clone(), f.data_type().clone()));
+            StructType::try_new(fields).expect("nullable add-file schema")
+        } else {
+            BASE_ADD_FILES_SCHEMA.as_ref().clone()
+        };
+        let arrow_schema: ArrowSchema = (&schema).try_into_arrow().expect("arrow schema");
+        let columns: Vec<ArrayRef> = arrow_schema
+            .fields()
+            .iter()
+            .map(|field| match field.name().as_str() {
+                "path" => Arc::new(StringArray::from(vec!["dummy"])) as ArrayRef,
+                "size" | "modificationTime" => Arc::new(Int64Array::from(vec![1i64])) as ArrayRef,
+                "partitionValues" => {
+                    let DataType::Map(entries_field, sorted) = field.data_type() else {
+                        panic!("partitionValues must be a map type");
+                    };
+                    let entries = new_empty_array(entries_field.data_type())
+                        .as_any()
+                        .downcast_ref::<StructArray>()
+                        .expect("map entries struct")
+                        .clone();
+                    // One row, empty partition map.
+                    let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 0]));
+                    Arc::new(
+                        MapArray::try_new(entries_field.clone(), offsets, entries, None, *sorted)
+                            .expect("empty map array"),
+                    )
+                }
+                // Non-mandatory fields (e.g. `stats`) are left null.
+                _ => new_null_array(field.data_type(), 1),
+            })
+            .collect();
+        RecordBatch::try_new(Arc::new(arrow_schema), columns).expect("valid add-file batch")
     }
 
     pub(crate) fn string_array_to_engine_data(string_array: StringArray) -> Box<dyn EngineData> {

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -228,7 +228,7 @@ pub(crate) mod test_utils {
     use itertools::Itertools;
     use serde::Serialize;
     use tempfile::TempDir;
-    use test_utils::{delta_path_for_version, load_test_data};
+    use test_utils::{copy_directory, delta_path_for_version, load_test_data};
     use tracing::subscriber::DefaultGuard;
     use tracing_subscriber::util::SubscriberInitExt as _;
     use url::Url;
@@ -1102,6 +1102,35 @@ pub(crate) mod test_utils {
         }
     }
 
+    fn resolve_test_table_path(table_name: &str) -> DeltaResult<(PathBuf, Option<TempDir>)> {
+        match load_test_data("tests/data", table_name) {
+            Ok(test_dir) => {
+                let test_path = test_dir.path().join(table_name);
+                Ok((test_path, Some(test_dir)))
+            }
+            Err(_) => {
+                let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests/data")
+                    .join(table_name);
+                let path = std::fs::canonicalize(path)
+                    .map_err(|e| Error::generic(format!("Failed to canonicalize path: {e}")))?;
+                Ok((path, None))
+            }
+        }
+    }
+
+    /// Copies a test-table fixture into a writable temporary directory.
+    pub(crate) fn copy_test_table(table_name: &str) -> DeltaResult<(Url, TempDir)> {
+        let (source, _source_tempdir) = resolve_test_table_path(table_name)?;
+        let tempdir = tempfile::tempdir()?;
+        let table_path = tempdir.path().join(table_name);
+        copy_directory(&source, &table_path)
+            .map_err(|e| Error::generic(format!("Failed to copy test table: {e}")))?;
+        let url = Url::from_directory_path(&table_path)
+            .map_err(|_| Error::generic("Failed to create URL from path"))?;
+        Ok((url, tempdir))
+    }
+
     /// Load a test table from tests/data directory.
     /// Tries compressed (tar.zst) first, falls back to extracted.
     /// Returns (engine, snapshot, optional tempdir). The TempDir must be kept alive
@@ -1109,27 +1138,10 @@ pub(crate) mod test_utils {
     pub(crate) fn load_test_table(
         table_name: &str,
     ) -> DeltaResult<(Arc<dyn Engine>, SnapshotRef, Option<TempDir>)> {
-        // Try loading compressed table first, fall back to extracted
-        let (path, tempdir) = match load_test_data("tests/data", table_name) {
-            Ok(test_dir) => {
-                let test_path = test_dir.path().join(table_name);
-                (test_path, Some(test_dir))
-            }
-            Err(_) => {
-                // Fall back to already-extracted table
-                let manifest_dir = env!("CARGO_MANIFEST_DIR");
-                let mut path = PathBuf::from(manifest_dir);
-                path.push("tests/data");
-                path.push(table_name);
-                let path = std::fs::canonicalize(path)
-                    .map_err(|e| Error::Generic(format!("Failed to canonicalize path: {e}")))?;
-                (path, None)
-            }
-        };
+        let (path, tempdir) = resolve_test_table_path(table_name)?;
 
-        // Create engine and snapshot from the resolved path
         let url = Url::from_directory_path(&path)
-            .map_err(|_| Error::Generic("Failed to create URL from path".to_string()))?;
+            .map_err(|_| Error::generic("Failed to create URL from path"))?;
 
         let engine = Arc::new(SyncEngine::new());
         let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -388,7 +388,7 @@ pub(crate) mod test_utils {
     /// Build an addFile with all required fields populated.
     ///
     /// When `all_nullable` is true, every field is marked nullable.
-    pub(crate) fn valid_add_file_batch(all_nullable: bool) -> RecordBatch {
+    pub(crate) fn create_valid_add_file_batch(all_nullable: bool) -> RecordBatch {
         let schema = if all_nullable {
             let fields = BASE_ADD_FILES_SCHEMA
                 .fields()

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -385,9 +385,11 @@ pub(crate) mod test_utils {
         assert_eq!(into_record_batch(actual), into_record_batch(expected));
     }
 
-    /// Build an addFile with all required fields populated.
+    /// Helper for building valid add-file batches.
     ///
-    /// When `all_nullable` is true, every field is marked nullable.
+    /// Tests can generate add-file metadata without writing a Parquet file using this helper. All
+    /// required fields are populated. When `all_nullable` is true, every field in the batch
+    /// schema is nullable.
     pub(crate) fn create_valid_add_file_batch(all_nullable: bool) -> RecordBatch {
         let schema = if all_nullable {
             let fields = BASE_ADD_FILES_SCHEMA

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -375,7 +375,6 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
-/// A commit is rejected when a staged `add` action is missing a required field.
 #[tokio::test]
 async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -420,10 +420,12 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
         let corrupted = RecordBatch::try_new(nullable_schema, columns)?;
         txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
 
-        let err = match txn.commit(engine.as_ref()) {
-            Err(e) => e.to_string(),
-            Ok(_) => panic!("commit should reject an add missing required field '{field}'"),
-        };
+        let err = txn
+            .commit(engine.as_ref())
+            .expect_err(&format!(
+                "commit should reject an add missing required field '{field}'"
+            ))
+            .to_string();
         assert!(
             err.contains(&format!("missing required field '{field}'")),
             "field {field}: unexpected error {err:?}"

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -4,7 +4,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{Int32Array, StringArray};
+use delta_kernel::arrow::array::{new_null_array, Int32Array, StringArray};
+use delta_kernel::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
@@ -16,7 +17,9 @@ use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::{DeltaResult, Error as KernelError};
 use itertools::Itertools;
 use serde_json::{json, Deserializer};
-use test_utils::{load_and_begin_transaction, set_json_value, setup_test_tables, test_read};
+use test_utils::{
+    into_record_batch, load_and_begin_transaction, set_json_value, setup_test_tables, test_read,
+};
 
 use crate::common::write_utils::{
     check_action_timestamps, get_and_check_all_parquet_sizes, get_simple_int_schema,
@@ -368,6 +371,63 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
                 true,
             _ => false,
         }));
+    }
+    Ok(())
+}
+
+/// A commit is rejected when a staged `add` action is missing a required field.
+#[tokio::test]
+async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let schema = get_simple_int_schema();
+
+    for field in ["path", "partitionValues", "size", "modificationTime"] {
+        let (table_url, engine, _store, _table_name) =
+            setup_test_tables(schema.clone(), &[], None, "required_field_table")
+                .await?
+                .into_iter()
+                .next()
+                .expect("at least one test table");
+        let engine = Arc::new(engine);
+        let mut txn =
+            load_and_begin_transaction(table_url, engine.as_ref())?.with_data_change(true);
+
+        // Produce valid `add` metadata, then null one required column so the commit must reject it.
+        let data = RecordBatch::try_new(
+            Arc::new(schema.as_ref().try_into_arrow()?),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        let write_context = Arc::new(txn.unpartitioned_write_context()?);
+        let meta = engine
+            .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
+            .await?;
+
+        let batch = into_record_batch(meta);
+        let index = batch.schema().index_of(field)?;
+
+        // The add-metadata schema declares these fields non-nullable, so rebuild the schema with
+        // the target field made nullable before inserting a null column.
+        let mut fields: Vec<ArrowField> = batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.as_ref().clone())
+            .collect();
+        fields[index] = fields[index].clone().with_nullable(true);
+        let nullable_schema = Arc::new(ArrowSchema::new(fields));
+        let mut columns = batch.columns().to_vec();
+        columns[index] = new_null_array(nullable_schema.field(index).data_type(), batch.num_rows());
+        let corrupted = RecordBatch::try_new(nullable_schema, columns)?;
+        txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
+
+        let err = match txn.commit(engine.as_ref()) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("commit should reject an add missing required field '{field}'"),
+        };
+        assert!(
+            err.contains(&format!("missing required field '{field}'")),
+            "field {field}: unexpected error {err:?}"
+        );
     }
     Ok(())
 }

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -391,17 +391,18 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
         let mut txn =
             load_and_begin_transaction(table_url, engine.as_ref())?.with_data_change(true);
 
-        // Produce valid `add` metadata, then null one required column so the commit must reject it.
-        let data = RecordBatch::try_new(
+        let data = ArrowEngineData::new(RecordBatch::try_new(
             Arc::new(schema.as_ref().try_into_arrow()?),
             vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-        )?;
+        )?);
         let write_context = Arc::new(txn.unpartitioned_write_context()?);
-        let meta = engine
-            .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
-            .await?;
 
-        let batch = into_record_batch(meta);
+        // Corrupt the addFile at the second batch.
+        let valid_meta = engine.write_parquet(&data, write_context.as_ref()).await?;
+        txn.add_files(valid_meta);
+        let to_be_corrupted_meta = engine.write_parquet(&data, write_context.as_ref()).await?;
+
+        let batch = into_record_batch(to_be_corrupted_meta);
         let index = batch.schema().index_of(field)?;
 
         // The add-metadata schema declares these fields non-nullable, so rebuild the schema with


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2856/files) to review incremental changes.
- [**stack/validate-require-field**](https://github.com/delta-io/delta-kernel-rs/pull/2856) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2856/files)] ← _this PR_
  - [stack/addFile-part-val](https://github.com/delta-io/delta-kernel-rs/pull/2939) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2939/files/b67125096645c650c7bcd913c4dba3dfd7041004..3c4c4d497a0b6f057bd4a362d24d12079d05d3c3)]
  - [stack/validate-required-field-removeFile](https://github.com/delta-io/delta-kernel-rs/pull/2974) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2974/files/b67125096645c650c7bcd913c4dba3dfd7041004..b1f5b7a48477f58c53a249f9b18917682f5e830a)]

---------
## What changes are proposed in this pull request?

- Added an abstraction for action validations
- Added validation for required addFile fields at commit time

## How was this change tested?

Unit tests and integration tests covers all the 4 required fields

Perf bench(TL;DR is no perf impact):

Local FS:

| N | baseline | required addFile fields validation |
|---|---:|---:|
| 1 | 298 µs | ~0 |
| 10 | 327 µs | +8 µs |
| 100 | 454 µs | ~0 |
| 1,000 | 1.96 ms | +0.01 ms |
| 100,000 | 199.2 ms | +1.4 ms |

S3 (middle of three fresh-process Criterion mean estimates):

| N | validate_off | required addFile fields validation |
|---|---:|---:|
| 1 | 32.7 ms | 32.2 ms |
| 10 | 31.1 ms | 36.2 ms |
| 100 | 34.2 ms | 35.8 ms |
| 1,000 | 74.4 ms | 73.7 ms |
| 10,000 | 135.6 ms | 137.7 ms |
