### PR TITLE
fix: tolerate stale column mapping annotations when disabled

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use crate::expressions::{column_name, ColumnName};
 use crate::reserved_field_ids::FILE_NAME;
 use crate::table_features::{
     validate_and_extract_column_mapping_annotations, validate_column_mapping_id, ColumnMappingMode,
+    StaleAnnotationPolicy,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::utils::require;
@@ -628,8 +629,8 @@ impl StructField {
     /// metadata if present, otherwise returns the logical name.
     ///
     /// NOTE: Caller affirms that the schema was already validated by
-    /// [`crate::table_configuration::TableConfiguration::try_new`], to ensure that annotations are
-    /// always and only present when column mapping mode is enabled.
+    /// [`crate::table_configuration::TableConfiguration::try_new`]. In `None` mode a stale
+    /// annotation may still be present (it is ignored, and the logical name is returned).
     #[internal_api]
     pub(crate) fn physical_name(&self, column_mapping_mode: ColumnMappingMode) -> &str {
         match column_mapping_mode {
@@ -721,8 +722,11 @@ impl StructField {
     /// Otherwise, the field's logical name is used.
     ///
     /// Returns an error if a field has invalid or inconsistent column mapping annotations (e.g.
-    /// missing when column mapping is enabled, present when disabled, or wrong type), or if a
-    /// metadata column is encountered (metadata columns should not participate in column mapping).
+    /// missing or wrong-typed when column mapping is enabled), or if a metadata column is
+    /// encountered (metadata columns should not participate in column mapping). When column
+    /// mapping is disabled, a stale annotation is tolerated (resolved by logical name and dropped
+    /// from the physical metadata); the write path rejects it via a separate strict validation
+    /// pass instead.
     ///
     /// [`read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     #[internal_api]
@@ -746,8 +750,8 @@ impl StructField {
     /// NOTE: Must not be called on metadata columns, which are not subject to column mapping.
     ///
     /// NOTE: Caller affirms that `self` was already validated by
-    /// [`crate::table_features::validate_and_extract_column_mapping_annotations`], to ensure that
-    /// annotations are always and only present when column mapping mode is enabled.
+    /// [`crate::table_features::validate_and_extract_column_mapping_annotations`]. In `None` mode a
+    /// stale annotation may be present; this drops the column-mapping keys regardless.
     fn logical_to_physical_metadata(
         &self,
         column_mapping_mode: ColumnMappingMode,
@@ -2323,6 +2327,10 @@ pub(crate) struct MakePhysical<'a> {
     /// When `true`, skips the physical-name + metadata rewrite, only validates the column
     /// mapping annotations.
     validation_only: bool,
+    /// How to treat a stale `delta.columnMapping.*` annotation found while mapping is disabled.
+    /// `make_physical` tolerates them (read path); `validate_schema_column_mapping` rejects them
+    /// (explicit strict write-path check).
+    stale_policy: StaleAnnotationPolicy,
 }
 impl<'a> MakePhysical<'a> {
     fn new(column_mapping_mode: ColumnMappingMode) -> Self {
@@ -2332,16 +2340,19 @@ impl<'a> MakePhysical<'a> {
             seen_ids: HashMap::new(),
             sibling_names_stack: vec![],
             validation_only: false,
+            stale_policy: StaleAnnotationPolicy::Ignore,
         }
     }
 
-    /// Walks `schema` and validates its column-mapping annotations.
+    /// Walks `schema` and validates its column-mapping annotations, rejecting stale annotations
+    /// left over on a column-mapping-disabled table.
     pub(crate) fn validate_schema_column_mapping(
         mode: ColumnMappingMode,
         schema: &'a StructType,
     ) -> DeltaResult<()> {
         let mut walker = Self {
             validation_only: true,
+            stale_policy: StaleAnnotationPolicy::Reject,
             ..Self::new(mode)
         };
         walker.transform_struct(schema).map(|_| ())
@@ -2384,6 +2395,7 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
         let (physical_name, _id) = validate_and_extract_column_mapping_annotations(
             field,
             self.column_mapping_mode,
+            self.stale_policy,
             &self.logical_path,
             Some(&mut self.seen_ids),
             self.sibling_names_stack.last_mut(),
@@ -2834,10 +2846,40 @@ mod tests {
     }
 
     #[test]
-    fn test_make_physical_rejects_annotated_fields_when_column_mapping_disabled() {
+    fn test_make_physical_tolerates_stale_annotations_when_column_mapping_disabled() {
+        // A table can carry `delta.columnMapping.*` annotations after mapping was enabled and then
+        // disabled. They are inert while mapping is off, so `make_physical` (the read path)
+        // tolerates them: the field keeps its logical name and the CM keys are dropped from the
+        // physical metadata, leaving a schema indistinguishable from a table that never had them.
         let data = example_schema_metadata();
         let field: StructField = serde_json::from_str(data).unwrap();
-        assert!(field.make_physical(ColumnMappingMode::None).is_err());
+        let physical = field.make_physical(ColumnMappingMode::None).unwrap();
+
+        assert_eq!(physical.name, "e");
+        assert!(!physical
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingId.as_ref()));
+        assert!(!physical
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref()));
+        // Non-column-mapping metadata is untouched.
+        assert!(physical.metadata.contains_key("delta.identity.start"));
+
+        // The nested leaf `d` is likewise tolerated: logical name kept, CM keys dropped.
+        let DataType::Array(atype) = &physical.data_type else {
+            panic!("Expected an Array");
+        };
+        let DataType::Struct(stype) = atype.element_type() else {
+            panic!("Expected a Struct");
+        };
+        let leaf = stype.fields().next().unwrap();
+        assert_eq!(leaf.name, "d");
+        assert!(!leaf
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingId.as_ref()));
+        assert!(!leaf
+            .metadata
+            .contains_key(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref()));
     }
 
     #[test]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2312,6 +2312,29 @@ impl<'a> SchemaTransform<'a> for GetSchemaLeaves {
     }
 }
 
+/// What a [`MakePhysical`] walk does with each field. The two modes bundle the physical-rewrite
+/// behavior with the matching treatment of a stale `delta.columnMapping.*` annotation left over on
+/// a mapping-disabled table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MakePhysicalMode {
+    /// Rewrite each field to its physical name + metadata (the read/build path). A stale
+    /// annotation in `None` mode is tolerated: resolved by logical name and dropped from the
+    /// physical metadata.
+    Rewrite,
+    /// Validate annotations only, without rewriting (the strict write-path check). A stale
+    /// annotation in `None` mode is rejected.
+    ValidateStrict,
+}
+
+impl MakePhysicalMode {
+    fn stale_annotation_policy(self) -> StaleAnnotationPolicy {
+        match self {
+            Self::Rewrite => StaleAnnotationPolicy::Ignore,
+            Self::ValidateStrict => StaleAnnotationPolicy::Reject,
+        }
+    }
+}
+
 pub(crate) struct MakePhysical<'a> {
     column_mapping_mode: ColumnMappingMode,
     /// Logical path of current field's parent, used for error messages.
@@ -2324,13 +2347,9 @@ pub(crate) struct MakePhysical<'a> {
     /// fields. Only structs introduce siblings; arrays/maps don't push frames since their
     /// elements / keys / values are anonymous.
     sibling_names_stack: Vec<HashMap<&'a str, &'a str>>,
-    /// When `true`, skips the physical-name + metadata rewrite, only validates the column
-    /// mapping annotations.
-    validation_only: bool,
-    /// How to treat a stale `delta.columnMapping.*` annotation found while mapping is disabled.
-    /// `make_physical` tolerates them (read path); `validate_schema_column_mapping` rejects them
-    /// (explicit strict write-path check).
-    stale_policy: StaleAnnotationPolicy,
+    /// Whether this walk rewrites fields to physical form or only validates (see
+    /// [`MakePhysicalMode`]).
+    mode: MakePhysicalMode,
 }
 impl<'a> MakePhysical<'a> {
     fn new(column_mapping_mode: ColumnMappingMode) -> Self {
@@ -2339,8 +2358,7 @@ impl<'a> MakePhysical<'a> {
             logical_path: vec![],
             seen_ids: HashMap::new(),
             sibling_names_stack: vec![],
-            validation_only: false,
-            stale_policy: StaleAnnotationPolicy::Ignore,
+            mode: MakePhysicalMode::Rewrite,
         }
     }
 
@@ -2351,8 +2369,7 @@ impl<'a> MakePhysical<'a> {
         schema: &'a StructType,
     ) -> DeltaResult<()> {
         let mut walker = Self {
-            validation_only: true,
-            stale_policy: StaleAnnotationPolicy::Reject,
+            mode: MakePhysicalMode::ValidateStrict,
             ..Self::new(mode)
         };
         walker.transform_struct(schema).map(|_| ())
@@ -2395,7 +2412,7 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
         let (physical_name, _id) = validate_and_extract_column_mapping_annotations(
             field,
             self.column_mapping_mode,
-            self.stale_policy,
+            self.mode.stale_annotation_policy(),
             &self.logical_path,
             Some(&mut self.seen_ids),
             self.sibling_names_stack.last_mut(),
@@ -2407,7 +2424,7 @@ impl<'a> SchemaTransform<'a> for MakePhysical<'a> {
 
         self.transform_inner(field.name(), |this| {
             let field = this.recurse_into_struct_field(field)?;
-            if this.validation_only {
+            if this.mode == MakePhysicalMode::ValidateStrict {
                 return Ok(field);
             }
             let metadata = field.logical_to_physical_metadata(this.column_mapping_mode);

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -725,8 +725,8 @@ impl StructField {
     /// missing or wrong-typed when column mapping is enabled), or if a metadata column is
     /// encountered (metadata columns should not participate in column mapping). When column
     /// mapping is disabled, a stale annotation is tolerated (resolved by logical name and dropped
-    /// from the physical metadata); the write path rejects it via a separate strict validation
-    /// pass instead.
+    /// from the physical metadata); CREATE / ALTER reject it via a separate strict validation pass
+    /// instead.
     ///
     /// [`read_parquet_files`]: crate::ParquetHandler::read_parquet_files
     #[internal_api]

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -115,10 +115,10 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// How to treat a stale `delta.columnMapping.*` annotation found on a field while column mapping
 /// is disabled ([`ColumnMappingMode::None`]).
 ///
-/// A table can carry these annotations after column mapping was enabled and then disabled. They
-/// are inert while mapping is off -- physical names resolve to logical names -- so the read path
-/// tolerates them (matching delta-spark, which ignores them on read), while the write path rejects
-/// them so kernel never persists a table in that shape.
+/// A table can carry residual annotations while mapping is off. They are inert -- physical names
+/// resolve to logical names -- so reads tolerate them (matching delta-spark, which ignores them in
+/// `NoMapping` mode), while CREATE / ALTER reject them so kernel never persists a table in that
+/// shape.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StaleAnnotationPolicy {
     /// Ignore a stale annotation and resolve the field by its logical name.
@@ -966,9 +966,10 @@ mod tests {
             });
     }
 
-    // `validate_schema_column_mapping` is the strict entry point (used by the write path), so a
-    // stale annotation on a mapping-disabled table is rejected. The read path's leniency is
-    // covered by `test_validate_and_extract_tolerates_stale_annotations_when_disabled`.
+    // `validate_schema_column_mapping` is the strict validator (CREATE / ALTER reach it via the
+    // `validate_schema_column_mapping_strict` alias), so a stale annotation on a mapping-disabled
+    // table is rejected. The lenient path is covered by
+    // `test_validate_and_extract_tolerates_stale_annotations_when_disabled`.
     #[test]
     fn test_column_mapping_disabled() {
         let schema = create_schema(None, None, None, None);

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -237,15 +237,15 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
                 logical_field_path(),
             )));
         }
-        (ColumnMappingMode::None, Some(_)) if stale_policy == StaleAnnotationPolicy::Ignore => {
-            field.name()
-        }
-        (ColumnMappingMode::None, Some(_)) => {
-            return Err(Error::schema(format!(
-                "Column mapping is not enabled but field '{}' is annotated with {annotation}",
-                logical_field_path(),
-            )));
-        }
+        (ColumnMappingMode::None, Some(_)) => match stale_policy {
+            StaleAnnotationPolicy::Ignore => field.name(),
+            StaleAnnotationPolicy::Reject => {
+                return Err(Error::schema(format!(
+                    "Column mapping is not enabled but field '{}' is annotated with {annotation}",
+                    logical_field_path(),
+                )));
+            }
+        },
     };
 
     let annotation = ColumnMetadataKey::ColumnMappingId.as_ref();
@@ -266,13 +266,15 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
                 logical_field_path(),
             )));
         }
