### PR TITLE
chore!: Define XXX_FIELD to go with XXX_NAME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,9 +295,13 @@ Keep this list updated when new protocol features are added to kernel.
   string literal splits on dots at compile time (`col!("a.b.c")` is a 3-segment nested column,
   same as `column_expr!`); one or more comma-separated args build a column with each segment taken
   verbatim (`col!("a.b", "c")` is two segments, `col!(name)` for a runtime string is one segment).
-- Prefer the `schema!` / `schema_ref!` macros for inline declarative schema literals, and
-  `try_schema!` when names of interpolated fields might collide. Prefer `StructType::try_new`
-  or schema builder/patch APIs for complex data-dependent schema manipulation.
+- Prefer the `schema!` / `schema_ref!` macros for inline declarative schema literals,
+  `lazy_schema_ref!` for `LazyLock<SchemaRef>` statics, and `try_schema!` when names of
+  interpolated fields might collide. For Delta log action schemas, reuse the canonical
+  `*_FIELD` and `LOG_*_SCHEMA` statics from `actions` instead of re-declaring
+  `StructField::nullable(ACTION_NAME, Action::to_schema())` or projecting from
+  `get_commit_schema()`. Prefer `StructType::try_new` or schema builder/patch APIs for complex
+  data-dependent schema manipulation.
 - NEVER panic in production code -- use errors instead. Panicking
   (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
 

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -32,6 +32,17 @@ pub fn schema_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     schema_macro::parse_schema(input, false, |block| quote!(::std::sync::Arc::new(#block)))
 }
 
+// `LazyLock<SchemaRef>`-wrapped `schema!`; see `delta_kernel::schema::lazy_schema_ref`.
+#[doc(hidden)]
+#[proc_macro]
+pub fn lazy_schema_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    schema_macro::parse_schema(
+        input,
+        false,
+        |block| quote!(::std::sync::LazyLock::new(|| ::std::sync::Arc::new(#block))),
+    )
+}
+
 /// Parses a dot-delimited column name into an array of field names. See
 /// `delta_kernel::expressions::column_name::column_name` macro for details.
 #[proc_macro]

--- a/derive-macros/src/schema_macro.rs
+++ b/derive-macros/src/schema_macro.rs
@@ -134,14 +134,19 @@ fn emit_field_entry(
         input.parse::<Token![..]>()?;
         let expr: Expr = parse_paren_to_end(input, "splice expression")?;
         return Ok(quote_spanned! { expr.span() =>
-            __fields.extend(::core::iter::IntoIterator::into_iter(#expr));
+            __fields.extend(
+                ::core::iter::IntoIterator::into_iter(#expr)
+                    .map(delta_kernel::schema::ToSchemaField::to_schema_field)
+            );
         });
     }
     // `(field)` -- interpolate one `StructField`. A named field always starts with a nullability
     // keyword, so a leading `(` is unambiguous.
     if input.peek(Paren) {
         let expr: Expr = parse_paren_to_end(input, "field expression")?;
-        return Ok(quote_spanned! { expr.span() => __fields.push(#expr); });
+        return Ok(quote_spanned! { expr.span() =>
+            __fields.push(delta_kernel::schema::ToSchemaField::to_schema_field(#expr));
+        });
     }
     // `nullability NAME : type`
     let nullable = parse_nullability(input)?;

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -11,7 +11,9 @@ use visitors::{MetadataVisitor, ProtocolVisitor};
 
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
-use crate::schema::{schema_ref, DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{
+    schema_ref, DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _,
+};
 use crate::table_features::{
     FeatureType, TableFeature, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
     TABLE_FEATURES_MIN_WRITER_VERSION,
@@ -90,44 +92,46 @@ pub(crate) static METADATA_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(METADATA_NAME, Metadata::to_schema()));
 pub(crate) static PROTOCOL_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()));
-pub(crate) static SET_TRANSACTION_FIELD: LazyLock<StructField> = LazyLock::new(|| {
-    StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema())
-});
+pub(crate) static SET_TRANSACTION_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema()));
 pub(crate) static COMMIT_INFO_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(COMMIT_INFO_NAME, CommitInfo::to_schema()));
 pub(crate) static CDC_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(CDC_NAME, Cdc::to_schema()));
-pub(crate) static DOMAIN_METADATA_FIELD: LazyLock<StructField> = LazyLock::new(|| {
-    StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema())
-});
+pub(crate) static DOMAIN_METADATA_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema()));
 pub(crate) static CHECKPOINT_METADATA_FIELD: LazyLock<StructField> = LazyLock::new(|| {
     StructField::nullable(CHECKPOINT_METADATA_NAME, CheckpointMetadata::to_schema())
 });
 pub(crate) static SIDECAR_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()));
 
-static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
-    (&REMOVE_FIELD),
-    (&METADATA_FIELD),
-    (&PROTOCOL_FIELD),
-    (&SET_TRANSACTION_FIELD),
-    (&COMMIT_INFO_FIELD),
-    (&CDC_FIELD),
-    (&DOMAIN_METADATA_FIELD),
+static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&ADD_FIELD),
+        (&REMOVE_FIELD),
+        (&METADATA_FIELD),
+        (&PROTOCOL_FIELD),
+        (&SET_TRANSACTION_FIELD),
+        (&COMMIT_INFO_FIELD),
+        (&CDC_FIELD),
+        (&DOMAIN_METADATA_FIELD),
+    }
 });
 
-static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
-    (&REMOVE_FIELD),
-    (&METADATA_FIELD),
-    (&PROTOCOL_FIELD),
-    (&SET_TRANSACTION_FIELD),
-    (&COMMIT_INFO_FIELD),
-    (&CDC_FIELD),
-    (&DOMAIN_METADATA_FIELD),
-    (&CHECKPOINT_METADATA_FIELD),
-    (&SIDECAR_FIELD),
+static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&ADD_FIELD),
+        (&REMOVE_FIELD),
+        (&METADATA_FIELD),
+        (&PROTOCOL_FIELD),
+        (&SET_TRANSACTION_FIELD),
+        (&COMMIT_INFO_FIELD),
+        (&CDC_FIELD),
+        (&DOMAIN_METADATA_FIELD),
+        (&CHECKPOINT_METADATA_FIELD),
+        (&SIDECAR_FIELD),
+    }
 });
 
 /// Schema for Add actions in the Delta log.

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -2,7 +2,7 @@
 //! specification](https://github.com/delta-io/delta/blob/master/PROTOCOL.md)
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use delta_kernel_derive::{internal_api, IntoEngineData, ToSchema};
 use serde::{Deserialize, Serialize};
@@ -11,9 +11,7 @@ use visitors::{MetadataVisitor, ProtocolVisitor};
 
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
-use crate::schema::{
-    schema_ref, DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _,
-};
+use crate::schema::{schema_ref, DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::table_features::{
     FeatureType, TableFeature, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
     TABLE_FEATURES_MIN_WRITER_VERSION,
@@ -84,50 +82,89 @@ pub(crate) const TIGHT_BOUNDS: &str = "tightBounds";
 #[internal_api]
 pub(crate) const STATS_PARSED: &str = "stats_parsed";
 
-static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable(ADD_NAME, Add::to_schema()),
-        StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-        StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-        StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-        StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema()),
-        StructField::nullable(COMMIT_INFO_NAME, CommitInfo::to_schema()),
-        StructField::nullable(CDC_NAME, Cdc::to_schema()),
-        StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema()),
-    ]))
+pub(crate) static ADD_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(ADD_NAME, Add::to_schema()));
+pub(crate) static REMOVE_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(REMOVE_NAME, Remove::to_schema()));
+pub(crate) static METADATA_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(METADATA_NAME, Metadata::to_schema()));
+pub(crate) static PROTOCOL_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()));
+pub(crate) static SET_TRANSACTION_FIELD: LazyLock<StructField> = LazyLock::new(|| {
+    StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema())
+});
+pub(crate) static COMMIT_INFO_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(COMMIT_INFO_NAME, CommitInfo::to_schema()));
+pub(crate) static CDC_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(CDC_NAME, Cdc::to_schema()));
+pub(crate) static DOMAIN_METADATA_FIELD: LazyLock<StructField> = LazyLock::new(|| {
+    StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema())
+});
+pub(crate) static CHECKPOINT_METADATA_FIELD: LazyLock<StructField> = LazyLock::new(|| {
+    StructField::nullable(CHECKPOINT_METADATA_NAME, CheckpointMetadata::to_schema())
+});
+pub(crate) static SIDECAR_FIELD: LazyLock<StructField> =
+    LazyLock::new(|| StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()));
+
+static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&COMMIT_INFO_FIELD),
+    (&CDC_FIELD),
+    (&DOMAIN_METADATA_FIELD),
 });
 
-static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked(
-        get_commit_schema().fields().cloned().chain([
-            StructField::nullable(CHECKPOINT_METADATA_NAME, CheckpointMetadata::to_schema()),
-            StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
-        ]),
-    ))
+static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&COMMIT_INFO_FIELD),
+    (&CDC_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    (&CHECKPOINT_METADATA_FIELD),
+    (&SIDECAR_FIELD),
 });
 
 /// Schema for Add actions in the Delta log.
 /// Wraps the Add action schema in a top-level struct with "add" field name.
