### PR TITLE
feat: strip newly-introduced column mapping metadata on none-mode writes

### DIFF
--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -3,6 +3,7 @@
 //! This module provides:
 //! - Read-side: Mode detection and schema validation
 //! - Write-side: Schema transformation for assigning IDs and physical names
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -731,6 +732,91 @@ impl<'a> SchemaTransform<'a> for MaxColumnId {
     }
 }
 
+/// The field-metadata keys that are meaningful only when column mapping is enabled. The detector
+/// [`schema_has_column_mapping_metadata`] and the stripper [`drop_column_mapping_metadata`] both
+/// key off this exact set, matching the `COLUMN_MAPPING_METADATA_KEYS` delta-spark strips and
+/// detects together.
+const COLUMN_MAPPING_METADATA_KEYS: &[ColumnMetadataKey] = &[
+    ColumnMetadataKey::ColumnMappingId,
+    ColumnMetadataKey::ColumnMappingPhysicalName,
+    ColumnMetadataKey::ColumnMappingNestedIds,
+    ColumnMetadataKey::ParquetFieldId,
+    ColumnMetadataKey::ParquetFieldNestedIds,
+];
+
+/// Returns whether any field in `schema` (recursively) carries any [`COLUMN_MAPPING_METADATA_KEYS`]
+/// annotation. Detection is by key presence (not value type), so a malformed annotation still
+/// counts -- the detector and [`drop_column_mapping_metadata`] must agree on what "carries column
+/// mapping metadata" means, else a write could strip a field the detector deemed clean (or persist
+/// one it missed).
+pub(crate) fn schema_has_column_mapping_metadata(schema: &StructType) -> bool {
+    struct HasCmMetadata(bool);
+    impl<'a> SchemaTransform<'a> for HasCmMetadata {
+        transform_output_type!(|'a, T| ());
+        fn transform_struct_field(&mut self, field: &'a StructField) {
+            if COLUMN_MAPPING_METADATA_KEYS
+                .iter()
+                .any(|key| field.metadata.contains_key(key.as_ref()))
+            {
+                self.0 = true;
+            }
+            self.recurse_into_struct_field(field)
+        }
+    }
+    let mut visitor = HasCmMetadata(false);
+    visitor.transform_struct(schema);
+    visitor.0
+}
+
+/// Strips the stray column-mapping annotations a write introduces into a previously-clean table,
+/// returning `Some(stripped_schema)` when a strip is needed and `None` when `candidate` can be
+/// persisted as-is.
+///
+/// A strip is needed only when `candidate` carries column-mapping annotations that `current` did
+/// not -- i.e. the write is introducing them into a clean table, so persisting `candidate` verbatim
+/// would originate a self-inconsistent table. When `current` already carries residual annotations
+/// they are left in place (matching delta-spark, which strips only annotations a commit newly
+/// introduces); `None` is returned.
+///
+/// Callers MUST gate this on `ColumnMappingMode::None`: with mapping enabled the annotations are
+/// load-bearing and must never be stripped. `current` is the pre-write schema (`None` for CREATE,
+/// which has no prior schema); `candidate` is the schema the write would otherwise persist.
+pub(crate) fn strip_stray_column_mapping_metadata(
+    current: Option<&StructType>,
+    candidate: &StructType,
+) -> Option<StructType> {
+    let current_has_cm = current.is_some_and(schema_has_column_mapping_metadata);
+    (!current_has_cm && schema_has_column_mapping_metadata(candidate))
+        .then(|| drop_column_mapping_metadata(candidate))
+}
+
+/// Removes every [`COLUMN_MAPPING_METADATA_KEYS`] annotation from every field in `schema`
+/// (recursively), leaving all other field metadata intact.
+pub(crate) fn drop_column_mapping_metadata(schema: &StructType) -> StructType {
+    struct DropCmMetadata;
+    impl<'a> SchemaTransform<'a> for DropCmMetadata {
+        transform_output_type!(|'a, T| Cow<'a, T>);
+        fn transform_struct_field(&mut self, field: &'a StructField) -> Cow<'a, StructField> {
+            let data_type = self.transform(&field.data_type);
+            let mut metadata = field.metadata.clone();
+            let mut had_cm = false;
+            for key in COLUMN_MAPPING_METADATA_KEYS {
+                had_cm |= metadata.remove(key.as_ref()).is_some();
+            }
+            match data_type {
+                Cow::Borrowed(_) if !had_cm => Cow::Borrowed(field),
+                data_type => Cow::Owned(StructField {
+                    name: field.name.clone(),
+                    data_type: data_type.into_owned(),
+                    nullable: field.is_nullable(),
+                    metadata,
+                }),
+            }
+        }
+    }
+    DropCmMetadata.transform_struct(schema).into_owned()
+}
+
 /// Translates a logical [`ColumnName`] to physical. It can be top level or nested.
 ///
 /// Uses `StructType::walk_column_fields` to walk the column path through nested structs,
@@ -966,9 +1052,8 @@ mod tests {
             });
     }
 
-    // `validate_schema_column_mapping` is the strict validator (CREATE / ALTER reach it via the
-    // `validate_schema_column_mapping_strict` alias), so a stale annotation on a mapping-disabled
-    // table is rejected. The lenient path is covered by
+    // `validate_schema_column_mapping` is the strict validator: a stale annotation on a
+    // mapping-disabled table is rejected. The lenient path (used by reads) is covered by
     // `test_validate_and_extract_tolerates_stale_annotations_when_disabled`.
     #[test]
     fn test_column_mapping_disabled() {
@@ -1051,6 +1136,129 @@ mod tests {
         )]);
         validate_schema_column_mapping(&schema, ColumnMappingMode::Id)
             .expect_err("missing annotation on struct field inside map value");
