### PR TITLE
feat: lower parsed CHECK constraint comparisons to a Predicate

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -452,8 +452,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
     (
         "Simple predicates but timestamp schema mismatch in result validation",
         &[
-            "cc_007_multiple_constraints/specs/cc_007_multiple_constraints_filter_amount",
-            "cc_020_decimal_constraint/specs/cc_020_decimal_constraint_filter_high_price",
             "ds_stats_after_drop/specs/ds_stats_after_drop_hit_c1_eq_1",
             "ds_stats_after_drop/specs/ds_stats_after_drop_hit_c10_gt_1_5",
             "ds_stats_after_drop/specs/ds_stats_after_drop_hit_c3_lt_1_5",
@@ -509,12 +507,10 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
             "ds_typed_stats/specs/ds_typed_stats_miss_c5_gte_future",
             "ds_typed_stats/specs/ds_typed_stats_miss_c6_gte_future_ntz",
             "ds_typed_stats/specs/ds_typed_stats_miss_c7_eq_future",
-            "dsReadDecimalType/specs/dsReadDecimalType_readExpensive",
             "gc_append_data/specs/gc_append_data_filter_partition",
             "gc_delete/specs/gc_delete_filter_remaining",
             "gc_insert_by_name/specs/gc_insert_by_name_filter_c2_g",
             "gc_update_source/specs/gc_update_source_filter_c2_g_updated",
-            "tw_decimal_precision_read_large_values",
         ],
     ),
     (

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -36,7 +36,8 @@ mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
 pub(crate) use self::sql::parse_sql;
 #[cfg(feature = "check-constraints-in-dev")]
-// TODO(#2896): Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this allow
+// TODO(#2896): Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this
+// allow
 #[allow(unused_imports)]
 pub(crate) use self::sql::parse_sql_simple_predicate;
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -35,6 +35,10 @@ mod scalars;
 mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
 pub(crate) use self::sql::parse_sql;
+#[cfg(feature = "check-constraints-in-dev")]
+// TODO: Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this allow
+#[allow(unused_imports)]
+pub(crate) use self::sql::parse_sql_simple_predicate;
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -36,7 +36,7 @@ mod sql;
 #[cfg(feature = "column-defaults-in-dev")]
 pub(crate) use self::sql::parse_sql;
 #[cfg(feature = "check-constraints-in-dev")]
-// TODO: Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this allow
+// TODO(#2896): Wire up `parse_sql_simple_predicate` to check-constraints discovery; remove this allow
 #[allow(unused_imports)]
 pub(crate) use self::sql::parse_sql_simple_predicate;
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -859,9 +859,9 @@ impl PrimitiveType {
             }
         };
 
-        // we can assume this won't underflow since `frac_digits` is at minimum 0, and exp is at
-        // most i128::MAX, and 0-i128::MAX doesn't underflow
-        let scale = frac_digits - exp;
+        // `exp` is untrusted (parsed from `raw`), so a pathological exponent near i128::MIN would
+        // overflow a plain `frac_digits - exp`; fail closed with checked_sub rather than panic.
+        let scale = frac_digits.checked_sub(exp).ok_or_else(parse_error)?;
         let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
         require!(scale == dtype.scale(), parse_error());
         let int: i128 = match frac_part {
@@ -1042,6 +1042,8 @@ mod tests {
         expect_fail_parse("0.999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999", 1, 0);
         // scale will be too small to fit in i8
         expect_fail_parse("0.E170141183460469231731687303715884105727", 1, 0);
+        // exp == i128::MIN: `frac_digits - exp` would overflow i128; must fail closed, not panic
+        expect_fail_parse("1E-170141183460469231731687303715884105728", 1, 0);
     }
 
     #[test]

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -860,7 +860,7 @@ impl PrimitiveType {
         };
 
         // `exp` is untrusted (parsed from `raw`), so a pathological exponent near i128::MIN would
-        // overflow a plain `frac_digits - exp`; fail closed with checked_sub rather than panic.
+        // overflow a plain `frac_digits - exp`; fail with checked_sub.
         let scale = frac_digits.checked_sub(exp).ok_or_else(parse_error)?;
         let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
         require!(scale == dtype.scale(), parse_error());

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -859,17 +859,29 @@ impl PrimitiveType {
             }
         };
 
-        // `exp` is untrusted (parsed from `raw`): a plain `frac_digits - exp` overflows i128 for
-        // `exp <= i128::MIN + frac_digits` (subtracting a large-magnitude negative). checked_sub
-        // turns that into a parse error instead of a panic.
-        let scale = frac_digits.checked_sub(exp).ok_or_else(parse_error)?;
-        let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
-        require!(scale == dtype.scale(), parse_error());
+        // The literal's own scale. `exp` is untrusted (parsed from `raw`): a plain
+        // `frac_digits - exp` overflows i128 for `exp <= i128::MIN + frac_digits` (subtracting a
+        // large-magnitude negative), so checked_sub turns that into a parse error, not a panic.
+        let literal_scale = frac_digits.checked_sub(exp).ok_or_else(parse_error)?;
         let int: i128 = match frac_part {
             None => int_part.parse()?,
             Some(frac_part) => format!("{int_part}{frac_part}").parse()?,
         };
-        Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
+        // Pad the literal up to the column's scale, matching Spark's coercion (it reads `0` as
+        // `0.00` against a `DECIMAL(_, 2)` column): multiply the unscaled value by `10^pad`.
+        // Reducing scale would drop precision, so a literal scale exceeding the column's is
+        // rejected (`pad < 0`). `checked_*` reject a `pad` or scaled value too large to
+        // represent.
+        let pad = i128::from(dtype.scale())
+            .checked_sub(literal_scale)
+            .filter(|pad| *pad >= 0)
+            .ok_or_else(parse_error)?;
+        let scaled = u32::try_from(pad)
+            .ok()
+            .and_then(|pad| 10i128.checked_pow(pad))
+            .and_then(|factor| int.checked_mul(factor))
+            .ok_or_else(parse_error)?;
+        Ok(Scalar::Decimal(DecimalData::try_new(scaled, dtype)?))
     }
 }
 
@@ -1009,6 +1021,13 @@ mod tests {
         assert_decimal("1234.5E-4", 12345, 5, 5)?;
         assert_decimal("-0", 0, 1, 0)?;
         assert_decimal("12.000000000000000000", 12000000000000000000, 38, 18)?;
+        // A literal with fewer fractional digits than the column is padded up to the column's
+        // scale (matching Spark): the unscaled value is multiplied by 10^(column_scale -
+        // lit_scale).
+        assert_decimal("0", 0, 10, 2)?; // 0 -> 0.00
+        assert_decimal("10", 1000, 10, 2)?; // 10 -> 10.00
+        assert_decimal("0.5", 50, 10, 2)?; // 0.5 -> 0.50
+        assert_decimal("-1.2", -1200, 10, 3)?; // -1.2 -> -1.200 (sign preserved)
         Ok(())
     }
 

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -859,8 +859,9 @@ impl PrimitiveType {
             }
         };
 
-        // `exp` is untrusted (parsed from `raw`), so a pathological exponent near i128::MIN would
-        // overflow a plain `frac_digits - exp`; fail with checked_sub.
+        // `exp` is untrusted (parsed from `raw`): a plain `frac_digits - exp` overflows i128 for
+        // `exp <= i128::MIN + frac_digits` (subtracting a large-magnitude negative). checked_sub
+        // turns that into a parse error instead of a panic.
         let scale = frac_digits.checked_sub(exp).ok_or_else(parse_error)?;
         let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
         require!(scale == dtype.scale(), parse_error());

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -12,11 +12,12 @@
 //! the supported SQL surface grows, options include moving parsing behind the
 //! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 //!
-//! Kernel errors out rather than guess, in cases where kernel cannot match Spark semantics, so the
-//! constraint is left to the connector (fail-closed, never a silent wrong answer). One notable such
-//! gap: a decimal literal must match the column's scale exactly (`parse_scalar` does not pad), so
-//! `amount >= 0` on a `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`.
-//! Padding the literal's scale to the column would recover these.
+//! In cases where kernel cannot match Spark semantics, kernel errors out rather than guess
+//! (fail-closed, never a silent wrong answer); how an un-lowerable constraint is then handled is
+//! the calling API's contract, not this module's. One notable such gap: a decimal literal must
+//! match the column's scale exactly (`parse_scalar` does not pad), so `amount >= 0` on a
+//! `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`. Padding the literal's
+//! scale to the column would recover these.
 
 #[cfg(feature = "check-constraints-in-dev")]
 use crate::expressions::Predicate;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -1,25 +1,74 @@
-//! Parse a SQL string into a kernel [`Expression`].
+//! Parse a SQL string into a kernel [`Expression`] or [`Predicate`].
 //!
-//! Delta stores column defaults, check constraints, and generated column definitions as SQL
-//! strings in table metadata. This module turns those strings into kernel [`Expression`] values
-//! so the kernel can interpret them without depending on a full SQL parser.
+//! Delta stores column defaults, generated column definitions, and check constraints as SQL strings
+//! in table metadata. This module turns those strings into kernel [`Expression`] or [`Predicate`]
+//! values so the kernel can interpret them without depending on a full SQL parser.
 //!
 //! The grammar follows the Spark SQL standard: this parser implements a subset of Spark's SQL
 //! grammar rather than defining a kernel-specific dialect, so the forms it accepts match what
 //! Spark reads and writes.
 //!
-//! This is an intentionally light start: a small internal parser covering only the literal forms
-//! Delta metadata contains today. If the supported SQL surface grows, options include moving
-//! parsing behind the [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
+//! This is an intentionally light start, covering only the forms Delta metadata contains today. If
+//! the supported SQL surface grows, options include moving parsing behind the
+//! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
+//!
+//! Where kernel cannot yet match Spark's coercion it errors rather than guess, so the constraint is
+//! left to the connector (fail-closed, never a silent wrong answer). One notable such gap: a
+//! decimal literal must match the column's scale exactly (`parse_scalar` does not pad), so
+//! `amount >= 0` on a `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`.
+//! Padding the literal's scale to the column would recover these.
 
+#[cfg(feature = "check-constraints-in-dev")]
+use crate::expressions::Predicate;
 use crate::expressions::{Expression, Scalar};
+#[cfg(feature = "check-constraints-in-dev")]
+use crate::schema::StructType;
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};
 
 #[cfg(feature = "check-constraints-in-dev")]
+mod lower;
+#[cfg(feature = "check-constraints-in-dev")]
 mod parser;
 #[cfg(feature = "check-constraints-in-dev")]
 mod token;
+
+/// Parse a single-comparison CHECK-constraint SQL string into a kernel [`Predicate`], resolving
+/// column references against `schema` and inferring each literal's type from the column it is
+/// compared against.
+///
+/// The supported grammar is exactly one comparison `<operand> <op> <operand>`, where each operand
+/// is a column reference (case-insensitive, dotted paths allowed), a literal, or `NULL`, and
+/// `<op>` is one of `< <= > >= = == != <>`. Literal leaves are parsed by [`parse_sql`], typed from
+/// the column on the other side of the comparison; a comparison must therefore reference at least
+/// one column.
+///
+/// Junctions (`AND`/`OR`/`NOT`), parentheses, and `IS [NOT] NULL` are intentionally out of scope
+/// and surface as errors.
+///
+/// The returned [`Predicate`] carries no CHECK-constraint NULL convention on its own. Delta rejects
+/// a row unless the constraint predicate is exactly TRUE: both FALSE *and* NULL abort the write
+/// (e.g. `CHECK (x > 0)` fails the row when `x` is NULL). This is NOT the ANSI-SQL rule where NULL
+/// passes -- see `CheckDeltaInvariant` in delta-io/delta (`result == null || result == false`
+/// throws). The caller enforcing the constraint must therefore keep a row only when the predicate
+/// evaluates to TRUE, treating NULL as a violation.
+///
+/// # Errors
+///
+/// Returns an error for any input outside the supported grammar (junctions, functions, arithmetic,
+/// `IN`, `BETWEEN`, ...), for unknown columns, and for type-incompatible literals. Callers treat
+/// that error as the signal that a constraint is *not kernel-parsable*.
+#[cfg(feature = "check-constraints-in-dev")]
+// TODO: remove once check-constraints discovery calls this; no in-crate caller until then.
+#[allow(dead_code)]
+pub(crate) fn parse_sql_simple_predicate(sql: &str, schema: &StructType) -> DeltaResult<Predicate> {
+    let tokens = token::tokenize(sql)?;
+    if tokens.is_empty() {
+        return Err(Error::generic("empty CHECK constraint expression"));
+    }
+    let comparison = parser::parse(tokens)?;
+    lower::lower(&comparison, schema)
+}
 
 /// Parse a SQL string into an [`Expression`] that yields a value of the given [`DataType`]
 /// (e.g. the type of the column whose default is being parsed).

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -59,7 +59,7 @@ mod token;
 /// `IN`, `BETWEEN`, ...), for unknown columns, and for type-incompatible literals. Callers treat
 /// that error as the signal that a constraint is *not kernel-parsable*.
 #[cfg(feature = "check-constraints-in-dev")]
