### PR TITLE
feat: expose incremental scan via FFI and document it

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Advanced Reads with scan_metadata()](./reading/scan_metadata.md)
 - [Distributed Log Replay](./reading/parallel_scan_metadata.md)
 - [Time Travel and Snapshot Management](./reading/time_travel.md)
+- [Incremental Scans](./reading/incremental_scan.md)
 - [Reading Change Data Feed](./reading/change_data_feed.md)
 
 # Writing Tables

--- a/docs/user-guide/src/reading/incremental_scan.md
+++ b/docs/user-guide/src/reading/incremental_scan.md
@@ -1,0 +1,288 @@
+# Incremental scans
+
+To advance a cached file listing from one table version to a newer one without replaying the
+whole log, you use an incremental scan. It streams only the file-level changes (added and
+removed files) between a version you already know about and a newer `Snapshot`, so you can
+patch your cache instead of rebuilding it from scratch.
+
+Before reading this page, make sure you understand [Building a Scan](./building_a_scan.md).
+
+An incremental scan is the right tool when you maintain a long-lived, cached listing of a
+table's active files and poll for updates. If you only need the current file list once, use a
+full scan (see [Building a Scan](./building_a_scan.md)). If you need row-level changes (the
+individual inserts, updates, and deletes), use [Change Data Feed](./change_data_feed.md)
+instead. An incremental scan reports file-level changes only.
+
+## The range model
+
+An incremental scan covers the half-open range `(base_version, target_version]`:
+
+- `base_version` is the version you already have cached. It is **excluded**.
+- `target_version` is the version of the `Snapshot` you build the scan from. It is
+  **included**.
+
+So `base_version` is the last version whose state your cache reflects, and the scan tells you
+what changed to reach the target `Snapshot`. The range must be non-empty:
+`base_version < target_version`, or `build()` returns an error.
+
+## Building the scan
+
+Call `incremental_scan_builder(base_version)` on a `Snapshot`, then `build(engine)`:
+
+```rust,no_run
+# extern crate delta_kernel;
+# extern crate delta_kernel_default_engine;
+# use delta_kernel_default_engine::DefaultEngine;
+# use delta_kernel_default_engine::storage::store_from_url;
+# use delta_kernel::{DeltaResult, Snapshot};
+# fn example() -> DeltaResult<()> {
+# let url = delta_kernel::try_parse_uri("/tmp/table")?;
+# let store = store_from_url(&url)?;
+# let engine = DefaultEngine::builder(store).build();
+// The cache already reflects version 5.
+let base_version = 5;
+
+// Build a Snapshot at the target version you want to advance to.
+let target = Snapshot::builder_for(url).build(&engine)?;
+
+// Scan the range (5, target.version()].
+let maybe_stream = target
+    .incremental_scan_builder(base_version)
+    .build(&engine)?;
+# Ok(())
+# }
+```
+
+`build()` returns `Option<IncrementalScanStream>`, not the stream directly. The next section
+explains why.
+
+### Handle `None`: fall back to a full scan
+
+`build()` returns `None` when the target `Snapshot`'s commit list can't cover the range. This
+happens when `base_version` predates the oldest commit the `Snapshot` retains, usually because
+a checkpoint truncated the log history before it. `None` is not an error. It's the signal that
+an incremental advance isn't possible, so you rebuild your cache from a full scan:
+
+```rust,no_run
+# extern crate delta_kernel;
+# extern crate delta_kernel_default_engine;
+# use std::sync::Arc;
+# use delta_kernel_default_engine::DefaultEngine;
+# use delta_kernel_default_engine::storage::store_from_url;
+# use delta_kernel::{DeltaResult, Snapshot};
+# use delta_kernel::incremental_scan::IncrementalScanStream;
+# fn consume(_: IncrementalScanStream) {}
+# fn example() -> DeltaResult<()> {
+# let url = delta_kernel::try_parse_uri("/tmp/table")?;
+# let store = store_from_url(&url)?;
+# let engine = DefaultEngine::builder(store).build();
+# let base_version = 5;
+# let target = Snapshot::builder_for(url).build(&engine)?;
+match target.clone().incremental_scan_builder(base_version).build(&engine)? {
+    Some(stream) => {
+        // The range is covered. Consume the diff and patch your cache.
+        consume(stream);
+    }
+    None => {
+        // History was truncated. Rebuild the listing from a full scan.
+        let _scan = target.scan_builder().build()?;
+    }
+}
+# Ok(())
+# }
+```
+
+> [!WARNING]
+> Never unwrap the `Option`. `None` is a normal outcome whenever a checkpoint has truncated
+> the log below your `base_version`. Treating it as an error strands your cache with no way to
+> advance.
+
+## Consuming the stream
+
+`IncrementalScanStream` yields the live added files as `FilteredEngineData` batches, newest
+commit first. A `FilteredEngineData` pairs a data batch with a selection vector, so respect
+the selection vector when reading. Kernel emits one row per Add action and marks inactive the
+rows an Add that later got cancelled within the range.
+
+Each batch corresponds to a source commit's surviving Adds. A commit whose Adds were all
+cancelled by a later Remove in the range produces no batch at all, and one commit's rows can
+span more than one batch.
+
+After you've read the batches you care about, call a terminal method to recover the file-key
+sets that describe the diff. `into_summary()` drains any batches you didn't read and returns
+the live added and removed file keys:
+
+```rust,no_run
+# extern crate delta_kernel;
+# extern crate delta_kernel_default_engine;
+# use delta_kernel_default_engine::DefaultEngine;
+# use delta_kernel_default_engine::storage::store_from_url;
+# use delta_kernel::{DeltaResult, Snapshot};
+# fn example() -> DeltaResult<()> {
+# let url = delta_kernel::try_parse_uri("/tmp/table")?;
+# let store = store_from_url(&url)?;
+# let engine = DefaultEngine::builder(store).build();
+# let base_version = 5;
+# let target = Snapshot::builder_for(url).build(&engine)?;
+# let Some(stream) = target.incremental_scan_builder(base_version).build(&engine)? else {
+#     return Ok(());
+# };
+let mut added_row_count = 0;
+let mut stream = stream;
+for batch in stream.by_ref() {
+    let batch = batch?;
+    // Only the rows selected by the selection vector are live Adds.
+    added_row_count += batch.selection_vector().iter().filter(|&&s| s).count();
+}
+
+// Recover the file-key sets after reading the batches.
+let summary = stream.into_summary()?;
+println!(
+    "range ({}, {}]: {} live adds, {} removes, {} added rows",
+    summary.base_version,
+    summary.target_version,
+    summary.live_adds.len(),
+    summary.removes.len(),
+    added_row_count,
+);
+# Ok(())
+# }
+```
+
+If you'd rather buffer the whole diff at once, `into_listing()` collects every Add batch into
+a `Vec` alongside the summary. Use it when the diff fits comfortably in memory.
+
+### File keys identify files by path _and_ deletion vector
+
+The `live_adds` and `removes` sets hold `FileActionKey` values, each a `(path, dv_unique_id)`
+pair. **Delta tables use deletion vectors to mark rows as deleted without rewriting the data
+file**, so the same path can appear with different deletion-vector ids. Match on the whole key,
+never on the path alone.
+
+For example, replacing a file's deletion vector adds `(P, dv=new)` and removes `(P, dv=old)`.
+Those are two distinct logical files. Collapsing them to the path `P` would treat the add and
+the remove as the same file and corrupt your listing.
+
+## Advancing a cached listing
+
+When your cache is a listing layered on top of a base version, an incremental scan gives you
+exactly the delta to apply. Append the streamed Add batches to your delta layer, then mask the
+base with the files that are no longer current.
+
+The mask is the union of two sets, so use `into_summary_against_base_closure` (or its `_iter`
+variant) rather than `into_summary`. That terminal method takes your base listing and returns
+both `removes` and `duplicate_adds`:
+
+- `removes` masks files that left the table.
+- `duplicate_adds` masks the stale base entry of each file the range re-added with new
+  metadata. Compaction (OPTIMIZE) and liquid clustering re-tag files this way: the file key is
+  already in your base, and the range re-adds it, so the base's old row must be evicted in
+  favor of the freshly streamed one.
+
+```rust,no_run
+# extern crate delta_kernel;
+# extern crate delta_kernel_default_engine;
+# use std::collections::HashSet;
+# use delta_kernel_default_engine::DefaultEngine;
+# use delta_kernel_default_engine::storage::store_from_url;
+# use delta_kernel::{DeltaResult, Snapshot};
+# use delta_kernel::log_replay::FileActionKey;
+# fn example() -> DeltaResult<()> {
+# let url = delta_kernel::try_parse_uri("/tmp/table")?;
+# let store = store_from_url(&url)?;
+# let engine = DefaultEngine::builder(store).build();
+# let base_version = 5;
+# let target = Snapshot::builder_for(url).build(&engine)?;
+# let Some(stream) = target.incremental_scan_builder(base_version).build(&engine)? else {
+#     return Ok(());
+# };
+// Your cache exposes a `contains` lookup keyed by (path, dv_unique_id).
+let base: HashSet<FileActionKey> = HashSet::new();
+
+let summary = stream.into_summary_against_base_closure(|key| base.contains(key))?;
+
+// Evict every base entry that either left the table or was re-added with new metadata.
+let mask: HashSet<&FileActionKey> =
+    summary.removes.iter().chain(summary.duplicate_adds.iter()).collect();
+# let _ = mask;
+# Ok(())
+# }
+```
+
+> [!WARNING]
+> Apply both `removes` and `duplicate_adds` to the base. Dropping `duplicate_adds` leaves stale
+> rows in your listing for every file that compaction or clustering re-tagged, so your cache
+> keeps pointing at data files that are no longer current.
+
+> [!TIP]
+> Pick the terminal variant by your cache's shape. Use `_closure` when your cache supports a
+> `contains` lookup (`HashSet`, `HashMap`, `BTreeMap`, or a sorted `Vec` with `binary_search`).
+> It probes the live-Add set, which is usually much smaller than the base. Use `_iter` only
+> when your cache can't do membership lookup and can only stream its keys.
+
+## Correctness requirements
+
+A few properties of the stream are easy to violate and produce a silently wrong listing rather
+than an error.
+
+### Errors are sticky
+
+Once `next()` yields an error, the stream is dead. Every later call returns `None`, and the
+terminal methods return an error instead of a partial summary. The dedup state is incomplete
+after an error, so a partial result would be wrong. To retry, drop the stream and build a fresh
+one.
+
+### A vacuumed commit means fall back to a full scan
+
+If consumption fails with a file-not-found error, a commit in the range was vacuumed between
+`build()` and draining the stream. Build a fresh incremental scan. It will most likely return
+`None` (the commits are no longer available), which is your signal to fall back to a full scan.
+
+### Catalog-managed tables need the log tail on the `Snapshot`
+
+For **catalog-managed tables** (tables whose commits a catalog ratifies), the incremental scan
+walks the `Snapshot`'s already-validated commit list and deliberately does not re-list the
+`_delta_log/` directory. Staged commits that the catalog has ratified but not yet published
+appear only if you passed them to the `Snapshot` when you built it. Build the target `Snapshot`
+with the catalog's log tail so the range includes those commits. A fresh storage listing would
+miss them. See [Reading Catalog-Managed Tables](../catalog_managed/reading.md).
+
+## Current limitations
+
+The incremental scan is narrower than a full scan. Know these limits before you build on it.
+
+### No predicate or column pushdown
+
+Unlike `scan_builder`, the incremental scan builder takes no predicate and no projection. It
+reports every added and removed file in the range, so you can't push data skipping or column
+selection into it. Apply any file-level or row-level filtering in your connector after the scan
+returns.
+
+### In-range metadata changes aren't surfaced
+
+`build()` validates reader features against the target `Snapshot` only. If the table's schema,
+column-mapping mode, or reader features changed _within_ the range, the scan doesn't tell you.
+Kernel decodes only the file path and deletion-vector fields, and those stay correct across
+such a change. But if your connector reads pass-through fields off each row (`stats`,
+`partitionValues`, `baseRowId`), interpret each row against the protocol at that row's commit
+version, not against the target `Snapshot`. Surfacing in-range metadata changes is tracked in
+[issue #2552](https://github.com/delta-io/delta-kernel-rs/issues/2552).
+
+> [!WARNING]
+> If the range may span a metadata change and your connector reads pass-through fields, decode
+> each row against its own commit's protocol. Decoding every row against the target `Snapshot`
+> silently misreads rows written under the older metadata.
+
+## What's next
+
+- [Time Travel and Snapshot Management](./time_travel.md): building and updating the `Snapshot`
+  you scan from
+- [Advanced Reads with scan_metadata()](./scan_metadata.md): full-scan file listing when an
+  incremental advance isn't possible
+- [Reading Change Data Feed](./change_data_feed.md): row-level changes instead of file-level
+  changes
+
+## See also
+
+- [Reading Catalog-Managed Tables](../catalog_managed/reading.md): building a `Snapshot` with a
+  log tail for staged commits

--- a/docs/user-guide/src/reading/incremental_scan.md
+++ b/docs/user-guide/src/reading/incremental_scan.md
@@ -58,10 +58,12 @@ explains why.
 
 ### Handle `None`: fall back to a full scan
 
-`build()` returns `None` when the target `Snapshot`'s commit list can't cover the range. This
-happens when `base_version` predates the oldest commit the `Snapshot` retains, usually because
-a checkpoint truncated the log history before it. `None` is not an error. It's the signal that
-an incremental advance isn't possible, so you rebuild your cache from a full scan:
+`build()` returns `None` when the target `Snapshot` doesn't retain commit `base_version + 1`,
+the first version in the range. Typically the `Snapshot` loaded from a checkpoint above
+`base_version`, so its retained commit list begins past the first version you need. The commit
+files may still exist on storage; the `Snapshot` just doesn't retain them. `None` is not an
+error. It's the signal that an incremental advance isn't possible, so you rebuild your cache
+from a full scan:
 
 ```rust,no_run
 # extern crate delta_kernel;
@@ -84,7 +86,7 @@ match target.clone().incremental_scan_builder(base_version).build(&engine)? {
         consume(stream);
     }
     None => {
-        // History was truncated. Rebuild the listing from a full scan.
+        // The Snapshot no longer retains commits back to the base. Rebuild from a full scan.
         let _scan = target.scan_builder().build()?;
     }
 }
@@ -93,16 +95,17 @@ match target.clone().incremental_scan_builder(base_version).build(&engine)? {
 ```
 
 > [!WARNING]
-> Never unwrap the `Option`. `None` is a normal outcome whenever a checkpoint has truncated
-> the log below your `base_version`. Treating it as an error strands your cache with no way to
-> advance.
+> Never unwrap the `Option`. `None` is a normal outcome whenever the `Snapshot` no longer
+> retains commits back to your `base_version`. Treating it as an error strands your cache with
+> no way to advance.
 
 ## Consuming the stream
 
 `IncrementalScanStream` yields the live added files as `FilteredEngineData` batches, newest
 commit first. A `FilteredEngineData` pairs a data batch with a selection vector, so respect
-the selection vector when reading. Kernel emits one row per Add action and marks inactive the
-rows an Add that later got cancelled within the range.
+the selection vector when reading. Each batch is a raw commit action batch, one row per action.
+Only the rows the selection vector marks active are live Adds. Every other row is present but
+inactive: Removes, Adds that a later commit in the range cancelled, and non-file actions.
 
 Each batch corresponds to a source commit's surviving Adds. A commit whose Adds were all
 cancelled by a later Remove in the range produces no batch at all, and one commit's rows can
@@ -222,8 +225,8 @@ let mask: HashSet<&FileActionKey> =
 
 ## Correctness requirements
 
-A few properties of the stream are easy to violate and produce a silently wrong listing rather
-than an error.
+A few properties of the stream, if violated, produce a silently wrong listing rather than an
+error.
 
 ### Errors are sticky
 

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -63,6 +63,30 @@ commit_range_builder_for(path, start_version, engine)
 The caller owns the builder and must call either `commit_range_builder_build` or
 `free_commit_range_builder`. Release the range with `free_commit_range`.
 
+## Incremental Scan Flow
+
+An incremental scan streams the file-action diff between a base version and a target snapshot,
+letting an engine advance a cached file listing without a full log replay
+(`ffi/src/incremental_scan.rs`):
+
+```
+snapshot_incremental_scan_builder(snapshot, base_version, engine)
+  -> incremental_scan_builder_build(builder)      // -> OptionalValue<stream>; None => full-scan fallback
+  -> incremental_scan_stream_next_arrow(stream)    // drain live-Add batches (Arrow), newest-first
+  -> incremental_scan_stream_into_summary(stream)  // -> summary; consumes the stream
+```
+
+`incremental_scan_builder_build` returns `OptionalValue::None` (not an error) when the target
+snapshot's commit list can't cover `(base_version, target_version]`, which is the signal to fall
+back to a full scan. The builder is always consumed by `build`; discard it early with
+`free_incremental_scan_builder`.
+
+Read the diff via `incremental_scan_summary_base_version` / `_target_version` and the
+`incremental_scan_summary_visit_live_adds` / `_visit_removes` callbacks (each key is a `(path,
+dv_unique_id)` pair; `dv_unique_id` is a zero-length slice when absent). Release handles with
+`free_incremental_scan_stream`, `free_incremental_scan_summary`, and each Arrow batch with
+`free_filtered_engine_data_arrow_result`.
+
 ## Write Flow
 
 ```

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -87,6 +87,12 @@ dv_unique_id)` pair; `dv_unique_id` is a zero-length slice when absent). Release
 `free_incremental_scan_stream`, `free_incremental_scan_summary`, and each Arrow batch with
 `free_filtered_engine_data_arrow_result`.
 