+    }
+
+    #[test]
+    fn test_schema_has_column_mapping_metadata() {
+        // Clean schema -> false.
+        let clean = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
+        assert!(!schema_has_column_mapping_metadata(&clean));
+
+        // id-only, physicalName-only -> true.
+        let id_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
+            .add_metadata([(
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::Number(1),
+            )])]);
+        assert!(schema_has_column_mapping_metadata(&id_only));
+        let name_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
+            .add_metadata([(
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::String("col-a".to_string()),
+            )])]);
+        assert!(schema_has_column_mapping_metadata(&name_only));
+
+        // Annotation on a nested struct leaf (clean top level) -> true.
+        let nested = StructType::new_unchecked([StructField::nullable(
+            "outer",
+            StructType::new_unchecked([make_cm_field("leaf", 2, DataType::INTEGER)]),
+        )]);
+        assert!(schema_has_column_mapping_metadata(&nested));
+
+        // Detection is by key presence, not value type: a `parquet.field.id`-only field and a
+        // wrong-typed id both count (they must, so the stripper -- which removes by presence --
+        // never leaves a key the detector deemed absent).
+        let pq_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
+            .add_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(5),
+            )])]);
+        assert!(schema_has_column_mapping_metadata(&pq_only));
+        let wrong_typed =
+            StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
+                .add_metadata([(
+                    ColumnMetadataKey::ColumnMappingId.as_ref(),
+                    MetadataValue::String("not-a-number".to_string()),
+                )])]);
+        assert!(schema_has_column_mapping_metadata(&wrong_typed));
+    }
+
+    #[test]
+    fn test_drop_column_mapping_metadata() {
+        // Top-level annotated field also carrying an unrelated key; nested annotated leaf.
+        let annotated_top = StructField::nullable("a", DataType::INTEGER).add_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::Number(1),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::String("col-a".to_string()),
+            ),
+            ("delta.identity.start", MetadataValue::Number(7)),
+        ]);
+        let schema = StructType::new_unchecked([
+            annotated_top,
+            StructField::nullable(
+                "outer",
+                StructType::new_unchecked([make_cm_field("leaf", 2, DataType::INTEGER)]),
+            ),
+        ]);
+
+        let stripped = drop_column_mapping_metadata(&schema);
+        assert!(!schema_has_column_mapping_metadata(&stripped));
+
+        // Unrelated metadata is preserved.
+        let a = stripped.field("a").unwrap();
+        assert!(a.column_mapping_id().is_none());
+        assert!(!a.has_physical_name_annotation());
+        assert_eq!(
+            a.metadata().get("delta.identity.start"),
+            Some(&MetadataValue::Number(7))
+        );
+
+        // Nested leaf is stripped too.
+        let DataType::Struct(outer) = stripped.field("outer").unwrap().data_type() else {
+            panic!("expected struct");
+        };
+        assert!(outer.field("leaf").unwrap().column_mapping_id().is_none());
+    }
+
+    #[test]
+    fn test_drop_column_mapping_metadata_strips_array_and_map_nested_leaves() {
+        // Annotated struct leaves living inside an array element and a map value.
+        let elem = StructType::new_unchecked([make_cm_field("in_arr", 3, DataType::INTEGER)]);
+        let val = StructType::new_unchecked([make_cm_field("in_map", 4, DataType::INTEGER)]);
+        let schema = StructType::new_unchecked([
+            StructField::nullable("arr", ArrayType::new(elem, true)),
+            StructField::nullable("m", MapType::new(DataType::STRING, val, true)),
+        ]);
+        assert!(schema_has_column_mapping_metadata(&schema));
+
+        let stripped = drop_column_mapping_metadata(&schema);
+        assert!(!schema_has_column_mapping_metadata(&stripped));
+    }
+
+    #[test]
+    fn test_strip_stray_column_mapping_metadata() {
+        // Mode gating lives at the call sites; this helper only decides strip-vs-leave from the
+        // current-vs-candidate comparison.
+        let clean = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
+        let annotated = StructType::new_unchecked([make_cm_field("a", 1, DataType::INTEGER)]);
+
+        // CREATE (no prior schema) introducing annotations -> stripped.
+        let stripped = strip_stray_column_mapping_metadata(None, &annotated)
+            .expect("newly-introduced annotations should be stripped");
+        assert!(!schema_has_column_mapping_metadata(&stripped));
+
+        // ALTER on a clean table introducing annotations -> stripped.
+        assert!(strip_stray_column_mapping_metadata(Some(&clean), &annotated).is_some());
+
+        // ALTER on an already-annotated table -> left in place (no strip).
+        assert!(strip_stray_column_mapping_metadata(Some(&annotated), &annotated).is_none());
+
+        // Candidate carries no annotations -> nothing to strip.
+        assert!(strip_stray_column_mapping_metadata(None, &clean).is_none());
     }
 
     fn make_cm_field(name: &str, id: i64, data_type: impl Into<DataType>) -> StructField {

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
+use tracing::debug;
 use uuid::Uuid;
 
 use super::TableFeature;
@@ -794,8 +795,13 @@ pub(crate) fn strip_stray_column_mapping_metadata(
     candidate: &StructType,
 ) -> Option<StructType> {
     let current_has_cm = current.is_some_and(schema_has_column_mapping_metadata);
-    (!current_has_cm && schema_has_column_mapping_metadata(candidate))
-        .then(|| drop_column_mapping_metadata(candidate))
+    (!current_has_cm && schema_has_column_mapping_metadata(candidate)).then(|| {
+        debug!(
+            "Column mapping is disabled; stripping newly-introduced `delta.columnMapping.*` \
+             annotations from the schema before persisting."
+        );
+        drop_column_mapping_metadata(candidate)
+    })
 }
 
 /// Removes every [`COLUMN_MAPPING_METADATA_KEYS`] annotation from every field in `schema`

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -118,8 +118,9 @@ pub fn validate_schema_column_mapping(schema: &Schema, mode: ColumnMappingMode) 
 ///
 /// A table can carry residual annotations while mapping is off. They are inert -- physical names
 /// resolve to logical names -- so reads tolerate them (matching delta-spark, which ignores them in
-/// `NoMapping` mode), while CREATE / ALTER reject them so kernel never persists a table in that
-/// shape.
+/// `NoMapping` mode). CREATE / ALTER strip the annotations a write newly introduces (so kernel
+/// never *originates* a table in that shape), but leave residual ones already on the table in
+/// place.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum StaleAnnotationPolicy {
     /// Ignore a stale annotation and resolve the field by its logical name.
@@ -754,11 +755,18 @@ pub(crate) fn schema_has_column_mapping_metadata(schema: &StructType) -> bool {
     impl<'a> SchemaTransform<'a> for HasCmMetadata {
         transform_output_type!(|'a, T| ());
         fn transform_struct_field(&mut self, field: &'a StructField) {
+            // Once a match is found the answer can't change, so skip the per-field key scan (and
+            // recursion) for the rest of the walk. The `SchemaTransform` trait has no early-exit
+            // hook, so nodes are still visited; this just short-circuits the work at each.
+            if self.0 {
+                return;
+            }
             if COLUMN_MAPPING_METADATA_KEYS
                 .iter()
                 .any(|key| field.metadata.contains_key(key.as_ref()))
             {
                 self.0 = true;
+                return;
             }
             self.recurse_into_struct_field(field)
         }
@@ -1138,42 +1146,42 @@ mod tests {
             .expect_err("missing annotation on struct field inside map value");
     }
 
+    /// Every key in `COLUMN_MAPPING_METADATA_KEYS` counts as column-mapping metadata, whether it
+    /// sits on a top-level field or a nested struct leaf.
+    #[rstest::rstest]
+    fn test_schema_has_column_mapping_metadata_detects_each_key(
+        #[values(
+            ColumnMetadataKey::ColumnMappingId,
+            ColumnMetadataKey::ColumnMappingPhysicalName,
+            ColumnMetadataKey::ColumnMappingNestedIds,
+            ColumnMetadataKey::ParquetFieldId,
+            ColumnMetadataKey::ParquetFieldNestedIds
+        )]
+        key: ColumnMetadataKey,
+    ) {
+        // Top-level field carrying only this key.
+        let top_level = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
+            .add_metadata([(key.as_ref(), MetadataValue::Number(1))])]);
+        assert!(schema_has_column_mapping_metadata(&top_level));
+
+        // Same key on a nested struct leaf (clean top level).
+        let nested = StructType::new_unchecked([StructField::nullable(
+            "outer",
+            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)
+                .add_metadata([(key.as_ref(), MetadataValue::Number(1))])]),
+        )]);
+        assert!(schema_has_column_mapping_metadata(&nested));
+    }
+
     #[test]
