### PR TITLE
feat(metrics): add snapshot-load event fields + enums (events layer)

### DIFF
--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -312,6 +312,8 @@ impl MetricEvent {
                 num_compaction_files,
                 has_latest_crc_file,
                 duration,
+                // Not yet exposed over FFI (prototype); see snapshot_metrics_consistency_v0.
+                load_purpose: _,
             }) => Self::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -326,6 +328,7 @@ impl MetricEvent {
                 operation_id,
                 correlation_id,
                 table_type,
+                load_purpose: _,
             }) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -336,6 +339,10 @@ impl MetricEvent {
                 correlation_id,
                 table_type,
                 duration,
+                // Not yet exposed over FFI (prototype); see snapshot_metrics_consistency_v0.
+                source: _,
+                num_commits_replayed_for_pm: _,
+                bytes_read_for_pm: _,
             }) => Self::ProtocolMetadataLoadSuccess(ProtocolMetadataLoadSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -357,6 +364,8 @@ impl MetricEvent {
                 table_type,
                 version,
                 duration,
+                // Not yet exposed over FFI (prototype); see snapshot_metrics_consistency_v0.
+                load_type: _,
             }) => Self::SnapshotBuildSuccess(SnapshotBuildSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -368,6 +377,7 @@ impl MetricEvent {
                 operation_id,
                 correlation_id,
                 table_type,
+                load_type: _,
             }) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -691,6 +701,7 @@ mod tests {
             num_compaction_files: 2,
             has_latest_crc_file: true,
             duration: Duration::from_nanos(61),
+            load_purpose: kernel::LogSegmentLoadPurpose::Snapshot,
         });
         with_ffi_event(&event, |ffi| {
             let MetricEvent::LogSegmentLoadSuccess(e) = ffi else {
@@ -720,6 +731,7 @@ mod tests {
             num_compaction_files: 0,
             has_latest_crc_file: false,
             duration: Duration::from_nanos(0),
+            load_purpose: kernel::LogSegmentLoadPurpose::IncrementalSnapshot,
         });
         with_ffi_event(&event, |ffi| {
             let MetricEvent::LogSegmentLoadSuccess(e) = ffi else {

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -37,6 +37,7 @@ mod domain_metadata_replay;
 mod protocol_metadata_replay;
 
 pub(crate) use domain_metadata_replay::DomainMetadataMap;
+pub(crate) use protocol_metadata_replay::PmReplayWork;
 
 #[cfg(test)]
 mod crc_tests;

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -11,8 +11,6 @@ use super::LogSegment;
 use crate::actions::{Metadata, Protocol, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
-use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
-use crate::metrics::SnapshotLoadMetricContext;
 use crate::schema::schema_ref;
 use crate::{DeltaResult, Engine, Error};
 
@@ -23,13 +21,13 @@ impl LogSegment {
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
     /// snapshot creation where both Protocol and Metadata must exist.
     ///
-    /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, crc))]
+    /// The `ProtocolMetadataLoad` metric is emitted by the snapshot layer (which owns the source
+    /// classification), not here, so it fires uniformly across the CRC-served and log-replay
+    /// branches on both the fresh and incremental paths.
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-        metric_context: SnapshotLoadMetricContext,
     ) -> DeltaResult<(Metadata, Protocol)> {
         match self.read_protocol_metadata_opt(engine, crc)? {
             (Some(m), Some(p)) => Ok((m, p)),
@@ -130,6 +128,42 @@ impl LogSegment {
         };
         self.read_actions(engine, schema)
     }
+
+    /// The work a P&M replay over commits `> lo_exclusive` covers: the number of commit files and
+    /// their summed on-disk bytes. When `include_checkpoint` is set (a full replay with no seeding
+    /// CRC), the checkpoint parts' bytes and counts are added, since the replay reads the
+    /// checkpoint too.
+    ///
+    /// These are the normalization denominators for [`ProtocolMetadataLoadSuccess`]. Bytes are an
+    /// upper bound on bytes actually decoded: row-group skipping and early termination can skip
+    /// data, and sidecars (not listed in the segment) are excluded.
+    pub(crate) fn pm_replay_work(
+        &self,
+        lo_exclusive: Option<crate::Version>,
+        include_checkpoint: bool,
+    ) -> PmReplayWork {
+        let above_lo = |v: crate::Version| lo_exclusive.is_none_or(|lo| lo < v);
+        let mut work = PmReplayWork::default();
+        for commit in &self.listed.ascending_commit_files {
+            if above_lo(commit.version) {
+                work.num_commits += 1;
+                work.bytes += commit.location.size;
+            }
+        }
+        if include_checkpoint {
+            for part in &self.listed.checkpoint_parts {
+                work.bytes += part.location.size;
+            }
+        }
+        work
+    }
+}
+
+/// Commit count and on-disk byte volume a P&M replay covered. See [`LogSegment::pm_replay_work`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PmReplayWork {
+    pub(crate) num_commits: u64,
+    pub(crate) bytes: u64,
 }
 
 #[cfg(test)]

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -320,8 +320,7 @@ impl fmt::Display for MetricEvent {
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
 /// Which caller loaded the log segment. A single `LogSegmentLoad` metric slices by this label so
-/// fresh and incremental snapshot loads (and, in the future, other segment loaders) share one
-/// metric definition instead of re-declaring file-count denominators per caller.
+/// fresh and incremental snapshot loads share one metric definition.
 ///
 /// Serializes to its `snake_case` name for the `load_purpose` span field.
 #[derive(
@@ -524,13 +523,10 @@ pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
 /// Where a snapshot's Protocol and Metadata came from during load.
 ///
-/// Note: on the CRC branches the load resolves more than P&M (file stats, domain metadata, set
-/// transactions, ICT are carried by the CRC); the event is named for the always-present P&M part.
-///
 /// The `Crc*` split reflects that a stale base CRC produces two different outcomes depending on the
 /// [`IncrementalReplay`] budget: `CrcAdvancedByReplay` reverse-replays commits to advance the CRC
 /// (yielding a warm, full-state snapshot), while `CrcSeededPmOnlyReplay` forward-replays only P&M
-/// columns (a cold snapshot with no cached stats/DM/txn). We record the outcome, not the budget.
+/// columns (a cold snapshot with no cached stats/DM/txn).
 ///
 /// Serializes to its `snake_case` name for the `pm_source` span field.
 ///
@@ -557,7 +553,12 @@ pub enum ProtocolMetadataSource {
 }
 
 impl ProtocolMetadataSource {
+    /// Empty means the field was not set (the failure-emit path leaves it `Empty`, since the event
+    /// is flipped to its failure counterpart which drops the source); a non-empty unknown warns.
     fn parse_lenient(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::FullReplay;
+        }
         Self::from_str(s).unwrap_or_else(|e| {
             warn!("Invalid pm_source '{s}' on span: {e}. Using FullReplay.");
             Self::FullReplay

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -568,9 +568,9 @@ impl ProtocolMetadataSource {
 /// Protocol and metadata actions were resolved for a snapshot, from a CRC and/or log replay.
 ///
 /// Emit-based (like [`ScanMetadataCompleted`]): the snapshot layer classifies the `source`,
-/// measures the `duration`, and sums the replay denominators, then fires the event via
-/// [`emit_protocol_metadata_load`]. `num_commits_replayed_for_pm` and `bytes_read_for_pm` are the
-/// work denominators; both are zero when P&M is served from a cache (`CrcAtTarget`,
+/// measures the `duration`, and sums the replay denominators, then fires the event via an
+/// internal emit helper. `num_commits_replayed_for_pm` and `bytes_read_for_pm` are the work
+/// denominators; both are zero when P&M is served from a cache (`CrcAtTarget`,
 /// `InheritedFromExisting`).
 ///
 /// `bytes_read_for_pm` is the on-disk size of the files the replay covered (commits, plus

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -117,16 +117,16 @@ impl MetricEvent {
         match self {
             // Lifecycle success: duration must be set by the tracing layer on span close.
             Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
-            Self::ProtocolMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SnapshotBuildSuccess(e) => e.set_duration(d),
             Self::TransactionCommitSuccess(e) => e.set_duration(d),
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
 
-            // For now, failure events carry no duration; storage/scan events set it at
-            // construction; read events have no duration field.
-            Self::LogSegmentLoadFailure(_)
+            // For now, failure events carry no duration; storage/scan/protocol-metadata events
+            // set it at construction (emit-based); read events have no duration field.
+            Self::ProtocolMetadataLoadSuccess(_)
+            | Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
             | Self::TransactionCommitFailure(_)
@@ -235,6 +235,7 @@ impl MetricEvent {
                 operation_id: e.operation_id,
                 table_type: e.table_type,
                 correlation_id: e.correlation_id,
+                load_purpose: e.load_purpose,
             }),
             Self::ProtocolMetadataLoadSuccess(e) => {
                 Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
@@ -247,6 +248,7 @@ impl MetricEvent {
                 operation_id: e.operation_id,
                 table_type: e.table_type,
                 correlation_id: e.correlation_id,
+                load_type: e.load_type,
             }),
             Self::TransactionCommitSuccess(e) => {
                 Self::TransactionCommitFailure(TransactionCommitFailure {
@@ -317,6 +319,38 @@ impl fmt::Display for MetricEvent {
 // not a multi-segment path like `Type::SPAN_NAME`.
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
+/// Which caller loaded the log segment. A single `LogSegmentLoad` metric slices by this label so
+/// fresh and incremental snapshot loads (and, in the future, other segment loaders) share one
+/// metric definition instead of re-declaring file-count denominators per caller.
+///
+/// Serializes to its `snake_case` name for the `load_purpose` span field.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum LogSegmentLoadPurpose {
+    /// A fresh snapshot build listed the segment from scratch (`Snapshot::builder_for`).
+    #[default]
+    Snapshot,
+    /// An incremental snapshot update re-listed the tail on top of an existing snapshot
+    /// (`Snapshot::builder_from`).
+    IncrementalSnapshot,
+}
+
+impl LogSegmentLoadPurpose {
+    /// Empty means the field was not set (fresh `#[instrument]` path, which defaults to
+    /// `Snapshot`); a non-empty unknown value warns.
+    fn parse_lenient(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::Snapshot;
+        }
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid load_purpose '{s}' on span: {e}. Using Snapshot.");
+            Self::Snapshot
+        })
+    }
+}
+
 /// A log segment was listed and assembled for a snapshot.
 #[derive(Debug, Clone)]
 pub struct LogSegmentLoadSuccess {
@@ -326,14 +360,17 @@ pub struct LogSegmentLoadSuccess {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    /// Which caller loaded the segment. On the fresh path this is set on span creation; on the
+    /// emit-based incremental path it is carried as a creation attr.
+    pub load_purpose: LogSegmentLoadPurpose,
 
-    // === Set during span lifetime ===
+    // === Set during span lifetime (fresh path) or on creation (emit-based incremental path) ===
     pub num_commit_files: u64,
     pub num_checkpoint_files: u64,
     pub num_compaction_files: u64,
     pub has_latest_crc_file: bool,
 
-    // === Set on span close ===
+    // === Set on span close (fresh path) or on creation (emit-based incremental path) ===
     pub duration: Duration,
 }
 
@@ -342,16 +379,23 @@ impl LogSegmentLoadSuccess {
 
     /// Construction-time channel. Extracts fields bound at span creation via
     /// `#[instrument(fields(X = expr))]` or `tracing::span!(..., X = expr)`.
+    ///
+    /// The count/duration fields read here so the emit-based incremental path can pass them as
+    /// creation attrs; on the fresh `#[instrument]` path they are absent at creation (default 0)
+    /// and filled later via `record_u64` / span-close duration.
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
+        let mut v = LogSegmentLoadAttrs::default();
+        attrs.record(&mut v);
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             correlation_id: correlation_id_from_attrs(attrs),
-            num_commit_files: 0,
-            num_checkpoint_files: 0,
-            num_compaction_files: 0,
-            has_latest_crc_file: false,
-            duration: Duration::default(),
+            load_purpose: LogSegmentLoadPurpose::parse_lenient(&v.load_purpose),
+            num_commit_files: v.num_commit_files,
+            num_checkpoint_files: v.num_checkpoint_files,
+            num_compaction_files: v.num_compaction_files,
+            has_latest_crc_file: v.has_latest_crc_file,
+            duration: Duration::from_nanos(v.duration_ns),
         }
     }
 
@@ -375,8 +419,15 @@ impl LogSegmentLoadSuccess {
         Ok(())
     }
 
+    /// Set the wall-clock duration from the span's `on_close`. Only fills a still-zero duration:
+    /// the emit-based incremental path provides its own duration as a creation attr, and the
+    /// near-zero `on_close` elapsed of an immediately-dropped emit span must not clobber it. The
+    /// fresh `#[instrument]` path has no creation-attr duration (starts at zero) and is filled
+    /// here.
     pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
+        if self.duration.is_zero() {
+            self.duration = d;
+        }
     }
 }
 
@@ -386,6 +437,7 @@ impl fmt::Display for LogSegmentLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            load_purpose,
             duration,
             num_commit_files,
             num_checkpoint_files,
@@ -395,12 +447,51 @@ impl fmt::Display for LogSegmentLoadSuccess {
         write!(
             f,
             "LogSegmentLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, \
+             correlation_id={correlation_id:?}, load_purpose={load_purpose}, \
              duration={duration:?}, commits={num_commit_files}, \
              checkpoints={num_checkpoint_files}, compactions={num_compaction_files}, \
              has_latest_crc={has_latest_crc_file})"
         )
     }
+}
+
+/// Shared attribute decoder for `LogSegmentLoadSuccess`. The fresh `#[instrument]` path leaves the
+/// count/duration fields as `Empty` at creation (they arrive via `record_u64` / span close), so
+/// they default to zero here; the emit-based incremental path binds them as real creation attrs.
+#[derive(Default)]
+struct LogSegmentLoadAttrs {
+    load_purpose: String,
+    num_commit_files: u64,
+    num_checkpoint_files: u64,
+    num_compaction_files: u64,
+    has_latest_crc_file: bool,
+    duration_ns: u64,
+}
+
+impl Visit for LogSegmentLoadAttrs {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "num_commit_files" => self.num_commit_files = value,
+            "num_checkpoint_files" => self.num_checkpoint_files = value,
+            "num_compaction_files" => self.num_compaction_files = value,
+            "duration_ns" => self.duration_ns = value,
+            _ => {}
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "has_latest_crc_file" {
+            self.has_latest_crc_file = value;
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "load_purpose" {
+            self.load_purpose = value.to_string();
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
 }
 
 /// Listing the log segment for a snapshot failed.
@@ -411,14 +502,16 @@ pub struct LogSegmentLoadFailure {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    /// Which caller attempted the load.
+    pub load_purpose: LogSegmentLoadPurpose,
 }
 
 impl fmt::Display for LogSegmentLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "LogSegmentLoadFailure(id={}, table_type={}, correlation_id={:?})",
-            self.operation_id, self.table_type, self.correlation_id
+            "LogSegmentLoadFailure(id={}, table_type={}, correlation_id={:?}, load_purpose={})",
+            self.operation_id, self.table_type, self.correlation_id, self.load_purpose
         )
     }
 }
@@ -429,17 +522,75 @@ impl fmt::Display for LogSegmentLoadFailure {
 
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
-/// Protocol and metadata actions were read from the log.
+/// Where a snapshot's Protocol and Metadata came from during load.
+///
+/// Note: on the CRC branches the load resolves more than P&M (file stats, domain metadata, set
+/// transactions, ICT are carried by the CRC); the event is named for the always-present P&M part.
+///
+/// The `Crc*` split reflects that a stale base CRC produces two different outcomes depending on the
+/// [`IncrementalReplay`] budget: `CrcAdvancedByReplay` reverse-replays commits to advance the CRC
+/// (yielding a warm, full-state snapshot), while `CrcSeededPmOnlyReplay` forward-replays only P&M
+/// columns (a cold snapshot with no cached stats/DM/txn). We record the outcome, not the budget.
+///
+/// Serializes to its `snake_case` name for the `pm_source` span field.
+///
+/// [`IncrementalReplay`]: crate::snapshot::IncrementalReplay
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum ProtocolMetadataSource {
+    /// A CRC already at the target version supplied P&M with zero replay.
+    CrcAtTarget,
+    /// A stale CRC was advanced to the target version by reverse-replaying commits, yielding a
+    /// full-state snapshot. P&M is a byproduct of the CRC advance.
+    CrcAdvancedByReplay,
+    /// A stale CRC seeded a forward, P&M-columns-only pruned replay of the commits above it (the
+    /// budget did not permit a full CRC advance). Cold snapshot: no cached stats/DM/txn.
+    CrcSeededPmOnlyReplay,
+    /// No usable CRC; full P&M log replay over the segment (commits + checkpoint).
+    #[default]
+    FullReplay,
+    /// Incremental update where the existing snapshot's P&M carried forward and the new commits
+    /// contributed no P&M change.
+    InheritedFromExisting,
+}
+
+impl ProtocolMetadataSource {
+    fn parse_lenient(s: &str) -> Self {
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid pm_source '{s}' on span: {e}. Using FullReplay.");
+            Self::FullReplay
+        })
+    }
+}
+
+/// Protocol and metadata actions were resolved for a snapshot, from a CRC and/or log replay.
+///
+/// Emit-based (like [`ScanMetadataCompleted`]): the snapshot layer classifies the `source`,
+/// measures the `duration`, and sums the replay denominators, then fires the event via
+/// [`emit_protocol_metadata_load`]. `num_commits_replayed_for_pm` and `bytes_read_for_pm` are the
+/// work denominators; both are zero when P&M is served from a cache (`CrcAtTarget`,
+/// `InheritedFromExisting`).
+///
+/// `bytes_read_for_pm` is the on-disk size of the files the replay covered (commits, plus
+/// checkpoint parts on `FullReplay`); it is an upper bound on bytes actually decoded, since
+/// row-group skipping and early termination can skip data. Sidecars are excluded (they are not
+/// listed in the segment). Bytes is the size-invariant normalization denominator.
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadSuccess {
-    // === Set on span creation ===
+    // === Set on span creation (emit-based: all fields are creation attrs) ===
     pub operation_id: MetricId,
     /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-
-    // === Set on span close ===
+    /// Where P&M came from.
+    pub source: ProtocolMetadataSource,
+    /// Commits read during the P&M replay. Zero on the cache-served sources.
+    pub num_commits_replayed_for_pm: u64,
+    /// On-disk bytes the P&M replay covered (normalization denominator). Zero on cache hits.
+    pub bytes_read_for_pm: u64,
     pub duration: Duration,
 }
 
@@ -447,16 +598,17 @@ impl ProtocolMetadataLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = PROTOCOL_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
+        let mut v = ProtocolMetadataLoadAttrs::default();
+        attrs.record(&mut v);
         Self {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             correlation_id: correlation_id_from_attrs(attrs),
-            duration: Duration::default(),
+            source: ProtocolMetadataSource::parse_lenient(&v.source),
+            num_commits_replayed_for_pm: v.num_commits_replayed_for_pm,
+            bytes_read_for_pm: v.bytes_read_for_pm,
+            duration: Duration::from_nanos(v.duration_ns),
         }
-    }
-
-    pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
     }
 }
 
