### PR TITLE
feat!: embed proto serialized schema inside of CParquetFooter

### DIFF
--- a/docs/user-guide/src/ffi/overview.md
+++ b/docs/user-guide/src/ffi/overview.md
@@ -354,6 +354,7 @@ calls return `false`.
 | Function | Purpose |
 |----------|---------|
 | `allocate_kernel_string` | Create a Kernel-owned string from a `KernelStringSlice` |
+| `allocate_kernel_bytes` | Create a Kernel-owned byte buffer from a `KernelBytesSlice` |
 
 ## Visitor callbacks
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 bytes = "1.10"
+prost = { version = "0.13", optional = true }
 tracing = "0.1"
 tracing-core = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
@@ -37,7 +38,6 @@ libc = "0.2.175"
 
 [dev-dependencies]
 paste = "1.0"
-prost = "0.13"
 rand = "0.9.2"
 serde = "1.0.219"
 serde_json = "1.0.142"
@@ -66,7 +66,7 @@ default-engine-base = ["delta_kernel/default-engine-base", "dep:delta_kernel_def
 # Requires `arrow` because iterators returned from plan execution use Arrow to pass along data
 # batches, and requires `default-engine-base` because the `PlanBasedEngine` FFI constructor pairs
 # the plan executor with `ArrowEvaluationHandler`
-declarative-plans = ["delta_kernel/declarative-plans", "arrow", "default-engine-base"]
+declarative-plans = ["delta_kernel/declarative-plans", "dep:prost", "arrow", "default-engine-base"]
 
 tracing = [ "tracing-core", "tracing-subscriber" ]
 internal-api = []

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -321,18 +321,22 @@ fn allocate_kernel_string_impl(
 pub struct ExclusiveRustBytes;
 
 /// Allow engines to create an opaque pointer to [`ExclusiveRustBytes`] by copying the provided
-/// `bytes`` into kernel-owned memory.
+/// `bytes` into kernel-owned memory.
 ///
 /// # Safety
 ///
 /// Caller is responsible for passing a valid [`KernelBytesSlice`] whose pointer references at least
-/// `len` readable bytes. The slice only needs to remain until after this call returns.
+/// `len` readable bytes. The slice only needs to remain valid until after this call returns.
 #[cfg(feature = "declarative-plans")]
 #[no_mangle]
 pub unsafe extern "C" fn allocate_kernel_bytes(
     bytes: KernelBytesSlice,
 ) -> Handle<ExclusiveRustBytes> {
-    let copied = unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) }.to_vec();
+    let copied = if bytes.len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) }.to_vec()
+    };
     Box::new(copied).into()
 }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -163,7 +163,7 @@ impl KernelStringSlice {
     }
 }
 
-/// A kernel-owned slice of raw bytes, intended for arg-passing from kernel to engine.
+/// A non-owned slice of raw bytes, intended for arg-passing between kernel and engine.
 ///
 /// Like [`KernelStringSlice`], the pointed-to data must outlive the slice itself, and the slice
 /// must not be retained beyond the foreign function call it was passed into.
@@ -311,6 +311,29 @@ fn allocate_kernel_string_impl(
 ) -> DeltaResult<Handle<ExclusiveRustString>> {
     let s = unsafe { String::try_from_slice(&kernel_str) }?;
     Ok(Box::new(s).into())
+}
+
+/// A kernel-allocated type representing an owned byte buffer. This can be obtained by
+/// calling [`allocate_kernel_bytes`] with a [`KernelBytesSlice`]. Kernel takes ownership of the
+/// handle when it consumes the bytes and the engine must not use the handle afterwards.
+#[cfg(feature = "declarative-plans")]
+#[handle_descriptor(target=Vec<u8>, mutable=true, sized=true)]
+pub struct ExclusiveRustBytes;
+
+/// Allow engines to create an opaque pointer to [`ExclusiveRustBytes`] by copying the provided
+/// `bytes`` into kernel-owned memory.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid [`KernelBytesSlice`] whose pointer references at least
+/// `len` readable bytes. The slice only needs to remain until after this call returns.
+#[cfg(feature = "declarative-plans")]
+#[no_mangle]
+pub unsafe extern "C" fn allocate_kernel_bytes(
+    bytes: KernelBytesSlice,
+) -> Handle<ExclusiveRustBytes> {
+    let copied = unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len) }.to_vec();
+    Box::new(copied).into()
 }
 
 // Put KernelBoolSlice in a sub-module, with non-public members, so rust code cannot instantiate it

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -142,8 +142,8 @@ mod tests {
     }
 
     /// Executes a dummy plan operation against a `PlanExecutor` whose callback returns the given
