### PR TITLE
feat!: Improve the column_name! macro and friends

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -1,9 +1,11 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, Data, DataStruct, DeriveInput, Error, Fields, Item, Meta, PathArguments,
-    Type, Visibility,
+    parse_macro_input, Data, DataStruct, DeriveInput, Error, Expr, ExprLit, Fields, Item, Lit,
+    Meta, PathArguments, Token, Type, Visibility,
 };
 
 mod schema_macro;
@@ -43,24 +45,69 @@ pub fn lazy_schema_ref(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     )
 }
 
-/// Parses a dot-delimited column name into an array of field names. See
-/// `delta_kernel::expressions::column_name::column_name` macro for details.
+/// Builds `&[&str]` from the arguments to `column_name!`. Each **string-literal** argument is a
+/// dot-separated path, split into individual segments; every other (constant) argument is taken as
+/// a single segment, validated at const-eval time. All segments must match `[a-zA-Z0-9_]+`.
 #[proc_macro]
-pub fn parse_column_name(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let is_valid = |c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.';
-    let err = match syn::parse(input) {
-        Ok(syn::Lit::Str(name)) => match name.value().chars().find(|c| !is_valid(*c)) {
-            Some(bad_char) => Error::new(name.span(), format!("Invalid character: {bad_char:?}")),
-            _ => {
-                let path = name.value();
-                let path = path.split('.').map(proc_macro2::Literal::string);
-                return quote_spanned! { name.span() => [#(#path),*] }.into();
+pub fn column_name_segments(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    column_name_segments_impl(input.into())
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+fn column_name_segments_impl(input: TokenStream) -> Result<TokenStream, Error> {
+    // `column_name!` requires at least one argument, so no empty check is needed here.
+    let mut emitted = Vec::new();
+    for expr in Punctuated::<Expr, Token![,]>::parse_terminated.parse2(input)? {
+        // Fragment-forwarding macros (col!, column_expr!, joined_column_name!, ...) capture with
+        // `:literal`/`:expr` and re-emit, which wraps the argument in an invisible (none-delimited)
+        // group. Peel away those groups to recover an underlying string literal.
+        let mut inner = &expr;
+        while let Expr::Group(group) = inner {
+            inner = &group.expr;
+        }
+        match inner {
+            // A string literal is a dot-separated path: split it and validate each segment now.
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(lit_str),
+                ..
+            }) => {
+                for segment in lit_str.value().split('.') {
+                    validate_single_segment(segment, lit_str.span())?;
+                    let literal = proc_macro2::Literal::string(segment);
+                    emitted.push(quote_spanned! { lit_str.span() => #literal });
+                }
             }
-        },
-        Ok(lit) => Error::new(lit.span(), "Expected a string literal"),
-        Err(err) => err,
-    };
-    err.into_compile_error().into()
+            // A string constant's value isn't visible until const-eval (after this macro expands),
+            // so wrap the value in a const fn validator with failure as a compile-time panic.
+            _ => emitted.push(quote_spanned! { expr.span() =>
+                match ::delta_kernel::expressions::__require_valid_simple_column_segment(#expr) {
+                    Some(segment) => segment,
+                    None => panic!("String constants passed to column_name! must be simple names \
+                                    matching [a-zA-Z0-9_]+; use a string literal for dot-separated \
+                                    paths, or ColumnName::new() to disambiguate"),
+                }
+            }),
+        }
+    }
+
+    Ok(quote! { &[ #(#emitted),* ] })
+}
+
+fn validate_single_segment(segment: &str, span: Span) -> Result<(), Error> {
+    if segment.is_empty() {
+        return Err(Error::new(span, "empty column name segment"));
+    }
+    if let Some(bad) = segment
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || *c == '_'))
+    {
+        return Err(Error::new(
+            span,
+            format!("invalid character {bad:?} in column name segment {segment:?}"),
+        ));
+    }
+    Ok(())
 }
 
 /// Derive a `delta_kernel::schemas::ToSchema` implementation for the annotated struct. The actual

--- a/kernel/src/expressions/column_names.rs
+++ b/kernel/src/expressions/column_names.rs
@@ -358,37 +358,81 @@ fn parse_escaped_field_name(chars: &mut Chars<'_>) -> DeltaResult<String> {
     Ok(name)
 }
 
+/// Validates a single column segment at compile time, returning it unchanged when valid. Used by
+/// the `column_name!` proc macro for non-literal segment expressions; the macro unwraps the result
+/// in a const context so an invalid segment surfaces as a compile error.
+#[doc(hidden)]
+pub const fn __require_valid_simple_column_segment(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if !b.is_ascii_alphanumeric() && b != b'_' {
+            return None;
+        }
+        i += 1;
+    }
+    Some(s)
+}
+
 /// Creates a nested column name whose field names are all simple column names (containing only
-/// alphanumeric characters and underscores), delimited by dots. This macro is provided as a
-/// convenience for the common case where the caller knows the column name contains only simple
-/// field names and that splitting by periods is safe:
+/// alphanumeric characters and underscores).
+///
+/// Each **string-literal** argument is treated as a dot-separated path and split into segments, so
+/// multiple literals concatenate into a single path:
 ///
 /// ```
 /// # use delta_kernel::expressions::{column_name, ColumnName};
 /// assert_eq!(column_name!("a.b.c"), ColumnName::new(["a", "b", "c"]));
+/// assert_eq!(column_name!("a.b", "c.d"), ColumnName::new(["a", "b", "c", "d"]));
 /// ```
 ///
-/// To avoid accidental misuse, the argument must be a string literal, so the compiler can validate
-/// the safety conditions. Thus, the following uses would fail to compile:
+/// Every **constant** argument is taken as a single segment (never split on `.`; its value is not
+/// visible at the call site, so a `.` is rejected):
+///
+/// ```
+/// # use delta_kernel::expressions::{column_name, ColumnName};
+/// const VERSION: &str = "version";
+/// assert_eq!(column_name!(VERSION), ColumnName::new(["version"]));
+/// assert_eq!(column_name!(VERSION, "a.b"), ColumnName::new(["version", "a", "b"]));
+/// ```
+///
+/// The following would fail to compile:
 ///
 /// ```fail_compile
 /// # use delta_kernel::expressions::column_name;
 /// let s = "a.b";
-/// let name = column_name!(s); // not a string literal
+/// let name = column_name!(s); // not a constant
 /// ```
 ///
 /// ```fail_compile
-/// # use delta_kernel::expressions::simple_column_name;
-/// let name = simple_column_name!("a b"); // non-alphanumeric character
+/// # use delta_kernel::expressions::column_name;
+/// const BAD: &str = "a.b";
+/// let name = column_name!(BAD); // dots not allowed in constant segments
+/// ```
+///
+/// ```fail_compile
+/// # use delta_kernel::expressions::column_name;
+/// let name = column_name!("a b"); // non-alphanumeric character in path
+/// ```
+///
+/// ```fail_compile
+/// # use delta_kernel::expressions::column_name;
+/// let name = column_name!("a..b"); // empty segment
 /// ```
 // NOTE: Macros are only public if exported, which defines them at the root of the crate. But we
 // don't want it there. So, we export a hidden macro and pub use it here where we actually want it.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __column_name {
-    ( $($name:tt)* ) => {
-        $crate::expressions::ColumnName::new($crate::delta_kernel_derive::parse_column_name!($($name)*))
-    };
+    ( $($segments:tt)+ ) => {{
+        const SEGMENTS: &[&str] =
+            $crate::delta_kernel_derive::column_name_segments!($($segments)+);
+        $crate::expressions::ColumnName::new(SEGMENTS.iter().copied())
+    }};
 }
 #[doc(inline)]
 pub use __column_name as column_name;
@@ -514,8 +558,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod test {
-    use delta_kernel_derive::parse_column_name;
-
     use super::*;
 
     impl ColumnName {
@@ -524,14 +566,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_parse_column_name_macros() {
-        assert_eq!(parse_column_name!("a"), ["a"]);
-
-        assert_eq!(parse_column_name!("a"), ["a"]);
-        assert_eq!(parse_column_name!("a.b"), ["a", "b"]);
-        assert_eq!(parse_column_name!("a.b.c"), ["a", "b", "c"]);
-    }
+    const TEST_ADD: &str = "add";
+    const TEST_STATS: &str = "stats";
 
     #[test]
     fn test_column_name_macros() {
@@ -542,7 +578,27 @@ mod test {
         assert_eq!(column_name!("a.b"), ColumnName::new(["a", "b"]));
         assert_eq!(column_name!("a.b.c"), ColumnName::new(["a", "b", "c"]));
 
-        assert_eq!(joined_column_name!("a", "b"), ColumnName::new(["a", "b"]));
+        // Every string literal is split on dots, so multiple literals concatenate into one path.
+        assert_eq!(
+            column_name!("a.b", "c.d"),
+            ColumnName::new(["a", "b", "c", "d"])
+        );
+
+        assert_eq!(column_name!(TEST_ADD), ColumnName::new(["add"]));
+        assert_eq!(
+            column_name!(TEST_ADD, TEST_STATS),
+            ColumnName::new(["add", "stats"])
+        );
+        assert_eq!(
+            column_name!(TEST_ADD, "parsed"),
+            ColumnName::new(["add", "parsed"])
+        );
+        // A constant segment mixed with a dotted literal path.
+        assert_eq!(
+            column_name!(TEST_ADD, "a.b"),
+            ColumnName::new(["add", "a", "b"])
+        );
+
         assert_eq!(joined_column_name!("a", "b"), ColumnName::new(["a", "b"]));
 
         assert_eq!(

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use itertools::Itertools;
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 
+#[doc(hidden)]
+pub use self::column_names::__require_valid_simple_column_segment;
 pub use self::column_names::{
     col, column_expr, column_expr_ref, column_name, column_pred, joined_column_expr,
     joined_column_name, ColumnName,

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -14,7 +14,7 @@ use crate::actions::{
     METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
-use crate::expressions::ColumnName;
+use crate::expressions::{column_name, ColumnName};
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
@@ -128,10 +128,10 @@ pub(crate) struct LogSegment {
 /// worthwhile since all app ids share one part with a large min/max range (typically UUIDs).
 fn action_identifying_column(action_name: &str) -> Option<ColumnName> {
     match action_name {
-        METADATA_NAME => Some(ColumnName::new([METADATA_NAME, "id"])),
-        PROTOCOL_NAME => Some(ColumnName::new([PROTOCOL_NAME, "minReaderVersion"])),
-        SET_TRANSACTION_NAME => Some(ColumnName::new([SET_TRANSACTION_NAME, "appId"])),
-        DOMAIN_METADATA_NAME => Some(ColumnName::new([DOMAIN_METADATA_NAME, "domain"])),
+        METADATA_NAME => Some(column_name!(METADATA_NAME, "id")),
+        PROTOCOL_NAME => Some(column_name!(PROTOCOL_NAME, "minReaderVersion")),
+        SET_TRANSACTION_NAME => Some(column_name!(SET_TRANSACTION_NAME, "appId")),
+        DOMAIN_METADATA_NAME => Some(column_name!(DOMAIN_METADATA_NAME, "domain")),
         _ => None,
     }
 }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -504,7 +504,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             None
         } else {
             Some(Expr::from(
-                ColumnName::new(["stats_parsed", MIN_VALUES]).join(col),
+                column_name!("stats_parsed", MIN_VALUES).join(col),
             ))
         }
     }
@@ -519,7 +519,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             None
         } else {
             Some(Expr::from(
-                ColumnName::new(["stats_parsed", MAX_VALUES]).join(col),
+                column_name!("stats_parsed", MAX_VALUES).join(col),
             ))
         }
     }
@@ -557,7 +557,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 
     /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(Expr::from(ColumnName::new(["stats_parsed", NUM_RECORDS])))
+        Some(column_expr!("stats_parsed", NUM_RECORDS))
     }
 
     /// For partition columns, wraps the comparison with `OR(NOT is_add, comparison)` so that
@@ -684,7 +684,7 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
         {
             return None;
         }
-        Some(Expr::from(ColumnName::new([MIN_VALUES]).join(col)))
+        Some(Expr::from(column_name!(MIN_VALUES).join(col)))
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
@@ -705,7 +705,7 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(Expr::from(ColumnName::new([NUM_RECORDS])))
+        Some(column_expr!(NUM_RECORDS))
     }
 
     /// Compares a column's max stat against a literal value, adjusting for timestamp

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -21,7 +21,8 @@ use crate::engine_data::FilteredEngineData;
 use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
 use crate::expressions::{
-    col, lit, ArrayData, ColumnName, ExpressionStructPatch, ExpressionStructPatchBuilder, Scalar,
+    col, column_name, lit, ArrayData, ColumnName, ExpressionStructPatch,
+    ExpressionStructPatchBuilder, Scalar,
 };
 use crate::log_segment::LogSegment;
 use crate::metrics::events::TRANSACTION_COMMIT_SPAN;
@@ -1513,7 +1514,7 @@ impl<S> Transaction<S> {
         // then drops the stats_parsed column.
         let base_eval = Arc::new(make_eval(false)?);
         let stats_parsed_eval = Arc::new(make_eval(true)?);
-        let stats_parsed_col = ColumnName::new([STATS_PARSED_NAME]);
+        let stats_parsed_col = column_name!(STATS_PARSED_NAME);
 
         Ok(remove_files_metadata.map(move |file_metadata_batch| {
             let data = file_metadata_batch.data();


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `column_name!` macro and friends are very nice for string literals, but string literals are magic constants, subject to all the usual problems: vulnerability to typos, hard to tell what's related vs. merely similar, hard to rename/refactor, etc.

Expand the macro to allow 1+ compile-time constant path segments, where:
```rust
column_name!(ADD_NAME, "deletionVector.offset")
```
is equivalent to 
```rust
ColumnName::new([ADD_NAME, "deletionVector", "offset")
```

The generalized rule is that literals continue to split on `.` to become simple path segments (as before), while other constant expressions must be simple path segments (no dots, no special characters). Empty segments and empty paths are rejected -- use `ColumnName::new` if you really want that.

### This PR affects the following public APIs

Behavior change: The `column_name!` macro now requires at least one argument and rejects empty path segments.

Expanded behavior: The `column_name!` macro now accepts multiple arguments and string constants (not merely string literals).

## How was this change tested?

New unit tests and some existing code was ported to use the new macros.