@@ -466,17 +618,49 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            source,
+            num_commits_replayed_for_pm,
+            bytes_read_for_pm,
             duration,
         } = self;
         write!(
             f,
             "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, duration={duration:?})"
+             correlation_id={correlation_id:?}, source={source}, \
+             commits_replayed={num_commits_replayed_for_pm}, bytes={bytes_read_for_pm}, \
+             duration={duration:?})"
         )
     }
 }
 
-/// Reading protocol and metadata from the log failed.
+#[derive(Default)]
+struct ProtocolMetadataLoadAttrs {
+    source: String,
+    num_commits_replayed_for_pm: u64,
+    bytes_read_for_pm: u64,
+    duration_ns: u64,
+}
+
+impl Visit for ProtocolMetadataLoadAttrs {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "num_commits_replayed_for_pm" => self.num_commits_replayed_for_pm = value,
+            "bytes_read_for_pm" => self.bytes_read_for_pm = value,
+            "duration_ns" => self.duration_ns = value,
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "pm_source" {
+            self.source = value.to_string();
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+}
+
+/// Reading protocol and metadata for a snapshot failed.
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadFailure {
     pub operation_id: MetricId,
@@ -502,6 +686,33 @@ impl fmt::Display for ProtocolMetadataLoadFailure {
 
 pub(crate) const SNAPSHOT_COMPLETED_SPAN: &str = "snap.build";
 
+/// Whether a snapshot was built from scratch or as an incremental update of an existing snapshot.
+///
+/// Serializes to its `snake_case` name for the `load_type` span field.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum SnapshotLoadType {
+    /// Built from scratch by listing the log (`Snapshot::builder_for`).
+    #[default]
+    Fresh,
+    /// Built by updating an existing snapshot (`Snapshot::builder_from`).
+    Incremental,
+}
+
+impl SnapshotLoadType {
+    fn parse_lenient(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::Fresh;
+        }
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid load_type '{s}' on span: {e}. Using Fresh.");
+            Self::Fresh
+        })
+    }
+}
+
 /// A snapshot was built successfully.
 #[derive(Debug, Clone)]
 pub struct SnapshotBuildSuccess {
@@ -511,6 +722,8 @@ pub struct SnapshotBuildSuccess {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    /// Whether this was a fresh or incremental build.
+    pub load_type: SnapshotLoadType,
 
     // === Set during span lifetime ===
     pub version: u64,
@@ -527,6 +740,7 @@ impl SnapshotBuildSuccess {
             operation_id: MetricId::from_attrs(attrs),
             table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
             correlation_id: correlation_id_from_attrs(attrs),
+            load_type: SnapshotLoadType::parse_lenient(&read_load_type(attrs)),
             version: 0,
             duration: Duration::default(),
         }
@@ -551,15 +765,37 @@ impl fmt::Display for SnapshotBuildSuccess {
             operation_id,
             table_type,
             correlation_id,
+            load_type,
             version,
             duration,
         } = self;
         write!(
             f,
             "SnapshotBuildSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, version={version}, duration={duration:?})"
+             correlation_id={correlation_id:?}, load_type={load_type}, version={version}, \
+             duration={duration:?})"
         )
     }