-    /// `expected_plan_result`. Returns the resulting `PlanResult` for furhter validation.
-    fn execute_dummy_op(expected_plan_result: CPlanResult) -> PlanResult {
+    /// `expected_plan_result`, returning the raw result of `execute_op`.
+    fn try_execute_dummy_op(expected_plan_result: CPlanResult) -> DeltaResult<PlanResult> {
         let cell: Mutex<Option<CPlanResult>> = Mutex::new(Some(expected_plan_result));
         let context = NonNull::new(&cell as *const Mutex<Option<CPlanResult>> as *mut c_void);
         let executor = unsafe { get_plan_executor(context, mock_execute_op) };
@@ -153,7 +153,13 @@ mod tests {
         let url = Url::parse("memory:///table/").unwrap();
         let op = Operation::IoOperation(delta_kernel::IoOperation::file_listing(url));
 
-        plan_executor.execute_op(op).expect("execute_op succeeds")
+        plan_executor.execute_op(op)
+    }
+
+    /// Like [`try_execute_dummy_op`], but asserts the operation succeeds and returns the
+    /// resulting `PlanResult` for further validation.
+    fn execute_dummy_op(expected_plan_result: CPlanResult) -> PlanResult {
+        try_execute_dummy_op(expected_plan_result).expect("execute_op succeeds")
     }
 
     #[test]
@@ -298,6 +304,22 @@ mod tests {
         let id_field = footer.schema.field("id").expect("id field");
         assert_eq!(id_field.data_type(), &KernelDataType::INTEGER);
         assert!(id_field.is_nullable());
+    }
+
+    #[test]
+    fn execute_op_parquet_footer_rejects_invalid_schema_bytes() {
+        // Bytes that are not a valid proto-encoded `StructType` message.
+        let bytes = vec![0xffu8; 8];
+        let schema_proto = unsafe { allocate_kernel_bytes(kernel_bytes_slice!(bytes)) };
+        let footer = CParquetFooter { schema_proto };
+
+        let Err(err) = try_execute_dummy_op(CPlanResult::ParquetFooter(footer)) else {
+            panic!("invalid schema proto bytes should fail to decode");
+        };
+        assert!(
+            matches!(err, Error::GenericError { .. }),
+            "expected a proto decode error, got {err:?}"
+        );
     }
 
     #[test]

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -2,13 +2,15 @@
 //! execution to happen outside of Rust).
 use std::sync::Arc;
 
+use delta_kernel::plans::proto::schema as proto_schema;
+use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error, Operation, ParquetFooter, PlanExecutor, PlanResult};
 use delta_kernel_ffi_macros::handle_descriptor;
+use prost::Message as _;
 
 use crate::error::EngineExecResult;
 use crate::plans::iter::{FfiBytesIter, FfiEngineDataIter, FfiFileMetaIter};
 use crate::plans::result::{CParquetFooter, CPlanResult};
-use crate::schema_visitor::{extract_kernel_schema, KernelSchemaVisitorState};
 use crate::{kernel_bytes_slice, KernelBytesSlice, NullableCvoid};
 
 /// A shared (`Arc`-like) handle to an [`PlanExecutor`].
@@ -83,46 +85,43 @@ impl PlanExecutor for FfiPlanExecutor {
     }
 }
 
-/// Convert a [`CParquetFooter`] into a kernel [`ParquetFooter`]
+/// Convert a [`CParquetFooter`] into a kernel [`ParquetFooter`].
 ///
