### PR TITLE
feat!: register intervalType reader-writer table feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   (experimental, in development). Gates `KernelSupport::Supported` for the
   `adaptiveMetadata-preview` reader+writer feature (reads/writes to tables listing it are blocked
   with the cargo feature off).
+- `interval-type-in-dev` -- ANSI interval type support (experimental, in development). Gates
+  `KernelSupport::Supported` for the `intervalType-preview` reader-writer feature (reads and writes
+  to tables listing this feature are blocked with the cargo feature off). Reads of legacy
+  featureless interval tables (which never declare the feature) are unaffected.
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost
@@ -265,9 +269,9 @@ is the source of truth. Key concepts:
   `clustering`, `domainMetadata`, `generatedColumns`, `icebergCompatV1`, `icebergCompatV2`,
   `icebergCompatV3`, `identityColumns`, `inCommitTimestamp`, `invariants`, `rowTracking`
 - Reader + writer: `adaptiveMetadata-preview`, `catalogManaged`, `catalogOwned-preview`,
-  `columnMapping`, `deletionVectors`, `timestampNtz`, `typeWidening`, `v2Checkpoint`,
-  `vacuumProtocolCheck`, `variantShredding`, `variantShredding-preview`, `variantType`,
-  `variantType-preview`
+  `columnMapping`, `deletionVectors`, `intervalType-preview`, `timestampNtz`, `typeWidening`,
+  `v2Checkpoint`, `vacuumProtocolCheck`, `variantShredding`, `variantShredding-preview`,
+  `variantType`, `variantType-preview`
 
 Keep this list updated when new protocol features are added to kernel.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,11 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   `adaptiveMetadata-preview` reader+writer feature (reads/writes to tables listing it are blocked
   with the cargo feature off).
 - `interval-type-in-dev` -- ANSI interval type support (experimental, in development). Gates
-  `KernelSupport::Supported` for the `intervalType-preview` reader-writer feature (reads and writes
-  to tables listing this feature are blocked with the cargo feature off). Reads of legacy
-  featureless interval tables (which never declare the feature) are unaffected.
+  kernel support for the `intervalType-preview` reader-writer feature: with the flag off, both
+  reads and writes of tables that declare this feature are blocked. With the flag on, such tables
+  are readable (scan and CDF) but writes are still refused, since write support is not yet
+  implemented. Reads of legacy featureless interval tables (which never declare the feature) are
+  unaffected either way.
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -174,7 +174,7 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
     ),
-    // Partitioned interval columns need a Scalar::Interval to materialize, not yet supported.
+    // partition values need Scalar::Interval; not yet supported
     (
         "Interval partition values not supported (needs Scalar::Interval)",
         &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -165,16 +165,19 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         ],
     ),
     (
-        "Interval reads not yet supported in the default engine",
+        "Arrow parquet reader cannot annotate Unknown logical type from BOOLEAN physical type",
         &[
-            "intv_001_interval_ym_basic/specs/intv_001_interval_ym_basic_read_all",
-            "intv_002_interval_dt_basic/specs/intv_002_interval_dt_basic_read_all",
-            "intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all",
-            "intv_004_interval_negative/specs/intv_004_interval_negative_read_all",
-            "intv_005_interval_mixed/specs/intv_005_interval_mixed_read_all",
-            "intv_boundary_values/specs/intv_boundary_values_read_all",
-            "intv_sub_second/specs/intv_sub_second_read_all",
+            "void_001_void_top_level/specs/void_001_void_top_level_read_all",
+            "void_002_void_nested_struct/specs/void_002_void_nested_struct_read_all",
+            "void_005_void_schema_evolution/specs/void_005_void_schema_evolution_read_all",
+            "void_006_void_multiple_columns/specs/void_006_void_multiple_columns_read_all",
+            "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
         ],
+    ),
+    // Partitioned interval columns need a Scalar::Interval to materialize, not yet supported.
+    (
+        "Interval partition values not supported (needs Scalar::Interval)",
+        &["intv_003_interval_partitioned/specs/intv_003_interval_partitioned_read_all"],
     ),
     (
         "Cannot fall back to log replay when checkpoint files are missing or incomplete",

--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -164,16 +164,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "var_null_top_level/specs/var_null_top_level_filter_null",
         ],
     ),
