### PR TITLE
fix!: resolve V1/V2 checkpoints by read intent and v2Checkpoint support

### DIFF
--- a/kernel/examples/inspect-table/src/main.rs
+++ b/kernel/examples/inspect-table/src/main.rs
@@ -14,6 +14,7 @@ use delta_kernel::actions::{
 };
 use delta_kernel::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use delta_kernel::expressions::ColumnName;
+use delta_kernel::log_segment::CheckpointReadIntent;
 use delta_kernel::metrics::{LoggingMetricsReporter, WithMetricsReporterLayer};
 use delta_kernel::scan::state::ScanFile;
 use delta_kernel::scan::ScanBuilder;
@@ -222,9 +223,12 @@ fn try_main() -> DeltaResult<()> {
         }
         Commands::Actions { oldest_first } => {
             let actions_schema = get_all_actions_schema();
-            let actions = snapshot
-                .log_segment()
-                .read_actions(&engine, actions_schema.clone())?;
+            let is_v2_supported = snapshot.table_configuration().supports_v2_checkpoint();
+            let actions = snapshot.log_segment().read_actions(
+                &engine,
+                actions_schema.clone(),
+                CheckpointReadIntent::FileActions { is_v2_supported },
+            )?;
 
             let mut visitor = LogVisitor::new();
             for action in actions {

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -2,7 +2,7 @@ pub(crate) use crate::actions::visitors::SetTransactionMap;
 use crate::actions::visitors::SetTransactionVisitor;
 use crate::actions::{SetTransaction, LOG_TXN_SCHEMA};
 use crate::log_replay::ActionsBatch;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{CheckpointReadIntent, LogSegment};
 use crate::{DeltaResult, Engine, RowVisitor as _};
 
 /// Returns `true` if a set transaction is expired according to the given expiration and
@@ -86,7 +86,11 @@ fn replay_for_app_ids(
     log_segment: &LogSegment,
     engine: &dyn Engine,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-    log_segment.read_actions(engine, LOG_TXN_SCHEMA.clone())
+    log_segment.read_actions(
+        engine,
+        LOG_TXN_SCHEMA.clone(),
+        CheckpointReadIntent::NonFileActions,
+    )
 }
 
 #[cfg(test)]

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -120,6 +120,7 @@ use crate::expressions::{
 };
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
+use crate::log_segment::CheckpointReadIntent;
 use crate::path::{self, ParsedLogPath};
 use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
@@ -468,11 +469,14 @@ impl CheckpointWriter {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<ActionReconciliationIterator> {
-        // Read actions from log segment
-        let actions = self
-            .snapshot
-            .log_segment()
-            .read_actions(engine, self.read_schema.clone())?;
+        // Read actions from log segment. The checkpoint read schema includes file actions, so a
+        // V2 source table's sidecars must be resolved.
+        let is_v2_supported = self.snapshot.table_configuration().supports_v2_checkpoint();
+        let actions = self.snapshot.log_segment().read_actions(
+            engine,
+            self.read_schema.clone(),
+            CheckpointReadIntent::FileActions { is_v2_supported },
+        )?;
 
         // Process actions through reconciliation
         let checkpoint_data = ActionReconciliationProcessor::new(

--- a/kernel/src/log_compaction/writer.rs
+++ b/kernel/src/log_compaction/writer.rs
@@ -7,7 +7,7 @@ use super::COMPACTION_ACTIONS_SCHEMA;
 use crate::action_reconciliation::log_replay::ActionReconciliationProcessor;
 use crate::action_reconciliation::{ActionReconciliationIterator, RetentionCalculator};
 use crate::log_replay::LogReplayProcessor;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{CheckpointReadIntent, LogSegment};
 use crate::path::ParsedLogPath;
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, Error, SnapshotRef, Version};
@@ -117,9 +117,14 @@ impl LogCompactionWriter {
             Some(self.end_version),
         )?;
 
-        // Read actions from the version-filtered log segment
-        let actions_iter =
-            compaction_log_segment.read_actions(engine, COMPACTION_ACTIONS_SCHEMA.clone())?;
+        // Read actions from the version-filtered log segment. Compaction reads file actions, so a
+        // V2 table's sidecars must be resolved.
+        let is_v2_supported = self.snapshot.table_configuration().supports_v2_checkpoint();
+        let actions_iter = compaction_log_segment.read_actions(
+            engine,
+            COMPACTION_ACTIONS_SCHEMA.clone(),
+            CheckpointReadIntent::FileActions { is_v2_supported },
+        )?;
 
         let min_file_retention_timestamp_millis = self.deleted_file_retention_timestamp()?;
 

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use tracing::instrument;
 
-use super::LogSegment;
+use super::{CheckpointReadIntent, LogSegment};
 use crate::actions::visitors::DomainMetadataVisitor;
 use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA};
 use crate::log_replay::ActionsBatch;
@@ -54,7 +54,11 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-        self.read_actions(engine, LOG_DOMAIN_METADATA_SCHEMA.clone())
+        self.read_actions(
+            engine,
+            LOG_DOMAIN_METADATA_SCHEMA.clone(),
+            CheckpointReadIntent::NonFileActions,
+        )
     }
 }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -153,6 +153,21 @@ fn schema_to_is_not_null_predicate(schema: &StructType) -> Option<PredicateRef> 
     Some(Arc::new(predicates.fold(first, Predicate::or)))
 }
 