-// TODO: remove once check-constraints discovery calls this; no in-crate caller until then.
+// TODO(#2896): remove once check-constraints discovery calls this; no in-crate caller until then.
 #[allow(dead_code)]
 pub(crate) fn parse_sql_simple_predicate(sql: &str, schema: &StructType) -> DeltaResult<Predicate> {
     let tokens = token::tokenize(sql)?;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -12,7 +12,7 @@
 //! the supported SQL surface grows, options include moving parsing behind the
 //! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 //!
-//! Where kernel cannot yet match Spark's coercion it errors rather than guess, so the constraint is
+//! Kernel errors out rather than guess, in cases where kernel cannot match Spark semantics, so the constraint is
 //! left to the connector (fail-closed, never a silent wrong answer). One notable such gap: a
 //! decimal literal must match the column's scale exactly (`parse_scalar` does not pad), so
 //! `amount >= 0` on a `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`.

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -14,10 +14,9 @@
 //!
 //! In cases where kernel cannot match Spark semantics, kernel errors out rather than guess
 //! (fail-closed, never a silent wrong answer); how an un-lowerable constraint is then handled is
-//! the calling API's contract, not this module's. One notable such gap: a decimal literal must
-//! match the column's scale exactly (`parse_scalar` does not pad), so `amount >= 0` on a
-//! `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`. Padding the literal's
-//! scale to the column would recover these.
+//! the calling API's contract, not this module's. One notable such gap: a FLOAT column compared
+//! against a literal that is not exactly representable in f32 is rejected, because kernel compares
+//! at f32 while Spark widens the column to f64 (see `type_literal_from_column` in `sql::lower`).
 
 #[cfg(feature = "check-constraints-in-dev")]
 use crate::expressions::Predicate;
@@ -467,6 +466,18 @@ mod tests {
             DecimalData::try_new(-1234567, DecimalType::try_new(10, 2).unwrap()).unwrap()
         ),
     )]