-    (
-        "Arrow parquet reader cannot annotate Unknown logical type from BOOLEAN physical type",
-        &[
-            "void_001_void_top_level/specs/void_001_void_top_level_read_all",
-            "void_002_void_nested_struct/specs/void_002_void_nested_struct_read_all",
-            "void_005_void_schema_evolution/specs/void_005_void_schema_evolution_read_all",
-            "void_006_void_multiple_columns/specs/void_006_void_multiple_columns_read_all",
-            "void_007_void_with_backticks/specs/void_007_void_with_backticks_read_all",
-        ],
-    ),
     // partition values need Scalar::Interval; not yet supported
     (
         "Interval partition values not supported (needs Scalar::Interval)",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -129,6 +129,12 @@ check-constraints-in-dev = []
 # (Iceberg V4 adaptive metadata tree) work. TODO(#2866): remove once full support ships.
 adaptive-metadata-in-dev = []
 
+# Experimental, temporary feature flag guarding the in-progress ANSI interval-type work.
+# Gates `KernelSupport::Supported` for the `intervalType-preview` reader-writer table feature;
+# with the flag off, reads and writes of tables listing this feature are blocked. TODO(#2840):
+# remove once the interval-type protocol RFC is ratified and interval support fully ships.
+interval-type-in-dev = []
+
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate
 # and the SyncEngine. Keeps `reqwest` only for the gated `Error::Reqwest` variant.

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -709,6 +709,18 @@ mod tests {
         Ok(())
     }
 
+    // Asserts forward direction of Interval column mapping (year-month/day-time to Int32/Int64)
+    #[rstest]
+    #[case(DataType::INTERVAL_YEAR_MONTH, ArrowDataType::Int32)]
+    #[case(DataType::INTERVAL_DAY_TIME, ArrowDataType::Int64)]
+    fn test_interval_type_arrow_conversion(
+        #[case] kernel_type: DataType,
+        #[case] expected: ArrowDataType,
+    ) -> DeltaResult<()> {
+        assert_eq!(ArrowDataType::try_from_kernel(&kernel_type)?, expected);
+        Ok(())
+    }
+
     // Millisecond-precision timestamps (e.g. from externally-written checkpoint stats)
     // must convert like microsecond/nanosecond: UTC tz -> TIMESTAMP, no tz -> TIMESTAMP_NTZ.
     #[test]
@@ -794,15 +806,6 @@ mod tests {
             .to_string()
             .contains("Incorrect Variant Schema"));
         Ok(())
-    }
-
-    // Make sure that interval types error gracefully since unsupported
-    #[rstest]
-    #[case(DataType::INTERVAL_YEAR_MONTH)]
-    #[case(DataType::INTERVAL_DAY_TIME)]
-    fn test_interval_type_arrow_conversion_unsupported(#[case] dt: DataType) {
-        let result: Result<ArrowDataType, _> = (&dt).try_into_arrow();
-        assert!(matches!(result.unwrap_err(), ArrowError::SchemaError(_)));
     }
 
     /// Helper visitor to collect all field IDs from a kernel StructType

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -369,11 +369,8 @@ impl TryFromKernel<&DataType> for ArrowDataType {
                         Ok(ArrowDataType::Timestamp(TimeUnit::Microsecond, None))
                     }
                     PrimitiveType::Void => Ok(ArrowDataType::Null),
