### PR TITLE
feat!: Simplify agg alias handling

### DIFF
--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -101,18 +101,13 @@ message MaxNonNullByAgg {
   delta.kernel.expressions.ColumnName key = 2;
 }
 
-message AggFn {
+message Agg {
   oneof func {
     MinAgg min = 1;
     MaxAgg max = 2;
     MinNonNullByAgg min_non_null_by = 3;
     MaxNonNullByAgg max_non_null_by = 4;
   }
-}
-
-message Agg {
-  AggFn func = 1;
-  optional string alias = 2;
 }
 
 message AggregateNode {

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -568,10 +568,14 @@ impl Aggregate {
 /// An aggregate function and its operand column(s) within an [`Aggregate`] operator.
 #[derive(Debug, Clone)]
 pub enum Agg {
-    Min(Min),
-    Max(Max),
-    MinNonNullBy(MinNonNullBy),
-    MaxNonNullBy(MaxNonNullBy),
+    /// Operands for [`Agg::min`].
+    Min { value: ColumnName },
+    /// Operands for [`Agg::max`].
+    Max { value: ColumnName },
+    /// Operands for [`Agg::min_non_null_by`].
+    MinNonNullBy { value: ColumnName, key: ColumnName },
+    /// Operands for [`Agg::max_non_null_by`].
+    MaxNonNullBy { value: ColumnName, key: ColumnName },
 }
 
 impl Agg {
@@ -583,9 +587,9 @@ impl Agg {
     /// []              -> NULL
     /// ```
     pub fn min(value: impl Into<ColumnName>) -> Self {
-        Self::Min(Min {
+        Self::Min {
             value: value.into(),
-        })
+        }
     }
 
     /// The greatest non-NULL value in each group, or NULL if the group has no non-NULL value.
@@ -597,18 +601,18 @@ impl Agg {
     /// []              -> NULL
     /// ```
     pub fn max(value: impl Into<ColumnName>) -> Self {
-        Self::Max(Max {
+        Self::Max {
             value: value.into(),
-        })
+        }
     }
 
     /// Like [`max_non_null_by`](Self::max_non_null_by), but selects the `value` from the row with
     /// the *least* `key`.
     pub fn min_non_null_by(value: impl Into<ColumnName>, key: impl Into<ColumnName>) -> Self {
-        Self::MinNonNullBy(MinNonNullBy {
+        Self::MinNonNullBy {
             value: value.into(),
             key: key.into(),
-        })
+        }
     }
 
     /// The `value` from the row with the greatest `key`, considering only rows where *both* `value`
@@ -649,10 +653,10 @@ impl Agg {
     /// ) WHERE rn = 1
     /// ```
     pub fn max_non_null_by(value: impl Into<ColumnName>, key: impl Into<ColumnName>) -> Self {
-        Self::MaxNonNullBy(MaxNonNullBy {
+        Self::MaxNonNullBy {
             value: value.into(),
             key: key.into(),
-        })
+        }
     }
 
     /// Derives this aggregate's output [`StructField`] over `input_schema`, validating that every
@@ -664,9 +668,8 @@ impl Agg {
         alias: Option<String>,
     ) -> DeltaResult<StructField> {
         let value = match self {
-            Agg::Min(Min { value }) | Agg::Max(Max { value }) => value,
-            Agg::MinNonNullBy(MinNonNullBy { value, key })
-            | Agg::MaxNonNullBy(MaxNonNullBy { value, key }) => {
+            Agg::Min { value } | Agg::Max { value } => value,
+            Agg::MinNonNullBy { value, key } | Agg::MaxNonNullBy { value, key } => {
                 input_schema.field_at(key)?;
                 value
             }
@@ -681,36 +684,6 @@ impl Agg {
             .into_owned();
         Ok(StructField::nullable(name, data_type))
     }
-}
-
-/// Operands for [`Agg::min`].
-#[derive(Debug, Clone)]
-pub struct Min {
-    pub value: ColumnName,
-}
-
-/// Operands for [`Agg::max`].
-#[derive(Debug, Clone)]
-pub struct Max {
-    pub value: ColumnName,
-}
-
-/// Operands for [`Agg::min_non_null_by`].
-#[derive(Debug, Clone)]
-pub struct MinNonNullBy {
-    /// Column whose value the aggregate emits.
-    pub value: ColumnName,
-    /// Column compared across rows to pick the winning (least-key) row.
-    pub key: ColumnName,
-}
-
-/// Operands for [`Agg::max_non_null_by`].
-#[derive(Debug, Clone)]
-pub struct MaxNonNullBy {
-    /// Column whose value the aggregate emits.
-    pub value: ColumnName,
-    /// Column compared across rows to pick the winning (greatest-key) row.
-    pub key: ColumnName,
 }
 
 /// Builds an [`Aggregate`] over an input schema, deriving the output schema from the group keys

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -479,14 +479,14 @@ impl Load {
 /// group-by key columns first (in order), then the aggregate columns (in order).
 ///
 /// Build an `Aggregate` with [`Aggregate::group_by`], which derives `schema` from the input
-/// schema -- including each output column's type and nullability -- so callers never restate it.
+/// schema -- including each output column's name, type, and nullability.
 ///
 /// # Output schema
 ///
 /// - **Group keys** pass through verbatim: each key column keeps its input type, nullability, and
 ///   metadata.
-/// - **Aggregate columns** take the type of their value column; nullability comes from the function
-///   (see [`Agg`]).
+/// - **Aggregate columns**: name, type, and nullability come from each [`Agg`] (see per-function
+///   docs); use [`AggregateBuilder::aggregate_as`] to override the name.
 ///
 /// # SQL equivalent
 ///
@@ -565,37 +565,17 @@ impl Aggregate {
     }
 }
 
-/// One aggregate function application within an [`Aggregate`] operator.
-///
-/// An `Agg` is a function ([`AggFn`]) applied to input column(s), optionally renamed via
-/// [`with_alias`](Self::with_alias). When no alias is set, the output column takes the name of the
-/// value column.
-///
-/// Construct with [`min`](Self::min) / [`max`](Self::max) /
-/// [`min_non_null_by`](Self::min_non_null_by) / [`max_non_null_by`](Self::max_non_null_by), then
-/// chain [`with_alias`](Self::with_alias):
-///
-/// ```
-/// # use delta_kernel::expressions::column_name;
-/// # use delta_kernel::plans::ir::nodes::Agg;
-/// let agg = Agg::max_non_null_by(column_name!("protocol"), column_name!("version"))
-///     .with_alias("latest_protocol");
-/// ```
-///
-/// # Nullability
-///
-/// Output nullability is a property of the function (see [`AggFn`]), not the input column. Every
-/// current function is nullable.
+/// An aggregate function and its operand column(s) within an [`Aggregate`] operator.
 #[derive(Debug, Clone)]
-pub struct Agg {
-    /// The aggregate function and its operand column(s).
-    pub func: AggFn,
-    /// Optional output column name. Defaults to the value column's name when unset.
-    pub alias: Option<String>,
+pub enum Agg {
+    Min(Min),
+    Max(Max),
+    MinNonNullBy(MinNonNullBy),
+    MaxNonNullBy(MaxNonNullBy),
 }
 
 impl Agg {
-    /// The least non-NULL value in each group, or NULL if the group has no non-NULL value.
+    /// Like [`max`](Self::max), but selects the least non-NULL value in each group.
     ///
     /// ```text
     /// [3, NULL, 5, 1] -> 1
@@ -603,12 +583,13 @@ impl Agg {
     /// []              -> NULL
     /// ```
     pub fn min(value: impl Into<ColumnName>) -> Self {
-        Self::new(AggFn::Min(Min {
+        Self::Min(Min {
             value: value.into(),
-        }))
+        })
     }
 
     /// The greatest non-NULL value in each group, or NULL if the group has no non-NULL value.
+    /// The output is always nullable, with name and type matching `value`.
     ///
     /// ```text
     /// [3, NULL, 5, 1] -> 5
@@ -616,23 +597,24 @@ impl Agg {
     /// []              -> NULL
     /// ```
     pub fn max(value: impl Into<ColumnName>) -> Self {
-        Self::new(AggFn::Max(Max {
+        Self::Max(Max {
             value: value.into(),
-        }))
+        })
     }
 
     /// Like [`max_non_null_by`](Self::max_non_null_by), but selects the `value` from the row with
     /// the *least* `key`.
     pub fn min_non_null_by(value: impl Into<ColumnName>, key: impl Into<ColumnName>) -> Self {
-        Self::new(AggFn::MinNonNullBy(MinNonNullBy {
+        Self::MinNonNullBy(MinNonNullBy {
             value: value.into(),
             key: key.into(),
-        }))
+        })
     }
 
     /// The `value` from the row with the greatest `key`, considering only rows where *both* `value`
     /// and `key` are non-null. NULL if no such row exists. If multiple rows tie for the greatest
-    /// `key`, which one's `value` is returned is unspecified.
+    /// `key`, which one's `value` is returned is unspecified. The output is always nullable, with
+    /// name and type matching `value`.
     ///
     /// ```text
     ///  key | value     ->  c
@@ -667,58 +649,38 @@ impl Agg {
     /// ) WHERE rn = 1
     /// ```
     pub fn max_non_null_by(value: impl Into<ColumnName>, key: impl Into<ColumnName>) -> Self {
-        Self::new(AggFn::MaxNonNullBy(MaxNonNullBy {
+        Self::MaxNonNullBy(MaxNonNullBy {
             value: value.into(),
             key: key.into(),
-        }))
-    }
-
-    /// Sets the output column name, overriding the default (the value column's name).
-    pub fn with_alias(mut self, name: impl Into<String>) -> Self {
-        self.alias = Some(name.into());
-        self
-    }
-
-    fn new(func: AggFn) -> Self {
-        Self { func, alias: None }
-    }
-
-    /// The output column name: the alias if set, else the value column's leaf name.
-    fn output_name(&self) -> DeltaResult<&str> {
-        self.alias
-            .as_ref()
-            .or_else(|| self.func.value().path().last())
-            .map(String::as_str)
-            .ok_or_else(|| Error::generic("Aggregate value column has an empty path"))
+        })
     }
 
     /// Derives this aggregate's output [`StructField`] over `input_schema`, validating that every
     /// operand column resolves. The output takes the value column's type (with field metadata
-    /// stripped); nullability comes from the function (see [`AggFn::nullable`]).
-    fn output_field(&self, input_schema: &StructType) -> DeltaResult<StructField> {
+    /// stripped).
+    fn output_field(
+        &self,
+        input_schema: &StructType,
+        alias: Option<String>,
+    ) -> DeltaResult<StructField> {
+        let value = match self {
+            Agg::Min(Min { value }) | Agg::Max(Max { value }) => value,
+            Agg::MinNonNullBy(MinNonNullBy { value, key })
+            | Agg::MaxNonNullBy(MaxNonNullBy { value, key }) => {
+                input_schema.field_at(key)?;
+                value
+            }
+        };
+        let name = alias
+            .or_else(|| value.path().last().cloned())
+            .ok_or_else(|| {
+                Error::generic("Cannot derive default output name from empty column path")
+            })?;
         let data_type = StripFieldMetadataTransform
-            .transform(input_schema.field_at(self.func.value())?.data_type())
+            .transform(input_schema.field_at(value)?.data_type())
             .into_owned();
-        // Validate the key column (for the `*_non_null_by` functions) resolves, even though it
-        // does not appear in the output.
-        if let Some(key) = self.func.key() {
-            input_schema.field_at(key)?;
-        }
-        Ok(StructField::new(
-            self.output_name()?,
-            data_type,
-            self.func.nullable(),
-        ))
+        Ok(StructField::nullable(name, data_type))
     }
-}
-
-/// An aggregate function and its operand column(s).
-#[derive(Debug, Clone)]
-pub enum AggFn {
-    Min(Min),
-    Max(Max),
-    MinNonNullBy(MinNonNullBy),
-    MaxNonNullBy(MaxNonNullBy),
 }
 
 /// Operands for [`Agg::min`].
@@ -751,57 +713,33 @@ pub struct MaxNonNullBy {
     pub key: ColumnName,
 }
 
-impl AggFn {
-    /// The column whose value this aggregate emits (and whose type the output column takes).
-    pub fn value(&self) -> &ColumnName {
-        match self {
-            AggFn::Min(Min { value })
-            | AggFn::Max(Max { value })
-            | AggFn::MinNonNullBy(MinNonNullBy { value, .. })
-            | AggFn::MaxNonNullBy(MaxNonNullBy { value, .. }) => value,
-        }
-    }
-
-    /// The key column this aggregate compares rows on, or `None` for functions that take only a
-    /// value column.
-    fn key(&self) -> Option<&ColumnName> {
-        match self {
-            AggFn::MinNonNullBy(MinNonNullBy { key, .. })
-            | AggFn::MaxNonNullBy(MaxNonNullBy { key, .. }) => Some(key),
-            AggFn::Min(_) | AggFn::Max(_) => None,
-        }
-    }
-
-    /// Whether this function's output can be NULL. True for every current function (each yields
-    /// NULL over an empty or fully-excluded group); a count-style function would be `false`.
-    fn nullable(&self) -> bool {
-        match self {
-            AggFn::Min(_) | AggFn::Max(_) | AggFn::MinNonNullBy(_) | AggFn::MaxNonNullBy(_) => true,
-        }
-    }
-}
-
 /// Builds an [`Aggregate`] over an input schema, deriving the output schema from the group keys
 /// and aggregators.
 ///
 /// Created by [`Aggregate::group_by`], which fixes the group keys. Aggregators are then collected
 /// by the named helpers or [`aggregate`](Self::aggregate); [`build`](Self::build) resolves keys and
-/// aggregators against the input schema, derives each output column's type and nullability, and
-/// validates that all output column names are unique.
+/// aggregators against the input schema; derives each output column's name, type and nullability
+/// from its [`Agg`] or group-by column; and validates that all output column names are unique.
 #[derive(Debug)]
 pub struct AggregateBuilder {
     input_schema: SchemaRef,
     group_by: Vec<ColumnName>,
-    aggs: Vec<Agg>,
+    aggs: Vec<(Agg, Option<String>)>,
 }
 
 impl AggregateBuilder {
-    /// Adds an aggregate column, emitted after the group keys in call order. Prefer the named
-    /// helpers ([`min`](Self::min), [`max`](Self::max), [`min_non_null_by`](Self::min_non_null_by),
-    /// [`max_non_null_by`](Self::max_non_null_by)) for the common, unaliased case; use this
-    /// directly to attach an alias via [`Agg::with_alias`].
+    /// Adds an aggregate column, emitted after the group keys in call order, using each [`Agg`]'s
+    /// default output name (see the per-function docs). Prefer the named helpers for the common
+    /// case (e.g. [`max`](Self::max); use [`aggregate_as`](Self::aggregate_as) to override the
+    /// output name.
     pub fn aggregate(mut self, agg: Agg) -> Self {
-        self.aggs.push(agg);
+        self.aggs.push((agg, None));
+        self
+    }
+
+    /// Like [`aggregate`](Self::aggregate), but with the specified output name.
+    pub fn aggregate_as(mut self, agg: Agg, name: impl Into<String>) -> Self {
+        self.aggs.push((agg, Some(name.into())));
         self
     }
 
@@ -836,13 +774,15 @@ impl AggregateBuilder {
         for key in &self.group_by {
             fields.push(self.input_schema.field_at(key)?.clone());
         }
-        for agg in &self.aggs {
-            fields.push(agg.output_field(&self.input_schema)?);
+        let mut aggs = Vec::with_capacity(self.aggs.len());
+        for (agg, alias) in self.aggs {
+            fields.push(agg.output_field(&self.input_schema, alias)?);
+            aggs.push(agg);
         }
         // NOTE: `StructType::try_new` rejects duplicate (case-insensitive) output column names.
         Ok(Aggregate {
             group_by: self.group_by,
-            aggs: self.aggs,
+            aggs,
             schema: Arc::new(StructType::try_new(fields)?),
         })
     }
@@ -999,7 +939,7 @@ mod tests {
     fn alias_overrides_default_output_name() {
         let input = schema(&[("a", true)]);
         let agg = Aggregate::group_by(input, [])
-            .aggregate(Agg::max(column_name!("a")).with_alias("a_max"))
+            .aggregate_as(Agg::max(column_name!("a")), "a_max")
             .build()
             .unwrap();
         assert!(agg.schema.field("a_max").is_some());
@@ -1021,8 +961,8 @@ mod tests {
     fn distinct_aliases_resolve_min_max_collision() {
         let input = schema(&[("a", true)]);
         let agg = Aggregate::group_by(input, [])
-            .aggregate(Agg::min(column_name!("a")).with_alias("a_min"))
-            .aggregate(Agg::max(column_name!("a")).with_alias("a_max"))
+            .aggregate_as(Agg::min(column_name!("a")), "a_min")
+            .aggregate_as(Agg::max(column_name!("a")), "a_max")
             .build()
             .unwrap();
         let names: Vec<&str> = agg.schema.fields().map(|f| f.name().as_str()).collect();

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -1,6 +1,6 @@
 //! Conversions from the kernel plan IR into the prost-generated proto wire types.
 
-use super::plan::agg_fn as proto_agg_fn;
+use super::plan::agg as proto_agg;
 use super::{
     expressions as proto_expr, operation as proto_op, plan as proto_plan, schema as proto_schema,
 };
@@ -12,7 +12,7 @@ use crate::expressions::{
     UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::plans::ir::nodes::{
-    Agg, AggFn, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Max, MaxNonNullBy, Min,
+    Agg, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Max, MaxNonNullBy, Min,
     MinNonNullBy, Operator, Project, ScanFile, ScanJson, ScanParquet, SemiJoin, Values,
 };
 use crate::plans::ir::plan::{Plan, PlanNode};
@@ -245,36 +245,27 @@ impl From<&Aggregate> for proto_plan::AggregateNode {
 
 impl From<&Agg> for proto_plan::Agg {
     fn from(agg: &Agg) -> Self {
-        proto_plan::Agg {
-            func: Some((&agg.func).into()),
-            alias: agg.alias.clone(),
-        }
-    }
-}
-
-impl From<&AggFn> for proto_plan::AggFn {
-    fn from(func: &AggFn) -> Self {
-        let func = match func {
-            AggFn::Min(Min { value }) => proto_agg_fn::Func::Min(proto_plan::MinAgg {
+        let func = match agg {
+            Agg::Min(Min { value }) => proto_agg::Func::Min(proto_plan::MinAgg {
                 value: Some(value.into()),
             }),
-            AggFn::Max(Max { value }) => proto_agg_fn::Func::Max(proto_plan::MaxAgg {
+            Agg::Max(Max { value }) => proto_agg::Func::Max(proto_plan::MaxAgg {
                 value: Some(value.into()),
             }),
-            AggFn::MinNonNullBy(MinNonNullBy { value, key }) => {
-                proto_agg_fn::Func::MinNonNullBy(proto_plan::MinNonNullByAgg {
+            Agg::MinNonNullBy(MinNonNullBy { value, key }) => {
+                proto_agg::Func::MinNonNullBy(proto_plan::MinNonNullByAgg {
                     value: Some(value.into()),
                     key: Some(key.into()),
                 })
             }
-            AggFn::MaxNonNullBy(MaxNonNullBy { value, key }) => {
-                proto_agg_fn::Func::MaxNonNullBy(proto_plan::MaxNonNullByAgg {
+            Agg::MaxNonNullBy(MaxNonNullBy { value, key }) => {
+                proto_agg::Func::MaxNonNullBy(proto_plan::MaxNonNullByAgg {
                     value: Some(value.into()),
                     key: Some(key.into()),
                 })
             }
         };
-        proto_plan::AggFn { func: Some(func) }
+        proto_plan::Agg { func: Some(func) }
     }
 }
 
@@ -1203,13 +1194,12 @@ mod tests {
     fn from_aggregate() {
         let node = Aggregate {
             group_by: vec![ColumnName::new(["g"])],
-            aggs: vec![Agg::max(ColumnName::new(["a"])).with_alias("a_max")],
+            aggs: vec![Agg::max(ColumnName::new(["a"]))],
             schema: sample_schema(),
         };
         let proto = proto_plan::AggregateNode::from(&node);
         assert_eq!(proto.group_by.len(), 1);
         assert_eq!(proto.aggs.len(), 1);
-        assert_eq!(proto.aggs[0].alias.as_deref(), Some("a_max"));
         assert!(proto.aggs[0].func.is_some());
         assert!(proto.schema.is_some());
     }
@@ -1219,17 +1209,16 @@ mod tests {
     #[case(Agg::max(ColumnName::new(["a"])), "max")]
     #[case(Agg::min_non_null_by(ColumnName::new(["a"]), ColumnName::new(["k"])), "min_non_null_by")]
     #[case(Agg::max_non_null_by(ColumnName::new(["a"]), ColumnName::new(["k"])), "max_non_null_by")]
-    fn from_agg_fn(#[case] agg: Agg, #[case] expected: &str) {
-        use proto_plan::agg_fn::Func;
+    fn from_agg(#[case] agg: Agg, #[case] expected: &str) {
+        use proto_plan::agg::Func;
         let proto = proto_plan::Agg::from(&agg);
-        let kind = match proto.func.unwrap().func.unwrap() {
+        let kind = match proto.func.unwrap() {
             Func::Min(_) => "min",
             Func::Max(_) => "max",
             Func::MinNonNullBy(_) => "min_non_null_by",
             Func::MaxNonNullBy(_) => "max_non_null_by",
         };
         assert_eq!(kind, expected);
-        assert_eq!(proto.alias, None);
     }
 
     #[rstest]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -12,8 +12,8 @@ use crate::expressions::{
     UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::plans::ir::nodes::{
-    Agg, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Max, MaxNonNullBy, Min,
-    MinNonNullBy, Operator, Project, ScanFile, ScanJson, ScanParquet, SemiJoin, Values,
+    Agg, Aggregate, FileType, Filter, Load, LoadColumnFileMeta, Operator, Project, ScanFile,
+    ScanJson, ScanParquet, SemiJoin, Values,
 };
 use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation};
@@ -246,19 +246,19 @@ impl From<&Aggregate> for proto_plan::AggregateNode {
 impl From<&Agg> for proto_plan::Agg {
     fn from(agg: &Agg) -> Self {
         let func = match agg {
-            Agg::Min(Min { value }) => proto_agg::Func::Min(proto_plan::MinAgg {
+            Agg::Min { value } => proto_agg::Func::Min(proto_plan::MinAgg {
                 value: Some(value.into()),
             }),
-            Agg::Max(Max { value }) => proto_agg::Func::Max(proto_plan::MaxAgg {
+            Agg::Max { value } => proto_agg::Func::Max(proto_plan::MaxAgg {
                 value: Some(value.into()),
             }),
-            Agg::MinNonNullBy(MinNonNullBy { value, key }) => {
+            Agg::MinNonNullBy { value, key } => {
                 proto_agg::Func::MinNonNullBy(proto_plan::MinNonNullByAgg {
                     value: Some(value.into()),
                     key: Some(key.into()),
                 })
             }
-            Agg::MaxNonNullBy(MaxNonNullBy { value, key }) => {
+            Agg::MaxNonNullBy { value, key } => {
                 proto_agg::Func::MaxNonNullBy(proto_plan::MaxNonNullByAgg {
                     value: Some(value.into()),
                     key: Some(key.into()),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Agg output columns normally inherit their name from their input. If that needs to be overridden, tell that to the builder who actually needs to create the output schema, instead of tracking it at individual `Agg` level.

The change allows to consolidate `Agg` and `AggFn` into a single enum, and column aliasing no longer leaks into the protos.

* Closes https://github.com/delta-io/delta-kernel-rs/issues/2867

### This PR affects the following public APIs

Changed methods and types for aggregate handling in the (experimental, cfg-gated) declarative plan and plan builder.
## How was this change tested?

Existing unit tests.