-/// Returns an error if schema visiting produces an invalid schema.
+/// Consumes the embedded [`ExclusiveRustBytes`](crate::ExclusiveRustBytes) handle carrying
+/// the proto-serialized schema, returning an error if the bytes are not a valid schema proto
+/// message.
 fn decode_parquet_footer(footer: CParquetFooter) -> DeltaResult<ParquetFooter> {
-    let CParquetFooter { schema } = footer;
-    let mut visitor_state = KernelSchemaVisitorState::default();
-    let schema_id = (schema.visitor)(schema.schema, &mut visitor_state);
-
-    // TODO: we currently use the existing visitor pattern for sending schema, but
-    // to be consistent with how we send the input plan (which includes schema), we could just use
-    // proto to serialize the schema here too.
-    let schema = extract_kernel_schema(&mut visitor_state, schema_id)?;
-    Ok(ParquetFooter {
-        schema: Arc::new(schema),
-    })
+    let CParquetFooter { schema_proto } = footer;
+    // SAFETY: ExclusiveRustBytes should only have a single owner, so consuming here is safe.
+    let bytes = *unsafe { schema_proto.into_inner() };
+    let proto = proto_schema::StructType::decode(bytes.as_slice()).map_err(Error::generic_err)?;
+    let schema = Arc::new(StructType::try_from(proto)?);
+    Ok(ParquetFooter { schema })
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::c_void;
     use std::ptr::NonNull;
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
 
     use delta_kernel::arrow::array::ffi::FFI_ArrowArray;
-    use delta_kernel::plans::proto::operation as proto;
-    use delta_kernel::schema::DataType as KernelDataType;
+    use delta_kernel::plans::proto::{operation as proto, schema as proto_schema};
+    use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
     use delta_kernel::Error;
     use prost::Message;
     use url::Url;
 
     use super::*;
     use crate::error::{EngineExecError, KernelError};
-    use crate::ffi_test_utils::{allocate_err, ok_or_panic};
     use crate::handle::Handle;
     use crate::plans::get_plan_executor;
     use crate::plans::iter::{CBytesIterator, CEngineDataIterator, CFileMetaIterator};
     use crate::plans::result::CParquetFooter;
-    use crate::scan::EngineSchema;
-    use crate::schema_visitor::{visit_field_integer, visit_field_struct};
-    use crate::{kernel_string_slice, ExclusiveEngineData, ExclusiveRustString, OptionalValue};
+    use crate::{
+        allocate_kernel_bytes, kernel_bytes_slice, ExclusiveEngineData, ExclusiveRustString,
+        OptionalValue,
+    };
 
     extern "C" fn noop_free(_state: NullableCvoid) {}
 
@@ -284,42 +283,14 @@ mod tests {
         assert!(bytes_iter.next().is_none(), "empty bytes iterator");
     }
 
-    /// Schema visitor that produces `{id: integer (nullable)}`.
-    extern "C" fn visit_id_only_schema(
-        _schema_ptr: *mut c_void,
-        state: &mut KernelSchemaVisitorState,
-    ) -> usize {
-        let id = "id";
-        let id_field_id = unsafe {
-            ok_or_panic(visit_field_integer(
-                state,
-                kernel_string_slice!(id),
-                true,
-                allocate_err,
-            ))
-        };
-        let field_ids = [id_field_id];
-        let schema = "schema";
-        unsafe {
-            ok_or_panic(visit_field_struct(
-                state,
-                kernel_string_slice!(schema),
-                field_ids.as_ptr(),
-                1,
-                false,
-                allocate_err,
-            ))
-        }
-    }
-
     #[test]
     fn execute_op_parquet_footer_variant() {
-        let footer = CParquetFooter {
-            schema: EngineSchema {
-                schema: std::ptr::null_mut(),
-                visitor: visit_id_only_schema,
-            },
-        };
+        let schema =
+            StructType::try_new(vec![StructField::nullable("id", KernelDataType::INTEGER)])
+                .unwrap();
+        let bytes = proto_schema::StructType::from(&schema).encode_to_vec();
+        let schema_proto = unsafe { allocate_kernel_bytes(kernel_bytes_slice!(bytes)) };
+        let footer = CParquetFooter { schema_proto };
         let footer = execute_dummy_op(CPlanResult::ParquetFooter(footer))
             .into_parquet_footer()
             .expect("ParquetFooter variant");

--- a/ffi/src/plans/result.rs
+++ b/ffi/src/plans/result.rs
@@ -1,15 +1,17 @@
 //! FFI types for mimicking the kernel's `PlanResult` enum.
 
 use super::iter::{CBytesIterator, CEngineDataIterator, CFileMetaIterator};
-use crate::scan::EngineSchema;
+use crate::handle::Handle;
+use crate::ExclusiveRustBytes;
 
 /// C-compatible equivalent of the kernel's `ParquetFooter` struct.
 ///
-/// The schema is delivered as an [`EngineSchema`] - an opaque engine-owned schema which will be
-/// materialized on the kernel-side via vistor pattern.
+/// The schema is delivered as a proto-serialized `delta.kernel.schema.StructType` message. The
+/// engine should call [`allocate_kernel_bytes`](crate::allocate_kernel_bytes) to copy those bytes
+/// into a kernel-owned [`ExclusiveRustBytes`] handle that can then be embedded into this struct.
 #[repr(C)]
 pub struct CParquetFooter {
-    pub schema: EngineSchema,
+    pub schema_proto: Handle<ExclusiveRustBytes>,
 }
 
 /// C-compatible equivalent of the kernel's `PlanResult` enum.

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -1,6 +1,10 @@
 //! Conversions from the kernel plan IR into the prost-generated proto wire types.
 
 use super::plan::agg as proto_agg;
+use super::schema::data_type::Kind as DataTypeKind;
+use super::schema::metadata_value::Value as MetadataValueKind;
+use super::schema::primitive_type::Kind as PrimitiveTypeKind;
+use super::schema::SimplePrimitiveType as Simple;
 use super::{
     expressions as proto_expr, operation as proto_op, plan as proto_plan, schema as proto_schema,
 };
@@ -21,11 +25,11 @@ use crate::schema::{
     ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType, StructField,
     StructType,
 };
-use crate::{FileMeta, FileSlice};
+use crate::{DeltaResult, Error, FileMeta, FileSlice};
 
 // === Helpers ===
 
-/// Converts each element of `items` via [`From`].
+/// Converts each element of `items` into proto via [`From`].
 fn convert_vec<'a, T, U>(items: &'a [T]) -> Vec<U>
 where
     U: From<&'a T>,
@@ -41,7 +45,7 @@ where
     items.iter().map(|e| e.as_ref().into()).collect()
 }
 
