### PR TITLE
refactor: Define and use FoldWithOption extension trait

### DIFF
--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -20,6 +20,7 @@ use crate::expressions::{col, Expression, ExpressionRef, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType};
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::table_properties::TableProperties;
+use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Error};
 
 pub(crate) const STATS_FIELD: &str = "stats";
@@ -159,17 +160,18 @@ pub(crate) fn build_checkpoint_read_schema(
                 "partitionValues_parsed field already exists in Add schema",
             ));
         }
-        let mut patch = SchemaStructPatchBuilder::new().insert_after(
-            STATS_FIELD,
-            StructField::nullable(STATS_PARSED_FIELD, stats_schema.clone()),
-        );
-        if let Some(pv_schema) = partition_schema {
-            patch = patch.insert_after(
-                PARTITION_VALUES_FIELD,
-                StructField::nullable(PARTITION_VALUES_PARSED_FIELD, pv_schema.clone()),
-            );
-        }
-        patch.build(add_struct)
+        SchemaStructPatchBuilder::new()
+            .insert_after(
+                STATS_FIELD,
+                StructField::nullable(STATS_PARSED_FIELD, stats_schema.clone()),
+            )
+            .fold_with(partition_schema, |patch, pv_schema| {
+                patch.insert_after(
+                    PARTITION_VALUES_FIELD,
+                    StructField::nullable(PARTITION_VALUES_PARSED_FIELD, pv_schema.clone()),
+                )
+            })
+            .build(add_struct)
     })
 }
 