-    fn test_schema_has_column_mapping_metadata() {
+    fn test_schema_has_column_mapping_metadata_edge_cases() {
         // Clean schema -> false.
         let clean = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
         assert!(!schema_has_column_mapping_metadata(&clean));
 
-        // id-only, physicalName-only -> true.
-        let id_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
-            .add_metadata([(
-                ColumnMetadataKey::ColumnMappingId.as_ref(),
-                MetadataValue::Number(1),
-            )])]);
-        assert!(schema_has_column_mapping_metadata(&id_only));
-        let name_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
-            .add_metadata([(
-                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                MetadataValue::String("col-a".to_string()),
-            )])]);
-        assert!(schema_has_column_mapping_metadata(&name_only));
-
-        // Annotation on a nested struct leaf (clean top level) -> true.
-        let nested = StructType::new_unchecked([StructField::nullable(
-            "outer",
-            StructType::new_unchecked([make_cm_field("leaf", 2, DataType::INTEGER)]),
-        )]);
-        assert!(schema_has_column_mapping_metadata(&nested));
-
-        // Detection is by key presence, not value type: a `parquet.field.id`-only field and a
-        // wrong-typed id both count (they must, so the stripper -- which removes by presence --
-        // never leaves a key the detector deemed absent).
-        let pq_only = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
-            .add_metadata([(
-                ColumnMetadataKey::ParquetFieldId.as_ref(),
-                MetadataValue::Number(5),
-            )])]);
-        assert!(schema_has_column_mapping_metadata(&pq_only));
+        // Detection is by key presence, not value type: a wrong-typed id still counts (it must, so
+        // the stripper -- which removes by presence -- never leaves a key the detector deemed
+        // absent).
         let wrong_typed =
             StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
                 .add_metadata([(

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -781,20 +781,21 @@ pub(crate) fn schema_has_column_mapping_metadata(schema: &StructType) -> bool {
 /// returning `Some(stripped_schema)` when a strip is needed and `None` when `candidate` can be
 /// persisted as-is.
 ///
-/// A strip is needed only when `candidate` carries column-mapping annotations that `current` did
-/// not -- i.e. the write is introducing them into a clean table, so persisting `candidate` verbatim
-/// would originate a self-inconsistent table. When `current` already carries residual annotations
-/// they are left in place (matching delta-spark, which strips only annotations a commit newly
-/// introduces); `None` is returned.
+/// A strip is needed only when `candidate` carries column-mapping annotations that the pre-write
+/// schema did not -- i.e. the write is introducing them into a clean table, so persisting
+/// `candidate` verbatim would originate a self-inconsistent table. When the pre-write schema
+/// already carried residual annotations they are left in place (matching delta-spark, which strips
+/// only annotations a commit newly introduces); `None` is returned.
 ///
 /// Callers MUST gate this on `ColumnMappingMode::None`: with mapping enabled the annotations are
-/// load-bearing and must never be stripped. `current` is the pre-write schema (`None` for CREATE,
-/// which has no prior schema); `candidate` is the schema the write would otherwise persist.
+/// load-bearing and must never be stripped. `current_has_cm` is whether the pre-write schema
+/// carried any column-mapping metadata (always `false` for CREATE, which has no prior schema);
+/// passing the bool rather than the schema lets ALTER avoid cloning its pre-alter schema.
+/// `candidate` is the schema the write would otherwise persist.
 pub(crate) fn strip_stray_column_mapping_metadata(
-    current: Option<&StructType>,
+    current_has_cm: bool,
     candidate: &StructType,
 ) -> Option<StructType> {
-    let current_has_cm = current.is_some_and(schema_has_column_mapping_metadata);
     (!current_has_cm && schema_has_column_mapping_metadata(candidate)).then(|| {
         debug!(
             "Column mapping is disabled; stripping newly-introduced `delta.columnMapping.*` \
@@ -1261,18 +1262,18 @@ mod tests {
         let annotated = StructType::new_unchecked([make_cm_field("a", 1, DataType::INTEGER)]);
 
         // CREATE (no prior schema) introducing annotations -> stripped.
-        let stripped = strip_stray_column_mapping_metadata(None, &annotated)
+        let stripped = strip_stray_column_mapping_metadata(false, &annotated)
             .expect("newly-introduced annotations should be stripped");
         assert!(!schema_has_column_mapping_metadata(&stripped));
 
         // ALTER on a clean table introducing annotations -> stripped.
-        assert!(strip_stray_column_mapping_metadata(Some(&clean), &annotated).is_some());
+        assert!(strip_stray_column_mapping_metadata(false, &annotated).is_some());
 
         // ALTER on an already-annotated table -> left in place (no strip).
-        assert!(strip_stray_column_mapping_metadata(Some(&annotated), &annotated).is_none());
+        assert!(strip_stray_column_mapping_metadata(true, &annotated).is_none());
 
         // Candidate carries no annotations -> nothing to strip.
-        assert!(strip_stray_column_mapping_metadata(None, &clean).is_none());
+        assert!(strip_stray_column_mapping_metadata(false, &clean).is_none());
     }
 
     fn make_cm_field(name: &str, id: i64, data_type: impl Into<DataType>) -> StructField {

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -7,9 +7,9 @@ pub use column_mapping::ColumnMappingMode;
 pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
     column_mapping_mode, get_column_mapping_mode_from_properties, physical_to_logical_column_name,
-    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
-    validate_and_extract_column_mapping_annotations, validate_column_mapping_id,
-    StaleAnnotationPolicy,
+    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata,
+    try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
+    validate_column_mapping_id, StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -2,15 +2,14 @@
 pub(crate) use column_mapping::get_any_level_column_physical_name;
 #[deprecated = "Enable internal-api and use TableConfiguration instead"]
 pub use column_mapping::validate_schema_column_mapping;
-// Crate-visible alias so kernel code avoids the deprecated `pub` re-export above.
-pub(crate) use column_mapping::validate_schema_column_mapping as validate_schema_column_mapping_strict;
 pub use column_mapping::ColumnMappingMode;
 #[internal_api]
 pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
     column_mapping_mode, get_column_mapping_mode_from_properties, physical_to_logical_column_name,
-    try_assign_flat_column_mapping_info, validate_and_extract_column_mapping_annotations,
-    validate_column_mapping_id, StaleAnnotationPolicy,
+    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
+    validate_and_extract_column_mapping_annotations, validate_column_mapping_id,
+    StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
 pub(crate) use iceberg_compat::v3::V3_VALIDATOR;

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -32,7 +32,9 @@ use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{validate_schema_column_mapping_strict, Operation, TableFeature};
+use crate::table_features::{
+    strip_stray_column_mapping_metadata, ColumnMappingMode, Operation, TableFeature,
+};
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
@@ -178,6 +180,10 @@ impl AlterTableTransactionBuilder<Modifying> {
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();
         let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+        // Capture the pre-alter schema so the strip below can tell whether the ALTER is
+        // *introducing* column-mapping annotations into a previously-clean table (strip) versus
+        // evolving a table that already carried residual ones (leave in place).
+        let current_schema = schema.clone();
         let SchemaEvolutionResult {
             schema: evolved_schema,
             new_max_column_id,
@@ -188,9 +194,15 @@ impl AlterTableTransactionBuilder<Modifying> {
             current_max_column_id,
         )?;
 
-        // Validates column mapping in strict mode (rejects stale CM annotations on a
-        // mapping-disabled table).
-        validate_schema_column_mapping_strict(&evolved_schema, column_mapping_mode)?;
+        // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
+        // that was clean before it, strip them; residual annotations already present on the
+        // table are left in place (see `strip_stray_column_mapping_metadata`).
+        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+            strip_stray_column_mapping_metadata(Some(&current_schema), &evolved_schema)
+                .map_or(evolved_schema, Arc::new)
+        } else {
+            evolved_schema
+        };
 
         let evolved_metadata = table_config
             .metadata()

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -33,7 +33,8 @@ use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    strip_stray_column_mapping_metadata, ColumnMappingMode, Operation, TableFeature,
+    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata, ColumnMappingMode,
+    Operation, TableFeature,
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
@@ -180,12 +181,12 @@ impl AlterTableTransactionBuilder<Modifying> {
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();
         let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
-        // Pre-alter schema, so the strip below can tell introduced-vs-residual annotations apart.
-        // Only cloned in `None` mode (the sole mode where the strip fires);
-        // `apply_schema_operations` consumes `schema` by value, so the clone must happen
-        // before the move.
-        let current_schema =
-            (column_mapping_mode == ColumnMappingMode::None).then(|| schema.clone());
+        // Whether the pre-alter schema already carried column-mapping metadata -- the only fact the
+        // strip below needs from it. Captured as a bool (not a clone) before
+        // `apply_schema_operations` consumes `schema` by value. Short-circuits outside
+        // `None` mode, where no strip fires.
+        let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+            && schema_has_column_mapping_metadata(&schema);
         let SchemaEvolutionResult {
             schema: evolved_schema,
             new_max_column_id,
@@ -199,10 +200,11 @@ impl AlterTableTransactionBuilder<Modifying> {
         // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
         // that was clean before it, strip them; residual annotations already present on the
         // table are left in place (see `strip_stray_column_mapping_metadata`).
-        let evolved_schema = match current_schema {
-            Some(current) => strip_stray_column_mapping_metadata(Some(&current), &evolved_schema)
-                .map_or(evolved_schema, Arc::new),
-            None => evolved_schema,
+        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+            strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+                .map_or(evolved_schema, Arc::new)
+        } else {
+            evolved_schema
         };
 
         let evolved_metadata = table_config

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -180,10 +180,12 @@ impl AlterTableTransactionBuilder<Modifying> {
         let schema = Arc::unwrap_or_clone(table_config.logical_schema());
         let column_mapping_mode = table_config.column_mapping_mode();
         let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
-        // Capture the pre-alter schema so the strip below can tell whether the ALTER is
-        // *introducing* column-mapping annotations into a previously-clean table (strip) versus
-        // evolving a table that already carried residual ones (leave in place).
-        let current_schema = schema.clone();
+        // Pre-alter schema, so the strip below can tell introduced-vs-residual annotations apart.
+        // Only cloned in `None` mode (the sole mode where the strip fires);
+        // `apply_schema_operations` consumes `schema` by value, so the clone must happen
+        // before the move.
+        let current_schema =
+            (column_mapping_mode == ColumnMappingMode::None).then(|| schema.clone());
         let SchemaEvolutionResult {
             schema: evolved_schema,
             new_max_column_id,
@@ -197,11 +199,10 @@ impl AlterTableTransactionBuilder<Modifying> {
         // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
         // that was clean before it, strip them; residual annotations already present on the
         // table are left in place (see `strip_stray_column_mapping_metadata`).
-        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
-            strip_stray_column_mapping_metadata(Some(&current_schema), &evolved_schema)
-                .map_or(evolved_schema, Arc::new)
-        } else {
-            evolved_schema
+        let evolved_schema = match current_schema {
+            Some(current) => strip_stray_column_mapping_metadata(Some(&current), &evolved_schema)
+                .map_or(evolved_schema, Arc::new),
+            None => evolved_schema,
         };
 
         let evolved_metadata = table_config

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -903,7 +903,9 @@ impl CreateTableTransactionBuilder {
         // any annotation the caller supplied is newly introduced (see
         // `strip_stray_column_mapping_metadata`).
         if column_mapping_mode == ColumnMappingMode::None {
-            if let Some(stripped) = strip_stray_column_mapping_metadata(None, &effective_schema) {
+            // A new table has no prior schema, so nothing was carried in (`current_has_cm =
+            // false`).
+            if let Some(stripped) = strip_stray_column_mapping_metadata(false, &effective_schema) {
                 effective_schema = Arc::new(stripped);
             }
         }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -28,7 +28,7 @@ use crate::table_features::{
     add_feature_to_lists, assign_column_mapping_metadata, auto_enable_property_driven_features,
     find_max_column_id_in_schema, get_any_level_column_physical_name,
     get_column_mapping_mode_from_properties, schema_contains_timestamp_ntz,
-    validate_schema_column_mapping_strict, ColumnMappingMode, TableFeature,
+    strip_stray_column_mapping_metadata, ColumnMappingMode, TableFeature,
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
@@ -892,16 +892,23 @@ impl CreateTableTransactionBuilder {
         let pre_cm = maybe_enable_iceberg_compat_v3_dependencies(&mut validated)?;
 
         // Apply column mapping if mode is name or id (must happen BEFORE data layout)
-        let (effective_schema, column_mapping_mode) =
+        let (mut effective_schema, column_mapping_mode) =
             maybe_apply_column_mapping_for_table_create(&self.schema, &mut validated, pre_cm)?;
 
         // Validate schema (column names, duplicates, no `delta.invariants` metadata).
         // Empty schemas are intentionally allowed.
         validate_schema(&effective_schema, column_mapping_mode)?;
 
-        // Validates column mapping in strict mode (rejects stale CM annotations on a
-        // mapping-disabled table).
-        validate_schema_column_mapping_strict(&effective_schema, column_mapping_mode)?;
+        // Only in `None` mode: a new table has no prior schema, so any `delta.columnMapping.*`
+        // annotation the caller supplied is newly introduced -- strip it rather than persist a
+        // self-inconsistent table. The annotations are inert in `None` mode, so this does not
+        // affect data-layout or feature-enablement decisions below. CREATE passes `None` as
+        // the prior schema (see `strip_stray_column_mapping_metadata`).
+        if column_mapping_mode == ColumnMappingMode::None {
+            if let Some(stripped) = strip_stray_column_mapping_metadata(None, &effective_schema) {
+                effective_schema = Arc::new(stripped);
+            }
+        }
 
         // Validate data layout and resolve column names (physical for clustering, logical
         // for partitioning). Adds required table features for clustering.

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -899,11 +899,9 @@ impl CreateTableTransactionBuilder {
         // Empty schemas are intentionally allowed.
         validate_schema(&effective_schema, column_mapping_mode)?;
 
-        // Only in `None` mode: a new table has no prior schema, so any `delta.columnMapping.*`
-        // annotation the caller supplied is newly introduced -- strip it rather than persist a
-        // self-inconsistent table. The annotations are inert in `None` mode, so this does not
-        // affect data-layout or feature-enablement decisions below. CREATE passes `None` as
-        // the prior schema (see `strip_stray_column_mapping_metadata`).
+        // Strip CM metadata in `None` mode: a new table has no prior schema (passed as `None`), so
+        // any annotation the caller supplied is newly introduced (see
+        // `strip_stray_column_mapping_metadata`).
         if column_mapping_mode == ColumnMappingMode::None {
             if let Some(stripped) = strip_stray_column_mapping_metadata(None, &effective_schema) {
                 effective_schema = Arc::new(stripped);

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -180,9 +180,9 @@ pub(crate) fn apply_schema_operations(
                     // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
                     try_assign_flat_column_mapping_info(&field, id)?
                 } else {
-                    // No upfront reject for stray CM metadata here: the AlterTable builder's
-                    // validate_schema_column_mapping rejects any CM annotation over the evolved
-                    // schema.
+                    // Stray CM metadata on a mapping-disabled table is handled by the AlterTable
+                    // builder, which strips annotations this ALTER newly introduces from the
+                    // evolved schema.
                     field
                 };
                 schema.field_map_mut().insert(field.name().clone(), field);

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -278,35 +278,72 @@ fn test_column_mapping_invalid_mode_rejected() {
         .contains("Invalid column mapping mode"));
 }
 
-/// CREATE TABLE with column mapping disabled strips any `delta.columnMapping.*` annotations the
-/// input schema carries: a new table has no prior schema, so the annotations are newly introduced
-/// and dropped (matching delta-spark's `dropColumnMappingMetadata`), leaving a clean persisted
-/// schema rather than a self-inconsistent table.
-#[test]
-fn test_create_table_strips_stale_column_mapping_when_disabled() -> DeltaResult<()> {
+/// CREATE TABLE with column mapping disabled strips every column-mapping annotation the input
+/// schema carries: a new table has no prior schema, so the annotations are newly introduced and
+/// dropped (matching delta-spark's `dropColumnMappingMetadata`), leaving a clean persisted schema
+/// rather than a self-inconsistent table. Parametrized over each detected key.
+#[rstest::rstest]
+fn test_create_table_strips_stale_column_mapping_when_disabled(
+    #[values(
+        ColumnMetadataKey::ColumnMappingId,
+        ColumnMetadataKey::ColumnMappingPhysicalName,
+        ColumnMetadataKey::ColumnMappingNestedIds,
+        ColumnMetadataKey::ParquetFieldId,
+        ColumnMetadataKey::ParquetFieldNestedIds
+    )]
+    key: ColumnMetadataKey,
+) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     let schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::INTEGER).add_metadata([
-            ("delta.columnMapping.id", MetadataValue::Number(2)),
-            (
-                "delta.columnMapping.physicalName",
-                MetadataValue::String("col-2f8a".to_string()),
-            ),
-        ]),
+        StructField::nullable("value", DataType::INTEGER)
+            .add_metadata([(key.as_ref(), MetadataValue::Number(2))]),
     ])?);
 
-    // No column mapping mode set -> mode resolves to None -> the stale annotations are stripped.
+    // No column mapping mode set -> mode resolves to None -> the stray annotation is stripped.
     let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
 
     // Mode is None and the persisted schema carries no residual column-mapping metadata.
     assert_column_mapping_config(&snapshot, ColumnMappingMode::None);
     let value = snapshot.schema().field("value").unwrap().clone();
-    assert!(value.column_mapping_id().is_none());
-    assert!(value
-        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
-        .is_none());
+    assert!(
+        value.get_config_value(&key).is_none(),
+        "stray {} should be stripped in None mode",
+        key.as_ref()
+    );
+    Ok(())
+}
+
+/// The strip is `None`-mode-only. With column mapping enabled (`id` / `name`) a field's
+/// pre-populated annotations are preserved (delta-spark's `assignColumnIdAndPhysicalName` keeps
+/// existing ids); only `None` mode drops them.
+#[rstest::rstest]
+#[case::none(ColumnMappingMode::None, &[], false)]
+#[case::id(ColumnMappingMode::Id, &[("delta.columnMapping.mode", "id")], true)]
+#[case::name(ColumnMappingMode::Name, &[("delta.columnMapping.mode", "name")], true)]
+fn test_create_table_column_mapping_strip_is_none_mode_only(
+    #[case] expected_mode: ColumnMappingMode,
+    #[case] properties: &[(&str, &str)],
+    #[case] annotation_kept: bool,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        fixtures::cm_field("value", 2, "col-2f8a", DataType::INTEGER),
+    ])?);
+
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), properties)?;
+
+    assert_column_mapping_config(&snapshot, expected_mode);
+    let value = snapshot.schema().field("value").unwrap().clone();
+    assert_eq!(
+        value.column_mapping_id().is_some(),
+        annotation_kept,
+        "column mapping id under {expected_mode:?} mode"
+    );
     Ok(())
 }
 

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -278,37 +278,36 @@ fn test_column_mapping_invalid_mode_rejected() {
         .contains("Invalid column mapping mode"));
 }
 
-/// CREATE TABLE with column mapping disabled must reject an input schema that already carries
-/// `delta.columnMapping.*` annotations, so kernel never originates a table in that shape. Reads
-/// tolerate such residual annotations, but CREATE / ALTER stay strict. Tracked for future
-/// tolerance in https://github.com/delta-io/delta-kernel-rs/issues/2885.
+/// CREATE TABLE with column mapping disabled strips any `delta.columnMapping.*` annotations the
+/// input schema carries: a new table has no prior schema, so the annotations are newly introduced
+/// and dropped (matching delta-spark's `dropColumnMappingMetadata`), leaving a clean persisted
+/// schema rather than a self-inconsistent table.
 #[test]
-fn test_create_table_rejects_stale_column_mapping_when_disabled() {
-    let (_temp_dir, table_path, engine) = test_table_setup().unwrap();
+fn test_create_table_strips_stale_column_mapping_when_disabled() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::INTEGER).add_metadata([
-                ("delta.columnMapping.id", MetadataValue::Number(2)),
-                (
-                    "delta.columnMapping.physicalName",
-                    MetadataValue::String("col-2f8a".to_string()),
-                ),
-            ]),
-        ])
-        .unwrap(),
-    );
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::INTEGER).add_metadata([
+            ("delta.columnMapping.id", MetadataValue::Number(2)),
+            (
+                "delta.columnMapping.physicalName",
+                MetadataValue::String("col-2f8a".to_string()),
+            ),
+        ]),
+    ])?);
 
-    // No column mapping mode set -> mode resolves to None -> the stale annotation is rejected.
-    let result = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
+    // No column mapping mode set -> mode resolves to None -> the stale annotations are stripped.
+    let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
 
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Column mapping is not enabled but field 'value'"));
+    // Mode is None and the persisted schema carries no residual column-mapping metadata.
+    assert_column_mapping_config(&snapshot, ColumnMappingMode::None);
+    let value = snapshot.schema().field("value").unwrap().clone();
+    assert!(value.column_mapping_id().is_none());
+    assert!(value
+        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+        .is_none());
+    Ok(())
 }
 
 /// Test cases for clustering columns with column mapping enabled.

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -13,6 +13,7 @@ use delta_kernel::schema::{
     StructType,
 };
 use delta_kernel::snapshot::Snapshot;
+use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
@@ -805,35 +806,48 @@ async fn chain_add_column_and_set_nullable(
     Ok(())
 }
 
-fn field_with_stray_cm_id(name: &str, ty: DataType) -> StructField {
+fn field_with_stray_key(name: &str, key: &ColumnMetadataKey, ty: DataType) -> StructField {
     let mut f = StructField::nullable(name, ty);
-    f.metadata.insert(
-        ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
-        MetadataValue::Number(99),
-    );
+    f.metadata
+        .insert(key.as_ref().to_string(), MetadataValue::Number(99));
     f
 }
 
 /// On a clean non-CM table, an ALTER that adds a column carrying stray CM metadata has that
 /// metadata stripped (the commit introduces it into a previously-clean table), rather than
-/// rejected -- matching delta-spark. Covers a top-level annotation and one nested in a struct.
+/// rejected -- matching delta-spark. Parametrized over each detected key and over placement
+/// (top-level vs nested in a struct).
 #[rstest]
-#[case::top_level(field_with_stray_cm_id("tainted", DataType::STRING), &["tainted"])]
-#[case::nested_in_struct(
-    StructField::nullable(
-        "outer",
-        StructType::try_new(vec![field_with_stray_cm_id("inner", DataType::STRING)]).unwrap(),
-    ),
-    &["outer", "inner"],
-)]
+#[case::top_level(false)]
+#[case::nested_in_struct(true)]
 #[tokio::test]
 async fn add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped(
-    #[case] field: StructField,
-    #[case] stripped_path: &[&str],
+    #[case] nested: bool,
+    #[values(
+        ColumnMetadataKey::ColumnMappingId,
+        ColumnMetadataKey::ColumnMappingPhysicalName,
+        ColumnMetadataKey::ColumnMappingNestedIds,
+        ColumnMetadataKey::ParquetFieldId,
+        ColumnMetadataKey::ParquetFieldNestedIds
+    )]
+    key: ColumnMetadataKey,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let snapshot =
         create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let (field, stripped_path): (StructField, Vec<String>) = if nested {
+        let outer = StructField::nullable(
+            "outer",
+            StructType::try_new(vec![field_with_stray_key("inner", &key, DataType::STRING)])?,
+        );
+        (outer, vec!["outer".to_string(), "inner".to_string()])
+    } else {
+        (
+            field_with_stray_key("tainted", &key, DataType::STRING),
+            vec!["tainted".to_string()],
+        )
+    };
 
     snapshot
         .alter_table()