-static LOG_ADD_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { nullable ADD_NAME: (Add::to_schema()) });
+#[internal_api]
+pub(crate) static LOG_ADD_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&ADD_FIELD) });
 
 /// Schema for Remove actions in the Delta log.
 /// Wraps the Remove action schema in a top-level struct with "remove" field name.
-static LOG_REMOVE_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { nullable REMOVE_NAME: (Remove::to_schema()) });
+#[internal_api]
+pub(crate) static LOG_REMOVE_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&REMOVE_FIELD) });
+
+#[internal_api]
+pub(crate) static LOG_METADATA_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&METADATA_FIELD) });
+
+#[internal_api]
+pub(crate) static LOG_PROTOCOL_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&PROTOCOL_FIELD) });
 
 /// Schema for CommitInfo actions in the Delta log.
 /// Wraps the CommitInfo schema in a top-level struct with "commitInfo" field name.
-static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { nullable COMMIT_INFO_NAME: (CommitInfo::to_schema()) });
+#[internal_api]
+pub(crate) static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&COMMIT_INFO_FIELD) });
 
 /// Schema for transaction (txn) actions in the Delta log.
 /// Wraps the SetTransaction schema in a top-level struct with "txn" field name.
-static LOG_TXN_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { nullable SET_TRANSACTION_NAME: (SetTransaction::to_schema()) });
+#[internal_api]
+pub(crate) static LOG_TXN_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&SET_TRANSACTION_FIELD) });
 
-static LOG_DOMAIN_METADATA_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { nullable DOMAIN_METADATA_NAME: (DomainMetadata::to_schema()) });
+#[internal_api]
+pub(crate) static LOG_DOMAIN_METADATA_SCHEMA: LazyLock<SchemaRef> =
+    LazyLock::new(|| schema_ref! { (&DOMAIN_METADATA_FIELD) });
 
 #[internal_api]
 /// Gets the schema for all actions that can appear in commits
@@ -141,27 +178,6 @@ pub(crate) fn get_commit_schema() -> &'static SchemaRef {
 /// Gets a schema for all actions defined by the delta spec.
 pub(crate) fn get_all_actions_schema() -> &'static SchemaRef {
     &ALL_ACTIONS_SCHEMA
-}
-
-#[internal_api]
-pub(crate) fn get_log_add_schema() -> &'static SchemaRef {
-    &LOG_ADD_SCHEMA
-}
-
-pub(crate) fn get_log_remove_schema() -> &'static SchemaRef {
-    &LOG_REMOVE_SCHEMA
-}
-
-pub(crate) fn get_log_commit_info_schema() -> &'static SchemaRef {
-    &LOG_COMMIT_INFO_SCHEMA
-}
-
-pub(crate) fn get_log_txn_schema() -> &'static SchemaRef {
-    &LOG_TXN_SCHEMA
-}
-
-pub(crate) fn get_log_domain_metadata_schema() -> &'static SchemaRef {
-    &LOG_DOMAIN_METADATA_SCHEMA
 }
 
 /// Returns true if the schema contains file actions (add or remove)
@@ -1053,6 +1069,8 @@ impl DomainMetadata {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use rstest::rstest;
     use serde_json::json;
 
@@ -1066,7 +1084,7 @@ mod tests {
     use crate::arrow::json::ReaderBuilder;
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
-    use crate::schema::{ArrayType, DataType, MapType, StructField};
+    use crate::schema::{schema_ref, ArrayType, DataType, MapType, StructField};
     use crate::utils::test_utils::assert_result_error_with_message;
     use crate::{
         Engine, EvaluationHandler, IntoEngineData, JsonHandler, ParquetHandler, StorageHandler,
@@ -1881,7 +1899,7 @@ mod tests {
         let metadata_id = metadata.id.clone();
 
         // test with the full log schema that wraps metadata in a "metaData" field
-        let commit_schema = get_commit_schema().project(&[METADATA_NAME]).unwrap();
+        let commit_schema = LOG_METADATA_SCHEMA.clone();
         let actual = metadata
             .into_engine_data(commit_schema, &engine)
             .unwrap()
@@ -1971,7 +1989,7 @@ mod tests {
         assert_eq!(record_batch, expected);
 
         // test with the full log schema that wraps protocol in a "protocol" field
-        let commit_schema = get_commit_schema().project(&[PROTOCOL_NAME]).unwrap();
+        let commit_schema = LOG_PROTOCOL_SCHEMA.clone();
         let engine_data = protocol.into_engine_data(commit_schema, &engine);
 
         let schema = Arc::new(Schema::new(vec![Field::new(

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -12,7 +12,8 @@ use visitors::{MetadataVisitor, ProtocolVisitor};
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
 use crate::schema::{
-    schema_ref, DataType, MapType, SchemaRef, StructField, StructType, ToSchema as _,
+    lazy_schema_ref, schema_ref, DataType, MapType, SchemaRef, StructField, StructType,
+    ToSchema as _,
 };
 use crate::table_features::{
     FeatureType, TableFeature, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
@@ -106,69 +107,61 @@ pub(crate) static CHECKPOINT_METADATA_FIELD: LazyLock<StructField> = LazyLock::n
 pub(crate) static SIDECAR_FIELD: LazyLock<StructField> =
     LazyLock::new(|| StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()));
 
-static COMMIT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&ADD_FIELD),
-        (&REMOVE_FIELD),
-        (&METADATA_FIELD),
-        (&PROTOCOL_FIELD),
-        (&SET_TRANSACTION_FIELD),
-        (&COMMIT_INFO_FIELD),
-        (&CDC_FIELD),
-        (&DOMAIN_METADATA_FIELD),
-    }
-});
+static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&COMMIT_INFO_FIELD),
+    (&CDC_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+};
 
-static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&ADD_FIELD),
-        (&REMOVE_FIELD),
-        (&METADATA_FIELD),
-        (&PROTOCOL_FIELD),
-        (&SET_TRANSACTION_FIELD),
-        (&COMMIT_INFO_FIELD),
-        (&CDC_FIELD),
-        (&DOMAIN_METADATA_FIELD),
-        (&CHECKPOINT_METADATA_FIELD),
-        (&SIDECAR_FIELD),
-    }
-});
+static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&COMMIT_INFO_FIELD),
+    (&CDC_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    (&CHECKPOINT_METADATA_FIELD),
+    (&SIDECAR_FIELD),
+};
 
 /// Schema for Add actions in the Delta log.
 /// Wraps the Add action schema in a top-level struct with "add" field name.
 #[internal_api]
-pub(crate) static LOG_ADD_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&ADD_FIELD) });
+pub(crate) static LOG_ADD_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! { (&ADD_FIELD) };
 
 /// Schema for Remove actions in the Delta log.
 /// Wraps the Remove action schema in a top-level struct with "remove" field name.
 #[internal_api]
-pub(crate) static LOG_REMOVE_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&REMOVE_FIELD) });
+pub(crate) static LOG_REMOVE_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! { (&REMOVE_FIELD) };
 
 #[internal_api]
-pub(crate) static LOG_METADATA_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&METADATA_FIELD) });
+pub(crate) static LOG_METADATA_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! { (&METADATA_FIELD) };
 
 #[internal_api]
-pub(crate) static LOG_PROTOCOL_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&PROTOCOL_FIELD) });
+pub(crate) static LOG_PROTOCOL_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! { (&PROTOCOL_FIELD) };
 
 /// Schema for CommitInfo actions in the Delta log.
 /// Wraps the CommitInfo schema in a top-level struct with "commitInfo" field name.
 #[internal_api]
 pub(crate) static LOG_COMMIT_INFO_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&COMMIT_INFO_FIELD) });
+    lazy_schema_ref! { (&COMMIT_INFO_FIELD) };
 
 /// Schema for transaction (txn) actions in the Delta log.
 /// Wraps the SetTransaction schema in a top-level struct with "txn" field name.
 #[internal_api]
 pub(crate) static LOG_TXN_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&SET_TRANSACTION_FIELD) });
+    lazy_schema_ref! { (&SET_TRANSACTION_FIELD) };
 
 #[internal_api]
 pub(crate) static LOG_DOMAIN_METADATA_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { (&DOMAIN_METADATA_FIELD) });
+    lazy_schema_ref! { (&DOMAIN_METADATA_FIELD) };
 
 #[internal_api]
 /// Gets the schema for all actions that can appear in commits

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -1,6 +1,6 @@
 pub(crate) use crate::actions::visitors::SetTransactionMap;
 use crate::actions::visitors::SetTransactionVisitor;
-use crate::actions::{get_log_txn_schema, SetTransaction};
+use crate::actions::{SetTransaction, LOG_TXN_SCHEMA};
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
 use crate::{DeltaResult, Engine, RowVisitor as _};
@@ -86,8 +86,7 @@ fn replay_for_app_ids(
     log_segment: &LogSegment,
     engine: &dyn Engine,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-    let txn_schema = get_log_txn_schema();
-    log_segment.read_actions(engine, txn_schema.clone())
+    log_segment.read_actions(engine, LOG_TXN_SCHEMA.clone())
 }
 
 #[cfg(test)]

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -336,9 +336,11 @@ fn checkpoint_metadata_field() -> StructField {
 }
 
 /// Schema for V2 checkpoints (includes checkpointMetadata action)
