### PR TITLE
docs: recommend TestTableBuilder for integration test setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,13 +113,15 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
   for a catalog of available test tables (schema, protocol, features, and which tests use
   them). Consult it before creating new test data to avoid duplication.
 - **Consider `TestTableBuilder` (`test_utils::table_builder`) to build the table under test.**
-  When a test needs a Delta table in a specific state -- a given set of features, a partitioned
-  or clustered layout, checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or
-  post-cleanup logs -- the builder is often a good fit, composing these axes (`LogState x
-  FeatureSet x DataLayoutConfig x TableConfig`) through the real kernel write path so the table
-  is protocol-correct by construction. Load a snapshot at any `VersionTarget` with the
-  `build_snapshot!` macro. For coverage across many table states, the `default_sweep`
-  cross-product template (or a per-axis template with your own `#[values]`) can help; see
+  Unlike `create_table`, which produces an empty table (just `00.json`) with a given set of
+  features and data layout, the builder *builds up* a multi-version table: data files written
+  across many commits, plus checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or
+  post-cleanup logs. So when a test needs a populated table history in a specific state, the
+  builder is often a good fit, composing these axes (`LogState x FeatureSet x DataLayoutConfig x
+  TableConfig`) through the real kernel write path so the table is protocol-correct by
+  construction. Load a snapshot at any `VersionTarget` with the `build_snapshot!` macro. For
+  coverage across many table states, the `default_sweep` cross-product template (or a per-axis
+  template with your own `#[values]`) can help; see
   `kernel/tests/integration/cross_product/mod.rs`. Drop to lower-level setup like
   `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) only when necessary --
   e.g. for states the builder cannot express, such as corrupt or malformed logs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,11 +117,13 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
   features and data layout, the builder *builds up* a multi-version table: data files written
   across many commits, plus checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or
   post-cleanup logs. So when a test needs a populated table history in a specific state, the
-  builder is often a good fit, composing these axes (`LogState x FeatureSet x DataLayoutConfig x
-  TableConfig`) through the real kernel write path so the table is protocol-correct by
+  builder is often a good fit, composing `LogState`, `FeatureSet`, `DataLayoutConfig`, and
+  `TableConfig` through the real kernel write path so the table is protocol-correct by
   construction. Load a snapshot at any `VersionTarget` with the `build_snapshot!` macro. For
-  coverage across many table states, the `default_sweep` cross-product template (or a per-axis
-  template with your own `#[values]`) can help; see
+  coverage across many table states, the `default_sweep` cross-product template
+  (`LogState x FeatureSet x (DataLayoutConfig, TableConfig) x VersionTarget` -- data layout and
+  table config are bundled into one axis to avoid a cartesian explosion), or a per-axis template
+  with your own `#[values]`, can help; see
   `kernel/tests/integration/cross_product/mod.rs`. Drop to lower-level setup like
   `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) only when necessary --
   e.g. for states the builder cannot express, such as corrupt or malformed logs.
@@ -195,9 +197,10 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 **Table creation in tests**
 
 - `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand) -- worth
-  considering for a table in a specific state: composes `LogState x FeatureSet x
-  DataLayoutConfig x TableConfig` through the real write path. Pair with the `build_snapshot!`
-  macro and, for broad coverage, the `default_sweep` template. See the Testing section above.
+  considering for a table in a specific state: composes `LogState`, `FeatureSet`,
+  `DataLayoutConfig`, and `TableConfig` through the real write path. Pair with the
+  `build_snapshot!` macro and, for broad coverage, the `default_sweep` template. See the Testing
+  section above.
 - Prefer the kernel `create_table` builder
   (`delta_kernel::transaction::create_table::create_table`) when you need a single bespoke
   table rather than the builder's composed states. It exercises the same path connectors use

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,17 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
 - **Integration tests** exercise only public APIs end-to-end. See `kernel/tests/README.md`
   for a catalog of available test tables (schema, protocol, features, and which tests use
   them). Consult it before creating new test data to avoid duplication.
+- **STRONGLY prefer `TestTableBuilder` (`test_utils::table_builder`) to build the table under
+  test.** Whenever a test needs a Delta table in a specific state -- a given set of features,
+  a partitioned or clustered layout, checkpoints, CRC files, a stale/missing `_last_checkpoint`
+  hint, or post-cleanup logs -- reach for the builder before hand-rolling commits. It composes
+  these axes (`LogState x FeatureSet x DataLayoutConfig x TableConfig`) through the real kernel
+  write path, so the table is protocol-correct by construction. Load a snapshot at any
+  `VersionTarget` with the `build_snapshot!` macro. For coverage across many table states, apply
+  the `default_sweep` cross-product template (or a per-axis template with your own `#[values]`);
+  see `kernel/tests/integration/cross_product/mod.rs`. Drop to hand-rolled `add_commit` /
+  `LocalMockTable` only for states the builder cannot yet express (e.g. corrupt or malformed
+  logs) -- and prefer extending the builder over duplicating setup.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific
@@ -181,9 +192,14 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 
 **Table creation in tests**
 