@@ -845,14 +859,51 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped(
     // Reload from disk so we assert on the persisted schemaString, not the in-memory config.
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let reloaded_schema = reloaded.schema();
-    let path: Vec<String> = stripped_path.iter().map(|s| s.to_string()).collect();
-    let leaf = reloaded_schema.field_at_path(&path);
+    let leaf = reloaded_schema.field_at_path(&stripped_path);
     assert!(
-        leaf.column_mapping_id().is_none()
-            && leaf
-                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
-                .is_none(),
-        "stray column-mapping metadata at {stripped_path:?} should be stripped"
+        leaf.get_config_value(&key).is_none(),
+        "stray {} at {stripped_path:?} should be stripped",
+        key.as_ref()
+    );
+    Ok(())
+}
+
+/// The ALTER strip is `None`-mode-only. Adding a column with pre-populated column-mapping metadata
+/// preserves it when mapping is enabled (`id` / `name`, delta-spark's
+/// `assignColumnIdAndPhysicalName` keeps existing ids) and strips it only in `None` mode.
+#[rstest]
+#[case::none(ColumnMappingMode::None, &[], false)]
+#[case::id(ColumnMappingMode::Id, &[("delta.columnMapping.mode", "id")], true)]
+#[case::name(ColumnMappingMode::Name, &[("delta.columnMapping.mode", "name")], true)]
+#[tokio::test]
+async fn add_column_strip_is_none_mode_only(
+    #[case] expected_mode: ColumnMappingMode,
+    #[case] properties: &[(&str, &str)],
+    #[case] annotation_kept: bool,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), properties)?;
+    assert_eq!(
+        snapshot.table_configuration().column_mapping_mode(),
+        expected_mode
+    );
+
+    // A well-formed id+physicalName pair so enabled modes have valid metadata to preserve.
+    let field = fixtures::cm_field("added", 99, "phys-added", DataType::STRING);
+    snapshot
+        .alter_table()
+        .add_column(field)
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let added = reloaded.schema().field("added").unwrap().clone();
+    assert_eq!(
+        added.column_mapping_id().is_some(),
+        annotation_kept,
+        "column mapping id under {expected_mode:?} mode"
     );
     Ok(())
 }