-        (ColumnMappingMode::None, Some(_)) if stale_policy == StaleAnnotationPolicy::Ignore => None,
-        (ColumnMappingMode::None, Some(_)) => {
-            return Err(Error::schema(format!(
-                "Column mapping is not enabled but field '{}' is annotated with {annotation}",
-                logical_field_path(),
-            )));
-        }
+        (ColumnMappingMode::None, Some(_)) => match stale_policy {
+            StaleAnnotationPolicy::Ignore => None,
+            StaleAnnotationPolicy::Reject => {
+                return Err(Error::schema(format!(
+                    "Column mapping is not enabled but field '{}' is annotated with {annotation}",
+                    logical_field_path(),
+                )));
+            }
+        },
     };
 
     // CM-disabled mode synthesizes `physical_name = field.name()`, which only has to be unique

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -112,6 +112,21 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
     MakePhysical::validate_schema_column_mapping(mode, schema)
 }
 
+/// How to treat a stale `delta.columnMapping.*` annotation found on a field while column mapping
+/// is disabled ([`ColumnMappingMode::None`]).
+///
+/// A table can carry these annotations after column mapping was enabled and then disabled. They
+/// are inert while mapping is off -- physical names resolve to logical names -- so the read path
+/// tolerates them (matching delta-spark, which ignores them on read), while the write path rejects
+/// them so kernel never persists a table in that shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StaleAnnotationPolicy {
+    /// Ignore a stale annotation and resolve the field by its logical name.
+    Ignore,
+    /// Reject a stale annotation with a schema error.
+    Reject,
+}
+
 /// Validates a field's column mapping annotations and extracts the physical name and column
 /// mapping id. If `seen_ids` is provided, also checks that this field's
 /// `delta.columnMapping.id` is globally unique. If `current_field_siblings` is provided, also