-// === Operation / IoOperation ===
+// === Operation / IoOperation to Proto ===
 
 impl From<&Operation> for proto_op::Operation {
     fn from(op: &Operation) -> Self {
@@ -111,7 +115,7 @@ impl From<&FileMeta> for proto_plan::FileMeta {
     }
 }
 
-// === Plan / nodes ===
+// === Plan / nodes to Proto ===
 
 impl From<&Plan> for proto_plan::Plan {
     fn from(plan: &Plan) -> Self {
@@ -288,7 +292,7 @@ impl From<FileType> for proto_plan::FileType {
     }
 }
 
-// === Expressions ===
+// === Expressions to Proto ===
 
 impl From<&Expression> for proto_expr::Expression {
     fn from(expr: &Expression) -> Self {
@@ -520,7 +524,7 @@ impl From<JunctionPredicateOp> for proto_expr::JunctionPredicateOp {
     }
 }
 
-// === Scalars ===
+// === Scalars to Proto ===
 
 impl From<&Scalar> for proto_expr::Scalar {
     fn from(scalar: &Scalar) -> Self {
@@ -592,18 +596,17 @@ impl From<&MapData> for proto_expr::MapData {
     }
 }
 
-// === Schema ===
+// === Schema to Proto ===
 
 impl From<&DataType> for proto_schema::DataType {
     fn from(data_type: &DataType) -> Self {
-        use proto_schema::data_type::Kind;
         let kind = match data_type {
-            DataType::Primitive(primitive) => Kind::Primitive(primitive.into()),
-            DataType::Array(array) => Kind::Array(Box::new(array.as_ref().into())),
-            DataType::Struct(struct_type) => Kind::Struct(struct_type.as_ref().into()),
-            DataType::Map(map) => Kind::Map(Box::new(map.as_ref().into())),
+            DataType::Primitive(primitive) => DataTypeKind::Primitive(primitive.into()),
+            DataType::Array(array) => DataTypeKind::Array(Box::new(array.as_ref().into())),
+            DataType::Struct(struct_type) => DataTypeKind::Struct(struct_type.as_ref().into()),
+            DataType::Map(map) => DataTypeKind::Map(Box::new(map.as_ref().into())),
             // The proto `VariantType` is intentionally empty: variants are opaque on the wire.
-            DataType::Variant(_) => Kind::Variant(proto_schema::VariantType {}),
+            DataType::Variant(_) => DataTypeKind::Variant(proto_schema::VariantType {}),
         };
         proto_schema::DataType { kind: Some(kind) }
     }
@@ -611,25 +614,27 @@ impl From<&DataType> for proto_schema::DataType {
 
 impl From<&PrimitiveType> for proto_schema::PrimitiveType {
     fn from(primitive: &PrimitiveType) -> Self {
-        use proto_schema::primitive_type::Kind;
-        use proto_schema::SimplePrimitiveType as Simple;
         let kind = match primitive {
-            PrimitiveType::String => Kind::Simple(Simple::String as i32),
-            PrimitiveType::Long => Kind::Simple(Simple::Long as i32),
-            PrimitiveType::Integer => Kind::Simple(Simple::Integer as i32),
-            PrimitiveType::Short => Kind::Simple(Simple::Short as i32),
-            PrimitiveType::Byte => Kind::Simple(Simple::Byte as i32),
-            PrimitiveType::Float => Kind::Simple(Simple::Float as i32),
-            PrimitiveType::Double => Kind::Simple(Simple::Double as i32),
-            PrimitiveType::Boolean => Kind::Simple(Simple::Boolean as i32),
-            PrimitiveType::Binary => Kind::Simple(Simple::Binary as i32),
-            PrimitiveType::Date => Kind::Simple(Simple::Date as i32),
-            PrimitiveType::Timestamp => Kind::Simple(Simple::Timestamp as i32),
-            PrimitiveType::TimestampNtz => Kind::Simple(Simple::TimestampNtz as i32),
-            PrimitiveType::Decimal(decimal) => Kind::Decimal((*decimal).into()),
-            PrimitiveType::Void => Kind::Simple(Simple::Void as i32),
-            PrimitiveType::IntervalYearMonth => Kind::Simple(Simple::IntervalYearMonth as i32),
-            PrimitiveType::IntervalDayTime => Kind::Simple(Simple::IntervalDayTime as i32),
+            PrimitiveType::String => PrimitiveTypeKind::Simple(Simple::String as i32),
+            PrimitiveType::Long => PrimitiveTypeKind::Simple(Simple::Long as i32),
+            PrimitiveType::Integer => PrimitiveTypeKind::Simple(Simple::Integer as i32),
+            PrimitiveType::Short => PrimitiveTypeKind::Simple(Simple::Short as i32),
+            PrimitiveType::Byte => PrimitiveTypeKind::Simple(Simple::Byte as i32),
+            PrimitiveType::Float => PrimitiveTypeKind::Simple(Simple::Float as i32),
+            PrimitiveType::Double => PrimitiveTypeKind::Simple(Simple::Double as i32),
+            PrimitiveType::Boolean => PrimitiveTypeKind::Simple(Simple::Boolean as i32),
+            PrimitiveType::Binary => PrimitiveTypeKind::Simple(Simple::Binary as i32),
+            PrimitiveType::Date => PrimitiveTypeKind::Simple(Simple::Date as i32),
+            PrimitiveType::Timestamp => PrimitiveTypeKind::Simple(Simple::Timestamp as i32),
+            PrimitiveType::TimestampNtz => PrimitiveTypeKind::Simple(Simple::TimestampNtz as i32),
+            PrimitiveType::Decimal(decimal) => PrimitiveTypeKind::Decimal((*decimal).into()),
+            PrimitiveType::Void => PrimitiveTypeKind::Simple(Simple::Void as i32),
+            PrimitiveType::IntervalYearMonth => {
+                PrimitiveTypeKind::Simple(Simple::IntervalYearMonth as i32)
+            }
+            PrimitiveType::IntervalDayTime => {
+                PrimitiveTypeKind::Simple(Simple::IntervalDayTime as i32)
+            }
         };
         proto_schema::PrimitiveType { kind: Some(kind) }
     }
@@ -689,14 +694,166 @@ impl From<&StructField> for proto_schema::StructField {
 
 impl From<&MetadataValue> for proto_schema::MetadataValue {
     fn from(metadata: &MetadataValue) -> Self {
-        use proto_schema::metadata_value::Value;
         let value = match metadata {
-            MetadataValue::Number(n) => Value::Number(*n),
-            MetadataValue::String(s) => Value::String(s.clone()),
-            MetadataValue::Boolean(b) => Value::Boolean(*b),
-            MetadataValue::Other(json) => Value::OtherJson(json.to_string()),
+            MetadataValue::Number(n) => MetadataValueKind::Number(*n),
+            MetadataValue::String(s) => MetadataValueKind::String(s.clone()),
+            MetadataValue::Boolean(b) => MetadataValueKind::Boolean(*b),
+            MetadataValue::Other(json) => MetadataValueKind::OtherJson(json.to_string()),
         };
         proto_schema::MetadataValue { value: Some(value) }
+    }
+}
+
+// === Schema from Proto ===
+
+impl TryFrom<proto_schema::StructType> for StructType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::StructType) -> DeltaResult<Self> {
+        let fields = proto
+            .fields
+            .into_iter()
+            .map(StructField::try_from)
+            .collect::<DeltaResult<Vec<_>>>()?;
+        StructType::try_new(fields)
+    }
+}
+
+impl TryFrom<proto_schema::StructField> for StructField {
+    type Error = Error;
+
+    fn try_from(proto: proto_schema::StructField) -> DeltaResult<Self> {
+        let data_type = proto
+            .data_type
+            .ok_or_else(|| Error::schema("StructField proto missing data_type"))?;
+        let metadata = proto
+            .metadata
+            .into_iter()
+            .map(|(key, value)| Ok::<_, Error>((key, MetadataValue::try_from(value)?)))
+            .collect::<DeltaResult<std::collections::HashMap<_, _>>>()?;
+        Ok(StructField {
+            name: proto.name,
+            data_type: DataType::try_from(data_type)?,
+            nullable: proto.nullable,
+            metadata,
+        })
+    }
+}
+
+impl TryFrom<proto_schema::DataType> for DataType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::DataType) -> DeltaResult<Self> {
+        let kind = proto
+            .kind
+            .ok_or_else(|| Error::schema("DataType proto missing kind"))?;
+        let data_type = match kind {
+            DataTypeKind::Primitive(primitive) => DataType::Primitive(primitive.try_into()?),
+            DataTypeKind::Array(array) => DataType::Array(Box::new((*array).try_into()?)),
+            DataTypeKind::Struct(struct_type) => {
+                DataType::Struct(Box::new(struct_type.try_into()?))
+            }
+            DataTypeKind::Map(map) => DataType::Map(Box::new((*map).try_into()?)),
+            // Kernel does not support shredded variants, so always decode as unshredded.
+            DataTypeKind::Variant(_) => DataType::unshredded_variant(),
+        };
+        Ok(data_type)
+    }
+}
+
+impl TryFrom<proto_schema::PrimitiveType> for PrimitiveType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::PrimitiveType) -> DeltaResult<Self> {
+        let kind = proto
+            .kind
+            .ok_or_else(|| Error::schema("PrimitiveType proto missing kind"))?;
+        let primitive = match kind {
+            PrimitiveTypeKind::Simple(simple) => {
+                let simple = Simple::try_from(simple).map_err(|_| {
+                    Error::schema(format!("unknown SimplePrimitiveType value: {simple}"))
+                })?;
+                match simple {
+                    Simple::String => PrimitiveType::String,
+                    Simple::Long => PrimitiveType::Long,
+                    Simple::Integer => PrimitiveType::Integer,
+                    Simple::Short => PrimitiveType::Short,
+                    Simple::Byte => PrimitiveType::Byte,
+                    Simple::Float => PrimitiveType::Float,
+                    Simple::Double => PrimitiveType::Double,
+                    Simple::Boolean => PrimitiveType::Boolean,
+                    Simple::Binary => PrimitiveType::Binary,
+                    Simple::Date => PrimitiveType::Date,
+                    Simple::Timestamp => PrimitiveType::Timestamp,
+                    Simple::TimestampNtz => PrimitiveType::TimestampNtz,
+                    Simple::Void => PrimitiveType::Void,
+                    Simple::IntervalYearMonth => PrimitiveType::IntervalYearMonth,
+                    Simple::IntervalDayTime => PrimitiveType::IntervalDayTime,
+                    Simple::Unspecified => {
+                        return Err(Error::schema("SimplePrimitiveType is unspecified"))
+                    }
+                }
+            }
+            PrimitiveTypeKind::Decimal(decimal) => PrimitiveType::Decimal(decimal.try_into()?),
+        };
+        Ok(primitive)
+    }
+}
+
+impl TryFrom<proto_schema::DecimalType> for DecimalType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::DecimalType) -> DeltaResult<Self> {
+        let precision = u8::try_from(proto.precision).map_err(|_| {
+            Error::invalid_decimal(format!("precision out of range: {}", proto.precision))
+        })?;
+        let scale = u8::try_from(proto.scale)
+            .map_err(|_| Error::invalid_decimal(format!("scale out of range: {}", proto.scale)))?;
+        DecimalType::try_new(precision, scale)
+    }
+}
+
+impl TryFrom<proto_schema::ArrayType> for ArrayType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::ArrayType) -> DeltaResult<Self> {
+        let element_type = proto
+            .element_type
+            .ok_or_else(|| Error::schema("ArrayType proto missing element_type"))?;
+        Ok(ArrayType::new(
+            DataType::try_from(*element_type)?,
+            proto.contains_null,
+        ))
+    }
+}
+
+impl TryFrom<proto_schema::MapType> for MapType {
+    type Error = Error;
+    fn try_from(proto: proto_schema::MapType) -> DeltaResult<Self> {
+        let key_type = proto
+            .key_type
+            .ok_or_else(|| Error::schema("MapType proto missing key_type"))?;
+        let value_type = proto
+            .value_type
+            .ok_or_else(|| Error::schema("MapType proto missing value_type"))?;
+        Ok(MapType::new(
+            DataType::try_from(*key_type)?,
+            DataType::try_from(*value_type)?,
+            proto.value_contains_null,
+        ))
+    }
+}
+
+impl TryFrom<proto_schema::MetadataValue> for MetadataValue {
+    type Error = Error;
+    fn try_from(proto: proto_schema::MetadataValue) -> DeltaResult<Self> {
+        let value = proto
+            .value
+            .ok_or_else(|| Error::schema("MetadataValue proto missing value"))?;
+        let metadata = match value {
+            MetadataValueKind::Number(n) => MetadataValue::Number(n),
+            MetadataValueKind::String(s) => MetadataValue::String(s),
+            MetadataValueKind::Boolean(b) => MetadataValue::Boolean(b),
+            MetadataValueKind::OtherJson(json) => {
+                MetadataValue::Other(serde_json::from_str(&json)?)
+            }
+        };
+        Ok(metadata)
     }
 }
 
