### PR TITLE
feat: add predicate pushdown to incremental scan

### DIFF
--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -47,13 +47,12 @@ impl IncrementalScanBuilder {
     /// drop stale cached entries). Skipping is best-effort and conservative: a file is dropped
     /// only when its stats prove no row can match, and files without stats are always kept.
     ///
-    /// For predicates over data columns, skipping reuses the same stats-based filter the read
-    /// path uses, so the surviving Add set matches what a full scan at the target version with
-    /// the same predicate would keep among these added files. Partition-value pruning is not
-    /// yet wired in on this path: predicates over partition columns fold to keep-all, so a
-    /// predicate touching partition columns yields a superset of what a cold scan would keep.
-    /// Skipping never drops a file a cold scan would keep, so consumers must re-apply the
-    /// predicate at read time regardless.
+    /// Skipping reuses the same stats-based filter the read path uses: data-column predicates
+    /// prune against file stats parsed from `add.stats`, and partition-column predicates prune
+    /// against the file's partition values. The surviving Add set matches what a full scan at the
+    /// target version with the same predicate would keep among these added files. Skipping never
+    /// drops a file a cold scan would keep, so consumers must re-apply the predicate at read time
+    /// regardless.
     pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
         self.predicate = predicate.into();
         self
@@ -182,9 +181,9 @@ impl IncrementalScanBuilder {
             PhysicalPredicate::None => Ok(AddSkipping::KeepAll),
             PhysicalPredicate::Some(physical_predicate, _referenced_schema) => {
                 // Reuse the same raw-action-batch filter the change-data-feed path builds:
-                // parse stats from `add.stats` JSON and skip against the shared
-                // `DataSkippingFilter`. `None` (predicate ineligible for skipping, or stats
-                // schema unbuildable) degrades to keep-all.
+                // parse stats from `add.stats` JSON and partition values from
+                // `add.partitionValues`, then skip against the shared `DataSkippingFilter`.
+                // `None` (predicate ineligible for skipping) degrades to keep-all.
                 let filter = DataSkippingFilter::for_raw_action_batch(
                     engine,
                     physical_predicate,

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -2,19 +2,21 @@
 //! [`IncrementalScanBuilder`] for the entry point.
 
 use std::collections::HashSet;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor};
 use crate::expressions::{column_name, ColumnName};
 use crate::log_replay::deduplicator::{Deduplicator, FileActionInfo};
 use crate::log_replay::{FileActionDeduplicator, FileActionKey};
-use crate::scan::COMMIT_READ_SCHEMA;
+use crate::scan::data_skipping::DataSkippingFilter;
+use crate::scan::{PhysicalPredicate, COMMIT_READ_SCHEMA};
 use crate::schema::{ColumnNamesAndTypes, DataType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
 use crate::utils::require;
 use crate::{
-    DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, Version,
+    DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, PredicateRef,
+    Version,
 };
 
 /// Builder for an incremental scan over `(base_version, target_version]`. Construct via
@@ -24,6 +26,7 @@ use crate::{
 pub struct IncrementalScanBuilder {
     target_snapshot: SnapshotRef,
     base_version: Version,
+    predicate: Option<PredicateRef>,
 }
 
 impl IncrementalScanBuilder {
@@ -32,7 +35,26 @@ impl IncrementalScanBuilder {
         Self {
             target_snapshot: target_snapshot.into(),
             base_version,
+            predicate: None,
         }
+    }
+
+    /// Restrict the streamed live `Add` actions to those whose file stats do not provably
+    /// exclude `predicate`. `None` (the default) preserves the current behavior: every live
+    /// Add is streamed.
+    ///
+    /// Removes are unaffected (they carry no stats and must all be reported so consumers can
+    /// drop stale cached entries). Skipping is best-effort and conservative: a file is dropped
+    /// only when its stats prove no row can match, and files without stats are always kept. The
+    /// surviving Add set is therefore identical to what a full scan at the target version with
+    /// the same predicate would keep among these added files.
+    ///
+    /// Skipping reuses the same stats-based filter the read path uses, so incremental skipping
+    /// is semantically identical to a cold scan. Partition-value pruning is not yet wired in on
+    /// this path; predicates over partition columns fold to keep-all.
+    pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
+        self.predicate = predicate.into();
+        self
     }
 
     /// Build the incremental scan stream, or `None` if the target snapshot's commit list
@@ -70,6 +92,10 @@ impl IncrementalScanBuilder {
                 self.base_version, target_version
             ))
         );
+        // Resolve the predicate into an Add-side skipping strategy up front so `build` can
+        // fail fast on a malformed predicate (e.g. references to unknown columns), rather
+        // than surfacing the error lazily from the stream.
+        let add_skipping = self.resolve_add_skipping(engine)?;
         // `base_version < target_version` above guarantees `base_version < u64::MAX`, but use
         // `checked_add` to make the dependency explicit and panic-free.
         let start_version = self.base_version.checked_add(1).ok_or_else(|| {
@@ -124,12 +150,60 @@ impl IncrementalScanBuilder {
             base_version: self.base_version,
             target_version,
             actions,
+            add_skipping,
             seen_file_keys: HashSet::new(),
             live_adds: HashSet::new(),
             removes: HashSet::new(),
             errored: false,
         }))
     }
+
+    /// Lowers `self.predicate` into the per-batch skipping strategy applied to live Adds.
+    ///
+    /// Returns [`AddSkipping::KeepAll`] when there is no predicate, when the predicate is
+    /// useless for data skipping ([`PhysicalPredicate::None`]), or when the filter cannot be
+    /// constructed. [`AddSkipping::SkipAll`] when the predicate statically excludes every file
+    /// ([`PhysicalPredicate::StaticSkipAll`]); the stream still reports Removes but yields no
+    /// live Adds. [`AddSkipping::Filter`] carries the reusable [`DataSkippingFilter`].
+    fn resolve_add_skipping(&self, engine: &dyn Engine) -> DeltaResult<AddSkipping> {
+        let Some(predicate) = self.predicate.as_ref() else {
+            return Ok(AddSkipping::KeepAll);
+        };
+
+        let table_configuration = self.target_snapshot.table_configuration();
+        let logical_schema = table_configuration.logical_schema();
+        let column_mapping_mode = table_configuration.column_mapping_mode();
+        match PhysicalPredicate::try_new(predicate, &logical_schema, column_mapping_mode)? {
+            PhysicalPredicate::StaticSkipAll => Ok(AddSkipping::SkipAll),
+            PhysicalPredicate::None => Ok(AddSkipping::KeepAll),
+            PhysicalPredicate::Some(physical_predicate, _referenced_schema) => {
+                // Reuse the same raw-action-batch filter the change-data-feed path builds:
+                // parse stats from `add.stats` JSON and skip against the shared
+                // `DataSkippingFilter`. `None` (predicate ineligible for skipping, or stats
+                // schema unbuildable) degrades to keep-all.
+                let filter = DataSkippingFilter::for_raw_action_batch(
+                    engine,
+                    physical_predicate,
+                    table_configuration,
+                    COMMIT_READ_SCHEMA.clone(),
+                    None,
+                );
+                Ok(filter.map_or(AddSkipping::KeepAll, |f| AddSkipping::Filter(Arc::new(f))))
+            }
+        }
+    }
+}
+
+/// How the streamed live `Add` actions are pruned against the builder's predicate.
+enum AddSkipping {
+    /// No predicate, or a predicate useless for data skipping: every live Add is streamed.
+    KeepAll,
+    /// The predicate statically excludes every file: no live Add is streamed (Removes are
+    /// still reported).
+    SkipAll,
+    /// Prune each Add batch through the stats-based filter, keeping only Adds the predicate
+    /// cannot provably exclude.
+    Filter(Arc<DataSkippingFilter>),
 }
 
 /// Streaming output of an incremental scan over `(base_version, target_version]`.
@@ -152,6 +226,7 @@ pub struct IncrementalScanStream {
     base_version: Version,
     target_version: Version,
     actions: FileDataReadResultIterator,
+    add_skipping: AddSkipping,
     seen_file_keys: HashSet<FileActionKey>,
     live_adds: HashSet<FileActionKey>,
     removes: HashSet<FileActionKey>,
@@ -173,6 +248,7 @@ impl Iterator for IncrementalScanStream {
                 }
                 Ok(batch) => match process_batch(
                     batch,
+                    &self.add_skipping,
                     &mut self.seen_file_keys,
                     &mut self.live_adds,
                     &mut self.removes,
@@ -468,15 +544,34 @@ impl std::fmt::Debug for IncrementalListingAgainstBase {
 }
 
 /// Visit one commit-batch, updating dedup state and accumulators. Returns the filtered Add
-/// rows for this batch, or `None` if no Adds survived dedup in this batch.
+/// rows for this batch, or `None` if no Adds survived dedup (and skipping) in this batch.
+///
+/// When `add_skipping` carries a [`DataSkippingFilter`], a per-row stats mask is computed
+/// once for the batch and AND-ed into the live-Add selection: an Add whose stats prove it
+/// cannot match the predicate is dropped from both the emitted selection vector and the
+/// `live_adds` set, keeping the streamed batches and the summary consistent. A skipped Add
+/// still advances dedup state (its `(path, dv_unique_id)` key is recorded as seen) so an
+/// older duplicate of the same file cannot leak through, matching newest-wins semantics.
+/// Removes are never skipped.
 fn process_batch(
     batch: Box<dyn EngineData>,
+    add_skipping: &AddSkipping,
     seen_file_keys: &mut HashSet<FileActionKey>,
     live_adds: &mut HashSet<FileActionKey>,
     removes: &mut HashSet<FileActionKey>,
 ) -> DeltaResult<Option<FilteredEngineData>> {
     let row_count = batch.len();
     let mut adds_sel = vec![false; row_count];
+
+    // Per-row "keep this Add" mask derived from the predicate. `true` (the default) keeps the
+    // Add; `false` drops it. `SkipAll` drops every Add; `KeepAll` keeps every Add; `Filter`
+    // consults the stats-based skipper (which conservatively keeps rows it cannot disprove,
+    // including Removes and stats-less files).
+    let keep_add: Vec<bool> = match add_skipping {
+        AddSkipping::KeepAll => vec![true; row_count],
+        AddSkipping::SkipAll => vec![false; row_count],
+        AddSkipping::Filter(filter) => filter.apply(batch.as_ref())?,
+    };
 
     let deduplicator = FileActionDeduplicator::new(
         seen_file_keys,
@@ -489,15 +584,17 @@ fn process_batch(
     );
     let mut visitor = IncrementalDedupVisitor {
         deduplicator,
+        keep_add: &keep_add,
         adds_sel: &mut adds_sel,
         live_adds,
         removes,
     };
     visitor.visit_rows_of(batch.as_ref())?;
 
-    // No Adds in the batch survived dedup, e.g. a Removes-only commit or a commit whose
-    // Adds were all cancelled by later commits in the range. Skip yielding an empty
-    // batch; dedup state has still been advanced by the visit above.
+    // No Adds in the batch survived dedup and skipping, e.g. a Removes-only commit, a commit
+    // whose Adds were all cancelled by later commits in the range, or one whose Adds were all
+    // pruned by the predicate. Skip yielding an empty batch; dedup state has still been
+    // advanced by the visit above.
     if !adds_sel.iter().any(|s| *s) {
         return Ok(None);
     }
@@ -521,6 +618,9 @@ const NUM_GETTERS: usize = 9; // 5 add + 4 remove columns
 // slimmer visitor is the right shape here.
 struct IncrementalDedupVisitor<'a, 'seen> {
     deduplicator: FileActionDeduplicator<'seen>,
+    /// Per-row predicate mask (`true` = keep the Add). Same length as the batch; indexed by
+    /// the visitor's row index. Removes ignore this mask.
+    keep_add: &'a [bool],
     adds_sel: &'a mut [bool],
     live_adds: &'a mut HashSet<FileActionKey>,
     removes: &'a mut HashSet<FileActionKey>,
@@ -578,8 +678,13 @@ impl RowVisitor for IncrementalDedupVisitor<'_, '_> {
             }
 
             if is_add {
-                self.adds_sel[i] = true;
-                self.live_adds.insert(key);
+                // Record `seen` above regardless of the predicate so an older duplicate of a
+                // pruned file stays suppressed (newest-wins). Only inclusion in the output
+                // and `live_adds` is gated by the stats mask.
+                if self.keep_add[i] {
+                    self.adds_sel[i] = true;
+                    self.live_adds.insert(key);
+                }
             } else {
                 self.removes.insert(key);
             }

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -43,8 +43,8 @@ impl IncrementalScanBuilder {
     /// exclude `predicate`. `None` (the default) preserves the current behavior: every live
     /// Add is streamed.
     ///
-    /// Removes are unaffected (they carry no stats and must all be reported so consumers can
-    /// drop stale cached entries). Skipping is best-effort and conservative: a file is dropped
+    /// Removes are unaffected: they are never pruned and must all be reported so consumers can
+    /// drop stale cached entries. Skipping is best-effort and conservative: a file is dropped
     /// only when its stats prove no row can match, and files without stats are always kept.
     ///
     /// Skipping reuses the same stats-based filter the read path uses: data-column predicates
@@ -189,7 +189,6 @@ impl IncrementalScanBuilder {
                     physical_predicate,
                     table_configuration,
                     COMMIT_READ_SCHEMA.clone(),
-                    None,
                 );
                 Ok(filter.map_or(AddSkipping::KeepAll, |f| AddSkipping::Filter(Arc::new(f))))
             }

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -45,13 +45,15 @@ impl IncrementalScanBuilder {
     ///
     /// Removes are unaffected (they carry no stats and must all be reported so consumers can
     /// drop stale cached entries). Skipping is best-effort and conservative: a file is dropped
-    /// only when its stats prove no row can match, and files without stats are always kept. The
-    /// surviving Add set is therefore identical to what a full scan at the target version with
-    /// the same predicate would keep among these added files.
+    /// only when its stats prove no row can match, and files without stats are always kept.
     ///
-    /// Skipping reuses the same stats-based filter the read path uses, so incremental skipping
-    /// is semantically identical to a cold scan. Partition-value pruning is not yet wired in on
-    /// this path; predicates over partition columns fold to keep-all.
+    /// For predicates over data columns, skipping reuses the same stats-based filter the read
+    /// path uses, so the surviving Add set matches what a full scan at the target version with
+    /// the same predicate would keep among these added files. Partition-value pruning is not
+    /// yet wired in on this path: predicates over partition columns fold to keep-all, so a
+    /// predicate touching partition columns yields a superset of what a cold scan would keep.
+    /// Skipping never drops a file a cold scan would keep, so consumers must re-apply the
+    /// predicate at read time regardless.
     pub fn with_predicate(mut self, predicate: impl Into<Option<PredicateRef>>) -> Self {
         self.predicate = predicate.into();
         self
@@ -77,6 +79,8 @@ impl IncrementalScanBuilder {
     ///
     /// # Errors
     /// - `Err` if `base_version >= target_snapshot.version()` (caller error).
+    /// - [`Error::MissingColumn`] if a [`with_predicate`](Self::with_predicate) predicate
+    ///   references a column absent from the table schema.
     /// - `Err` if the target snapshot's protocol contains an unsupported reader feature.
     /// - `Err` if the engine fails to open the commit stream.
     pub fn build(self, engine: &dyn Engine) -> DeltaResult<Option<IncrementalScanStream>> {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,7 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
-    column_expr, column_expr_ref, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
+    column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
     Expression as Expr, ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef,
     Predicate as Pred, PredicateRef, Scalar,
 };
@@ -230,15 +230,17 @@ impl DataSkippingFilter {
     /// The stats schema is derived from the predicate's column references via
     /// [`TableConfiguration::build_expected_stats_schemas`], matching the write side exactly;
     /// references outside the table's stats columns fold to NULL (keeping the file). Partition
-    /// pruning is not wired in here, so partition predicates fold to keep-all.
+    /// values are parsed from the raw `add.partitionValues` string map with
+    /// [`Expression::map_to_struct`], so predicates over partition columns prune too.
     ///
     /// Returns `None` (equivalent to keep-all) when the predicate is ineligible for data
-    /// skipping or when the stats schema cannot be built.
+    /// skipping or when neither data stats nor referenced partition columns are available.
     ///
     /// # Parameters
     /// - `engine`: Engine for creating evaluators.
     /// - `physical_predicate`: The predicate, already lowered to physical column names.
-    /// - `table_configuration`: Source of the stats schema and stats-column gate.
+    /// - `table_configuration`: Source of the stats schema, partition schema, and stats-column
+    ///   gate.
     /// - `input_schema`: Schema of the raw action batches passed to [`apply()`](Self::apply).
     /// - `metrics`: Optional metrics to record data skipping statistics.
     pub(crate) fn for_raw_action_batch(
@@ -262,21 +264,24 @@ impl DataSkippingFilter {
             .build_expected_stats_schemas(None, Some(&predicate_refs))
             .ok()?
             .physical;
+        let partition_schema = table_configuration.predicate_partition_schema(&predicate_refs);
 
-        // Parse JSON stats from the raw action batch's `add.stats` column, and identify Add
-        // rows by `add.path IS NOT NULL` (raw batches keep the nested layout).
+        // Parse JSON stats from the raw action batch's `add.stats` column, parse partition values
+        // from the raw `add.partitionValues` string map, and identify Add rows by
+        // `add.path IS NOT NULL` (raw batches keep the nested layout).
         let stats_expr = Arc::new(Expr::parse_json(
             column_expr!("add.stats"),
             physical_stats_schema.clone(),
         ));
+        let partition_expr = Arc::new(Expr::map_to_struct(column_expr!("add.partitionValues")));
         let is_add_expr = Arc::new(Pred::is_not_null(column_expr!("add.path")).into());
         Self::new(
             engine,
             Some(physical_predicate),
             Some(&physical_stats_schema),
             stats_expr,
-            None, // partition pruning not wired in for raw-action-batch skipping
-            column_expr_ref!("partitionValues_parsed"),
+            partition_schema.as_ref(),
+            partition_expr,
             is_add_expr,
             input_schema,
             &physical_stats_columns,

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,7 +9,7 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
-    column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
+    column_expr, column_expr_ref, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
     Expression as Expr, ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef,
     Predicate as Pred, PredicateRef, Scalar,
 };
@@ -19,6 +19,7 @@ use crate::kernel_predicates::{
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
 use crate::scan::metrics::ScanMetrics;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::table_configuration::TableConfiguration;
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
 
@@ -219,6 +220,68 @@ impl DataSkippingFilter {
             filter_evaluator,
             metrics,
         })
+    }
+
+    /// Builds a filter over raw `{ add, remove, ... }` action batches, parsing file stats from
+    /// the JSON `add.stats` string. This is the shape used by log-replay paths that skip
+    /// *before* transforming actions (the change-data-feed path and the incremental scan),
+    /// unlike the scan path which reads pre-parsed `stats_parsed` from transformed batches.
+    ///
+    /// The stats schema is derived from the predicate's column references via
+    /// [`TableConfiguration::build_expected_stats_schemas`], matching the write side exactly;
+    /// references outside the table's stats columns fold to NULL (keeping the file). Partition
+    /// pruning is not wired in here, so partition predicates fold to keep-all.
+    ///
+    /// Returns `None` (equivalent to keep-all) when the predicate is ineligible for data
+    /// skipping or when the stats schema cannot be built.
+    ///
+    /// # Parameters
+    /// - `engine`: Engine for creating evaluators.
+    /// - `physical_predicate`: The predicate, already lowered to physical column names.
+    /// - `table_configuration`: Source of the stats schema and stats-column gate.
+    /// - `input_schema`: Schema of the raw action batches passed to [`apply()`](Self::apply).
+    /// - `metrics`: Optional metrics to record data skipping statistics.
+    pub(crate) fn for_raw_action_batch(
+        engine: &dyn Engine,
+        physical_predicate: PredicateRef,
+        table_configuration: &TableConfiguration,
+        input_schema: SchemaRef,
+        metrics: Option<Arc<ScanMetrics>>,
+    ) -> Option<Self> {
+        // Predicate refs become the `requested_physical_columns` filter; refs outside
+        // `physical_stats_columns` fold to NULL via the gate below. Clustering columns are
+        // deliberately not required here (see the scan path and #2588): loading clustering
+        // domain metadata would add an unbounded log replay to setup.
+        let predicate_refs: Vec<ColumnName> = physical_predicate
+            .references()
+            .into_iter()
+            .cloned()
+            .collect();
+        let physical_stats_columns = table_configuration.physical_stats_columns_set(None);
+        let physical_stats_schema = table_configuration
+            .build_expected_stats_schemas(None, Some(&predicate_refs))
+            .ok()?
+            .physical;
+
+        // Parse JSON stats from the raw action batch's `add.stats` column, and identify Add
+        // rows by `add.path IS NOT NULL` (raw batches keep the nested layout).
+        let stats_expr = Arc::new(Expr::parse_json(
+            column_expr!("add.stats"),
+            physical_stats_schema.clone(),
+        ));
+        let is_add_expr = Arc::new(Pred::is_not_null(column_expr!("add.path")).into());
+        Self::new(
+            engine,
+            Some(physical_predicate),
+            Some(&physical_stats_schema),
+            stats_expr,
+            None, // partition pruning not wired in for raw-action-batch skipping
+            column_expr_ref!("partitionValues_parsed"),
+            is_add_expr,
+            input_schema,
+            &physical_stats_columns,
+            metrics,
+        )
     }
 
     /// Builds the unified schema and extraction expression from separate data stats and partition

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -233,8 +233,12 @@ impl DataSkippingFilter {
     /// values are parsed from the raw `add.partitionValues` string map with
     /// [`Expression::map_to_struct`], so predicates over partition columns prune too.
     ///
-    /// Returns `None` (equivalent to keep-all) when the predicate is ineligible for data
-    /// skipping or when neither data stats nor referenced partition columns are available.
+    /// Returns `None` (equivalent to keep-all) when the predicate is ineligible for data skipping
+    /// (references no stats columns, or fails evaluator construction).
+    ///
+    /// Pruning applies only to Add rows: Remove and cdc rows (null `add.path`) are never pruned,
+    /// guarded by the `add.path IS NOT NULL` `is_add` expression wired in below. Callers on the
+    /// change-data-feed path rely on this so tombstones survive a non-matching predicate.
     ///
     /// # Parameters
     /// - `engine`: Engine for creating evaluators.
@@ -242,18 +246,16 @@ impl DataSkippingFilter {
     /// - `table_configuration`: Source of the stats schema, partition schema, and stats-column
     ///   gate.
     /// - `input_schema`: Schema of the raw action batches passed to [`apply()`](Self::apply).
-    /// - `metrics`: Optional metrics to record data skipping statistics.
     pub(crate) fn for_raw_action_batch(
         engine: &dyn Engine,
         physical_predicate: PredicateRef,
         table_configuration: &TableConfiguration,
         input_schema: SchemaRef,
-        metrics: Option<Arc<ScanMetrics>>,
     ) -> Option<Self> {
         // Predicate refs become the `requested_physical_columns` filter; refs outside
         // `physical_stats_columns` fold to NULL via the gate below. Clustering columns are
         // deliberately not required here (see the scan path and #2588): loading clustering
-        // domain metadata would add an unbounded log replay to setup.
+        // domain metadata would require a separate scan of the log, which this filter avoids.
         let predicate_refs: Vec<ColumnName> = physical_predicate
             .references()
             .into_iter()
@@ -285,7 +287,7 @@ impl DataSkippingFilter {
             is_add_expr,
             input_schema,
             &physical_stats_columns,
-            metrics,
+            None,
         )
     }
 

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -137,23 +137,14 @@ fn build_data_skipping_schemas(
     physical_predicate: &PhysicalPredicate,
     predicate_column_names_logical: &[ColumnName],
     table_configuration: &TableConfiguration,
-    table_partition_schema: Option<SchemaRef>,
 ) -> DeltaResult<(Option<SchemaRef>, Option<SchemaRef>)> {
-    // Filter partition schema to only predicate-referenced columns. The DataSkippingFilter
-    // only needs partition columns that appear in the predicate, and the transform output
-    // should not include unused partition columns.
-    let predicate_partition_schema = match (&table_partition_schema, physical_predicate) {
-        (Some(tps), PhysicalPredicate::Some(_, ref_schema)) => {
-            // Partition values extracted from the string map via MapToStruct are always
-            // nullable (map lookup can return null), so we force all partition fields nullable.
-            ref_schema
-                .with_fields_filtered_nonempty(|f| tps.field(f.name()).is_some())?
-                .map(|partition_schema| {
-                    let nullable_fields = partition_schema
-                        .fields()
-                        .map(|f| StructField::nullable(f.name(), f.data_type().clone()));
-                    Arc::new(StructType::new_unchecked(nullable_fields))
-                })
+    // Narrow the table's typed partition schema to the columns the predicate references. The
+    // DataSkippingFilter only needs partition columns that appear in the predicate, and the
+    // shared helper forces every field nullable (MapToStruct can yield null for a missing key).
+    let predicate_partition_schema = match physical_predicate {
+        PhysicalPredicate::Some(pred, _ref_schema) => {
+            let refs: Vec<ColumnName> = pred.references().into_iter().cloned().collect();
+            table_configuration.predicate_partition_schema(&refs)
         }
         _ => None,
     };
@@ -419,7 +410,6 @@ impl StateInfo {
             &physical_predicate,
             &predicate_column_names,
             table_configuration,
-            table_partition_schema.clone(),
         )?;
 
         // When the engine requested the typed struct, emit all partition columns rather than

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -57,7 +57,7 @@ pub(crate) fn table_changes_action_iter(
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
     // Skip against the raw `{ add, remove, ... }` action batch: table_changes must resolve
     // deletion vector pairs before filtering, so unlike the scan path it operates on raw
-    // batches with stats parsed from `add.stats` JSON. `None` metrics: not wired in yet.
+    // batches with stats parsed from `add.stats` JSON.
     let filter = physical_predicate
         .and_then(|(predicate, _ref_schema)| {
             DataSkippingFilter::for_raw_action_batch(
@@ -65,7 +65,6 @@ pub(crate) fn table_changes_action_iter(
                 predicate,
                 start_table_configuration,
                 LOG_ADD_SCHEMA.clone(),
-                None,
             )
         })
         .map(Arc::new);

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -14,9 +14,7 @@ use crate::actions::{
     PROTOCOL_FIELD, REMOVE_FIELD,
 };
 use crate::engine_data::{GetData, TypedGetData};
-use crate::expressions::{
-    column_expr, column_expr_ref, column_name, ColumnName, Expression, Predicate,
-};
+use crate::expressions::{column_name, ColumnName};
 use crate::path::{AsUrl, ParsedLogPath};
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::scan::state::DvInfo;
@@ -57,47 +55,17 @@ pub(crate) fn table_changes_action_iter(
     table_schema: SchemaRef,
     physical_predicate: Option<(PredicateRef, SchemaRef)>,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
-    // Stats-eligible columns for the DataSkippingFilter below. Roughly parallels the scan
-    // path's `StateInfo::physical_stats_columns`. Clustering columns are deliberately not
-    // passed here, for the same reason the scan path leaves them out (see #2588):
-    // loading clustering domain metadata on the table-changes path would add an unbounded
-    // log replay to setup. If #2588 lands a writer-side fix that keeps
-    // `dataSkippingStatsColumns` in sync with clustering, both call sites stay simple.
-    let physical_stats_columns = start_table_configuration.physical_stats_columns_set(None);
-
+    // Skip against the raw `{ add, remove, ... }` action batch: table_changes must resolve
+    // deletion vector pairs before filtering, so unlike the scan path it operates on raw
+    // batches with stats parsed from `add.stats` JSON. `None` metrics: not wired in yet.
     let filter = physical_predicate
         .and_then(|(predicate, _ref_schema)| {
-            // Build the stats schema via the same path the scan side uses
-            // (`build_expected_stats_schemas`), so the read-side shape matches the write-side
-            // exactly. Predicate refs become the `requested_physical_columns` filter; refs
-            // outside `physical_stats_columns` fold to NULL via `DataSkippingFilter`'s gate.
-            let predicate_refs: Vec<ColumnName> =
-                predicate.references().into_iter().cloned().collect();
-            let physical_stats_schema = start_table_configuration
-                .build_expected_stats_schemas(None, Some(&predicate_refs))
-                .ok()?
-                .physical;
-
-            // Parse JSON stats from the raw action batch's `add.stats` column. Unlike the scan
-            // path (which transforms first and reads pre-parsed stats), table_changes must
-            // resolve deletion vector pairs before filtering, so it operates on raw batches.
-            let stats_expr = Arc::new(Expression::parse_json(
-                column_expr!("add.stats"),
-                physical_stats_schema.clone(),
-            ));
-            DataSkippingFilter::new(
+            DataSkippingFilter::for_raw_action_batch(
                 engine.as_ref(),
-                Some(predicate),
-                Some(&physical_stats_schema),
-                stats_expr,
-                None, // no partition columns for table changes (partition_expr unused)
-                column_expr_ref!("partitionValues_parsed"),
-                // Raw action batches keep the nested layout, so Add rows are
-                // `add.path IS NOT NULL`.
-                Arc::new(Predicate::is_not_null(column_expr!("add.path")).into()),
+                predicate,
+                start_table_configuration,
                 LOG_ADD_SCHEMA.clone(),
-                &physical_stats_columns,
-                None, // Table changes doesn't use metrics yet
+                None,
             )
         })
         .map(Arc::new);

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -859,9 +859,11 @@ async fn data_skipping_filter() {
 
 // The shared `for_raw_action_batch` filter prunes on partition values on the table_changes path
 // too: partition values are parsed from `add.partitionValues` via `map_to_struct`, so `part = 'x'`
-// drops the Add in partition `y`.
+// drops the Add in partition `y`. The Remove in partition `y` must survive: the `OR(NOT is_add,
+// ...)` guard shields non-Add rows from the predicate, so tombstones are never dropped from the
+// change feed even when their partition does not match.
 #[tokio::test]
-async fn data_skipping_filter_prunes_partition_values() {
+async fn data_skipping_filter_prunes_partition_values_but_keeps_removes() {
     let engine = Arc::new(SyncEngine::new());
     let mut mock_table = LocalMockTable::new();
     mock_table
@@ -875,6 +877,14 @@ async fn data_skipping_filter_prunes_partition_values() {
             Action::Add(Add {
                 path: "in_y".into(),
                 partition_values: HashMap::from([("part".to_string(), "y".to_string())]),
+                data_change: true,
+                ..Default::default()
+            }),
+            // A tombstone in the pruned partition `y`. If the guard broke, `part = 'x'` would
+            // silently drop it from the change feed.
+            Action::Remove(Remove {
+                path: "gone_y".into(),
+                partition_values: Some(HashMap::from([("part".to_string(), "y".to_string())])),
                 data_change: true,
                 ..Default::default()
             }),
@@ -918,8 +928,70 @@ async fn data_skipping_filter_prunes_partition_values() {
         .flat_map(|scan_metadata| scan_metadata.unwrap().selection_vector)
         .collect_vec();
 
-    // Only the Add in partition `x` survives; the one in `y` is pruned.
-    assert_eq!(sv, &[true, false]);
+    // Add in `x` survives, Add in `y` is pruned, and the Remove in `y` survives via the guard.
+    assert_eq!(sv, &[true, false, true]);
+}
+
+// Stats-based pruning (as opposed to partition-value pruning) with a Remove present: `id > 4`
+// drops the out-of-range Add via its `add.stats`, keeps the in-range Add, and the standalone
+// Remove survives regardless of the predicate because non-Add rows bypass the stats filter.
+#[tokio::test]
+async fn data_skipping_filter_prunes_stats_but_keeps_removes() {
+    let engine = Arc::new(SyncEngine::new());
+    let mut mock_table = LocalMockTable::new();
+    mock_table
+        .commit([
+            // Standalone Remove (no matching Add, no DV): survives as a tombstone.
+            Action::Remove(Remove {
+                path: "gone".into(),
+                data_change: true,
+                ..Default::default()
+            }),
+            // id in [0, 2]: provably excluded by `id > 4`.
+            Action::Add(Add {
+                path: "out_of_range".into(),
+                stats: Some(
+                    "{\"numRecords\":4,\"minValues\":{\"id\":0},\"maxValues\":{\"id\":2},\"nullCount\":{\"id\":0}}".into(),
+                ),
+                data_change: true,
+                ..Default::default()
+            }),
+            // id in [4, 6]: overlaps `id > 4`, so kept.
+            Action::Add(Add {
+                path: "in_range".into(),
+                stats: Some(
+                    "{\"numRecords\":4,\"minValues\":{\"id\":4},\"maxValues\":{\"id\":6},\"nullCount\":{\"id\":0}}".into(),
+                ),
+                data_change: true,
+                ..Default::default()
+            }),
+        ])
+        .await;
+
+    let logical_schema = get_schema();
+    let predicate = Predicate::binary(
+        BinaryPredicateOp::GreaterThan,
+        column_expr!("id"),
+        Scalar::from(4),
+    );
+    let predicate =
+        match PhysicalPredicate::try_new(&predicate, &logical_schema, ColumnMappingMode::None) {
+            Ok(PhysicalPredicate::Some(p, s)) => Some((p, s)),
+            other => panic!("Unexpected result: {other:?}"),
+        };
+    let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None)
+        .unwrap()
+        .into_iter();
+
+    let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+    let table_config = get_default_table_config(&table_root_url);
+    let sv = table_changes_action_iter(engine, &table_config, commits, logical_schema, predicate)
+        .unwrap()
+        .flat_map(|scan_metadata| scan_metadata.unwrap().selection_vector)
+        .collect_vec();
+
+    // Remove survives, out-of-range Add is pruned, in-range Add survives.
+    assert_eq!(sv, &[true, false, true]);
 }
 
 #[tokio::test]

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -857,6 +857,71 @@ async fn data_skipping_filter() {
     assert_eq!(sv, &[false, true, false, false, true]);
 }
 
+// The shared `for_raw_action_batch` filter prunes on partition values on the table_changes path
+// too: partition values are parsed from `add.partitionValues` via `map_to_struct`, so `part = 'x'`
+// drops the Add in partition `y`.
+#[tokio::test]
+async fn data_skipping_filter_prunes_partition_values() {
+    let engine = Arc::new(SyncEngine::new());
+    let mut mock_table = LocalMockTable::new();
+    mock_table
+        .commit([
+            Action::Add(Add {
+                path: "in_x".into(),
+                partition_values: HashMap::from([("part".to_string(), "x".to_string())]),
+                data_change: true,
+                ..Default::default()
+            }),
+            Action::Add(Add {
+                path: "in_y".into(),
+                partition_values: HashMap::from([("part".to_string(), "y".to_string())]),
+                data_change: true,
+                ..Default::default()
+            }),
+        ])
+        .await;
+
+    // Partitioned schema: `part` is the partition column, `id` a data column.
+    let logical_schema: SchemaRef = Arc::new(StructType::new_unchecked([
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("part", DataType::STRING),
+    ]));
+    let metadata = Metadata::try_new(
+        None,
+        None,
+        logical_schema.clone(),
+        vec!["part".to_string()],
+        0,
+        HashMap::from([("delta.enableChangeDataFeed".to_string(), "true".to_string())]),
+    )
+    .unwrap();
+    let protocol = Protocol::try_new_legacy(1, 4).unwrap();
+    let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+    let table_config = TableConfiguration::try_new(metadata, protocol, table_root_url, 0).unwrap();
+
+    let predicate = Predicate::binary(
+        BinaryPredicateOp::Equal,
+        column_expr!("part"),
+        Scalar::from("x"),
+    );
+    let predicate =
+        match PhysicalPredicate::try_new(&predicate, &logical_schema, ColumnMappingMode::None) {
+            Ok(PhysicalPredicate::Some(p, s)) => Some((p, s)),
+            other => panic!("Unexpected result: {other:?}"),
+        };
+    let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None)
+        .unwrap()
+        .into_iter();
+
+    let sv = table_changes_action_iter(engine, &table_config, commits, logical_schema, predicate)
+        .unwrap()
+        .flat_map(|scan_metadata| scan_metadata.unwrap().selection_vector)
+        .collect_vec();
+
+    // Only the Add in partition `x` survives; the one in `y` is pruned.
+    assert_eq!(sv, &[true, false]);
+}
+
 #[tokio::test]
 async fn failing_protocol() {
     let engine = Arc::new(SyncEngine::new());

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -354,9 +354,8 @@ impl TableConfiguration {
     }
 
     /// Stats-column set for `DataSkippingFilter`'s predicate-rewrite gate. The gate tests
-    /// every column reference in the rewritten predicate against this set, so the two
-    /// callers (`StateInfo::try_new` and `table_changes_action_iter`) share this entry
-    /// point to keep their gate input in lockstep.
+    /// every column reference in the rewritten predicate against this set; every data-skipping
+    /// call site shares this entry point so their gate input stays in lockstep.
     pub(crate) fn physical_stats_columns_set(
         &self,
         required_columns: Option<&[ColumnName]>,

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -397,6 +397,35 @@ impl TableConfiguration {
         Some(Arc::new(StructType::new_unchecked(partition_fields)))
     }
 
+    /// Typed physical partition schema for `DataSkippingFilter`, narrowed to the partition
+    /// columns referenced by `predicate_refs` (physical leaf names) with every field forced
+    /// nullable.
+    ///
+    /// Returns `None` when the table has no partition columns or the predicate references none;
+    /// the filter then treats partitions as unavailable and folds partition predicates to
+    /// keep-all. Every retained field is nullable because a `MapToStruct` over `partitionValues`
+    /// yields null for a missing key or the protocol's empty-string-is-null rule, which a
+    /// non-nullable field would reject.
+    pub(crate) fn predicate_partition_schema(
+        &self,
+        predicate_refs: &[ColumnName],
+    ) -> Option<SchemaRef> {
+        let referenced: HashSet<&str> = predicate_refs
+            .iter()
+            .filter_map(|c| match c.path() {
+                [name] => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        let nullable_fields: Vec<StructField> = self
+            .build_partition_values_parsed_schema()?
+            .fields()
+            .filter(|f| referenced.contains(f.name().as_str()))
+            .map(|f| StructField::nullable(f.name(), f.data_type().clone()))
+            .collect();
+        (!nullable_fields.is_empty()).then(|| Arc::new(StructType::new_unchecked(nullable_fields)))
+    }
+
     /// Returns the logical schema excluding partition columns.
     pub(crate) fn logical_schema_without_partition_columns(&self) -> SchemaRef {
         self.logical_schema_without_partition_columns.clone()

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -18,15 +18,16 @@ use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path as ObjectStorePath;
 use delta_kernel::object_store::ObjectStoreExt;
 use delta_kernel::{
-    Engine, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, StorageHandler,
+    Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, StorageHandler,
 };
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::json::DefaultJsonHandler;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
-    actions_to_string, actions_to_string_catalog_managed, add_commit, add_staged_commit,
-    compacted_log_path_for_versions, create_log_path, delta_path_for_version, TestAction,
+    actions_to_string, actions_to_string_catalog_managed, actions_to_string_partitioned,
+    add_commit, add_staged_commit, compacted_log_path_for_versions, create_log_path,
+    delta_path_for_version, TestAction,
 };
 use url::Url;
 
@@ -1204,15 +1205,44 @@ fn remove_action(path: &str) -> String {
     )
 }
 
-fn live_add_keys(listing: &IncrementalListing) -> &HashSet<FileActionKey> {
-    &listing.summary.live_adds
+// Build a raw Add action with a partition value for the `val` partition column and no stats.
+fn add_partitioned(path: &str, val: &str) -> String {
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{\"val\":\"{val}\"}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true}}}}"
+    )
 }
 
-// Pushdown drops added files whose stats prove they cannot match, and keeps the rest. Three
-// files span disjoint `id` ranges; `id > 25` keeps only the file whose range extends past 25.
-// Also asserts the emitted selection vector agrees with `live_adds` (no summary/stream drift).
+// Column-mapping (name mode) metadata whose `id` column maps to the physical name `col-id`.
+const COLUMN_MAPPING_METADATA: &str = "{\"metaData\":{\"id\":\"cm-test-id\",\"format\":{\"provider\":\"parquet\",\"options\":{}},\"schemaString\":\"{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"name\\\":\\\"id\\\",\\\"type\\\":\\\"integer\\\",\\\"nullable\\\":true,\\\"metadata\\\":{\\\"delta.columnMapping.id\\\":1,\\\"delta.columnMapping.physicalName\\\":\\\"col-id\\\"}}]}\",\"partitionColumns\":[],\"configuration\":{\"delta.columnMapping.mode\":\"name\",\"delta.columnMapping.maxColumnId\":\"1\"},\"createdTime\":1700000000000}}\n{\"protocol\":{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"columnMapping\"],\"writerFeatures\":[\"columnMapping\"]}}";
+
+// Build a raw Add whose stats are keyed by the physical column name `col-id` (column mapping).
+fn add_with_physical_id_stats(path: &str, id_min: i32, id_max: i32) -> String {
+    let stats = format!(
+        "{{\\\"numRecords\\\":10,\\\"nullCount\\\":{{\\\"col-id\\\":0}},\
+         \\\"minValues\\\":{{\\\"col-id\\\":{id_min}}},\\\"maxValues\\\":{{\\\"col-id\\\":{id_max}}}}}"
+    );
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":\"{stats}\"}}}}"
+    )
+}
+
+// Pushdown drops added files whose stats prove they cannot match and keeps the rest; the
+// `None` predicate keeps every live Add unchanged. Three files span disjoint `id` ranges over
+// a single commit. Each case asserts the surviving key set and that the emitted selection
+// vector agrees with `live_adds` (no summary/stream drift).
+#[rstest]
+#[case::pushdown(
+    Some(Arc::new(column_expr!("id").gt(Expr::literal(25i32))) as PredicateRef),
+    vec!["high.parquet"],
+)]
+#[case::no_predicate(None, vec!["low.parquet", "mid.parquet", "high.parquet"])]
 #[tokio::test]
-async fn pushdown_drops_non_matching_added_files() -> Result<(), Box<dyn std::error::Error>> {
+async fn pushdown_keeps_only_matching_added_files(
+    #[case] predicate: Option<PredicateRef>,
+    #[case] expected_live: Vec<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (storage, engine, table_url) = setup_test();
     let table_root = table_url.as_str();
 
@@ -1223,7 +1253,8 @@ async fn pushdown_drops_non_matching_added_files() -> Result<(), Box<dyn std::er
         actions_to_string(vec![TestAction::Metadata]),
     )
     .await?;
-    // low: id in [0, 9]; mid: id in [10, 19]; high: id in [20, 30].
+    // low: id in [0, 9]; mid: id in [10, 19]; high: id in [20, 30]. `id > 25` can only match
+    // high; low and mid are provably excluded. No predicate keeps all three.
     let v1 = [
         add_with_id_stats("low.parquet", 0, 9),
         add_with_id_stats("mid.parquet", 10, 19),
@@ -1235,9 +1266,6 @@ async fn pushdown_drops_non_matching_added_files() -> Result<(), Box<dyn std::er
     let target = Snapshot::builder_for(table_url)
         .at_version(1)
         .build(engine.as_ref())?;
-
-    // `id > 25` can only match high.parquet ([20, 30]); low and mid are provably excluded.
-    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
     let listing = unwrap_listing(
         target
             .incremental_scan_builder(0)
@@ -1245,51 +1273,11 @@ async fn pushdown_drops_non_matching_added_files() -> Result<(), Box<dyn std::er
             .build(engine.as_ref())?,
     );
 
-    assert_eq!(
-        live_add_keys(&listing),
-        &HashSet::from([key("high.parquet")]),
-        "only high.parquet ([20, 30]) can match id > 25"
-    );
+    let expected: HashSet<FileActionKey> = expected_live.iter().map(|p| key(p)).collect();
+    assert_eq!(listing.summary.live_adds, expected);
     // The streamed selection vector must agree with the summary's live_adds count.
-    assert_eq!(live_add_count(&listing), 1);
+    assert_eq!(live_add_count(&listing), expected.len());
     assert!(listing.summary.removes.is_empty());
-
-    Ok(())
-}
-
-// The default (no predicate) path is unchanged: every live Add is streamed regardless of
-// stats. Guards against the predicate wiring leaking into the `None` case.
-#[tokio::test]
-async fn no_predicate_streams_every_live_add() -> Result<(), Box<dyn std::error::Error>> {
-    let (storage, engine, table_url) = setup_test();
-    let table_root = table_url.as_str();
-
-    add_commit(
-        table_root,
-        storage.as_ref(),
-        0,
-        actions_to_string(vec![TestAction::Metadata]),
-    )
-    .await?;
-    let v1 = [
-        add_with_id_stats("low.parquet", 0, 9),
-        add_with_id_stats("mid.parquet", 10, 19),
-        add_with_id_stats("high.parquet", 20, 30),
-    ]
-    .join("\n");
-    add_commit(table_root, storage.as_ref(), 1, v1).await?;
-
-    let target = Snapshot::builder_for(table_url)
-        .at_version(1)
-        .build(engine.as_ref())?;
-    let listing = unwrap_listing(target.incremental_scan_builder(0).build(engine.as_ref())?);
-
-    assert_eq!(
-        live_add_keys(&listing),
-        &HashSet::from([key("low.parquet"), key("mid.parquet"), key("high.parquet")]),
-        "no predicate keeps every live Add"
-    );
-    assert_eq!(live_add_count(&listing), 3);
 
     Ok(())
 }
@@ -1331,8 +1319,8 @@ async fn added_file_without_stats_is_always_kept() -> Result<(), Box<dyn std::er
     );
 
     assert_eq!(
-        live_add_keys(&listing),
-        &HashSet::from([key("no_stats.parquet"), key("in_range.parquet")]),
+        listing.summary.live_adds,
+        HashSet::from([key("no_stats.parquet"), key("in_range.parquet")]),
         "the stats-less file is kept; only the provably-excluded file is dropped"
     );
 
@@ -1390,8 +1378,8 @@ async fn removes_are_never_filtered_by_predicate() -> Result<(), Box<dyn std::er
     );
     // Only kept.parquet ([20, 30]) survives among the live Adds.
     assert_eq!(
-        live_add_keys(&listing),
-        &HashSet::from([key("kept.parquet")]),
+        listing.summary.live_adds,
+        HashSet::from([key("kept.parquet")])
     );
 
     Ok(())
@@ -1493,6 +1481,195 @@ async fn against_base_classification_composes_with_predicate(
         "the pruned file is not classified as a duplicate"
     );
     assert!(summary.removes.is_empty());
+
+    Ok(())
+}
+
+// Newest-wins holds when the newest Add of a key is pruned but an older Add of the same key
+// (with a matching range) exists earlier in the range. The pruned newest Add still records the
+// key as `seen`, so the older duplicate must not leak into `live_adds`. The file's live (newest)
+// metadata does not match the predicate, so a cold scan at the target would exclude it too --
+// net zero live Adds. Guards the "record seen regardless of the mask" invariant.
+#[tokio::test]
+async fn pruned_newest_add_suppresses_older_matching_duplicate(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1: dupe.parquet with a range that WOULD match `id > 25`.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        add_with_id_stats("dupe.parquet", 20, 30),
+    )
+    .await?;
+    // v2: dupe.parquet re-added with a range the predicate provably excludes ([0, 5]).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        2,
+        add_with_id_stats("dupe.parquet", 0, 5),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert!(
+        listing.summary.live_adds.is_empty(),
+        "the pruned newest Add records `seen`, so the older matching duplicate must not leak"
+    );
+    assert_eq!(live_add_count(&listing), 0);
+
+    Ok(())
+}
+
+// A predicate referencing a column absent from the table schema fails at `build` (fail-fast),
+// not lazily mid-stream, matching the documented `# Errors` contract.
+#[tokio::test]
+async fn unknown_column_predicate_fails_at_build() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        add_with_id_stats("a.parquet", 0, 9),
+    )
+    .await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("nonexistent").gt(Expr::literal(1i32)));
+    let result = target
+        .incremental_scan_builder(0)
+        .with_predicate(predicate)
+        .build(engine.as_ref());
+
+    assert!(
+        matches!(result, Err(Error::MissingColumn(_))),
+        "build must fail fast with MissingColumn on an unknown-column predicate, got {result:?}"
+    );
+
+    Ok(())
+}
+
+// Predicate over a partition column folds to keep-all: partition-value pruning is not wired in
+// on this path, so every live Add survives regardless of the partition predicate. Locks in the
+// documented conservative behavior (and doubles as the regression guard once partition pruning
+// lands).
+#[tokio::test]
+async fn partition_column_predicate_keeps_all_added_files() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    // METADATA_WITH_PARTITION_COLS partitions by `val`.
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string_partitioned(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let v1 = [
+        add_partitioned("a.parquet", "x"),
+        add_partitioned("b.parquet", "y"),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // `val = 'x'` is a partition predicate; it must not prune either file.
+    let predicate: PredicateRef = Arc::new(column_expr!("val").eq(Expr::literal("x")));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        listing.summary.live_adds,
+        HashSet::from([key("a.parquet"), key("b.parquet")]),
+        "a partition-column predicate folds to keep-all"
+    );
+
+    Ok(())
+}
+
+// Under column mapping, `with_predicate` lowers the logical predicate column to its physical
+// name before reading stats keyed by that physical name. A logical `id > 25` skips against the
+// physical-name stats, so only the in-range file survives -- proving the physical-vs-logical
+// lowering on this path.
+#[tokio::test]
+async fn pushdown_resolves_column_mapping_physical_names() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        COLUMN_MAPPING_METADATA.to_string(),
+    )
+    .await?;
+    // Stats are keyed by the physical name `col-id`, while the predicate references logical `id`.
+    let v1 = [
+        add_with_physical_id_stats("low.parquet", 0, 5),
+        add_with_physical_id_stats("high.parquet", 20, 30),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        listing.summary.live_adds,
+        HashSet::from([key("high.parquet")]),
+        "predicate on logical `id` resolves to physical `col-id` stats and drops the low file"
+    );
 
     Ok(())
 }

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::num::NonZero;
 use std::sync::Arc;
 
+use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred, PredicateRef};
 use delta_kernel::incremental_scan::{
     IncrementalListing, IncrementalListingAgainstBase, IncrementalScanStream,
     IncrementalScanSummary,
@@ -1162,6 +1163,336 @@ async fn empty_base_keys_produces_no_duplicates() -> Result<(), Box<dyn std::err
     let summary_with = stream.into_summary_against_base_closure(|_| false)?;
     assert!(summary_with.duplicate_adds.is_empty());
     assert_eq!(summary_with.removes, HashSet::from([key("gone.parquet")]));
+
+    Ok(())
+}
+
+// === Predicate pushdown ===
+//
+// `with_predicate` prunes streamed live Adds against file stats using the same
+// `DataSkippingFilter` the read path uses. These tests use raw commit JSON so each Add can
+// carry a distinct `id` min/max range. The metadata (`test_utils::METADATA`) declares an
+// `id: integer` column, so `id`-predicates are eligible for data skipping. Skipping is
+// conservative: an Add is dropped only when its stats prove no row matches; Adds with no
+// stats and all Removes are always kept.
+
+// Build a raw Add action carrying `id` stats over the closed range `[id_min, id_max]`.
+fn add_with_id_stats(path: &str, id_min: i32, id_max: i32) -> String {
+    let stats = format!(
+        "{{\\\"numRecords\\\":10,\\\"nullCount\\\":{{\\\"id\\\":0}},\
+         \\\"minValues\\\":{{\\\"id\\\":{id_min}}},\\\"maxValues\\\":{{\\\"id\\\":{id_max}}}}}"
+    );
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":\"{stats}\"}}}}"
+    )
+}
+
+// Build a raw Add action with no stats (`stats` omitted). Data skipping must always keep it.
+fn add_without_stats(path: &str) -> String {
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true}}}}"
+    )
+}
+
+// Build a raw Remove action.
+fn remove_action(path: &str) -> String {
+    format!(
+        "{{\"remove\":{{\"path\":\"{path}\",\"deletionTimestamp\":1700000000000,\
+         \"dataChange\":true}}}}"
+    )
+}
+
+fn live_add_keys(listing: &IncrementalListing) -> &HashSet<FileActionKey> {
+    &listing.summary.live_adds
+}
+
+// Pushdown drops added files whose stats prove they cannot match, and keeps the rest. Three
+// files span disjoint `id` ranges; `id > 25` keeps only the file whose range extends past 25.
+// Also asserts the emitted selection vector agrees with `live_adds` (no summary/stream drift).
+#[tokio::test]
+async fn pushdown_drops_non_matching_added_files() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // low: id in [0, 9]; mid: id in [10, 19]; high: id in [20, 30].
+    let v1 = [
+        add_with_id_stats("low.parquet", 0, 9),
+        add_with_id_stats("mid.parquet", 10, 19),
+        add_with_id_stats("high.parquet", 20, 30),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // `id > 25` can only match high.parquet ([20, 30]); low and mid are provably excluded.
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        live_add_keys(&listing),
+        &HashSet::from([key("high.parquet")]),
+        "only high.parquet ([20, 30]) can match id > 25"
+    );
+    // The streamed selection vector must agree with the summary's live_adds count.
+    assert_eq!(live_add_count(&listing), 1);
+    assert!(listing.summary.removes.is_empty());
+
+    Ok(())
+}
+
+// The default (no predicate) path is unchanged: every live Add is streamed regardless of
+// stats. Guards against the predicate wiring leaking into the `None` case.
+#[tokio::test]
+async fn no_predicate_streams_every_live_add() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let v1 = [
+        add_with_id_stats("low.parquet", 0, 9),
+        add_with_id_stats("mid.parquet", 10, 19),
+        add_with_id_stats("high.parquet", 20, 30),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    let listing = unwrap_listing(target.incremental_scan_builder(0).build(engine.as_ref())?);
+
+    assert_eq!(
+        live_add_keys(&listing),
+        &HashSet::from([key("low.parquet"), key("mid.parquet"), key("high.parquet")]),
+        "no predicate keeps every live Add"
+    );
+    assert_eq!(live_add_count(&listing), 3);
+
+    Ok(())
+}
+
+// A file with no stats is always kept, even under a predicate whose range would exclude it if
+// stats were present. Conservative skipping never drops a stats-less file.
+#[tokio::test]
+async fn added_file_without_stats_is_always_kept() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // no_stats has no stats; in_range has id in [20, 30]. Both must survive `id > 25`:
+    // no_stats because it can't be disproven, in_range because [20, 30] overlaps.
+    let v1 = [
+        add_without_stats("no_stats.parquet"),
+        add_with_id_stats("in_range.parquet", 20, 30),
+        add_with_id_stats("out_of_range.parquet", 0, 5),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        live_add_keys(&listing),
+        &HashSet::from([key("no_stats.parquet"), key("in_range.parquet")]),
+        "the stats-less file is kept; only the provably-excluded file is dropped"
+    );
+
+    Ok(())
+}
+
+// Removes are never filtered by the predicate. A removed file whose stat range the predicate
+// excludes must still appear in `removes` in full -- the consumer needs every removal to evict
+// stale cached entries.
+#[tokio::test]
+async fn removes_are_never_filtered_by_predicate() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1 adds gone.parquet (id in [0, 5], which `id > 25` would exclude).
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        1,
+        add_with_id_stats("gone.parquet", 0, 5),
+    )
+    .await?;
+    // v2 removes gone.parquet and adds kept.parquet (id in [20, 30]).
+    let v2 = [
+        remove_action("gone.parquet"),
+        add_with_id_stats("kept.parquet", 20, 30),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 2, v2).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(2)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    // The Remove is reported in full even though the predicate excludes its stat range.
+    assert_eq!(
+        listing.summary.removes,
+        HashSet::from([key("gone.parquet")]),
+        "removes must never be filtered by the predicate"
+    );
+    // Only kept.parquet ([20, 30]) survives among the live Adds.
+    assert_eq!(
+        live_add_keys(&listing),
+        &HashSet::from([key("kept.parquet")]),
+    );
+
+    Ok(())
+}
+
+// A predicate that statically excludes every file (`id > 25 AND FALSE`) yields an empty live-Add
+// stream, but Removes are still reported. A tautology (`id > 25 OR TRUE`) is useless for
+// skipping and behaves like no predicate.
+#[rstest]
+#[case::static_skip_all(Pred::and(column_expr!("id").gt(Expr::literal(25i32)), Pred::literal(false)), 0)]
+#[case::tautology(Pred::or(column_expr!("id").gt(Expr::literal(25i32)), Pred::literal(true)), 2)]
+#[tokio::test]
+async fn static_skip_all_and_tautology(
+    #[case] predicate: Pred,
+    #[case] expected_live: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // v1 adds two files and removes a third, so removes is non-empty regardless of the predicate.
+    let v1 = [
+        add_with_id_stats("a.parquet", 0, 9),
+        add_with_id_stats("b.parquet", 20, 30),
+        remove_action("removed.parquet"),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(Arc::new(predicate))
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(live_add_count(&listing), expected_live);
+    // Removes are reported regardless of the Add-side skipping strategy.
+    assert_eq!(
+        listing.summary.removes,
+        HashSet::from([key("removed.parquet")]),
+        "removes are reported even when all Adds are statically skipped"
+    );
+
+    Ok(())
+}
+
+// Consumer classification (`into_summary_against_base_*`) composes with the predicate: base
+// intersection runs over the predicate-pruned live Adds, so a base key whose file the
+// predicate dropped is not reported as a duplicate.
+#[tokio::test]
+async fn against_base_classification_composes_with_predicate(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // matches.parquet (id in [20, 30]) survives `id > 25`; dropped.parquet (id in [0, 5]) does not.
+    let v1 = [
+        add_with_id_stats("matches.parquet", 20, 30),
+        add_with_id_stats("dropped.parquet", 0, 5),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    // Both files are in the consumer's base. Only the predicate-surviving one should classify
+    // as a duplicate; the dropped file was pruned before base intersection.
+    let base_keys = [key("matches.parquet"), key("dropped.parquet")];
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let stream = target
+        .incremental_scan_builder(0)
+        .with_predicate(predicate)
+        .build(engine.as_ref())?
+        .expect("expected Some(stream)");
+    let summary = stream.into_summary_against_base_iter(&base_keys)?;
+
+    assert_eq!(
+        summary.duplicate_adds,
+        HashSet::from([key("matches.parquet")]),
+        "the pruned file is not classified as a duplicate"
+    );
+    assert!(summary.removes.is_empty());
 
     Ok(())
 }

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -18,7 +18,7 @@ use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path as ObjectStorePath;
 use delta_kernel::object_store::ObjectStoreExt;
 use delta_kernel::{
-    Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, StorageHandler,
+    Engine, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, StorageHandler,
 };
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
@@ -26,8 +26,8 @@ use test_utils::delta_kernel_default_engine::json::DefaultJsonHandler;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
     actions_to_string, actions_to_string_catalog_managed, actions_to_string_partitioned,
-    add_commit, add_staged_commit, compacted_log_path_for_versions, create_log_path,
-    delta_path_for_version, TestAction,
+    add_commit, add_staged_commit, assert_result_error_with_message,
+    compacted_log_path_for_versions, create_log_path, delta_path_for_version, TestAction,
 };
 use url::Url;
 
@@ -1573,10 +1573,10 @@ async fn unknown_column_predicate_fails_at_build() -> Result<(), Box<dyn std::er
         .with_predicate(predicate)
         .build(engine.as_ref());
 
-    assert!(
-        matches!(result, Err(Error::MissingColumn(_))),
-        "build must fail fast with MissingColumn on an unknown-column predicate, got {result:?}"
-    );
+    // Fail-fast at build, surfacing the unresolved column. The concrete error is
+    // `Error::MissingColumn`, but a captured backtrace wraps it in `Error::Backtraced`, so match
+    // on the message rather than the variant.
+    assert_result_error_with_message(result, "unknown column: nonexistent");
 
     Ok(())
 }

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -4,10 +4,13 @@
 //! cross-commit deduplication: cross-commit cancellation, chained add/remove/add, log
 //! compaction interactions, catalog-managed staged commits, and vacuum races.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZero;
 use std::sync::Arc;
 
+use delta_kernel::arrow::array::{Int32Array, RecordBatch};
+use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred, PredicateRef};
 use delta_kernel::incremental_scan::{
     IncrementalListing, IncrementalListingAgainstBase, IncrementalScanStream,
@@ -17,17 +20,22 @@ use delta_kernel::log_replay::FileActionKey;
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path as ObjectStorePath;
 use delta_kernel::object_store::ObjectStoreExt;
+use delta_kernel::scan::state::ScanFile;
+use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::{
-    Engine, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, StorageHandler,
+    Engine, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, SnapshotRef, StorageHandler,
 };
 use rstest::rstest;
-use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
+use test_utils::delta_kernel_default_engine::executor::tokio::{
+    TokioBackgroundExecutor, TokioMultiThreadExecutor,
+};
 use test_utils::delta_kernel_default_engine::json::DefaultJsonHandler;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
     actions_to_string, actions_to_string_catalog_managed, actions_to_string_partitioned,
     add_commit, add_staged_commit, assert_result_error_with_message,
-    compacted_log_path_for_versions, create_log_path, delta_path_for_version, TestAction,
+    compacted_log_path_for_versions, create_log_path, create_table_and_load_snapshot,
+    delta_path_for_version, test_table_setup_mt, write_batch_to_table, TestAction,
 };
 use url::Url;
 
@@ -1840,6 +1848,145 @@ async fn column_free_predicate_keeps_all_added_files() -> Result<(), Box<dyn std
         listing.summary.live_adds,
         HashSet::from([key("a.parquet"), key("b.parquet")]),
         "a column-free predicate is ineligible for skipping and keeps every live Add"
+    );
+
+    Ok(())
+}
+
+// === Round-trip against a full scan ===
+//
+// The correctness promise of `with_predicate` is that the incremental live-Add set, reconciled
+// against the base, reproduces what a full `Scan` at the target with the same predicate keeps.
+// The two paths parse stats differently: a full scan reads pre-parsed `stats_parsed` (from a
+// checkpoint), while the incremental path parses `add.stats` JSON via `for_raw_action_batch`.
+//
+// The incremental scan reads only raw commit JSON and never touches checkpoints, so it cannot
+// serve a range predating a checkpoint (the target snapshot's log segment drops pre-checkpoint
+// commit JSON). The checkpoint therefore sits at the base version: the full scan at the base
+// prunes via the checkpoint's `stats_parsed`, the incremental delta over `(base, target]` prunes
+// via JSON, and `full_scan(base) union live_adds` must equal `full_scan(target)`.
+
+type MtEngine = DefaultEngine<TokioMultiThreadExecutor>;
+
+// Single-column `id: integer` table.
+fn id_schema() -> Arc<StructType> {
+    Arc::new(StructType::new_unchecked([StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )]))
+}
+
+// One `RecordBatch` holding a single `id` value, so each written file gets a tight [id, id] range.
+fn id_batch(schema: &Arc<StructType>, id: i32) -> RecordBatch {
+    let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow().unwrap();
+    RecordBatch::try_new(
+        Arc::new(arrow_schema),
+        vec![Arc::new(Int32Array::from(vec![id]))],
+    )
+    .unwrap()
+}
+
+// Surviving file paths from a full scan at `snapshot` under `predicate`. A snapshot loaded after a
+// checkpoint prunes using the checkpoint's `stats_parsed`.
+fn full_scan_surviving_paths(
+    snapshot: SnapshotRef,
+    engine: &MtEngine,
+    predicate: PredicateRef,
+) -> Result<HashSet<String>, Box<dyn std::error::Error>> {
+    fn insert_path(paths: &mut HashSet<String>, scan_file: ScanFile) {
+        paths.insert(scan_file.path);
+    }
+
+    let scan = snapshot.scan_builder().with_predicate(predicate).build()?;
+    let mut paths: HashSet<String> = HashSet::new();
+    for sm in scan.scan_metadata(engine)? {
+        paths = sm?.visit_scan_files(paths, insert_path)?;
+    }
+    Ok(paths)
+}
+
+// Reconciling a base full scan with the incremental delta reproduces a full scan at the target,
+// even though the base prunes via the checkpoint's `stats_parsed` while the incremental delta
+// prunes via `add.stats` JSON. Guards the stats-parsing divergence the two paths could exhibit.
+#[tokio::test(flavor = "multi_thread")]
+async fn predicate_pushdown_reconciled_with_base_matches_full_scan_across_checkpoint(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = Url::from_directory_path(&table_path).map_err(|_| "invalid table path")?;
+    let schema = id_schema();
+    let mut snapshot =
+        create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
+
+    // Files added before the checkpoint: id 5, 15, 25. The checkpoint captures their stats.
+    for id in [5, 15, 25] {
+        snapshot = write_batch_to_table(
+            &snapshot,
+            engine.as_ref(),
+            id_batch(&schema, id),
+            HashMap::new(),
+        )
+        .await?;
+    }
+    let (_, snapshot) = snapshot.checkpoint(engine.as_ref(), None)?;
+    let base_version = snapshot.version();
+
+    // Files added after the checkpoint: id 35, 45. These live only in raw commit JSON.
+    let mut snapshot = snapshot;
+    for id in [35, 45] {
+        snapshot = write_batch_to_table(
+            &snapshot,
+            engine.as_ref(),
+            id_batch(&schema, id),
+            HashMap::new(),
+        )
+        .await?;
+    }
+    let target_version = snapshot.version();
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(20i32)));
+
+    // Base full scan (reads the checkpoint's `stats_parsed`) and target full scan, both loaded
+    // fresh off disk so they replay through the checkpoint.
+    let base = Snapshot::builder_for(table_url.clone())
+        .at_version(base_version)
+        .build(engine.as_ref())?;
+    let base_paths = full_scan_surviving_paths(base, engine.as_ref(), predicate.clone())?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(target_version)
+        .build(engine.as_ref())?;
+    let target_paths = full_scan_surviving_paths(target, engine.as_ref(), predicate.clone())?;
+
+    // Incremental delta over `(base, target]` (parses `add.stats` JSON).
+    let listing = unwrap_listing(
+        snapshot
+            .incremental_scan_builder(base_version)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+    let live_adds: HashSet<String> = listing
+        .summary
+        .live_adds
+        .iter()
+        .map(|k| k.path().to_string())
+        .collect();
+
+    // Sanity: the checkpoint kept a pre-checkpoint match (id 25) that the incremental delta does
+    // not re-report, so the reconciliation is doing real work.
+    assert!(
+        !base_paths.is_empty() && !live_adds.is_empty(),
+        "both the base scan and the incremental delta should contribute matches"
+    );
+    assert!(
+        listing.summary.removes.is_empty(),
+        "no removes in this range"
+    );
+
+    // No in-range removes, so reconciliation is a union of the base and the incremental live Adds.
+    let reconciled: HashSet<String> = base_paths.union(&live_adds).cloned().collect();
+    assert_eq!(
+        reconciled, target_paths,
+        "base full scan plus incremental live_adds must equal the full scan at the target"
     );
 
     Ok(())

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -1213,6 +1213,19 @@ fn add_partitioned(path: &str, val: &str) -> String {
     )
 }
 