@@ -124,14 +139,18 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// `delta.columnMapping.physicalName` (string) and `delta.columnMapping.id` (number) annotation.
 /// Returns the physical name and `Some(id)`.
 ///
-/// When disabled (`None`), neither annotation should be present. Returns the logical field name
-/// and `None`. In `None` mode no dedup is performed (the returned "physical name" is just the
-/// logical field name and is only schema-unique within its parent struct, not globally).
+/// When disabled (`None`), a stale annotation is handled per `stale_policy`:
+/// [`StaleAnnotationPolicy::Ignore`] resolves the field by its logical name (returning the logical
+/// name and `None`), while [`StaleAnnotationPolicy::Reject`] errors. Either way, in `None` mode no
+/// dedup is performed (the returned "physical name" is just the logical field name and is only
+/// schema-unique within its parent struct, not globally).
 ///
 /// # Parameters
 ///
 /// - `field`: The field to validate.
 /// - `mode`: Column mapping mode.
+/// - `stale_policy`: In `None` mode, whether to ignore or reject a stale `delta.columnMapping.*`
+///   annotation. Unused when mapping is enabled.
 /// - `parent_field_logical_path`: The field's parent path, used to render full paths in error
 ///   messages (e.g. parent `&["a", "b"]` and field `c` renders as `a.b.c`).
 /// - `seen_ids`: Global map of `delta.columnMapping.id` -> first claimer logical name. `None` skips