-static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    ..(base_checkpoint_action_fields()),
-    (checkpoint_metadata_field()),
+static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        ..(base_checkpoint_action_fields()),
+        (checkpoint_metadata_field()),
+    }
 });
 
 /// Orchestrates the process of creating a checkpoint for a table.

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -121,7 +121,7 @@ use crate::expressions::{
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
-use crate::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
+use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
@@ -323,7 +323,7 @@ fn base_checkpoint_action_fields() -> [&'static LazyLock<StructField>; 7] {
 
 /// Schema for V1 checkpoints (without checkpointMetadata action)
 static CHECKPOINT_ACTIONS_SCHEMA_V1: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_ref! { ..(base_checkpoint_action_fields()) });
+    lazy_schema_ref! { ..(base_checkpoint_action_fields()) };
 
 /// Schema for the checkpointMetadata field in V2 checkpoints.
 /// We cannot use `CheckpointMetadata::to_schema()` as it would include the 'tags' field which
@@ -336,12 +336,10 @@ fn checkpoint_metadata_field() -> StructField {
 }
 
 /// Schema for V2 checkpoints (includes checkpointMetadata action)
-static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        ..(base_checkpoint_action_fields()),
-        (checkpoint_metadata_field()),
-    }
-});
+static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = lazy_schema_ref! {
+    ..(base_checkpoint_action_fields()),
+    (checkpoint_metadata_field()),
+};
 
 /// Orchestrates the process of creating a checkpoint for a table.
 ///

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -111,9 +111,8 @@ use crate::action_reconciliation::{
     ActionReconciliationIterator, ActionReconciliationIteratorState, RetentionCalculator,
 };
 use crate::actions::{
-    Add, DomainMetadata, Metadata, Protocol, Remove, SetTransaction, Sidecar, ADD_NAME,
-    CHECKPOINT_METADATA_NAME, DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
-    SET_TRANSACTION_NAME, SIDECAR_NAME,
+    ADD_FIELD, CHECKPOINT_METADATA_NAME, DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD,
+    REMOVE_FIELD, SET_TRANSACTION_FIELD, SIDECAR_FIELD,
 };
 use crate::engine_data::FilteredEngineData;
 use crate::expressions::{
@@ -122,7 +121,7 @@ use crate::expressions::{
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
-use crate::schema::{DataType, SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
@@ -310,21 +309,21 @@ static LAST_CHECKPOINT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 /// Action fields shared by V1 and V2 checkpoint schemas.
-fn base_checkpoint_action_fields() -> Vec<StructField> {
-    vec![
-        StructField::nullable(ADD_NAME, Add::to_schema()),
-        StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-        StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-        StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-        StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema()),
-        StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema()),
-        StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
+fn base_checkpoint_action_fields() -> [&'static LazyLock<StructField>; 7] {
+    [
+        &ADD_FIELD,
+        &REMOVE_FIELD,
+        &METADATA_FIELD,
+        &PROTOCOL_FIELD,
+        &SET_TRANSACTION_FIELD,
+        &DOMAIN_METADATA_FIELD,
+        &SIDECAR_FIELD,
     ]
 }
 
 /// Schema for V1 checkpoints (without checkpointMetadata action)
 static CHECKPOINT_ACTIONS_SCHEMA_V1: LazyLock<SchemaRef> =
-    LazyLock::new(|| Arc::new(StructType::new_unchecked(base_checkpoint_action_fields())));
+    LazyLock::new(|| schema_ref! { ..(base_checkpoint_action_fields()) });
 
 /// Schema for the checkpointMetadata field in V2 checkpoints.
 /// We cannot use `CheckpointMetadata::to_schema()` as it would include the 'tags' field which
@@ -337,10 +336,9 @@ fn checkpoint_metadata_field() -> StructField {
 }
 
 /// Schema for V2 checkpoints (includes checkpointMetadata action)
-static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = LazyLock::new(|| {
-    let mut fields = base_checkpoint_action_fields();
-    fields.push(checkpoint_metadata_field());
-    Arc::new(StructType::new_unchecked(fields))
+static CHECKPOINT_ACTIONS_SCHEMA_V2: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    ..(base_checkpoint_action_fields()),
+    (checkpoint_metadata_field()),
 });
 
 /// Orchestrates the process of creating a checkpoint for a table.

--- a/kernel/src/commit_range/actions.rs
+++ b/kernel/src/commit_range/actions.rs
@@ -4,9 +4,7 @@ use std::sync::LazyLock;
 use url::Url;
 
 use crate::actions::visitors::InCommitTimestampVisitor;
-use crate::actions::{
-    COMMIT_INFO_FIELD, METADATA_FIELD, PROTOCOL_FIELD, Metadata, Protocol,
-};
+use crate::actions::{Metadata, Protocol, COMMIT_INFO_FIELD, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::commit_range::with_version_context;
 use crate::engine_data::RowVisitor as _;
 use crate::path::ParsedLogPath;
@@ -35,10 +33,12 @@ pub enum DeltaAction {
 
 /// Read schema for the per-commit header: protocol + metadata (for validation and the effective
 /// table configuration) plus commitInfo (for the in-commit timestamp).
-static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&PROTOCOL_FIELD),
-    (&METADATA_FIELD),
-    (&COMMIT_INFO_FIELD),
+static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&PROTOCOL_FIELD),
+        (&METADATA_FIELD),
+        (&COMMIT_INFO_FIELD),
+    }
 });
 
 /// Per-commit handle returned by [`super::CommitRange::commits`].

--- a/kernel/src/commit_range/actions.rs
+++ b/kernel/src/commit_range/actions.rs
@@ -8,7 +8,7 @@ use crate::actions::{Metadata, Protocol, COMMIT_INFO_FIELD, METADATA_FIELD, PROT
 use crate::commit_range::with_version_context;
 use crate::engine_data::RowVisitor as _;
 use crate::path::ParsedLogPath;
-use crate::schema::{schema_ref, SchemaRef};
+use crate::schema::{lazy_schema_ref, SchemaRef};
 use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
 use crate::table_features::{ensure_table_can_be_read, Operation};
 use crate::{DeltaResult, Engine, Error, FileDataReadResultIterator, Version};
@@ -33,13 +33,11 @@ pub enum DeltaAction {
 
 /// Read schema for the per-commit header: protocol + metadata (for validation and the effective
 /// table configuration) plus commitInfo (for the in-commit timestamp).
-static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&PROTOCOL_FIELD),
-        (&METADATA_FIELD),
-        (&COMMIT_INFO_FIELD),
-    }
-});
+static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&PROTOCOL_FIELD),
+    (&METADATA_FIELD),
+    (&COMMIT_INFO_FIELD),
+};
 
 /// Per-commit handle returned by [`super::CommitRange::commits`].
 ///

--- a/kernel/src/commit_range/actions.rs
+++ b/kernel/src/commit_range/actions.rs
@@ -1,16 +1,16 @@
 use std::slice;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use url::Url;
 
 use crate::actions::visitors::InCommitTimestampVisitor;
 use crate::actions::{
-    CommitInfo, Metadata, Protocol, COMMIT_INFO_NAME, METADATA_NAME, PROTOCOL_NAME,
+    COMMIT_INFO_FIELD, METADATA_FIELD, PROTOCOL_FIELD, Metadata, Protocol,
 };
 use crate::commit_range::with_version_context;
 use crate::engine_data::RowVisitor as _;
 use crate::path::ParsedLogPath;
-use crate::schema::{SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{schema_ref, SchemaRef};
 use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration};
 use crate::table_features::{ensure_table_can_be_read, Operation};
 use crate::{DeltaResult, Engine, Error, FileDataReadResultIterator, Version};
@@ -35,12 +35,10 @@ pub enum DeltaAction {
 
 /// Read schema for the per-commit header: protocol + metadata (for validation and the effective
 /// table configuration) plus commitInfo (for the in-commit timestamp).
-static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-        StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-        StructField::nullable(COMMIT_INFO_NAME, CommitInfo::to_schema()),
-    ]))
+static HEADER_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&PROTOCOL_FIELD),
+    (&METADATA_FIELD),
+    (&COMMIT_INFO_FIELD),
 });
 
 /// Per-commit handle returned by [`super::CommitRange::commits`].

--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -54,13 +54,12 @@ pub use builder::{CommitOrdering, CommitRangeBuilder};
 use url::Url;
 
 use crate::actions::{
-    Add, Cdc, CheckpointMetadata, CommitInfo, DomainMetadata, Metadata, Protocol, Remove,
-    SetTransaction, Sidecar, ADD_NAME, CDC_NAME, CHECKPOINT_METADATA_NAME, COMMIT_INFO_NAME,
-    DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME,
-    SIDECAR_NAME,
+    ADD_FIELD, CDC_FIELD, CHECKPOINT_METADATA_FIELD, COMMIT_INFO_FIELD, DOMAIN_METADATA_FIELD,
+    METADATA_FIELD, PROTOCOL_FIELD, REMOVE_FIELD, SET_TRANSACTION_FIELD, SIDECAR_FIELD, Metadata,
+    Protocol,
 };
 use crate::path::ParsedLogPath;