@@ -1112,15 +1163,18 @@ async fn add_column_with_id_colliding_existing_field_is_rejected() -> DeltaResul
 /// A mapping-disabled table that already carries residual `delta.columnMapping.*` annotations is
 /// left untouched by an ALTER: the pre-existing annotation on `value` survives, and whatever the
 /// added column carries is persisted verbatim -- kernel strips only annotations a commit newly
-/// introduces into a *clean* table, so an already-dirty table is never rewritten (delta-spark's
-/// `addsColumnMappingMetadata` is false here). The clean-table strip is covered by
+/// introduces into a *clean* table, so an already-dirty table is never rewritten (matching
+/// delta-spark). The clean-table strip is covered by
 /// `add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped`.
 ///
 /// Cases: adding a clean column (stays clean) and adding a stray-annotated column (annotation
 /// left in place, not stripped).
 #[rstest]
 #[case::clean_column(StructField::nullable("added", DataType::STRING), None)]
-#[case::introduced_stray(field_with_stray_cm_id("added", DataType::STRING), Some(99))]
+#[case::introduced_stray(
+    field_with_stray_key("added", &ColumnMetadataKey::ColumnMappingId, DataType::STRING),
+    Some(99)
+)]
 #[tokio::test]
 async fn add_column_on_stale_table_leaves_schema_untouched(
     #[case] added_field: StructField,

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -814,32 +814,45 @@ fn field_with_stray_cm_id(name: &str, ty: DataType) -> StructField {
     f
 }
 
-/// On a non-CM table, `apply_schema_operations` doesn't reject stray CM metadata up front --
-/// `StructType::make_physical` (run from `TableConfiguration::try_new_with_schema`) is the
-/// gate. This test locks in that downstream rejection, including for nested annotations.
+/// On a clean non-CM table, an ALTER that adds a column carrying stray CM metadata has that
+/// metadata stripped (the commit introduces it into a previously-clean table), rather than
+/// rejected -- matching delta-spark. Covers a top-level annotation and one nested in a struct.
 #[rstest]
-#[case::top_level(field_with_stray_cm_id("tainted", DataType::STRING))]
-#[case::nested_in_struct(StructField::nullable(
-    "outer",
-    StructType::try_new(vec![field_with_stray_cm_id("inner", DataType::STRING)]).unwrap(),
-))]
+#[case::top_level(field_with_stray_cm_id("tainted", DataType::STRING), &["tainted"])]
+#[case::nested_in_struct(
+    StructField::nullable(
+        "outer",
+        StructType::try_new(vec![field_with_stray_cm_id("inner", DataType::STRING)]).unwrap(),
+    ),
+    &["outer", "inner"],
+)]
 #[tokio::test]