+// Build a raw Add carrying both a `val` partition value and `id` stats over `[id_min, id_max]`,
+// for predicates that touch both a partition and a data column.
+fn add_partitioned_with_id_stats(path: &str, val: &str, id_min: i32, id_max: i32) -> String {
+    let stats = format!(
+        "{{\\\"numRecords\\\":10,\\\"nullCount\\\":{{\\\"id\\\":0}},\
+         \\\"minValues\\\":{{\\\"id\\\":{id_min}}},\\\"maxValues\\\":{{\\\"id\\\":{id_max}}}}}"
+    );
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{\"val\":\"{val}\"}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":\"{stats}\"}}}}"
+    )
+}
+
 // Column-mapping (name mode) metadata whose `id` column maps to the physical name `col-id`.
 const COLUMN_MAPPING_METADATA: &str = "{\"metaData\":{\"id\":\"cm-test-id\",\"format\":{\"provider\":\"parquet\",\"options\":{}},\"schemaString\":\"{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"name\\\":\\\"id\\\",\\\"type\\\":\\\"integer\\\",\\\"nullable\\\":true,\\\"metadata\\\":{\\\"delta.columnMapping.id\\\":1,\\\"delta.columnMapping.physicalName\\\":\\\"col-id\\\"}}]}\",\"partitionColumns\":[],\"configuration\":{\"delta.columnMapping.mode\":\"name\",\"delta.columnMapping.maxColumnId\":\"1\"},\"createdTime\":1700000000000}}\n{\"protocol\":{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"columnMapping\"],\"writerFeatures\":[\"columnMapping\"]}}";
 