-use crate::schema::{SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -252,22 +251,16 @@ impl Iterator for CommitActionsIterator {
 /// Build the nullable [`StructField`] that represents this action kind in the read schema.
 fn action_to_field(action: &DeltaAction) -> StructField {
     match action {
-        DeltaAction::Add => StructField::nullable(ADD_NAME, Add::to_schema()),
-        DeltaAction::Remove => StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-        DeltaAction::Metadata => StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-        DeltaAction::Protocol => StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-        DeltaAction::CommitInfo => StructField::nullable(COMMIT_INFO_NAME, CommitInfo::to_schema()),
-        DeltaAction::Cdc => StructField::nullable(CDC_NAME, Cdc::to_schema()),
-        DeltaAction::DomainMetadata => {
-            StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema())
-        }
-        DeltaAction::SetTxn => {
-            StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema())
-        }
-        DeltaAction::CheckpointMetadata => {
-            StructField::nullable(CHECKPOINT_METADATA_NAME, CheckpointMetadata::to_schema())
-        }
-        DeltaAction::Sidecar => StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
+        DeltaAction::Add => ADD_FIELD.clone(),
+        DeltaAction::Remove => REMOVE_FIELD.clone(),
+        DeltaAction::Metadata => METADATA_FIELD.clone(),
+        DeltaAction::Protocol => PROTOCOL_FIELD.clone(),
+        DeltaAction::CommitInfo => COMMIT_INFO_FIELD.clone(),
+        DeltaAction::Cdc => CDC_FIELD.clone(),
+        DeltaAction::DomainMetadata => DOMAIN_METADATA_FIELD.clone(),
+        DeltaAction::SetTxn => SET_TRANSACTION_FIELD.clone(),
+        DeltaAction::CheckpointMetadata => CHECKPOINT_METADATA_FIELD.clone(),
+        DeltaAction::Sidecar => SIDECAR_FIELD.clone(),
     }
 }
 
@@ -281,6 +274,7 @@ mod tests {
 
     use super::*;
     use crate::actions::visitors::{AddVisitor, RemoveVisitor};
+    use crate::actions::{Add, Remove};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::RowVisitor;

--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -54,9 +54,9 @@ pub use builder::{CommitOrdering, CommitRangeBuilder};
 use url::Url;
 
 use crate::actions::{
-    ADD_FIELD, CDC_FIELD, CHECKPOINT_METADATA_FIELD, COMMIT_INFO_FIELD, DOMAIN_METADATA_FIELD,
-    METADATA_FIELD, PROTOCOL_FIELD, REMOVE_FIELD, SET_TRANSACTION_FIELD, SIDECAR_FIELD, Metadata,
-    Protocol,
+    Metadata, Protocol, ADD_FIELD, CDC_FIELD, CHECKPOINT_METADATA_FIELD, COMMIT_INFO_FIELD,
+    DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD, REMOVE_FIELD, SET_TRANSACTION_FIELD,
+    SIDECAR_FIELD,
 };
 use crate::path::ParsedLogPath;
 use crate::schema::{SchemaRef, StructField, StructType};

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -537,7 +537,7 @@ mod tests {
     use rstest::rstest;
 
     use super::{extract_record_batch, ArrowEngineData};
-    use crate::actions::{get_commit_schema, Metadata, Protocol};
+    use crate::actions::{get_commit_schema, Metadata, Protocol, LOG_PROTOCOL_SCHEMA};
     use crate::arrow::array::types::{Int32Type, Int64Type};
     use crate::arrow::array::{
         Array, ArrayRef, AsArray, BinaryArray, BooleanArray, Int32Array, Int64Array,
@@ -583,7 +583,7 @@ mod tests {
             r#"{"protocol": {"minReaderVersion": 3, "minWriterVersion": 7, "readerFeatures": ["rw1"], "writerFeatures": ["rw1", "w2"]}}"#,
         ]
         .into();
-        let output_schema = get_commit_schema().project(&["protocol"])?;
+        let output_schema = LOG_PROTOCOL_SCHEMA.clone();
         let parsed = handler
             .parse_json(string_array_to_engine_data(json_strings), output_schema)
             .unwrap();

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -4,25 +4,18 @@
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use crate::actions::{ADD_FIELD, REMOVE_FIELD};
-use crate::schema::schema_ref;
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor};
 use crate::expressions::{column_name, ColumnName};
 use crate::log_replay::deduplicator::{Deduplicator, FileActionInfo};
 use crate::log_replay::{FileActionDeduplicator, FileActionKey};
-use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef};
+use crate::scan::COMMIT_READ_SCHEMA;
+use crate::schema::{ColumnNamesAndTypes, DataType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, Version,
 };
-
-/// Schema projected from each commit JSON: `add` and `remove` only.
-static INCREMENTAL_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
-    (&REMOVE_FIELD),
-});
 
 /// Builder for an incremental scan over `(base_version, target_version]`. Construct via
 /// [`crate::Snapshot::incremental_scan_builder`] and drive with
@@ -123,7 +116,7 @@ impl IncrementalScanBuilder {
 
         let actions = engine.json_handler().read_json_files(
             &commit_locations,
-            INCREMENTAL_READ_SCHEMA.clone(),
+            COMMIT_READ_SCHEMA.clone(),
             None,
         )?;
 

--- a/kernel/src/incremental_scan/mod.rs
+++ b/kernel/src/incremental_scan/mod.rs
@@ -2,14 +2,15 @@
 //! [`IncrementalScanBuilder`] for the entry point.
 
 use std::collections::HashSet;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
-use crate::actions::{Add, Remove, ADD_NAME, REMOVE_NAME};
+use crate::actions::{ADD_FIELD, REMOVE_FIELD};
+use crate::schema::schema_ref;
 use crate::engine_data::{FilteredEngineData, GetData, RowVisitor};
 use crate::expressions::{column_name, ColumnName};
 use crate::log_replay::deduplicator::{Deduplicator, FileActionInfo};
 use crate::log_replay::{FileActionDeduplicator, FileActionKey};
-use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef, StructField, StructType, ToSchema};
+use crate::schema::{ColumnNamesAndTypes, DataType, SchemaRef};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
 use crate::utils::require;
@@ -18,11 +19,9 @@ use crate::{
 };
 
 /// Schema projected from each commit JSON: `add` and `remove` only.
-static INCREMENTAL_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable(ADD_NAME, Add::to_schema()),
-        StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-    ]))
+static INCREMENTAL_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
 });
 
 /// Builder for an incremental scan over `(base_version, target_version]`. Construct via

--- a/kernel/src/log_compaction/mod.rs
+++ b/kernel/src/log_compaction/mod.rs
@@ -94,12 +94,14 @@ mod tests;
 
 /// Schema for extracting relevant actions from log files for compaction.
 /// CommitInfo is excluded as it's not needed in compaction files.
-static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
-    (&REMOVE_FIELD),
-    (&METADATA_FIELD),
-    (&PROTOCOL_FIELD),
-    (&SET_TRANSACTION_FIELD),
-    (&DOMAIN_METADATA_FIELD),
-    (&SIDECAR_FIELD),
+static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&ADD_FIELD),
+        (&REMOVE_FIELD),
+        (&METADATA_FIELD),
+        (&PROTOCOL_FIELD),
+        (&SET_TRANSACTION_FIELD),
+        (&DOMAIN_METADATA_FIELD),
+        (&SIDECAR_FIELD),
+    }
 });

--- a/kernel/src/log_compaction/mod.rs
+++ b/kernel/src/log_compaction/mod.rs
@@ -77,14 +77,13 @@
 //! - **Log Compaction**: Aggregates only a specific range of commit files
 //! - Both use similar action reconciliation logic but serve different use cases
 
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use crate::actions::{
-    Add, DomainMetadata, Metadata, Protocol, Remove, SetTransaction, Sidecar, ADD_NAME,
-    DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME,
-    SIDECAR_NAME,
+    ADD_FIELD, DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD, REMOVE_FIELD,
+    SET_TRANSACTION_FIELD, SIDECAR_FIELD,
 };
-use crate::schema::{SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{schema_ref, SchemaRef};
 
 mod writer;
 
@@ -95,14 +94,12 @@ mod tests;
 
 /// Schema for extracting relevant actions from log files for compaction.
 /// CommitInfo is excluded as it's not needed in compaction files.
-static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable(ADD_NAME, Add::to_schema()),
-        StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-        StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-        StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-        StructField::nullable(SET_TRANSACTION_NAME, SetTransaction::to_schema()),
-        StructField::nullable(DOMAIN_METADATA_NAME, DomainMetadata::to_schema()),
-        StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
-    ]))
+static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    (&SIDECAR_FIELD),
 });

--- a/kernel/src/log_compaction/mod.rs
+++ b/kernel/src/log_compaction/mod.rs
@@ -83,7 +83,7 @@ use crate::actions::{
     ADD_FIELD, DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD, REMOVE_FIELD,
     SET_TRANSACTION_FIELD, SIDECAR_FIELD,
 };
-use crate::schema::{schema_ref, SchemaRef};
+use crate::schema::{lazy_schema_ref, SchemaRef};
 
 mod writer;
 
@@ -94,14 +94,12 @@ mod tests;
 
 /// Schema for extracting relevant actions from log files for compaction.
 /// CommitInfo is excluded as it's not needed in compaction files.
-static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&ADD_FIELD),
-        (&REMOVE_FIELD),
-        (&METADATA_FIELD),
-        (&PROTOCOL_FIELD),
-        (&SET_TRANSACTION_FIELD),
-        (&DOMAIN_METADATA_FIELD),
-        (&SIDECAR_FIELD),
-    }
-});
+static COMPACTION_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    (&SIDECAR_FIELD),
+};

