### PR TITLE
ci: skip CI on docs-only PRs via an aggregator gate

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -44,22 +44,22 @@ GitHub treats two kinds of "skip" differently for required status checks:
   check of the same name. This is the mechanism we use.
 
 The shared `detect-changes.yml` reusable workflow emits `docs_only`. Callers gate on
-`needs: detect_changes` + `if: needs.detect_changes.outputs.docs_only == 'false'`. How to
-gate depends on the job shape:
+`needs: detect_changes` + a `docs_only` `if:`. How to gate depends on the job shape:
 
-- **Single (non-matrix) jobs** (`format`, `docs`, `run-examples`, ...): the job-level `if:`
-  is enough. A skipped job reports its own name as "skipped", satisfying its required check.
 - **Matrix jobs** (`build`, `test`, `ffi_test`, `miri`): a job-level `if:` skip never expands
   the matrix, so its per-leg checks (`build (ubuntu-latest)`, ...) never report and the PR
-  blocks. These CANNOT be individually required. Instead, `build.yml` funnels every job into
-  one `all-required-checks-pass` aggregator (`if: always()`, `needs:` every job) whose step
-  fails only when a needed job is `failure`/`cancelled` (`success`/`skipped` pass). Branch
-  protection requires ONLY that aggregator, so matrix jobs skip cleanly as a unit with a
-  single job-level `if:` and no per-step gating.
-
-The aggregator's `name:` is load-bearing: renaming it silently disables branch protection.
-When adding a job to `build.yml`, add it to the aggregator's `needs:` unless it is
-intentionally non-required (e.g. `invalid-handle-code`).
+  blocks. These CANNOT be individually required. `build.yml` funnels every job into one
+  `all-required-checks-pass` aggregator (`if: always()`, `needs:` every job) whose step fails
+  only when a needed job is `failure`/`cancelled` (`success`/`skipped` pass). Branch protection
+  requires ONLY that aggregator, so each job (matrix included) carries a single job-level
+  `if: docs_only == 'false'` and skips as a unit. The aggregator's `name:` is load-bearing:
+  renaming it silently disables branch protection. Add every new job to its `needs:` unless
+  intentionally non-required (e.g. `invalid-handle-code`).
+- **Single directly-required jobs** (`run-examples`): with no aggregator to catch a `failure`,
+  gate on `if: always() && docs_only != 'true'`, NOT `== 'false'`. A failed `detect_changes`
+  yields an empty output; `== 'false'` plus the implicit `success()` would skip the job, and a
+  skipped required check counts as passing, so the work would silently never run. `!= 'true'`
+  under `always()` runs the job unless docs-only is positively confirmed (fail-safe).
 
 ## Supply chain security: `--locked`
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -33,12 +33,33 @@ on:
   merge_group:
 ```
 
-## Never `paths`/`paths-ignore` a workflow whose jobs are required checks
+## Skipping docs-only PRs without wedging required checks
 
-Do NOT add `paths` or `paths-ignore` filters to a workflow whose jobs are required
-status checks (most of `build.yml`). When a path filter skips the whole workflow,
-the required checks never report, and the PR stays blocked on "Expected, waiting
-for status" indefinitely. A skipped workflow is not the same as a passing one.
+GitHub treats two kinds of "skip" differently for required status checks:
+
+- A **workflow** skipped by `paths`/`paths-ignore` never reports its checks, so any
+  required check stays "Expected, waiting for status" and blocks the merge forever.
+  NEVER add `paths`/`paths-ignore` to a workflow whose jobs are required.
+- A **job** skipped by its own `if:` reports "skipped", which satisfies a required
+  check of the same name. This is the mechanism we use.
+
+The shared `detect-changes.yml` reusable workflow emits `docs_only`. Callers gate on
+`needs: detect_changes` + `if: needs.detect_changes.outputs.docs_only == 'false'`. How to
+gate depends on the job shape:
+
+- **Single (non-matrix) jobs** (`format`, `docs`, `run-examples`, ...): the job-level `if:`
+  is enough. A skipped job reports its own name as "skipped", satisfying its required check.
+- **Matrix jobs** (`build`, `test`, `ffi_test`, `miri`): a job-level `if:` skip never expands
+  the matrix, so its per-leg checks (`build (ubuntu-latest)`, ...) never report and the PR
+  blocks. These CANNOT be individually required. Instead, `build.yml` funnels every job into
+  one `all-required-checks-pass` aggregator (`if: always()`, `needs:` every job) whose step
+  fails only when a needed job is `failure`/`cancelled` (`success`/`skipped` pass). Branch
+  protection requires ONLY that aggregator, so matrix jobs skip cleanly as a unit with a
+  single job-level `if:` and no per-step gating.
+
+The aggregator's `name:` is load-bearing: renaming it silently disables branch protection.
+When adding a job to `build.yml`, add it to the aggregator's `needs:` unless it is
+intentionally non-required (e.g. `invalid-handle-code`).
 
 ## Supply chain security: `--locked`
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,17 @@ env:
 # are installed via taiki-e/install-action, which fetches prebuilt binaries.
 
 jobs:
+  # Detect docs-only PRs. Every job below declares `needs: detect_changes` and runs only
+  # `if: needs.detect_changes.outputs.docs_only == 'false'`, so a docs-only PR skips the work.
+  # The `all-required-checks-pass` aggregator collapses the skipped jobs into a single green
+  # required check (a skipped `needs` counts as pass there). See .github/CLAUDE.md.
+  detect_changes:
+    uses: ./.github/workflows/detect-changes.yml
+
   format:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install nightly with rustfmt
@@ -74,6 +83,8 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable and cargo msrv
@@ -95,6 +106,8 @@ jobs:
           cargo msrv --path ffi-proc-macros/ verify --all-features
   msrv-run-tests:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable and cargo msrv
@@ -125,6 +138,8 @@ jobs:
           cargo +$(cargo msrv show --output-format minimal) test --doc
   docs:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
@@ -164,6 +179,8 @@ jobs:
   #    - delta_kernel_ffi_macros
   build:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     strategy:
       matrix:
         os:
@@ -201,6 +218,8 @@ jobs:
         run: cargo test --locked -p feature_tests --features default-engine-rustls
   test:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     strategy:
       matrix:
         os:
@@ -264,6 +283,8 @@ jobs:
 
   ffi_test:
     runs-on: ${{ matrix.os }}
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     strategy:
       matrix:
         os:
@@ -383,6 +404,8 @@ jobs:
   miri:
     name: "Miri (shard ${{ matrix.partition }}/3)"
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -405,6 +428,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -428,3 +453,37 @@ jobs:
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Single required status check. Branch protection requires only this job, so the matrix jobs
+  # skip cleanly on docs-only PRs without leaving per-leg checks pending. `if: always()` makes
+  # it report on every run; a needed job that is `failure` or `cancelled` fails the gate, while
+  # `success` and `skipped` pass. `detect_changes` is included so a broken detector fails the
+  # gate instead of silently skipping everything. `invalid-handle-code` is excluded on purpose:
+  # it is non-required by design. See .github/CLAUDE.md.
+  all-required-checks-pass:
+    name: all required checks pass
+    if: always()
+    needs:
+      - detect_changes
+      - format
+      - msrv
+      - msrv-run-tests
+      - docs
+      - build
+      - test
+      - ffi_test
+      - miri
+      - coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all needed jobs succeeded or were skipped
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failing=$(jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key): \(.value.result)"' <<< "$NEEDS_JSON")
+          if [ -n "$failing" ]; then
+            echo "The following required jobs did not pass:"
+            echo "$failing"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,18 +1,14 @@
 name: detect-changes
 
 # Reusable detector shared by the CI workflows. A caller adds a `detect_changes` job that
-# `uses:` this file, then gates its expensive jobs with
-# `needs: detect_changes` + `if: needs.detect_changes.outputs.docs_only == 'false'`.
-#
-# Gating at the job level (not via `paths-ignore`) keeps each job reporting a status: a job
-# skipped by its own `if:` reports "skipped", whereas a skipped *workflow* leaves its required
-# checks pending and blocks the merge. Callers pair this with an aggregator gate job so the
-# skipped jobs still resolve to a single green required check. See .github/CLAUDE.md.
+# `uses:` this file, then gates its jobs on the `docs_only` output. See .github/CLAUDE.md for
+# how callers gate (job-level `if:` + aggregator) and why job-level skips are used over
+# `paths-ignore`.
 #
 # docs_only is meaningful only for pull_request events. On a pull_request it is 'true' when
-# paths-filter confirms every changed file is docs/markdown, so callers skip. On push,
-# merge_group, or any other event the filter does not run, so docs_only is 'false' and callers
-# always run their full work. (Fail-safe: we skip only on a confirmed docs-only PR.)
+# every changed file is docs/markdown. On push, merge_group, or any other event the filter
+# does not run, so docs_only is 'false' and callers run their full work. (Fail-safe: we skip
+# only on a confirmed docs-only PR.)
 on:
   workflow_call:
     outputs:

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,41 @@
+name: detect-changes
+
+# Reusable detector shared by the CI workflows. A caller adds a `detect_changes` job that
+# `uses:` this file, then gates its expensive jobs with
+# `needs: detect_changes` + `if: needs.detect_changes.outputs.docs_only == 'false'`.
+#
+# Gating at the job level (not via `paths-ignore`) keeps each job reporting a status: a job
+# skipped by its own `if:` reports "skipped", whereas a skipped *workflow* leaves its required
+# checks pending and blocks the merge. Callers pair this with an aggregator gate job so the
+# skipped jobs still resolve to a single green required check. See .github/CLAUDE.md.
+#
+# docs_only is meaningful only for pull_request events. On a pull_request it is 'true' when
+# paths-filter confirms every changed file is docs/markdown, so callers skip. On push,
+# merge_group, or any other event the filter does not run, so docs_only is 'false' and callers
+# always run their full work. (Fail-safe: we skip only on a confirmed docs-only PR.)
+on:
+  workflow_call:
+    outputs:
+      docs_only:
+        description: "'true' when a pull_request changed only docs/markdown; 'false' otherwise."
+        value: ${{ jobs.detect.outputs.docs_only }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.code == 'false' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          # 'every' means a file matches only if it satisfies ALL the negations below, so
+          # `code` is true when any changed file falls outside those docs paths.
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -18,8 +18,15 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  detect_changes:
+    uses: ./.github/workflows/detect-changes.yml
+
+  # Single job, so a docs-only skip reports "skipped" and satisfies its own required check
+  # directly. No aggregator needed (unlike build.yml's matrix jobs). See .github/CLAUDE.md.
   run-examples:
     runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.docs_only == 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -22,11 +22,14 @@ jobs:
     uses: ./.github/workflows/detect-changes.yml
 
   # Single job, so a docs-only skip reports "skipped" and satisfies its own required check
-  # directly. No aggregator needed (unlike build.yml's matrix jobs). See .github/CLAUDE.md.
+  # directly; no aggregator needed (unlike build.yml's matrix jobs). The guard is
+  # `docs_only != 'true'` under `always()`, not `== 'false'`, so a failed detect_changes
+  # (output empty, not 'true') runs the examples rather than silently skipping a required
+  # check. See .github/CLAUDE.md.
   run-examples:
     runs-on: ubuntu-latest
     needs: detect_changes
-    if: needs.detect_changes.outputs.docs_only == 'false'
+    if: always() && needs.detect_changes.outputs.docs_only != 'true'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install minimal stable


### PR DESCRIPTION
## What changes are proposed in this pull request?

Skip CI work on docs-only PRs (changes touching only `**.md`, `docs/**`, or
`.github/ISSUE_TEMPLATE/**`) while keeping required status checks green.

- Add `detect-changes.yml`, a reusable workflow that reports `docs_only` for a
  `pull_request` via `dorny/paths-filter`.
- `build.yml` and `run-examples.yml` gate each job on `needs: detect_changes` +
  `if: needs.detect_changes.outputs.docs_only == 'false'`.
- Single (non-matrix) jobs skip cleanly: a skipped job satisfies its own required check.
- Matrix jobs (`build`, `test`, `ffi_test`, `miri`) cannot be individually required
  (a skipped job never expands the matrix, so its per-leg checks stay pending). Instead,
  `build.yml` funnels every job into one `all-required-checks-pass` aggregator
  (`if: always()`, `needs:` every job) that fails only when a needed job is
  `failure`/`cancelled`; `success` and `skipped` pass.
- `push` and `merge_group` always run the full suite (the detector only skips a
  confirmed docs-only `pull_request`).

> [!IMPORTANT]
> **CI admin action required before this merges.** Branch protection for `main` must be
> updated to require **only** the `all required checks pass` job (from `build.yml`), and the
> individual `build.yml` jobs (`format`, `msrv`, `msrv-run-tests`, `docs`, `build`, `test`,
> `ffi_test`, `miri`, `coverage`) must be **removed** from the required-checks list.
> `run-examples` stays required as-is (it is a single job that skips cleanly). If the
> individual matrix jobs remain required, docs-only PRs will block on their per-leg checks
> staying pending. The aggregator job's name (`all required checks pass`) is load-bearing:
> renaming it silently disables enforcement.

## How was this change tested?

- Validated all three workflow YAML files parse.
- Verified the aggregator's `jq` gate locally across result combinations: docs-only (all
  `skipped`) passes, all-`success` passes, any `failure`/`cancelled` fails, and a failed
  `detect_changes` fails the gate.
- End-to-end behavior (docs-only skip, code-PR full run) exercised by this PR's own CI.