-                    PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
-                        Err(ArrowError::SchemaError(format!(
-                            "Interval types are not yet supported in the default engine: {p}"
-                        )))
-                    }
+                    PrimitiveType::IntervalYearMonth => Ok(ArrowDataType::Int32),
+                    PrimitiveType::IntervalDayTime => Ok(ArrowDataType::Int64),
                 }
             }
             DataType::Struct(s) => Ok(ArrowDataType::Struct(

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1491,3 +1491,15 @@ fn test_void_scalar_to_array() {
     assert_eq!(array.len(), 5);
     assert_eq!(*array.data_type(), DataType::Null);
 }
+
+// Unit test to ensure `Scalar::validate` rejects interval types
+#[rstest]
+#[case::year_month(KernelDataType::INTERVAL_YEAR_MONTH)]
+#[case::day_time(KernelDataType::INTERVAL_DAY_TIME)]
+fn test_interval_scalar_to_array_unsupported(#[case] interval_type: KernelDataType) {
+    let result = Scalar::Null(interval_type).to_array(1);
+    assert!(
+        matches!(result, Err(crate::error::Error::Unsupported(_))),
+        "expected Unsupported, got {result:?}"
+    );
+}

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -1492,7 +1492,7 @@ fn test_void_scalar_to_array() {
     assert_eq!(*array.data_type(), DataType::Null);
 }
 
-// Unit test to ensure `Scalar::validate` rejects interval types
+// Unit test to ensure scalars reject interval types
 #[rstest]
 #[case::year_month(KernelDataType::INTERVAL_YEAR_MONTH)]
 #[case::day_time(KernelDataType::INTERVAL_DAY_TIME)]

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -898,6 +898,23 @@ mod tests {
         );
     }
 
+    #[rstest]
+    fn interval_rejects_incompatible_arrow_types(
+        #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,
+        #[values(
+            ArrowDataType::Utf8,
+            ArrowDataType::Boolean,
+            ArrowDataType::Date32,
+            ArrowDataType::Float64
+        )]
+        arrow_type: ArrowDataType,
+    ) {
+        assert_result_error_with_message(
+            ensure_data_types(&interval, &arrow_type, ValidationMode::TypesAndNames),
+            "Incorrect datatype",
+        );
+    }
+
     /// Ensures that every kernel-level checkpoint reinterpretation rule in
     /// `PrimitiveType::is_checkpoint_cast_compatible` has a corresponding Arrow cast
     /// in `check_cast_compat`. If one side is updated without the other, this test fails.

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -876,6 +876,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn interval_maps_to_physical_integer() {
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_YEAR_MONTH,
+                &ArrowDataType::Int32,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+        assert_eq!(
+            ensure_data_types(
+                &DataType::INTERVAL_DAY_TIME,
+                &ArrowDataType::Int64,
+                ValidationMode::TypesAndNames
+            )
+            .unwrap(),
+            DataTypeCompat::Identical
+        );
+    }
+
     /// Ensures that every kernel-level checkpoint reinterpretation rule in
     /// `PrimitiveType::is_checkpoint_cast_compatible` has a corresponding Arrow cast
     /// in `check_cast_compat`. If one side is updated without the other, this test fails.

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1721,6 +1721,21 @@ mod test {
         );
     }
 