@@ -144,7 +163,8 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 /// - The field is a metadata column carrying any CM annotation.
 /// - CM is enabled but `delta.columnMapping.physicalName` is missing or non-string.
 /// - CM is enabled but `delta.columnMapping.id` is missing or non-numeric.
-/// - CM is disabled but either annotation is present.
+/// - CM is disabled, `stale_policy` is [`StaleAnnotationPolicy::Reject`], and either annotation is
+///   present.
 /// - `seen_ids` is provided and the current field's `delta.columnMapping.id` is already in the map.
 ///   Example rejection (two fields share `delta.columnMapping.id=1`):
 ///
@@ -171,6 +191,7 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
     field: &'a StructField,
     mode: ColumnMappingMode,
+    stale_policy: StaleAnnotationPolicy,
     parent_field_logical_path: &[&'a str],
     seen_ids: Option<&mut HashMap<i64, &'a str>>,
     current_field_siblings: Option<&mut HashMap<&'a str, &'a str>>,
@@ -216,6 +237,9 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
                 logical_field_path(),
             )));
         }
+        (ColumnMappingMode::None, Some(_)) if stale_policy == StaleAnnotationPolicy::Ignore => {
+            field.name()
+        }
         (ColumnMappingMode::None, Some(_)) => {
             return Err(Error::schema(format!(
                 "Column mapping is not enabled but field '{}' is annotated with {annotation}",
@@ -242,6 +266,7 @@ pub(crate) fn validate_and_extract_column_mapping_annotations<'a>(
                 logical_field_path(),
             )));
         }