-async fn add_column_with_stray_cm_metadata_on_non_cm_table_fails(
+async fn add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped(
     #[case] field: StructField,
+    #[case] stripped_path: &[&str],
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let snapshot =
         create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
 
-    let err = snapshot
+    snapshot
         .alter_table()
         .add_column(field)
-        .build(engine.as_ref(), committer())
-        .unwrap_err();
-    let msg = err.to_string();
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Reload from disk so we assert on the persisted schemaString, not the in-memory config.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let reloaded_schema = reloaded.schema();
+    let path: Vec<String> = stripped_path.iter().map(|s| s.to_string()).collect();
+    let leaf = reloaded_schema.field_at_path(&path);
     assert!(
-        msg.contains("column mapping") || msg.contains("columnMapping"),
-        "error should mention column mapping, got: {msg}"
+        leaf.column_mapping_id().is_none()
+            && leaf
+                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                .is_none(),
+        "stray column-mapping metadata at {stripped_path:?} should be stripped"
     );
     Ok(())
 }
@@ -1096,30 +1109,34 @@ async fn add_column_with_id_colliding_existing_field_is_rejected() -> DeltaResul
     Ok(())
 }
 
-/// A mapping-disabled table carrying residual `delta.columnMapping.*` annotations reads fine
-/// (`StructField::make_physical` tolerates them), but ALTER is still rejected: the strict check
-/// validates the whole evolved schema, so a stale annotation on an untouched column fails even
-/// when the ALTER only adds a clean column. delta-spark tolerates this; closing the gap is tracked
-/// in https://github.com/delta-io/delta-kernel-rs/issues/2885. This test pins the current strict
-/// behavior until then.
+/// A mapping-disabled table that already carries residual `delta.columnMapping.*` annotations is
+/// left untouched by an ALTER: the pre-existing annotation on `value` survives, and whatever the
+/// added column carries is persisted verbatim -- kernel strips only annotations a commit newly
+/// introduces into a *clean* table, so an already-dirty table is never rewritten (delta-spark's
+/// `addsColumnMappingMetadata` is false here). The clean-table strip is covered by
+/// `add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped`.
+///
+/// Cases: adding a clean column (stays clean) and adding a stray-annotated column (annotation
+/// left in place, not stripped).
+#[rstest]
+#[case::clean_column(StructField::nullable("added", DataType::STRING), None)]
+#[case::introduced_stray(field_with_stray_cm_id("added", DataType::STRING), Some(99))]
 #[tokio::test]
