### PR TITLE
fix: rename IntoArray::into_array to avoid std name collision on Rust 1.97

### DIFF
--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -465,8 +465,11 @@ mod tests {
 
     pub fn generate_batch_with_id(start_i: i32) -> Result<RecordBatch, ArrowError> {
         generate_batch(vec![
-            ("id", vec![start_i, start_i + 1, start_i + 2].into_array()),
-            ("val", vec!["a", "b", "c"].into_array()),
+            (
+                "id",
+                vec![start_i, start_i + 1, start_i + 2].into_arrow_array(),
+            ),
+            ("val", vec!["a", "b", "c"].into_arrow_array()),
         ])
     }
 

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -67,7 +67,7 @@ async fn try_main() -> DeltaResult<()> {
         create_dir_all(&cli.location_args.path).map_err(|e| {
             Error::generic(format!(
                 "Failed to create directory {}: {e}",
-                &cli.location_args.path
+                cli.location_args.path
             ))
         })?;
     }

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -254,7 +254,7 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
 
     fn size_batch(sizes: Vec<i64>) -> Box<dyn EngineData> {
-        let batch = generate_batch(vec![("size", sizes.into_array())]).unwrap();
+        let batch = generate_batch(vec![("size", sizes.into_arrow_array())]).unwrap();
         Box::new(ArrowEngineData::new(batch))
     }
 

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -67,18 +67,21 @@ async fn test_clustered_table_write_and_checkpoint(
 
     // First write: 3 rows
     let batch = generate_batch(vec![
-        ("id", vec![1, 2, 3].into_array()),
-        ("name", vec!["alice", "bob", "charlie"].into_array()),
-        ("city", vec!["seattle", "portland", "seattle"].into_array()),
+        ("id", vec![1, 2, 3].into_arrow_array()),
+        ("name", vec!["alice", "bob", "charlie"].into_arrow_array()),
+        (
+            "city",
+            vec!["seattle", "portland", "seattle"].into_arrow_array(),
+        ),
     ])?;
     let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
     assert_eq!(snapshot.version(), 1);
 
     // Second write: 2 more rows
     let batch = generate_batch(vec![
-        ("id", vec![4, 5].into_array()),
-        ("name", vec!["dave", "eve"].into_array()),
-        ("city", vec!["austin", "portland"].into_array()),
+        ("id", vec![4, 5].into_arrow_array()),
+        ("name", vec!["dave", "eve"].into_arrow_array()),
+        ("city", vec!["austin", "portland"].into_arrow_array()),
     ])?;
     let snapshot = write_batch_to_table(&snapshot, engine.as_ref(), batch, HashMap::new()).await?;
     assert_eq!(snapshot.version(), 2);
@@ -179,7 +182,7 @@ async fn test_clustered_table_write_all_null_clustering_column() {
     // This should succeed -- all-null clustering columns are valid.
     let all_null_region: ArrayRef = Arc::new(Int32Array::from(vec![None, None, None]));
     let batch = generate_batch(vec![
-        ("category", vec!["a", "b", "c"].into_array()),
+        ("category", vec!["a", "b", "c"].into_arrow_array()),
         ("region_id", all_null_region),
     ])
     .unwrap();

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -168,21 +168,21 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
 
     // Step 1: Create and write two parquet files
     let data_batch_1 = generate_batch(vec![
-        ("id", vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array()),
+        ("id", vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_arrow_array()),
         (
             "value",
-            vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"].into_array(),
+            vec!["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"].into_arrow_array(),
         ),
     ])?;
 
     let data_batch_2 = generate_batch(vec![
         (
             "id",
-            vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19].into_array(),
+            vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19].into_arrow_array(),
         ),
         (
             "value",
-            vec!["k", "l", "m", "n", "o", "p", "q", "r", "s", "t"].into_array(),
+            vec!["k", "l", "m", "n", "o", "p", "q", "r", "s", "t"].into_arrow_array(),
         ),
     ])?;
 

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -241,8 +241,8 @@ async fn stats() -> Result<(), Box<dyn std::error::Error>> {
 
     let batch1 = make_top_level_fields_nullable(&generate_simple_batch()?);
     let batch2 = make_top_level_fields_nullable(&generate_batch(vec![
-        ("id", vec![5, 7].into_array()),
-        ("val", vec!["e", "g"].into_array()),
+        ("id", vec![5, 7].into_arrow_array()),
+        ("val", vec!["e", "g"].into_arrow_array()),
     ])?);
     let file_size1 = record_batch_to_bytes(&batch1).len() as u64;
     let file_size2 = record_batch_to_bytes(&batch2).len() as u64;
@@ -1053,7 +1053,7 @@ async fn test_partition_pruning_with_column_mapping(
     #[case] select_cols: Option<Vec<&'static str>>,
     #[case] expected_files: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let batch = generate_batch(vec![("phys_val", vec!["x", "y", "z"].into_array())])?;
+    let batch = generate_batch(vec![("phys_val", vec!["x", "y", "z"].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let table_root = "memory:///";
@@ -1434,7 +1434,7 @@ fn with_predicate_and_removes() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn predicate_on_non_nullable_partition_column() -> Result<(), Box<dyn std::error::Error>> {
     // Test for https://github.com/delta-io/delta-kernel-rs/issues/698
-    let batch = generate_batch(vec![("val", vec!["a", "b", "c"].into_array())])?;
+    let batch = generate_batch(vec![("val", vec!["a", "b", "c"].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let table_root = "memory:///";
@@ -1485,8 +1485,8 @@ async fn predicate_on_non_nullable_partition_column() -> Result<(), Box<dyn std:
 #[tokio::test]
 async fn predicate_on_non_nullable_column_missing_stats() -> Result<(), Box<dyn std::error::Error>>
 {
-    let batch_1 = generate_batch(vec![("val", vec!["a", "b", "c"].into_array())])?;
-    let batch_2 = generate_batch(vec![("val", vec!["d", "e", "f"].into_array())])?;
+    let batch_1 = generate_batch(vec![("val", vec!["a", "b", "c"].into_arrow_array())])?;
+    let batch_2 = generate_batch(vec![("val", vec!["d", "e", "f"].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let table_root = "memory:///";
@@ -1755,16 +1755,16 @@ fn unshredded_variant_table() -> Result<(), Box<dyn std::error::Error>> {
 async fn test_row_index_metadata_column() -> Result<(), Box<dyn std::error::Error>> {
     // Setup up an in-memory table with different numbers of rows in each file
     let batch1 = generate_batch(vec![
-        ("id", vec![1i32, 2, 3, 4, 5].into_array()),
-        ("value", vec!["a", "b", "c", "d", "e"].into_array()),
+        ("id", vec![1i32, 2, 3, 4, 5].into_arrow_array()),
+        ("value", vec!["a", "b", "c", "d", "e"].into_arrow_array()),
     ])?;
     let batch2 = generate_batch(vec![
-        ("id", vec![10i32, 20, 30].into_array()),
-        ("value", vec!["x", "y", "z"].into_array()),
+        ("id", vec![10i32, 20, 30].into_arrow_array()),
+        ("value", vec!["x", "y", "z"].into_arrow_array()),
     ])?;
     let batch3 = generate_batch(vec![
-        ("id", vec![100i32, 200, 300, 400].into_array()),
-        ("value", vec!["p", "q", "r", "s"].into_array()),
+        ("id", vec![100i32, 200, 300, 400].into_arrow_array()),
+        ("value", vec!["p", "q", "r", "s"].into_arrow_array()),
     ])?;
 
     let file_size1 = record_batch_to_bytes(&batch1).len() as u64;
@@ -1858,12 +1858,12 @@ async fn test_file_path_metadata_column() -> Result<(), Box<dyn std::error::Erro
 
     // Set up an in-memory table with multiple data files
     let batch1 = generate_batch(vec![
-        ("id", vec![1i32, 2, 3].into_array()),
-        ("value", vec!["a", "b", "c"].into_array()),
+        ("id", vec![1i32, 2, 3].into_arrow_array()),
+        ("value", vec!["a", "b", "c"].into_arrow_array()),
     ])?;
     let batch2 = generate_batch(vec![
-        ("id", vec![10i32, 20].into_array()),
-        ("value", vec!["x", "y"].into_array()),
+        ("id", vec![10i32, 20].into_arrow_array()),
+        ("value", vec!["x", "y"].into_arrow_array()),
     ])?;
 
     let file_size1 = record_batch_to_bytes(&batch1).len() as u64;
@@ -2494,7 +2494,7 @@ async fn timestamp_max_stat_truncation_does_not_over_prune(
 #[tokio::test]
 async fn read_table_with_void_column() -> Result<(), Box<dyn std::error::Error>> {
     // Parquet batch has only the non-void column (parquet cannot represent void)
-    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_array())])?;
+    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let actions = [
@@ -2580,7 +2580,7 @@ fn timestamp_truncation_real_table_gt() -> Result<(), Box<dyn std::error::Error>
 #[tokio::test]
 async fn explicit_projection_with_void_column_returns_nulls(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_array())])?;
+    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let actions = [
@@ -2842,7 +2842,7 @@ async fn scan_with_void_schema(
 ) -> Result<Vec<RecordBatch>, Box<dyn std::error::Error>> {
     let batch = generate_batch(vec![(
         "id",
-        (1..=num_rows).collect::<Vec<_>>().into_array(),
+        (1..=num_rows).collect::<Vec<_>>().into_arrow_array(),
     )])?;
 
     let storage = Arc::new(InMemory::new());
@@ -3012,7 +3012,7 @@ async fn read_all_void_table() -> Result<(), Box<dyn std::error::Error>> {
 #[tokio::test]
 async fn read_table_with_void_partition_column() -> Result<(), Box<dyn std::error::Error>> {
     // Parquet file has only the non-partition, non-void column
-    let batch = generate_batch(vec![("id", vec![1, 2].into_array())])?;
+    let batch = generate_batch(vec![("id", vec![1, 2].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let actions = [
@@ -3057,7 +3057,7 @@ async fn read_table_with_void_partition_column() -> Result<(), Box<dyn std::erro
 // A predicate like `void_col IS NULL` is always true for void columns, so no rows are skipped.
 #[tokio::test]
 async fn read_with_predicate_on_void_column() -> Result<(), Box<dyn std::error::Error>> {
-    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_array())])?;
+    let batch = generate_batch(vec![("id", vec![1, 2, 3].into_arrow_array())])?;
 
     let storage = Arc::new(InMemory::new());
     let actions = [

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -367,29 +367,29 @@ pub fn record_batch_to_bytes_with_props(
 
 /// Anything that implements `IntoArray` can turn itself into a reference to an arrow array
 pub trait IntoArray {
-    fn into_array(self) -> ArrayRef;
+    fn into_arrow_array(self) -> ArrayRef;
 }
 
 impl IntoArray for Vec<i32> {
-    fn into_array(self) -> ArrayRef {
+    fn into_arrow_array(self) -> ArrayRef {
         Arc::new(Int32Array::from(self))
     }
 }
 
 impl IntoArray for Vec<i64> {
-    fn into_array(self) -> ArrayRef {
+    fn into_arrow_array(self) -> ArrayRef {
         Arc::new(Int64Array::from(self))
     }
 }
 
 impl IntoArray for Vec<bool> {
-    fn into_array(self) -> ArrayRef {
+    fn into_arrow_array(self) -> ArrayRef {
         Arc::new(BooleanArray::from(self))
     }
 }
 
 impl IntoArray for Vec<&'static str> {
-    fn into_array(self) -> ArrayRef {
+    fn into_arrow_array(self) -> ArrayRef {
         Arc::new(StringArray::from(self))
     }
 }
@@ -408,8 +408,8 @@ where
 /// respectively
 pub fn generate_simple_batch() -> Result<RecordBatch, ArrowError> {
     generate_batch(vec![
-        ("id", vec![1, 2, 3].into_array()),
-        ("val", vec!["a", "b", "c"].into_array()),
+        ("id", vec![1, 2, 3].into_arrow_array()),
+        ("val", vec!["a", "b", "c"].into_arrow_array()),
     ])
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rust 1.97.0 (2026-07-07) added an `into_array` method, which collides with test-utils' `IntoArray::into_array` and breaks CI. This change rename the trait method to `into_arrow_array`, which resolves the collision.

## How was this change tested?
Pure rename, existing tests should suffice.