+/// Which category of actions a checkpoint read needs from a [`LogSegment`].
+///
+/// File actions (add/remove) may live in sidecar files on V2 checkpoints, while non-file actions
+/// only ever live in the top-level checkpoint. The read path uses this to decide whether sidecars
+/// must be resolved.
+#[derive(Debug, Clone, Copy)]
+#[internal_api]
+pub(crate) enum CheckpointReadIntent {
+    /// Reads only non-file actions (protocol, metaData, txn, domainMetadata).
+    NonFileActions,
+    /// Reads file actions (add/remove). `is_v2_supported` is whether the table supports the
+    /// `v2Checkpoint` feature; when it does, a parquet checkpoint may be V2 and carry sidecars.
+    FileActions { is_v2_supported: bool },
+}
+
 impl LogSegment {
     /// Creates a LogSegment for a newly created table at version 0 from a single commit file.
     ///
@@ -702,6 +717,7 @@ impl LogSegment {
     /// IS NOT NULL predicates are automatically derived from `checkpoint_read_schema` and combined
     /// (AND) with `meta_predicate`, so callers only need to supply query-based skipping predicates.
     #[internal_api]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn read_actions_with_projected_checkpoint_actions(
         &self,
         engine: &dyn Engine,
@@ -710,6 +726,7 @@ impl LogSegment {
         meta_predicate: Option<PredicateRef>,
         stats_schema: Option<&StructType>,
         partition_schema: Option<&StructType>,
+        intent: CheckpointReadIntent,
     ) -> DeltaResult<
         ActionsWithCheckpointInfo<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send>,
     > {
@@ -732,6 +749,7 @@ impl LogSegment {
             effective_predicate,
             stats_schema,
             partition_schema,
+            intent,
         )?;
 
         Ok(ActionsWithCheckpointInfo {
@@ -748,6 +766,7 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
         action_schema: SchemaRef,
+        intent: CheckpointReadIntent,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
         let result = self.read_actions_with_projected_checkpoint_actions(
             engine,
@@ -756,6 +775,7 @@ impl LogSegment {
             None,
             None,
             None,
+            intent,
         )?;
         Ok(result.actions)
     }
@@ -820,6 +840,7 @@ impl LogSegment {
     fn get_file_actions_schema_and_sidecars(
         &self,
         engine: &dyn Engine,
+        is_v2_supported: bool,
     ) -> DeltaResult<(Option<SchemaRef>, Vec<FileMeta>)> {
         // Hint schema from `_last_checkpoint` avoids footer reads when available.
         let hint_schema = self.checkpoint_schema();
@@ -832,9 +853,10 @@ impl LogSegment {
 
         match &checkpoint.file_type {
             MultiPartCheckpoint { .. } => {
-                // Multi-part checkpoints are always V1 and never have sidecars.
+                // Multi-part checkpoints are always V1 and never have sidecars, so the hint is
+                // trusted regardless of `is_v2_supported`.
                 let schema =
-                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema.as_ref())?;
+                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema.as_ref(), false)?;
                 Ok((Some(schema), vec![]))
             }
             UuidCheckpoint if checkpoint.extension.as_str() == "json" => {
@@ -844,9 +866,15 @@ impl LogSegment {
             }
             SinglePartCheckpoint | UuidCheckpoint if checkpoint.extension.as_str() == "parquet" => {
                 // Parquet checkpoint (classic-named or UUID-named): either can be V1 or V2.
-                // Check for sidecar column to distinguish.
-                let checkpoint_schema =
-                    Self::read_checkpoint_schema(engine, checkpoint, hint_schema.as_ref())?;
+                // Distinguish by the sidecar column; when the table could be V2 the hint is
+                // trusted only if it proves V2, else the footer is read (see
+                // `read_checkpoint_schema`).
+                let checkpoint_schema = Self::read_checkpoint_schema(
+                    engine,
+                    checkpoint,
+                    hint_schema.as_ref(),
+                    is_v2_supported,
+                )?;
                 if checkpoint_schema.field(SIDECAR_NAME).is_some() {
                     self.read_sidecar_schema_and_files(engine, checkpoint, Some(&checkpoint_schema))
                 } else {
@@ -857,16 +885,26 @@ impl LogSegment {
         }
     }
 
-    /// Returns the checkpoint's parquet schema, using the hint from `_last_checkpoint` if
-    /// available or reading the parquet footer otherwise.
+    /// Returns the checkpoint's parquet schema, from the `_last_checkpoint` hint when it is safe to
+    /// trust or from the parquet footer otherwise. When the table could hold a V2 checkpoint
+    /// (`is_v2_supported`), the hint is trusted only if it already has a `sidecar` column, since a
+    /// hint that omits `sidecar` cannot rule out a V2 checkpoint whose `checkpointSchema` was
+    /// written without it. A checkpoint that can only be V1 (`is_v2_supported` false) trusts the
+    /// hint whenever present.
     fn read_checkpoint_schema(
         engine: &dyn Engine,
         checkpoint: &ParsedLogPath<FileMeta>,
         hint_schema: Option<&SchemaRef>,
+        is_v2_supported: bool,
     ) -> DeltaResult<SchemaRef> {
         match hint_schema {
-            Some(schema) => Ok(schema.clone()),
-            None => Ok(engine
+            // Trust the hint: always for V1-only checkpoints, or for possibly-V2 ones that already
+            // show a `sidecar` column.
+            Some(hint) if !is_v2_supported || hint.field(SIDECAR_NAME).is_some() => {
+                Ok(hint.clone())
+            }
+            // No hint, or a possibly-V2 hint without `sidecar`: read the footer to decide.
+            _ => Ok(engine
                 .parquet_handler()
                 .read_parquet_footer(&checkpoint.location)?
                 .schema),
@@ -905,15 +943,23 @@ impl LogSegment {
         meta_predicate: Option<PredicateRef>,
         stats_schema: Option<&StructType>,
         partition_schema: Option<&StructType>,
+        intent: CheckpointReadIntent,
     ) -> DeltaResult<
         ActionsWithCheckpointInfo<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send>,
     > {
-        let need_file_actions = schema_contains_file_actions(&action_schema);
+        // The intent must agree with the projected schema: only file-action reads request the
+        // add/remove columns that sidecars carry.
+        debug_assert_eq!(
+            matches!(intent, CheckpointReadIntent::FileActions { .. }),
+            schema_contains_file_actions(&action_schema),
+            "checkpoint read intent must match the projected schema's file-action columns",
+        );
 
-        let (file_actions_schema, sidecar_files) = if need_file_actions {
-            self.get_file_actions_schema_and_sidecars(engine)?
-        } else {
-            (None, vec![])
+        let (file_actions_schema, sidecar_files) = match intent {
+            CheckpointReadIntent::FileActions { is_v2_supported } => {
+                self.get_file_actions_schema_and_sidecars(engine, is_v2_supported)?
+            }
+            CheckpointReadIntent::NonFileActions => (None, vec![]),
         };
 
         // Check if checkpoint has compatible stats_parsed and add it to the schema if so
@@ -929,8 +975,9 @@ impl LogSegment {
             .is_some_and(|(ps, fs)| Self::schema_has_compatible_partition_values_parsed(fs, ps));
 
         // Build final schema with any additional fields needed
-        // (stats_parsed, partitionValues_parsed, sidecar)
-        let needs_sidecar = need_file_actions && !sidecar_files.is_empty();
+        // (stats_parsed, partitionValues_parsed, sidecar). Sidecars are only resolved for
+        // file-action reads, so a non-empty `sidecar_files` already implies that intent.
+        let needs_sidecar = !sidecar_files.is_empty();
         let needs_add_augmentation = has_stats_parsed || has_partition_values_parsed;
         let augmented_checkpoint_read_schema = if needs_add_augmentation || needs_sidecar {
             let mut new_fields: Vec<StructField> = if let (true, Some(add_field)) =

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use tracing::{info, instrument};
 
-use super::LogSegment;
+use super::{CheckpointReadIntent, LogSegment};
 use crate::actions::{Metadata, Protocol, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
@@ -128,7 +128,7 @@ impl LogSegment {
             (&PROTOCOL_FIELD),
             (&METADATA_FIELD),
         };
-        self.read_actions(engine, schema)
+        self.read_actions(engine, schema, CheckpointReadIntent::NonFileActions)
     }
 }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1217,6 +1217,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
         None, // meta_predicate
         None, // stats_schema
         None, // partition_schema
+        CheckpointReadIntent::NonFileActions,
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1290,6 +1291,9 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
         None, // meta_predicate
         None, // stats_schema
         None, // partition_schema
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1355,6 +1359,9 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
         None, // meta_predicate
         None, // stats_schema
         None, // partition_schema
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1408,6 +1415,9 @@ async fn test_create_checkpoint_stream_reads_json_checkpoint_batch_without_sidec
         None, // meta_predicate
         None, // stats_schema
         None, // partition_schema
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1500,6 +1510,9 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
         None, // meta_predicate
         None, // stats_schema
         None, // partition_schema
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
     let mut iter = checkpoint_result.actions;
 
@@ -1544,6 +1557,188 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
     );
 
     assert!(iter.next().is_none());
+
+    Ok(())
+}
+
+/// A `_last_checkpoint` hint whose schema omits `sidecar` must not make a V2 checkpoint read as V1.
+#[tokio::test]
+async fn test_v2_checkpoint_not_read_as_v1_when_hint_omits_sidecar() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    let sidecar1_size = add_sidecar_to_store(
+        &store,
+        add_batch_simple(get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?),
+        "sidecarfile1.parquet",
+    )
+    .await?
+    .size;
+    let sidecar2_size = add_sidecar_to_store(
+        &store,
+        add_batch_with_remove(get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?),
+        "sidecarfile2.parquet",
+    )
+    .await?
+    .size;
+
+    add_checkpoint_to_store(
+        &store,
+        sidecar_batch_with_given_paths_and_sizes(
+            vec![
+                ("sidecarfile1.parquet", sidecar1_size),
+                ("sidecarfile2.parquet", sidecar2_size),
+            ],
+            get_all_actions_schema().clone(),
+        ),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_file_path = log_root
+        .join("00000000000000000001.checkpoint.parquet")?
+        .to_string();
+    let checkpoint_size =
+        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+    let v2_checkpoint_read_schema = get_all_actions_schema().project(&[ADD_NAME, SIDECAR_NAME])?;
+
+    // Hint at the checkpoint's version whose schema omits `sidecar`. Before the fix this makes the
+    // V2 checkpoint read as V1 and silently drops the sidecar file actions.
+    let sidecar_less_hint = LastCheckpointHintSummary {
+        version: 1,
+        schema: Some(get_all_actions_schema().project(&[ADD_NAME, REMOVE_NAME])?),
+    };
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(
+                &checkpoint_file_path,
+                checkpoint_size,
+            )],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(sidecar_less_hint),
+    )?;
+    let checkpoint_result = log_segment.create_checkpoint_stream(
+        &engine,
+        v2_checkpoint_read_schema.clone(),
+        None,
+        None,
+        None,
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
+    )?;
+    let mut iter = checkpoint_result.actions;
+
+    // The sidecar files must still be read: V2 is detected from the footer despite the hint.
+    let ActionsBatch {
+        actions: first_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
+    assert!(!is_log_batch);
+    assert_batch_matches(
+        first_batch,
+        sidecar_batch_with_given_paths_and_sizes(
+            vec![
+                ("sidecarfile1.parquet", sidecar1_size),
+                ("sidecarfile2.parquet", sidecar2_size),
+            ],
+            get_all_actions_schema().project(&[ADD_NAME, SIDECAR_NAME])?,
+        ),
+    );
+    let ActionsBatch {
+        actions: second_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
+    assert!(!is_log_batch);
+    assert_batch_matches(
+        second_batch,
+        add_batch_simple(v2_checkpoint_read_schema.clone()),
+    );
+    let ActionsBatch {
+        actions: third_batch,
+        is_log_batch,
+    } = iter.next().unwrap()?;
+    assert!(!is_log_batch);
+    assert_batch_matches(
+        third_batch,
+        add_batch_with_remove(v2_checkpoint_read_schema),
+    );
+
+    assert!(iter.next().is_none());
+
+    Ok(())
+}
+
+/// When the table cannot be V2 (`is_v2_supported` false), a classic parquet checkpoint trusts the
+/// `_last_checkpoint` schema hint and does not read the parquet footer. Uses a hint that omits
+/// `sidecar` over a file that does contain sidecar references: trusting the hint yields the V1
+/// path (no sidecars resolved); a stray footer read would instead surface the sidecar column and
+/// resolve sidecars, so the single top-level batch proves the footer was not read.
+#[tokio::test]
+async fn test_v1_checkpoint_trusts_hint_without_footer_read() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    add_checkpoint_to_store(
+        &store,
+        sidecar_batch_with_given_paths(vec!["sidecar1.parquet"], get_all_actions_schema().clone()),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_file_path = log_root
+        .join("00000000000000000001.checkpoint.parquet")?
+        .to_string();
+    let checkpoint_size =
+        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+
+    // Hint schema without a `sidecar` column. With `is_v2_supported: false` the hint is trusted, so
+    // the checkpoint is read as V1 and sidecars are never resolved.
+    let hint_schema = get_commit_schema().project(&[ADD_NAME])?;
+    let read_schema = get_commit_schema().project(&[ADD_NAME])?;
+    let v1_hint = LastCheckpointHintSummary {
+        version: 1,
+        schema: Some(hint_schema),
+    };
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(
+                &checkpoint_file_path,
+                checkpoint_size,
+            )],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(v1_hint),
+    )?;
+    let checkpoint_result = log_segment.create_checkpoint_stream(
+        &engine,
+        read_schema.clone(),
+        None,
+        None,
+        None,
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: false,
+        },
+    )?;
+    let mut iter = checkpoint_result.actions;
+
+    // Only the top-level checkpoint batch is returned; no sidecar batches, because the hint (which
+    // lacks `sidecar`) was trusted without reading the footer.
+    let ActionsBatch { is_log_batch, .. } = iter.next().unwrap()?;
+    assert!(!is_log_batch);
+    assert!(
+        iter.next().is_none(),
+        "sidecars must not be resolved when the V1 hint is trusted",
+    );
 
     Ok(())
 }
@@ -2702,15 +2897,21 @@ async fn test_checkpoint_schema_propagation_from_hint() {
     assert_eq!(log_segment.checkpoint_schema().unwrap(), sample_schema);
 }
 
-/// Checkpoint schema resolution uses the `_last_checkpoint` schema only when the hint's version
-/// matches [`LogSegment::checkpoint_version`]. Otherwise the parquet footer is read.
+/// `checkpoint_schema()` returns the `_last_checkpoint` hint only when the hint version matches
+/// [`LogSegment::checkpoint_version`]. `get_file_actions_schema_and_sidecars` for a single-file
+/// parquet checkpoint trusts a usable hint only when the table cannot be V2 (`is_v2_supported`
+/// false); when it could be V2, or the hint version does not match, it reads the footer.
+///
+/// Cases: (hint_version, is_v2_supported, expect_hint_schema_used_for_file_actions).
 #[rstest]
-#[case::hint_matches_checkpoint(1, true)]
-#[case::hint_newer_than_checkpoint(99, false)]
-#[case::hint_older_than_checkpoint(0, false)]
+#[case::v1_table_matching_hint(1, false, true)]
+#[case::v2_table_matching_hint(1, true, false)]
+#[case::v1_table_stale_newer_hint(99, false, false)]
+#[case::v1_table_stale_older_hint(0, false, false)]
 #[tokio::test]
 async fn test_get_file_actions_schema_v1_parquet_with_hint(
     #[case] hint_version: u64,
+    #[case] is_v2_supported: bool,
     #[case] expect_hint_schema_used: bool,
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
@@ -2729,6 +2930,9 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
     let checkpoint_file = log_root.join(checkpoint_rel)?.to_string();
     let cp_size = get_file_size(&store, &format!("_delta_log/{checkpoint_rel}")).await;
 
+    // A hint schema that differs from the checkpoint footer, so we can tell which one was used.
+    // It has no `sidecar` column, so only a V1 (`is_v2_supported` false) table with a matching hint
+    // version trusts it.
     let hint_schema: SchemaRef = schema_ref! {
         nullable "metadata": {},
     };
@@ -2736,6 +2940,7 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
     // Build a commit that uses v1 checkpoint and a hint that describes a different schema
     let commit_v2_path = log_root.join("00000000000000000002.json")?.to_string();
     let commit_v2 = create_log_path(&commit_v2_path);
+    let hint_version_matches = hint_version == 1;
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, cp_size)],
@@ -2751,10 +2956,10 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
         }),
     )?;
 
-    // Verify that checkpoint_schema only returns schema if it is valid
+    // `checkpoint_schema()` returns the hint only when the hint version matches the checkpoint.
     assert_eq!(log_segment.checkpoint_version, Some(1));
     assert_eq!(log_segment.end_version, 2);
-    if expect_hint_schema_used {
+    if hint_version_matches {
         assert_eq!(log_segment.checkpoint_schema().as_ref(), Some(&hint_schema));
     } else {
         assert!(
@@ -2763,16 +2968,20 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
         );
     }
 
-    // Verify that get_file_actions_schema_and_sidecars returns appropriate schema based on hint
-    // version
-    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
+    // The file-actions schema comes from the hint only when it is trusted (V1 table + matching
+    // hint version); otherwise it comes from the parquet footer.
+    let (schema, sidecars) =
+        log_segment.get_file_actions_schema_and_sidecars(&engine, is_v2_supported)?;
     let schema = schema.expect("V1 checkpoint should yield a file actions schema");
     if expect_hint_schema_used {
-        assert_eq!(schema, hint_schema, "should use hint when versions match");
+        assert_eq!(
+            schema, hint_schema,
+            "should trust the hint for a V1-only table"
+        );
     } else {
         assert_eq!(
             schema, v1_schema,
-            "should read schema from parquet footer when versions mismatch"
+            "should read the schema from the parquet footer"
         );
     }
     assert!(sidecars.is_empty(), "V1 checkpoint should have no sidecars");
@@ -2842,7 +3051,8 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
         }),
     )?;
 
-    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine)?;
+    // Multi-part checkpoints are always V1, so `is_v2_supported` is inert here.
+    let (schema, sidecars) = log_segment.get_file_actions_schema_and_sidecars(&engine, false)?;
     let schema = schema.expect("Multi-part V1 should return file actions schema");
 
     // Verify stats_parsed is detectable in the returned schema.
@@ -3566,6 +3776,9 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
         None, // meta_predicate
         None, // stats_schema
         Some(&partition_schema),
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
 
     // Verify that checkpoint_info reports partitionValues_parsed as available
@@ -3631,6 +3844,9 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
         None,
         None,
         Some(&partition_schema),
+        CheckpointReadIntent::FileActions {
+            is_v2_supported: true,
+        },
     )?;
 
     // Verify it's false
@@ -4341,7 +4557,13 @@ async fn read_actions_with_null_map_values(
     // Use all_actions_schema to cover sidecar and checkpointMetadata (checkpoint-only actions).
     let action_schema = get_all_actions_schema().clone();
     let action_batches = log_segment
-        .read_actions(&engine, action_schema)
+        .read_actions(
+            &engine,
+            action_schema,
+            CheckpointReadIntent::FileActions {
+                is_v2_supported: true,
+            },
+        )
         .expect("read_actions should succeed");
 
     // Iterate batches and verify the map value field is nullable.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -22,7 +22,9 @@ use crate::kernel_predicates::{
     DefaultKernelPredicateEvaluator, EmptyColumnResolver, KernelPredicateEvaluator as _,
 };
 use crate::log_replay::{ActionsBatch, HasSelectionVector};
-use crate::log_segment::{ActionsWithCheckpointInfo, CheckpointReadInfo, LogSegment};
+use crate::log_segment::{
+    ActionsWithCheckpointInfo, CheckpointReadInfo, CheckpointReadIntent, LogSegment,
+};
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::events::emit_scan_metadata_completed;
 use crate::metrics::{MetricId, ScanType};
@@ -893,6 +895,7 @@ impl Scan {
                 self.build_actions_meta_predicate(),
             )
         };
+        let is_v2_supported = self.snapshot.table_configuration().supports_v2_checkpoint();
         let result = new_log_segment.read_actions_with_projected_checkpoint_actions(
             engine,
             COMMIT_READ_SCHEMA.clone(),
@@ -903,6 +906,7 @@ impl Scan {
                 .as_ref()
                 .map(|s| s.as_ref()),
             None,
+            CheckpointReadIntent::FileActions { is_v2_supported },
         )?;
         let actions_with_checkpoint_info = ActionsWithCheckpointInfo {
             actions: result
@@ -976,6 +980,7 @@ impl Scan {
                 self.build_actions_meta_predicate(),
             )
         };
+        let is_v2_supported = self.snapshot.table_configuration().supports_v2_checkpoint();
         self.snapshot
             .log_segment()
             .read_actions_with_projected_checkpoint_actions(
@@ -991,6 +996,7 @@ impl Scan {
                     .physical_partition_schema
                     .as_ref()
                     .map(|s| s.as_ref()),
+                CheckpointReadIntent::FileActions { is_v2_supported },
             )
     }
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -519,6 +519,13 @@ impl TableConfiguration {
             || self.is_feature_supported(&TableFeature::CatalogOwnedPreview)
     }
 
+    /// Whether this table supports the `v2Checkpoint` feature, meaning a parquet checkpoint may be
+    /// a V2 checkpoint carrying sidecar files.
+    #[internal_api]
+    pub(crate) fn supports_v2_checkpoint(&self) -> bool {
+        self.is_feature_supported(&TableFeature::V2Checkpoint)
+    }
+
     /// The [`ColumnMappingMode`] for this table at this version.
     #[internal_api]
     pub(crate) fn column_mapping_mode(&self) -> ColumnMappingMode {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -186,6 +186,7 @@ use delta_kernel::committer::{
 use delta_kernel::engine::arrow_conversion::TryFromKernel;
 use delta_kernel::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
 use delta_kernel::expressions::Scalar;
+use delta_kernel::log_segment::CheckpointReadIntent;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path;
@@ -1381,7 +1382,12 @@ pub fn read_add_infos(
     engine: &impl Engine,
 ) -> Result<Vec<AddInfo>, Box<dyn std::error::Error>> {
     let schema = LOG_ADD_SCHEMA.clone();
-    let batches = snapshot.log_segment().read_actions(engine, schema)?;
+    let is_v2_supported = snapshot.table_configuration().supports_v2_checkpoint();
+    let batches = snapshot.log_segment().read_actions(
+        engine,
+        schema,
+        CheckpointReadIntent::FileActions { is_v2_supported },
+    )?;
     let mut actions = Vec::new();
     for batch_result in batches {
         let actions_batch = batch_result?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

When kernel loads a checkpoint, it decides whether a parquet checkpoint is V1 or V2 by looking for a top-level `sidecar` column in the checkpoint schema. It takes that schema from the `_last_checkpoint` hint (`checkpointSchema`) whenever the hint is present, and only reads the parquet footer when the hint is absent.

`checkpointSchema` is an optional, writer-provided field, so a hint can be present but incomplete. If a V2 checkpoint's hint omits the `sidecar` column, the checkpoint is treated as V1: the sidecar files under `_delta_log/_sidecars/` are never read, and their `add`/`remove` actions are silently dropped from log replay, giving an incomplete view of the table with no error surfaced.

This revises the earlier version of this PR, which read the footer for every ambiguous parquet checkpoint whose hint lacked `sidecar`. That penalized the common V1 case: since real V1 tables usually do have a `checkpointSchema` hint (just one without a `sidecar` column), they would lose the hint fast path and always read the footer.

Instead, gate the decision on the caller's read intent plus the table's protocol, mirroring how the reference engine resolves checkpoints (by the `v2Checkpoint` table feature, not the hint schema):

- Reads that project only non-file actions (protocol, metaData, txn, domainMetadata) never resolve sidecars, because those actions live in the top-level checkpoint, never in sidecars. These pass `CheckpointReadIntent::NonFileActions` and always trust the hint.
- Reads that project file actions (scan, incremental scan, log compaction, the checkpoint writer) pass `CheckpointReadIntent::FileActions { could_be_v2 }`, where `could_be_v2` is whether the table supports the `v2Checkpoint` feature. A table without the feature can only have V1 checkpoints, so it keeps trusting the hint with no footer read; a table with the feature reads the footer only when the hint lacks `sidecar`.

The result: the hint fast path is preserved for the common V1 case (no extra footer read), and the silent sidecar drop is closed for V2 tables. The `v2Checkpoint` support check is available at every file-action call site from the snapshot's `TableConfiguration`, so there is no chicken-and-egg with protocol resolution: the one path where the protocol is not yet known (protocol/metadata log replay) reads no file actions and therefore never resolves sidecars. A `debug_assert` keeps the read intent in sync with the projected schema.

## How was this change tested?

Added two `log_segment` tests: `test_v2_checkpoint_not_read_as_v1_when_hint_omits_sidecar` (a V2 checkpoint with sidecars plus a hint that omits `sidecar`, asserting the sidecar actions are still read) and `test_v1_checkpoint_trusts_hint_without_footer_read` (with `could_be_v2` false, a sidecar-less hint is trusted and sidecars are not resolved, so no footer read happens). Extended `test_get_file_actions_schema_v1_parquet_with_hint` to cover both the V1-trusts-hint and V2-reads-footer branches. The V2 regression test fails before this change and passes after.

Ran `cargo test -p delta_kernel --lib --all-features` (all pass), plus `cargo +nightly fmt`, `cargo clippy -p delta_kernel --all-features --tests -- -D warnings`, and `cargo doc`.