--- a/kernel/src/log_reader/checkpoint_manifest.rs
+++ b/kernel/src/log_reader/checkpoint_manifest.rs
@@ -40,10 +40,12 @@ impl CheckpointManifestReader {
         manifest: &ParsedLogPath,
         log_root: Url,
     ) -> DeltaResult<Self> {
-        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-            (&ADD_FIELD),
-            (&REMOVE_FIELD),
-            (&SIDECAR_FIELD),
+        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = LazyLock::new(|| {
+            schema_ref! {
+                (&ADD_FIELD),
+                (&REMOVE_FIELD),
+                (&SIDECAR_FIELD),
+            }
         });
 
         let actions = match manifest.extension.as_str() {

--- a/kernel/src/log_reader/checkpoint_manifest.rs
+++ b/kernel/src/log_reader/checkpoint_manifest.rs
@@ -6,10 +6,10 @@ use itertools::Itertools;
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{Add, Remove, Sidecar, ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
+use crate::actions::{ADD_FIELD, REMOVE_FIELD, SIDECAR_FIELD};
 use crate::log_replay::ActionsBatch;
 use crate::path::ParsedLogPath;
-use crate::schema::{SchemaRef, StructField, StructType, ToSchema};
+use crate::schema::{schema_ref, SchemaRef};
 use crate::utils::require;
 use crate::{DeltaResult, DeltaResultIteratorStatic, Engine, Error, FileMeta, RowVisitor};
 
@@ -40,12 +40,10 @@ impl CheckpointManifestReader {
         manifest: &ParsedLogPath,
         log_root: Url,
     ) -> DeltaResult<Self> {
-        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = LazyLock::new(|| {
-            Arc::new(StructType::new_unchecked([
-                StructField::nullable(ADD_NAME, Add::to_schema()),
-                StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-                StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()),
-            ]))
+        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+            (&SIDECAR_FIELD),
         });
 
         let actions = match manifest.extension.as_str() {

--- a/kernel/src/log_reader/checkpoint_manifest.rs
+++ b/kernel/src/log_reader/checkpoint_manifest.rs
@@ -9,7 +9,7 @@ use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{ADD_FIELD, REMOVE_FIELD, SIDECAR_FIELD};
 use crate::log_replay::ActionsBatch;
 use crate::path::ParsedLogPath;
-use crate::schema::{schema_ref, SchemaRef};
+use crate::schema::{lazy_schema_ref, SchemaRef};
 use crate::utils::require;
 use crate::{DeltaResult, DeltaResultIteratorStatic, Engine, Error, FileMeta, RowVisitor};
 
@@ -40,13 +40,11 @@ impl CheckpointManifestReader {
         manifest: &ParsedLogPath,
         log_root: Url,
     ) -> DeltaResult<Self> {
-        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = LazyLock::new(|| {
-            schema_ref! {
-                (&ADD_FIELD),
-                (&REMOVE_FIELD),
-                (&SIDECAR_FIELD),
-            }
-        });
+        static MANIFEST_READ_SCHMEA: LazyLock<SchemaRef> = lazy_schema_ref! {
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+            (&SIDECAR_FIELD),
+        };
 
         let actions = match manifest.extension.as_str() {
             "json" => engine.json_handler().read_json_files(

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -16,8 +16,8 @@ use crate::actions::visitors::{
     visit_metadata_at, visit_protocol_at, METADATA_LEAVES, PROTOCOL_LEAVES,
 };
 use crate::actions::{
-    DomainMetadata, Metadata, Protocol, SetTransaction, ADD_NAME, COMMIT_INFO_NAME,
-    DOMAIN_METADATA_NAME, METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME, SET_TRANSACTION_NAME,
+    DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD, SET_TRANSACTION_FIELD,
+    DomainMetadata, SetTransaction, ADD_NAME, COMMIT_INFO_NAME, REMOVE_NAME,
 };
 use crate::crc::{
     is_incremental_safe_operation, read_crc_file_or_none, size_to_u64, Crc, CrcDelta,
@@ -26,7 +26,6 @@ use crate::crc::{
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::{
     column_name, schema, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
-    ToSchema as _,
 };
 use crate::snapshot::IncrementalReplay;
 use crate::utils::require;
@@ -44,10 +43,10 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
             not_null "path": STRING,
             nullable "size": LONG,
         },
-        nullable PROTOCOL_NAME: (Protocol::to_schema()),
-        nullable METADATA_NAME: (Metadata::to_schema()),
-        nullable SET_TRANSACTION_NAME: (SetTransaction::to_schema()),
-        nullable DOMAIN_METADATA_NAME: (DomainMetadata::to_schema()),
+        (&PROTOCOL_FIELD),
+        (&METADATA_FIELD),
+        (&SET_TRANSACTION_FIELD),
+        (&DOMAIN_METADATA_FIELD),
         nullable COMMIT_INFO_NAME: {
             nullable "operation": STRING,
             nullable "inCommitTimestamp": LONG,

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -16,8 +16,8 @@ use crate::actions::visitors::{
     visit_metadata_at, visit_protocol_at, METADATA_LEAVES, PROTOCOL_LEAVES,
 };
 use crate::actions::{
-    DOMAIN_METADATA_FIELD, METADATA_FIELD, PROTOCOL_FIELD, SET_TRANSACTION_FIELD,
-    DomainMetadata, SetTransaction, ADD_NAME, COMMIT_INFO_NAME, REMOVE_NAME,
+    DomainMetadata, SetTransaction, ADD_NAME, COMMIT_INFO_NAME, DOMAIN_METADATA_FIELD,
+    METADATA_FIELD, PROTOCOL_FIELD, REMOVE_NAME, SET_TRANSACTION_FIELD,
 };
 use crate::crc::{
     is_incremental_safe_operation, read_crc_file_or_none, size_to_u64, Crc, CrcDelta,

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 
 use super::LogSegment;
 use crate::actions::visitors::DomainMetadataVisitor;
-use crate::actions::{get_log_domain_metadata_schema, DomainMetadata};
+use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA};
 use crate::log_replay::ActionsBatch;
 use crate::{DeltaResult, Engine, RowVisitor as _};
 
@@ -54,8 +54,7 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-        let schema = get_log_domain_metadata_schema();
-        self.read_actions(engine, schema.clone())
+        self.read_actions(engine, LOG_DOMAIN_METADATA_SCHEMA.clone())
     }
 }
 

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    get_log_add_schema, schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, MAX_VALUES,
+    schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA, MAX_VALUES,
     METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
@@ -72,7 +72,7 @@ impl CheckpointReadInfo {
         Self {
             has_stats_parsed: false,
             has_partition_values_parsed: false,
-            checkpoint_read_schema: get_log_add_schema().clone(),
+            checkpoint_read_schema: LOG_ADD_SCHEMA.clone(),
         }
     }
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -25,7 +25,7 @@ use crate::metrics::SnapshotLoadMetricContext;
 use crate::path::LogPathFileType::*;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::compare::SchemaComparison;
-use crate::schema::{schema_ref, DataType, SchemaRef, StructField, StructType, ToSchema as _};
+use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField, StructType, ToSchema as _};
 use crate::utils::require;
 use crate::{
     DeltaResult, Engine, Error, Expression, FileMeta, Predicate, PredicateRef, RowVisitor,
@@ -1199,7 +1199,7 @@ impl LogSegment {
     /// Schema to read just the sidecar column from a checkpoint file.
     fn sidecar_read_schema() -> SchemaRef {
         static SIDECAR_SCHEMA: LazyLock<SchemaRef> =
-            LazyLock::new(|| schema_ref! { nullable SIDECAR_NAME: (Sidecar::to_schema()) });
+            lazy_schema_ref! { nullable SIDECAR_NAME: (Sidecar::to_schema()) };
         SIDECAR_SCHEMA.clone()
     }
 

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -3,13 +3,12 @@
 //! This module contains the methods that perform a lightweight log replay to extract the latest
 //! Protocol and Metadata actions from a [`LogSegment`].
 
-
 use std::sync::Arc;
 
 use tracing::{info, instrument};
 
 use super::LogSegment;
-use crate::actions::{METADATA_FIELD, PROTOCOL_FIELD, Metadata, Protocol};
+use crate::actions::{Metadata, Protocol, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
 use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -3,16 +3,18 @@
 //! This module contains the methods that perform a lightweight log replay to extract the latest
 //! Protocol and Metadata actions from a [`LogSegment`].
 
+
 use std::sync::Arc;
 
 use tracing::{info, instrument};
 
 use super::LogSegment;
-use crate::actions::{get_commit_schema, Metadata, Protocol, METADATA_NAME, PROTOCOL_NAME};
+use crate::actions::{METADATA_FIELD, PROTOCOL_FIELD, Metadata, Protocol};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
 use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
 use crate::metrics::SnapshotLoadMetricContext;
+use crate::schema::schema_ref;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
@@ -123,7 +125,10 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send> {
-        let schema = get_commit_schema().project(&[PROTOCOL_NAME, METADATA_NAME])?;
+        let schema = schema_ref! {
+            (&PROTOCOL_FIELD),
+            (&METADATA_FIELD),
+        };
         self.read_actions(engine, schema)
     }
 }

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -10,8 +10,8 @@ use url::Url;
 use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
-    get_all_actions_schema, get_commit_schema, ADD_FIELD, METADATA_FIELD, REMOVE_FIELD, Add, Sidecar,
-    ADD_NAME, DOMAIN_METADATA_NAME, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME,
+    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
+    LOG_METADATA_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME,
     REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
@@ -32,6 +32,7 @@ use crate::scan::test_utils::{
     add_batch_simple, add_batch_with_remove, sidecar_batch_with_given_paths,
     sidecar_batch_with_given_paths_and_sizes,
 };
+use crate::scan::{CHECKPOINT_READ_SCHEMA, COMMIT_READ_SCHEMA};
 use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
 use crate::utils::test_utils::{
     assert_batch_matches, assert_result_error_with_message, string_array_to_engine_data, Action,
@@ -1198,7 +1199,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
         .join("00000000000000000001.checkpoint.parquet")?
         .to_string();
 
-    let v2_checkpoint_read_schema = schema_ref! { (&METADATA_FIELD) };
+    let v2_checkpoint_read_schema = LOG_METADATA_SCHEMA.clone();
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
@@ -1268,7 +1269,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
     let checkpoint_one_file = log_root.join(checkpoint_part_1)?.to_string();
     let checkpoint_two_file = log_root.join(checkpoint_part_2)?.to_string();
 
-    let v2_checkpoint_read_schema = schema_ref! { (&ADD_FIELD) };
+    let v2_checkpoint_read_schema = CHECKPOINT_READ_SCHEMA.clone();
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
@@ -1441,10 +1442,7 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
     // Write sidecars first so we can get their actual sizes
     let sidecar1_size = add_sidecar_to_store(
         &store,
-        add_batch_simple(schema_ref! {
-            (&ADD_FIELD),
-            (&REMOVE_FIELD),
-        }),
+        add_batch_simple(COMMIT_READ_SCHEMA.clone()),
         "sidecarfile1.parquet",
     )
     .await?
@@ -1452,10 +1450,7 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
 
     let sidecar2_size = add_sidecar_to_store(
         &store,
-        add_batch_with_remove(schema_ref! {
-            (&ADD_FIELD),
-            (&REMOVE_FIELD),
-        }),
+        add_batch_with_remove(COMMIT_READ_SCHEMA.clone()),
         "sidecarfile2.parquet",
     )
     .await?
@@ -2722,10 +2717,7 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
     let engine = SyncEngine::new_with_store(store.clone());
 
     // Build a checkpoint with an initial v1 schema
-    let v1_schema = schema_ref! {
-        (&ADD_FIELD),
-        (&REMOVE_FIELD),
-    };
+    let v1_schema = COMMIT_READ_SCHEMA.clone();
     add_checkpoint_to_store(
         &store,
         add_batch_simple(v1_schema.clone()),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -10,9 +10,9 @@ use url::Url;
 use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
-    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
-    MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME, REMOVE_NAME,
-    SET_TRANSACTION_NAME, SIDECAR_NAME,
+    get_all_actions_schema, get_commit_schema, ADD_FIELD, METADATA_FIELD, REMOVE_FIELD, Add, Sidecar,
+    ADD_NAME, DOMAIN_METADATA_NAME, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME,
+    REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -1198,7 +1198,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_as_is_if_schem
         .join("00000000000000000001.checkpoint.parquet")?
         .to_string();
 
-    let v2_checkpoint_read_schema = get_commit_schema().project(&[METADATA_NAME])?;
+    let v2_checkpoint_read_schema = schema_ref! { (&METADATA_FIELD) };
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
@@ -1268,7 +1268,7 @@ async fn test_create_checkpoint_stream_returns_checkpoint_batches_if_checkpoint_
     let checkpoint_one_file = log_root.join(checkpoint_part_1)?.to_string();
     let checkpoint_two_file = log_root.join(checkpoint_part_2)?.to_string();
 
-    let v2_checkpoint_read_schema = get_commit_schema().project(&[ADD_NAME])?;
+    let v2_checkpoint_read_schema = schema_ref! { (&ADD_FIELD) };
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
@@ -1441,7 +1441,10 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
     // Write sidecars first so we can get their actual sizes
     let sidecar1_size = add_sidecar_to_store(
         &store,
-        add_batch_simple(get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?),
+        add_batch_simple(schema_ref! {
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+        }),
         "sidecarfile1.parquet",
     )
     .await?
@@ -1449,7 +1452,10 @@ async fn test_create_checkpoint_stream_reads_checkpoint_file_and_returns_sidecar
 
     let sidecar2_size = add_sidecar_to_store(
         &store,
-        add_batch_with_remove(get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?),
+        add_batch_with_remove(schema_ref! {
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+        }),
         "sidecarfile2.parquet",
     )
     .await?
@@ -2716,7 +2722,10 @@ async fn test_get_file_actions_schema_v1_parquet_with_hint(
     let engine = SyncEngine::new_with_store(store.clone());
 
     // Build a checkpoint with an initial v1 schema
-    let v1_schema = get_commit_schema().project(&[ADD_NAME, REMOVE_NAME])?;
+    let v1_schema = schema_ref! {
+        (&ADD_FIELD),
+        (&REMOVE_FIELD),
+    };
     add_checkpoint_to_store(
         &store,
         add_batch_simple(v1_schema.clone()),

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -130,7 +130,6 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::get_log_add_schema;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
     use crate::log_replay::FileActionKey;

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -15,8 +15,7 @@ use self::log_replay::{get_scan_metadata_transform_expr, scan_action_iter};
 use crate::actions::deletion_vector::{
     deletion_treemap_to_bools, split_vector, DeletionVectorDescriptor,
 };
-use crate::actions::{ADD_FIELD, REMOVE_FIELD, Add, ADD_NAME};
-use crate::schema::schema_ref;
+use crate::actions::{Add, ADD_FIELD, ADD_NAME, REMOVE_FIELD};
 use crate::engine_data::FilteredEngineData;
 use crate::expressions::{ColumnName, ExpressionRef, Predicate, PredicateRef, Scalar};
 use crate::kernel_predicates::{
@@ -35,8 +34,8 @@ use crate::scan::log_replay::{
 use crate::scan::metrics::ScanMetrics;
 use crate::scan::state_info::StateInfo;
 use crate::schema::{
-    ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField, StructType,
-    ToSchema as _,
+    schema_ref, ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
+    StructType, ToSchema as _,
 };
 use crate::table_features::{ColumnMappingMode, Operation};
 use crate::transforms::{transform_output_type, ExpressionTransform, SchemaTransform};
@@ -57,12 +56,16 @@ pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
 
-pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
-    (&REMOVE_FIELD),
+pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&ADD_FIELD),
+        (&REMOVE_FIELD),
+    }
 });
-pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
-    (&ADD_FIELD),
+pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    schema_ref! {
+        (&ADD_FIELD),
+    }
 });
 
 /// Checkpoint schema WITHOUT stats for column projection pushdown.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -15,7 +15,8 @@ use self::log_replay::{get_scan_metadata_transform_expr, scan_action_iter};
 use crate::actions::deletion_vector::{
     deletion_treemap_to_bools, split_vector, DeletionVectorDescriptor,
 };
-use crate::actions::{get_commit_schema, Add, ADD_NAME, REMOVE_NAME};
+use crate::actions::{ADD_FIELD, REMOVE_FIELD, Add, ADD_NAME};
+use crate::schema::schema_ref;
 use crate::engine_data::FilteredEngineData;
 use crate::expressions::{ColumnName, ExpressionRef, Predicate, PredicateRef, Scalar};
 use crate::kernel_predicates::{
@@ -56,17 +57,13 @@ pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
 
-// safety: we define get_commit_schema() and _know_ it contains ADD_NAME and REMOVE_NAME
-#[allow(clippy::unwrap_used)]
-pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    get_commit_schema()
-        .project(&[ADD_NAME, REMOVE_NAME])
-        .unwrap()
+pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
 });
-// safety: we define get_commit_schema() and _know_ it contains ADD_NAME and SIDECAR_NAME
-#[allow(clippy::unwrap_used)]
-pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| get_commit_schema().project(&[ADD_NAME]).unwrap());
+pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| schema_ref! {
+    (&ADD_FIELD),
+});
 
 /// Checkpoint schema WITHOUT stats for column projection pushdown.
 /// When skip_stats is enabled, we use this schema to avoid reading the stats column from parquet.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -34,7 +34,7 @@ use crate::scan::log_replay::{
 use crate::scan::metrics::ScanMetrics;
 use crate::scan::state_info::StateInfo;
 use crate::schema::{
-    schema_ref, ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
+    lazy_schema_ref, ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
     StructType, ToSchema as _,
 };
 use crate::table_features::{ColumnMappingMode, Operation};
@@ -56,17 +56,13 @@ pub(crate) mod test_utils;
 #[cfg(test)]
 mod tests;
 
-pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&ADD_FIELD),
-        (&REMOVE_FIELD),
-    }
-});
-pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        (&ADD_FIELD),
-    }
-});
+pub(crate) static COMMIT_READ_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+};
+pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+};
 
 /// Checkpoint schema WITHOUT stats for column projection pushdown.
 /// When skip_stats is enabled, we use this schema to avoid reading the stats column from parquet.

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -43,6 +43,11 @@ pub(crate) mod void_utils;
 pub type Schema = StructType;
 pub type SchemaRef = Arc<StructType>;
 