+To advance a cached listing, evict base entries whose key is in `removes` OR is re-added by the
+range. OPTIMIZE / clustering re-tags a file under the same `(path, dv_unique_id)` key, so it
+lands in `live_adds` but not `removes`; masking with `removes` alone leaves a stale row. The
+full mask is `removes` unioned with the base keys also present in `live_adds`. The Rust API
+computes this via `into_summary_against_base_*`, which the FFI does not yet expose.
+
 ## Write Flow
 
 ```

--- a/ffi/src/incremental_scan.rs
+++ b/ffi/src/incremental_scan.rs
@@ -1,0 +1,611 @@
+//! FFI bindings for the incremental scan API.
+//!
+//! An incremental scan streams the file-action diff between a base version and a target
+//! [`SharedSnapshot`], letting an engine advance a cached file listing without a full log replay.
+//! The flow mirrors the Rust API:
+//!
+//! ```text
+//! snapshot_incremental_scan_builder(snapshot, base_version)
+//!   -> incremental_scan_builder_build(builder)   // -> OptionalValue<stream>; None => full-scan fallback
+//!   -> incremental_scan_stream_next_arrow(stream) // drain filtered Add batches, newest-first
+//!   -> incremental_scan_stream_into_summary(stream) // -> summary; consumes the stream
+//! ```
+//!
+//! [`incremental_scan_builder_build`] returns [`OptionalValue::None`] (not an error) when the
+//! target snapshot's commit list can't cover the range, which is the signal to fall back to a
+//! full scan.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+
+use delta_kernel::incremental_scan::{IncrementalScanStream, IncrementalScanSummary};
+use delta_kernel::log_replay::FileActionKey;
+use delta_kernel::snapshot::SnapshotRef;
+use delta_kernel::{DeltaResult, Error, Version};
+use delta_kernel_ffi_macros::handle_descriptor;
+
+#[cfg(feature = "default-engine-base")]
+use crate::engine_data::ArrowFFIData;
+use crate::handle::Handle;
+#[cfg(feature = "default-engine-base")]
+use crate::KernelBoolSlice;
+use crate::{
+    kernel_string_slice, ExternEngine, ExternResult, IntoExternResult, KernelStringSlice,
+    NullableCvoid, OptionalValue, SharedExternEngine, SharedSnapshot,
+};
+
+/// Opaque builder for constructing an [`IncrementalScanStream`] from a snapshot.
+///
+/// Create with [`snapshot_incremental_scan_builder`]. Call [`incremental_scan_builder_build`] to
+/// consume the builder and obtain the stream, or [`free_incremental_scan_builder`] to drop it
+/// without building.
+pub struct FfiIncrementalScanBuilder {
+    engine: Arc<dyn ExternEngine>,
+    target_snapshot: SnapshotRef,
+    base_version: Version,
+}
+
+/// An opaque handle with exclusive (Box-like) ownership of a [`FfiIncrementalScanBuilder`].
+#[handle_descriptor(target=FfiIncrementalScanBuilder, mutable=true, sized=true)]
+pub struct MutableFfiIncrementalScanBuilder;
+
+/// An incremental scan stream, guarded by a mutex so it can cross the FFI boundary as a shared
+/// handle. The stream itself is single-consumer; the mutex serializes concurrent `next` calls.
+///
+/// The engine `Arc` is retained so the JSON reader's runtime outlives the stream even if the
+/// caller drops its own engine handle first.
+pub struct FfiIncrementalScanStream {
+    stream: Mutex<Option<IncrementalScanStream>>,
+    engine: Arc<dyn ExternEngine>,
+}
+
+/// An opaque, shared handle owning an [`FfiIncrementalScanStream`]. Release with
+/// [`free_incremental_scan_stream`], or consume it with
+/// [`incremental_scan_stream_into_summary`].
+#[handle_descriptor(target=FfiIncrementalScanStream, mutable=false, sized=true)]
+pub struct SharedIncrementalScanStream;
+
+/// An opaque, shared handle owning an [`IncrementalScanSummary`]. Release with
+/// [`free_incremental_scan_summary`].
+#[handle_descriptor(target=IncrementalScanSummary, mutable=false, sized=true)]
+pub struct SharedIncrementalScanSummary;
+
+/// Get a builder for an incremental scan over the range `(base_version, snapshot.version()]`.
+///
+/// The caller owns the returned handle and must eventually call either
+/// [`incremental_scan_builder_build`] to produce a stream, or [`free_incremental_scan_builder`]
+/// to drop it without building. Does not consume the snapshot handle.
+///
+/// # Safety
+///
+/// Caller must pass a valid snapshot handle and engine handle.
+#[no_mangle]
+pub unsafe extern "C" fn snapshot_incremental_scan_builder(
+    snapshot: Handle<SharedSnapshot>,
+    base_version: Version,
+    engine: Handle<SharedExternEngine>,
+) -> Handle<MutableFfiIncrementalScanBuilder> {
+    let target_snapshot = unsafe { snapshot.clone_as_arc() };
+    let engine = unsafe { engine.clone_as_arc() };
+    Box::new(FfiIncrementalScanBuilder {
+        engine,
+        target_snapshot,
+        base_version,
+    })
+    .into()
+}
+
+/// Consume the builder and return the incremental scan stream, or [`OptionalValue::None`] when
+/// the target snapshot's commit list can't cover `(base_version, target_version]`.
+///
+/// [`OptionalValue::None`] is not an error. It means an incremental advance isn't possible
+/// (typically a checkpoint truncated the log below `base_version`), so the caller should fall
+/// back to a full scan. The builder is always freed by this call, whether or not it succeeds.
+///
+/// Returns an error if `base_version >= target_version`, the target snapshot's protocol has an
+/// unsupported reader feature, or the engine fails to open the commit stream.
+///
+/// # Safety
+///
+/// Caller must pass a valid builder pointer and must not use it again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_builder_build(
+    builder: Handle<MutableFfiIncrementalScanBuilder>,
+) -> ExternResult<OptionalValue<Handle<SharedIncrementalScanStream>>> {
+    let builder = unsafe { builder.into_inner() };
+    let engine = builder.engine.clone();
+    incremental_scan_builder_build_impl(*builder).into_extern_result(&engine.as_ref())
+}
+
+fn incremental_scan_builder_build_impl(
+    builder: FfiIncrementalScanBuilder,
+) -> DeltaResult<OptionalValue<Handle<SharedIncrementalScanStream>>> {
+    let engine = builder.engine.engine();
+    let maybe_stream = builder
+        .target_snapshot
+        .incremental_scan_builder(builder.base_version)
+        .build(engine.as_ref())?;
+    let handle = maybe_stream.map(|stream| {
+        Arc::new(FfiIncrementalScanStream {
+            stream: Mutex::new(Some(stream)),
+            engine: builder.engine,
+        })
+        .into()
+    });
+    Ok(handle.into())
+}
+
+/// Free an incremental scan builder without building (e.g. on an error path).
+///
+/// # Safety
+///
+/// Caller must pass a valid builder pointer and must not use it again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn free_incremental_scan_builder(
+    builder: Handle<MutableFfiIncrementalScanBuilder>,
+) {
+    builder.drop_handle();
+}
+
+/// Get the next live-Add batch from the stream as Arrow via the C Data Interface.
+///
+/// Returns `Ok(non-null)` with the next [`FilteredEngineDataArrowResult`] (an Arrow batch paired
+/// with a boolean selection vector), `Ok(null)` when the stream is exhausted, or `Err` on a read
+/// failure. Only rows selected by the vector are live Adds; batches are yielded newest-commit
+/// first. The engine must free each non-null result with
+/// [`free_filtered_engine_data_arrow_result`].
+///
+/// Once this returns an error the stream is dead: later calls return `Ok(null)` and
+/// [`incremental_scan_stream_into_summary`] will error. Rebuild the stream to retry.
+///
+/// # Safety
+///
+/// Caller must pass a valid stream handle.
+#[cfg(feature = "default-engine-base")]
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_stream_next_arrow(
+    stream: Handle<SharedIncrementalScanStream>,
+) -> ExternResult<*mut FilteredEngineDataArrowResult> {
+    let stream = unsafe { stream.as_ref() };
+    incremental_scan_stream_next_arrow_impl(stream).into_extern_result(&stream.engine.as_ref())
+}
+
+#[cfg(feature = "default-engine-base")]
+fn incremental_scan_stream_next_arrow_impl(
+    stream: &FfiIncrementalScanStream,
+) -> DeltaResult<*mut FilteredEngineDataArrowResult> {
+    let mut guard = lock_stream(stream)?;
+    let Some(inner) = guard.as_mut() else {
+        // The stream was already consumed by `into_summary`.
+        return Err(Error::generic(
+            "incremental scan stream was already consumed",
+        ));
+    };
+    match inner.next().transpose()? {
+        Some(filtered) => {
+            let (engine_data, selection_vector) = filtered.into_parts();
+            let arrow_data = ArrowFFIData::try_from_engine_data(engine_data)?;
+            let result = Box::new(FilteredEngineDataArrowResult {
+                arrow_data,
+                selection_vector: selection_vector.into(),
+            });
+            Ok(Box::into_raw(result))
+        }
+        None => Ok(std::ptr::null_mut()),
+    }
+}
+
+/// Drain any unread batches, then consume the stream and return its summary of live Add and
+/// Remove file keys for the range.
+///
+/// Consumes the stream handle: the pointer is no longer valid after this call, whether or not it
+/// succeeds. Returns an error if a prior [`incremental_scan_stream_next_arrow`] call errored, or
+/// if draining the remaining batches fails.
+///
+/// # Safety
+///
+/// Caller must pass a valid stream handle and must not use it again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_stream_into_summary(
+    stream: Handle<SharedIncrementalScanStream>,
+) -> ExternResult<Handle<SharedIncrementalScanSummary>> {
+    let engine = unsafe { stream.as_ref() }.engine.clone();
+    let result = incremental_scan_stream_into_summary_impl(&stream);
+    stream.drop_handle();
+    result.into_extern_result(&engine.as_ref())
+}
+
+fn incremental_scan_stream_into_summary_impl(
+    stream: &Handle<SharedIncrementalScanStream>,
+) -> DeltaResult<Handle<SharedIncrementalScanSummary>> {
+    let stream = unsafe { stream.as_ref() };
+    let inner = lock_stream(stream)?
+        .take()
+        .ok_or_else(|| Error::generic("incremental scan stream was already consumed"))?;
+    let summary = inner.into_summary()?;
+    Ok(Arc::new(summary).into())
+}
+
+fn lock_stream(
+    stream: &FfiIncrementalScanStream,
+) -> DeltaResult<std::sync::MutexGuard<'_, Option<IncrementalScanStream>>> {
+    stream
+        .stream
+        .lock()
+        .map_err(|_| Error::generic("poisoned incremental scan stream mutex"))
+}
+
+/// The base (exclusive lower bound) version of the scanned range.
+///
+/// # Safety
+///
+/// Caller must pass a valid summary handle.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_summary_base_version(
+    summary: Handle<SharedIncrementalScanSummary>,
+) -> Version {
+    unsafe { summary.as_ref() }.base_version
+}
+
+/// The target (inclusive upper bound) version of the scanned range.
+///
+/// # Safety
+///
+/// Caller must pass a valid summary handle.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_summary_target_version(
+    summary: Handle<SharedIncrementalScanSummary>,
+) -> Version {
+    unsafe { summary.as_ref() }.target_version
+}
+
+/// Visit each live-Add file key in the summary, invoking `callback` once per key with its path
+/// and (nullable) deletion-vector unique id.
+///
+/// A live Add is a file still present at the target version. Match on the whole `(path,
+/// dv_unique_id)` key, not the path alone: the same path with different DV ids refers to
+/// distinct logical files. `dv_unique_id` is passed as a zero-length slice when the file has no
+/// deletion vector.
+///
+/// The slices passed to the callback are only valid for the duration of the callback.
+///
+/// # Safety
+///
+/// Caller must pass a valid summary handle and a non-null callback pointer.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_summary_visit_live_adds(
+    summary: Handle<SharedIncrementalScanSummary>,
+    engine_context: NullableCvoid,
+    callback: FileKeyCallback,
+) {
+    let summary = unsafe { summary.as_ref() };
+    visit_file_keys(&summary.live_adds, engine_context, callback);
+}
+
+/// Visit each Remove file key in the summary, invoking `callback` once per key with its path and
+/// (nullable) deletion-vector unique id.
+///
+/// See [`incremental_scan_summary_visit_live_adds`] for the callback contract.
+///
+/// # Safety
+///
+/// Caller must pass a valid summary handle and a non-null callback pointer.
+#[no_mangle]
+pub unsafe extern "C" fn incremental_scan_summary_visit_removes(
+    summary: Handle<SharedIncrementalScanSummary>,
+    engine_context: NullableCvoid,
+    callback: FileKeyCallback,
+) {
+    let summary = unsafe { summary.as_ref() };
+    visit_file_keys(&summary.removes, engine_context, callback);
+}
+
+/// Callback invoked once per file key by the summary visitors. `dv_unique_id` is a zero-length
+/// slice when the file carries no deletion vector. Both slices are only valid for the duration
+/// of the call.
+pub type FileKeyCallback = extern "C" fn(
+    engine_context: NullableCvoid,
+    path: KernelStringSlice,
+    dv_unique_id: KernelStringSlice,
+);
+
+fn visit_file_keys(
+    keys: &HashSet<FileActionKey>,
+    engine_context: NullableCvoid,
+    callback: FileKeyCallback,
+) {
+    for key in keys {
+        let path = key.path();
+        let dv = key.dv_unique_id().unwrap_or("");
+        callback(
+            engine_context,
+            kernel_string_slice!(path),
+            kernel_string_slice!(dv),
+        );
+    }
+}
+
+/// Free an incremental scan stream. Use this when abandoning a stream without draining it to a
+/// summary. After [`incremental_scan_stream_into_summary`] consumes the stream, do not call this.
+///
+/// # Safety
+///
+/// Caller must pass a valid stream handle and must not use it again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn free_incremental_scan_stream(stream: Handle<SharedIncrementalScanStream>) {
+    stream.drop_handle();
+}
+
+/// Free an incremental scan summary.
+///
+/// # Safety
+///
+/// Caller must pass a valid summary handle and must not use it again after this call.
+#[no_mangle]
+pub unsafe extern "C" fn free_incremental_scan_summary(
+    summary: Handle<SharedIncrementalScanSummary>,
+) {
+    summary.drop_handle();
+}
+
+/// Result of [`incremental_scan_stream_next_arrow`]: an Arrow C Data Interface batch of live Add
+/// actions plus a boolean selection vector.
+///
+/// The engine must free this with [`free_filtered_engine_data_arrow_result`] exactly once.
+#[cfg(feature = "default-engine-base")]
+#[repr(C)]
+pub struct FilteredEngineDataArrowResult {
+    /// Arrow C Data Interface batch of Add actions for one source commit.
+    pub arrow_data: ArrowFFIData,
+    /// Boolean selection vector; `true` at index `i` means row `i` is a live Add. Length equals
+    /// the batch row count.
+    pub selection_vector: KernelBoolSlice,
+}
+
+/// Free a [`FilteredEngineDataArrowResult`] returned by [`incremental_scan_stream_next_arrow`].
+///
+/// # Safety
+///
+/// `result` must be a pointer returned by [`incremental_scan_stream_next_arrow`], or null. Must
+/// be called at most once per result.
+#[cfg(feature = "default-engine-base")]
+#[no_mangle]
+pub unsafe extern "C" fn free_filtered_engine_data_arrow_result(
+    result: *mut FilteredEngineDataArrowResult,
+) {
+    if result.is_null() {
+        return;
+    }
+    let FilteredEngineDataArrowResult {
+        arrow_data,
+        selection_vector,
+    } = unsafe { *Box::from_raw(result) };
+    // KernelBoolSlice is a leaked Vec<bool>; reconstitute and drop to free.
+    let _ = unsafe { selection_vector.into_vec() };
+    // ArrowFFIData's FFI structs release themselves on drop; a no-op if the consumer already
+    // imported the data.
+    drop(arrow_data);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::sync::Arc;
+
+    use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel_default_engine::DefaultEngineBuilder;
+    use test_utils::{actions_to_string, add_commit, TestAction};
+
+    use super::*;
+    use crate::error::KernelError;
+    use crate::ffi_test_utils::{
+        allocate_err, assert_extern_result_error_with_message, ok_or_panic,
+    };
+    use crate::{
+        engine_to_handle, free_engine, free_snapshot, get_snapshot_builder, kernel_string_slice,
+        snapshot_builder_build, snapshot_builder_set_version, NullableCvoid, TryFromStringSlice,
+    };
+
+    /// Build an in-memory engine handle and a snapshot pinned to `target_version`, pre-loaded
+    /// with a metadata commit at v0 and the given `commits` at v1.. Returns
+    /// `(engine_handle, snapshot_handle)`; the caller frees both.
+    async fn setup(
+        commits: Vec<Vec<TestAction>>,
+    ) -> (Handle<SharedExternEngine>, Handle<SharedSnapshot>) {
+        let table_root = "memory:///";
+        let storage = Arc::new(InMemory::new());
+        add_commit(
+            table_root,
+            storage.as_ref(),
+            0,
+            actions_to_string(vec![TestAction::Metadata]),
+        )
+        .await
+        .unwrap();
+        let target_version = commits.len() as u64;
+        for (idx, body) in commits.into_iter().enumerate() {
+            add_commit(
+                table_root,
+                storage.as_ref(),
+                (idx + 1) as u64,
+                actions_to_string(body),
+            )
+            .await
+            .unwrap();
+        }
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let mut builder = unsafe {
+            ok_or_panic(get_snapshot_builder(
+                kernel_string_slice!(table_root),
+                engine.shallow_copy(),
+            ))
+        };
+        unsafe { snapshot_builder_set_version(&mut builder, target_version) };
+        let snapshot = unsafe { ok_or_panic(snapshot_builder_build(builder)) };
+        (engine, snapshot)
+    }
+
+    // Collect the (path, dv_unique_id) pairs a summary visitor reports. `RefCell` because the
+    // C callback takes `&self` context; the visit is single-threaded.
+    extern "C" fn collect_key(
+        engine_context: NullableCvoid,
+        path: KernelStringSlice,
+        dv_unique_id: KernelStringSlice,
+    ) {
+        let keys =
+            engine_context.unwrap().as_ptr() as *const RefCell<Vec<(String, Option<String>)>>;
+        let path = unsafe { String::try_from_slice(&path) }.unwrap();
+        let dv = unsafe { String::try_from_slice(&dv_unique_id) }.unwrap();
+        let dv = if dv.is_empty() { None } else { Some(dv) };
+        unsafe { &*keys }.borrow_mut().push((path, dv));
+    }
+
+    fn visit_live_adds(
+        summary: &Handle<SharedIncrementalScanSummary>,
+    ) -> Vec<(String, Option<String>)> {
+        let keys = RefCell::new(Vec::new());
+        let ctx = std::ptr::NonNull::new(&keys as *const _ as *mut std::ffi::c_void);
+        unsafe {
+            incremental_scan_summary_visit_live_adds(summary.shallow_copy(), ctx, collect_key)
+        };
+        keys.into_inner()
+    }
+
+    fn visit_removes(
+        summary: &Handle<SharedIncrementalScanSummary>,
+    ) -> Vec<(String, Option<String>)> {
+        let keys = RefCell::new(Vec::new());
+        let ctx = std::ptr::NonNull::new(&keys as *const _ as *mut std::ffi::c_void);
+        unsafe { incremental_scan_summary_visit_removes(summary.shallow_copy(), ctx, collect_key) };
+        keys.into_inner()
+    }
+
+    #[tokio::test]
+    async fn build_and_summary_reports_live_adds_and_removes(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Range (0, 3]: A added at v1, removed at v3; B added at v2 stays live; C added at v3.
+        let (engine, snapshot) = setup(vec![
+            vec![TestAction::Add("A".to_string())],
+            vec![TestAction::Add("B".to_string())],
+            vec![
+                TestAction::Add("C".to_string()),
+                TestAction::Remove("A".to_string()),
+            ],
+        ])
+        .await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+
+        let summary = unsafe { ok_or_panic(incremental_scan_stream_into_summary(stream)) };
+
+        assert_eq!(
+            unsafe { incremental_scan_summary_base_version(summary.shallow_copy()) },
+            0
+        );
+        assert_eq!(
+            unsafe { incremental_scan_summary_target_version(summary.shallow_copy()) },
+            3
+        );
+
+        let mut live_adds: Vec<_> = visit_live_adds(&summary)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        live_adds.sort();
+        assert_eq!(live_adds, vec!["B".to_string(), "C".to_string()]);
+
+        let removes: Vec<_> = visit_removes(&summary)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        assert_eq!(removes, vec!["A".to_string()]);
+
+        unsafe { free_incremental_scan_summary(summary) };
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[cfg(feature = "default-engine-base")]
+    #[tokio::test]
+    async fn next_arrow_drains_then_null_then_summary() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup(vec![
+            vec![TestAction::Add("A".to_string())],
+            vec![TestAction::Add("B".to_string())],
+        ])
+        .await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+
+        let mut batches = 0;
+        loop {
+            let ptr =
+                unsafe { ok_or_panic(incremental_scan_stream_next_arrow(stream.shallow_copy())) };
+            if ptr.is_null() {
+                break;
+            }
+            batches += 1;
+            unsafe { free_filtered_engine_data_arrow_result(ptr) };
+        }
+        assert_eq!(batches, 2, "one live-Add batch per commit");
+
+        // The stream is drained; into_summary still recovers the key sets.
+        let summary = unsafe { ok_or_panic(incremental_scan_stream_into_summary(stream)) };
+        let mut live_adds: Vec<_> = visit_live_adds(&summary)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        live_adds.sort();
+        assert_eq!(live_adds, vec!["A".to_string(), "B".to_string()]);
+
+        unsafe { free_incremental_scan_summary(summary) };
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_errors_when_base_not_below_target() -> Result<(), Box<dyn std::error::Error>> {
+        // Target snapshot is v2; base_version 2 makes the range empty.
+        let (engine, snapshot) = setup(vec![
+            vec![TestAction::Add("A".to_string())],
+            vec![TestAction::Add("B".to_string())],
+        ])
+        .await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 2, engine.shallow_copy())
+        };
+        let result = unsafe { incremental_scan_builder_build(builder) };
+        assert_extern_result_error_with_message(result, KernelError::GenericError, None);
+
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn free_builder_without_building() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup(vec![vec![TestAction::Add("A".to_string())]]).await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        unsafe { free_incremental_scan_builder(builder) };
+
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+}

