### PR TITLE
feat: add SQL predicate tokenizer for CHECK constraints

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -121,6 +121,11 @@ declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc
 # work. TODO(#2630): remove once full column-defaults support ships.
 column-defaults-in-dev = []
 
+# Experimental, temporary, test-only feature flag guarding the in-progress check-constraints
+# work: the SQL predicate parser and, later, `checkConstraints` write enforcement. Remove once
+# full check-constraints support ships.
+check-constraints-in-dev = []
+
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate
 # and the SyncEngine. Keeps `reqwest` only for the gated `Error::Reqwest` variant.

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -345,6 +345,7 @@ fn parse_simple_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
 /// name. The caller must have already consumed the opening backtick. Shared with the
 /// check-constraint tokenizer ([`crate::expressions::sql`]) so backtick-quoted column references
 /// parse identically.
+/// Examples: `col` -> col;  `ab `` -> ``ab``. Returns an error if there is no closing backtick.
 pub(crate) fn parse_escaped_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
     let mut name = String::new();
     loop {

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -234,7 +234,7 @@ impl Display for ColumnName {
 }
 
 // Simple column names contain only simple chars, and do not need to be wrapped in backticks.
-fn is_simple_char(c: char) -> bool {
+pub(crate) fn is_simple_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_'
 }
 
@@ -341,8 +341,11 @@ fn parse_simple_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
     Ok(name)
 }
 
-/// Parses a field name escaped with backticks, e.g. "`ab``c``d`".
-fn parse_escaped_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
+/// Parses a field name escaped with backticks, e.g. "`ab``c``d`", returning its unescaped logical
+/// name. The caller must have already consumed the opening backtick. Shared with the
+/// check-constraint tokenizer ([`crate::expressions::sql`]) so backtick-quoted column references
+/// parse identically.
+pub(crate) fn parse_escaped_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
     let mut name = String::new();
     loop {
         match chars.next() {

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -26,7 +26,10 @@ mod column_names;
 pub(crate) mod literal_expression_transform;
 pub(crate) use literal_expression_transform::literal_expression_transform;
 mod scalars;
-#[cfg(feature = "column-defaults-in-dev")]
+#[cfg(any(
+    feature = "column-defaults-in-dev",
+    feature = "check-constraints-in-dev"
+))]
 mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
 pub(crate) use self::sql::parse_sql;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -16,6 +16,9 @@ use crate::expressions::{Expression, Scalar};
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};
 
+#[cfg(feature = "check-constraints-in-dev")]
+mod token;
+
 /// Parse a SQL string into an [`Expression`] that yields a value of the given [`DataType`]
 /// (e.g. the type of the column whose default is being parsed).
 ///
@@ -34,6 +37,12 @@ use crate::{DeltaResult, Error};
 ///
 /// Returns an error if the input is not a SQL form this parser accepts, or if the parsed value
 /// is not compatible with `data_type` (incompatible type, out of range, etc.).