--- a/kernel/src/commit_range/builder.rs
+++ b/kernel/src/commit_range/builder.rs
@@ -183,6 +183,7 @@ mod tests {
     use super::*;
     use crate::commit_range::DeltaAction;
     use crate::engine::sync::SyncEngine;
+    use crate::utils::FoldWithOption as _;
     use crate::{Engine, Snapshot};
 
     /// `table-with-dv-small` has versions 0 and 1 (snapshot version = 1).
@@ -248,11 +249,10 @@ mod tests {
         let snapshot = Snapshot::builder_for(table_root.as_str())
             .build(&engine)
             .unwrap();
-        let mut builder = CommitRange::builder_from(snapshot, start);
-        if let Some(end) = end {
-            builder = builder.with_end_version(end);
-        }
-        let err = builder.build(&engine).expect_err("must error");
+        let err = CommitRange::builder_from(snapshot, start)
+            .fold_with(end, CommitRangeBuilder::with_end_version)
+            .build(&engine)
+            .expect_err("must error");
         let msg = format!("{err}");
         for needle in expected_substrings {
             assert!(

--- a/kernel/src/engine/arrow_conversion/scalar.rs
+++ b/kernel/src/engine/arrow_conversion/scalar.rs
@@ -179,6 +179,7 @@ mod tests {
     use crate::engine::arrow_conversion::TryFromArrow as _;
     use crate::partition::serialization::serialize_partition_value;
     use crate::schema::PrimitiveType;
+    use crate::utils::FoldWithOption as _;
 
     // ============================================================================
     // extract_primitive_scalar: non-null values for each supported type
@@ -300,10 +301,7 @@ mod tests {
         #[case] tz: Option<&str>,
     ) {
         let array = TimestampMicrosecondArray::from(vec![1_000_000i64]);
-        let array = match tz {
-            Some(tz) => array.with_timezone(tz),
-            None => array,
-        };
+        let array = array.fold_with(tz, TimestampMicrosecondArray::with_timezone);
         assert_eq!(
             extract_primitive_scalar(&array, 0).unwrap(),
             Scalar::TimestampNtz(1_000_000)

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -909,7 +909,7 @@ mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
-    use crate::snapshot::Snapshot;
+    use crate::snapshot::{Snapshot, SnapshotBuilder};
     use crate::table_features::TableFeature;
     use crate::utils::test_utils::{Action, LocalMockTable};
     use crate::utils::FoldWithOption as _;
@@ -1030,7 +1030,7 @@ mod tests {
         let engine = SyncEngine::new();
         let path = Url::from_directory_path(table.table_root()).unwrap();
         let snapshot = Snapshot::builder_for(path)
-            .fold_with(at_version, crate::snapshot::SnapshotBuilder::at_version)
+            .fold_with(at_version, SnapshotBuilder::at_version)
             .build(&engine)
             .unwrap();
         let log_segment = LogSegment::for_timestamp_conversion(

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -912,6 +912,7 @@ mod tests {
     use crate::snapshot::Snapshot;
     use crate::table_features::TableFeature;
     use crate::utils::test_utils::{Action, LocalMockTable};
+    use crate::utils::FoldWithOption as _;
     use crate::Version;
 
     fn get_test_schema() -> SchemaRef {
@@ -1028,11 +1029,10 @@ mod tests {
         let table = mock_table_with_timestamps(timestamps, ict_enablement).await;
         let engine = SyncEngine::new();
         let path = Url::from_directory_path(table.table_root()).unwrap();
-        let mut builder = Snapshot::builder_for(path);
-        if let Some(v) = at_version {
-            builder = builder.at_version(v);
-        }
-        let snapshot = builder.build(&engine).unwrap();
+        let snapshot = Snapshot::builder_for(path)
+            .fold_with(at_version, crate::snapshot::SnapshotBuilder::at_version)
+            .build(&engine)
+            .unwrap();
         let log_segment = LogSegment::for_timestamp_conversion(
             engine.storage_handler().as_ref(),
             snapshot.log_segment().log_root.clone(),

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -21,6 +21,7 @@ use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
 use crate::path::ParsedLogPath;
 use crate::snapshot::{IncrementalReplay, SnapshotRef};
+use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Snapshot};
 
 // ============================================================================
@@ -413,11 +414,11 @@ impl BuiltCrcTest {
         version: Option<u64>,
         mode: IncrementalReplay,
     ) -> (SnapshotRef, String) {
-        let mut builder = Snapshot::builder_for(self.url.clone()).with_incremental_crc_replay(mode);
-        if let Some(v) = version {
-            builder = builder.at_version(v);
-        }
-        let snapshot = builder.build(&self.engine).unwrap();
+        let snapshot = Snapshot::builder_for(self.url.clone())
+            .with_incremental_crc_replay(mode)
+            .fold_with(version, crate::snapshot::SnapshotBuilder::at_version)
+            .build(&self.engine)
+            .unwrap();
         let label = version.map_or("latest".to_string(), |v| format!("v{v}"));
         (snapshot, label)
     }

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -20,7 +20,7 @@ use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::ObjectStoreExt as _;
 use crate::path::ParsedLogPath;
-use crate::snapshot::{IncrementalReplay, SnapshotRef};
+use crate::snapshot::{IncrementalReplay, SnapshotBuilder, SnapshotRef};
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Snapshot};
 
@@ -416,7 +416,7 @@ impl BuiltCrcTest {
     ) -> (SnapshotRef, String) {
         let snapshot = Snapshot::builder_for(self.url.clone())
             .with_incremental_crc_replay(mode)
-            .fold_with(version, crate::snapshot::SnapshotBuilder::at_version)
+            .fold_with(version, SnapshotBuilder::at_version)
             .build(&self.engine)
             .unwrap();
         let label = version.map_or("latest".to_string(), |v| format!("v{v}"));

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -152,6 +152,7 @@ mod tests {
     use crate::utils::test_utils::{
         install_thread_local_metrics_reporter, load_test_table, parse_json_batch, CapturingReporter,
     };
+    use crate::utils::FoldWithOption as _;
     use crate::{PredicateRef, SnapshotRef};
 
     // ============================================================
@@ -385,11 +386,11 @@ mod tests {
         snapshot: &SnapshotRef,
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<Vec<String>> {
-        let mut builder = snapshot.clone().scan_builder();
-        if let Some(pred) = predicate {
-            builder = builder.with_predicate(pred);
-        }
-        let scan = builder.build()?;
+        let scan = snapshot
+            .clone()
+            .scan_builder()
+            .fold_with(predicate, crate::scan::ScanBuilder::with_predicate)
+            .build()?;
         let mut scan_metadata_iter = scan.scan_metadata(engine)?;
 
         let mut paths = scan_metadata_iter.try_fold(Vec::new(), |acc, metadata_res| {
@@ -412,11 +413,11 @@ mod tests {
 
         let expected_paths = get_expected_paths(engine.as_ref(), &snapshot, predicate.clone())?;
 
-        let mut builder = snapshot.scan_builder();
-        if let Some(pred) = predicate {
-            builder = builder.with_predicate(pred);
-        }
-        let scan = builder.build()?;
+        let scan = snapshot
+            .clone()
+            .scan_builder()
+            .fold_with(predicate, crate::scan::ScanBuilder::with_predicate)
+            .build()?;
         let mut sequential = scan.parallel_scan_metadata(engine.clone())?;
 
         let mut all_paths = sequential.try_fold(Vec::new(), |acc, metadata_res| {

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -147,7 +147,7 @@ mod tests {
     };
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::get_simple_state_info;
-    use crate::scan::StatsOptions;
+    use crate::scan::{ScanBuilder, StatsOptions};
     use crate::schema::{DataType, StructField, StructType};
     use crate::utils::test_utils::{
         install_thread_local_metrics_reporter, load_test_table, parse_json_batch, CapturingReporter,
@@ -389,7 +389,7 @@ mod tests {
         let scan = snapshot
             .clone()
             .scan_builder()
-            .fold_with(predicate, crate::scan::ScanBuilder::with_predicate)
+            .fold_with(predicate, ScanBuilder::with_predicate)
             .build()?;
         let mut scan_metadata_iter = scan.scan_metadata(engine)?;
 
@@ -416,7 +416,7 @@ mod tests {
         let scan = snapshot
             .clone()
             .scan_builder()
-            .fold_with(predicate, crate::scan::ScanBuilder::with_predicate)
+            .fold_with(predicate, ScanBuilder::with_predicate)
             .build()?;
         let mut sequential = scan.parallel_scan_metadata(engine.clone())?;
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -28,7 +28,7 @@ use crate::schema::{
     StructField, StructType, ToSchema as _,
 };
 use crate::table_features::ColumnMappingMode;
-use crate::utils::require;
+use crate::utils::{require, FoldWithOption as _};
 use crate::{DeltaResult, Engine, Error, ExpressionEvaluator};
 
 /// Read-time stats toggles consumed by [`ScanLogReplayProcessor`].
@@ -685,19 +685,16 @@ fn scan_row_schema_with_parsed_columns(
     if !needs_extra {
         return Ok(SCAN_ROW_SCHEMA.clone());
     }
-    let mut patch = SchemaStructPatchBuilder::new();
-    if let Some(schema) = stats_schema {
-        patch = patch.append(StructField::nullable(
-            STATS_PARSED_NAME,
-            schema.as_ref().clone(),
-        ));
-    }
-    if let Some(schema) = partition_schema {
-        patch = patch.append(StructField::nullable(
-            PARTITION_VALUES_PARSED_NAME,
-            schema.as_ref().clone(),
-        ));
-    }
+    let patch = SchemaStructPatchBuilder::new()
+        .fold_with(stats_schema.as_ref(), |patch, schema| {
+            patch.append(StructField::nullable(STATS_PARSED_NAME, schema.clone()))
+        })
+        .fold_with(partition_schema.as_ref(), |patch, schema| {
+            patch.append(StructField::nullable(
+                PARTITION_VALUES_PARSED_NAME,
+                schema.clone(),
+            ))
+        });
     Ok(Arc::new(patch.build(&SCAN_ROW_SCHEMA)?))
 }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -39,7 +39,7 @@ use crate::schema::{
 };
 use crate::table_features::{ColumnMappingMode, Operation};
 use crate::transforms::{transform_output_type, ExpressionTransform, SchemaTransform};
-use crate::utils::IteratorExt;
+use crate::utils::{FoldWithOption as _, IteratorExt};
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, SnapshotRef, Version};
 
 pub(crate) mod data_skipping;
@@ -268,10 +268,7 @@ impl ScanBuilder {
     ///
     /// [`Snapshot`]: crate::Snapshot
     pub fn with_schema_opt(self, schema_opt: Option<SchemaRef>) -> Self {
-        match schema_opt {
-            Some(schema) => self.with_schema(schema),
-            None => self,
-        }
+        self.fold_with(schema_opt, ScanBuilder::with_schema)
     }
 
     /// Optionally provide an expression to filter rows. For example, using the predicate `x <
@@ -1229,10 +1226,9 @@ impl Scan {
                     // to `rest` in a moment anyway
                     let mut sv = selection_vector.take();
                     let rest = split_vector(sv.as_mut(), len, None);
-                    let result = match sv {
-                        Some(sv) => logical.and_then(|data| data.apply_selection_vector(sv)),
-                        None => logical,
-                    };
+                    let result = logical.fold_with(sv, |logical, sv| {
+                        logical.and_then(|data| data.apply_selection_vector(sv))
+                    });
                     selection_vector = rest;
                     result
                 }))

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1766,14 +1766,13 @@ mod scan_metadata_completed_tests {
 
     use rstest::rstest;
 
+    use super::ScanBuilder;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{column_expr, Expression as Expr, Predicate as Pred};
     use crate::metrics::MetricEvent;
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
     use crate::utils::FoldWithOption as _;
     use crate::Snapshot;
-
-    use super::ScanBuilder;
 
     fn run_scan(
         table: &str,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1770,7 +1770,10 @@ mod scan_metadata_completed_tests {
     use crate::expressions::{column_expr, Expression as Expr, Predicate as Pred};
     use crate::metrics::MetricEvent;
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+    use crate::utils::FoldWithOption as _;
     use crate::Snapshot;
+
+    use super::ScanBuilder;
 
     fn run_scan(
         table: &str,
@@ -1787,14 +1790,12 @@ mod scan_metadata_completed_tests {
         let engine = Arc::new(SyncEngine::new());
         let guard = install_thread_local_metrics_reporter(reporter.clone());
         let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
-        let mut builder = snapshot.scan_builder();
-        if let Some(pred) = predicate {
-            builder = builder.with_predicate(pred);
-        }
-        if let Some(id) = correlation_id {
-            builder = builder.with_correlation_id(id);
-        }
-        let scan = builder.build().unwrap();
+        let scan = snapshot
+            .scan_builder()
+            .fold_with(predicate, ScanBuilder::with_predicate)
+            .fold_with(correlation_id, ScanBuilder::with_correlation_id)
+            .build()
+            .unwrap();
         let results: Vec<_> = scan
             .scan_metadata(engine.as_ref())
             .unwrap()

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -447,6 +447,7 @@ mod tests {
     use crate::object_store::path::Path;
     use crate::object_store::{DynObjectStore, ObjectStoreExt as _};
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
+    use crate::utils::FoldWithOption as _;
 
     fn setup_test() -> (Arc<SyncEngine>, Arc<DynObjectStore>, String) {
         let table_root = String::from("memory:///");
@@ -767,11 +768,9 @@ mod tests {
         create_table(&store, &table_root).await?;
 
         let (reporter, _guard) = measuring_reporter();
-        let mut builder = SnapshotBuilder::new_for(table_root);
-        if let Some(id) = correlation_id {
-            builder = builder.with_correlation_id(id);
-        }
-        builder.build(engine.as_ref())?;
+        let _ = SnapshotBuilder::new_for(table_root)
+            .fold_with(correlation_id, SnapshotBuilder::with_correlation_id)
+            .build(engine.as_ref())?;
 
         // The build event and its snapshot-load child events must all carry the id, since they
         // ride the same SnapshotLoadMetricContext.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1161,6 +1161,7 @@ mod tests {
     use crate::table_properties::ENABLE_IN_COMMIT_TIMESTAMPS;
     use crate::transaction::create_table::create_table;
     use crate::utils::test_utils::{assert_result_error_with_message, string_array_to_engine_data};
+    use crate::utils::FoldWithOption as _;
 
     /// Helper function to create a commitInfo action with optional ICT
     fn create_commit_info(timestamp: i64, ict: Option<i64>) -> serde_json::Value {
@@ -2122,14 +2123,13 @@ mod tests {
             ])
             .unwrap(),
         );
-        let mut builder = create_table("memory:///", schema, "test");
-        if let Some(cols) = &clustering_cols {
-            builder = builder.with_data_layout(DataLayout::clustered(cols.clone()));
-        }
-        if let Some(mode) = column_mapping_mode {
-            builder = builder.with_table_properties([("delta.columnMapping.mode", mode)]);
-        }
-        let _ = builder
+        let _ = create_table("memory:///", schema, "test")
+            .fold_with(clustering_cols.as_ref(), |builder, cols| {
+                builder.with_data_layout(DataLayout::clustered(cols.clone()))
+            })
+            .fold_with(column_mapping_mode, |builder, mode| {
+                builder.with_table_properties([("delta.columnMapping.mode", mode)])
+            })
             .build(
                 &engine,
                 Box::new(crate::committer::FileSystemCommitter::new()),

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::expressions::{ColumnName, Expression, ExpressionRef};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
-use crate::utils::CollectInto;
+use crate::utils::{CollectInto, FoldWithOption as _};
 use crate::{DeltaResult, Error};
 
 // === Raw expression patch ===
@@ -873,10 +873,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
 /// Joins an optional input prefix with a field name into a (possibly nested) input column path.
 fn join_prefix(prefix: Option<&ColumnName>, name: &str) -> ColumnName {
     let leaf = ColumnName::new([name]);
-    match prefix {
-        Some(prefix) => prefix.join(&leaf),
-        None => leaf,
-    }
+    leaf.fold_with(prefix, |leaf, prefix| prefix.join(&leaf))
 }
 
 #[cfg(test)]

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -15,6 +15,7 @@ use crate::scan::field_classifiers::CdfTransformFieldClassifier;
 use crate::scan::state_info::StateInfo;
 use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
 use crate::schema::SchemaRef;
+use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, PredicateRef};
 
 /// The result of building a [`TableChanges`] scan over a table. This can be used to get the change
@@ -321,10 +322,9 @@ fn read_scan_file(
         // because the selection vector is `None`.
         let extend = Some(!is_dv_resolved_pair);
         let rest = split_vector(sv.as_mut(), len, extend);
-        let result = match sv {
-            Some(sv) => logical.and_then(|data| data.apply_selection_vector(sv)),
-            None => logical,
-        };
+        let result = logical.fold_with(sv, |logical, sv| {
+            logical.and_then(|data| data.apply_selection_vector(sv))
+        });
         selection_vector = rest;
         result
     });

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -778,6 +778,7 @@ mod tests {
         assert_result_error_with_message, column_mapping_physical_name_dedup_fixtures as fixtures,
         make_test_tc, test_deep_nested_schema_missing_leaf_cm,
     };
+    use crate::utils::FoldWithOption as _;
 
     #[test]
     fn test_column_mapping_mode() {
@@ -1902,11 +1903,10 @@ mod tests {
         #[case] annotation: Option<MetadataValue>,
         #[case] expected: Option<&str>,
     ) {
-        let mut field = StructField::new("a", DataType::INTEGER, true);
-        if let Some(value) = annotation {
-            field = field
-                .add_metadata([(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(), value)]);
-        }
+        let field =
+            StructField::new("a", DataType::INTEGER, true).fold_with(annotation, |field, value| {
+                field.add_metadata([(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(), value)])
+            });
         let result = expect_physical_name(&field);
         match expected {
             Some(expected) => assert_eq!(result.unwrap(), expected),

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -38,6 +38,7 @@ use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
 };
+use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
@@ -187,14 +188,14 @@ impl AlterTableTransactionBuilder<Modifying> {
             current_max_column_id,
         )?;
 
-        let mut evolved_metadata = table_config
+        let evolved_metadata = table_config
             .metadata()
             .clone()
-            .with_schema(evolved_schema.clone())?;
-        if let Some(id) = new_max_column_id {
-            evolved_metadata = evolved_metadata
-                .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string());
-        }
+            .with_schema(evolved_schema.clone())?
+            .fold_with(new_max_column_id, |evolved_metadata, id| {
+                evolved_metadata
+                    .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+            });
 
         // Validates the evolved metadata against the protocol.
         let evolved_table_config = TableConfiguration::try_new_with_schema(

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -138,6 +138,7 @@ mod tests {
     use crate::schema::{Schema, SchemaRef, StructField, StructType, ToSchema};
     use crate::transaction::Transaction;
     use crate::utils::test_utils::load_test_table;
+    use crate::utils::FoldWithOption as _;
     use crate::{DeltaResult, Engine, EngineData};
 
     // ── build_commit_info tests ────────────────────────────────────────────────
@@ -231,12 +232,12 @@ mod tests {
         engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction)> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
-        let mut txn = snapshot
+        let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-            .with_operation("WRITE".to_string());
-        if let Some((engine_commit_info_data, engine_commit_info_schema)) = engine_commit_info {
-            txn = txn.with_commit_info(engine_commit_info_data, engine_commit_info_schema);
-        }
+            .with_operation("WRITE".to_string())
+            .fold_with(engine_commit_info, |txn, (data, schema)| {
+                txn.with_commit_info(data, schema)
+            });
         Ok((engine, txn))
     }
 

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -144,6 +144,24 @@ pub(crate) fn current_time_ms() -> DeltaResult<i64> {
         .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))
 }
 
+/// Extension trait for folding zero or one value from an [`Option`] into a base value.
+pub(crate) trait FoldWithOption: Sized {
+    /// Folds `opt` into `self`: if `opt` is [`Some`], returns `f(self, value)`; otherwise
+    /// returns `self`.
+    ///
+    /// Equivalent to `opt.iter().fold(self, |acc, value| f(acc, value))`.
+    fn fold_with<U>(self, opt: Option<U>, f: impl FnOnce(Self, U) -> Self) -> Self;
+}
+
+impl<T: Sized> FoldWithOption for T {
+    fn fold_with<U>(self, opt: Option<U>, f: impl FnOnce(Self, U) -> Self) -> Self {
+        match opt {
+            Some(value) => f(self, value),
+            None => self,
+        }
+    }
+}
+
 /// Extension trait for adding completion callbacks to iterators.
 pub(crate) trait IteratorExt: Iterator + Sized {
     /// Wraps this iterator to call a closure when fully exhausted.

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -145,11 +145,13 @@ pub(crate) fn current_time_ms() -> DeltaResult<i64> {
 }
 
 /// Extension trait for folding zero or one value from an [`Option`] into a base value.
+#[internal_api]
 pub(crate) trait FoldWithOption: Sized {
-    /// Folds `opt` into `self`: if `opt` is [`Some`], returns `f(self, value)`; otherwise
-    /// returns `self`.
+    /// Applies an optional fold operation `f` to `self` if `opt` is [`Some`]; otherwise returns
+    /// `self`.
     ///
-    /// Equivalent to `opt.iter().fold(self, |acc, value| f(acc, value))`.
+    /// Similar to `opt.iter().fold(self, |acc, value| f(acc, value))`, but accepting `FnOnce`
+    /// instead of requiring `FnMut`, and with the base value as receiver instead of the option.
     fn fold_with<U>(self, opt: Option<U>, f: impl FnOnce(Self, U) -> Self) -> Self;
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kernel frequently encounters cases where the content of Some option is used to frob some base value. It often manifests as a match whose `None` arm just returns the base, or as a `let mut` + `if let Some` combo:

```rust
let base = match foo {
    Some(foo) => f(base, foo),
    None => base,
};
```
or
```rust
let mut base = ...;
if let Some(foo) = foo {
    base = f(base, foo);
}
```

`Option::map_or` doesn't work, because both args would need to capture an owned `base`; `Option::into_iter()` + `Iterator::fold` doesn't work because it requires a `FnMut` and taking ownership of `base` means we only have a `FnOnce`. Plus, both of those are kind of backward user surface: We're really frobbing a base with an option, not frobbing an option with a base.

So, we define a new `FoldWithOption` extension trait, with blanket impl for all `T: Sized` whose `fold_with` method takes the base value as receiver, plus an option and a `FnOnce` to run when the option is inhabited.

Result:
```rust
let base = base.fold_with(opt, |base, value| { ... });
```

The trait is especially helpful for builders, because it allows e.g.:
```rust
let built = MyBuilder::new(...)
    .with_something(arg)
    .fold_with(val_opt, MyBuilder::with_val)
    .with_something_else(arg)
    .build()?;
```

### This PR affects the following public APIs

The new trait is `#[internal_api]`

## How was this change tested?

Lots of existing calls sites and unit tests.