+}
+
+/// The `load_type` string span field on the snapshot-build span. Empty means unset (defaults to
+/// `Fresh`).
+pub(crate) const LOAD_TYPE_FIELD: &str = "load_type";
+
+fn read_load_type(attrs: &Attributes<'_>) -> String {
+    #[derive(Default)]
+    struct V(String);
+    impl Visit for V {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == LOAD_TYPE_FIELD {
+                self.0 = value.to_string();
+            }
+        }
+        fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+    }
+    let mut v = V::default();
+    attrs.record(&mut v);
+    v.0
 }
 
 // ====================================================================
@@ -574,14 +810,16 @@ pub struct SnapshotBuildFailure {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    /// Whether this was a fresh or incremental build attempt.
+    pub load_type: SnapshotLoadType,
 }
 
 impl fmt::Display for SnapshotBuildFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SnapshotBuildFailure(id={}, table_type={}, correlation_id={:?})",
-            self.operation_id, self.table_type, self.correlation_id
+            "SnapshotBuildFailure(id={}, table_type={}, correlation_id={:?}, load_type={})",
+            self.operation_id, self.table_type, self.correlation_id, self.load_type
         )
     }
 }
@@ -1511,6 +1749,80 @@ pub fn emit_parquet_read_completed(num_files: u64, bytes_read: u64) {
         report = tracing::field::Empty,
         num_files,
         bytes_read,
+    );
+}
+
+/// Emit a successful [`MetricEvent::ProtocolMetadataLoadSuccess`] via a tracing span.
+///
+/// Emit-based: the snapshot layer classifies the source, measures the duration, and sums the
+/// replay denominators, then calls this once per snapshot load (all source branches, fresh and
+/// incremental).
+pub(crate) fn emit_protocol_metadata_load(
+    metric_context: &SnapshotLoadMetricContext,
+    source: ProtocolMetadataSource,
+    num_commits_replayed_for_pm: u64,
+    bytes_read_for_pm: u64,
+    duration: Duration,
+) {
+    let _span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %metric_context.operation_id,
+        is_catalog_managed = metric_context.is_catalog_managed,
+        correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""),
+        pm_source = source.as_ref(),
+        num_commits_replayed_for_pm,
+        bytes_read_for_pm,
+        duration_ns = duration.as_nanos() as u64,
+    );
+}
+
+/// Emit a [`MetricEvent::ProtocolMetadataLoadFailure`] via a tracing span.
+///
+/// The `error` field flips the span-close event to its failure counterpart, matching how
+/// `#[instrument(err)]` records failures on the instrument-based paths.
+pub(crate) fn emit_protocol_metadata_load_failure(metric_context: &SnapshotLoadMetricContext) {
+    let _span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %metric_context.operation_id,
+        is_catalog_managed = metric_context.is_catalog_managed,
+        correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""),
+        pm_source = tracing::field::Empty,
+        num_commits_replayed_for_pm = tracing::field::Empty,
+        bytes_read_for_pm = tracing::field::Empty,
+        duration_ns = tracing::field::Empty,
+        error = "protocol/metadata load failed",
+    );
+}
+
+/// Emit a [`MetricEvent::LogSegmentLoadSuccess`] via a tracing span, for callers that assemble a
+/// segment outside the instrumented `for_snapshot` path (e.g. the incremental snapshot update).
+/// The fresh path uses the `#[instrument]` on `LogSegment::for_snapshot` instead.
+pub(crate) fn emit_log_segment_load(
+    metric_context: &SnapshotLoadMetricContext,
+    load_purpose: LogSegmentLoadPurpose,
+    num_commit_files: u64,
+    num_checkpoint_files: u64,
+    num_compaction_files: u64,
+    has_latest_crc_file: bool,
+    duration: Duration,
+) {
+    let _span = tracing::span!(
+        tracing::Level::INFO,
+        LogSegmentLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %metric_context.operation_id,
+        is_catalog_managed = metric_context.is_catalog_managed,
+        correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""),
+        load_purpose = load_purpose.as_ref(),
+        num_commit_files,
+        num_checkpoint_files,
+        num_compaction_files,
+        has_latest_crc_file,
+        duration_ns = duration.as_nanos() as u64,
     );
 }
 

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1780,10 +1780,12 @@ pub(crate) fn emit_protocol_metadata_load(
 
 /// Emit a [`MetricEvent::ProtocolMetadataLoadFailure`] via a tracing span.
 ///
-/// The `error` field flips the span-close event to its failure counterpart, matching how
-/// `#[instrument(err)]` records failures on the instrument-based paths.
+/// Mirrors how `#[instrument(err)]` records failures: enter the span and emit an event carrying a
+/// debug-valued `error` field. The layer's `on_event` routes that field through the visitor's
+/// `record_debug`, flipping the stashed success event to its failure counterpart before the span
+/// closes.
 pub(crate) fn emit_protocol_metadata_load_failure(metric_context: &SnapshotLoadMetricContext) {
-    let _span = tracing::span!(
+    let span = tracing::span!(
         tracing::Level::INFO,
         ProtocolMetadataLoadSuccess::SPAN_NAME,
         report = tracing::field::Empty,
@@ -1794,7 +1796,11 @@ pub(crate) fn emit_protocol_metadata_load_failure(metric_context: &SnapshotLoadM
         num_commits_replayed_for_pm = tracing::field::Empty,
         bytes_read_for_pm = tracing::field::Empty,
         duration_ns = tracing::field::Empty,
-        error = "protocol/metadata load failed",
+    );
+    let _enter = span.enter();
+    tracing::info!(
+        error = tracing::field::debug("protocol/metadata load failed"),
+        "P&M load failed"
     );
 }
 

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1989,6 +1989,7 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: Some("snap-req-3".into()),
+            load_type: SnapshotLoadType::Fresh,
             version: 0,
             duration: Duration::default(),
         };

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -85,12 +85,16 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
-    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
-    SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadPurpose,
+    LogSegmentLoadSuccess, MetricEvent, MetricId, ParquetReadCompleted,
+    ProtocolMetadataLoadFailure, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+    ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess, SnapshotBuildFailure,
+    SnapshotBuildSuccess, SnapshotLoadMetricContext, SnapshotLoadType, StorageCopyCompleted,
     StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
     TransactionCommitSuccess,
+};
+pub(crate) use events::{
+    emit_log_segment_load, emit_protocol_metadata_load, emit_protocol_metadata_load_failure,
 };
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -756,6 +756,35 @@ mod tests {
         Ok(())
     }
 
+    #[test_log::test(tokio::test)]
+    async fn fresh_build_no_crc_emits_full_replay_protocol_metadata_load(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::metrics::ProtocolMetadataSource;
+
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?; // no CRC on disk
+
+        let (reporter, _guard) = measuring_reporter();
+        let _snap = SnapshotBuilder::new_for(table_root).build(engine.as_ref())?;
+
+        let pm = reporter
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("expected ProtocolMetadataLoadSuccess on a fresh no-CRC build");
+        assert_eq!(pm.source, ProtocolMetadataSource::FullReplay);
+        // A full replay reads commit files, so it covers a nonzero commit count and byte volume.
+        assert!(
+            pm.num_commits_replayed_for_pm > 0,
+            "expected commits replayed"
+        );
+        assert!(pm.bytes_read_for_pm > 0, "expected nonzero replay bytes");
+        Ok(())
+    }
+
     #[rstest::rstest]
     #[case::with_id(Some("req-abc-123"))]
     #[case::without_id(None)]

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -7,7 +7,7 @@ use tracing::{info, instrument};
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-use crate::metrics::{MetricId, SnapshotLoadMetricContext};
+use crate::metrics::{MetricId, SnapshotLoadMetricContext, SnapshotLoadType};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
@@ -214,7 +214,7 @@ impl SnapshotBuilder {
     #[instrument(
         name = SNAPSHOT_COMPLETED_SPAN,
         skip_all,
-        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %self.operation_id, is_catalog_managed = self.max_catalog_version.is_some(), correlation_id = self.correlation_id.as_deref().unwrap_or("")),
+        fields(path = %self.table_path(), report, version = tracing::field::Empty, operation_id = %self.operation_id, is_catalog_managed = self.max_catalog_version.is_some(), correlation_id = self.correlation_id.as_deref().unwrap_or(""), load_type = self.load_type_label()),
         err
     )]
     pub fn build(self, engine: &dyn Engine) -> DeltaResult<SnapshotRef> {
@@ -415,6 +415,17 @@ impl SnapshotBuilder {
                     .map(|s| s.table_root().as_str())
             })
             .unwrap_or("unknown")