-async fn add_column_rejected_when_table_has_stale_column_mapping() -> DeltaResult<()> {
+async fn add_column_on_stale_table_leaves_schema_untouched(
+    #[case] added_field: StructField,
+    #[case] expected_added_cm_id: Option<i64>,
+) -> DeltaResult<()> {
     let (store, engine, table_url) = engine_store_setup("alter_stale_cm", None);
 
-    // `value` carries a stale physicalName + id; protocol omits columnMapping and no mode is set
-    // (resolves to None) -- the enable-then-disable artifact.
+    // `value` carries a stale id; protocol omits columnMapping and no mode is set (resolves to
+    // None) -- residual annotations already on the table.
     let stale_schema = StructType::try_new([
         StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::INTEGER).add_metadata([
-            ("delta.columnMapping.id", MetadataValue::Number(2)),
-            (
-                "delta.columnMapping.physicalName",
-                MetadataValue::String("col-2f8a".to_string()),
-            ),
-        ]),
+        StructField::nullable("value", DataType::INTEGER)
+            .add_metadata([("delta.columnMapping.id", MetadataValue::Number(2))]),
     ])?;
     let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?).unwrap();
-    // v0 written directly to bypass create_table validation (which rejects stale annotations).
+    // v0 written directly to bypass create_table validation (which strips stale annotations).
     let v0 = format!(
         r#"{{"protocol":{{"minReaderVersion":1,"minWriterVersion":2}}}}
 {{"metaData":{{"id":"alter-stale-cm","format":{{"provider":"parquet","options":{{}}}},"schemaString":{escaped},"partitionColumns":[],"configuration":{{}},"createdTime":1700000000000}}}}
@@ -1129,18 +1146,25 @@ async fn add_column_rejected_when_table_has_stale_column_mapping() -> DeltaResul
         .await
         .unwrap();
 
-    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-
-    // Adding a brand-new clean column still fails, and the error names the untouched stale field.
-    let err = snapshot
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+    snapshot
         .alter_table()
-        .add_column(StructField::nullable("region", DataType::STRING))
-        .build(&engine, committer())
-        .unwrap_err()
-        .to_string();
-    assert!(
-        err.contains("Column mapping is not enabled but field 'value'"),
-        "expected the ALTER to be rejected naming the untouched stale field, got: {err}"
+        .add_column(added_field)
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    // Reload from disk so we assert on the persisted schemaString, not the in-memory config.
+    let reloaded = Snapshot::builder_for(table_url).build(&engine)?;
+    let schema = reloaded.schema();
+
+    // The pre-existing annotation on the untouched `value` field survives verbatim.
+    assert_eq!(schema.field("value").unwrap().column_mapping_id(), Some(2));
+    // The added column is persisted verbatim -- clean stays clean, stray annotation is left in
+    // place (not stripped, because the table was already dirty).
+    assert_eq!(
+        schema.field("added").unwrap().column_mapping_id(),
+        expected_added_cm_id
     );
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #2886, which made kernel *read* a column-mapping-`none` table carrying residual
`delta.columnMapping.*` field annotations. This closes the write-path half tracked in #2885
(Gaps 1 and 2): kernel was stricter than delta-spark on writes, so an ALTER on such a table was
rejected even when it only touched clean columns, and kernel had no way to normalize these tables.

This matches delta-spark's `verifyAndUpdateMetadataChange` rule for `NoMapping` writes. On a
`none`-mode CREATE / ALTER:

- If the current table has no column-mapping metadata and the write introduces some, the
  annotations are stripped from the persisted schema (mirroring `dropColumnMappingMetadata`), so
  kernel never originates a self-inconsistent table.
- If the current table already carries residual annotations, they are left in place. This is what
  lets an ALTER touching only clean columns on a stale table succeed (Gap 1).

This replaces the read-side fix's temporary strict-reject on the two write builders with the
strip. `Name` / `Id` mode is unchanged. The now-unused `validate_schema_column_mapping_strict`
alias is removed.

Gap 3 from #2885 (collapsing the redundant second schema walk by threading the policy through
`TableConfiguration::try_new`) is intentionally left for a separate PR.

New helpers `schema_has_column_mapping_metadata` and `drop_column_mapping_metadata` in
`table_features::column_mapping` mirror delta-spark's `schemaHasColumnMappingMetadata` and
`dropColumnMappingMetadata`. Both key off one shared set of column-mapping metadata keys, so
detection and stripping stay symmetric.

## How was this change tested?

- Unit tests: `schema_has_column_mapping_metadata` detects a field carrying any column-mapping
  key by presence (id, physicalName, nested ids, parquet field id / nested ids), including
  physicalName-only and wrong-typed-id cases, and is false for a clean schema;
  `drop_column_mapping_metadata` removes those keys from every field (top level, nested struct,
  and array/map leaves) while preserving unrelated metadata.
- Integration: CREATE with a stale-annotated schema (`none` mode) now succeeds and persists a
  stripped schema; ALTER add-column on an already-stale table succeeds and leaves the pre-existing
  annotation in place while the new field carries none; ALTER add-column that introduces an
  annotation on a previously-clean table has it stripped.
- The read/append tolerance from #2886 remains covered.

