### PR TITLE
feat: include more error mappings from UC rest client status to API errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,7 @@ dependencies = [
  "chrono",
  "clap",
  "reqwest 0.13.2",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/unity-catalog-delta-client-api/src/error.rs
+++ b/unity-catalog-delta-client-api/src/error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// implementation-specific dependencies.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// The requested table was not found.
+    /// The requested table was not found (HTTP 404).
     #[error("Table not found: {0}")]
     TableNotFound(String),
 
@@ -19,9 +19,22 @@ pub enum Error {
     #[error("Operation not supported: {0}")]
     UnsupportedOperation(String),
 
-    /// Authentication with Unity Catalog failed.
+    /// Authentication with Unity Catalog failed (HTTP 401).
     #[error("Authentication failed")]
     AuthenticationFailed,
+
+    /// Another writer already ratified this version, so the commit was rejected
+    /// (HTTP 409).
+    #[error("Commit conflict: version already ratified")]
+    CommitConflict,
+
+    /// Unity Catalog rejected the commit as invalid (HTTP 400).
+    #[error("Invalid commit: {0}")]
+    InvalidCommit(String),
+
+    /// Unity Catalog rate-limited the request (HTTP 429).
+    #[error("Rate limited")]
+    RateLimited,
 
     /// A generic error with a descriptive message.
     #[error("{0}")]

--- a/unity-catalog-delta-rest-client/Cargo.toml
+++ b/unity-catalog-delta-rest-client/Cargo.toml
@@ -32,3 +32,4 @@ test-utils = ["unity-catalog-delta-client-api/test-utils"]
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+rstest = "0.23"

--- a/unity-catalog-delta-rest-client/src/error.rs
+++ b/unity-catalog-delta-rest-client/src/error.rs
@@ -56,43 +56,41 @@ impl From<Error> for unity_catalog_delta_client_api::Error {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+    use unity_catalog_delta_client_api::Error as ApiError;
+
     use super::*;
 
-    #[test]
-    fn from_error_unwraps_api_variant() {
-        let api_err = unity_catalog_delta_client_api::Error::TableNotFound("t1".into());
-        let rest_err = Error::Api(api_err);
-        assert!(matches!(
-            unity_catalog_delta_client_api::Error::from(rest_err),
-            unity_catalog_delta_client_api::Error::TableNotFound(msg) if msg == "t1"
-        ));
-
-        let rest_err = Error::Api(unity_catalog_delta_client_api::Error::AuthenticationFailed);
-        assert!(matches!(
-            unity_catalog_delta_client_api::Error::from(rest_err),
-            unity_catalog_delta_client_api::Error::AuthenticationFailed
-        ));
-
-        let rest_err =
-            Error::Api(unity_catalog_delta_client_api::Error::MaxUnpublishedCommitsExceeded(5));
-        assert!(matches!(
-            unity_catalog_delta_client_api::Error::from(rest_err),
-            unity_catalog_delta_client_api::Error::MaxUnpublishedCommitsExceeded(5)
-        ));
+    /// Each rest client error that wraps a UC delta client API error (Error::API)
+    /// preserves the API error.
+    #[rstest]
+    #[case(ApiError::TableNotFound("t1".into()))]
+    #[case(ApiError::AuthenticationFailed)]
+    #[case(ApiError::MaxUnpublishedCommitsExceeded(5))]
+    #[case(ApiError::CommitConflict)]
+    #[case(ApiError::InvalidCommit("bad".into()))]
+    #[case(ApiError::RateLimited)]
+    fn from_error_unwraps_api_variant(#[case] api_err: ApiError) {
+        let expected = format!("{api_err:?}");
+        let unwrapped = ApiError::from(Error::Api(api_err));
+        assert_eq!(format!("{unwrapped:?}"), expected);
     }
 
-    #[test]
-    fn from_error_maps_rest_only_variants_to_generic() {
-        let api_err = unity_catalog_delta_client_api::Error::from(Error::MaxRetriesExceeded);
+    /// Rest client-only variants have no API counterpart, so they collapse to
+    /// `Generic` carrying the display message.
+    #[rstest]
+    #[case(Error::MaxRetriesExceeded, "Max retries exceeded")]
+    #[case(
+        Error::InvalidConfiguration("bad".into()),
+        "Invalid configuration: bad"
+    )]
+    fn from_error_maps_rest_only_variants_to_generic(
+        #[case] rest_err: Error,
+        #[case] expected_msg: &str,
+    ) {
+        let api_err = ApiError::from(rest_err);
         assert!(
-            matches!(api_err, unity_catalog_delta_client_api::Error::Generic(ref msg) if msg == "Max retries exceeded"),
-            "unexpected: {api_err:?}"
-        );
-
-        let api_err =
-            unity_catalog_delta_client_api::Error::from(Error::InvalidConfiguration("bad".into()));
-        assert!(
-            matches!(api_err, unity_catalog_delta_client_api::Error::Generic(ref msg) if msg == "Invalid configuration: bad"),
+            matches!(api_err, ApiError::Generic(ref msg) if msg == expected_msg),
             "unexpected: {api_err:?}"
         );
     }

--- a/unity-catalog-delta-rest-client/src/http.rs
+++ b/unity-catalog-delta-rest-client/src/http.rs
@@ -96,10 +96,6 @@ where
 /// [`Error::HttpStatusError`].
 fn error_for_errored_status(status: StatusCode, body: String) -> Error {
     use unity_catalog_delta_client_api::Error as ApiError;
-    assert!(
-        !status.is_success(),
-        "passed in status shouldn't be successful"
-    );
     match status {
         StatusCode::UNAUTHORIZED => ApiError::AuthenticationFailed.into(),
         StatusCode::NOT_FOUND => ApiError::TableNotFound(body).into(),

--- a/unity-catalog-delta-rest-client/src/http.rs
+++ b/unity-catalog-delta-rest-client/src/http.rs
@@ -85,18 +85,63 @@ where
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
 
-        match status {
-            StatusCode::UNAUTHORIZED => {
-                Err(unity_catalog_delta_client_api::Error::AuthenticationFailed.into())
-            }
-            StatusCode::NOT_FOUND => Err(Error::HttpStatusError {
-                status: status.as_u16(),
-                message: format!("Resource not found: {error_body}"),
-            }),
-            _ => Err(Error::HttpStatusError {
-                status: status.as_u16(),
-                message: error_body,
-            }),
-        }
+        Err(error_for_errored_status(status, error_body))
+    }
+}
+
+/// Map a non-success HTTP status and response body to a client [`Error`].
+///
+/// Some commit-semantic status codes UC returns become UC delta client API errors
+/// that are preserved as rest client errors. Anything else stays a generic
+/// [`Error::HttpStatusError`].
+fn error_for_errored_status(status: StatusCode, body: String) -> Error {
+    use unity_catalog_delta_client_api::Error as ApiError;
+    assert!(
+        !status.is_success(),
+        "passed in status shouldn't be successful"
+    );
+    match status {
+        StatusCode::UNAUTHORIZED => ApiError::AuthenticationFailed.into(),
+        StatusCode::NOT_FOUND => ApiError::TableNotFound(body).into(),
+        StatusCode::CONFLICT => ApiError::CommitConflict.into(),
+        StatusCode::BAD_REQUEST => ApiError::InvalidCommit(body).into(),
+        StatusCode::TOO_MANY_REQUESTS => ApiError::RateLimited.into(),
+        _ => Error::HttpStatusError {
+            status: status.as_u16(),
+            message: body,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use unity_catalog_delta_client_api::Error as ApiError;
+
+    use super::*;
+
+    /// Each response status maps to its distinct UC delta client API error (the
+    /// trait error implementations see), and response bodies are preserved.
+    #[rstest]
+    #[case(StatusCode::UNAUTHORIZED, ApiError::AuthenticationFailed)]
+    #[case(StatusCode::NOT_FOUND, ApiError::TableNotFound("boom".into()))]
+    #[case(StatusCode::CONFLICT, ApiError::CommitConflict)]
+    #[case(StatusCode::BAD_REQUEST, ApiError::InvalidCommit("boom".into()))]
+    #[case(StatusCode::TOO_MANY_REQUESTS, ApiError::RateLimited)]
+    fn error_for_status_maps_commit_semantic_codes_to_distinct_api_errors(
+        #[case] status: StatusCode,
+        #[case] expected: ApiError,
+    ) {
+        let api_err = ApiError::from(error_for_errored_status(status, "boom".into()));
+        assert_eq!(format!("{api_err:?}"), format!("{expected:?}"));
+    }
+
+    #[test]
+    fn error_for_status_maps_unrecognized_status_to_http_status_error() {
+        let err = error_for_errored_status(StatusCode::IM_A_TEAPOT, "teapot".into());
+        assert!(
+            matches!(err, Error::HttpStatusError { status: 418, ref message } if message == "teapot"),
+            "unexpected: {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
In the current implementation, `unity-catalog-delta-rest-client::Error` and `unity-catalog-delta-client-api::Error` In the future, we want to be able to surface errors with higher fidelity. 

## How was this change tested?
Run the tests on UC rest client and UC client api. The command to run: `cargo nextest run -p unity-catalog-delta-rest-client -p unity-catalog-delta-client-api --all-features`.