+/// Sugar for `LazyLock::new(|| `[`schema_ref!`](schema_ref)` { ... })`, yielding a lazy
+/// [`SchemaRef`].
+#[internal_api]
+#[doc(inline)]
+pub(crate) use delta_kernel_derive::lazy_schema_ref;
 /// Builds a [`StructType`] from a JSON-shaped description that freely mixes literal structure
 /// with interpolated runtime values, in the spirit of [`serde_json::json!`].
 ///

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 use std::iter::{DoubleEndedIterator, FusedIterator};
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 
@@ -129,6 +130,33 @@ pub(crate) use delta_kernel_derive::schema_ref;
 #[internal_api]
 #[doc(inline)]
 pub(crate) use delta_kernel_derive::try_schema;
+
+/// Converts field interpolation inputs in [`schema!`] and [`try_schema!`] to [`StructField`].
+#[internal_api]
+pub(crate) trait ToSchemaField {
+    fn to_schema_field(self) -> StructField;
+}
+
+impl ToSchemaField for StructField {
+    fn to_schema_field(self) -> StructField {
+        self
+    }
+}
+
+impl ToSchemaField for &StructField {
+    fn to_schema_field(self) -> StructField {
+        self.clone()
+    }
+}
+
+impl<T> ToSchemaField for &T
+where
+    T: Deref<Target = StructField>,
+{
+    fn to_schema_field(self) -> StructField {
+        self.deref().clone()
+    }
+}
 
 /// A [`StructPatchBuilder`](crate::struct_patch::StructPatchBuilder) whose emitted items are schema
 /// fields, lowered into an output [`StructType`] directly from an input schema via

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -10,8 +10,8 @@ use tracing::info;
 
 use crate::actions::visitors::{visit_deletion_vector_at, InCommitTimestampVisitor};
 use crate::actions::{
-    get_log_add_schema, Add, Cdc, Metadata, Protocol, Remove, ADD_NAME, CDC_NAME, COMMIT_INFO_NAME,
-    METADATA_NAME, PROTOCOL_NAME, REMOVE_NAME,
+    Metadata, Protocol, ADD_FIELD, CDC_FIELD, LOG_ADD_SCHEMA, METADATA_FIELD, PROTOCOL_FIELD,
+    REMOVE_FIELD, COMMIT_INFO_NAME,
 };
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::{
@@ -20,9 +20,7 @@ use crate::expressions::{
 use crate::path::{AsUrl, ParsedLogPath};
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::scan::state::DvInfo;
-use crate::schema::{
-    ColumnNamesAndTypes, DataType, SchemaRef, StructField, StructType, ToSchema as _,
-};
+use crate::schema::{schema_ref, ColumnNamesAndTypes, DataType, SchemaRef};
 use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{format_features, Operation, TableFeature};
@@ -97,7 +95,7 @@ pub(crate) fn table_changes_action_iter(
                 // Raw action batches keep the nested layout, so Add rows are
                 // `add.path IS NOT NULL`.
                 Arc::new(Predicate::is_not_null(column_expr!("add.path")).into()),
-                get_log_add_schema().clone(),
+                LOG_ADD_SCHEMA.clone(),
                 &physical_stats_columns,
                 None, // Table changes doesn't use metrics yet
             )
@@ -372,7 +370,7 @@ impl LogReplayScanner {
             .try_into()
             .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
-            get_log_add_schema().clone(),
+            LOG_ADD_SCHEMA.clone(),
             Arc::new(cdf_scan_row_expression(timestamp, commit_version)),
             cdf_scan_row_schema().into(),
         )?;
@@ -410,22 +408,17 @@ struct PreparePhaseVisitor<'a> {
     remove_dvs: &'a mut HashMap<String, DvInfo>,
 }
 impl PreparePhaseVisitor<'_> {
-    fn schema() -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable(ADD_NAME, Add::to_schema()),
-            StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-            StructField::nullable(CDC_NAME, Cdc::to_schema()),
-            StructField::nullable(METADATA_NAME, Metadata::to_schema()),
-            StructField::nullable(PROTOCOL_NAME, Protocol::to_schema()),
-            StructField::nullable(
-                COMMIT_INFO_NAME,
-                StructType::new_unchecked([StructField::new(
-                    "inCommitTimestamp",
-                    DataType::LONG,
-                    true,
-                )]),
-            ),
-        ]))
+    fn schema() -> SchemaRef {
+        schema_ref! {
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+            (&CDC_FIELD),
+            (&METADATA_FIELD),
+            (&PROTOCOL_FIELD),
+            nullable COMMIT_INFO_NAME: {
+                nullable "inCommitTimestamp": LONG,
+            },
+        }
     }
 }
 