@@ -1840,5 +1997,202 @@ mod tests {
             proto_schema::MetadataValue::from(&metadata).value.unwrap(),
             expected
         );
+    }
+
+    // === Schema decode (proto -> kernel) ===
+
+    /// Round-trips a [`DataType`] through its proto form and back, asserting it is unchanged.
+    fn assert_data_type_round_trips(data_type: DataType) {
+        let decoded = DataType::try_from(proto_schema::DataType::from(&data_type));
+        assert_eq!(decoded.expect("decode succeeds"), data_type);
+    }
+
+    /// Round-trips a [`StructType`] through its proto form and back, asserting it is unchanged.
+    fn assert_schema_round_trips(schema: StructType) {
+        let decoded = StructType::try_from(proto_schema::StructType::from(&schema));
+        assert_eq!(decoded.expect("decode succeeds"), schema);
+    }
+
+    #[rstest]
+    fn round_trip_primitive(
+        #[values(
+            PrimitiveType::String,
+            PrimitiveType::Long,
+            PrimitiveType::Integer,
+            PrimitiveType::Short,
+            PrimitiveType::Byte,
+            PrimitiveType::Float,
+            PrimitiveType::Double,
+            PrimitiveType::Boolean,
+            PrimitiveType::Binary,
+            PrimitiveType::Date,
+            PrimitiveType::Timestamp,
+            PrimitiveType::TimestampNtz,
+            PrimitiveType::Void,
+            PrimitiveType::IntervalYearMonth,
+            PrimitiveType::IntervalDayTime
+        )]
+        primitive: PrimitiveType,
+    ) {
+        assert_data_type_round_trips(DataType::Primitive(primitive));
+    }
+
+    #[rstest]
+    #[case(1, 0)]
+    #[case(10, 2)]
+    #[case(38, 0)]
+    #[case(38, 38)]
+    fn round_trip_decimal(#[case] precision: u8, #[case] scale: u8) {
+        assert_data_type_round_trips(DataType::Primitive(
+            PrimitiveType::decimal(precision, scale).unwrap(),
+        ));
+    }
+
+    #[rstest]
+    #[case(DataType::from(ArrayType::new(DataType::INTEGER, true)))]
+    #[case(DataType::from(ArrayType::new(DataType::STRING, false)))]
+    #[case(DataType::from(MapType::new(DataType::STRING, DataType::LONG, true)))]
+    #[case(DataType::from(MapType::new(DataType::INTEGER, DataType::BOOLEAN, false)))]
+    #[case(DataType::from(ArrayType::new(
+        MapType::new(DataType::STRING, DataType::LONG, true),
+        true
+    )))]
+    #[case(DataType::from(StructType::try_new(vec![
+        StructField::nullable("a", DataType::INTEGER),
+        StructField::not_null("b", DataType::STRING),
+    ]).unwrap()))]
+    fn round_trip_composite(#[case] data_type: DataType) {
+        assert_data_type_round_trips(data_type);
+    }
+
+    #[rstest]
+    #[case(MetadataValue::Number(7))]
+    #[case(MetadataValue::String("hello".to_string()))]
+    #[case(MetadataValue::Boolean(true))]
+    #[case(MetadataValue::Other(serde_json::json!({"nested": [1, 2, 3]})))]
+    fn round_trip_field_metadata(#[case] value: MetadataValue) {
+        let field = StructField::nullable("f", DataType::INTEGER).with_metadata([("k", value)]);
+        let decoded = StructField::try_from(proto_schema::StructField::from(&field));
+        assert_eq!(decoded.expect("decode succeeds"), field);
+    }
+
+    #[test]
+    fn round_trip_full_schema() {
+        let schema = StructType::try_new(vec![
+            StructField::nullable("id", DataType::LONG)
+                .with_metadata([("k", MetadataValue::Number(7))]),
+            StructField::not_null("name", DataType::STRING),
+            StructField::nullable("scores", ArrayType::new(DataType::INTEGER, true)),
+            StructField::nullable(
+                "attrs",
+                MapType::new(DataType::STRING, DataType::LONG, true),
+            ),
+            StructField::nullable(
+                "price",
+                DataType::Primitive(PrimitiveType::decimal(10, 2).unwrap()),
+            ),
+            StructField::nullable(
+                "nested",
+                StructType::try_new(vec![StructField::not_null("inner", DataType::BOOLEAN)])
+                    .unwrap(),
+            ),
+        ])
+        .unwrap();
+        assert_schema_round_trips(schema);
+    }
+
+    /// The proto `VariantType` is currently opaque, so any variant (even a shredded one)
+    /// decodes to the canonical unshredded form rather than round-tripping its inner struct.
+    #[test]
+    fn variant_decodes_to_unshredded() {
+        let shredded = DataType::Variant(Box::new(
+            StructType::try_new(vec![
+                StructField::not_null("metadata", DataType::BINARY),
+                StructField::not_null("value", DataType::BINARY),
+                StructField::nullable("typed_value", DataType::INTEGER),
+            ])
+            .unwrap(),
+        ));
+        let decoded = DataType::try_from(proto_schema::DataType::from(&shredded));
+        assert_eq!(
+            decoded.expect("decode succeeds"),
+            DataType::unshredded_variant()
+        );
+    }
+
+    // Builds a proto `DataType::Primitive` with the given (possibly malformed) primitive kind.
+    fn primitive_data_type(
+        kind: Option<proto_schema::primitive_type::Kind>,
+    ) -> proto_schema::DataType {
+        proto_schema::DataType {
+            kind: Some(proto_schema::data_type::Kind::Primitive(
+                proto_schema::PrimitiveType { kind },
+            )),
+        }
+    }
+
+    fn simple_primitive_data_type(value: i32) -> proto_schema::DataType {
+        primitive_data_type(Some(proto_schema::primitive_type::Kind::Simple(value)))
+    }
+
+    fn decimal_data_type(precision: u32, scale: u32) -> proto_schema::DataType {
+        primitive_data_type(Some(proto_schema::primitive_type::Kind::Decimal(
+            proto_schema::DecimalType { precision, scale },
+        )))
+    }
+
+    #[rstest]
+    #[case::missing_data_type_kind(proto_schema::DataType { kind: None })]
+    #[case::missing_primitive_kind(primitive_data_type(None))]
+    #[case::unspecified_primitive(simple_primitive_data_type(
+        proto_schema::SimplePrimitiveType::Unspecified as i32
+    ))]
+    #[case::unknown_primitive(simple_primitive_data_type(9999))]
+    #[case::decimal_zero_precision(decimal_data_type(0, 0))]
+    #[case::decimal_precision_too_large(decimal_data_type(39, 0))]
+    #[case::decimal_scale_exceeds_precision(decimal_data_type(5, 6))]
+    #[case::decimal_precision_out_of_u8_range(decimal_data_type(256, 0))]
+    #[case::array_missing_element_type(proto_schema::DataType {
+        kind: Some(proto_schema::data_type::Kind::Array(Box::new(proto_schema::ArrayType {
+            element_type: None,
+            contains_null: true,
+        }))),
+    })]
+    #[case::map_missing_key_type(proto_schema::DataType {
+        kind: Some(proto_schema::data_type::Kind::Map(Box::new(proto_schema::MapType {
+            key_type: None,
+            value_type: Some(Box::new(proto_schema::DataType::from(&DataType::STRING))),
+            value_contains_null: true,
+        }))),
+    })]
+    #[case::map_missing_value_type(proto_schema::DataType {
+        kind: Some(proto_schema::data_type::Kind::Map(Box::new(proto_schema::MapType {
+            key_type: Some(Box::new(proto_schema::DataType::from(&DataType::STRING))),
+            value_type: None,
+            value_contains_null: true,
+        }))),
+    })]
+    fn data_type_decode_rejects_invalid(#[case] proto: proto_schema::DataType) {
+        assert!(DataType::try_from(proto).is_err());
+    }
+
+    #[test]
+    fn struct_field_decode_rejects_missing_data_type() {
+        let proto = proto_schema::StructField {
+            name: "f".to_string(),
+            data_type: None,
+            nullable: true,
+            metadata: Default::default(),
+        };
+        assert!(StructField::try_from(proto).is_err());
+    }
+
+    #[rstest]
+    #[case::missing_value(proto_schema::MetadataValue { value: None })]
+    #[case::invalid_other_json(proto_schema::MetadataValue {
+        value: Some(proto_schema::metadata_value::Value::OtherJson("not json".to_string())),
+    })]
+    fn metadata_value_decode_rejects_invalid(#[case] proto: proto_schema::MetadataValue) {
+        assert!(MetadataValue::try_from(proto).is_err());
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
During a parquet footer IoOperation, a plan executor passes schema back to kernel through the visitor pattern. However this currently has a memory leak because there is no way to free the engine-side schema once the kernel is done with it. Instead, it is simpler to just pass proto-serialized schema (and more consistent with how kernel passes schema TO the engine for plan execution).

To achieve this, this PR updates the CParquetFooter type to embed bytes instead of a schema visitor. It also adds utilities needed for this:
- `ExclusiveRustBytes` type and `allocate_kernel_bytes` method, similar to `ExclusiveRustString` and `allocate_kernel_string`
- `TryFom` impls for converting from proto schema to kernel schema

## How was this change tested?
Unit tests