+    // A literal with fewer fractional digits than the column is padded up to the column's scale
+    // (matching Spark): `0` -> `0.00`, `1.2` -> `1.20`.
+    #[case(
+        "0",
+        decimal_type(10, 2),
+        Scalar::Decimal(DecimalData::try_new(0, DecimalType::try_new(10, 2).unwrap()).unwrap()),
+    )]
+    #[case(
+        "1.2",
+        decimal_type(5, 2),
+        Scalar::Decimal(DecimalData::try_new(120, DecimalType::try_new(5, 2).unwrap()).unwrap()),
+    )]
     fn parses_basic_literals(#[case] sql: &str, #[case] ty: DataType, #[case] expected: Scalar) {
         let got = parse_sql(sql, &ty).unwrap();
         assert_eq!(got, Expression::literal(expected));
@@ -619,8 +630,6 @@ mod tests {
     #[case("now()", DataType::TIMESTAMP)]
     #[case("1 + 1", DataType::INTEGER)]
     #[case("concat('a', 'b')", DataType::STRING)]
-    #[case("0", decimal_type(10, 2))] // parse_scalar requires the literal's scale to match exactly
-    #[case("1.2", decimal_type(5, 2))]
     fn currently_unsupported_valid_sql(#[case] sql: &str, #[case] ty: DataType) {
         let result = parse_sql(sql, &ty);
         assert!(

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -1,6 +1,6 @@
 //! Parse a SQL string into a kernel [`Expression`] or [`Predicate`].
 //!
-//! Delta stores column defaults, generated column definitions, and check constraints as SQL strings
+//! Delta stores column defaults, generated column definitions and check constraints as SQL strings
 //! in table metadata. This module turns those strings into kernel [`Expression`] or [`Predicate`]
 //! values so the kernel can interpret them without depending on a full SQL parser.
 //!

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -88,11 +88,18 @@ pub(crate) fn parse_sql_simple_predicate(sql: &str, schema: &StructType) -> Delt
 ///
 /// Returns an error if the input is not a SQL form this parser accepts, or if the parsed value
 /// is not compatible with `data_type` (incompatible type, out of range, etc.).
-// Reached only via the `column-defaults-in-dev` re-export today; under `check-constraints-in-dev`
-// alone it has no caller until the lowering stage lands (which calls it via `super::parse_sql`).
+// Reached via the `column-defaults-in-dev` re-export and, under `check-constraints-in-dev`, by the
+// lowering stage (`lower` types each literal through `super::parse_sql`); dead only when neither
+// feature is enabled.
 #[cfg_attr(
-    not(feature = "column-defaults-in-dev"),
-    allow(dead_code, reason = "wired up by the check-constraints lowering stage")
+    not(any(
+        feature = "column-defaults-in-dev",
+        feature = "check-constraints-in-dev"
+    )),
+    allow(
+        dead_code,
+        reason = "wired up by column defaults and check-constraint lowering"
+    )
 )]
 pub(crate) fn parse_sql(sql: &str, data_type: &DataType) -> DeltaResult<Expression> {
     let trimmed = sql.trim();

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -39,7 +39,8 @@ mod token;
 ///
 /// The supported grammar is exactly one comparison `<operand> <op> <operand>`, where each operand
 /// is a column reference (case-insensitive, dotted paths allowed), a literal, or `NULL`, and
-/// `<op>` is one of `< <= > >= = == != <>`. Literal leaves are parsed by [`parse_sql`], typed from
+/// `<op>` is any comparison operator: `<`, `<=`, `>`, `>=`, `=`, `<>`, null-safe `<=>`, and their
+/// Spark spellings (`==`, `!=`, `!>`, `!<`). Literal leaves are parsed by [`parse_sql`], typed from
 /// the column on the other side of the comparison; a comparison must therefore reference at least
 /// one column.
 ///
@@ -55,9 +56,18 @@ mod token;
 ///
 /// # Errors
 ///
-/// Returns an error for any input outside the supported grammar (junctions, functions, arithmetic,
-/// `IN`, `BETWEEN`, ...), for unknown columns, and for type-incompatible literals. Callers treat
-/// that error as the signal that a constraint is *not kernel-parsable*.
+/// Returns an error for any input the kernel cannot lower. Two distinct conditions currently share
+/// the one error channel, and a caller may want to treat them differently:
+/// - *Not kernel-parsable* -- grammar or types the kernel cannot yet lower but Spark accepts
+///   (junctions, functions, arithmetic, `IN`/`BETWEEN`, type-incompatible literals, the
+///   FLOAT-vs-DECIMAL/DOUBLE-literal rejection). The constraint is well-formed; the connector can
+///   still enforce it.
+/// - *Invalid constraint* -- a column reference absent from `schema`. A stored constraint is
+///   validated against the schema at `ADD CONSTRAINT` time, so this signals corrupt metadata (or a
+///   wrong schema view) rather than a lowering gap; the connector cannot enforce it either.
+///
+/// Both surface as `Error::generic` today; the taxonomy is documented here so a future caller
+/// (#2896) can decide fall-back-to-connector vs hard-fail without string-matching messages.
 #[cfg(feature = "check-constraints-in-dev")]
 // TODO(#2896): remove once check-constraints discovery calls this; no in-crate caller until then.
 #[allow(dead_code)]
@@ -88,19 +98,6 @@ pub(crate) fn parse_sql_simple_predicate(sql: &str, schema: &StructType) -> Delt
 ///
 /// Returns an error if the input is not a SQL form this parser accepts, or if the parsed value
 /// is not compatible with `data_type` (incompatible type, out of range, etc.).
-// Reached via the `column-defaults-in-dev` re-export and, under `check-constraints-in-dev`, by the
-// lowering stage (`lower` types each literal through `super::parse_sql`); dead only when neither
-// feature is enabled.
-#[cfg_attr(
-    not(any(
-        feature = "column-defaults-in-dev",
-        feature = "check-constraints-in-dev"
-    )),
-    allow(
-        dead_code,
-        reason = "wired up by column defaults and check-constraint lowering"
-    )
-)]
 pub(crate) fn parse_sql(sql: &str, data_type: &DataType) -> DeltaResult<Expression> {
     let trimmed = sql.trim();
     if trimmed.is_empty() {

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -12,9 +12,9 @@
 //! the supported SQL surface grows, options include moving parsing behind the
 //! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 //!
-//! Kernel errors out rather than guess, in cases where kernel cannot match Spark semantics, so the constraint is
-//! left to the connector (fail-closed, never a silent wrong answer). One notable such gap: a
-//! decimal literal must match the column's scale exactly (`parse_scalar` does not pad), so
+//! Kernel errors out rather than guess, in cases where kernel cannot match Spark semantics, so the
+//! constraint is left to the connector (fail-closed, never a silent wrong answer). One notable such
+//! gap: a decimal literal must match the column's scale exactly (`parse_scalar` does not pad), so
 //! `amount >= 0` on a `DECIMAL(10,2)` column is rejected where Spark would read `0` as `0.00`.
 //! Padding the literal's scale to the column would recover these.
 
@@ -58,16 +58,17 @@ mod token;
 ///
 /// Returns an error for any input the kernel cannot lower. Two distinct conditions currently share
 /// the one error channel, and a caller may want to treat them differently:
-/// - *Not kernel-parsable* -- grammar or types the kernel cannot yet lower but Spark accepts
-///   (junctions, functions, arithmetic, `IN`/`BETWEEN`, type-incompatible literals, the
-///   FLOAT-vs-DECIMAL/DOUBLE-literal rejection). The constraint is well-formed; the connector can
-///   still enforce it.
+/// - *Not kernel-parsable* -- a well-formed constraint whose grammar or types the kernel cannot yet
+///   lower faithfully (junctions, functions, arithmetic, `IN`/`BETWEEN`, type-incompatible
+///   literals, an f32-inexact literal against a FLOAT column). Kernel simply declines to enforce
+///   it.
 /// - *Invalid constraint* -- a column reference absent from `schema`. A stored constraint is
 ///   validated against the schema at `ADD CONSTRAINT` time, so this signals corrupt metadata (or a
-///   wrong schema view) rather than a lowering gap; the connector cannot enforce it either.
+///   wrong schema view) rather than a lowering gap.
 ///
-/// Both surface as `Error::generic` today; the taxonomy is documented here so a future caller
-/// (#2896) can decide fall-back-to-connector vs hard-fail without string-matching messages.
+/// Both surface as `Error::generic` today; the taxonomy is noted here so a future caller (#2896)
+/// can distinguish them without string-matching messages. What a caller *does* with each -- fall
+/// back to its own enforcement, hard-fail, etc. -- is that caller's contract, not this function's.
 #[cfg(feature = "check-constraints-in-dev")]
 // TODO(#2896): remove once check-constraints discovery calls this; no in-crate caller until then.
 #[allow(dead_code)]

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -17,9 +17,9 @@ use crate::{DeltaResult, Error};
 /// Lower a parsed [`Comparison`] into a kernel [`Predicate`], resolving each operand against
 /// `schema`.
 ///
-/// Kernel can only lower a comparison it can evaluate to the *same* boolean Spark would; anything
-/// else is rejected so the caller treats the constraint as not-kernel-parsable
-/// (connector-enforced). The resolved operands must therefore satisfy all of:
+/// Kernel only lowers a comparison it can evaluate to the *same* boolean the writer would;
+/// anything else returns `Err` (what the caller does with an un-lowerable constraint is the
+/// caller's contract, not this function's). The resolved operands must therefore satisfy all of:
 /// - at least one operand is a column, so a literal can be typed from it;
 /// - every column operand is primitive-typed (struct/array/map have no scalar comparison);
 /// - the two operands share a single comparison type, because the engine compares only matching
@@ -131,30 +131,30 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
 /// FLOAT-column cases where kernel would silently disagree with Spark.
 ///
 /// Kernel types a literal from the compared column, so against a FLOAT column it narrows the
-/// literal to f32 and compares at f32. Spark instead types the literal on its own and coerces to a
-/// common type; whether the FLOAT column stays f32 or is widened to f64 depends on the literal's
-/// Spark type:
-/// - INT/LONG literal (an integer in i64 range): the common type is FLOAT, so Spark casts the
-///   *literal* to f32 and compares at f32 -- identical compare *width* to kernel, so safe to lower.
-///   (The signed-zero divergence in [`lower`]'s doc is orthogonal: it is about the column's stored
-///   value, not the literal's type, and applies to any float comparison regardless of this gate.)
-/// - DECIMAL/DOUBLE literal (has a `.`/exponent, or an integer beyond i64): the common type is
-///   DOUBLE, so Spark widens the *column* to f64 and compares at f64. For a literal not exactly
-///   representable in f32 (e.g. `0.1`) this reaches the opposite result from kernel's f32 compare,
-///   silently. Kernel has no cast expression and the engine cannot compare f32 to f64, so it cannot
-///   reproduce Spark's widening; these are left to the connector.
+/// literal to f32 and compares at f32. Spark (ANSI, the DBR / Spark-4 default) instead widens the
+/// *column* to f64 for any numeric literal and compares at f64. The two agree only when the literal
+/// is exactly representable in f32: an integer qualifies iff it round-trips through f32 unchanged
+/// (`v as f32 as i64 == v`), which fails past 2^24 even well within i64 range (e.g. `16777217`
+/// rounds to `16777216.0`). Any literal with a `.`/exponent, or an out-of-i64 integer, is likewise
+/// not gated in and is rejected -- left to the connector.
 ///
-/// `NULL` is allowed (a null comparison involves no f32/f64 rounding). The i64 gate is exactly
-/// Spark's INT/LONG-vs-DECIMAL literal boundary, and is intentionally conservative: an f32-exact
-/// exponent literal like `1e3` would in fact agree, but is still rejected rather than
-/// special-cased. Only FLOAT is affected; a DOUBLE column already compares at f64, matching Spark.
+/// Kernel has no cast expression and cannot compare f32 to f64, so it cannot reproduce Spark's
+/// widening. `NULL` is allowed (a null comparison involves no f32/f64 rounding). Only FLOAT is
+/// affected; a DOUBLE column already compares at f64, matching Spark. (The signed-zero divergence
+/// in [`lower`]'s doc is orthogonal: it is about the column's stored value, and applies to any
+/// float comparison regardless of this gate.)
+// TODO(#2896): once kernel has a cast expression, lower `cast(col AS DOUBLE) <op> lit` and drop
+// this gate, matching Spark's f64 compare for every literal.
 fn type_literal_from_column(raw: &str, column_type: &DataType) -> DeltaResult<Expression> {
     let is_null = raw.eq_ignore_ascii_case("null");
-    let is_int_or_long_literal = raw.parse::<i64>().is_ok();
-    if column_type == &DataType::FLOAT && !is_null && !is_int_or_long_literal {
+    // A FLOAT column narrows the literal to f32, but Spark widens the column to f64, so the two
+    // compares agree only when the literal is f32-exact. For an integer that means round-tripping
+    // through f32 unchanged (which also rejects out-of-i64 integers, since those fail to parse).
+    let is_f32_exact_int = raw.parse::<i64>().is_ok_and(|v| v as f32 as i64 == v);
+    if column_type == &DataType::FLOAT && !is_null && !is_f32_exact_int {
         return Err(Error::generic(format!(
-            "CHECK constraint comparing a FLOAT column against the literal '{raw}' is not supported: \
-             Spark widens the column to DOUBLE (compares at f64) while kernel compares at f32"
+            "CHECK constraint comparing a FLOAT column against the literal '{raw}' is not \
+             supported: kernel compares at f32 while Spark (ANSI) widens the column to f64"
         )));
     }
     parse_sql(raw, column_type)
@@ -178,34 +178,19 @@ enum ResolvedOperand {
 fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
     match operand {
         Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
-        Operand::Column(column) => {
-            let (canonical, data_type) = resolve_column(column, schema)?;
-            Ok(ResolvedOperand::Column {
-                canonical,
-                data_type,
-            })
-        }
+        Operand::Column(column) => resolve_column(column, schema),
     }
 }
 
-/// Resolve a (case-insensitive) column reference against `schema`, returning the *canonical* path
-/// (the schema's stored field names) and the leaf field's type. The canonical names are what the
-/// engine sees in the logical batch, so the emitted column reference must use them rather than the
-/// as-written casing.
-fn resolve_column(
-    column: &ColumnName,
-    schema: &StructType,
-) -> DeltaResult<(Vec<String>, DataType)> {
-    let fields = schema.fields_of_path_by(column, |parent, name| {
-        parent
-            .fields()
-            .find(|f| f.name().eq_ignore_ascii_case(name))
-    })?;
-    let canonical = Vec::from_iter(fields.iter().map(|f| f.name().to_string());
-    let leaf = fields
-        .last()
-        .ok_or_else(|| Error::generic("CHECK constraint references an empty column path"))?;
-    Ok((canonical, leaf.data_type().clone()))
+/// Resolve a (case-insensitive) column reference against `schema` into a [`ResolvedOperand`],
+/// carrying the *canonical* (schema-cased) path and the leaf field's type. See
+/// [`StructType::resolve_path_ci`] for why the canonical casing matters.
+fn resolve_column(column: &ColumnName, schema: &StructType) -> DeltaResult<ResolvedOperand> {
+    let (canonical, leaf) = schema.resolve_path_ci(column)?;
+    Ok(ResolvedOperand::Column {
+        canonical,
+        data_type: leaf.data_type().clone(),
+    })
 }
 
 #[cfg(test)]
@@ -238,6 +223,7 @@ mod tests {
             StructField::nullable("ts", DataType::TIMESTAMP),
             StructField::nullable("tsn", DataType::TIMESTAMP_NTZ),
             StructField::nullable("cost", DataType::decimal(10, 2).unwrap()),
+            StructField::nullable("cost2", DataType::decimal(12, 4).unwrap()),
             StructField::nullable(
                 "nested",
                 DataType::try_struct_type([StructField::nullable("inner", DataType::LONG)])
@@ -363,8 +349,9 @@ mod tests {
     #[case::column_vs_column("amount2 < amount", Predicate::lt(col("amount2"), col("amount")))]
     #[case::float_column_vs_column("weight < height", Predicate::lt(col("weight"), col("height")))]
     #[case::literal_on_left("0 < amount", Predicate::lt(Expression::literal(0i64), col("amount")))]
-    // An INT/LONG-range literal against a FLOAT column is safe: Spark casts the literal to f32 and
-    // compares at f32, exactly as kernel does (only fractional/DOUBLE/`>i64` literals diverge).
+    // An f32-exact integer literal against a FLOAT column lowers: kernel's f32 compare matches
+    // Spark's f64 compare because the value survives the narrowing. Non-f32-exact ints diverge and
+    // are rejected below.
     #[case::float_column_vs_int_literal(
         "weight > 0",
         Predicate::gt(col("weight"), Expression::literal(Scalar::Float(0.0)))
@@ -441,9 +428,13 @@ mod tests {
     #[case::two_nulls("NULL = NULL")]
     #[case::unknown_column("nope > 0")]
     // Cross-type column-vs-column comparisons are rejected: the engine compares only matching types
-    // (no coercion), while Spark coerces to a common type. Same-type pairs lower (see above).
+    // (no coercion), while Spark coerces to a common type. Same-type pairs lower (see above). The
+    // check is on the full `DataType`, so mismatched decimal precision/scale and TIMESTAMP vs
+    // TIMESTAMP_NTZ are rejected too.
     #[case::cross_type_int_long_columns("price < amount")]
     #[case::cross_type_float_double_columns("weight < ratio")]
+    #[case::cross_type_decimal_scale_columns("cost < cost2")]
+    #[case::cross_type_timestamp_ntz_columns("ts < tsn")]
     // Non-primitive (struct/array/map) columns have no scalar comparison and are rejected on either
     // side of the operator -- symmetric with the literal path, which rejects non-primitive targets.
     #[case::struct_column_vs_struct_column("nested = nested")]
@@ -459,15 +450,18 @@ mod tests {
     // read `0` as `0.00`. Left to the connector (see the `sql` module doc). `cost <= 10.00` lowers.
     #[case::decimal_integer_literal_scale_mismatch("cost >= 0")]
     #[case::decimal_wrong_scale_literal("cost >= 0.5")]
-    // A FLOAT column against a DECIMAL/DOUBLE literal (a `.`/exponent, or an integer beyond i64) is
-    // rejected: Spark widens the column to f64 while kernel compares at f32, disagreeing silently
-    // for an f32-inexact literal. The exponent and `>i64` cases are rejected conservatively even
-    // though they would happen to agree; INT/LONG-range literals are allowed (see above).
+    // A FLOAT column against any literal not exactly representable in f32 is rejected: kernel
+    // compares at f32 while Spark widens the column to f64, disagreeing silently. This covers
+    // fractional/exponent literals, out-of-i64 integers, AND in-i64 integers past 2^24 that round
+    // when narrowed to f32 (`16777217` -> `16777216.0`) -- the fail-open the old i64-only gate let
+    // through. `weight = 0.5` (f32-exact) is still rejected: conservatively, only integers are
+    // gated in, since a fractional literal's raw text may not round-trip its intended value.
     #[case::float_column_inexact_decimal_literal("weight = 0.1")]
     #[case::float_column_decimal_literal_on_left("0.1 < weight")]
     #[case::float_column_f32_exact_decimal_literal("weight = 0.5")]
     #[case::float_column_exponent_literal("weight = 1e3")]
     #[case::float_column_integer_beyond_i64("weight > 99999999999999999999")]
+    #[case::float_column_non_f32_exact_int("weight = 16777217")]
     // Malformed input.
     #[case::unterminated_string("name = 'oops")]
     #[case::bang_without_eq("amount ! 0")]

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -10,7 +10,7 @@
 
 use super::parse_sql;
 use super::parser::{CmpOp, Comparison, Operand};
-use crate::expressions::{ColumnName, Expression, Predicate};
+use crate::expressions::{ColumnName, Expression, Predicate, Scalar};
 use crate::schema::{DataType, StructType};
 use crate::{DeltaResult, Error};
 
@@ -20,7 +20,7 @@ use crate::{DeltaResult, Error};
 /// Kernel only lowers a comparison it can evaluate to the *same* boolean the writer would;
 /// anything else returns `Err` (what the caller does with an un-lowerable constraint is the
 /// caller's contract, not this function's). The resolved operands must therefore satisfy all of:
-/// - at least one operand is a column, so a literal can be typed from it;
+/// - at least one operand is a column, so a literal or `NULL` can be typed from it;
 /// - every column operand is primitive-typed. Spark does support `=`/`<=>` on struct/array/map
 ///   (only ordering is primitive-only), but kernel's engine cannot: the default engine's comparison
 ///   routes through arrow's `cmp` kernels, which error on nested types. Lowering a complex-type
@@ -49,20 +49,21 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-    // `nested = NULL` would otherwise lower silently: `parse_sql("NULL", <struct>)` succeeds (NULL
-    // is valid for any type), so the primitive-only check must run on the column operand here.
-    // (`nested = 0` is already caught by `parse_sql` rejecting a non-primitive literal target.)
+    // Reject a non-primitive column up front: the column-vs-other arms below would otherwise type
+    // the other operand against the struct/array/map type (e.g. `nested = NULL` -> a valid
+    // `Scalar::Null(<struct>)`) and lower a comparison the engine cannot evaluate.
     left.ensure_comparable()?;
     right.ensure_comparable()?;
-    // A literal is typed from the column on the other side, so at least one operand must be a
-    // column.
-    let (left_expr, right_expr) = match (left, right) {
+    // A non-column operand (literal or NULL) is typed from the column on the other side, so at
+    // least one operand must be a column.
+    use ResolvedOperand::Column;
+    let (left_expr, right_expr) = match (&left, &right) {
         (
-            ResolvedOperand::Column {
+            Column {
                 canonical: l,
                 data_type: l_type,
             },
-            ResolvedOperand::Column {
+            Column {
                 canonical: r,
                 data_type: r_type,
             },
@@ -80,29 +81,29 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
                     r.join(".")
                 )));
             }
-            (Expression::column(l), Expression::column(r))
+            (Expression::column(l.clone()), Expression::column(r.clone()))
         }
         (
-            ResolvedOperand::Column {
+            Column {
                 canonical,
                 data_type,
             },
-            ResolvedOperand::Literal(raw),
+            other,
         ) => (
-            Expression::column(canonical),
-            type_literal_from_column(&raw, &data_type)?,
+            Expression::column(canonical.clone()),
+            other.type_against_column(data_type)?,
         ),
         (
-            ResolvedOperand::Literal(raw),
-            ResolvedOperand::Column {
+            other,
+            Column {
                 canonical,
                 data_type,
             },
         ) => (
-            type_literal_from_column(&raw, &data_type)?,
-            Expression::column(canonical),
+            other.type_against_column(data_type)?,
+            Expression::column(canonical.clone()),
         ),
-        (ResolvedOperand::Literal(_), ResolvedOperand::Literal(_)) => {
+        _ => {
             return Err(Error::generic(
                 "CHECK constraint comparison must reference at least one column",
             ))
@@ -133,19 +134,18 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
 /// not gated in and is rejected.
 ///
 /// Kernel has no cast expression and cannot compare f32 to f64, so it cannot reproduce Spark's
-/// widening. `NULL` is allowed (a null comparison involves no f32/f64 rounding). Only FLOAT is
-/// affected; a DOUBLE column already compares at f64, matching Spark. (The signed-zero divergence
-/// in [`lower`]'s doc is orthogonal: it is about the column's stored value, and applies to any
-/// float comparison regardless of this gate.)
+/// widening. Only FLOAT is affected; a DOUBLE column already compares at f64, matching Spark. (The
+/// signed-zero divergence in [`lower`]'s doc is orthogonal: it is about the column's stored value,
+/// and applies to any float comparison regardless of this gate.)
 // TODO(#2896): once kernel has a cast expression, lower `cast(col AS DOUBLE) <op> lit` and drop
 // this gate, matching Spark's f64 compare for every literal.
 fn type_literal_from_column(raw: &str, column_type: &DataType) -> DeltaResult<Expression> {
-    let is_null = raw.eq_ignore_ascii_case("null");
     // A FLOAT column narrows the literal to f32, but Spark widens the column to f64, so the two
     // compares agree only when the literal is f32-exact. For an integer that means round-tripping
     // through f32 unchanged (which also rejects out-of-i64 integers, since those fail to parse).
+    // NULL never reaches here -- it is a structural `ResolvedOperand::Null`, typed directly.
     let is_f32_exact_int = raw.parse::<i64>().is_ok_and(|v| v as f32 as i64 == v);
-    if column_type == &DataType::FLOAT && !is_null && !is_f32_exact_int {
+    if column_type == &DataType::FLOAT && !is_f32_exact_int {
         return Err(Error::generic(format!(
             "CHECK constraint comparing a FLOAT column against the literal '{raw}' is not \
              supported: kernel compares at f32 while Spark (ANSI) widens the column to f64"
@@ -155,20 +155,22 @@ fn type_literal_from_column(raw: &str, column_type: &DataType) -> DeltaResult<Ex
 }
 
 /// A comparison operand after schema resolution: a column (its canonical schema-cased path and
-/// resolved leaf type) or a not-yet-typed literal (typed by [`lower`] from the column on the other
-/// side).
+/// resolved leaf type), a not-yet-typed literal (typed by [`lower`] from the column on the other
+/// side), or `NULL` (typed from the column, like a literal, but needs no parsing).
 enum ResolvedOperand {
     Column {
         canonical: Vec<String>,
         data_type: DataType,
     },
     Literal(String),
+    Null,
 }
 
 impl ResolvedOperand {
     /// Reject an operand the engine cannot compare. Only a column carries a type to check here (a
-    /// literal is typed later from the column on the other side, so it is a deliberate no-op); the
-    /// engine cannot compare nested types, so a non-primitive column is rejected. See [`lower`].
+    /// literal or `NULL` is typed later from the column on the other side, so both are a deliberate
+    /// no-op); the engine cannot compare nested types, so a non-primitive column is rejected. See
+    /// [`lower`].
     fn ensure_comparable(&self) -> DeltaResult<()> {
         let Self::Column {
             canonical,
@@ -185,6 +187,20 @@ impl ResolvedOperand {
         }
         Ok(())
     }
+
+    /// Type a non-column operand as an [`Expression`] of `column_type` -- the type of the column on
+    /// the other side of the comparison. A `NULL` becomes a typed null (no rounding, so no
+    /// FLOAT-gate); a literal is parsed and gated by [`type_literal_from_column`]. Only called for
+    /// the non-column operand of a column-vs-other comparison, so `Column` is unreachable.
+    fn type_against_column(&self, column_type: &DataType) -> DeltaResult<Expression> {
+        match self {
+            Self::Null => Ok(Expression::literal(Scalar::Null(column_type.clone()))),
+            Self::Literal(raw) => type_literal_from_column(raw, column_type),
+            Self::Column { .. } => Err(Error::generic(
+                "internal: type_against_column called on a column operand",
+            )),
+        }
+    }
 }
 
 /// Resolve an operand against `schema`, walking a column path at most once: a column yields its
@@ -194,6 +210,7 @@ impl ResolvedOperand {
 fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
     match operand {
         Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
+        Operand::Null => Ok(ResolvedOperand::Null),
         Operand::Column(column) => resolve_column(column, schema),
     }
 }
@@ -376,9 +393,9 @@ mod tests {
         "5 < weight",
         Predicate::lt(Expression::literal(Scalar::Float(5.0)), col("weight"))
     )]
-    // A NULL literal against a FLOAT column is allowed: a null comparison involves no f32/f64
-    // rounding, so the FLOAT-widening gate exempts it (the `!is_null` guard in
-    // `type_literal_from_column`). Without the exemption this would wrongly error.
+    // NULL against a FLOAT column lowers: NULL is a structural operand typed directly as
+    // `Scalar::Null(FLOAT)`, so it never hits the f32/f64 FLOAT gate (a null compare has no
+    // rounding). Pins that NULL bypasses `type_literal_from_column`.
     #[case::float_column_vs_null(
         "weight = NULL",
         Predicate::eq(col("weight"), Expression::literal(Scalar::Null(DataType::FLOAT)))

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -201,7 +201,7 @@ fn resolve_column(
             .fields()
             .find(|f| f.name().eq_ignore_ascii_case(name))
     })?;
-    let canonical: Vec<String> = fields.iter().map(|f| f.name().to_string()).collect();
+    let canonical = Vec::from_iter(fields.iter().map(|f| f.name().to_string());
     let leaf = fields
         .last()
         .ok_or_else(|| Error::generic("CHECK constraint references an empty column path"))?;

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -211,8 +211,15 @@ mod tests {
     use rstest::rstest;
 
     use super::super::parse_sql_simple_predicate;
-    use crate::expressions::{Expression, Predicate, Scalar};
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::expressions::{DecimalData, Expression, Predicate, Scalar};
+    use crate::schema::{DataType, DecimalType, StructField, StructType};
+
+    fn decimal_scalar(unscaled: i128, precision: u8, scale: u8) -> Scalar {
+        Scalar::Decimal(
+            DecimalData::try_new(unscaled, DecimalType::try_new(precision, scale).unwrap())
+                .unwrap(),
+        )
+    }
 
     fn schema() -> StructType {
         StructType::new_unchecked([
@@ -228,6 +235,7 @@ mod tests {
             StructField::nullable("data", DataType::BINARY),
             StructField::nullable("ts", DataType::TIMESTAMP),
             StructField::nullable("tsn", DataType::TIMESTAMP_NTZ),
+            StructField::nullable("cost", DataType::decimal(10, 2).unwrap()),
             StructField::nullable(
                 "nested",
                 DataType::try_struct_type([StructField::nullable("inner", DataType::LONG)])
@@ -255,6 +263,10 @@ mod tests {
     #[case::eq_double("amount == 0", Predicate::eq(col("amount"), Expression::literal(0i64)))]
     #[case::ne_bang("amount != 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
     #[case::ne_angle("amount <> 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
+    // Spark's `!>`/`!<` aliases tokenize to `<=`/`>=`; drive them end-to-end so the alias survives
+    // parse and lowering, not just tokenization.
+    #[case::not_gt_alias("amount !> 0", Predicate::le(col("amount"), Expression::literal(0i64)))]
+    #[case::not_lt_alias("amount !< 0", Predicate::ge(col("amount"), Expression::literal(0i64)))]
     // Whitespace between tokens is optional.
     #[case::no_whitespace("amount>0", Predicate::gt(col("amount"), Expression::literal(0i64)))]
     // A literal is typed from the column on the other side: `price` is INTEGER, not the default
@@ -262,6 +274,13 @@ mod tests {
     #[case::literal_typed_from_column(
         "price <= 10",
         Predicate::le(col("price"), Expression::literal(10i32))
+    )]
+    // A DECIMAL literal whose scale matches the column lowers; `parse_scalar` requires an exact
+    // scale match, so the literal must be written with the column's scale (`10.00`, not `10`). The
+    // scale-mismatch case is rejected below.
+    #[case::decimal_matching_scale(
+        "cost <= 10.00",
+        Predicate::le(col("cost"), Expression::literal(decimal_scalar(1000, 10, 2)))
     )]
     // Literal forms across the primitive type matrix, each typed from its column. Exercises the
     // tokenizer's bareword (`TRUE`), fractional-number, typed-literal (`DATE '...'`), and binary
@@ -426,6 +445,11 @@ mod tests {
     #[case::string_literal_for_numeric_column("amount = 'foo'")]
     #[case::quoted_number_for_numeric_column("amount = '10'")]
     #[case::literal_out_of_range_for_column("price = 9999999999")]
+    // A DECIMAL literal must match the column's scale exactly (`parse_scalar` does not pad), so an
+    // integer or wrong-scale literal against a DECIMAL(10,2) column is rejected where Spark would
+    // read `0` as `0.00`. Left to the connector (see the `sql` module doc). `cost <= 10.00` lowers.
+    #[case::decimal_integer_literal_scale_mismatch("cost >= 0")]
+    #[case::decimal_wrong_scale_literal("cost >= 0.5")]
     // A FLOAT column against a DECIMAL/DOUBLE literal (a `.`/exponent, or an integer beyond i64) is
     // rejected: Spark widens the column to f64 while kernel compares at f32, disagreeing silently
     // for an f32-inexact literal. The exponent and `>i64` cases are rejected conservatively even

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -4,8 +4,8 @@
 //! column-resolution paths). A literal's type is inferred from the column on the other side of the
 //! comparison, and the literal itself is parsed by reusing [`super::parse_sql`].
 
-// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
-// TODO(#2896): remove this allow once check-constraint enforcement wires up a caller.
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until discovery lands.
+// TODO(#2896): remove this allow once check-constraint discovery wires up a caller.
 #![allow(dead_code)]
 
 use super::parse_sql;
@@ -30,17 +30,22 @@ use crate::{DeltaResult, Error};
 /// semantics the parser cannot re-express as a `Predicate`. These are engine-wide gaps (not
 /// constraint-specific) and are left to the enforcement layer rather than rejected here, which
 /// would forgo nearly all float and string constraints:
-/// - NaN: Spark SQL makes `NaN = NaN` true and orders NaN above every value; kernel compares floats
-///   with IEEE semantics (NaN unordered), so a float/double constraint on a NaN-bearing column can
-///   silently disagree -- affecting even the DOUBLE and FLOAT-vs-FLOAT cases that lower here.
+/// - Float semantics: the default engine compares floats via arrow's IEEE-754 *totalOrder*
+///   (bitwise), not Spark/ANSI float equality. The two mostly agree -- kernel makes `NaN = NaN`
+///   TRUE and orders NaN as the maximum, matching Spark -- but `-0.0 = 0.0` is FALSE under
+///   totalOrder (the bits differ) where Spark returns TRUE. So a float/double `=`/`<>`/`<=>` on a
+///   column holding `-0.0` can silently disagree, affecting even the DOUBLE and FLOAT-vs-FLOAT
+///   cases that lower here. The enforcement layer must normalize signed zero (Spark's
+///   `NormalizeFloatingNumbers`) before evaluating, or reject float equality outright.
 /// - String collation: kernel compares bytewise; a non-default collation (e.g. `UTF8_LCASE`) would
 ///   compare differently under Spark.
 pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-    // Comparison policy lives here, not in `resolve_operand`: only primitive-typed columns are
-    // comparable (struct/array/map columns have no scalar comparison semantics).
+    // Reject non-primitive columns explicitly: `parse_sql("NULL", <struct>)` succeeds (NULL is
+    // valid for any type), so without this check `nested = NULL` would lower silently. (`nested =
+    // 0` is already caught by `parse_sql`, which rejects a non-primitive literal target.)
     for operand in [&left, &right] {
         if let ResolvedOperand::Column {
             canonical,
@@ -130,7 +135,9 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
 /// common type; whether the FLOAT column stays f32 or is widened to f64 depends on the literal's
 /// Spark type:
 /// - INT/LONG literal (an integer in i64 range): the common type is FLOAT, so Spark casts the
-///   *literal* to f32 and compares at f32 -- identical to kernel. Safe to lower.
+///   *literal* to f32 and compares at f32 -- identical compare *width* to kernel, so safe to lower.
+///   (The signed-zero divergence in [`lower`]'s doc is orthogonal: it is about the column's stored
+///   value, not the literal's type, and applies to any float comparison regardless of this gate.)
 /// - DECIMAL/DOUBLE literal (has a `.`/exponent, or an integer beyond i64): the common type is
 ///   DOUBLE, so Spark widens the *column* to f64 and compares at f64. For a literal not exactly
 ///   representable in f32 (e.g. `0.1`) this reaches the opposite result from kernel's f32 compare,
@@ -166,8 +173,8 @@ enum ResolvedOperand {
 
 /// Resolve an operand against `schema`, walking a column path at most once: a column yields its
 /// canonical (schema-cased) path and leaf type; a literal is carried as raw text and typed by
-/// [`lower`]. This is pure resolution -- comparison-specific policy (primitive-only operands) lives
-/// in [`lower`], so `resolve_operand` can also resolve non-primitive columns for other callers.
+/// [`lower`]. Resolution is kept separate from comparison policy (the primitive-only check) because
+/// [`lower`] must inspect *both* resolved operands jointly before it can judge them.
 fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
     match operand {
         Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
@@ -189,16 +196,11 @@ fn resolve_column(
     column: &ColumnName,
     schema: &StructType,
 ) -> DeltaResult<(Vec<String>, DataType)> {
-    let mut fields = Vec::with_capacity(column.len());
-    schema.visit_fields_of_path_by(
-        column,
-        |parent, name| {
-            parent
-                .fields()
-                .find(|f| f.name().eq_ignore_ascii_case(name))
-        },
-        |field| fields.push(field),
-    )?;
+    let fields = schema.fields_of_path_by(column, |parent, name| {
+        parent
+            .fields()
+            .find(|f| f.name().eq_ignore_ascii_case(name))
+    })?;
     let canonical: Vec<String> = fields.iter().map(|f| f.name().to_string()).collect();
     let leaf = fields
         .last()
@@ -370,6 +372,13 @@ mod tests {
     #[case::float_column_int_literal_on_left(
         "5 < weight",
         Predicate::lt(Expression::literal(Scalar::Float(5.0)), col("weight"))
+    )]
+    // A NULL literal against a FLOAT column is allowed: a null comparison involves no f32/f64
+    // rounding, so the FLOAT-widening gate exempts it (the `!is_null` guard in
+    // `type_literal_from_column`). Without the exemption this would wrongly error.
+    #[case::float_column_vs_null(
+        "weight = NULL",
+        Predicate::eq(col("weight"), Expression::literal(Scalar::Null(DataType::FLOAT)))
     )]
     // `NULL` is an operand, typed from the column it is compared against.
     #[case::null_operand(

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -5,6 +5,7 @@
 //! comparison, and the literal itself is parsed by reusing [`super::parse_sql`].
 
 // WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+// TODO(#2896): remove this allow once check-constraint enforcement wires up a caller.
 #![allow(dead_code)]
 
 use super::parse_sql;

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -288,16 +288,25 @@ mod tests {
         "ratio < 1e3",
         Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1000.0)))
     )]
-    // Signed numbers: a leading sign, and a signed exponent, each stay part of one numeric literal.
+    // Signed numbers: the tokenizer emits the sign as a separate operator and the parser folds it
+    // back into the literal, so `-5` and `- 5` (whitespace-insensitive, matching Spark) both lower
+    // to the same negative literal. A leading `+` is accepted and is a no-op.
     #[case::negative_literal(
         "amount = -5",
         Predicate::eq(col("amount"), Expression::literal(-5i64))
+    )]
+    #[case::negative_literal_with_space(
+        "amount = - 5",
+        Predicate::eq(col("amount"), Expression::literal(-5i64))
+    )]
+    #[case::positive_literal(
+        "amount = +5",
+        Predicate::eq(col("amount"), Expression::literal(5i64))
     )]
     #[case::signed_exponent(
         "ratio >= -2e+1",
         Predicate::ge(col("ratio"), Expression::literal(Scalar::Double(-20.0)))
     )]
-    // A leading sign immediately followed by a leading-dot decimal stays one numeric literal.
     #[case::negative_leading_dot_decimal(
         "ratio > -.5",
         Predicate::gt(col("ratio"), Expression::literal(Scalar::Double(-0.5)))

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -1,0 +1,440 @@
+//! Lowering: resolve a parsed [`Comparison`] against the table schema into a kernel [`Predicate`].
+//!
+//! Column references resolve case-insensitively (matching Delta/Spark and kernel's other
+//! column-resolution paths). A literal's type is inferred from the column on the other side of the
+//! comparison, and the literal itself is parsed by reusing [`super::parse_sql`].
+
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
+#![allow(dead_code)]
+
+use super::parse_sql;
+use super::parser::{CmpOp, Comparison, Operand};
+use crate::expressions::{ColumnName, Expression, Predicate};
+use crate::schema::{DataType, StructType};
+use crate::{DeltaResult, Error};
+
+/// Lower a parsed [`Comparison`] into a kernel [`Predicate`], resolving each operand against
+/// `schema`.
+///
+/// Kernel can only lower a comparison it can evaluate to the *same* boolean Spark would; anything
+/// else is rejected so the caller treats the constraint as not-kernel-parsable
+/// (connector-enforced). The resolved operands must therefore satisfy all of:
+/// - at least one operand is a column, so a literal can be typed from it;
+/// - every column operand is primitive-typed (struct/array/map have no scalar comparison);
+/// - the two operands share a single comparison type, because the engine compares only matching
+///   types (no implicit numeric coercion) -- see [`type_literal_from_column`] (FLOAT-vs-literal)
+///   and the column-vs-column arm (cross-type columns).
+///
+/// Even a predicate that lowers can still diverge from Spark at *evaluation* time, on comparison
+/// semantics the parser cannot re-express as a `Predicate`. These are engine-wide gaps (not
+/// constraint-specific) and are left to the enforcement layer rather than rejected here, which
+/// would forgo nearly all float and string constraints:
+/// - NaN: Spark SQL makes `NaN = NaN` true and orders NaN above every value; kernel compares floats
+///   with IEEE semantics (NaN unordered), so a float/double constraint on a NaN-bearing column can
+///   silently disagree -- affecting even the DOUBLE and FLOAT-vs-FLOAT cases that lower here.
+/// - String collation: kernel compares bytewise; a non-default collation (e.g. `UTF8_LCASE`) would
+///   compare differently under Spark.
+pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
+    let Comparison { op, left, right } = comparison;
+    let left = resolve_operand(left, schema)?;
+    let right = resolve_operand(right, schema)?;
+    // Comparison policy lives here, not in `resolve_operand`: only primitive-typed columns are
+    // comparable (struct/array/map columns have no scalar comparison semantics).
+    for operand in [&left, &right] {
+        if let ResolvedOperand::Column {
+            canonical,
+            data_type,
+        } = operand
+        {
+            if !matches!(data_type, DataType::Primitive(_)) {
+                return Err(Error::generic(format!(
+                    "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
+                    canonical.join(".")
+                )));
+            }
+        }
+    }
+    // A literal is typed from the column on the other side, so at least one operand must be a
+    // column.
+    let (left_expr, right_expr) = match (left, right) {
+        (
+            ResolvedOperand::Column {
+                canonical: l,
+                data_type: l_type,
+            },
+            ResolvedOperand::Column {
+                canonical: r,
+                data_type: r_type,
+            },
+        ) => {
+            // The engine compares only matching Arrow types -- it applies no numeric coercion (it
+            // would error on e.g. INT vs LONG). Spark instead coerces both columns to a common type
+            // and compares there, so a cross-type comparison kernel cannot reproduce is rejected
+            // (left to the connector). The check is on the full `DataType`, so it also rejects
+            // mismatched decimal precision/scale and TIMESTAMP vs TIMESTAMP_NTZ.
+            if l_type != r_type {
+                return Err(Error::generic(format!(
+                    "CHECK constraint comparing columns of different types is not supported: \
+                     '{}' has type {l_type:?}, '{}' has type {r_type:?}",
+                    l.join("."),
+                    r.join(".")
+                )));
+            }
+            (Expression::column(l), Expression::column(r))
+        }
+        (
+            ResolvedOperand::Column {
+                canonical,
+                data_type,
+            },
+            ResolvedOperand::Literal(raw),
+        ) => (
+            Expression::column(canonical),
+            type_literal_from_column(&raw, &data_type)?,
+        ),
+        (
+            ResolvedOperand::Literal(raw),
+            ResolvedOperand::Column {
+                canonical,
+                data_type,
+            },
+        ) => (
+            type_literal_from_column(&raw, &data_type)?,
+            Expression::column(canonical),
+        ),
+        (ResolvedOperand::Literal(_), ResolvedOperand::Literal(_)) => {
+            return Err(Error::generic(
+                "CHECK constraint comparison must reference at least one column",
+            ))
+        }
+    };
+    Ok(match op {
+        CmpOp::Eq => Predicate::eq(left_expr, right_expr),
+        CmpOp::Ne => Predicate::ne(left_expr, right_expr),
+        CmpOp::Lt => Predicate::lt(left_expr, right_expr),
+        CmpOp::Le => Predicate::le(left_expr, right_expr),
+        CmpOp::Gt => Predicate::gt(left_expr, right_expr),
+        CmpOp::Ge => Predicate::ge(left_expr, right_expr),
+        // Null-safe equal: `a <=> b` is "a is not distinct from b" -- kernel has no direct
+        // constructor, so negate the distinct predicate.
+        CmpOp::NullSafeEq => Predicate::not(Predicate::distinct(left_expr, right_expr)),
+    })
+}
+
+/// Type a literal from the column it is compared with (via [`parse_sql`]), rejecting the
+/// FLOAT-column cases where kernel would silently disagree with Spark.
+///
+/// Kernel types a literal from the compared column, so against a FLOAT column it narrows the
+/// literal to f32 and compares at f32. Spark instead types the literal on its own and coerces to a
+/// common type; whether the FLOAT column stays f32 or is widened to f64 depends on the literal's
+/// Spark type:
+/// - INT/LONG literal (an integer in i64 range): the common type is FLOAT, so Spark casts the
+///   *literal* to f32 and compares at f32 -- identical to kernel. Safe to lower.
+/// - DECIMAL/DOUBLE literal (has a `.`/exponent, or an integer beyond i64): the common type is
+///   DOUBLE, so Spark widens the *column* to f64 and compares at f64. For a literal not exactly
+///   representable in f32 (e.g. `0.1`) this reaches the opposite result from kernel's f32 compare,
+///   silently. Kernel has no cast expression and the engine cannot compare f32 to f64, so it cannot
+///   reproduce Spark's widening; these are left to the connector.
+///
+/// `NULL` is allowed (a null comparison involves no f32/f64 rounding). The i64 gate is exactly
+/// Spark's INT/LONG-vs-DECIMAL literal boundary, and is intentionally conservative: an f32-exact
+/// exponent literal like `1e3` would in fact agree, but is still rejected rather than
+/// special-cased. Only FLOAT is affected; a DOUBLE column already compares at f64, matching Spark.
+fn type_literal_from_column(raw: &str, column_type: &DataType) -> DeltaResult<Expression> {
+    let is_null = raw.eq_ignore_ascii_case("null");
+    let is_int_or_long_literal = raw.parse::<i64>().is_ok();
+    if column_type == &DataType::FLOAT && !is_null && !is_int_or_long_literal {
+        return Err(Error::generic(format!(
+            "CHECK constraint comparing a FLOAT column against the literal '{raw}' is not supported: \
+             Spark widens the column to DOUBLE (compares at f64) while kernel compares at f32"
+        )));
+    }
+    parse_sql(raw, column_type)
+}
+
+/// A comparison operand after schema resolution: a column (its canonical schema-cased path and
+/// resolved leaf type) or a not-yet-typed literal (typed by [`lower`] from the column on the other
+/// side).
+enum ResolvedOperand {
+    Column {
+        canonical: Vec<String>,
+        data_type: DataType,
+    },
+    Literal(String),
+}
+
+/// Resolve an operand against `schema`, walking a column path at most once: a column yields its
+/// canonical (schema-cased) path and leaf type; a literal is carried as raw text and typed by
+/// [`lower`]. This is pure resolution -- comparison-specific policy (primitive-only operands) lives
+/// in [`lower`], so `resolve_operand` can also resolve non-primitive columns for other callers.
+fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
+    match operand {
+        Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
+        Operand::Column(path) => {
+            let (canonical, data_type) = resolve_column(path, schema)?;
+            Ok(ResolvedOperand::Column {
+                canonical,
+                data_type,
+            })
+        }
+    }
+}
+
+/// Resolve a (case-insensitive) column path against `schema`, returning the *canonical* path (the
+/// schema's stored field names) and the leaf field's type. The canonical names are what the engine
+/// sees in the logical batch, so the emitted column reference must use them rather than the
+/// as-written casing.
+fn resolve_column(path: &[String], schema: &StructType) -> DeltaResult<(Vec<String>, DataType)> {
+    let column = ColumnName::new(path.iter().cloned());
+    let mut fields = Vec::with_capacity(path.len());
+    schema.visit_fields_of_path_by(
+        &column,
+        |parent, name| {
+            parent
+                .fields()
+                .find(|f| f.name().eq_ignore_ascii_case(name))
+        },
+        |field| fields.push(field),
+    )?;
+    let canonical: Vec<String> = fields.iter().map(|f| f.name().to_string()).collect();
+    let leaf = fields
+        .last()
+        .ok_or_else(|| Error::generic("CHECK constraint references an empty column path"))?;
+    Ok((canonical, leaf.data_type().clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::super::parse_sql_simple_predicate;
+    use crate::expressions::{Expression, Predicate, Scalar};
+    use crate::schema::{DataType, StructField, StructType};
+
+    fn schema() -> StructType {
+        StructType::new_unchecked([
+            StructField::nullable("amount", DataType::LONG),
+            StructField::nullable("amount2", DataType::LONG),
+            StructField::nullable("price", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+            StructField::nullable("active", DataType::BOOLEAN),
+            StructField::nullable("ratio", DataType::DOUBLE),
+            StructField::nullable("weight", DataType::FLOAT),
+            StructField::nullable("height", DataType::FLOAT),
+            StructField::nullable("created", DataType::DATE),
+            StructField::nullable("data", DataType::BINARY),
+            StructField::nullable("ts", DataType::TIMESTAMP),
+            StructField::nullable("tsn", DataType::TIMESTAMP_NTZ),
+            StructField::nullable(
+                "nested",
+                DataType::try_struct_type([StructField::nullable("inner", DataType::LONG)])
+                    .unwrap(),
+            ),
+        ])
+    }
+
+    fn col(name: &str) -> Expression {
+        Expression::column([name])
+    }
+
+    /// Kernel-parsable inputs: exactly one `operand <op> operand` comparison between a column and a
+    /// column, a literal, or `NULL`, for every comparison operator and across the primitive literal
+    /// types. Each literal is typed from the column it is compared against (via `parse_sql`), and
+    /// column names resolve case-insensitively to their canonical casing. All of these lower to a
+    /// `Predicate`.
+    #[rstest]
+    // Every comparison operator (`=`, `==`, `!=`, `<>`, `<`, `<=`, `>`, `>=`).
+    #[case::gt("amount > 0", Predicate::gt(col("amount"), Expression::literal(0i64)))]
+    #[case::lt("amount < 0", Predicate::lt(col("amount"), Expression::literal(0i64)))]
+    #[case::ge("amount >= 0", Predicate::ge(col("amount"), Expression::literal(0i64)))]
+    #[case::le("amount <= 0", Predicate::le(col("amount"), Expression::literal(0i64)))]
+    #[case::eq("amount = 0", Predicate::eq(col("amount"), Expression::literal(0i64)))]
+    #[case::eq_double("amount == 0", Predicate::eq(col("amount"), Expression::literal(0i64)))]
+    #[case::ne_bang("amount != 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
+    #[case::ne_angle("amount <> 0", Predicate::ne(col("amount"), Expression::literal(0i64)))]
+    // Whitespace between tokens is optional.
+    #[case::no_whitespace("amount>0", Predicate::gt(col("amount"), Expression::literal(0i64)))]
+    // A literal is typed from the column on the other side: `price` is INTEGER, not the default
+    // Long.
+    #[case::literal_typed_from_column(
+        "price <= 10",
+        Predicate::le(col("price"), Expression::literal(10i32))
+    )]
+    // Literal forms across the primitive type matrix, each typed from its column. Exercises the
+    // tokenizer's bareword (`TRUE`), fractional-number, typed-literal (`DATE '...'`), and binary
+    // (`X'..'`) paths.
+    #[case::boolean_literal(
+        "active = TRUE",
+        Predicate::eq(col("active"), Expression::literal(Scalar::Boolean(true)))
+    )]
+    #[case::double_literal(
+        "ratio < 1.5",
+        Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1.5)))
+    )]
+    #[case::typed_date_literal(
+        "created = DATE '1970-01-02'",
+        Predicate::eq(col("created"), Expression::literal(Scalar::Date(1)))
+    )]
+    #[case::binary_literal(
+        "data = X'01ff'",
+        Predicate::eq(col("data"), Expression::literal(Scalar::Binary(vec![0x01, 0xff])))
+    )]
+    // Leading-dot and exponent numeric forms each tokenize as a single numeric literal.
+    #[case::leading_dot_decimal(
+        "ratio > .5",
+        Predicate::gt(col("ratio"), Expression::literal(Scalar::Double(0.5)))
+    )]
+    #[case::exponent_number(
+        "ratio < 1e3",
+        Predicate::lt(col("ratio"), Expression::literal(Scalar::Double(1000.0)))
+    )]
+    // Signed numbers: a leading sign, and a signed exponent, each stay part of one numeric literal.
+    #[case::negative_literal(
+        "amount = -5",
+        Predicate::eq(col("amount"), Expression::literal(-5i64))
+    )]
+    #[case::signed_exponent(
+        "ratio >= -2e+1",
+        Predicate::ge(col("ratio"), Expression::literal(Scalar::Double(-20.0)))
+    )]
+    // A leading sign immediately followed by a leading-dot decimal stays one numeric literal.
+    #[case::negative_leading_dot_decimal(
+        "ratio > -.5",
+        Predicate::gt(col("ratio"), Expression::literal(Scalar::Double(-0.5)))
+    )]
+    // Timestamp typed literals: LTZ (bare `TIMESTAMP` or explicit `TIMESTAMP_LTZ`, both requiring a
+    // `Z` suffix) and zoneless `TIMESTAMP_NTZ`.
+    #[case::typed_timestamp(
+        "ts = TIMESTAMP '1970-01-01T00:00:00Z'",
+        Predicate::eq(col("ts"), Expression::literal(Scalar::Timestamp(0)))
+    )]
+    #[case::typed_timestamp_ltz(
+        "ts = TIMESTAMP_LTZ '1970-01-01T00:00:00Z'",
+        Predicate::eq(col("ts"), Expression::literal(Scalar::Timestamp(0)))
+    )]
+    #[case::typed_timestamp_ntz(
+        "tsn = TIMESTAMP_NTZ '1970-01-01 00:00:00'",
+        Predicate::eq(col("tsn"), Expression::literal(Scalar::TimestampNtz(0)))
+    )]
+    // Column casing in the source is normalized to the schema's stored casing.
+    #[case::case_insensitive_column(
+        "AMOUNT >= 0",
+        Predicate::ge(col("amount"), Expression::literal(0i64))
+    )]
+    #[case::string_with_doubled_quote(
+        "name = 'O''Brien'",
+        Predicate::eq(col("name"), Expression::literal("O'Brien"))
+    )]
+    // Same-type column-vs-column comparisons are allowed; cross-type ones are rejected (see the
+    // not-kernel-parsable cases below). FLOAT-vs-FLOAT stays at f32, matching Spark.
+    #[case::column_vs_column("amount2 < amount", Predicate::lt(col("amount2"), col("amount")))]
+    #[case::float_column_vs_column("weight < height", Predicate::lt(col("weight"), col("height")))]
+    #[case::literal_on_left("0 < amount", Predicate::lt(Expression::literal(0i64), col("amount")))]
+    // An INT/LONG-range literal against a FLOAT column is safe: Spark casts the literal to f32 and
+    // compares at f32, exactly as kernel does (only fractional/DOUBLE/`>i64` literals diverge).
+    #[case::float_column_vs_int_literal(
+        "weight > 0",
+        Predicate::gt(col("weight"), Expression::literal(Scalar::Float(0.0)))
+    )]
+    #[case::float_column_int_literal_on_left(
+        "5 < weight",
+        Predicate::lt(Expression::literal(Scalar::Float(5.0)), col("weight"))
+    )]
+    // `NULL` is an operand, typed from the column it is compared against.
+    #[case::null_operand(
+        "name = NULL",
+        Predicate::eq(col("name"), Expression::literal(Scalar::Null(DataType::STRING)))
+    )]
+    // Null-safe equality `<=>` lowers to a negated distinct predicate, for both a column-column
+    // and a column-NULL comparison (the latter is the operator's whole point: `x <=> NULL` is a
+    // total, non-NULL test rather than the always-unknown `x = NULL`).
+    #[case::null_safe_eq_columns(
+        "amount <=> amount2",
+        Predicate::not(Predicate::distinct(col("amount"), col("amount2")))
+    )]
+    #[case::null_safe_eq_null(
+        "name <=> NULL",
+        Predicate::not(Predicate::distinct(
+            col("name"),
+            Expression::literal(Scalar::Null(DataType::STRING))
+        ))
+    )]
+    // Dotted paths resolve into nested structs.
+    #[case::nested_column(
+        "nested.inner > 0",
+        Predicate::gt(Expression::column(["nested", "inner"]), Expression::literal(0i64))
+    )]
+    fn kernel_parsable_comparison_lowers_to_expected_predicate(
+        #[case] sql: &str,
+        #[case] expected: Predicate,
+    ) {
+        assert_eq!(
+            parse_sql_simple_predicate(sql, &schema()).unwrap(),
+            expected
+        );
+    }
+
+    /// Not-kernel-parsable inputs: everything outside the single-comparison grammar must error, so
+    /// the caller treats the constraint as not-kernel-parsable (connector-enforced / fail-closed).
+    /// Covers boolean junctions, parentheses, `IS [NOT] NULL`, multi-operand predicates
+    /// (`IN`/`BETWEEN`/`LIKE`), functions, arithmetic, comparisons with no column,
+    /// type-incompatible literals (kernel applies no implicit casts), and malformed input.
+    #[rstest]
+    // Boolean structure beyond a single comparison.
+    #[case::and_junction("amount > 0 AND price < 10")]
+    #[case::or_junction("amount > 0 OR price < 10")]
+    #[case::not_prefix("NOT active")]
+    #[case::parentheses("(amount > 0)")]
+    #[case::is_null("name IS NULL")]
+    #[case::is_not_null("name IS NOT NULL")]
+    // Multi-operand predicate forms are not comparisons.
+    #[case::in_list("amount IN (1, 2)")]
+    #[case::between("amount BETWEEN 0 AND 10")]
+    #[case::like("name LIKE 'a%'")]
+    // A bare operand is not a comparison (no `<op>`), even when boolean-typed.
+    #[case::bare_boolean_column("active")]
+    // Operands richer than a column/literal/NULL.
+    #[case::function_call("length(name) > 0")]
+    #[case::arithmetic("amount + 1 > 0")]
+    // A comparison must reference at least one column (so a literal can be typed).
+    #[case::two_literals("1 > 0")]
+    #[case::two_nulls("NULL = NULL")]
+    #[case::unknown_column("nope > 0")]
+    // Cross-type column-vs-column comparisons are rejected: the engine compares only matching types
+    // (no coercion), while Spark coerces to a common type. Same-type pairs lower (see above).
+    #[case::cross_type_int_long_columns("price < amount")]
+    #[case::cross_type_float_double_columns("weight < ratio")]
+    // Non-primitive (struct/array/map) columns have no scalar comparison and are rejected on either
+    // side of the operator -- symmetric with the literal path, which rejects non-primitive targets.
+    #[case::struct_column_vs_struct_column("nested = nested")]
+    #[case::struct_column_vs_null("nested = NULL")]
+    #[case::struct_column_vs_literal("nested = 0")]
+    // No implicit casts: a literal whose SQL form does not match the compared column's type is
+    // rejected -- including a quoted number for a numeric column, which Spark would coerce.
+    #[case::string_literal_for_numeric_column("amount = 'foo'")]
+    #[case::quoted_number_for_numeric_column("amount = '10'")]
+    #[case::literal_out_of_range_for_column("price = 9999999999")]
+    // A FLOAT column against a DECIMAL/DOUBLE literal (a `.`/exponent, or an integer beyond i64) is
+    // rejected: Spark widens the column to f64 while kernel compares at f32, disagreeing silently
+    // for an f32-inexact literal. The exponent and `>i64` cases are rejected conservatively even
+    // though they would happen to agree; INT/LONG-range literals are allowed (see above).
+    #[case::float_column_inexact_decimal_literal("weight = 0.1")]
+    #[case::float_column_decimal_literal_on_left("0.1 < weight")]
+    #[case::float_column_f32_exact_decimal_literal("weight = 0.5")]
+    #[case::float_column_exponent_literal("weight = 1e3")]
+    #[case::float_column_integer_beyond_i64("weight > 99999999999999999999")]
+    // Malformed input.
+    #[case::unterminated_string("name = 'oops")]
+    #[case::bang_without_eq("amount ! 0")]
+    #[case::malformed_dotted_path("nested..inner > 0")]
+    #[case::missing_operator("amount price")]
+    #[case::trailing_tokens("amount > 0 extra")]
+    #[case::operator_only(">")]
+    #[case::empty("")]
+    fn not_kernel_parsable_input_is_rejected(#[case] sql: &str) {
+        assert!(
+            parse_sql_simple_predicate(sql, &schema()).is_err(),
+            "expected {sql:?} to be rejected as not kernel-parsable"
+        );
+    }
+}

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -296,12 +296,23 @@ mod tests {
         "price <= 10",
         Predicate::le(col("price"), Expression::literal(10i32))
     )]