@@ -1225,6 +1238,31 @@ fn add_with_physical_id_stats(path: &str, id_min: i32, id_max: i32) -> String {
     format!(
         "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\
          \"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":\"{stats}\"}}}}"
+    )
+}
+
+// Metadata declaring an `id: integer` column AND the deletionVectors feature, so a DV-bearing
+// Add carrying `id` stats parses and an `id`-predicate is skipping-eligible.
+const DV_AND_ID_METADATA: &str = "{\"metaData\":{\"id\":\"dv-id-test\",\"format\":{\"provider\":\"parquet\",\"options\":{}},\"schemaString\":\"{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[{\\\"name\\\":\\\"id\\\",\\\"type\\\":\\\"integer\\\",\\\"nullable\\\":true,\\\"metadata\\\":{}}]}\",\"partitionColumns\":[],\"configuration\":{},\"createdTime\":1700000000000}}\n{\"protocol\":{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"deletionVectors\"],\"writerFeatures\":[\"deletionVectors\"]}}";
+
+// Build a raw DV-bearing Add carrying `id` stats over `[id_min, id_max]`.
+fn add_with_dv_and_id_stats(
+    path: &str,
+    storage_type: &str,
+    path_or_inline: &str,
+    offset: i32,
+    id_min: i32,
+    id_max: i32,
+) -> String {
+    let stats = format!(
+        "{{\\\"numRecords\\\":10,\\\"nullCount\\\":{{\\\"id\\\":0}},\
+         \\\"minValues\\\":{{\\\"id\\\":{id_min}}},\\\"maxValues\\\":{{\\\"id\\\":{id_max}}}}}"
+    );
+    format!(
+        "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\
+         \"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":\"{stats}\",\
+         \"deletionVector\":{{\"storageType\":\"{storage_type}\",\"pathOrInlineDv\":\"{path_or_inline}\",\
+         \"offset\":{offset},\"sizeInBytes\":10,\"cardinality\":1}}}}}}"
     )
 }
 