@@ -505,12 +498,12 @@ impl<'a> FileActionSelectionVisitor<'a> {
             remove_dvs,
         }
     }
-    fn schema() -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable(CDC_NAME, Cdc::to_schema()),
-            StructField::nullable(ADD_NAME, Add::to_schema()),
-            StructField::nullable(REMOVE_NAME, Remove::to_schema()),
-        ]))
+    fn schema() -> SchemaRef {
+        schema_ref! {
+            (&CDC_FIELD),
+            (&ADD_FIELD),
+            (&REMOVE_FIELD),
+        }
     }
 }
 

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -10,8 +10,8 @@ use tracing::info;
 
 use crate::actions::visitors::{visit_deletion_vector_at, InCommitTimestampVisitor};
 use crate::actions::{
-    Metadata, Protocol, ADD_FIELD, CDC_FIELD, LOG_ADD_SCHEMA, METADATA_FIELD, PROTOCOL_FIELD,
-    REMOVE_FIELD, COMMIT_INFO_NAME,
+    Metadata, Protocol, ADD_FIELD, CDC_FIELD, COMMIT_INFO_NAME, LOG_ADD_SCHEMA, METADATA_FIELD,
+    PROTOCOL_FIELD, REMOVE_FIELD,
 };
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::{

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::Transaction;
-use crate::actions::{CommitInfo, LOG_COMMIT_INFO_SCHEMA, COMMIT_INFO_NAME};
+use crate::actions::{CommitInfo, COMMIT_INFO_NAME, LOG_COMMIT_INFO_SCHEMA};
 use crate::expressions::{MapData, Scalar};
 use crate::schema::{schema_ref, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
@@ -114,9 +114,7 @@ impl<S> Transaction<S> {
                 )?;
                 evaluator.evaluate(engine_commit_info.as_ref())
             }
-            None => {
-                kernel_commit_info.into_engine_data(LOG_COMMIT_INFO_SCHEMA.clone(), engine)
-            }
+            None => kernel_commit_info.into_engine_data(LOG_COMMIT_INFO_SCHEMA.clone(), engine),
         }
     }
 }

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::Transaction;
-use crate::actions::{get_log_commit_info_schema, CommitInfo, COMMIT_INFO_NAME};
+use crate::actions::{CommitInfo, LOG_COMMIT_INFO_SCHEMA, COMMIT_INFO_NAME};
 use crate::expressions::{MapData, Scalar};
 use crate::schema::{schema_ref, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
@@ -104,7 +104,7 @@ impl<S> Transaction<S> {
 
                 // Step 3: Wrap the patch in a struct expression so the output matches the
                 // Delta log action format `{ "commitInfo": { merged fields... } }`, consistent
-                // with the None branch which uses `get_log_commit_info_schema()`.
+                // with the None branch which uses `LOG_COMMIT_INFO_SCHEMA`.
                 let wrapped_expr = Expression::struct_from([patch]);
                 let wrapped_schema = schema_ref! { nullable (COMMIT_INFO_NAME): (output_schema) };
                 let evaluator = engine.evaluation_handler().new_expression_evaluator(
@@ -115,7 +115,7 @@ impl<S> Transaction<S> {
                 evaluator.evaluate(engine_commit_info.as_ref())
             }
             None => {
-                kernel_commit_info.into_engine_data(get_log_commit_info_schema().clone(), engine)
+                kernel_commit_info.into_engine_data(LOG_COMMIT_INFO_SCHEMA.clone(), engine)
             }
         }
     }
@@ -243,7 +243,7 @@ mod tests {
     }
 
     /// no engine_commit_info -- output is the kernel CommitInfo wrapped in a "commitInfo"
-    /// outer struct, matching the Delta log action format produced by `get_log_commit_info_schema`.
+    /// outer struct, matching the Delta log action format produced by `LOG_COMMIT_INFO_SCHEMA`.
     #[test]
     fn test_build_commit_info_none_branch() -> DeltaResult<()> {
         let (engine, txn) = make_txn(None)?;

--- a/kernel/src/transaction/domain_metadata.rs
+++ b/kernel/src/transaction/domain_metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::{EngineDataResultIterator, Transaction};
-use crate::actions::{get_log_domain_metadata_schema, DomainMetadata, INTERNAL_DOMAIN_PREFIX};
+use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA, INTERNAL_DOMAIN_PREFIX};
 use crate::error::Error;
 use crate::row_tracking::{RowTrackingDomainMetadata, ROW_TRACKING_DOMAIN_NAME};
 use crate::table_features::TableFeature;
@@ -222,7 +222,7 @@ impl<S> Transaction<S> {
             .chain(removal_actions)
             .collect();
 
-        let schema = get_log_domain_metadata_schema().clone();
+        let schema = LOG_DOMAIN_METADATA_SCHEMA.clone();
 
         let dm_actions_iter: Vec<_> = dm_actions_vec
             .iter()

--- a/kernel/src/transaction/domain_metadata.rs
+++ b/kernel/src/transaction/domain_metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use super::{EngineDataResultIterator, Transaction};
-use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA, INTERNAL_DOMAIN_PREFIX};
+use crate::actions::{DomainMetadata, INTERNAL_DOMAIN_PREFIX, LOG_DOMAIN_METADATA_SCHEMA};
 use crate::error::Error;
 use crate::row_tracking::{RowTrackingDomainMetadata, ROW_TRACKING_DOMAIN_NAME};
 use crate::table_features::TableFeature;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -40,7 +40,7 @@ use crate::schema::void_utils::{add_void_stripping, validate_schema_for_write};
 #[cfg(feature = "column-defaults-in-dev")]
 use crate::schema::ColumnDefault;
 use crate::schema::{
-    schema_ref, ArrayType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType,
+    lazy_schema_ref, ArrayType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType,
 };
 use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::struct_patch::ProjectionStructPatchBuilder;
@@ -89,14 +89,12 @@ pub(crate) type EngineDataResultIterator<'a> =
 
 /// The static instance referenced by [`add_files_schema`] that doesn't contain the dataChange
 /// column.
-pub(crate) static MANDATORY_ADD_FILE_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        not_null "path": STRING,
-        not_null "partitionValues": { STRING => nullable STRING },
-        not_null "size": LONG,
-        not_null "modificationTime": LONG,
-    }
-});
+pub(crate) static MANDATORY_ADD_FILE_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    not_null "path": STRING,
+    not_null "partitionValues": { STRING => nullable STRING },
+    not_null "size": LONG,
+    not_null "modificationTime": LONG,
+};
 
 /// Returns a reference to the mandatory fields in an add action.
 ///