-    // A DECIMAL literal whose scale matches the column lowers; `parse_scalar` requires an exact
-    // scale match, so the literal must be written with the column's scale (`10.00`, not `10`). The
-    // scale-mismatch case is rejected below.
+    // A DECIMAL literal is padded up to the column's scale (matching Spark), so `10.00`, `10`, and
+    // `0`/`0.5` against DECIMAL(10,2) all lower -- the unscaled value is scaled by `10^(2-s)`.
     #[case::decimal_matching_scale(
         "cost <= 10.00",
         Predicate::le(col("cost"), Expression::literal(decimal_scalar(1000, 10, 2)))
+    )]
+    #[case::decimal_integer_literal_padded(
+        "cost <= 10",
+        Predicate::le(col("cost"), Expression::literal(decimal_scalar(1000, 10, 2)))
+    )]
+    #[case::decimal_zero_padded(
+        "cost >= 0",
+        Predicate::ge(col("cost"), Expression::literal(decimal_scalar(0, 10, 2)))
+    )]
+    #[case::decimal_lower_scale_padded(
+        "cost >= 0.5",
+        Predicate::ge(col("cost"), Expression::literal(decimal_scalar(50, 10, 2)))
     )]
     // Literal forms across the primitive type matrix, each typed from its column. Exercises the
     // tokenizer's bareword (`TRUE`), fractional-number, typed-literal (`DATE '...'`), and binary