@@ -1581,13 +1619,11 @@ async fn unknown_column_predicate_fails_at_build() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-// Predicate over a partition column folds to keep-all: partition-value pruning is not wired in
-// on this path, so every live Add survives regardless of the partition predicate. Locks in the
-// documented conservative behavior (and doubles as the regression guard once partition pruning
-// lands).
+// A predicate over a partition column prunes added files by their partition value: values are
+// parsed from the raw `add.partitionValues` map via `map_to_struct`, so `val = 'x'` drops the
+// file in partition `y`.
 #[tokio::test]
-async fn partition_column_predicate_keeps_all_added_files() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn partition_column_predicate_prunes_added_files() -> Result<(), Box<dyn std::error::Error>> {
     let (storage, engine, table_url) = setup_test();
     let table_root = table_url.as_str();
 
@@ -1610,7 +1646,6 @@ async fn partition_column_predicate_keeps_all_added_files() -> Result<(), Box<dy
         .at_version(1)
         .build(engine.as_ref())?;
 
-    // `val = 'x'` is a partition predicate; it must not prune either file.
     let predicate: PredicateRef = Arc::new(column_expr!("val").eq(Expr::literal("x")));
     let listing = unwrap_listing(
         target
@@ -1621,8 +1656,58 @@ async fn partition_column_predicate_keeps_all_added_files() -> Result<(), Box<dy
 
     assert_eq!(
         listing.summary.live_adds,
-        HashSet::from([key("a.parquet"), key("b.parquet")]),
-        "a partition-column predicate folds to keep-all"
+        HashSet::from([key("a.parquet")]),
+        "only the file in partition `val = 'x'` survives"
+    );
+
+    Ok(())
+}
+
+// A mixed predicate `id > 25 AND val = 'x'` prunes on both axes: the data conjunct skips on
+// `add.stats`, the partition conjunct skips on `add.partitionValues`. Only the file satisfying
+// both survives; a file failing either is dropped.
+#[tokio::test]
+async fn mixed_data_and_partition_predicate_prunes_on_both(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string_partitioned(vec![TestAction::Metadata]),
+    )
+    .await?;
+    // match: id in [20,30] and val=x. wrong_val: in-range id but val=y. wrong_id: val=x but
+    // id in [0,5]. Only `match` satisfies `id > 25 AND val = 'x'`.
+    let v1 = [
+        add_partitioned_with_id_stats("match.parquet", "x", 20, 30),
+        add_partitioned_with_id_stats("wrong_val.parquet", "y", 20, 30),
+        add_partitioned_with_id_stats("wrong_id.parquet", "x", 0, 5),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(Pred::and(
+        column_expr!("id").gt(Expr::literal(25i32)),
+        column_expr!("val").eq(Expr::literal("x")),
+    ));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        listing.summary.live_adds,
+        HashSet::from([key("match.parquet")]),
+        "only the file matching both the data and partition conjuncts survives"
     );
 
     Ok(())
@@ -1669,6 +1754,92 @@ async fn pushdown_resolves_column_mapping_physical_names() -> Result<(), Box<dyn
         listing.summary.live_adds,
         HashSet::from([key("high.parquet")]),
         "predicate on logical `id` resolves to physical `col-id` stats and drops the low file"
+    );
+
+    Ok(())
+}
+
+// A DV-bearing Add is pruned by its stats like any other, and the surviving live Add is keyed by
+// its full `(path, dv_unique_id)`, not path alone. Two DV-bearing Adds with disjoint `id` ranges:
+// `id > 25` drops the out-of-range one and keeps the in-range one under its DV key.
+#[tokio::test]
+async fn pushdown_prunes_dv_bearing_adds_keyed_by_dv() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        DV_AND_ID_METADATA.to_string(),
+    )
+    .await?;
+    let v1 = [
+        add_with_dv_and_id_stats("keep.parquet", "u", "abc", 1, 20, 30),
+        add_with_dv_and_id_stats("prune.parquet", "u", "xyz", 2, 0, 5),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(column_expr!("id").gt(Expr::literal(25i32)));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        listing.summary.live_adds,
+        HashSet::from([key_with_dv("keep.parquet", "uabc@1")]),
+        "the in-range DV Add survives keyed by its full (path, dv_unique_id)"
+    );
+
+    Ok(())
+}
+
+// A predicate that references no columns and is not statically false (`lit(true)`) resolves to
+// `PhysicalPredicate::None`, which folds to keep-all. Distinct from the tautology case (which
+// references `id` and keeps all via the filter), this exercises the `None -> KeepAll` arm.
+#[tokio::test]
+async fn column_free_predicate_keeps_all_added_files() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, engine, table_url) = setup_test();
+    let table_root = table_url.as_str();
+
+    add_commit(
+        table_root,
+        storage.as_ref(),
+        0,
+        actions_to_string(vec![TestAction::Metadata]),
+    )
+    .await?;
+    let v1 = [
+        add_with_id_stats("a.parquet", 0, 9),
+        add_with_id_stats("b.parquet", 20, 30),
+    ]
+    .join("\n");
+    add_commit(table_root, storage.as_ref(), 1, v1).await?;
+
+    let target = Snapshot::builder_for(table_url)
+        .at_version(1)
+        .build(engine.as_ref())?;
+
+    let predicate: PredicateRef = Arc::new(Pred::literal(true));
+    let listing = unwrap_listing(
+        target
+            .incremental_scan_builder(0)
+            .with_predicate(predicate)
+            .build(engine.as_ref())?,
+    );
+
+    assert_eq!(
+        listing.summary.live_adds,
+        HashSet::from([key("a.parquet"), key("b.parquet")]),
+        "a column-free predicate is ineligible for skipping and keeps every live Add"
     );
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds optional predicate pushdown (data skipping) to the incremental scan. A new `IncrementalScanBuilder::with_predicate` restricts the streamed live `Add` actions to those whose file stats do not provably exclude the predicate, so a consumer can ask "what files changed in `(base_version, target_version]` that could match P?" and get back only the relevant added files instead of every changed file.

Skipping is conservative and reuses the same stats-based filter the read path uses, so the surviving `Add` set is identical to what a full scan at the target version with the same predicate would keep among those added files. Files without stats are always kept, and `Remove` actions are never filtered (consumers need every removal to evict stale cached entries). With no predicate, the default path is unchanged.

The change-data-feed path already built a data-skipping filter over raw `{ add, remove }` action batches by parsing `add.stats` JSON. That construction is now a shared `DataSkippingFilter::for_raw_action_batch` helper that both the CDF path and the incremental scan call, so the two stay in lockstep with no duplicated logic.

## How was this change tested?

Added integration tests in `kernel/tests/incremental_scan.rs`: pushdown drops non-matching added files, the `None` predicate path is unchanged, files without stats are kept, removes are never filtered, static skip-all and tautology predicates behave correctly, and the consumer against-base classification composes with a predicate. The existing scan and CDF suites pass unchanged, confirming the shared filter refactor is behavior-preserving.