@@ -118,21 +116,19 @@ pub(crate) fn mandatory_add_file_schema() -> &'static SchemaRef {
 /// The nested structures within nullCount/minValues/maxValues depend on the table's data schema
 /// and which columns have statistics enabled. Use [`Transaction::stats_schema`] to get the
 /// expected stats schema for a specific table.
-pub(crate) static BASE_ADD_FILES_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    schema_ref! {
-        ..(mandatory_add_file_schema().fields().cloned()),
-        nullable "stats": {
-            nullable NUM_RECORDS: LONG,
-            // nullCount, minValues, maxValues are dynamic based on data schema. Empty struct
-            // placeholders indicate these fields exist but their inner structure depends on the
-            // table schema and stats column configuration.
-            nullable NULL_COUNT: {},
-            nullable MIN_VALUES: {},
-            nullable MAX_VALUES: {},
-            nullable TIGHT_BOUNDS: BOOLEAN,
-        },
-    }
-});
+pub(crate) static BASE_ADD_FILES_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    ..(mandatory_add_file_schema().fields().cloned()),
+    nullable "stats": {
+        nullable NUM_RECORDS: LONG,
+        // nullCount, minValues, maxValues are dynamic based on data schema. Empty struct
+        // placeholders indicate these fields exist but their inner structure depends on the
+        // table schema and stats column configuration.
+        nullable NULL_COUNT: {},
+        nullable MIN_VALUES: {},
+        nullable MAX_VALUES: {},
+        nullable TIGHT_BOUNDS: BOOLEAN,
+    },
+};
 
 static DATA_CHANGE_COLUMN: LazyLock<StructField> =
     LazyLock::new(|| StructField::not_null("dataChange", DataType::BOOLEAN));
@@ -1762,7 +1758,7 @@ mod tests {
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
-    use crate::schema::MapType;
+    use crate::schema::{schema_ref, MapType};
     use crate::table_features::ColumnMappingMode;
     use crate::transaction::create_table::create_table;
     use crate::transaction::data_layout::DataLayout;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -9,9 +9,9 @@ use delta_kernel_derive::internal_api;
 use tracing::{info, instrument};
 
 use crate::actions::{
-    as_log_add_schema, get_commit_schema, get_log_remove_schema, get_log_txn_schema, CommitInfo,
-    DomainMetadata, Metadata, Protocol, SetTransaction, MAX_VALUES, METADATA_NAME, MIN_VALUES,
-    NULL_COUNT, NUM_RECORDS, PROTOCOL_NAME, TIGHT_BOUNDS,
+    as_log_add_schema, CommitInfo, DomainMetadata, Metadata, Protocol, SetTransaction,
+    LOG_METADATA_SCHEMA, LOG_PROTOCOL_SCHEMA, LOG_REMOVE_SCHEMA, LOG_TXN_SCHEMA, MAX_VALUES,
+    MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use crate::committer::{
     CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType, Committer,
@@ -427,7 +427,7 @@ impl<S> Transaction<S> {
             .set_transactions
             .clone()
             .into_iter()
-            .map(|txn| txn.into_engine_data(get_log_txn_schema().clone(), engine));
+            .map(|txn| txn.into_engine_data(LOG_TXN_SCHEMA.clone(), engine));
 
         // Step 2: Construct commit info with ICT if enabled
         let in_commit_timestamp = self.get_in_commit_timestamp(engine)?;
@@ -443,7 +443,7 @@ impl<S> Transaction<S> {
         // Step 3: Generate Protocol and Metadata actions based on emit flags
         let (protocol_action, protocol) = if self.should_emit_protocol {
             let protocol = self.effective_table_config.protocol().clone();
-            let schema = get_commit_schema().project(&[PROTOCOL_NAME])?;
+            let schema = LOG_PROTOCOL_SCHEMA.clone();
             let action = protocol.clone().into_engine_data(schema, engine)?;
             (Some(action), Some(protocol))
         } else {
@@ -451,7 +451,7 @@ impl<S> Transaction<S> {
         };
         let (metadata_action, metadata) = if self.should_emit_metadata {
             let metadata = self.effective_table_config.metadata().clone();
-            let schema = get_commit_schema().project(&[METADATA_NAME])?;
+            let schema = LOG_METADATA_SCHEMA.clone();
             let action = metadata.clone().into_engine_data(schema, engine)?;
             (Some(action), Some(metadata))
         } else {
@@ -1492,7 +1492,7 @@ impl<S> Transaction<S> {
         }
 
         let input_schema = scan_row_schema();
-        let target_schema = schema_with_all_fields_nullable(get_log_remove_schema());
+        let target_schema = schema_with_all_fields_nullable(&LOG_REMOVE_SCHEMA);
         let evaluation_handler = engine.evaluation_handler();
 
         let make_eval = |coalesce_stats_with_parsed: bool| -> DeltaResult<_> {

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
-use crate::actions::{get_log_add_schema, NUM_RECORDS, TIGHT_BOUNDS};
+use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::committer::Committer;
 use crate::engine_data::{
     FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, TypedGetData,
@@ -410,7 +410,7 @@ fn nullable_restored_add_schema() -> &'static SchemaRef {
 /// Schema for add actions that is nullable for use in transforms as as a workaround to avoid issues
 /// with null values in required fields that aren't selected.
 static NULLABLE_ADD_LOG_SCHEMA: LazyLock<SchemaRef> =
-    LazyLock::new(|| schema_with_all_fields_nullable(get_log_add_schema()).into());
+    LazyLock::new(|| schema_with_all_fields_nullable(&LOG_ADD_SCHEMA).into());
 
 /// Returns the schema for nullable restored add actions with dataChange field.
 /// This schema extends the nullable restored add schema with a dataChange boolean field

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -168,7 +168,7 @@ pub use counting_reporter::{
     CapturingReporter, CountingReporter, RelaxedCounter,
 };
 use delta_kernel::actions::{
-    get_log_add_schema, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
+    LOG_ADD_SCHEMA, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
 use delta_kernel::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray,
@@ -1380,7 +1380,7 @@ pub fn read_add_infos(
     snapshot: &Snapshot,
     engine: &impl Engine,
 ) -> Result<Vec<AddInfo>, Box<dyn std::error::Error>> {
-    let schema = get_log_add_schema().clone();
+    let schema = LOG_ADD_SCHEMA.clone();
     let batches = snapshot.log_segment().read_actions(engine, schema)?;
     let mut actions = Vec::new();
     for batch_result in batches {


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `schema!` family of macros makes it really easy to create new schemas, including from existing fields... but a caller who wants e.g. `add` field in their schema has to either create it from scratch from `ADD_NAME` and `Add::to_schema()`, or `project` it out of a schema that already has it. Both are super annoying.

To simplify things, define e.g. `ADD_FIELD` which everyone can use, and expand the schema macros so they can accept not just owned `StructField`, but also `&StructField` and `&LazyLock<StructField>`. Justification: somebody creating a new schema has stated intent, so silently cloning the field is not just acceptable, but a welcome courtesy.

While we're at it, define and use a new `lazy_schema_ref!` macro so that this:
```rust
let FOO_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
    schema_ref! {
        ...
    }
});
```
Simplifies to just
```rust
let FOO_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
    ...
};
```

### This PR affects the following public APIs

Removed a bunch of silly `#[internal_api]` methods as no longer necessary.

## How was this change tested?

Existing unit tests.