@@ -478,11 +489,11 @@ mod tests {
     #[case::string_literal_for_numeric_column("amount = 'foo'")]
     #[case::quoted_number_for_numeric_column("amount = '10'")]
     #[case::literal_out_of_range_for_column("price = 9999999999")]
-    // A DECIMAL literal must match the column's scale exactly (`parse_scalar` does not pad), so an
-    // integer or wrong-scale literal against a DECIMAL(10,2) column is rejected where Spark would
-    // read `0` as `0.00` (see the `sql` module doc). `cost <= 10.00` lowers.
-    #[case::decimal_integer_literal_scale_mismatch("cost >= 0")]
-    #[case::decimal_wrong_scale_literal("cost >= 0.5")]
+    // A DECIMAL literal is padded UP to the column's scale, but never reduced (that would drop
+    // precision), so a literal with more fractional digits than the column (scale 3 vs DECIMAL's 2)
+    // is rejected. A value exceeding the column's precision is likewise rejected.
+    #[case::decimal_literal_scale_exceeds_column("cost >= 0.123")]
+    #[case::decimal_literal_exceeds_precision("cost >= 999999999.99")]
     // A FLOAT column against any literal not exactly representable in f32 is rejected: kernel
     // compares at f32 while Spark widens the column to f64, disagreeing silently. This covers
     // fractional/exponent literals, out-of-i64 integers, AND in-i64 integers past 2^24 that round

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -41,8 +41,10 @@ use crate::{DeltaResult, Error};
 ///   column holding `-0.0` can silently disagree, affecting even the DOUBLE and FLOAT-vs-FLOAT
 ///   cases that lower here. The enforcement layer must normalize signed zero (Spark's
 ///   `NormalizeFloatingNumbers`) before evaluating, or reject float equality outright.
-/// - String collation: kernel compares bytewise; a non-default collation (e.g. `UTF8_LCASE`) would
-///   compare differently under Spark.
+/// - String collation: kernel compares bytewise (Spark's default `UTF8_BINARY`). Collation is not
+///   yet in the Delta spec or kernel; if adopted (see the collated-string-type RFC), a non-default
+///   collation (e.g. `UTF8_LCASE`) would need a collation-aware engine compare, and a reject arm
+///   here until then.
 pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult<Predicate> {
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -49,24 +49,11 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-    // Reject non-primitive columns: the engine cannot compare nested types (see the fn doc), and
-    // this is the only place that catches a column on its own. `parse_sql("NULL", <struct>)`
-    // succeeds (NULL is valid for any type), so without this `nested = NULL` would lower silently;
-    // `nested = 0` is already caught by `parse_sql` rejecting a non-primitive literal target.
-    for operand in [&left, &right] {
-        if let ResolvedOperand::Column {
-            canonical,
-            data_type,
-        } = operand
-        {
-            if !matches!(data_type, DataType::Primitive(_)) {
-                return Err(Error::generic(format!(
-                    "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
-                    canonical.join(".")
-                )));
-            }
-        }
-    }
+    // `nested = NULL` would otherwise lower silently: `parse_sql("NULL", <struct>)` succeeds (NULL
+    // is valid for any type), so the primitive-only check must run on the column operand here.
+    // (`nested = 0` is already caught by `parse_sql` rejecting a non-primitive literal target.)
+    left.ensure_comparable()?;
+    right.ensure_comparable()?;
     // A literal is typed from the column on the other side, so at least one operand must be a
     // column.
     let (left_expr, right_expr) = match (left, right) {
@@ -176,6 +163,28 @@ enum ResolvedOperand {
         data_type: DataType,
     },
     Literal(String),
+}
+
+impl ResolvedOperand {
+    /// Reject an operand the engine cannot compare. Only a column carries a type to check here (a
+    /// literal is typed later from the column on the other side, so it is a deliberate no-op); the
+    /// engine cannot compare nested types, so a non-primitive column is rejected. See [`lower`].
+    fn ensure_comparable(&self) -> DeltaResult<()> {
+        let Self::Column {
+            canonical,
+            data_type,
+        } = self
+        else {
+            return Ok(());
+        };
+        if !matches!(data_type, DataType::Primitive(_)) {
+            return Err(Error::generic(format!(
+                "CHECK constraint can only compare primitive-typed columns, but '{}' has type {data_type:?}",
+                canonical.join(".")
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Resolve an operand against `schema`, walking a column path at most once: a column yields its

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -21,7 +21,11 @@ use crate::{DeltaResult, Error};
 /// anything else returns `Err` (what the caller does with an un-lowerable constraint is the
 /// caller's contract, not this function's). The resolved operands must therefore satisfy all of:
 /// - at least one operand is a column, so a literal can be typed from it;
-/// - every column operand is primitive-typed (struct/array/map have no scalar comparison);
+/// - every column operand is primitive-typed. Spark does support `=`/`<=>` on struct/array/map
+///   (only ordering is primitive-only), but kernel's engine cannot: the default engine's comparison
+///   routes through arrow's `cmp` kernels, which error on nested types. Lowering a complex-type
+///   equality would therefore fail at *evaluation*, so we reject it up front until the engine gains
+///   nested comparison (via `make_comparator`).
 /// - the two operands share a single comparison type, because the engine compares only matching
 ///   types (no implicit numeric coercion) -- see [`type_literal_from_column`] (FLOAT-vs-literal)
 ///   and the column-vs-column arm (cross-type columns).
@@ -43,9 +47,10 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
     let Comparison { op, left, right } = comparison;
     let left = resolve_operand(left, schema)?;
     let right = resolve_operand(right, schema)?;
-    // Reject non-primitive columns explicitly: `parse_sql("NULL", <struct>)` succeeds (NULL is
-    // valid for any type), so without this check `nested = NULL` would lower silently. (`nested =
-    // 0` is already caught by `parse_sql`, which rejects a non-primitive literal target.)
+    // Reject non-primitive columns: the engine cannot compare nested types (see the fn doc), and
+    // this is the only place that catches a column on its own. `parse_sql("NULL", <struct>)`
+    // succeeds (NULL is valid for any type), so without this `nested = NULL` would lower silently;
+    // `nested = 0` is already caught by `parse_sql` rejecting a non-primitive literal target.
     for operand in [&left, &right] {
         if let ResolvedOperand::Column {
             canonical,
@@ -75,9 +80,9 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
         ) => {
             // The engine compares only matching Arrow types -- it applies no numeric coercion (it
             // would error on e.g. INT vs LONG). Spark instead coerces both columns to a common type
-            // and compares there, so a cross-type comparison kernel cannot reproduce is rejected
-            // (left to the connector). The check is on the full `DataType`, so it also rejects
-            // mismatched decimal precision/scale and TIMESTAMP vs TIMESTAMP_NTZ.
+            // and compares there, so a cross-type comparison kernel cannot reproduce is rejected.
+            // The check is on the full `DataType`, so it also rejects mismatched decimal
+            // precision/scale and TIMESTAMP vs TIMESTAMP_NTZ.
             if l_type != r_type {
                 return Err(Error::generic(format!(
                     "CHECK constraint comparing columns of different types is not supported: \
@@ -136,7 +141,7 @@ pub(super) fn lower(comparison: &Comparison, schema: &StructType) -> DeltaResult
 /// is exactly representable in f32: an integer qualifies iff it round-trips through f32 unchanged
 /// (`v as f32 as i64 == v`), which fails past 2^24 even well within i64 range (e.g. `16777217`
 /// rounds to `16777216.0`). Any literal with a `.`/exponent, or an out-of-i64 integer, is likewise
-/// not gated in and is rejected -- left to the connector.
+/// not gated in and is rejected.
 ///
 /// Kernel has no cast expression and cannot compare f32 to f64, so it cannot reproduce Spark's
 /// widening. `NULL` is allowed (a null comparison involves no f32/f64 rounding). Only FLOAT is
@@ -401,8 +406,8 @@ mod tests {
         );
     }
 
-    /// Not-kernel-parsable inputs: everything outside the single-comparison grammar must error, so
-    /// the caller treats the constraint as not-kernel-parsable (connector-enforced / fail-closed).
+    /// Not-kernel-parsable inputs: everything outside the single-comparison grammar must error
+    /// (fail-closed), so the caller can treat the constraint as not-kernel-parsable.
     /// Covers boolean junctions, parentheses, `IS [NOT] NULL`, multi-operand predicates
     /// (`IN`/`BETWEEN`/`LIKE`), functions, arithmetic, comparisons with no column,
     /// type-incompatible literals (kernel applies no implicit casts), and malformed input.
@@ -447,7 +452,7 @@ mod tests {
     #[case::literal_out_of_range_for_column("price = 9999999999")]
     // A DECIMAL literal must match the column's scale exactly (`parse_scalar` does not pad), so an
     // integer or wrong-scale literal against a DECIMAL(10,2) column is rejected where Spark would
-    // read `0` as `0.00`. Left to the connector (see the `sql` module doc). `cost <= 10.00` lowers.
+    // read `0` as `0.00` (see the `sql` module doc). `cost <= 10.00` lowers.
     #[case::decimal_integer_literal_scale_mismatch("cost >= 0")]
     #[case::decimal_wrong_scale_literal("cost >= 0.5")]
     // A FLOAT column against any literal not exactly representable in f32 is rejected: kernel

--- a/kernel/src/expressions/sql/lower.rs
+++ b/kernel/src/expressions/sql/lower.rs
@@ -171,8 +171,8 @@ enum ResolvedOperand {
 fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<ResolvedOperand> {
     match operand {
         Operand::Literal(raw) => Ok(ResolvedOperand::Literal(raw.clone())),
-        Operand::Column(path) => {
-            let (canonical, data_type) = resolve_column(path, schema)?;
+        Operand::Column(column) => {
+            let (canonical, data_type) = resolve_column(column, schema)?;
             Ok(ResolvedOperand::Column {
                 canonical,
                 data_type,
@@ -181,15 +181,17 @@ fn resolve_operand(operand: &Operand, schema: &StructType) -> DeltaResult<Resolv
     }
 }
 
-/// Resolve a (case-insensitive) column path against `schema`, returning the *canonical* path (the
-/// schema's stored field names) and the leaf field's type. The canonical names are what the engine
-/// sees in the logical batch, so the emitted column reference must use them rather than the
+/// Resolve a (case-insensitive) column reference against `schema`, returning the *canonical* path
+/// (the schema's stored field names) and the leaf field's type. The canonical names are what the
+/// engine sees in the logical batch, so the emitted column reference must use them rather than the
 /// as-written casing.
-fn resolve_column(path: &[String], schema: &StructType) -> DeltaResult<(Vec<String>, DataType)> {
-    let column = ColumnName::new(path.iter().cloned());
-    let mut fields = Vec::with_capacity(path.len());
+fn resolve_column(
+    column: &ColumnName,
+    schema: &StructType,
+) -> DeltaResult<(Vec<String>, DataType)> {
+    let mut fields = Vec::with_capacity(column.len());
     schema.visit_fields_of_path_by(
-        &column,
+        column,
         |parent, name| {
             parent
                 .fields()

--- a/kernel/src/expressions/sql/parser.rs
+++ b/kernel/src/expressions/sql/parser.rs
@@ -5,8 +5,8 @@
 //! (`AND`/`OR`/`NOT`), parentheses, and `IS [NOT] NULL` are not yet supported and surface as
 //! errors. A later stage resolves the operands against a schema.
 
-// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
-// TODO(#2896): remove this allow once check-constraint enforcement wires up a caller.
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until discovery lands.
+// TODO(#2896): remove this allow once check-constraint discovery wires up a caller.
 #![allow(dead_code)]
 
 use std::iter::Peekable;

--- a/kernel/src/expressions/sql/parser.rs
+++ b/kernel/src/expressions/sql/parser.rs
@@ -16,12 +16,13 @@ use super::token::Token;
 use crate::expressions::ColumnName;
 use crate::{DeltaResult, Error};
 
-/// An operand of a comparison: a column reference (its as-written path) or a literal (raw source
-/// text, e.g. `42`, `'foo'`, `NULL`).
+/// An operand of a comparison: a column reference (its as-written path), a literal (raw source
+/// text, e.g. `42`, `'foo'`), or `NULL`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum Operand {
     Column(ColumnName),
     Literal(String),
+    Null,
 }
 
 /// A comparison operator. Kernel has no native `<=`/`>=`/`!=` predicate op; lowering composes them
@@ -113,6 +114,7 @@ impl Parser {
                 }
             }
             Some(Token::Number(raw)) | Some(Token::Literal(raw)) => Ok(Operand::Literal(raw)),
+            Some(Token::Null) => Ok(Operand::Null),
             Some(Token::Ident(first)) => self.parse_column_path(first),
             other => Err(expected("a column or literal", other)),
         }
@@ -156,6 +158,10 @@ mod tests {
 
     fn lit(s: &str) -> Operand {
         Operand::Literal(s.to_string())
+    }
+
+    fn null() -> Operand {
+        Operand::Null
     }
 
     /// Each operator token maps to its `CmpOp`, with the two operands preserved in order.
@@ -239,7 +245,7 @@ mod tests {
     #[case("ratio == .25", CmpOp::Eq, col(&["ratio"]), lit(".25"))]
     #[case("a.b.c <= 100", CmpOp::Le, col(&["a", "b", "c"]), lit("100"))]
     #[case("x != y", CmpOp::Ne, col(&["x"]), col(&["y"]))]
-    #[case("n <=> NULL", CmpOp::NullSafeEq, col(&["n"]), lit("NULL"))]
+    #[case("n <=> NULL", CmpOp::NullSafeEq, col(&["n"]), null())]
     #[case("+5 < a", CmpOp::Lt, lit("+5"), col(&["a"]))]
     #[case("status = 'active'", CmpOp::Eq, col(&["status"]), lit("'active'"))]
     fn tokenize_then_parse_yields_expected_comparison(

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -6,8 +6,8 @@
 //!
 //! Example: `` `col1` > 5 `` tokenizes to `[Ident("col1"), Gt, Number("5")]`.
 
-// WIP feature behind `check-constraints-in-dev`; some items have no caller until enforcement lands.
-// TODO(#2896): remove this allow once check-constraint enforcement wires up a caller.
+// WIP feature behind `check-constraints-in-dev`; some items have no caller until discovery lands.
+// TODO(#2896): remove this allow once check-constraint discovery wires up a caller.
 #![allow(dead_code)]
 
 use std::iter::Peekable;

--- a/kernel/src/expressions/sql/token.rs
+++ b/kernel/src/expressions/sql/token.rs
@@ -28,9 +28,13 @@ pub(super) enum Token {
     /// caller need not re-derive number-ness from the raw text.
     Number(String),
     /// A non-numeric literal's raw, undecoded source text (quotes and any typed-literal keyword
-    /// retained): quoted strings, `X'..'` binary, `TRUE`/`FALSE`/`NULL`, and typed
+    /// retained): quoted strings, `X'..'` binary, `TRUE`/`FALSE`, and typed
     /// `DATE`/`TIMESTAMP`/ `TIMESTAMP_LTZ`/`TIMESTAMP_NTZ` literals.
     Literal(String),
+    /// The `NULL` keyword (case-insensitive). Recognized here rather than carried as raw
+    /// [`Literal`] text so downstream stages match it structurally instead of re-detecting the
+    /// string and its casing.
+    Null,
     Dot,
     Lt,
     Le,
@@ -227,8 +231,8 @@ fn take_number(chars: &mut CharStream<'_>) -> String {
     out
 }
 
-/// Scan a bare word and classify it: a keyword (`AND`/`OR`/`NOT`/`IS`), a boolean/null/typed/binary
-/// literal, or an identifier. All classification is case-insensitive.
+/// Scan a bare word and classify it: a keyword (`AND`/`OR`/`NOT`/`IS`), `NULL`, a
+/// boolean/typed/binary literal, or an identifier. All classification is case-insensitive.
 ///
 /// Keywords are recognized here rather than downstream so a backtick-quoted `` `AND` `` (parsed as
 /// an `Ident` by the caller of this function) stays distinct from the bareword keyword `AND`.
@@ -242,7 +246,8 @@ fn classify_word(chars: &mut CharStream<'_>, sql: &str) -> DeltaResult<Token> {
         "OR" => Token::Keyword(Keyword::Or),
         "NOT" => Token::Keyword(Keyword::Not),
         "IS" => Token::Keyword(Keyword::Is),
-        "NULL" | "TRUE" | "FALSE" => Token::Literal(word),
+        "NULL" => Token::Null,
+        "TRUE" | "FALSE" => Token::Literal(word),
         // `X'deadbeef'` binary literal: only when a quote immediately follows (no whitespace),
         // otherwise `x` is a column named `x`.
         "X" if chars.peek() == Some(&'\'') => {
@@ -345,7 +350,6 @@ mod tests {
     #[rstest]
     #[case("'foo'", lit("'foo'"))]
     #[case("'O''Brien'", lit("'O''Brien'"))] // doubled '' escape retained
-    #[case("NULL", lit("NULL"))]
     #[case("TRUE", lit("TRUE"))]
     #[case("false", lit("false"))]
     #[case("DATE '1970-01-02'", lit("DATE '1970-01-02'"))]
@@ -353,6 +357,16 @@ mod tests {
     #[case("X'01ff'", lit("X'01ff'"))]
     fn tokenizes_literal_as_single_raw_token(#[case] sql: &str, #[case] expected: Token) {
         assert_eq!(tokenize(sql).unwrap(), [expected]);
+    }
+
+    /// `NULL` tokenizes to the dedicated `Token::Null` (not a raw `Literal`), case-insensitively,
+    /// so downstream stages need not re-detect the string or its casing.
+    #[rstest]
+    #[case("NULL")]
+    #[case("null")]
+    #[case("Null")]
+    fn tokenizes_null_keyword(#[case] sql: &str) {
+        assert_eq!(tokenize(sql).unwrap(), [Token::Null]);
     }
 
     /// Every typed-literal keyword tokenizes to exactly one literal, so dropping one from the

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1073,6 +1073,26 @@ impl StructType {
         Ok(result)
     }
 
+    /// Like [`fields_of_path`](Self::fields_of_path), but with a caller-provided field name
+    /// resolver (e.g. a case-insensitive one) -- the collecting sibling of
+    /// [`visit_fields_of_path_by`](Self::visit_fields_of_path_by).
+    ///
+    /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
+    /// a struct type.
+    #[cfg(feature = "check-constraints-in-dev")]
+    pub(crate) fn fields_of_path_by<'a, F>(
+        &'a self,
+        col: &ColumnName,
+        find_field: F,
+    ) -> DeltaResult<Vec<&'a StructField>>
+    where
+        F: for<'b> Fn(&'b StructType, &str) -> Option<&'b StructField>,
+    {
+        let mut result = Vec::with_capacity(col.path().len());
+        self.visit_fields_of_path_by(col, find_field, |f| result.push(f))?;
+        Ok(result)
+    }
+
     /// Visits all fields along the given column path, using a caller-provided field name resolver.
     ///
     /// Returns an error if the path is empty, a field is not found, or an intermediate field is not

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1069,24 +1069,35 @@ impl StructType {
         Ok(result)
     }
 
-    /// Like [`fields_of_path`](Self::fields_of_path), but with a caller-provided field name
-    /// resolver (e.g. a case-insensitive one) -- the collecting sibling of
-    /// [`visit_fields_of_path_by`](Self::visit_fields_of_path_by).
+    /// Resolves a column path case-insensitively (Delta's field-matching rule), returning the
+    /// schema's *canonical* (stored-cased) path segments alongside the leaf [`StructField`]. The
+    /// canonical names -- not the caller's as-written casing -- are what the engine sees in the
+    /// logical batch, so an emitted column reference must use them.
     ///
     /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
     /// a struct type.
     #[cfg(feature = "check-constraints-in-dev")]
-    pub(crate) fn fields_of_path_by<'a, F>(
+    pub(crate) fn resolve_path_ci<'a>(
         &'a self,
         col: &ColumnName,
-        find_field: F,
-    ) -> DeltaResult<Vec<&'a StructField>>
-    where
-        F: for<'b> Fn(&'b StructType, &str) -> Option<&'b StructField>,
-    {
-        let mut result = Vec::with_capacity(col.path().len());
-        self.visit_fields_of_path_by(col, find_field, |f| result.push(f))?;
-        Ok(result)
+    ) -> DeltaResult<(Vec<String>, &'a StructField)> {
+        let mut canonical = Vec::with_capacity(col.path().len());
+        let mut leaf = None;
+        self.visit_fields_of_path_by(
+            col,
+            |parent, name| {
+                parent
+                    .fields()
+                    .find(|f| f.name().eq_ignore_ascii_case(name))
+            },
+            |f| {
+                canonical.push(f.name().to_string());
+                leaf = Some(f);
+            },
+        )?;
+        // visit_fields_of_path_by errors on an empty path, so it always visits >= 1 field.
+        let leaf = leaf.ok_or_else(|| Error::generic("empty column path"))?;
+        Ok((canonical, leaf))
     }
 
     /// Visits all fields along the given column path, using a caller-provided field name resolver.


### PR DESCRIPTION
## Stacked PR

Splitting #2812 per review feedback. Each PR is based on `main`; use the incremental link to review only this PR's changes.
- stack/check-constraints-tokenizer (#2882)
  - stack/check-constraints-parser (#2883)
    - **stack/check-constraints-lower** (this PR, #2884) -- [incremental changes](https://github.com/delta-io/delta-kernel-rs/pull/2884/files/076f5195c7e006821dd2023cd06dcdaa47a134f5..e28b1b42b25290c5a02a75e9f4dc6fd4583b6e92)

## What changes are proposed in this pull request?

Final PR of the stack. Resolves a parsed constraint against the table schema and
lowers it to a kernel `Predicate`

Comparisons are only lowered when kernel can evaluate them to the same boolean Spark
would; otherwise they error:
- a FLOAT column vs a DECIMAL/DOUBLE literal is rejected (Spark widens the column to
  f64, kernel compares at f32); INT/LONG-range literals and `NULL` are allowed.
- cross-type column vs column comparisons are rejected.

`<=>` (null-safe equal) lowers to a negated distinct predicate; signed literals
(`amount = - 5`, `+5`) lower like `-5`/`5`, whitespace-insensitive

## How was this change tested?

New UTs
