### PR TITLE
fix: parse empty-string partition values with spark cast semantics

### DIFF
--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -200,6 +200,11 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// itself carries no schema, so the expression evaluator uses the expected output type to
 /// parse each string value into the correct native type.
 ///
+/// `MAP_TO_STRUCT` reconstructs the same typed struct the scan reads, so a checkpoint and its
+/// source commits surface identical partition values (the read and this fallback never disagree).
+/// Kernel never writes a literal empty-string partition value, so the only rows this affects hold
+/// a foreign `""`, which reconstructs identically here and on read.
+///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {
     Arc::new(Expression::coalesce([
@@ -425,6 +430,25 @@ mod tests {
         assert!(
             is_replacement(inner, PARTITION_VALUES_PARSED_FIELD),
             "partitionValues_parsed should be replaced"
+        );
+    }
+
+    /// The checkpoint falls back to `MAP_TO_STRUCT` over `partitionValues` when no native
+    /// `partitionValues_parsed` column is present, so a checkpoint reconstructs the same typed
+    /// struct the scan reads and the two can never disagree on a value.
+    #[test]
+    fn build_partition_values_parsed_expr_falls_back_to_map_to_struct() {
+        let expr = build_partition_values_parsed_expr();
+        let Expression::Variadic(coalesce) = expr.as_ref() else {
+            panic!("expected a COALESCE expression");
+        };
+        let has_map_to_struct_fallback = coalesce
+            .exprs
+            .iter()
+            .any(|e| matches!(e, Expression::MapToStruct(_)));
+        assert!(
+            has_map_to_struct_fallback,
+            "checkpoint partitionValues_parsed must reconstruct via MAP_TO_STRUCT"
         );
     }
 

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -201,8 +201,9 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// parse each string value into the correct native type.
 ///
 /// The fallback uses the same `MAP_TO_STRUCT` the scan applies, so an empty-string partition value
-/// (only ever a foreign `""`, since the kernel collapses empties to an absent map entry on write)
-/// reconstructs into the checkpoint identically to how the scan reconstructs it from a commit.
+/// (only ever a foreign `""`, since kernel serializes its own empty and null partition values to
+/// JSON null on write) reconstructs into the checkpoint identically to how the scan reconstructs it
+/// from a commit.
 ///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -200,10 +200,9 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 /// itself carries no schema, so the expression evaluator uses the expected output type to
 /// parse each string value into the correct native type.
 ///
-/// `MAP_TO_STRUCT` reconstructs the same typed struct the scan reads, so a checkpoint and its
-/// source commits surface identical partition values (the read and this fallback never disagree).
-/// Kernel never writes a literal empty-string partition value, so the only rows this affects hold
-/// a foreign `""`, which reconstructs identically here and on read.
+/// The fallback uses the same `MAP_TO_STRUCT` the scan applies, so an empty-string partition value
+/// (only ever a foreign `""`, since the kernel collapses empties to an absent map entry on write)
+/// reconstructs into the checkpoint identically to how the scan reconstructs it from a commit.
 ///
 /// Column paths are relative to the full batch, not the nested Add struct.
 fn build_partition_values_parsed_expr() -> ExpressionRef {

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -897,16 +897,24 @@ pub fn coalesce_arrays(
 
 /// Parses one raw partition-value string into its target [`Scalar`], or `None` for a null value.
 ///
+/// An empty string mirrors DBR's non-ANSI `Cast` of the partition-value map: it casts to itself for
+/// string, to empty bytes for binary, and to null for every other type. A literal empty string only
+/// reaches this path from a foreign writer, since the kernel collapses empties to an absent map
+/// entry on write.
+///
 /// Date and timestamp use arrow's `Date32Type::parse` / `string_to_datetime`, which are much
 /// faster than `parse_scalar`'s chrono path and yield the same value for valid Delta partition
 /// values. These arrow parsers accept a superset of the canonical formats (e.g. `20240115`, or a
 /// timestamp carrying an explicit offset) and interpret no-offset timestamps as UTC, matching
 /// `parse_scalar`; spec-compliant writers only emit canonical values, so the extra leniency is
-/// harmless on the read path. All other types go through `parse_scalar`, including its handling of
-/// the empty string as a null value.
+/// harmless on the read path. All other types go through `parse_scalar`.
 fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
     if raw.is_empty() {
-        return Ok(None);
+        return Ok(match prim {
+            PrimitiveType::String => Some(Scalar::String(String::new())),
+            PrimitiveType::Binary => Some(Scalar::Binary(Vec::new())),
+            _ => None,
+        });
     }
     match prim {
         PrimitiveType::Date => {
@@ -934,8 +942,8 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 }
 
 /// Evaluates `MAP_TO_STRUCT(map_col, output_schema)`: extracts keys from a `Map<String, String>`
-/// and parses each value into its target type using Delta's partition value serialization rules,
-/// producing a `StructArray`.
+/// and parses each value into its target type, producing a `StructArray`. An empty-string value
+/// casts to itself for string, to empty bytes for binary, and to null for every other type.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -2479,14 +2487,17 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// An empty-string map value mirrors DBR's non-ANSI Cast: `""` for string, empty bytes for
+    /// binary, and null for every other type. A literal empty string only reaches this path from a
+    /// foreign writer; the kernel collapses empties to an absent map entry on write.
     #[test]
-    fn test_map_to_struct_empty_string_is_null() {
-        // An empty string maps to null, matching `parse_scalar`. MapToStruct must agree with the
-        // canonical partition-value parser used elsewhere in the kernel.
+    fn test_map_to_struct_empty_string_casts_like_dbr() {
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("region");
         builder.values().append_value("");
         builder.keys().append_value("blob");
+        builder.values().append_value("");
+        builder.keys().append_value("count");
         builder.values().append_value("");
         builder.append(true).unwrap();
 
@@ -2501,6 +2512,7 @@ mod tests {
         let output_schema = StructType::new_unchecked(vec![
             StructField::nullable("region", DataType::STRING),
             StructField::nullable("blob", DataType::BINARY),
+            StructField::nullable("count", DataType::INTEGER),
         ]);
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(column_expr!("pv"));
@@ -2512,14 +2524,23 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
-        assert!(regions.is_null(0));
+        assert!(!regions.is_null(0));
+        assert_eq!(regions.value(0), "");
 
         let blobs = structs
             .column(1)
             .as_any()
             .downcast_ref::<crate::arrow::array::BinaryArray>()
             .unwrap();
-        assert!(blobs.is_null(0));
+        assert!(!blobs.is_null(0));
+        assert_eq!(blobs.value(0), b"");
+
+        let counts = structs
+            .column(2)
+            .as_any()
+            .downcast_ref::<crate::arrow::array::Int32Array>()
+            .unwrap();
+        assert!(counts.is_null(0));
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -897,10 +897,7 @@ pub fn coalesce_arrays(
 
 /// Parses one raw partition-value string into its target [`Scalar`], or `None` for a null value.
 ///
-/// An empty string mirrors DBR's non-ANSI `Cast` of the partition-value map: it casts to itself for
-/// string, to empty bytes for binary, and to null for every other type. A literal empty string only
-/// reaches this path from a foreign writer, since the kernel collapses empties to an absent map
-/// entry on write.
+/// An empty string casts via [`PrimitiveType::empty_string_partition_cast`].
 ///
 /// Date and timestamp use arrow's `Date32Type::parse` / `string_to_datetime`, which are much
 /// faster than `parse_scalar`'s chrono path and yield the same value for valid Delta partition
@@ -910,11 +907,7 @@ pub fn coalesce_arrays(
 /// harmless on the read path. All other types go through `parse_scalar`.
 fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
     if raw.is_empty() {
-        return Ok(match prim {
-            PrimitiveType::String => Some(Scalar::String(String::new())),
-            PrimitiveType::Binary => Some(Scalar::Binary(Vec::new())),
-            _ => None,
-        });
+        return Ok(prim.empty_string_partition_cast());
     }
     match prim {
         PrimitiveType::Date => {
@@ -943,7 +936,7 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 
 /// Evaluates `MAP_TO_STRUCT(map_col, output_schema)`: extracts keys from a `Map<String, String>`
 /// and parses each value into its target type, producing a `StructArray`. An empty-string value
-/// casts to itself for string, to empty bytes for binary, and to null for every other type.
+/// casts via [`PrimitiveType::empty_string_partition_cast`].
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -2487,11 +2480,10 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// An empty-string map value mirrors DBR's non-ANSI Cast: `""` for string, empty bytes for
-    /// binary, and null for every other type. A literal empty string only reaches this path from a
-    /// foreign writer; the kernel collapses empties to an absent map entry on write.
+    /// An empty-string map value casts via `empty_string_partition_cast`: `""` for string, empty
+    /// bytes for binary, and null for every other type.
     #[test]
-    fn test_map_to_struct_empty_string_casts_like_dbr() {
+    fn test_map_to_struct_empty_string_cast_semantics() {
         let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
         builder.keys().append_value("region");
         builder.values().append_value("");

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -539,8 +539,8 @@ impl ParseJsonExpression {
 /// evaluator's output type (via `result_type`). Each row in the map column becomes one row in
 /// the output struct column: a `key` -> `value` mapping in the map means the struct field named
 /// `key` receives `value`, parsed into the field's target type via [`PrimitiveType::parse_scalar`].
-/// An empty-string value is the exception: it casts to itself for string, to empty bytes for
-/// binary, and to null for every other type.
+/// An empty-string value is the exception (aligning with Spark): it casts to itself for string, to
+/// empty bytes for binary, and to null for every other type.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -739,9 +739,9 @@ impl Expression {
     }
 
     /// Extracts keys from a `Map<String, String>` and parses values into a typed struct. The output
-    /// struct schema is determined by the evaluator's `result_type`. An empty-string value casts to
-    /// itself for string, to empty bytes for binary, and to null for every other type. See
-    /// [`MapToStructExpression`] for the full contract.
+    /// struct schema is determined by the evaluator's `result_type`. An empty-string value is the
+    /// exception (aligning with Spark): it casts to itself for string, to empty bytes for binary,
+    /// and to null for every other type. See [`MapToStructExpression`] for the full contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
     }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -410,8 +410,8 @@ pub enum Expression {
     Unknown(String),
     /// Parse a JSON string expression into a struct with the given schema.
     ParseJson(ParseJsonExpression),
-    /// Extract keys from a `Map<String, String>` and parse values into a typed struct using
-    /// Delta's partition value serialization rules.
+    /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
+    /// [`MapToStructExpression`] for how values are parsed.
     MapToStruct(MapToStructExpression),
 }
 
@@ -539,8 +539,8 @@ impl ParseJsonExpression {
 /// evaluator's output type (via `result_type`). Each row in the map column becomes one row in
 /// the output struct column: a `key` -> `value` mapping in the map means the struct field named
 /// `key` receives `value`, parsed into the field's target type via [`PrimitiveType::parse_scalar`].
-/// An empty-string value mirrors DBR's non-ANSI `Cast`: it casts to itself for string, to empty
-/// bytes for binary, and to null for every other type.
+/// An empty-string value is the exception: it casts to itself for string, to empty bytes for
+/// binary, and to null for every other type.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -740,7 +740,8 @@ impl Expression {
 
     /// Extracts keys from a `Map<String, String>` and parses values into a typed struct. The output
     /// struct schema is determined by the evaluator's `result_type`. An empty-string value casts to
-    /// itself for string, to empty bytes for binary, and to null for every other type.
+    /// itself for string, to empty bytes for binary, and to null for every other type. See
+    /// [`MapToStructExpression`] for the full contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
     }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -538,8 +538,9 @@ impl ParseJsonExpression {
 /// Transforms a `Map<String, String>` column into a struct whose schema is provided by the
 /// evaluator's output type (via `result_type`). Each row in the map column becomes one row in
 /// the output struct column: a `key` -> `value` mapping in the map means the struct field named
-/// `key` receives `value`, parsed into the field's target type using Delta's partition value
-/// serialization rules ([`PrimitiveType::parse_scalar`]).
+/// `key` receives `value`, parsed into the field's target type via [`PrimitiveType::parse_scalar`].
+/// An empty-string value mirrors DBR's non-ANSI `Cast`: it casts to itself for string, to empty
+/// bytes for binary, and to null for every other type.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -737,9 +738,9 @@ impl Expression {
         Self::ParseJson(ParseJsonExpression::new(json_expr, output_schema))
     }
 
-    /// Extracts keys from a `Map<String, String>` and parses values into a typed struct using
-    /// Delta's partition value serialization rules. The output struct schema is determined by the
-    /// evaluator's `result_type`.
+    /// Extracts keys from a `Map<String, String>` and parses values into a typed struct. The output
+    /// struct schema is determined by the evaluator's `result_type`. An empty-string value casts to
+    /// itself for string, to empty bytes for binary, and to null for every other type.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
     }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -794,12 +794,13 @@ impl PrimitiveType {
     /// Casts an empty partition-value string to its target [`Scalar`], or `None` for a null value.
     ///
     /// An empty string is a value for a string or binary column (the empty string / empty bytes)
-    /// but has no representation for any other type, so it casts to null there. This mirrors a
-    /// non-ANSI SQL cast of the partition-value map and is the empty-string rule the scan read path
-    /// applies, in place of [`parse_scalar`]'s null-for-every-type handling.
+    /// but has no representation for any other type, so it casts to null there. This aligns with
+    /// Spark, which reads the partition-value map as a non-ANSI SQL cast, and is the empty-string
+    /// rule the scan read path applies, in place of [`parse_scalar`]'s null-for-every-type
+    /// handling.
     ///
-    /// A literal empty string only reaches this path from a foreign writer, since the kernel
-    /// collapses empty partition values to an absent map entry on write.
+    /// A literal empty string only reaches this path from a foreign writer, since kernel
+    /// serializes its own empty and null partition values to JSON null on write.
     ///
     /// [`parse_scalar`]: PrimitiveType::parse_scalar
     pub(crate) fn empty_string_partition_cast(&self) -> Option<Scalar> {

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -709,6 +709,10 @@ impl PrimitiveType {
     /// protocol's [partition value serialization] rules. An empty string parses as
     /// [`Scalar::Null`].
     ///
+    /// Note: the scan read path does not use this empty-string handling for partition values; it
+    /// applies a type-dependent cast instead (empty string on a string or binary column surfaces as
+    /// an empty value rather than null).
+    ///
     /// Timestamp and TimestampNtz accept the space-separated form `{year}-{month}-{day}
     /// {hour}:{minute}:{second}[.{fraction}]`. Timestamp (only) also accepts ISO 8601 / RFC 3339
     /// strings such as `1970-01-01T00:00:00.123456Z`; an explicit offset is honored and the value
@@ -784,6 +788,25 @@ impl PrimitiveType {
             IntervalYearMonth | IntervalDayTime => Err(Error::unsupported(
                 "Interval types are not supported as scalar or partition values",
             )),
+        }
+    }
+
+    /// Casts an empty partition-value string to its target [`Scalar`], or `None` for a null value.
+    ///
+    /// An empty string is a value for a string or binary column (the empty string / empty bytes)
+    /// but has no representation for any other type, so it casts to null there. This mirrors a
+    /// non-ANSI SQL cast of the partition-value map and is the empty-string rule the scan read path
+    /// applies, in place of [`parse_scalar`]'s null-for-every-type handling.
+    ///
+    /// A literal empty string only reaches this path from a foreign writer, since the kernel
+    /// collapses empty partition values to an absent map entry on write.
+    ///
+    /// [`parse_scalar`]: PrimitiveType::parse_scalar
+    pub(crate) fn empty_string_partition_cast(&self) -> Option<Scalar> {
+        match self {
+            PrimitiveType::String => Some(Scalar::String(String::new())),
+            PrimitiveType::Binary => Some(Scalar::Binary(Vec::new())),
+            _ => None,
         }
     }
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -726,8 +726,9 @@ fn scan_row_schema_with_parsed_columns(
 ///   to pay the per-batch `ToJson` cost over potentially large stats structs.
 /// - `partition_schema`: Schema of typed partition columns for data skipping, or None if partition
 ///   value parsing is not needed.
-/// - `has_partition_values_parsed`: Whether checkpoint has pre-parsed partitionValues_parsed
-///   column.
+/// - `has_partition_values_parsed`: Whether the source carries a native `partitionValues_parsed`
+///   column (checkpoint). When true it is read directly; otherwise the struct is reconstructed from
+///   the `partitionValues` string map.
 ///
 /// The transform includes `stats_parsed` only when `physical_stats_schema` is Some,
 /// and `partitionValues_parsed` only when `partition_schema` is Some.
@@ -786,10 +787,10 @@ fn get_add_transform_expr(
     // engine-facing typed output column.
     if partition_schema.is_some() {
         let pv_parsed_expr = if has_partition_values_parsed {
-            // Checkpoint has partitionValues_parsed column - read directly
+            // Checkpoint carries a native partitionValues_parsed column - read it directly.
             column_expr!("add.partitionValues_parsed")
         } else {
-            // No partitionValues_parsed available (JSON log files) - parse from string map
+            // No native column (JSON commit): reconstruct from the string map.
             Expression::map_to_struct(column_expr!("add.partitionValues"))
         };
         fields.push(Arc::new(pv_parsed_expr));
@@ -1921,10 +1922,8 @@ mod tests {
 
     /// `synthesize_json=false` removes every `ToJson` node from the add transform;
     /// `synthesize_json=true` leaves exactly one inside the COALESCE branch.
-    #[rstest]
-    fn add_transform_omits_to_json_when_synthesis_skipped(
-        #[values(false, true)] has_partition_values_parsed: bool,
-    ) {
+    #[test]
+    fn add_transform_omits_to_json_when_synthesis_skipped() {
         let stats_schema: SchemaRef = Arc::new(StructType::new_unchecked([
             StructField::nullable("id", DataType::LONG),
             StructField::nullable("value", DataType::STRING),
@@ -1940,7 +1939,7 @@ mod tests {
             false, // skip_stats
             true,  // synthesize_json
             partition_schema.clone(),
-            has_partition_values_parsed,
+            false, // has_partition_values_parsed
         );
         assert_eq!(
             count_to_json(&with_synthesis),
@@ -1955,7 +1954,7 @@ mod tests {
             false, // skip_stats
             false, // synthesize_json
             partition_schema,
-            has_partition_values_parsed,
+            false, // has_partition_values_parsed
         );
         assert_eq!(
             count_to_json(&without_synthesis),

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -426,7 +426,8 @@ impl StateInfo {
         // the predicate-narrowed subset. The data skipping filter only references the columns
         // its predicate needs, so the superset is safe for pruning too. All fields are forced
         // nullable: MapToStruct can yield null even for a non-nullable column (a missing key, or
-        // the protocol's empty-string-is-null rule), and a non-nullable field would then error.
+        // an empty string cast to a non-string/binary type), and a non-nullable field would then
+        // error.
         let physical_partition_schema = if partition_values.parsed_struct {
             table_partition_schema.map(|tps| {
                 let nullable_fields = tps

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::expressions::{
     col, lit, Expression, ExpressionRef, ExpressionStructPatchBuilder, Scalar,
 };
-use crate::schema::{DataType, PrimitiveType, SchemaRef, StructType};
+use crate::schema::{DataType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
 
@@ -210,20 +210,17 @@ fn apply_insert_after(
 
 /// Parse a partition value from the raw string representation.
 ///
-/// An empty string mirrors DBR's non-ANSI `Cast` of the partition-value map: it casts to itself
-/// for string, to empty bytes for binary, and to null for every other type. A literal empty string
-/// only reaches this path from a foreign writer, since the kernel collapses empties to an absent
-/// map entry on write.
+/// An empty string casts via [`PrimitiveType::empty_string_partition_cast`].
+///
+/// [`PrimitiveType::empty_string_partition_cast`]: crate::schema::PrimitiveType::empty_string_partition_cast
 pub(crate) fn parse_partition_value_raw(
     raw: Option<&String>,
     data_type: &DataType,
 ) -> DeltaResult<Scalar> {
     match (raw, data_type.as_primitive_opt()) {
-        (Some(v), Some(primitive)) if v.is_empty() => Ok(match primitive {
-            PrimitiveType::String => Scalar::String(String::new()),
-            PrimitiveType::Binary => Scalar::Binary(Vec::new()),
-            _ => Scalar::Null(data_type.clone()),
-        }),
+        (Some(v), Some(primitive)) if v.is_empty() => Ok(primitive
+            .empty_string_partition_cast()
+            .unwrap_or_else(|| Scalar::Null(data_type.clone()))),
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(
             "Unexpected partition column type: {data_type:?}"
@@ -347,10 +344,9 @@ mod tests {
 
     #[test]
     fn test_parse_partition_value_raw_empty_string_cast_semantics() {
-        // Mirror DBR's non-ANSI Cast of the partition-value map: an empty string casts to itself
-        // for string and to empty bytes for binary, and to null for every other type. A literal
-        // empty string only reaches this path from a foreign writer, since the kernel collapses
-        // empties to an absent map entry on write.
+        // An empty string casts to itself for string and to empty bytes for binary, and to null
+        // for every other type. A literal empty string only reaches this path from a foreign
+        // writer, since the kernel collapses empties to an absent map entry on write.
         let empty = String::new();
 
         let string_value = parse_partition_value_raw(Some(&empty), &DataType::STRING).unwrap();

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::expressions::{
     col, lit, Expression, ExpressionRef, ExpressionStructPatchBuilder, Scalar,
 };
-use crate::schema::{DataType, SchemaRef, StructType};
+use crate::schema::{DataType, PrimitiveType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
 
@@ -208,12 +208,22 @@ fn apply_insert_after(
     }
 }
 
-/// Parse a partition value from the raw string representation
+/// Parse a partition value from the raw string representation.
+///
+/// An empty string mirrors DBR's non-ANSI `Cast` of the partition-value map: it casts to itself
+/// for string, to empty bytes for binary, and to null for every other type. A literal empty string
+/// only reaches this path from a foreign writer, since the kernel collapses empties to an absent
+/// map entry on write.
 pub(crate) fn parse_partition_value_raw(
     raw: Option<&String>,
     data_type: &DataType,
 ) -> DeltaResult<Scalar> {
     match (raw, data_type.as_primitive_opt()) {
+        (Some(v), Some(primitive)) if v.is_empty() => Ok(match primitive {
+            PrimitiveType::String => Scalar::String(String::new()),
+            PrimitiveType::Binary => Scalar::Binary(Vec::new()),
+            _ => Scalar::Null(data_type.clone()),
+        }),
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(
             "Unexpected partition column type: {data_type:?}"
@@ -333,6 +343,26 @@ mod tests {
     fn test_parse_partition_value_raw_null() {
         let result = parse_partition_value_raw(None, &DataType::STRING).unwrap();
         assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_parse_partition_value_raw_empty_string_cast_semantics() {
+        // Mirror DBR's non-ANSI Cast of the partition-value map: an empty string casts to itself
+        // for string and to empty bytes for binary, and to null for every other type. A literal
+        // empty string only reaches this path from a foreign writer, since the kernel collapses
+        // empties to an absent map entry on write.
+        let empty = String::new();
+
+        let string_value = parse_partition_value_raw(Some(&empty), &DataType::STRING).unwrap();
+        assert_eq!(string_value, Scalar::String(String::new()));
+
+        let binary_value = parse_partition_value_raw(Some(&empty), &DataType::BINARY).unwrap();
+        assert_eq!(binary_value, Scalar::Binary(Vec::new()));
+
+        let int_value =
+            parse_partition_value_raw(Some(&empty), &DataType::Primitive(PrimitiveType::Integer))
+                .unwrap();
+        assert!(int_value.is_null());
     }
 
     #[test]

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -346,7 +346,7 @@ mod tests {
     fn test_parse_partition_value_raw_empty_string_cast_semantics() {
         // An empty string casts to itself for string and to empty bytes for binary, and to null
         // for every other type. A literal empty string only reaches this path from a foreign
-        // writer, since the kernel collapses empties to an absent map entry on write.
+        // writer, since kernel serializes its own empty and null partition values to JSON null.
         let empty = String::new();
 
         let string_value = parse_partition_value_raw(Some(&empty), &DataType::STRING).unwrap();

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -17,7 +17,10 @@ use delta_kernel::Snapshot;
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::table_builder::{partitioned, version_latest, FeatureSet, LogState, TableConfig};
-use test_utils::{add_commit, create_default_engine_mt_executor, get_column, test_context};
+use test_utils::{
+    add_commit, create_default_engine_mt_executor, get_column,
+    install_thread_local_metrics_reporter, test_context, CountingReporter,
+};
 use url::Url;
 
 /// Requesting the typed struct via `with_struct()` on a partitioned table must emit a
@@ -147,10 +150,10 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
 
 // === Foreign-writer literal empty-string partition values ===
 //
-// The kernel never persists a literal "" partition value (it collapses empties to an absent map
-// entry on write), so these tests stand in a raw-JSON foreign writer that did, then assert the
-// kernel reconstructs `partitionValues_parsed` with the empty-string cast: "" stays "" for string,
-// becomes empty bytes for binary, and becomes null for every other type.
+// The kernel never persists a literal "" partition value (it serializes its own empty and null
+// partition values to JSON null on write), so these tests stand in a raw-JSON foreign writer that
+// did, then assert the kernel reconstructs `partitionValues_parsed` with the empty-string cast: ""
+// stays "" for string, becomes empty bytes for binary, and becomes null for every other type.
 
 /// Writes a foreign-writer table under `table_path`: protocol + metadata declaring string, binary,
 /// and integer partition columns (with `writeStatsAsStruct` enabled so a checkpoint writes its own
@@ -251,9 +254,19 @@ async fn parsed_partition_values_read_foreign_empty_string(
         snapshot.checkpoint(engine.as_ref(), None).unwrap();
     }
 
+    // Confirm the scan reads from the intended source: the checkpoint axis must actually place a
+    // checkpoint in the snapshot's log segment (and the non-checkpoint axis must not), otherwise a
+    // silently-skipped checkpoint would re-test the JSON-commit path twice.
+    let reporter = Arc::new(CountingReporter::new());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
     let snapshot = Snapshot::builder_for(url.clone())
         .build(engine.as_ref())
         .unwrap();
+    assert_eq!(
+        reporter.checkpoint_files.get(),
+        u64::from(native_checkpoint),
+        "log segment checkpoint parts must match native_checkpoint={native_checkpoint}"
+    );
     let scan = snapshot
         .scan_builder()
         .with_partition_values(PartitionValuesOptions::with_struct())
@@ -265,9 +278,6 @@ async fn parsed_partition_values_read_foreign_empty_string(
         let (data, selection) = scan_metadata.unwrap().scan_files.into_parts();
         let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data).unwrap().into();
         let batch = filter_record_batch(&batch, &BooleanArray::from(selection)).unwrap();
-        if batch.num_rows() == 0 {
-            continue;
-        }
         let pv = get_column!(batch, "partitionValues_parsed", StructArray);
 
         let p_str = pv.column_by_name("p_str").unwrap();
@@ -298,8 +308,7 @@ fn collect_path(paths: &mut Vec<String>, scan_file: ScanFile) {
 
 /// A file whose partition value is a foreign literal "" is a real empty value, not null, so
 /// partition skipping treats it accordingly:
-/// - `p_str = ''` keeps it, `p_str = 'other'` prunes it (before the cast change "" collapsed to
-///   null, so `p_str = 'other'` kept the file conservatively).
+/// - `p_str = ''` keeps it and `p_str = 'other'` prunes it.
 /// - `p_str IS NULL` prunes it and `p_str IS NOT NULL` keeps it (the value is "", not null).
 /// - the same holds for the binary column (`p_bin`), whose "" reconstructs as empty bytes.
 ///
@@ -364,8 +373,7 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
         "empty-string file must be pruned under p_str = 'other'"
     );
     // Both partition values are non-null ("" and "other"), so IS NULL prunes both and IS NOT NULL
-    // keeps both. The empty file surviving IS NOT NULL is the fix: before the cast change "" was
-    // null, so it would have been kept under IS NULL and pruned under IS NOT NULL.
+    // keeps both.
     assert!(
         surviving(Predicate::is_null(col!("p_str"))).is_empty(),
         "no file has a null p_str, so IS NULL prunes both (the empty file's value is \"\", not null)"

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -148,8 +148,9 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
 // === Foreign-writer literal empty-string partition values ===
 //
 // The kernel never persists a literal "" partition value (it collapses empties to an absent map
-// entry on write), so these tests stand in a raw-JSON foreign writer (Spark) that did, then assert
-// the kernel reconstructs `partitionValues_parsed` with DBR's non-ANSI `Cast` semantics.
+// entry on write), so these tests stand in a raw-JSON foreign writer that did, then assert the
+// kernel reconstructs `partitionValues_parsed` with the empty-string cast: "" stays "" for string,
+// becomes empty bytes for binary, and becomes null for every other type.
 
 /// Writes a foreign-writer table under `table_path`: protocol + metadata declaring string, binary,
 /// and integer partition columns (with `writeStatsAsStruct` enabled so a checkpoint writes its own
@@ -217,13 +218,13 @@ fn add_action(path: &str, p_str: &str, p_bin: &str, p_int: &str) -> String {
 }
 
 /// A foreign writer can persist a literal "" in the `partitionValues` map. On read, kernel
-/// reconstructs `partitionValues_parsed` with DBR's non-ANSI `Cast` semantics: "" stays "" for
-/// string, becomes empty bytes for binary, and becomes null for every other type.
+/// reconstructs `partitionValues_parsed` with the empty-string cast: "" stays "" for string,
+/// becomes empty bytes for binary, and becomes null for every other type.
 ///
 /// The result is identical whether the value is reconstructed from the `partitionValues` map (JSON
 /// commit) or read from a kernel-written checkpoint's native `partitionValues_parsed` column: the
 /// checkpoint reconstructs that column with the same cast, so a checkpoint never changes the value
-/// a scan surfaces. `native_checkpoint` pins that equivalence.
+/// a scan surfaces. The `native_checkpoint` axis exercises both sources.
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn parsed_partition_values_read_foreign_empty_string(
@@ -295,19 +296,19 @@ fn collect_path(paths: &mut Vec<String>, scan_file: ScanFile) {
     paths.push(scan_file.path);
 }
 
-/// A file whose string partition value is a foreign literal "" is KEPT under a `p_str = ''`
-/// predicate (the reconstructed value is "", matching DBR) and PRUNED under `p_str = 'other'`.
-/// This locks in the DBR-consistent partition skipping the cast change enables: before the change
-/// "" collapsed to null and `p_str = 'other'` kept the file conservatively, diverging from DBR.
+/// A file whose partition value is a foreign literal "" is a real empty value, not null, so
+/// partition skipping treats it accordingly:
+/// - `p_str = ''` keeps it, `p_str = 'other'` prunes it (before the cast change "" collapsed to
+///   null, so `p_str = 'other'` kept the file conservatively).
+/// - `p_str IS NULL` prunes it and `p_str IS NOT NULL` keeps it (the value is "", not null).
+/// - the same holds for the binary column (`p_bin`), whose "" reconstructs as empty bytes.
 ///
-/// `native_checkpoint` pins that pruning is identical before and after a kernel checkpoint: the
-/// checkpoint reconstructs the same "" into its native `partitionValues_parsed` column, so skipping
-/// keeps and prunes the same files a scan of the JSON commit would.
+/// The `native_checkpoint` axis exercises that pruning is identical before and after a kernel
+/// checkpoint: the checkpoint reconstructs the same "" into its native `partitionValues_parsed`
+/// column, so skipping keeps and prunes the same files a scan of the JSON commit would.
 #[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn empty_string_partition_pruning_matches_dbr(
-    #[values(false, true)] native_checkpoint: bool,
-) {
+async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
     let table_path = temp_dir.path().join("empty-string-pruning");
     let url = write_foreign_partition_table(
@@ -347,14 +348,38 @@ async fn empty_string_partition_pruning_matches_dbr(
         paths
     };
 
+    let empty = "p_str=/empty.parquet".to_string();
+    let other = "p_str=other/other.parquet".to_string();
+    let both = vec![empty.clone(), other.clone()];
+
+    // The empty-string value is a real "", so equality and null predicates treat it as such.
     assert_eq!(
         surviving(Predicate::eq(col!("p_str"), lit(""))),
-        vec!["p_str=/empty.parquet".to_string()],
+        vec![empty.clone()],
         "empty-string file must be kept under p_str = ''"
     );
     assert_eq!(
         surviving(Predicate::eq(col!("p_str"), lit("other"))),
-        vec!["p_str=other/other.parquet".to_string()],
-        "empty-string file must be pruned under p_str = 'other' (matches DBR)"
+        vec![other.clone()],
+        "empty-string file must be pruned under p_str = 'other'"
+    );
+    // Both partition values are non-null ("" and "other"), so IS NULL prunes both and IS NOT NULL
+    // keeps both. The empty file surviving IS NOT NULL is the fix: before the cast change "" was
+    // null, so it would have been kept under IS NULL and pruned under IS NOT NULL.
+    assert!(
+        surviving(Predicate::is_null(col!("p_str"))).is_empty(),
+        "no file has a null p_str, so IS NULL prunes both (the empty file's value is \"\", not null)"
+    );
+    assert_eq!(
+        surviving(Predicate::is_not_null(col!("p_str"))),
+        both,
+        "both files must be kept under p_str IS NOT NULL"
+    );
+
+    // The binary column reconstructs "" as empty bytes, pruned the same way.
+    assert_eq!(
+        surviving(Predicate::eq(col!("p_bin"), lit(b"other".as_slice()))),
+        vec![other.clone()],
+        "empty-bytes file must be pruned under p_bin = X'6f74686572'"
     );
 }

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -1,27 +1,37 @@
 //! Integration tests for parsed partition-value output (`partitionValues_parsed`).
 
-use delta_kernel::arrow::array::{Array, BooleanArray, RecordBatch, StructArray};
+use std::sync::Arc;
+
+use delta_kernel::arrow::array::{
+    Array, BinaryArray, BooleanArray, Int32Array, RecordBatch, StringArray, StructArray,
+};
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::expressions::ColumnName;
+use delta_kernel::expressions::{col, lit, ColumnName, Predicate};
+use delta_kernel::object_store::local::LocalFileSystem;
+use delta_kernel::object_store::DynObjectStore;
+use delta_kernel::scan::state::ScanFile;
 use delta_kernel::scan::PartitionValuesOptions;
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::Snapshot;
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::table_builder::{partitioned, version_latest, FeatureSet, LogState, TableConfig};
-use test_utils::{get_column, test_context};
+use test_utils::{add_commit, create_default_engine_mt_executor, get_column, test_context};
+use url::Url;
 
 /// Requesting the typed struct via `with_struct()` on a partitioned table must emit a
 /// `partitionValues_parsed` column with one field per partition column, keyed by physical name.
 ///
-/// Run across every column mapping mode and both partition-value sources:
+/// Run across every column mapping mode and both log-segment shapes:
 /// - `native_checkpoint = false`: no checkpoint, so the struct is synthesized from the
-///   `partitionValues` string map via `MAP_TO_STRUCT`.
-/// - `native_checkpoint = true`: a checkpoint with `writeStatsAsStruct=true`, so the checkpoint
-///   carries a native `partitionValues_parsed` column that kernel reads directly.
+///   `partitionValues` string map via `MAP_TO_STRUCT` on a JSON commit.
+/// - `native_checkpoint = true`: a checkpoint with `writeStatsAsStruct=true`, so the read takes the
+///   checkpoint's native `partitionValues_parsed` column directly. For the non-null values this
+///   table writes, that column matches what `MAP_TO_STRUCT` would reconstruct, so both sources
+///   yield the same struct.
 ///
-/// Both sources key on physical names, so a logical-vs-physical mismatch under `Id`/`Name` mapping
+/// The struct keys on physical names, so a logical-vs-physical mismatch under `Id`/`Name` mapping
 /// would surface every partition value as null. The builder writes well-defined (non-null)
 /// partition values, so the non-null assertion guards physical-name matching in all combinations.
 #[rstest]
@@ -133,4 +143,218 @@ fn scan_metadata_emits_partition_values_parsed_across_column_mapping(
     }
 
     assert_eq!(file_count, 1, "Should have processed exactly one file");
+}
+
+// === Foreign-writer literal empty-string partition values ===
+//
+// The kernel never persists a literal "" partition value (it collapses empties to an absent map
+// entry on write), so these tests stand in a raw-JSON foreign writer (Spark) that did, then assert
+// the kernel reconstructs `partitionValues_parsed` with DBR's non-ANSI `Cast` semantics.
+
+/// Writes a foreign-writer table under `table_path`: protocol + metadata declaring string, binary,
+/// and integer partition columns (with `writeStatsAsStruct` enabled so a checkpoint writes its own
+/// `partitionValues_parsed` column), followed by one `add` commit holding `add_actions`.
+/// Returns the table URL.
+async fn write_foreign_partition_table(
+    table_path: &std::path::Path,
+    add_actions: &[String],
+) -> Url {
+    std::fs::create_dir_all(table_path).unwrap();
+    let url = Url::from_directory_path(table_path).unwrap();
+    let table_root = url.to_string();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+
+    let schema_string = serde_json::json!({
+        "type": "struct",
+        "fields": [
+            {"name": "p_str", "type": "string", "nullable": true, "metadata": {}},
+            {"name": "p_bin", "type": "binary", "nullable": true, "metadata": {}},
+            {"name": "p_int", "type": "integer", "nullable": true, "metadata": {}},
+            {"name": "value", "type": "integer", "nullable": true, "metadata": {}},
+        ],
+    })
+    .to_string();
+    let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+    let metadata = serde_json::json!({
+        "metaData": {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": ["p_str", "p_bin", "p_int"],
+            "configuration": {"delta.checkpoint.writeStatsAsStruct": "true"},
+            "createdTime": 1700000000000_i64,
+        },
+    })
+    .to_string();
+
+    add_commit(
+        &table_root,
+        store.as_ref(),
+        0,
+        format!("{protocol}\n{metadata}"),
+    )
+    .await
+    .unwrap();
+    add_commit(&table_root, store.as_ref(), 1, add_actions.join("\n"))
+        .await
+        .unwrap();
+    url
+}
+
+/// Builds an `add` action whose `partitionValues` map holds the given raw strings.
+fn add_action(path: &str, p_str: &str, p_bin: &str, p_int: &str) -> String {
+    serde_json::json!({
+        "add": {
+            "path": path,
+            "partitionValues": {"p_str": p_str, "p_bin": p_bin, "p_int": p_int},
+            "size": 100,
+            "modificationTime": 1700000000000_i64,
+            "dataChange": true,
+            "stats": "{\"numRecords\":1}",
+        },
+    })
+    .to_string()
+}
+
+/// A foreign writer can persist a literal "" in the `partitionValues` map. On read, kernel
+/// reconstructs `partitionValues_parsed` with DBR's non-ANSI `Cast` semantics: "" stays "" for
+/// string, becomes empty bytes for binary, and becomes null for every other type.
+///
+/// The result is identical whether the value is reconstructed from the `partitionValues` map (JSON
+/// commit) or read from a kernel-written checkpoint's native `partitionValues_parsed` column: the
+/// checkpoint reconstructs that column with the same cast, so a checkpoint never changes the value
+/// a scan surfaces. `native_checkpoint` pins that equivalence.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parsed_partition_values_read_foreign_empty_string(
+    #[values(false, true)] native_checkpoint: bool,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let table_path = temp_dir.path().join("foreign-empty-string");
+    let url = write_foreign_partition_table(
+        &table_path,
+        &[add_action(
+            "p_str=/p_bin=/p_int=/part-0.parquet",
+            "",
+            "",
+            "",
+        )],
+    )
+    .await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+
+    if native_checkpoint {
+        let snapshot = Snapshot::builder_for(url.clone())
+            .build(engine.as_ref())
+            .unwrap();
+        snapshot.checkpoint(engine.as_ref(), None).unwrap();
+    }
+
+    let snapshot = Snapshot::builder_for(url.clone())
+        .build(engine.as_ref())
+        .unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()
+        .unwrap();
+
+    let mut asserted_rows = 0;
+    for scan_metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let (data, selection) = scan_metadata.unwrap().scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data).unwrap().into();
+        let batch = filter_record_batch(&batch, &BooleanArray::from(selection)).unwrap();
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let pv = get_column!(batch, "partitionValues_parsed", StructArray);
+
+        let p_str = pv.column_by_name("p_str").unwrap();
+        let p_str = p_str.as_any().downcast_ref::<StringArray>().unwrap();
+        let p_bin = pv.column_by_name("p_bin").unwrap();
+        let p_bin = p_bin.as_any().downcast_ref::<BinaryArray>().unwrap();
+        let p_int = pv.column_by_name("p_int").unwrap();
+        let p_int = p_int.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        // Identical whether read from the map (JSON commit) or the checkpoint's native column.
+        assert!(!p_str.is_null(0), "string \"\" reconstructs as \"\"");
+        assert_eq!(p_str.value(0), "");
+        assert!(!p_bin.is_null(0), "binary \"\" reconstructs as empty bytes");
+        assert_eq!(p_bin.value(0), b"");
+        assert!(p_int.is_null(0), "non-string \"\" must be null");
+
+        asserted_rows += batch.num_rows();
+    }
+    assert_eq!(
+        asserted_rows, 1,
+        "expected exactly one file (native_checkpoint={native_checkpoint})"
+    );
+}
+
+fn collect_path(paths: &mut Vec<String>, scan_file: ScanFile) {
+    paths.push(scan_file.path);
+}
+
+/// A file whose string partition value is a foreign literal "" is KEPT under a `p_str = ''`
+/// predicate (the reconstructed value is "", matching DBR) and PRUNED under `p_str = 'other'`.
+/// This locks in the DBR-consistent partition skipping the cast change enables: before the change
+/// "" collapsed to null and `p_str = 'other'` kept the file conservatively, diverging from DBR.
+///
+/// `native_checkpoint` pins that pruning is identical before and after a kernel checkpoint: the
+/// checkpoint reconstructs the same "" into its native `partitionValues_parsed` column, so skipping
+/// keeps and prunes the same files a scan of the JSON commit would.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_string_partition_pruning_matches_dbr(
+    #[values(false, true)] native_checkpoint: bool,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let table_path = temp_dir.path().join("empty-string-pruning");
+    let url = write_foreign_partition_table(
+        &table_path,
+        &[
+            add_action("p_str=/empty.parquet", "", "", ""),
+            add_action("p_str=other/other.parquet", "other", "other", "7"),
+        ],
+    )
+    .await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+
+    if native_checkpoint {
+        let snapshot = Snapshot::builder_for(url.clone())
+            .build(engine.as_ref())
+            .unwrap();
+        snapshot.checkpoint(engine.as_ref(), None).unwrap();
+    }
+
+    let surviving = |predicate: Predicate| -> Vec<String> {
+        let snapshot = Snapshot::builder_for(url.clone())
+            .build(engine.as_ref())
+            .unwrap();
+        let scan = snapshot
+            .scan_builder()
+            .with_predicate(Arc::new(predicate))
+            .build()
+            .unwrap();
+        let mut paths = Vec::new();
+        for scan_metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+            paths = scan_metadata
+                .unwrap()
+                .visit_scan_files(paths, collect_path)
+                .unwrap();
+        }
+        paths.sort();
+        paths
+    };
+
+    assert_eq!(
+        surviving(Predicate::eq(col!("p_str"), lit(""))),
+        vec!["p_str=/empty.parquet".to_string()],
+        "empty-string file must be kept under p_str = ''"
+    );
+    assert_eq!(
+        surviving(Predicate::eq(col!("p_str"), lit("other"))),
+        vec!["p_str=other/other.parquet".to_string()],
+        "empty-string file must be pruned under p_str = 'other' (matches DBR)"
+    );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kernel never persists a literal empty-string partition value (it collapses empties to an absent map entry on write), but a foreign writer can. On read, an empty string was parsed to null for every type. This changes empty-string partition values to follow a non-ANSI SQL cast: `""` stays `""` for string, becomes empty bytes for binary, and becomes null for every other type (an empty string has no representation for non-string/binary types).

The rule lives in one place, `PrimitiveType::empty_string_partition_cast`, and is applied consistently across the parse paths so a checkpoint and its source commits always agree:

- `parse_partition_value_raw` (transform spec, scan skipping)
- `parse_partition_scalar` (Arrow expression evaluation)
- `MAP_TO_STRUCT` (checkpoint `partitionValues_parsed` reconstruction)

This also fixes partition pruning: previously an empty-string value collapsed to null, so `p_str = 'other'` conservatively kept an empty-string file. It is now pruned correctly, and `IS NULL` / `IS NOT NULL` behave consistently with the value being a real empty string.

## How was this change tested?

- Unit tests for each parse path asserting the cast semantics (string/binary/other).
- Integration tests standing in a foreign writer that persists a literal `""`, asserting the reconstructed `partitionValues_parsed` matches for both a JSON commit and a kernel-written checkpoint's native column.
- Partition-pruning tests asserting an empty-string file is kept under `p_str = ''` / `IS NULL`, pruned under `p_str = 'other'` / `IS NOT NULL`, plus a binary-column case, parameterized over `native_checkpoint`.

`add_transform_omits_to_json_when_synthesis_skipped` was converted from an `#[rstest]` over `has_partition_values_parsed` to a plain `#[test]`: that parameter toggles a column read vs. `MAP_TO_STRUCT`, neither of which is a `ToJson` node, so it was orthogonal to the `ToJson` count the test asserts.