+    // Read-only slice: with the gate on, intervalType-preview tables are readable via Scan and CDF
+    // but not writable. Gated because `INTERVAL_TYPE_PREVIEW_INFO` is `NotSupported` without the
+    // flag.
+    #[cfg(feature = "interval-type-in-dev")]
+    #[test]
+    fn test_ensure_operation_supported_interval_type_is_read_only() {
+        let config = create_mock_table_config(&[], &[TableFeature::IntervalTypePreview]);
+        assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+        assert!(config.ensure_operation_supported(Operation::Cdf).is_ok());
+        assert_result_error_with_message(
+            config.ensure_operation_supported(Operation::Write),
+            r#"Feature 'intervalType-preview' is not supported for writes"#,
+        );
+    }
+
     #[test]
     fn test_illegal_writer_feature_combination() {
         let schema = schema_ref! { nullable "value": INTEGER };

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -145,6 +145,14 @@ pub(crate) enum TableFeature {
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
+    /// ANSI interval types (`interval year to month`, `interval day to second`).
+    ///
+    /// TODO(#2840): intervalType is not fully supported yet. Kernel support is gated by the
+    /// `interval-type-in-dev` cargo feature. Registering the feature lets kernel read tables that
+    /// declare it; writing interval data lands in a later change.
+    #[strum(serialize = "intervalType")]
+    #[serde(rename = "intervalType")]
+    IntervalType,
     /// timestamps without timezone support
     #[strum(serialize = "timestampNtz")]
     #[serde(rename = "timestampNtz")]
@@ -558,6 +566,19 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+// TODO(#2840): drop the gate (make `kernel_support` unconditionally `Supported`) once the
+// interval-type protocol RFC is ratified in PROTOCOL.md.
+static INTERVAL_TYPE_INFO: FeatureInfo = FeatureInfo {
+    feature_type: FeatureType::ReaderWriter,
+    min_legacy_version: None,
+    feature_requirements: &[],
+    #[cfg(feature = "interval-type-in-dev")]
+    kernel_support: KernelSupport::Supported,
+    #[cfg(not(feature = "interval-type-in-dev"))]
+    kernel_support: KernelSupport::NotSupported,
+    enablement_check: EnablementCheck::AlwaysIfSupported,
+};
+
 /// TODO: When type widening is supported on writes, restrict the allowed
 /// widenings on IcebergCompatV3 tables to the subset permitted by the Iceberg v3
 /// schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
@@ -690,6 +711,7 @@ impl TableFeature {
             | TableFeature::CatalogOwnedPreview
             | TableFeature::ColumnMapping
             | TableFeature::DeletionVectors
+            | TableFeature::IntervalType
             | TableFeature::TimestampWithoutTimezone
             | TableFeature::TypeWidening
             | TableFeature::TypeWideningPreview
@@ -757,6 +779,7 @@ impl TableFeature {
             TableFeature::CatalogOwnedPreview => &CATALOG_OWNED_PREVIEW_INFO,
             TableFeature::ColumnMapping => &COLUMN_MAPPING_INFO,
             TableFeature::DeletionVectors => &DELETION_VECTORS_INFO,
+            TableFeature::IntervalType => &INTERVAL_TYPE_INFO,
             TableFeature::TimestampWithoutTimezone => &TIMESTAMP_WITHOUT_TIMEZONE_INFO,
             TableFeature::TypeWidening => &TYPE_WIDENING_INFO,
             TableFeature::TypeWideningPreview => &TYPE_WIDENING_PREVIEW_INFO,
@@ -1046,6 +1069,24 @@ mod tests {
         }
     }
 
+    /// A table that declares `intervalType` in its reader features is readable exactly when kernel
+    /// support is compiled in (the `interval-type-in-dev` gate); otherwise the read is refused.
+    #[test]
+    fn test_read_protocol_with_interval_type_feature() {
+        let protocol =
+            Protocol::try_new_modern([TableFeature::IntervalType], [TableFeature::IntervalType])
+                .unwrap();
+        let result = ensure_table_can_be_read(&protocol);
+        if cfg!(feature = "interval-type-in-dev") {
+            result.expect("intervalType table must be readable when the feature is enabled");
+        } else {
+            assert!(
+                matches!(result, Err(Error::Unsupported(_))),
+                "intervalType read must be Unsupported when the feature is off, got: {result:?}"
+            );
+        }
+    }
+
     #[test]
     fn test_roundtrip_table_features() {
         use strum::IntoEnumIterator as _;
@@ -1070,6 +1111,7 @@ mod tests {
                 TableFeature::CatalogOwnedPreview => "catalogOwned-preview",
                 TableFeature::ColumnMapping => "columnMapping",
                 TableFeature::DeletionVectors => "deletionVectors",
+                TableFeature::IntervalType => "intervalType",
                 TableFeature::TimestampWithoutTimezone => "timestampNtz",
                 TableFeature::TypeWidening => "typeWidening",
                 TableFeature::TypeWideningPreview => "typeWidening-preview",

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -145,11 +145,8 @@ pub(crate) enum TableFeature {
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
-    /// ANSI interval types (`interval year to month`, `interval day to second`).
-    ///
-    /// TODO(#2840): intervalType is not fully supported yet. Kernel support is gated by the
-    /// `interval-type-in-dev` cargo feature. Registering the feature lets kernel read tables that
-    /// declare it; writing interval data lands in a later change.
+    /// TODO(#2840): intervalType is not yet fully supported, gated on `interval-type-in-dev`
+    /// feature. Registering the feature now lets kernel read tables that declare the feature.
     #[strum(serialize = "intervalType")]
     #[serde(rename = "intervalType")]
     IntervalType,
@@ -566,8 +563,7 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
-// TODO(#2840): drop the gate (make `kernel_support` unconditionally `Supported`) once the
-// interval-type protocol RFC is ratified in PROTOCOL.md.
+// TODO(#2840): drop the gate once RFC is ratified and interval support is merged.
 static INTERVAL_TYPE_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -145,11 +145,13 @@ pub(crate) enum TableFeature {
     ColumnMapping,
     /// Deletion vectors for merge, update, delete
     DeletionVectors,
-    /// TODO(#2840): intervalType is not yet fully supported, gated on `interval-type-in-dev`
-    /// feature. Registering the feature now lets kernel read tables that declare the feature.
-    #[strum(serialize = "intervalType")]
-    #[serde(rename = "intervalType")]
-    IntervalType,
+    /// ANSI interval types, in preview pending RFC ratification (`intervalType-preview`).
+    ///
+    /// TODO(#2840): intervalType is not yet fully supported, gated on `interval-type-in-dev`. With
+    /// the gate on, tables that declare this feature are readable.
+    #[strum(serialize = "intervalType-preview")]
+    #[serde(rename = "intervalType-preview")]
+    IntervalTypePreview,
     /// timestamps without timezone support
     #[strum(serialize = "timestampNtz")]
     #[serde(rename = "timestampNtz")]
@@ -563,13 +565,21 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
-// TODO(#2840): drop the gate once RFC is ratified and interval support is merged.
-static INTERVAL_TYPE_INFO: FeatureInfo = FeatureInfo {
+// TODO(#2840): allow `Operation::Write` once interval writes are implemented, and drop the gate
+// entirely once the RFC is ratified and interval support is merged.
+static INTERVAL_TYPE_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
+    // Read-only slice: kernel can scan interval tables and read their change feed, but cannot yet
+    // write them.
     #[cfg(feature = "interval-type-in-dev")]
-    kernel_support: KernelSupport::Supported,
+    kernel_support: KernelSupport::Custom(|_, _, op| match op {
+        Operation::Scan | Operation::Cdf => Ok(()),
+        Operation::Write => Err(Error::unsupported(
+            "Feature 'intervalType-preview' is not supported for writes",
+        )),
+    }),
     #[cfg(not(feature = "interval-type-in-dev"))]
     kernel_support: KernelSupport::NotSupported,
     enablement_check: EnablementCheck::AlwaysIfSupported,
@@ -707,7 +717,7 @@ impl TableFeature {
             | TableFeature::CatalogOwnedPreview
             | TableFeature::ColumnMapping
             | TableFeature::DeletionVectors
-            | TableFeature::IntervalType
+            | TableFeature::IntervalTypePreview
             | TableFeature::TimestampWithoutTimezone
             | TableFeature::TypeWidening
             | TableFeature::TypeWideningPreview
@@ -775,7 +785,7 @@ impl TableFeature {
             TableFeature::CatalogOwnedPreview => &CATALOG_OWNED_PREVIEW_INFO,
             TableFeature::ColumnMapping => &COLUMN_MAPPING_INFO,
             TableFeature::DeletionVectors => &DELETION_VECTORS_INFO,
-            TableFeature::IntervalType => &INTERVAL_TYPE_INFO,
+            TableFeature::IntervalTypePreview => &INTERVAL_TYPE_PREVIEW_INFO,
             TableFeature::TimestampWithoutTimezone => &TIMESTAMP_WITHOUT_TIMEZONE_INFO,
             TableFeature::TypeWidening => &TYPE_WIDENING_INFO,
             TableFeature::TypeWideningPreview => &TYPE_WIDENING_PREVIEW_INFO,
@@ -1065,20 +1075,24 @@ mod tests {
         }
     }
 
-    /// A table that declares `intervalType` in its reader features is readable exactly when kernel
-    /// support is compiled in (the `interval-type-in-dev` gate); otherwise the read is refused.
+    /// A table that declares `intervalType-preview` in its reader features is readable exactly when
+    /// kernel support is compiled in (the `interval-type-in-dev` gate); otherwise the read is
+    /// refused.
     #[test]
     fn test_read_protocol_with_interval_type_feature() {
-        let protocol =
-            Protocol::try_new_modern([TableFeature::IntervalType], [TableFeature::IntervalType])
-                .unwrap();
+        let protocol = Protocol::try_new_modern(
+            [TableFeature::IntervalTypePreview],
+            [TableFeature::IntervalTypePreview],
+        )
+        .unwrap();
         let result = ensure_table_can_be_read(&protocol);
         if cfg!(feature = "interval-type-in-dev") {
-            result.expect("intervalType table must be readable when the feature is enabled");
+            result
+                .expect("intervalType-preview table must be readable when the feature is enabled");
         } else {
             assert!(
                 matches!(result, Err(Error::Unsupported(_))),
-                "intervalType read must be Unsupported when the feature is off, got: {result:?}"
+                "intervalType-preview read must be Unsupported when the feature is off, got: {result:?}"
             );
         }
     }
@@ -1107,7 +1121,7 @@ mod tests {
                 TableFeature::CatalogOwnedPreview => "catalogOwned-preview",
                 TableFeature::ColumnMapping => "columnMapping",
                 TableFeature::DeletionVectors => "deletionVectors",
-                TableFeature::IntervalType => "intervalType",
+                TableFeature::IntervalTypePreview => "intervalType-preview",
                 TableFeature::TimestampWithoutTimezone => "timestampNtz",
                 TableFeature::TypeWidening => "typeWidening",
                 TableFeature::TypeWideningPreview => "typeWidening-preview",

--- a/kernel/tests/integration/features/interval.rs
+++ b/kernel/tests/integration/features/interval.rs
@@ -1,0 +1,64 @@
+//! Reader-side behavior for the `intervalType` reader-writer feature.
+//!
+//! A table that declares `intervalType` is readable only when kernel support is compiled in (the
+//! `interval-type-in-dev` gate). Tables that carry interval columns without declaring the feature
+//! (e.g. legacy DBR-written tables) are covered by the `intv_*` acceptance workloads and read
+//! regardless of the gate, since the read path never checks for the feature.
+
+use std::sync::Arc;
+
+use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::Snapshot;
+use test_utils::{create_table, engine_store_setup};
+
+/// Builds a `(3,7)` table that declares `intervalType` in both feature lists and carries a single
+/// interval column, then returns the result of building a scan over it.
+async fn build_scan_over_interval_table(
+    name: &str,
+    interval: DataType,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "iv", interval,
+    )])?);
+
+    let (store, engine, table_location) = engine_store_setup(name, None);
+    let table_url = create_table(
+        store,
+        table_location,
+        schema,
+        &[],
+        true,
+        vec!["intervalType"],
+        vec!["intervalType"],
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    // The reader-feature support gate fires here, in `Scan::build`, not at snapshot load.
+    snapshot.scan_builder().build()?;
+    Ok(())
+}
+
+#[cfg(feature = "interval-type-in-dev")]
+#[tokio::test]
+async fn test_scan_interval_feature_table_succeeds_when_enabled(
+) -> Result<(), Box<dyn std::error::Error>> {
+    build_scan_over_interval_table("interval_read_ym", DataType::INTERVAL_YEAR_MONTH).await?;
+    build_scan_over_interval_table("interval_read_dt", DataType::INTERVAL_DAY_TIME).await?;
+    Ok(())
+}
+
+#[cfg(not(feature = "interval-type-in-dev"))]
+#[tokio::test]
+async fn test_scan_interval_feature_table_blocked_when_disabled(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let err = build_scan_over_interval_table("interval_read_off", DataType::INTERVAL_DAY_TIME)
+        .await
+        .expect_err("scanning an intervalType table must be blocked when the feature is off")
+        .to_string();
+    assert!(
+        err.contains("intervalType") && err.contains("not supported"),
+        "error must name the unsupported feature; got: {err}",
+    );
+    Ok(())
+}

--- a/kernel/tests/integration/features/interval.rs
+++ b/kernel/tests/integration/features/interval.rs
@@ -2,8 +2,9 @@
 //!
 //! A table that declares `intervalType` is readable only when kernel support is compiled in (the
 //! `interval-type-in-dev` gate). Tables that carry interval columns without declaring the feature
-//! (e.g. legacy DBR-written tables) are covered by the `intv_*` acceptance workloads and read
-//! regardless of the gate, since the read path never checks for the feature.
+//! (e.g. legacy DBR-written tables) read regardless of the gate, since the read-support check only
+//! inspects features the protocol declares. That featureless case is covered directly below and
+//! end-to-end by the `intv_*` acceptance workloads.
 
 use std::sync::Arc;
 
@@ -50,15 +51,34 @@ async fn test_scan_interval_feature_table_succeeds_when_enabled(
 
 #[cfg(not(feature = "interval-type-in-dev"))]
 #[tokio::test]
-async fn test_scan_interval_feature_table_blocked_when_disabled(
+async fn test_scan_interval_feature_table_blocked_when_kernel_support_off(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let err = build_scan_over_interval_table("interval_read_off", DataType::INTERVAL_DAY_TIME)
         .await
-        .expect_err("scanning an intervalType table must be blocked when the feature is off")
+        .expect_err("scanning an intervalType table must be blocked when kernel support is off")
         .to_string();
     assert!(
         err.contains("intervalType") && err.contains("not supported"),
         "error must name the unsupported feature; got: {err}",
     );
+    Ok(())
+}
+
+/// A featureless table carrying an interval column reads regardless of feature gate (mirrors DBR)
+#[tokio::test]
+async fn test_scan_featureless_interval_table_succeeds_regardless_of_kernel_support(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "iv",
+        DataType::INTERVAL_DAY_TIME,
+    )])?);
+
+    let (store, engine, table_location) = engine_store_setup("interval_read_featureless", None);
+    // A (3,7) table that declares no reader/writer features, so the read path never sees
+    // `intervalType` even though the schema carries an interval column.
+    let table_url = create_table(store, table_location, schema, &[], true, vec![], vec![]).await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    snapshot.scan_builder().build()?;
     Ok(())
 }

--- a/kernel/tests/integration/features/interval.rs
+++ b/kernel/tests/integration/features/interval.rs
@@ -1,8 +1,8 @@
-//! Reader-side behavior for the `intervalType` reader-writer feature.
+//! Reader-side behavior for the `intervalType-preview` reader-writer feature.
 //!
-//! A table that declares `intervalType` is readable only when kernel support is compiled in (the
-//! `interval-type-in-dev` gate). Tables that carry interval columns without declaring the feature
-//! (e.g. legacy DBR-written tables) read regardless of the gate, since the read-support check only
+//! A table that declares `intervalType-preview` is readable only when kernel support is compiled
+//! in (the `interval-type-in-dev` gate). Tables that carry interval columns without declaring the
+//! feature (e.g. legacy tables) read regardless of the gate, since the read-support check only
 //! inspects features the protocol declares. That featureless case is covered directly below and
 //! end-to-end by the `intv_*` acceptance workloads.
 
@@ -12,15 +12,22 @@ use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::Snapshot;
 use test_utils::{create_table, engine_store_setup};
 
-/// Builds a `(3,7)` table that declares `intervalType` in both feature lists and carries a single
-/// interval column, then returns the result of building a scan over it.
+/// Builds a `(3,7)` table carrying a single interval column and builds a scan over it. When
+/// `declare_feature` is set, the table declares `intervalType-preview` in both feature lists;
+/// otherwise it declares no features (a featureless interval table).
 async fn build_scan_over_interval_table(
     name: &str,
     interval: DataType,
+    declare_feature: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "iv", interval,
     )])?);
+    let features = if declare_feature {
+        vec!["intervalType-preview"]
+    } else {
+        vec![]
+    };
 
     let (store, engine, table_location) = engine_store_setup(name, None);
     let table_url = create_table(
@@ -29,8 +36,8 @@ async fn build_scan_over_interval_table(
         schema,
         &[],
         true,
-        vec!["intervalType"],
-        vec!["intervalType"],
+        features.clone(),
+        features,
     )
     .await?;
 
@@ -40,45 +47,42 @@ async fn build_scan_over_interval_table(
     Ok(())
 }
 
-#[cfg(feature = "interval-type-in-dev")]
+/// A table declaring `intervalType-preview` is scannable exactly when the `interval-type-in-dev`
+/// gate is compiled in; otherwise the scan is refused, naming the unsupported feature.
 #[tokio::test]
-async fn test_scan_interval_feature_table_succeeds_when_enabled(
+async fn test_scan_interval_feature_table_respects_kernel_support_gate(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    build_scan_over_interval_table("interval_read_ym", DataType::INTERVAL_YEAR_MONTH).await?;
-    build_scan_over_interval_table("interval_read_dt", DataType::INTERVAL_DAY_TIME).await?;
+    for (name, interval) in [
+        ("interval_read_ym", DataType::INTERVAL_YEAR_MONTH),
+        ("interval_read_dt", DataType::INTERVAL_DAY_TIME),
+    ] {
+        let result = build_scan_over_interval_table(name, interval, true).await;
+        if cfg!(feature = "interval-type-in-dev") {
+            result?;
+        } else {
+            let err = result
+                .expect_err(
+                    "scanning an interval feature table must be blocked when support is off",
+                )
+                .to_string();
+            assert!(
+                err.contains("intervalType-preview"),
+                "error must name the unsupported feature; got: {err}",
+            );
+        }
+    }
     Ok(())
 }
 
-#[cfg(not(feature = "interval-type-in-dev"))]
-#[tokio::test]
-async fn test_scan_interval_feature_table_blocked_when_kernel_support_off(
-) -> Result<(), Box<dyn std::error::Error>> {
-    let err = build_scan_over_interval_table("interval_read_off", DataType::INTERVAL_DAY_TIME)
-        .await
-        .expect_err("scanning an intervalType table must be blocked when kernel support is off")
-        .to_string();
-    assert!(
-        err.contains("intervalType") && err.contains("not supported"),
-        "error must name the unsupported feature; got: {err}",
-    );
-    Ok(())
-}
-
-/// A featureless table carrying an interval column reads regardless of feature gate (mirrors DBR)
+/// A featureless table carrying an interval column reads regardless of the gate: the read-support
+/// check only inspects declared features, and this table declares none (mirrors legacy tables).
 #[tokio::test]
 async fn test_scan_featureless_interval_table_succeeds_regardless_of_kernel_support(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "iv",
+    build_scan_over_interval_table(
+        "interval_read_featureless",
         DataType::INTERVAL_DAY_TIME,
-    )])?);
-
-    let (store, engine, table_location) = engine_store_setup("interval_read_featureless", None);
-    // A (3,7) table that declares no reader/writer features, so the read path never sees
-    // `intervalType` even though the schema carries an interval column.
-    let table_url = create_table(store, table_location, schema, &[], true, vec![], vec![]).await?;
-
-    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-    snapshot.scan_builder().build()?;
-    Ok(())
+        false,
+    )
+    .await
 }