+    }
+
+    /// The `load_type` label for the snapshot-build metric span: `incremental` when built from an
+    /// existing snapshot, else `fresh`. Determined at span-creation time.
+    fn load_type_label(&self) -> &'static str {
+        let load_type = if self.existing_snapshot.is_some() {
+            SnapshotLoadType::Incremental
+        } else {
+            SnapshotLoadType::Fresh
+        };
+        load_type.into()
     }
 
     fn target_version_str(&self) -> String {
@@ -753,6 +764,58 @@ mod tests {
             snap_duration >= segment_duration,
             "SnapshotBuildSuccess.duration ({snap_duration:?}) should be >= LogSegmentLoadSuccess.duration ({segment_duration:?})"
         );
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn incremental_build_emits_log_segment_and_protocol_metadata_loads(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::metrics::{LogSegmentLoadPurpose, ProtocolMetadataSource, SnapshotLoadType};
+
+        let (engine, store, table_root) = setup_test();
+        create_table(&store, &table_root).await?;
+
+        // Build v0 before installing the reporter so only the incremental update is measured.
+        let snap_v0 = SnapshotBuilder::new_for(table_root)
+            .at_version(0)
+            .build(engine.as_ref())?;
+
+        let (reporter, _guard) = measuring_reporter();
+        let snap_v1 = SnapshotBuilder::new_from(snap_v0).build(engine.as_ref())?;
+        assert_eq!(snap_v1.version(), 1);
+
+        let events = reporter.events();
+
+        // (a) The incremental path emits a LogSegmentLoad labelled incremental_snapshot.
+        let seg = events
+            .iter()
+            .find_map(|e| match e {
+                MetricEvent::LogSegmentLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("incremental build must emit LogSegmentLoadSuccess");
+        assert_eq!(seg.load_purpose, LogSegmentLoadPurpose::IncrementalSnapshot);
+
+        // (b) It also emits a ProtocolMetadataLoad. With no CRC and no P&M change in the new
+        // commit, P&M is inherited from the existing snapshot.
+        let pm = events
+            .iter()
+            .find_map(|e| match e {
+                MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("incremental build must emit ProtocolMetadataLoadSuccess");
+        assert_eq!(pm.source, ProtocolMetadataSource::InheritedFromExisting);
+
+        // (c) The build event is labelled incremental.
+        let build = events
+            .iter()
+            .find_map(|e| match e {
+                MetricEvent::SnapshotBuildSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("expected SnapshotBuildSuccess");
+        assert_eq!(build.load_type, SnapshotLoadType::Incremental);
         Ok(())
     }
 

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -8,9 +8,12 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use super::{IncrementalReplay, Snapshot};
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogSegment, PmReplayWork};
 use crate::log_segment_files::LogSegmentFiles;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_log_segment_load, emit_protocol_metadata_load, LogSegmentLoadPurpose,
+    ProtocolMetadataSource, SnapshotLoadMetricContext,
+};
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -117,6 +120,11 @@ impl Snapshot {
         // Start listing just after the previous segment's checkpoint, if any.
         let listing_start = existing_log_segment.checkpoint_version.unwrap_or(0) + 1;
 
+        // The incremental path lists and assembles the segment inline (not via
+        // `LogSegment::for_snapshot`), so it emits its own `LogSegmentLoad` metric at the
+        // productive exits (cases D.1 and F) with `load_purpose = incremental_snapshot`.
+        let segment_load_start = std::time::Instant::now();
+
         // Check for new commits (and CRC)
         let new_listed_files = LogSegmentFiles::list(
             storage.as_ref(),
@@ -177,6 +185,14 @@ impl Snapshot {
                 // of the listing, so a full rebuild is required. The existing snapshot's CRC
                 // is older than the new checkpoint and cannot apply, but a fresh on-disk CRC
                 // at or above the new checkpoint still advances per `incremental_replay`.
+                //
+                // Emit the segment-load metric for the incremental listing; the delegated
+                // `try_new_from_log_segment` emits the `ProtocolMetadataLoad` metric.
+                Self::emit_incremental_segment_load(
+                    &metric_context,
+                    &new_log_segment,
+                    segment_load_start.elapsed(),
+                );
                 let snapshot = Self::try_new_from_log_segment(
                     existing_snapshot.table_root().clone(),
                     new_log_segment,
@@ -292,6 +308,14 @@ impl Snapshot {
             new_checkpoint_schema,
         )?;
 
+        // Emit the segment-load metric for the incremental listing now that the combined segment
+        // is assembled.
+        Self::emit_incremental_segment_load(
+            &metric_context,
+            &combined_log_segment,
+            segment_load_start.elapsed(),
+        );
+
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
         // `incremental_replay`.
@@ -302,16 +326,24 @@ impl Snapshot {
             incremental_replay,
         )?;
 
+        // Resolve P&M, classifying where it came from for the `ProtocolMetadataLoad` metric.
+        let pm_load_start = std::time::Instant::now();
         let existing_table_config = existing_snapshot.table_configuration();
-        let (new_metadata, new_protocol) = match &crc_at_version {
+        let (new_metadata, new_protocol, pm_source, pm_work) = match &crc_at_version {
             Some(crc) => {
-                // If we were able to build a new CRC, then re-use it for TableConfiguration
-                // creation.
+                // A CRC resolved at the target version supplied P&M. Distinguish already-at-target
+                // from advanced-by-replay via the base CRC version.
+                let source = match base_crc.as_deref() {
+                    Some(base) if base.version == new_end_version => {
+                        ProtocolMetadataSource::CrcAtTarget
+                    }
+                    _ => ProtocolMetadataSource::CrcAdvancedByReplay,
+                };
                 let new_metadata = (crc.metadata != *existing_table_config.metadata())
                     .then(|| crc.metadata.clone());
                 let new_protocol = (crc.protocol != *existing_table_config.protocol())
                     .then(|| crc.protocol.clone());
-                (new_metadata, new_protocol)
+                (new_metadata, new_protocol, source, PmReplayWork::default())
             }
             None => {
                 // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
@@ -321,11 +353,34 @@ impl Snapshot {
                 let newer_base = base_crc
                     .as_ref()
                     .filter(|c| c.version > existing_snapshot_version);
-                combined_log_segment
-                    .segment_after_version(existing_snapshot_version)
-                    .read_protocol_metadata_opt(engine, newer_base)?
+                let pruned = combined_log_segment.segment_after_version(existing_snapshot_version);
+                let work = pruned.pm_replay_work(None, /* include_checkpoint */ false);
+                let (new_metadata, new_protocol) =
+                    match pruned.read_protocol_metadata_opt(engine, newer_base) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            crate::metrics::emit_protocol_metadata_load_failure(&metric_context);
+                            return Err(e);
+                        }
+                    };
+                // A newer base CRC seeds the pruned replay; otherwise the existing snapshot's P&M
+                // is the baseline and the new commits are only checked for P&M changes.
+                let source = if newer_base.is_some() {
+                    ProtocolMetadataSource::CrcSeededPmOnlyReplay
+                } else {
+                    ProtocolMetadataSource::InheritedFromExisting
+                };
+                (new_metadata, new_protocol, source, work)
             }
         };
+        emit_protocol_metadata_load(
+            &metric_context,
+            pm_source,
+            pm_work.num_commits,
+            pm_work.bytes,
+            pm_load_start.elapsed(),
+        );
+
         let table_configuration = TableConfiguration::try_new_from(
             existing_table_config,
             new_metadata,
@@ -339,6 +394,24 @@ impl Snapshot {
             table_configuration,
             crc_at_version,
         )?))
+    }
+
+    /// Emit a `LogSegmentLoad` metric for the incremental snapshot path, which assembles its
+    /// segment inline rather than via the instrumented `LogSegment::for_snapshot`.
+    fn emit_incremental_segment_load(
+        metric_context: &SnapshotLoadMetricContext,
+        segment: &LogSegment,
+        duration: std::time::Duration,
+    ) {
+        emit_log_segment_load(
+            metric_context,
+            LogSegmentLoadPurpose::IncrementalSnapshot,
+            segment.listed.ascending_commit_files.len() as u64,
+            segment.listed.checkpoint_parts.len() as u64,
+            segment.listed.ascending_compaction_files.len() as u64,
+            segment.listed.latest_crc_file.is_some(),
+            duration,
+        );
     }
 
     // ============================================================================

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -11,8 +11,8 @@ use super::{IncrementalReplay, Snapshot};
 use crate::log_segment::{LogSegment, PmReplayWork};
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::{
-    emit_log_segment_load, emit_protocol_metadata_load, LogSegmentLoadPurpose,
-    ProtocolMetadataSource, SnapshotLoadMetricContext,
+    emit_log_segment_load, emit_protocol_metadata_load, emit_protocol_metadata_load_failure,
+    LogSegmentLoadPurpose, ProtocolMetadataSource, SnapshotLoadMetricContext,
 };
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
@@ -121,8 +121,8 @@ impl Snapshot {
         let listing_start = existing_log_segment.checkpoint_version.unwrap_or(0) + 1;
 
         // The incremental path lists and assembles the segment inline (not via
-        // `LogSegment::for_snapshot`), so it emits its own `LogSegmentLoad` metric at the
-        // productive exits (cases D.1 and F) with `load_purpose = incremental_snapshot`.
+        // `LogSegment::for_snapshot`), so it emits its own `LogSegmentLoad` metric with
+        // `load_purpose = incremental_snapshot`.
         let segment_load_start = std::time::Instant::now();
 
         // Check for new commits (and CRC)
@@ -318,16 +318,25 @@ impl Snapshot {
 
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
-        // `incremental_replay`.
+        // `incremental_replay`. The CRC advance is a reverse replay whose cost belongs to the P&M
+        // resolution it feeds, so the `ProtocolMetadataLoad` timer wraps it (matching the fresh
+        // path, whose timer also spans the CRC build). A failure here emits the P&M failure
+        // counterpart before propagating, so the metric fires on every exit.
+        let pm_load_start = std::time::Instant::now();
         let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
-        let crc_at_version = combined_log_segment.try_build_crc_within_budget(
+        let crc_at_version = match combined_log_segment.try_build_crc_within_budget(
             engine,
             base_crc.as_ref(),
             incremental_replay,
-        )?;
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                emit_protocol_metadata_load_failure(&metric_context);
+                return Err(e);
+            }
+        };
 
         // Resolve P&M, classifying where it came from for the `ProtocolMetadataLoad` metric.
-        let pm_load_start = std::time::Instant::now();
         let existing_table_config = existing_snapshot.table_configuration();
         let (new_metadata, new_protocol, pm_source, pm_work) = match &crc_at_version {
             Some(crc) => {
@@ -359,7 +368,7 @@ impl Snapshot {
                     match pruned.read_protocol_metadata_opt(engine, newer_base) {
                         Ok(v) => v,
                         Err(e) => {
-                            crate::metrics::emit_protocol_metadata_load_failure(&metric_context);
+                            emit_protocol_metadata_load_failure(&metric_context);
                             return Err(e);
                         }
                     };
@@ -1360,6 +1369,85 @@ mod tests {
         assert_eq!(pm.source, ProtocolMetadataSource::CrcAtTarget);
         assert_eq!(pm.num_commits_replayed_for_pm, 0);
         assert_eq!(pm.bytes_read_for_pm, 0);
+        Ok(())
+    }
+
+    // A fresh build whose only CRC is stale (older than the target) advances it by reverse replay
+    // when the budget permits (Unlimited), classified as crc_advanced_by_replay.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fresh_build_with_stale_crc_and_unlimited_budget_emits_crc_advanced_by_replay(
+    ) -> DeltaResult<()> {
+        use crate::metrics::{MetricEvent, ProtocolMetadataSource};
+        use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+        // CRC at v1, target latest (v3): stale by 2 commits.
+        ctx.store
+            .put(
+                &delta_path_for_version(1, "crc"),
+                make_test_crc_json(200, 2).to_string().into(),
+            )
+            .await?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let snapshot = Snapshot::builder_for(ctx.url.as_str())
+            .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot.crc().map(|c| c.version), Some(3));
+
+        let pm = reporter
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("expected ProtocolMetadataLoadSuccess");
+        assert_eq!(pm.source, ProtocolMetadataSource::CrcAdvancedByReplay);
+        Ok(())
+    }
+
+    // A fresh build with a stale CRC but no advance budget (Disabled) falls back to a forward
+    // P&M-only replay seeded by that CRC, classified as crc_seeded_pm_only_replay.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fresh_build_with_stale_crc_and_disabled_budget_emits_crc_seeded_pm_only_replay(
+    ) -> DeltaResult<()> {
+        use crate::metrics::{MetricEvent, ProtocolMetadataSource};
+        use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+        // CRC at v1; a P&M change (protocol upgrade) lands at v2, above the CRC.
+        commit(ctx.url.as_str(), &ctx.store, 2, vec![protocol_action(2, 5)]).await;
+        ctx.store
+            .put(
+                &delta_path_for_version(1, "crc"),
+                make_test_crc_json(200, 2).to_string().into(),
+            )
+            .await?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        // Disabled (the default) never advances a stale CRC, so P&M falls back to a seeded replay.
+        let snapshot = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot.crc().map(|c| c.version), None);
+
+        let pm = reporter
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("expected ProtocolMetadataLoadSuccess");
+        assert_eq!(pm.source, ProtocolMetadataSource::CrcSeededPmOnlyReplay);
+        // The seeded replay covers commits above the CRC (v2, v3), so its denominators are nonzero.
+        assert!(pm.num_commits_replayed_for_pm > 0);
+        assert!(pm.bytes_read_for_pm > 0);
         Ok(())
     }
 

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -1323,6 +1323,46 @@ mod tests {
         Ok(())
     }
 
+    // A fresh build that finds a CRC already at the target version serves P&M straight from it,
+    // with no replay. Before this work that branch emitted no ProtocolMetadataLoad at all
+    // (#2677); now it emits one classified as crc_at_target with zero replay denominators.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fresh_build_with_crc_at_target_emits_crc_at_target_source() -> DeltaResult<()> {
+        use crate::metrics::{MetricEvent, ProtocolMetadataSource};
+        use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 3).await?;
+        // Plant a CRC at the latest version (2) so a default (Disabled) fresh build serves P&M
+        // from it without any replay.
+        ctx.store
+            .put(
+                &delta_path_for_version(2, "crc"),
+                make_test_crc_json(300, 3).to_string().into(),
+            )
+            .await?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let snapshot = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref())?;
+        assert_eq!(snapshot.version(), 2);
+        assert_eq!(snapshot.crc().map(|c| c.version), Some(2));
+
+        let pm = reporter
+            .events()
+            .into_iter()
+            .find_map(|e| match e {
+                MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+                _ => None,
+            })
+            .expect("expected ProtocolMetadataLoadSuccess even on the CRC-served branch");
+        assert_eq!(pm.source, ProtocolMetadataSource::CrcAtTarget);
+        assert_eq!(pm.num_commits_replayed_for_pm, 0);
+        assert_eq!(pm.bytes_read_for_pm, 0);
+        Ok(())
+    }
+
     // Stronger regression for the `resolve_crc_file` invariant filter: set up a metadata change
     // at the checkpoint version so that a stale inherited CRC would produce wrong
     // Metadata, not just wrong bookkeeping. Without the filter, the incremental update

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -252,8 +252,7 @@ impl Snapshot {
                 }
                 _ => ProtocolMetadataSource::CrcAdvancedByReplay,
             };
-            // CRC-served P&M does no P&M-specific replay work (the reverse replay that advanced the
-            // CRC is accounted under CRC construction, not the P&M denominator).
+            // CRC-served P&M does no P&M-specific replay work.
             let work = crate::log_segment::PmReplayWork::default();
             return Ok((
                 crc.metadata.clone(),

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -182,6 +182,56 @@ impl Snapshot {
         metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Self> {
+        // Steps 1 and 2 together resolve the snapshot's Protocol and Metadata (and, on the CRC
+        // branches, the rest of the cached state). Time and classify the whole resolution so the
+        // `ProtocolMetadataLoad` metric fires uniformly across CRC-served and log-replay branches.
+        let pm_load_start = std::time::Instant::now();
+        let resolved =
+            Self::resolve_fresh_protocol_metadata(&log_segment, engine, incremental_replay);
+        let (metadata, protocol, crc_at_version, pm_source, pm_work) = match resolved {
+            Ok(v) => v,
+            Err(e) => {
+                crate::metrics::emit_protocol_metadata_load_failure(&metric_context);
+                return Err(e);
+            }
+        };
+        crate::metrics::emit_protocol_metadata_load(
+            &metric_context,
+            pm_source,
+            pm_work.num_commits,
+            pm_work.bytes,
+            pm_load_start.elapsed(),
+        );
+
+        let table_configuration =
+            TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
+
+        tracing::Span::current().record("version", table_configuration.version());
+
+        Self::new_with_crc(log_segment, table_configuration, crc_at_version)
+    }
+
+    /// Resolve Protocol and Metadata for a fresh snapshot load, classifying where they came from
+    /// (for the `ProtocolMetadataLoad` metric) and measuring the replay work.
+    ///
+    /// Returns the resolved P&M, the CRC at the target version (if one was available or built),
+    /// the [`ProtocolMetadataSource`] classification, and the replay-work denominators.
+    ///
+    /// [`ProtocolMetadataSource`]: crate::metrics::ProtocolMetadataSource
+    #[allow(clippy::type_complexity)]
+    fn resolve_fresh_protocol_metadata(
+        log_segment: &LogSegment,
+        engine: &dyn Engine,
+        incremental_replay: IncrementalReplay,
+    ) -> DeltaResult<(
+        crate::actions::Metadata,
+        crate::actions::Protocol,
+        Option<Arc<Crc>>,
+        crate::metrics::ProtocolMetadataSource,
+        crate::log_segment::PmReplayWork,
+    )> {
+        use crate::metrics::ProtocolMetadataSource;
+
         // Step 1: read the latest on-disk CRC and, if usable, advance it to the end version
         //         (or use it as-is when already there) per `incremental_replay`.
         let base_crc = log_segment.read_latest_crc(engine);
@@ -192,22 +242,41 @@ impl Snapshot {
         )?;
 
         // Step 2: P&M from that CRC, else log replay rooted at the base CRC, checkpoint, or
-        //         first commit.
-        // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
-        //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
-        let (metadata, protocol) = match crc_at_version.as_deref() {
-            Some(c) => (c.metadata.clone(), c.protocol.clone()),
-            None => {
-                log_segment.read_protocol_metadata(engine, base_crc.as_ref(), metric_context)?
-            }
+        //         first commit. Classify the source and compute the replay denominators.
+        if let Some(crc) = crc_at_version.as_deref() {
+            // A CRC resolved at the target version. Distinguish an already-at-target CRC from one
+            // advanced by reverse replay: the base CRC's version tells us which.
+            let source = match base_crc.as_deref() {
+                Some(base) if base.version == log_segment.end_version => {
+                    ProtocolMetadataSource::CrcAtTarget
+                }
+                _ => ProtocolMetadataSource::CrcAdvancedByReplay,
+            };
+            // CRC-served P&M does no P&M-specific replay work (the reverse replay that advanced the
+            // CRC is accounted under CRC construction, not the P&M denominator).
+            let work = crate::log_segment::PmReplayWork::default();
+            return Ok((
+                crc.metadata.clone(),
+                crc.protocol.clone(),
+                crc_at_version,
+                source,
+                work,
+            ));
+        }
+
+        // No CRC at target: forward P&M log replay, optionally seeded by an earlier base CRC.
+        let (source, work) = match base_crc.as_deref() {
+            Some(base) if base.version < log_segment.end_version => (
+                ProtocolMetadataSource::CrcSeededPmOnlyReplay,
+                log_segment.pm_replay_work(Some(base.version), /* include_checkpoint */ false),
+            ),
+            _ => (
+                ProtocolMetadataSource::FullReplay,
+                log_segment.pm_replay_work(None, /* include_checkpoint */ true),
+            ),
         };
-
-        let table_configuration =
-            TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
-
-        tracing::Span::current().record("version", table_configuration.version());
-
-        Self::new_with_crc(log_segment, table_configuration, crc_at_version)
+        let (metadata, protocol) = log_segment.read_protocol_metadata(engine, base_crc.as_ref())?;
+        Ok((metadata, protocol, crc_at_version, source, work))
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -397,10 +397,11 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
-        ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
-        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-        TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadPurpose, LogSegmentLoadSuccess,
+        MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
+        SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadType, StorageCopyCompleted,
+        StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
+        TransactionCommitSuccess,
     };
 
     use super::*;
@@ -453,6 +454,7 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: None,
+            load_type: SnapshotLoadType::Fresh,
             version: 0,
             duration: dur(),
         }));
@@ -471,6 +473,7 @@ mod tests {
             num_checkpoint_files: 2,
             num_compaction_files: 1,
             has_latest_crc_file: true,
+            load_purpose: LogSegmentLoadPurpose::Snapshot,
         }));
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.commit_files.get(), 7);
@@ -491,6 +494,7 @@ mod tests {
             num_checkpoint_files: 1,
             num_compaction_files: 0,
             has_latest_crc_file: false,
+            load_purpose: LogSegmentLoadPurpose::IncrementalSnapshot,
         }));
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.latest_crc_files_found.get(), 0);
@@ -615,6 +619,9 @@ mod tests {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
                 correlation_id: None,
+                source: ProtocolMetadataSource::FullReplay,
+                num_commits_replayed_for_pm: 0,
+                bytes_read_for_pm: 0,
                 duration: dur(),
             },
         ));
@@ -622,6 +629,7 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: None,
+            load_type: SnapshotLoadType::Fresh,
         }));
         assert_eq!(reporter.snapshot_completions.get(), 0);
     }
@@ -650,6 +658,7 @@ mod tests {
             num_checkpoint_files: 2,
             num_compaction_files: 1,
             has_latest_crc_file: true,
+            load_purpose: LogSegmentLoadPurpose::Snapshot,
         }));
         reporter.report(MetricEvent::CrcReadSuccess(CrcReadSuccess {
             duration: dur(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add the metric-event scaffolding for consistent snapshot-load metrics:
- LogSegmentLoadPurpose (snapshot / incremental_snapshot) + load_purpose field
- ProtocolMetadataSource (crc_at_target / crc_advanced_by_replay /
  crc_seeded_pm_only_replay / full_replay / inherited_from_existing) and reshape
  ProtocolMetadataLoad to emit-based with num_commits_replayed_for_pm +
  bytes_read_for_pm denominators
- SnapshotLoadType (fresh / incremental) + load_type field
- emit_protocol_metadata_load(_failure) and emit_log_segment_load helpers

Call sites (snapshot/incremental paths) wired in follow-up commits. FFI ignores
the new fields for now (prototype).

## How was this change tested?