+        (ColumnMappingMode::None, Some(_)) if stale_policy == StaleAnnotationPolicy::Ignore => None,
         (ColumnMappingMode::None, Some(_)) => {
             return Err(Error::schema(format!(
                 "Column mapping is not enabled but field '{}' is annotated with {annotation}",
@@ -939,6 +964,9 @@ mod tests {
             });
     }
 
+    // `validate_schema_column_mapping` is the strict entry point (used by the write path), so a
+    // stale annotation on a mapping-disabled table is rejected. The read path's leniency is
+    // covered by `test_validate_and_extract_tolerates_stale_annotations_when_disabled`.
     #[test]
     fn test_column_mapping_disabled() {
         let schema = create_schema(None, None, None, None);
@@ -952,6 +980,61 @@ mod tests {
         validate_schema_column_mapping(&schema, ColumnMappingMode::None).expect_err("field id");
         let schema = create_schema(None, None, None, "\"col-5f422f40\"");
         validate_schema_column_mapping(&schema, ColumnMappingMode::None).expect_err("field name");
+    }
+
+    /// A field carrying a stale `delta.columnMapping.*` annotation while mapping is disabled is
+    /// tolerated under [`StaleAnnotationPolicy::Ignore`] (the read path) -- it resolves to the
+    /// logical name with no id -- and rejected under [`StaleAnnotationPolicy::Reject`] (the write
+    /// path).
+    #[rstest::rstest]
+    #[case::physical_name_only(None, Some("col-abc"))]
+    #[case::id_only(Some(7), None)]
+    #[case::both(Some(7), Some("col-abc"))]
+    fn test_validate_and_extract_tolerates_stale_annotations_when_disabled(
+        #[case] stale_id: Option<i64>,
+        #[case] stale_physical_name: Option<&str>,
+    ) {
+        let mut metadata: Vec<(&str, MetadataValue)> = Vec::new();
+        if let Some(id) = stale_id {
+            metadata.push((
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::Number(id),
+            ));
+        }
+        if let Some(name) = stale_physical_name {
+            metadata.push((
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::String(name.to_string()),
+            ));
+        }
+        let field = StructField::not_null("stale", DataType::INTEGER).with_metadata(metadata);
+
+        // Ignore: resolves to the logical name, no id.
+        let (physical_name, id) = validate_and_extract_column_mapping_annotations(
+            &field,
+            ColumnMappingMode::None,
+            StaleAnnotationPolicy::Ignore,
+            &[],
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(physical_name, "stale");
+        assert_eq!(id, None);
+
+        // Reject: errors, naming the field.
+        assert_result_error_with_message(
+            validate_and_extract_column_mapping_annotations(
+                &field,
+                ColumnMappingMode::None,
+                StaleAnnotationPolicy::Reject,
+                &[],
+                None,
+                None,
+            )
+            .map(|_| ()),
+            "Column mapping is not enabled but field 'stale'",
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -2,13 +2,15 @@
 pub(crate) use column_mapping::get_any_level_column_physical_name;
 #[deprecated = "Enable internal-api and use TableConfiguration instead"]
 pub use column_mapping::validate_schema_column_mapping;
+// Crate-visible alias so kernel code avoids the deprecated `pub` re-export above.
+pub(crate) use column_mapping::validate_schema_column_mapping as validate_schema_column_mapping_strict;
 pub use column_mapping::ColumnMappingMode;
 #[internal_api]
 pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
     column_mapping_mode, get_column_mapping_mode_from_properties, physical_to_logical_column_name,
     try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
-    validate_column_mapping_id,
+    validate_column_mapping_id, StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -32,7 +32,7 @@ use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{Operation, TableFeature};
+use crate::table_features::{validate_schema_column_mapping_strict, Operation, TableFeature};
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
@@ -187,6 +187,11 @@ impl AlterTableTransactionBuilder<Modifying> {
             column_mapping_mode,
             current_max_column_id,
         )?;
+
+        // Reject stale column-mapping annotations on a mapping-disabled table. `make_physical`
+        // (run when building the evolved `TableConfiguration` below) tolerates these on the read
+        // path, so this explicit check keeps ALTER from persisting a table in that shape.
+        validate_schema_column_mapping_strict(&evolved_schema, column_mapping_mode)?;
 
         let evolved_metadata = table_config
             .metadata()

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -188,9 +188,8 @@ impl AlterTableTransactionBuilder<Modifying> {
             current_max_column_id,
         )?;
 
-        // Reject stale column-mapping annotations on a mapping-disabled table. `make_physical`
-        // (run when building the evolved `TableConfiguration` below) tolerates these on the read
-        // path, so this explicit check keeps ALTER from persisting a table in that shape.
+        // Validates column mapping in strict mode (rejects stale CM annotations on a
+        // mapping-disabled table).
         validate_schema_column_mapping_strict(&evolved_schema, column_mapping_mode)?;
 
         let evolved_metadata = table_config

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -27,8 +27,9 @@ use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
     add_feature_to_lists, assign_column_mapping_metadata, auto_enable_property_driven_features,
     find_max_column_id_in_schema, get_any_level_column_physical_name,
-    get_column_mapping_mode_from_properties, schema_contains_timestamp_ntz, ColumnMappingMode,
-    TableFeature, SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
+    get_column_mapping_mode_from_properties, schema_contains_timestamp_ntz,
+    validate_schema_column_mapping_strict, ColumnMappingMode, TableFeature,
+    SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
     TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_WRITE_STATS_AS_JSON,
@@ -897,6 +898,11 @@ impl CreateTableTransactionBuilder {
         // Validate schema (column names, duplicates, no `delta.invariants` metadata).
         // Empty schemas are intentionally allowed.
         validate_schema(&effective_schema, column_mapping_mode)?;
+
+        // Reject stale column-mapping annotations on a mapping-disabled table. `make_physical`
+        // (run when building the `TableConfiguration` below) tolerates these on the read path, so
+        // this explicit check keeps writes from persisting a table in that shape.
+        validate_schema_column_mapping_strict(&effective_schema, column_mapping_mode)?;
 
         // Validate data layout and resolve column names (physical for clustering, logical
         // for partitioning). Adds required table features for clustering.

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -899,9 +899,8 @@ impl CreateTableTransactionBuilder {
         // Empty schemas are intentionally allowed.
         validate_schema(&effective_schema, column_mapping_mode)?;
 
-        // Reject stale column-mapping annotations on a mapping-disabled table. `make_physical`
-        // (run when building the `TableConfiguration` below) tolerates these on the read path, so
-        // this explicit check keeps writes from persisting a table in that shape.
+        // Validates column mapping in strict mode (rejects stale CM annotations on a
+        // mapping-disabled table).
         validate_schema_column_mapping_strict(&effective_schema, column_mapping_mode)?;
 
         // Validate data layout and resolve column names (physical for clustering, logical

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -180,11 +180,10 @@ pub(crate) fn apply_schema_operations(
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
                     try_assign_flat_column_mapping_info(&field, id)?
                 } else {
-                    // No upfront reject for stray CM metadata: the recursive walk in
-                    // `StructType::make_physical` (called from
-                    // `TableConfiguration::try_new_with_schema`
-                    // by the AlterTable builder) catches any CM annotation anywhere in the tree.
-                    // CREATE TABLE's non-CM path relies on the same mechanism.
+                    // No upfront reject for stray CM metadata here: the AlterTable builder runs an
+                    // explicit `validate_schema_column_mapping` over the evolved schema, which
+                    // rejects any CM annotation while mapping is disabled. CREATE TABLE runs the
+                    // same check on its non-CM path.
                     field
                 };
                 schema.field_map_mut().insert(field.name().clone(), field);

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -180,10 +180,9 @@ pub(crate) fn apply_schema_operations(
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
                     try_assign_flat_column_mapping_info(&field, id)?
                 } else {
-                    // No upfront reject for stray CM metadata here: the AlterTable builder runs an
-                    // explicit `validate_schema_column_mapping` over the evolved schema, which
-                    // rejects any CM annotation while mapping is disabled. CREATE TABLE runs the
-                    // same check on its non-CM path.
+                    // No upfront reject for stray CM metadata here: the AlterTable builder's
+                    // validate_schema_column_mapping rejects any CM annotation over the evolved
+                    // schema.
                     field
                 };
                 schema.field_map_mut().insert(field.name().clone(), field);

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -278,6 +278,40 @@ fn test_column_mapping_invalid_mode_rejected() {
         .contains("Invalid column mapping mode"));
 }
 
+/// CREATE TABLE with column mapping disabled must reject an input schema that already carries
+/// `delta.columnMapping.*` annotations, so kernel never originates a table in that shape. The
+/// read path tolerates such annotations (they can pre-exist from an enable-then-disable), but the
+/// write path stays strict. Tracked for future tolerance in
+/// https://github.com/delta-io/delta-kernel-rs/issues/2885.
+#[test]
+fn test_create_table_rejects_stale_column_mapping_when_disabled() {
+    let (_temp_dir, table_path, engine) = test_table_setup().unwrap();
+
+    let schema = Arc::new(
+        StructType::try_new(vec![
+            StructField::nullable("id", DataType::INTEGER),
+            StructField::nullable("value", DataType::INTEGER).add_metadata([
+                ("delta.columnMapping.id", MetadataValue::Number(2)),
+                (
+                    "delta.columnMapping.physicalName",
+                    MetadataValue::String("col-2f8a".to_string()),
+                ),
+            ]),
+        ])
+        .unwrap(),
+    );
+
+    // No column mapping mode set -> mode resolves to None -> the stale annotation is rejected.
+    let result = create_table(&table_path, schema, "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Column mapping is not enabled but field 'value'"));
+}
+
 /// Test cases for clustering columns with column mapping enabled.
 /// Each case specifies: (logical_column_names, description)
 #[rstest::rstest]

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -279,10 +279,9 @@ fn test_column_mapping_invalid_mode_rejected() {
 }
 
 /// CREATE TABLE with column mapping disabled must reject an input schema that already carries
-/// `delta.columnMapping.*` annotations, so kernel never originates a table in that shape. The
-/// read path tolerates such annotations (they can pre-exist from an enable-then-disable), but the
-/// write path stays strict. Tracked for future tolerance in
-/// https://github.com/delta-io/delta-kernel-rs/issues/2885.
+/// `delta.columnMapping.*` annotations, so kernel never originates a table in that shape. Reads
+/// tolerate such residual annotations, but CREATE / ALTER stay strict. Tracked for future
+/// tolerance in https://github.com/delta-io/delta-kernel-rs/issues/2885.
 #[test]
 fn test_create_table_rejects_stale_column_mapping_when_disabled() {
     let (_temp_dir, table_path, engine) = test_table_setup().unwrap();

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -18,8 +18,8 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
-    column_mapping_fixtures as fixtures, create_table_and_load_snapshot, test_table_setup,
-    test_table_setup_mt, write_batch_to_table,
+    add_commit, column_mapping_fixtures as fixtures, create_table_and_load_snapshot,
+    engine_store_setup, test_table_setup, test_table_setup_mt, write_batch_to_table,
 };
 
 fn simple_schema() -> SchemaRef {
@@ -1092,6 +1092,55 @@ async fn add_column_with_id_colliding_existing_field_is_rejected() -> DeltaResul
     assert!(
         err.contains("Duplicate column mapping ID") && err.contains(&existing_id.to_string()),
         "expected duplicate-id error naming id {existing_id}, got: {err}"
+    );
+    Ok(())
+}
+
+/// A mapping-disabled table carrying residual `delta.columnMapping.*` annotations reads fine
+/// (see the read-side tolerance), but ALTER is still rejected: the write path validates the whole
+/// evolved schema, so a stale annotation on an untouched column fails even when the ALTER only adds
+/// a clean column. delta-spark tolerates this; closing the gap is tracked in
+/// https://github.com/delta-io/delta-kernel-rs/issues/2885. This test pins the current strict
+/// behavior until then.
+#[tokio::test]
+async fn add_column_rejected_when_table_has_stale_column_mapping() -> DeltaResult<()> {
+    let (store, engine, table_url) = engine_store_setup("alter_stale_cm", None);
+
+    // `value` carries a stale physicalName + id; protocol omits columnMapping and no mode is set
+    // (resolves to None) -- the enable-then-disable artifact.
+    let stale_schema = StructType::try_new([
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::INTEGER).add_metadata([
+            ("delta.columnMapping.id", MetadataValue::Number(2)),
+            (
+                "delta.columnMapping.physicalName",
+                MetadataValue::String("col-2f8a".to_string()),
+            ),
+        ]),
+    ])?;
+    let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?).unwrap();
+    // v0 written directly to bypass create_table validation (which rejects stale annotations).
+    let v0 = format!(
+        r#"{{"protocol":{{"minReaderVersion":1,"minWriterVersion":2}}}}
+{{"metaData":{{"id":"alter-stale-cm","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{}},"createdTime":1700000000000}}}}
+"#
+    );
+    add_commit(table_url.as_str(), store.as_ref(), 0, v0)
+        .await
+        .unwrap();
+
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+    // Adding a brand-new clean column still fails, and the error names the untouched stale field.
+    let err = snapshot
+        .alter_table()
+        .add_column(StructField::nullable("region", DataType::STRING))
+        .build(&engine, committer())
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("Column mapping is not enabled but field 'value'"),
+        "expected the ALTER to be rejected naming the untouched stale field, got: {err}"
     );
     Ok(())
 }

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -1097,10 +1097,10 @@ async fn add_column_with_id_colliding_existing_field_is_rejected() -> DeltaResul
 }
 
 /// A mapping-disabled table carrying residual `delta.columnMapping.*` annotations reads fine
-/// (see the read-side tolerance), but ALTER is still rejected: the write path validates the whole
-/// evolved schema, so a stale annotation on an untouched column fails even when the ALTER only adds
-/// a clean column. delta-spark tolerates this; closing the gap is tracked in
-/// https://github.com/delta-io/delta-kernel-rs/issues/2885. This test pins the current strict
+/// (`StructField::make_physical` tolerates them), but ALTER is still rejected: the strict check
+/// validates the whole evolved schema, so a stale annotation on an untouched column fails even
+/// when the ALTER only adds a clean column. delta-spark tolerates this; closing the gap is tracked
+/// in https://github.com/delta-io/delta-kernel-rs/issues/2885. This test pins the current strict
 /// behavior until then.
 #[tokio::test]
 async fn add_column_rejected_when_table_has_stale_column_mapping() -> DeltaResult<()> {

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -480,12 +480,11 @@ async fn test_duplicated_phy_path_rejected(
     Ok(())
 }
 
-/// A table left with `delta.columnMapping.*` annotations after mapping was enabled and then
-/// disabled must still be readable: mapping is off, so the annotations are inert and columns
-/// resolve by logical name. Kernel matches delta-spark, which ignores residual annotations when
-/// mapping is disabled.
+/// A table left with residual `delta.columnMapping.*` annotations while mapping is off must still
+/// be readable and appendable: the annotations are inert and columns resolve by logical name.
+/// Kernel matches delta-spark, which ignores residual annotations in `NoMapping` mode.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_read_tolerates_stale_column_mapping_when_disabled(
+async fn test_read_and_append_tolerates_stale_column_mapping_when_disabled(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = tempfile::tempdir()?;
     let table_url = Url::from_directory_path(tmp_dir.path()).unwrap();
@@ -499,7 +498,7 @@ async fn test_read_tolerates_stale_column_mapping_when_disabled(
     );
 
     // A `value` column carrying a stale physicalName + id, with no columnMapping feature in the
-    // protocol and mode absent (so it resolves to None) -- the enable-then-disable artifact.
+    // protocol and mode absent (so it resolves to None).
     let stale_schema = schema_ref! {
         nullable "id": INTEGER,
         nullable "value": INTEGER
@@ -526,13 +525,7 @@ async fn test_read_tolerates_stale_column_mapping_when_disabled(
 
     // Snapshot load succeeds and reports column mapping disabled.
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    assert_eq!(
-        snapshot
-            .table_properties()
-            .column_mapping_mode
-            .unwrap_or(ColumnMappingMode::None),
-        ColumnMappingMode::None
-    );
+    assert_eq!(snapshot.table_properties().column_mapping_mode, None);
     // The `value` column resolves by its logical name, not the stale physical name.
     let physical_name = get_any_level_column_physical_name(
         snapshot.schema().as_ref(),

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -16,7 +16,7 @@ use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
 use delta_kernel::scan::StatsOptions;
-use delta_kernel::schema::schema_ref;
+use delta_kernel::schema::{schema_ref, MetadataValue, StructType};
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{Engine, FileMeta, Snapshot};
@@ -477,5 +477,86 @@ async fn test_duplicated_phy_path_rejected(
             && msg.contains(".b'"),
         "expected path-aware dedup error naming colliding leaves, got: {msg}"
     );
+    Ok(())
+}
+
+/// A table left with `delta.columnMapping.*` annotations after mapping was enabled and then
+/// disabled must still be readable: mapping is off, so the annotations are inert and columns
+/// resolve by logical name. Kernel matches delta-spark, which ignores residual annotations when
+/// mapping is disabled.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_read_tolerates_stale_column_mapping_when_disabled(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempfile::tempdir()?;
+    let table_url = Url::from_directory_path(tmp_dir.path()).unwrap();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let engine = Arc::new(
+        DefaultEngineBuilder::new(store.clone())
+            .with_task_executor(Arc::new(TokioMultiThreadExecutor::new(
+                tokio::runtime::Handle::current(),
+            )))
+            .build(),
+    );
+
+    // A `value` column carrying a stale physicalName + id, with no columnMapping feature in the
+    // protocol and mode absent (so it resolves to None) -- the enable-then-disable artifact.
+    let stale_schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": INTEGER
+    };
+    let stale_schema = StructType::try_new([
+        stale_schema.field("id").unwrap().clone(),
+        stale_schema.field("value").unwrap().clone().add_metadata([
+            ("delta.columnMapping.id", MetadataValue::Number(2)),
+            (
+                "delta.columnMapping.physicalName",
+                MetadataValue::String("col-2f8a".to_string()),
+            ),
+        ]),
+    ])?;
+    let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?)?;
+    // Create a v0 commit directly to bypass create_table validation (which would reject the
+    // stale annotations on the write path).
+    let v0 = format!(
+        r#"{{"protocol":{{"minReaderVersion":1,"minWriterVersion":2}}}}
+{{"metaData":{{"id":"stale-cm-id","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{}},"createdTime":1700000000000}}}}
+"#
+    );
+    add_commit(table_url.as_str(), store.as_ref(), 0, v0).await?;
+
+    // Snapshot load succeeds and reports column mapping disabled.
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    assert_eq!(
+        snapshot
+            .table_properties()
+            .column_mapping_mode
+            .unwrap_or(ColumnMappingMode::None),
+        ColumnMappingMode::None
+    );
+    // The `value` column resolves by its logical name, not the stale physical name.
+    let physical_name = get_any_level_column_physical_name(
+        snapshot.schema().as_ref(),
+        &ColumnName::new(["value"]),
+        ColumnMappingMode::None,
+    )?
+    .into_inner()
+    .remove(0);
+    assert_eq!(physical_name, "value");
+
+    // Write data through the tolerated snapshot and read it back to confirm the full path works.
+    let batch = RecordBatch::try_new(
+        Arc::new(snapshot.schema().as_ref().try_into_arrow()?),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2])),
+            Arc::new(Int32Array::from(vec![10, 20])),
+        ],
+    )?;
+    let post_write =
+        write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
+
+    let scan = post_write.scan_builder().build()?;
+    let batches = read_scan(&scan, engine.clone())?;
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(total_rows, 2, "expected the two written rows back");
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
**Issue:**

Reading a Delta table fails at snapshot load when the table's column mapping mode is
`none` but its schema still carries `delta.columnMapping.physicalName` /
`delta.columnMapping.id` field annotations:

```
Schema error: Column mapping is not enabled but field '<x>' is annotated with
delta.columnMapping.physicalName
```

Such tables arise when column mapping was enabled and later disabled - the mode reverts
to `none` but the residual annotations remain in the schema. While mapping is off these
annotations are ignored and the columns resolve by logical name, so the table is well-formed to
read, yet kernel rejected it on every read. This diverges from delta-spark behavior.

**Fix:**

Kernel re-validates column-mapping annotations on every snapshot load, via the shared
`make_physical` transform used by both the read and write paths. delta-spark does not: its
`createPhysicalSchema` early-returns in `NoMapping` mode, ignoring the annotations. This
change aligns the read path with that behavior:

1/ `make_physical` (read path) now tolerates a stale annotation in `None` mode - it resolves
  the field by its logical name and drops the column-mapping keys from the physical schema,
  yielding a schema indistinguishable from a table that never carried them.
2/ The write path stays strict: CREATE TABLE and ALTER TABLE still reject stale annotations,
  so kernel never originates a table in this shape. Because `make_physical` (shared by both
  paths) is now lenient, the two builders run an explicit strict column-mapping validation
  pass to preserve that rejection. Making the write path tolerate/normalize such tables to
  fully match delta-spark is tracked in #2885.

## How was this change tested?

- Unit tests for the validator's ignore-vs-reject behavior in `None` mode (physicalName
  only, id only, both), and that `make_physical` strips the column-mapping keys while
  preserving unrelated field metadata, at top level and on a nested leaf.
- Integration test that loads a snapshot from a table with residual annotations (mode
  `none`) and reads data back end to end.
- Integration tests that CREATE TABLE and ALTER TABLE still reject stale annotations while
  mapping is disabled.