+// Reached only via the `column-defaults-in-dev` re-export today; under `check-constraints-in-dev`
+// alone it has no caller until the lowering stage lands (which calls it via `super::parse_sql`).
+#[cfg_attr(
+    not(feature = "column-defaults-in-dev"),
+    allow(dead_code, reason = "wired up by the check-constraints lowering stage")
+)]
 pub(crate) fn parse_sql(sql: &str, data_type: &DataType) -> DeltaResult<Expression> {
     let trimmed = sql.trim();
     if trimmed.is_empty() {

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -1,4 +1,4 @@
-//! A tokenizer for a small subset of SQL.
+//! A tokenizer for a subset of SQL.
 //!
 //! Splits a SQL string into [`Token`]s; what the tokens mean is up to the caller. The token set is
 //! intentionally minimal and grows with the grammar the parser supports. Literal tokens keep their

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -169,14 +169,14 @@ fn peek_second(chars: &CharStream<'_>) -> Option<char> {
 /// Consume a `'...'` string literal, returning its raw text *including* the surrounding quotes and
 /// any doubled `''` escapes.
 ///
-/// Example: `'it''s'` returns `'it''s'` (verbatim). The caller must guarantee a leading `'`.
+/// Example: `'it''s'` returns `'it''s'` (verbatim). Returns an error if the input does not start
+/// with a `'`.
 fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<String> {
-    debug_assert_eq!(
-        chars.peek(),
-        Some(&'\''),
-        "take_quoted_string requires a leading quote"
-    );
-    chars.next();
+    if chars.next_if_eq(&'\'').is_none() {
+        return Err(Error::generic(format!(
+            "string literal must start with a quote in {sql}"
+        )));
+    }
     let mut out = String::from('\'');
     loop {
         match chars.next() {
@@ -203,12 +203,9 @@ fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Stri
 /// leading `+`/`-` is a separate operator token (see the `Plus`/`Minus` arms), not consumed here;
 /// the exponent's own sign (`2e+1`) is part of the number.
 ///
-/// A leading dot needs no digit before it, so `.2` is a number. The `.` is not validated: `3.14159`
-/// and `0.2` are numbers, as is a malformed `1.2.3` (emitted verbatim). `3/4` is not a number: `/`
-/// is not consumed, so only the `3` is taken.
-///
-/// Examples: `3.14159` -> `3.14159`; `.2` -> `.2`; `2e+1` -> `2e+1`. Stops before a second
-/// operator, so `1+1` yields just `1`.
+/// Examples: `3.14159` -> `3.14159`; `.2` -> `.2` (no leading digit needed); `2e+1` -> `2e+1`;
+/// `1.2.3` -> `1.2.3` (malformed, emitted verbatim); `3/4` -> `3` (stops at `/`); `1+1` -> `1`
+/// (stops before a second operator).
 fn take_number(chars: &mut CharStream<'_>) -> String {
     let mut out = String::new();
     while let Some(c) = chars.next_if(|c| c.is_ascii_digit() || *c == '.') {

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -1,0 +1,404 @@
+//! A tokenizer for a small subset of SQL.
+//!
+//! Splits a SQL string into [`Token`]s; what the tokens mean is up to the caller. The token set is
+//! intentionally minimal and grows with the grammar the parser supports. Literal tokens keep their
+//! raw source text so a caller can decode them however it needs.
+//!
+//! Example: `` `col1` > 5 `` tokenizes to `[Ident("col1"), Gt, Literal("5")]`.
+
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+#![allow(dead_code)]
+
+use std::iter::Peekable;
+use std::str::Chars;
+
+use crate::expressions::column_names::{is_simple_char, parse_escaped_field_name};
+use crate::{DeltaResult, Error};
+
+/// A peekable character stream over the source string.
+type CharStream<'a> = Peekable<Chars<'a>>;
+
+/// A lexical token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Token {
+    Ident(String),
+    /// A literal's raw, undecoded source text (quotes and any typed-literal keyword retained):
+    /// numbers, quoted strings, `X'..'` binary, `TRUE`/`FALSE`/`NULL`, and typed
+    /// `DATE`/`TIMESTAMP`/ `TIMESTAMP_LTZ`/`TIMESTAMP_NTZ` literals.
+    Literal(String),
+    Dot,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    /// `<>` or `!=` (both mean not-equal).
+    Ne,
+    /// `<=>`, Spark's null-safe equality (`NULL <=> NULL` is true).
+    NullSafeEq,
+    /// The `AND`/`OR`/`NOT`/`IS` keywords. Recognized here (not left as [`Token::Ident`]) so a
+    /// backtick-quoted column literally named `` `AND` `` stays an `Ident`, distinct from the
+    /// keyword. The current parser has no grammar for them and rejects them; they are tokenized so
+    /// it can do so unambiguously.
+    Keyword(Keyword),
+}
+
+/// A SQL keyword the tokenizer recognizes as a distinct token (see [`Token::Keyword`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Keyword {
+    And,
+    Or,
+    Not,
+    Is,
+}
+
+/// Tokenize `sql`, or return an error for any character/run outside the recognized token set (e.g.
+/// arithmetic operators, parentheses, an unterminated string).
+pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
+    let mut chars = sql.chars().peekable();
+    let mut tokens = Vec::new();
+    while let Some(&c) = chars.peek() {
+        match c {
+            c if c.is_whitespace() => {
+                chars.next();
+            }
+            // A `.` starts a number when a digit follows (a leading-dot decimal like `.5`);
+            // otherwise it is a column-path separator.
+            '.' => {
+                if matches!(peek_second(&chars), Some(d) if d.is_ascii_digit()) {
+                    tokens.push(Token::Literal(take_number(&mut chars)));
+                } else {
+                    chars.next();
+                    tokens.push(Token::Dot);
+                }
+            }
+            '=' => {
+                chars.next();
+                // Accept `==` as an alias for `=` (Spark SQL allows both); consume the optional
+                // second `=`.
+                chars.next_if_eq(&'=');
+                tokens.push(Token::Eq);
+            }
+            '<' => {
+                chars.next();
+                // Maximal munch: `<=` may extend to `<=>` (null-safe equal), so after consuming
+                // `=` check for a trailing `>` before settling on `Le`.
+                let tok = if chars.next_if_eq(&'=').is_some() {
+                    if chars.next_if_eq(&'>').is_some() {
+                        Token::NullSafeEq
+                    } else {
+                        Token::Le
+                    }
+                } else if chars.next_if_eq(&'>').is_some() {
+                    Token::Ne
+                } else {
+                    Token::Lt
+                };
+                tokens.push(tok);
+            }
+            '>' => {
+                chars.next();
+                let tok = if chars.next_if_eq(&'=').is_some() {
+                    Token::Ge
+                } else {
+                    Token::Gt
+                };
+                tokens.push(tok);
+            }
+            // `!=` is not-equal; `!>` and `!<` are Spark aliases for `<=` and `>=` respectively
+            // (Spark lexer: `LTE: '<=' | '!>'`, `GTE: '>=' | '!<'`).
+            '!' => {
+                chars.next();
+                let tok = if chars.next_if_eq(&'=').is_some() {
+                    Token::Ne
+                } else if chars.next_if_eq(&'>').is_some() {
+                    Token::Le
+                } else if chars.next_if_eq(&'<').is_some() {
+                    Token::Ge
+                } else {
+                    return Err(unexpected('!', sql));
+                };
+                tokens.push(tok);
+            }
+            '\'' => tokens.push(Token::Literal(take_quoted_string(&mut chars, sql)?)),
+            // A backtick-quoted column field (`` `my col` ``, `` `a.b` ``). Reuse the crate's
+            // column-name field parser so quoting/escaping matches `ColumnName` exactly; it expects
+            // the opening backtick already consumed.
+            '`' => {
+                chars.next();
+                tokens.push(Token::Ident(parse_escaped_field_name(&mut chars)?));
+            }
+            // TODO: recognize `(` / `)` as LParen / RParen tokens once the grammar supports
+            // grouping; today a sign is only valid as the start of a numeric literal (no arithmetic
+            // operators yet), so `a - b` and `(a)` are rejected here.
+            '+' | '-' => match peek_second(&chars) {
+                Some(d) if d.is_ascii_digit() || d == '.' => {
+                    tokens.push(Token::Literal(take_number(&mut chars)))
+                }
+                _ => return Err(unexpected(c, sql)),
+            },
+            c if c.is_ascii_digit() => tokens.push(Token::Literal(take_number(&mut chars))),
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                tokens.push(classify_word(&mut chars, sql)?)
+            }
+            _ => return Err(unexpected(c, sql)),
+        }
+    }
+    Ok(tokens)
+}
+
+fn unexpected(c: char, sql: &str) -> Error {
+    Error::generic(format!("unexpected character '{c}' in {sql}"))
+}
+
+/// Peek the second character of the stream (the one after the next), without consuming anything.
+fn peek_second(chars: &CharStream<'_>) -> Option<char> {
+    let mut lookahead = chars.clone();
+    lookahead.next();
+    lookahead.peek().copied()
+}
+
+/// Consume a `'...'` string literal, returning its raw text *including* the surrounding quotes and
+/// any doubled `''` escapes.
+///
+/// Example: `'it''s'` returns `'it''s'` (verbatim). The caller must guarantee a leading `'`.
+fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<String> {
+    chars.next();
+    let mut out = String::from('\'');
+    loop {
+        match chars.next() {
+            Some('\'') => {
+                out.push('\'');
+                // A doubled quote is an embedded single quote; keep scanning. Otherwise this was
+                // the closing quote.
+                match chars.next_if_eq(&'\'') {
+                    Some(q) => out.push(q),
+                    None => return Ok(out),
+                }
+            }
+            Some(c) => out.push(c),
+            None => {
+                return Err(Error::generic(format!(
+                    "unterminated string literal in {sql}"
+                )))
+            }
+        }
+    }
+}
+
+/// Consume a numeric literal: optional leading sign, integer/fraction digits, optional exponent.
+///
+/// Example: `-2e+1` returns `-2e+1`. Stops before a second operator, so `1+1` yields just `1`.
+fn take_number(chars: &mut CharStream<'_>) -> String {
+    let mut out = String::new();
+    if let Some(sign) = chars.next_if(|c| *c == '+' || *c == '-') {
+        out.push(sign);
+    }
+    while let Some(c) = chars.next_if(|c| c.is_ascii_digit() || *c == '.') {
+        out.push(c);
+    }
+    if let Some(e) = chars.next_if(|c| *c == 'e' || *c == 'E') {
+        out.push(e);
+        if let Some(sign) = chars.next_if(|c| *c == '+' || *c == '-') {
+            out.push(sign);
+        }
+        while let Some(c) = chars.next_if(|c| c.is_ascii_digit()) {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Scan a bare word and classify it: a keyword (`AND`/`OR`/`NOT`/`IS`), a boolean/null/typed/binary
+/// literal, or an identifier. All classification is case-insensitive.
+///
+/// Keywords are recognized here rather than downstream so a backtick-quoted `` `AND` `` (parsed as
+/// an `Ident` by the caller of this function) stays distinct from the bareword keyword `AND`.
+fn classify_word(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Token> {
+    let mut word = String::new();
+    while let Some(c) = chars.next_if(|c| is_simple_char(*c)) {
+        word.push(c);
+    }
+    let token = match word.to_ascii_uppercase().as_str() {
+        "AND" => Token::Keyword(Keyword::And),
+        "OR" => Token::Keyword(Keyword::Or),
+        "NOT" => Token::Keyword(Keyword::Not),
+        "IS" => Token::Keyword(Keyword::Is),
+        "NULL" | "TRUE" | "FALSE" => Token::Literal(word),
+        // `X'deadbeef'` binary literal: only when a quote immediately follows (no whitespace),
+        // otherwise `x` is a column named `x`.
+        "X" if chars.peek() == Some(&'\'') => {
+            let quoted = take_quoted_string(chars, sql)?;
+            Token::Literal(format!("{word}{quoted}"))
+        }
+        // Typed literal: the keyword followed (whitespace allowed) by a quoted string. Without the
+        // quote it is just a column named `date`/`timestamp`/etc.
+        "DATE" | "TIMESTAMP" | "TIMESTAMP_LTZ" | "TIMESTAMP_NTZ" if quote_follows(chars) => {
+            while chars.next_if(|c| c.is_whitespace()).is_some() {}
+            let quoted = take_quoted_string(chars, sql)?;
+            Token::Literal(format!("{word} {quoted}"))
+        }
+        _ => Token::Ident(word),
+    };
+    Ok(token)
+}
+
+/// Peek (without consuming) past any whitespace to see whether the next character is a `'`.
+fn quote_follows(chars: &CharStream<'_>) -> bool {
+    let mut lookahead = chars.clone();
+    while matches!(lookahead.peek(), Some(c) if c.is_whitespace()) {
+        lookahead.next();
+    }
+    lookahead.peek() == Some(&'\'')
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::{tokenize, Keyword, Token};
+
+    fn ident(s: &str) -> Token {
+        Token::Ident(s.to_string())
+    }
+
+    fn lit(s: &str) -> Token {
+        Token::Literal(s.to_string())
+    }
+
+    /// `==` aliases `=`; `<>`/`!=` are `Ne`; `!>`/`!<` are Spark aliases for `<=`/`>=`.
+    #[rstest]
+    #[case("<", Token::Lt)]
+    #[case("<=", Token::Le)]
+    #[case(">", Token::Gt)]
+    #[case(">=", Token::Ge)]
+    #[case("=", Token::Eq)]
+    #[case("==", Token::Eq)]
+    #[case("!=", Token::Ne)]
+    #[case("<>", Token::Ne)]
+    #[case("<=>", Token::NullSafeEq)]
+    #[case("!>", Token::Le)]
+    #[case("!<", Token::Ge)]
+    fn tokenizes_each_operator(#[case] op: &str, #[case] expected: Token) {
+        assert_eq!(
+            tokenize(&format!("a {op} 1")).unwrap(),
+            [ident("a"), expected.clone(), lit("1")]
+        );
+        // Whitespace around the operator is optional.
+        assert_eq!(
+            tokenize(&format!("a{op}1")).unwrap(),
+            [ident("a"), expected, lit("1")]
+        );
+    }
+
+    #[rstest]
+    #[case("42", lit("42"))]
+    #[case("-5", lit("-5"))]
+    #[case(".5", lit(".5"))]
+    #[case("-.5", lit("-.5"))]
+    #[case("1e3", lit("1e3"))]
+    #[case("-2e+1", lit("-2e+1"))]
+    #[case("'foo'", lit("'foo'"))]
+    #[case("'O''Brien'", lit("'O''Brien'"))] // doubled '' escape retained
+    #[case("NULL", lit("NULL"))]
+    #[case("TRUE", lit("TRUE"))]
+    #[case("false", lit("false"))]
+    #[case("DATE '1970-01-02'", lit("DATE '1970-01-02'"))]
+    #[case("DATE'1970-01-02'", lit("DATE '1970-01-02'"))] // butted quote, space normalized in output
+    #[case("X'01ff'", lit("X'01ff'"))]
+    fn tokenizes_literal_as_single_raw_token(#[case] sql: &str, #[case] expected: Token) {
+        assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    /// Every typed-literal keyword tokenizes to exactly one literal, so dropping one from the
+    /// tokenizer's set (which would mis-lex it as an identifier) fails here.
+    #[rstest]
+    #[case("DATE '2024-01-01'")]
+    #[case("TIMESTAMP '2024-01-01T00:00:00Z'")]
+    #[case("TIMESTAMP_LTZ '2024-01-01T00:00:00Z'")]
+    #[case("TIMESTAMP_NTZ '2024-01-01 00:00:00'")]
+    fn every_typed_keyword_tokenizes_to_one_literal(#[case] sql: &str) {
+        assert!(matches!(
+            tokenize(sql).unwrap().as_slice(),
+            [Token::Literal(_)]
+        ));
+    }
+
+    /// `AND`/`OR`/`NOT`/`IS` are keyword tokens (case-insensitive); a backtick-quoted `` `AND` ``
+    /// stays an `Ident`, distinct from the keyword.
+    #[rstest]
+    #[case("AND", Token::Keyword(Keyword::And))]
+    #[case("or", Token::Keyword(Keyword::Or))]
+    #[case("Not", Token::Keyword(Keyword::Not))]
+    #[case("IS", Token::Keyword(Keyword::Is))]
+    #[case("`AND`", ident("AND"))]
+    fn tokenizes_keyword_vs_quoted_identifier(#[case] sql: &str, #[case] expected: Token) {
+        assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    #[test]
+    fn tokenizes_dotted_column_path() {
+        assert_eq!(
+            tokenize("a.b.c").unwrap(),
+            [ident("a"), Token::Dot, ident("b"), Token::Dot, ident("c")]
+        );
+    }
+
+    #[rstest]
+    #[case("")]
+    #[case("   ")]
+    #[case("\t\n ")]
+    fn tokenizes_empty_or_whitespace_only_input_to_no_tokens(#[case] sql: &str) {
+        assert_eq!(tokenize(sql).unwrap(), []);
+    }
+
+    /// A malformed number is emitted verbatim as one raw literal token; the tokenizer does not
+    /// validate numeric structure.
+    #[rstest]
+    #[case("1e", lit("1e"))]
+    #[case("1.2.3", lit("1.2.3"))]
+    #[case("1E3", lit("1E3"))]
+    #[case("5e-3", lit("5e-3"))]
+    fn tokenizes_malformed_number_as_single_raw_token(#[case] sql: &str, #[case] expected: Token) {
+        assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    /// A backtick-quoted field is one `Ident` carrying its unescaped name (spaces, dots, and
+    /// doubled-backtick escapes included), matching `ColumnName`.
+    #[rstest]
+    #[case("`my col`", ident("my col"))]
+    #[case("`a.b`", ident("a.b"))]
+    #[case("`a``b`", ident("a`b"))]
+    fn tokenizes_backtick_quoted_field(#[case] sql: &str, #[case] expected: Token) {
+        assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    #[test]
+    fn tokenizes_backtick_field_in_comparison_and_path() {
+        assert_eq!(
+            tokenize("`my col` > 0").unwrap(),
+            [ident("my col"), Token::Gt, lit("0")]
+        );
+        assert_eq!(
+            tokenize("a.`b c`").unwrap(),
+            [ident("a"), Token::Dot, ident("b c")]
+        );
+        assert!(tokenize("`unterminated").is_err());
+    }
+
+    #[rstest]
+    #[case("amount", ident("amount"))]
+    #[case("date", ident("date"))] // keyword not followed by a quote is a plain identifier
+    #[case("x", ident("x"))]
+    fn tokenizes_bareword_as_identifier(#[case] sql: &str, #[case] expected: Token) {
+        assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    #[rstest]
+    #[case("a ! b")] // lone `!`
+    #[case("(a)")] // grouping not yet supported
+    #[case("'unterminated")]
+    fn rejects_ungrammatical_input(#[case] sql: &str) {
+        assert!(tokenize(sql).is_err(), "expected {sql:?} to be rejected");
+    }
+}

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -58,7 +58,7 @@ pub(super) enum Keyword {
 }
 
 /// Tokenize `sql`, or return an error for any character/run outside the recognized token set (e.g.
-/// arithmetic operators, parentheses, an unterminated string).
+/// parentheses, `*` or `/`, a lone `!`, or an unterminated string).
 pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
     let mut chars = sql.chars().peekable();
     let mut tokens = Vec::new();
@@ -171,6 +171,11 @@ fn peek_second(chars: &CharStream<'_>) -> Option<char> {
 ///
 /// Example: `'it''s'` returns `'it''s'` (verbatim). The caller must guarantee a leading `'`.
 fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<String> {
+    debug_assert_eq!(
+        chars.peek(),
+        Some(&'\''),
+        "take_quoted_string requires a leading quote"
+    );
     chars.next();
     let mut out = String::from('\'');
     loop {
@@ -194,11 +199,16 @@ fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Stri
     }
 }
 
-/// Consume an unsigned numeric literal: integer/fraction digits and an optional exponent. A leading
-/// `+`/`-` is a separate operator token (see the `Plus`/`Minus` arms), not consumed here; the
-/// exponent's own sign (`2e+1`) is part of the number.
+/// Consume an unsigned numeric literal: a run of digits and `.` followed by an optional exponent. A
+/// leading `+`/`-` is a separate operator token (see the `Plus`/`Minus` arms), not consumed here;
+/// the exponent's own sign (`2e+1`) is part of the number.
 ///
-/// Example: `2e+1` returns `2e+1`. Stops before a second operator, so `1+1` yields just `1`.
+/// A leading dot needs no digit before it, so `.2` is a number. The `.` is not validated: `3.14159`
+/// and `0.2` are numbers, as is a malformed `1.2.3` (emitted verbatim). `3/4` is not a number: `/`
+/// is not consumed, so only the `3` is taken.
+///
+/// Examples: `3.14159` -> `3.14159`; `.2` -> `.2`; `2e+1` -> `2e+1`. Stops before a second
+/// operator, so `1+1` yields just `1`.
 fn take_number(chars: &mut CharStream<'_>) -> String {
     let mut out = String::new();
     while let Some(c) = chars.next_if(|c| c.is_ascii_digit() || *c == '.') {
@@ -250,7 +260,9 @@ fn classify_word(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Token> {
     Ok(token)
 }
 
-/// Peek (without consuming) past any whitespace to see whether the next character is a `'`.
+/// Peek (without consuming) past any whitespace to see whether the next character is a `'`. Used to
+/// tell a typed literal from a plain identifier: in `TIMESTAMP '..'` a quote follows (true), but a
+/// bare `timestamp` column has none (false).
 fn quote_follows(chars: &CharStream<'_>) -> bool {
     let mut lookahead = chars.clone();
     while matches!(lookahead.peek(), Some(c) if c.is_whitespace()) {

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -42,10 +42,9 @@ pub(super) enum Token {
     /// reassembles a signed literal from `Minus`/`Plus` followed by a numeric `Literal`.
     Plus,
     Minus,
-    /// The `AND`/`OR`/`NOT`/`IS` keywords. Recognized here (not left as [`Token::Ident`]) so a
-    /// backtick-quoted column literally named `` `AND` `` stays an `Ident`, distinct from the
-    /// keyword. The current parser has no grammar for them and rejects them; they are tokenized so
-    /// it can do so unambiguously.
+    /// The `AND`/`OR`/`NOT`/`IS` keywords. Recognized here so a backtick-quoted column
+    /// named `` `AND` `` stays an `Ident`, distinct from the keyword. The current
+    /// parser has no grammar for them and rejects them.
     Keyword(Keyword),
 }
 
@@ -136,7 +135,7 @@ pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
             }
             // `+`/`-` are standalone operators (Spark treats a leading sign as unary +/-, not part
             // of the number); the parser reassembles a signed literal from the sign + number.
-            // TODO: recognize `(` / `)` as LParen / RParen tokens once the grammar supports
+            // TODO(#2895): recognize `(` / `)` as LParen / RParen tokens once the grammar supports
             // grouping.
             '+' => {
                 chars.next();

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -36,6 +36,11 @@ pub(super) enum Token {
     Ne,
     /// `<=>`, Spark's null-safe equality (`NULL <=> NULL` is true).
     NullSafeEq,
+    /// `+` and `-`. Emitted as standalone operators (matching Spark, where a leading sign is unary
+    /// minus/plus, not part of the number). A number is never lexed with a sign; the caller
+    /// reassembles a signed literal from `Minus`/`Plus` followed by a numeric `Literal`.
+    Plus,
+    Minus,
     /// The `AND`/`OR`/`NOT`/`IS` keywords. Recognized here (not left as [`Token::Ident`]) so a
     /// backtick-quoted column literally named `` `AND` `` stays an `Ident`, distinct from the
     /// keyword. The current parser has no grammar for them and rejects them; they are tokenized so
@@ -128,15 +133,18 @@ pub(super) fn tokenize(sql: &str) -> DeltaResult<Vec<Token>> {
                 chars.next();
                 tokens.push(Token::Ident(parse_escaped_field_name(&mut chars)?));
             }
+            // `+`/`-` are standalone operators (Spark treats a leading sign as unary +/-, not part
+            // of the number); the parser reassembles a signed literal from the sign + number.
             // TODO: recognize `(` / `)` as LParen / RParen tokens once the grammar supports
-            // grouping; today a sign is only valid as the start of a numeric literal (no arithmetic
-            // operators yet), so `a - b` and `(a)` are rejected here.
-            '+' | '-' => match peek_second(&chars) {
-                Some(d) if d.is_ascii_digit() || d == '.' => {
-                    tokens.push(Token::Literal(take_number(&mut chars)))
-                }
-                _ => return Err(unexpected(c, sql)),
-            },
+            // grouping.
+            '+' => {
+                chars.next();
+                tokens.push(Token::Plus);
+            }
+            '-' => {
+                chars.next();
+                tokens.push(Token::Minus);
+            }
             c if c.is_ascii_digit() => tokens.push(Token::Literal(take_number(&mut chars))),
             c if c.is_ascii_alphabetic() || c == '_' => {
                 tokens.push(classify_word(&mut chars, sql)?)
@@ -186,14 +194,13 @@ fn take_quoted_string(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Stri
     }
 }
 
-/// Consume a numeric literal: optional leading sign, integer/fraction digits, optional exponent.
+/// Consume an unsigned numeric literal: integer/fraction digits and an optional exponent. A leading
+/// `+`/`-` is a separate operator token (see the `Plus`/`Minus` arms), not consumed here; the
+/// exponent's own sign (`2e+1`) is part of the number.
 ///
-/// Example: `-2e+1` returns `-2e+1`. Stops before a second operator, so `1+1` yields just `1`.
+/// Example: `2e+1` returns `2e+1`. Stops before a second operator, so `1+1` yields just `1`.
 fn take_number(chars: &mut CharStream<'_>) -> String {
     let mut out = String::new();
-    if let Some(sign) = chars.next_if(|c| *c == '+' || *c == '-') {
-        out.push(sign);
-    }
     while let Some(c) = chars.next_if(|c| c.is_ascii_digit() || *c == '.') {
         out.push(c);
     }
@@ -279,6 +286,8 @@ mod tests {
     #[case("<=>", Token::NullSafeEq)]
     #[case("!>", Token::Le)]
     #[case("!<", Token::Ge)]
+    #[case("+", Token::Plus)]
+    #[case("-", Token::Minus)]
     fn tokenizes_each_operator(#[case] op: &str, #[case] expected: Token) {
         assert_eq!(
             tokenize(&format!("a {op} 1")).unwrap(),
@@ -291,13 +300,24 @@ mod tests {
         );
     }
 
+    /// A leading `+`/`-` is a standalone operator, not part of the number -- so a signed literal
+    /// lexes as two tokens (the parser reassembles it), and whitespace between the sign and the
+    /// digits (`- 5`) is irrelevant. The exponent's own sign stays inside the number.
+    #[rstest]
+    #[case("-5", &[Token::Minus, lit("5")])]
+    #[case("- 5", &[Token::Minus, lit("5")])]
+    #[case("+5", &[Token::Plus, lit("5")])]
+    #[case("-.5", &[Token::Minus, lit(".5")])]
+    #[case("-2e+1", &[Token::Minus, lit("2e+1")])]
+    fn tokenizes_signed_number_as_sign_then_literal(#[case] sql: &str, #[case] expected: &[Token]) {
+        assert_eq!(tokenize(sql).unwrap(), expected);
+    }
+
     #[rstest]
     #[case("42", lit("42"))]
-    #[case("-5", lit("-5"))]
     #[case(".5", lit(".5"))]
-    #[case("-.5", lit("-.5"))]
     #[case("1e3", lit("1e3"))]
-    #[case("-2e+1", lit("-2e+1"))]
+    #[case("2e+1", lit("2e+1"))] // the exponent sign is part of the number
     #[case("'foo'", lit("'foo'"))]
     #[case("'O''Brien'", lit("'O''Brien'"))] // doubled '' escape retained
     #[case("NULL", lit("NULL"))]

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -7,6 +7,7 @@
 //! Example: `` `col1` > 5 `` tokenizes to `[Ident("col1"), Gt, Literal("5")]`.
 
 // WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+// TODO(#2896): remove this allow once check-constraint enforcement wires up a caller.
 #![allow(dead_code)]
 
 use std::iter::Peekable;
@@ -309,6 +310,9 @@ mod tests {
     #[case("+5", &[Token::Plus, lit("5")])]
     #[case("-.5", &[Token::Minus, lit(".5")])]
     #[case("-2e+1", &[Token::Minus, lit("2e+1")])]
+    // `1+1` is three tokens (the sign never glues onto the following number), so the number after
+    // an operator is not swallowed into the previous one.
+    #[case("1+1", &[lit("1"), Token::Plus, lit("1")])]
     fn tokenizes_signed_number_as_sign_then_literal(#[case] sql: &str, #[case] expected: &[Token]) {
         assert_eq!(tokenize(sql).unwrap(), expected);
     }


### PR DESCRIPTION
## Stacked PR

Splitting #2812 per review feedback. Each PR is based on `main`; use the incremental link to review only this PR's changes.
- **stack/check-constraints-tokenizer** (this PR, #2882) -- bottom of the stack, so its full diff is already incremental.
  - stack/check-constraints-parser (#2883)
    - stack/check-constraints-lower (#2884)

## What changes are proposed in this pull request?

We add a tokenizer as the first layer for this series of stacked PRs to expand kernel's SQL parser to support predicates. The structure of these PRs is meant for ease of integration when supporting more complex logic in CHECKs down the road

## How was this change tested?

new UTs