+- `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand) -- the
+  default choice for a table in a specific state: composes `LogState x FeatureSet x
+  DataLayoutConfig x TableConfig` through the real write path. Pair with the `build_snapshot!`
+  macro and, for broad coverage, the `default_sweep` template. See the Testing section above.
 - Prefer the kernel `create_table` builder
-  (`delta_kernel::transaction::create_table::create_table`). It exercises the same path
-  connectors use and auto-derives the protocol from the schema and feature flags.
+  (`delta_kernel::transaction::create_table::create_table`) when you need a single bespoke
+  table rather than the builder's composed states. It exercises the same path connectors use
+  and auto-derives the protocol from the schema and feature flags.
 - `test_utils::create_table` (a JSON helper that hand-rolls protocol + metadata) is older
   but still needed when the kernel builder cannot enable a particular feature combination.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,17 +112,16 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
 - **Integration tests** exercise only public APIs end-to-end. See `kernel/tests/README.md`
   for a catalog of available test tables (schema, protocol, features, and which tests use
   them). Consult it before creating new test data to avoid duplication.
-- **STRONGLY prefer `TestTableBuilder` (`test_utils::table_builder`) to build the table under
-  test.** Whenever a test needs a Delta table in a specific state -- a given set of features,
-  a partitioned or clustered layout, checkpoints, CRC files, a stale/missing `_last_checkpoint`
-  hint, or post-cleanup logs -- reach for the builder before hand-rolling commits. It composes
-  these axes (`LogState x FeatureSet x DataLayoutConfig x TableConfig`) through the real kernel
-  write path, so the table is protocol-correct by construction. Load a snapshot at any
-  `VersionTarget` with the `build_snapshot!` macro. For coverage across many table states, apply
-  the `default_sweep` cross-product template (or a per-axis template with your own `#[values]`);
-  see `kernel/tests/integration/cross_product/mod.rs`. Drop to hand-rolled `add_commit` /
-  `LocalMockTable` only for states the builder cannot yet express (e.g. corrupt or malformed
-  logs) -- and prefer extending the builder over duplicating setup.
+- **Consider `TestTableBuilder` (`test_utils::table_builder`) to build the table under test.**
+  When a test needs a Delta table in a specific state -- a given set of features, a partitioned
+  or clustered layout, checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or
+  post-cleanup logs -- the builder is often a good fit, composing these axes (`LogState x
+  FeatureSet x DataLayoutConfig x TableConfig`) through the real kernel write path so the table
+  is protocol-correct by construction. Load a snapshot at any `VersionTarget` with the
+  `build_snapshot!` macro. For coverage across many table states, the `default_sweep`
+  cross-product template (or a per-axis template with your own `#[values]`) can help; see
+  `kernel/tests/integration/cross_product/mod.rs`. For states the builder cannot express (e.g.
+  corrupt or malformed logs), hand-rolled `add_commit` / `LocalMockTable` remain available.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific
@@ -192,8 +191,8 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 
 **Table creation in tests**
 
-- `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand) -- the
-  default choice for a table in a specific state: composes `LogState x FeatureSet x
+- `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand) -- worth
+  considering for a table in a specific state: composes `LogState x FeatureSet x
   DataLayoutConfig x TableConfig` through the real write path. Pair with the `build_snapshot!`
   macro and, for broad coverage, the `default_sweep` template. See the Testing section above.
 - Prefer the kernel `create_table` builder

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,9 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
   is protocol-correct by construction. Load a snapshot at any `VersionTarget` with the
   `build_snapshot!` macro. For coverage across many table states, the `default_sweep`
   cross-product template (or a per-axis template with your own `#[values]`) can help; see
-  `kernel/tests/integration/cross_product/mod.rs`. For states the builder cannot express (e.g.
-  corrupt or malformed logs), hand-rolled `add_commit` / `LocalMockTable` remain available.
+  `kernel/tests/integration/cross_product/mod.rs`. Drop to lower-level setup like
+  `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) only when necessary --
+  e.g. for states the builder cannot express, such as corrupt or malformed logs.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updates the `Testing` guidance in `CLAUDE.md` to suggest `TestTableBuilder` (`test_utils::table_builder`) when a test needs a Delta table in a specific state, rather than hand-rolling commits.

- Adds a bullet in the `Testing` section suggesting the builder for feature sets, partitioned/clustered layouts, checkpoints, CRC files, hint states, and post-cleanup logs; loading snapshots via `build_snapshot!`; and `default_sweep` for broad coverage. Notes that lower-level setup like `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) is the fallback for states the builder cannot express, such as corrupt or malformed logs.
- Adds `TestTableBuilder` as the leading entry under **Common test helpers -> Table creation in tests**, and clarifies when to reach for the kernel `create_table` builder instead.

Docs-only; no code changes.

## How was this change tested?

N/A (documentation only).