--- a/ffi/src/incremental_scan.rs
+++ b/ffi/src/incremental_scan.rs
@@ -5,7 +5,7 @@
 //! The flow mirrors the Rust API:
 //!
 //! ```text
-//! snapshot_incremental_scan_builder(snapshot, base_version)
+//! snapshot_incremental_scan_builder(snapshot, base_version, engine)
 //!   -> incremental_scan_builder_build(builder)   // -> OptionalValue<stream>; None => full-scan fallback
 //!   -> incremental_scan_stream_next_arrow(stream) // drain filtered Add batches, newest-first
 //!   -> incremental_scan_stream_into_summary(stream) // -> summary; consumes the stream
@@ -202,6 +202,13 @@ fn incremental_scan_stream_next_arrow_impl(
 /// succeeds. Returns an error if a prior [`incremental_scan_stream_next_arrow`] call errored, or
 /// if draining the remaining batches fails.
 ///
+/// To advance a cached listing with the result, evict every base entry whose key is in
+/// `removes` OR is re-added by the range. A file that OPTIMIZE or clustering re-tags keeps its
+/// `(path, dv_unique_id)` key, so it appears in `live_adds` but not `removes`. Masking the base
+/// with `removes` alone leaves that file's stale row pointing at a data file that's no longer
+/// current. The full eviction mask is `removes` unioned with the intersection of your base and
+/// `live_adds` (visit `live_adds` and keep the keys your base already holds).
+///
 /// # Safety
 ///
 /// Caller must pass a valid stream handle and must not use it again after this call.
@@ -271,7 +278,7 @@ pub unsafe extern "C" fn incremental_scan_summary_target_version(
 ///
 /// # Safety
 ///
-/// Caller must pass a valid summary handle and a non-null callback pointer.
+/// Caller must pass a valid summary handle.
 #[no_mangle]
 pub unsafe extern "C" fn incremental_scan_summary_visit_live_adds(
     summary: Handle<SharedIncrementalScanSummary>,
@@ -289,7 +296,7 @@ pub unsafe extern "C" fn incremental_scan_summary_visit_live_adds(
 ///
 /// # Safety
 ///
-/// Caller must pass a valid summary handle and a non-null callback pointer.
+/// Caller must pass a valid summary handle.
 #[no_mangle]
 pub unsafe extern "C" fn incremental_scan_summary_visit_removes(
     summary: Handle<SharedIncrementalScanSummary>,
@@ -352,6 +359,9 @@ pub unsafe extern "C" fn free_incremental_scan_summary(
 /// actions plus a boolean selection vector.
 ///
 /// The engine must free this with [`free_filtered_engine_data_arrow_result`] exactly once.
+///
+/// This mirrors [`crate::scan::ScanMetadataArrowResult`] minus its per-row transforms (the
+/// incremental scan produces none). Keep the release sequence in sync with that type's.
 #[cfg(feature = "default-engine-base")]
 #[repr(C)]
 pub struct FilteredEngineDataArrowResult {
@@ -432,6 +442,45 @@ mod tests {
             )
             .await
             .unwrap();
+        }
+        let engine = DefaultEngineBuilder::new(storage.clone()).build();
+        let engine = engine_to_handle(Arc::new(engine), allocate_err);
+        let mut builder = unsafe {
+            ok_or_panic(get_snapshot_builder(
+                kernel_string_slice!(table_root),
+                engine.shallow_copy(),
+            ))
+        };
+        unsafe { snapshot_builder_set_version(&mut builder, target_version) };
+        let snapshot = unsafe { ok_or_panic(snapshot_builder_build(builder)) };
+        (engine, snapshot)
+    }
+
+    // Protocol + metadata commit enabling the deletionVectors feature, so DV-bearing Adds
+    // parse. `TestAction` can't emit a `deletionVector` field, so DV tests write raw JSON.
+    const DV_METADATA: &str = "{\"metaData\":{\"id\":\"test-id\",\"format\":{\"provider\":\"parquet\",\"options\":{}},\"schemaString\":\"{\\\"type\\\":\\\"struct\\\",\\\"fields\\\":[]}\",\"partitionColumns\":[],\"configuration\":{},\"createdTime\":1700000000000}}\n{\"protocol\":{\"minReaderVersion\":3,\"minWriterVersion\":7,\"readerFeatures\":[\"deletionVectors\"],\"writerFeatures\":[\"deletionVectors\"]}}";
+
+    fn add_with_dv(path: &str, storage_type: &str, path_or_inline: &str, offset: i32) -> String {
+        format!(
+            "{{\"add\":{{\"path\":\"{path}\",\"partitionValues\":{{}},\"size\":100,\"modificationTime\":1700000000000,\"dataChange\":true,\"stats\":null,\"deletionVector\":{{\"storageType\":\"{storage_type}\",\"pathOrInlineDv\":\"{path_or_inline}\",\"offset\":{offset},\"sizeInBytes\":10,\"cardinality\":1}}}}}}"
+        )
+    }
+
+    /// Build an engine + snapshot (pinned to the last version) from raw commit-JSON strings at
+    /// v1.., with a DV-enabling metadata commit at v0.
+    async fn setup_raw(
+        commits: Vec<String>,
+    ) -> (Handle<SharedExternEngine>, Handle<SharedSnapshot>) {
+        let table_root = "memory:///";
+        let storage = Arc::new(InMemory::new());
+        add_commit(table_root, storage.as_ref(), 0, DV_METADATA.to_string())
+            .await
+            .unwrap();
+        let target_version = commits.len() as u64;
+        for (idx, body) in commits.into_iter().enumerate() {
+            add_commit(table_root, storage.as_ref(), (idx + 1) as u64, body)
+                .await
+                .unwrap();
         }
         let engine = DefaultEngineBuilder::new(storage.clone()).build();
         let engine = engine_to_handle(Arc::new(engine), allocate_err);
@@ -604,6 +653,129 @@ mod tests {
         };
         unsafe { free_incremental_scan_builder(builder) };
 
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    // The whole point of the (path, dv_unique_id) key is that the same path with different DV
+    // ids is a distinct file. Assert the FFI visitor passes the full key through, not just the
+    // path: v1 adds (X, dv=uabc@1), v2 adds (X, dv=uxyz@2) -> two distinct live Adds.
+    #[tokio::test]
+    async fn visit_reports_full_dv_unique_id() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup_raw(vec![
+            add_with_dv("X.parquet", "u", "abc", 1),
+            add_with_dv("X.parquet", "u", "xyz", 2),
+        ])
+        .await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+        let summary = unsafe { ok_or_panic(incremental_scan_stream_into_summary(stream)) };
+
+        let mut live_adds = visit_live_adds(&summary);
+        live_adds.sort();
+        assert_eq!(
+            live_adds,
+            vec![
+                ("X.parquet".to_string(), Some("uabc@1".to_string())),
+                ("X.parquet".to_string(), Some("uxyz@2".to_string())),
+            ],
+        );
+
+        unsafe { free_incremental_scan_summary(summary) };
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    // into_summary consumes the stream by taking the inner Option. When a second Arc reference
+    // to the same stream survives (via clone_handle, which bumps the refcount), a further
+    // terminal call hits the taken-Option guard and errors cleanly instead of double-consuming.
+    // (A single-refcount handle reused after into_summary is use-after-free per the # Safety
+    // contract, not this path; this test holds a real second reference.)
+    #[cfg(feature = "default-engine-base")]
+    #[tokio::test]
+    async fn terminal_calls_after_into_summary_error() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup(vec![vec![TestAction::Add("A".to_string())]]).await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+
+        // A second owning reference keeps the object alive after into_summary consumes it.
+        let surviving = unsafe { stream.clone_handle() };
+        let summary = unsafe { ok_or_panic(incremental_scan_stream_into_summary(stream)) };
+
+        let next = unsafe { incremental_scan_stream_next_arrow(surviving.clone_handle()) };
+        assert_extern_result_error_with_message(next, KernelError::GenericError, None);
+        let again = unsafe { incremental_scan_stream_into_summary(surviving) };
+        assert_extern_result_error_with_message(again, KernelError::GenericError, None);
+
+        unsafe { free_incremental_scan_summary(summary) };
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    // Abandoning a never-drained stream must free the retained engine Arc and undrained kernel
+    // stream without leak or panic (the symmetric counterpart to free_builder_without_building).
+    #[tokio::test]
+    async fn free_stream_without_draining() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup(vec![vec![TestAction::Add("A".to_string())]]).await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+        unsafe { free_incremental_scan_stream(stream) };
+
+        unsafe { free_snapshot(snapshot) };
+        unsafe { free_engine(engine) };
+        Ok(())
+    }
+
+    // into_summary must drain the batches the caller didn't read. Read exactly one of two
+    // batches, then assert the summary still reports both commits' Adds.
+    #[cfg(feature = "default-engine-base")]
+    #[tokio::test]
+    async fn into_summary_drains_unread_batches() -> Result<(), Box<dyn std::error::Error>> {
+        let (engine, snapshot) = setup(vec![
+            vec![TestAction::Add("A".to_string())],
+            vec![TestAction::Add("B".to_string())],
+        ])
+        .await;
+
+        let builder = unsafe {
+            snapshot_incremental_scan_builder(snapshot.shallow_copy(), 0, engine.shallow_copy())
+        };
+        let maybe_stream: Option<Handle<SharedIncrementalScanStream>> =
+            unsafe { ok_or_panic(incremental_scan_builder_build(builder)) }.into();
+        let stream = maybe_stream.expect("range covered, expected Some(stream)");
+
+        // Read exactly one batch, leaving the other for into_summary to drain.
+        let ptr = unsafe { ok_or_panic(incremental_scan_stream_next_arrow(stream.shallow_copy())) };
+        assert!(!ptr.is_null());
+        unsafe { free_filtered_engine_data_arrow_result(ptr) };
+
+        let summary = unsafe { ok_or_panic(incremental_scan_stream_into_summary(stream)) };
+        let mut live_adds: Vec<_> = visit_live_adds(&summary)
+            .into_iter()
+            .map(|(p, _)| p)
+            .collect();
+        live_adds.sort();
+        assert_eq!(live_adds, vec!["A".to_string(), "B".to_string()]);
+
+        unsafe { free_incremental_scan_summary(summary) };
         unsafe { free_snapshot(snapshot) };
         unsafe { free_engine(engine) };
         Ok(())

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -60,6 +60,7 @@ pub mod expressions;
 pub mod ffi_metrics;
 #[cfg(feature = "tracing")]
 pub mod ffi_tracing;
+pub mod incremental_scan;
 pub mod log_path;
 #[cfg(feature = "declarative-plans")]
 pub mod plans;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds C FFI bindings for the incremental scan API and a user-guide page documenting it. The kernel API (`incremental_scan_builder`, landed in earlier PRs) was reachable only by linking the Rust crate directly; this exposes it to connectors that consume kernel through the C FFI.

The FFI surface mirrors the existing `commit_range` and scan iterator conventions:

- `snapshot_incremental_scan_builder` builds a range `(base_version, target_version]` from a snapshot.
- `incremental_scan_builder_build` returns an `OptionalValue<stream>`, modeling the kernel's `Option` return so callers get the full-scan-fallback signal (`None` when the snapshot's commit list can't cover the range) rather than an error.
- `incremental_scan_stream_next_arrow` drains live-Add batches as Arrow C Data Interface data, newest commit first.
- `incremental_scan_stream_into_summary` consumes the stream and returns the live-Add and Remove file-key sets, read back via `incremental_scan_summary_visit_live_adds` / `_visit_removes` callbacks that surface each `(path, dv_unique_id)` key.

The stream handle wraps the kernel stream in a mutex behind a shared handle (the stream is `Send` but not `Sync`) and retains an engine `Arc` so the reader's runtime outlives the caller's own engine handle.

The user-guide page (`docs/user-guide/src/reading/incremental_scan.md`) covers the range model, the `None` fallback, `(path, dv_unique_id)` keying, advancing a cached listing with the `removes` and `duplicate_adds` masks, sticky errors, the vacuum race, the catalog-managed log-tail requirement, and current limitations (no predicate or column pushdown; in-range metadata changes not surfaced, tracked in #2552).

Only `into_summary` is exposed as a terminal for now. The against-base terminals and per-batch commit-version signal are deferred; the FFI docs point callers at the manual `removes ∪ (base ∩ live_adds)` mask in the meantime.

## How was this change tested?

- New FFI unit tests in `ffi/src/incremental_scan.rs` cover build to summary, Arrow batch draining, the empty-range error, deletion-vector key round-trip, double-consume guards, stream abandonment, and drain-on-partial-read.
- `cargo nextest run -p delta_kernel_ffi --all-features`, clippy, and `cargo doc` pass.
- `make test` and `mdbook build` compile every code example on the new user-guide page.