--- a/kernel/tests/integration/features/mod.rs
+++ b/kernel/tests/integration/features/mod.rs
@@ -5,5 +5,6 @@ mod cdf;
 mod clustering_e2e;
 mod dv;
 mod iceberg_compat;
+mod interval;
 mod maintenance_ops;
 mod row_tracking;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2880/files/21a1fbb3f198f05ba8f40cf29ab57a472832dc91..602480e64fa74a0ef59015d1de282cf4a6fe10a5) to review incremental changes.
- [stack/interval_reads_engine](https://github.com/delta-io/delta-kernel-rs/pull/2769) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2769/files)]
  - [**stack/interval-reads-feature**](https://github.com/delta-io/delta-kernel-rs/pull/2880) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2880/files/21a1fbb3f198f05ba8f40cf29ab57a472832dc91..602480e64fa74a0ef59015d1de282cf4a6fe10a5)] ← _this PR_
    - [stack/interval_write_support](https://github.com/delta-io/delta-kernel-rs/pull/2845) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2845/files/602480e64fa74a0ef59015d1de282cf4a6fe10a5..39353a4de9a591afac5e18503fef825c07715536)]
      - [stack/interval_scalars](https://github.com/delta-io/delta-kernel-rs/pull/2854) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2854/files/39353a4de9a591afac5e18503fef825c07715536..a19ba2800f690ae049c648e2b3102eb4aa4a447e)]
        - [stack/interval_ffi_changes](https://github.com/delta-io/delta-kernel-rs/pull/2903) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2903/files/a19ba2800f690ae049c648e2b3102eb4aa4a447e..6f04535206b4b659c8e028e064102da52db12fdc)]

---------
## What changes are proposed in this pull request?

Introduce a new reader-writer table feature `intervalType-preview` gated on a feature flag. Enable reads and CDF of Delta tables with this table feature enabled, but keep writes disabled (this will change in the next PR in the stack).

## How was this change tested?

New unit tests + integration test.
