### PR TITLE
feat!: add interval support to FFI visitors

### DIFF
--- a/ffi/examples/read-table/kernel_schema_visitor.h
+++ b/ffi/examples/read-table/kernel_schema_visitor.h
@@ -36,6 +36,10 @@ uintptr_t visit_schema_item(SchemaItem* item, KernelSchemaVisitorState *state, C
     visit_res = visit_field_timestamp(state, name, item->is_nullable, allocate_error);
   } else if (strcmp(item->type, "timestamp_ntz") == 0) {
     visit_res = visit_field_timestamp_ntz(state, name, item->is_nullable, allocate_error);
+  } else if (strcmp(item->type, "interval year to month") == 0) {
+    visit_res = visit_field_interval_year_month(state, name, item->is_nullable, allocate_error);
+  } else if (strcmp(item->type, "interval day to second") == 0) {
+    visit_res = visit_field_interval_day_time(state, name, item->is_nullable, allocate_error);
   } else if (strncmp(item->type, "decimal", 7) == 0) {
     unsigned int precision;
     int scale;

--- a/ffi/examples/read-table/schema.h
+++ b/ffi/examples/read-table/schema.h
@@ -254,6 +254,25 @@ DEFINE_VISIT_SIMPLE_TYPE(date)
 DEFINE_VISIT_SIMPLE_TYPE(timestamp)
 DEFINE_VISIT_SIMPLE_TYPE(timestamp_ntz)
 DEFINE_VISIT_SIMPLE_TYPE(void)
+DEFINE_VISIT_SIMPLE_TYPE(variant)
+
+void visit_interval_year_month(void* data,
+                               uintptr_t sibling_list_id,
+                               struct KernelStringSlice name,
+                               bool is_nullable,
+                               const CStringMap * metadata)
+{
+  visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, "interval year to month");
+}
+
+void visit_interval_day_time(void* data,
+                             uintptr_t sibling_list_id,
+                             struct KernelStringSlice name,
+                             bool is_nullable,
+                             const CStringMap * metadata)
+{
+  visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, "interval day to second");
+}
 
 // free all the data in the builder and the builder itself
 void free_builder(SchemaBuilder* builder)
@@ -308,7 +327,10 @@ CSchema* get_cschema(SharedSnapshot* snapshot, SharedExternEngine* engine)
     .visit_date = visit_date,
     .visit_timestamp = visit_timestamp,
     .visit_timestamp_ntz = visit_timestamp_ntz,
+    .visit_interval_year_month = visit_interval_year_month,
+    .visit_interval_day_time = visit_interval_day_time,
     .visit_void = visit_void,
+    .visit_variant = visit_variant,
   };
   SharedSchema* schema = logical_schema(snapshot);
   uintptr_t schema_list_id = visit_schema(schema, &visitor);

--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -56,6 +56,10 @@ uintptr_t convert_engine_to_kernel_literal(
           lit->value.long_data);
     case Date:
       return visit_expression_literal_date(state, lit->value.integer_data);
+    case IntervalYearMonth:
+      return visit_expression_literal_interval_year_month(state, lit->value.integer_data);
+    case IntervalDayTime:
+      return visit_expression_literal_interval_day_time(state, lit->value.long_data);
     case Binary: {
       return visit_expression_literal_binary(
           state, lit->value.binary.buf, lit->value.binary.len);
@@ -340,5 +344,4 @@ SharedPredicate* convert_engine_to_kernel_predicate(
     abort();
   }
 }
-
 

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -46,6 +46,8 @@ enum LitType {
   Timestamp,
   TimestampNtz,
   Date,
+  IntervalYearMonth,
+  IntervalDayTime,
   Binary,
   Decimal,
   Null,
@@ -235,6 +237,16 @@ DEFINE_SIMPLE_SCALAR(visit_expr_boolean_literal, Boolean, _Bool, boolean_data);
 DEFINE_SIMPLE_SCALAR(visit_expr_timestamp_literal, Timestamp, int64_t, long_data);
 DEFINE_SIMPLE_SCALAR(visit_expr_timestamp_ntz_literal, TimestampNtz, int64_t, long_data);
 DEFINE_SIMPLE_SCALAR(visit_expr_date_literal, Date, int32_t, integer_data);
+DEFINE_SIMPLE_SCALAR(
+    visit_expr_interval_year_month_literal,
+    IntervalYearMonth,
+    int32_t,
+    integer_data);
+DEFINE_SIMPLE_SCALAR(
+    visit_expr_interval_day_time_literal,
+    IntervalDayTime,
+    int64_t,
+    long_data);
 #undef DEFINE_SIMPLE_SCALAR
 
 void visit_expr_string_literal(void* data, uintptr_t sibling_list_id, KernelStringSlice string) {
@@ -491,6 +503,8 @@ ExpressionItemList construct_expression(SharedExpression* expression) {
     .visit_literal_timestamp = visit_expr_timestamp_literal,
     .visit_literal_timestamp_ntz = visit_expr_timestamp_ntz_literal,
     .visit_literal_date = visit_expr_date_literal,
+    .visit_literal_interval_year_month = visit_expr_interval_year_month_literal,
+    .visit_literal_interval_day_time = visit_expr_interval_day_time_literal,
     .visit_literal_binary = visit_expr_binary_literal,
     .visit_literal_null = visit_expr_null_literal,
     .visit_literal_decimal = visit_expr_decimal_literal,
@@ -543,6 +557,8 @@ ExpressionItemList construct_predicate(SharedPredicate* predicate) {
     .visit_literal_timestamp = visit_expr_timestamp_literal,
     .visit_literal_timestamp_ntz = visit_expr_timestamp_ntz_literal,
     .visit_literal_date = visit_expr_date_literal,
+    .visit_literal_interval_year_month = visit_expr_interval_year_month_literal,
+    .visit_literal_interval_day_time = visit_expr_interval_day_time_literal,
     .visit_literal_binary = visit_expr_binary_literal,
     .visit_literal_null = visit_expr_null_literal,
     .visit_literal_decimal = visit_expr_decimal_literal,
@@ -667,6 +683,8 @@ void free_expression_item(ExpressionItem ref) {
         case Timestamp:
         case TimestampNtz:
         case Date:
+        case IntervalYearMonth:
+        case IntervalDayTime:
         case Decimal:
         case Null:
           break;

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -213,10 +213,11 @@ void print_tree_helper(ExpressionItem ref, int depth) {
             "Double", "String", "Binary", "Date", "Timestamp", "TimestampNtz",
             "Decimal", "IntervalYearMonth", "IntervalDayTime",
           };
+          const size_t null_type_count = sizeof(null_type_names) / sizeof(null_type_names[0]);
           struct NullTypeInfo* nt = &lit->value.null_type;
           if (nt->type_tag == 12) {
             printf("Null(Decimal(%d,%d))\n", nt->precision, nt->scale);
-          } else if (nt->type_tag < 15) {
+          } else if (nt->type_tag < null_type_count) {
             printf("Null(%s)\n", null_type_names[nt->type_tag]);
           } else {
             printf("Null(tag=%d)\n", nt->type_tag);

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -184,6 +184,12 @@ void print_tree_helper(ExpressionItem ref, int depth) {
         case Date:
           printf("Date(%d)\n", lit->value.integer_data);
           break;
+        case IntervalYearMonth:
+          printf("IntervalYearMonth(%d)\n", lit->value.integer_data);
+          break;
+        case IntervalDayTime:
+          printf("IntervalDayTime(%lld)\n", (long long)lit->value.long_data);
+          break;
         case Binary: {
           printf("Binary(");
           for (size_t i = 0; i < lit->value.binary.len; i++) {
@@ -205,12 +211,13 @@ void print_tree_helper(ExpressionItem ref, int depth) {
           static const char* null_type_names[] = {
             "Boolean", "Byte", "Short", "Integer", "Long", "Float",
             "Double", "String", "Binary", "Date", "Timestamp", "TimestampNtz",
+            "Decimal", "IntervalYearMonth", "IntervalDayTime",
           };
           struct NullTypeInfo* nt = &lit->value.null_type;
-          if (nt->type_tag < 12) { // 12 == Decimal (has special precision/scale handling)
-            printf("Null(%s)\n", null_type_names[nt->type_tag]);
-          } else if (nt->type_tag == 12) {
+          if (nt->type_tag == 12) {
             printf("Null(Decimal(%d,%d))\n", nt->precision, nt->scale);
+          } else if (nt->type_tag < 15) {
+            printf("Null(%s)\n", null_type_names[nt->type_tag]);
           } else {
             printf("Null(tag=%d)\n", nt->type_tag);
           }

--- a/ffi/examples/visit-expression/visit_expression.c
+++ b/ffi/examples/visit-expression/visit_expression.c
@@ -102,8 +102,8 @@ int main() {
       .description = 
         "This test validates expressions/predicates with full support.\n"
         "Supported types: primitives (int, long, float, double, bool, "
-        "string),\n  temporal (date, timestamp, timestamp_ntz), binary, "
-        "decimal, null,\n  binary operations (+, -, *, /), struct "
+        "string),\n  temporal (date, timestamp, timestamp_ntz), intervals, "
+        "binary, decimal, null,\n  binary operations (+, -, *, /), struct "
         "expressions, predicates (eq, ne, lt, le,\n  gt, ge, distinct, "
         "is_null, is_not_null, not, and, or)"
     }

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -136,10 +136,9 @@ pub struct EngineExpressionVisitor {
     ),
     /// Visits a typed null value belonging to the list identified by `sibling_list_id`.
     ///
-    /// The `type_tag` identifies the data type using the `NullTypeTag` encoding. For decimal
-    /// nulls (`type_tag == 12`), `precision` and `scale` carry the decimal type parameters;
-    /// for all other types, they are zero. Non-primitive types (struct, array, map, variant)
-    /// use `type_tag == 255`.
+    /// The `type_tag` identifies reconstructible primitive types with tags 0-14. Decimal nulls
+    /// use tag 12 with `precision` and `scale`; interval year-month and day-time nulls use tags
+    /// 13 and 14. Non-primitive types and `void` use the sentinel tag 255.
     pub visit_literal_null: extern "C" fn(
         data: *mut c_void,
         sibling_list_id: usize,
@@ -801,126 +800,37 @@ mod tests {
         });
     }
 
-    macro_rules! ignored_literal_fn {
-        ($fn_name:ident, $value_type:ty) => {
+    macro_rules! ignore_fn {
+        ($fn_name:ident $(, $arg_type:ty)*) => {
             extern "C" fn $fn_name(
                 _data: *mut c_void,
                 _sibling_list_id: usize,
-                _value: $value_type,
+                $(_: $arg_type),*
             ) {
             }
         };
     }
 
-    ignored_literal_fn!(ignore_i32, i32);
-    ignored_literal_fn!(ignore_i64, i64);
-    ignored_literal_fn!(ignore_i16, i16);
-    ignored_literal_fn!(ignore_i8, i8);
-    ignored_literal_fn!(ignore_f32, f32);
-    ignored_literal_fn!(ignore_f64, f64);
-    ignored_literal_fn!(ignore_bool, bool);
-    ignored_literal_fn!(ignore_string_slice, KernelStringSlice);
-
-    extern "C" fn ignore_binary(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _buffer: *const u8,
-        _len: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_decimal(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _value_ms: i64,
-        _value_ls: u64,
-        _precision: u8,
-        _scale: u8,
-    ) {
-    }
-
-    extern "C" fn ignore_struct_literal(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _child_field_list_id: usize,
-        _child_value_list_id: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_child_list(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _child_list_id: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_map_literal(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _key_list_id: usize,
-        _value_list_id: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_null(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _type_tag: u8,
-        _precision: u8,
-        _scale: u8,
-    ) {
-    }
-
-    extern "C" fn ignore_parse_json(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _child_list_id: usize,
-        _output_schema: Handle<SharedSchema>,
-    ) {
-    }
-
-    extern "C" fn ignore_column(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _name: KernelStringSlice,
-    ) {
-    }
-
-    extern "C" fn ignore_struct_patch(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _input_path_list_id: usize,
-        _prepended_field_list_id: usize,
-        _field_patch_list_id: usize,
-        _appended_field_list_id: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_field_patch(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _field_name: KernelStringSlice,
-        _insertion_expr_list_id: usize,
-        _keep_input: bool,
-        _optional: bool,
-    ) {
-    }
-
-    extern "C" fn ignore_opaque_expr(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _op: Handle<SharedOpaqueExpressionOp>,
-        _child_list_id: usize,
-    ) {
-    }
-
-    extern "C" fn ignore_opaque_pred(
-        _data: *mut c_void,
-        _sibling_list_id: usize,
-        _op: Handle<SharedOpaquePredicateOp>,
-        _child_list_id: usize,
-    ) {
-    }
+    ignore_fn!(ignore_i32, i32);
+    ignore_fn!(ignore_i64, i64);
+    ignore_fn!(ignore_i16, i16);
+    ignore_fn!(ignore_i8, i8);
+    ignore_fn!(ignore_f32, f32);
+    ignore_fn!(ignore_f64, f64);
+    ignore_fn!(ignore_bool, bool);
+    ignore_fn!(ignore_string_slice, KernelStringSlice);
+    ignore_fn!(ignore_binary, *const u8, usize);
+    ignore_fn!(ignore_decimal, i64, u64, u8, u8);
+    ignore_fn!(ignore_struct_literal, usize, usize);
+    ignore_fn!(ignore_child_list, usize);
+    ignore_fn!(ignore_map_literal, usize, usize);
+    ignore_fn!(ignore_null, u8, u8, u8);
+    ignore_fn!(ignore_parse_json, usize, Handle<SharedSchema>);
+    ignore_fn!(ignore_column, KernelStringSlice);
+    ignore_fn!(ignore_struct_patch, usize, usize, usize, usize);
+    ignore_fn!(ignore_field_patch, KernelStringSlice, usize, bool, bool);
+    ignore_fn!(ignore_opaque_expr, Handle<SharedOpaqueExpressionOp>, usize);
+    ignore_fn!(ignore_opaque_pred, Handle<SharedOpaquePredicateOp>, usize);
 
     fn test_visitor(builder: &mut TestExpressionBuilder) -> EngineExpressionVisitor {
         EngineExpressionVisitor {
@@ -981,6 +891,30 @@ mod tests {
     #[case(
         Expression::literal(Scalar::IntervalDayTime(987_654)),
         LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: 987_654 }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalYearMonth(-13)),
+        LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: -13 }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalYearMonth(i32::MIN)),
+        LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: i32::MIN }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalYearMonth(i32::MAX)),
+        LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: i32::MAX }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalDayTime(-86_400_000_000)),
+        LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: -86_400_000_000 }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalDayTime(i64::MIN)),
+        LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: i64::MIN }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalDayTime(i64::MAX)),
+        LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: i64::MAX }
     )]
     fn visit_expression_uses_interval_literal_callbacks(
         #[case] expression: Expression,

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -93,6 +93,10 @@ pub struct EngineExpressionVisitor {
     /// Visit a 32bit integer `date` representing days since UNIX epoch 1970-01-01.  The `date`
     /// belongs to the list identified by `sibling_list_id`.
     pub visit_literal_date: VisitLiteralFn<i32>,
+    /// Visit an `interval year to month` literal as a signed month count.
+    pub visit_literal_interval_year_month: VisitLiteralFn<i32>,
+    /// Visit an `interval day to second` literal as a signed microsecond count.
+    pub visit_literal_interval_day_time: VisitLiteralFn<i64>,
     /// Visit binary data at the `buffer` with length `len` belonging to the list identified by
     /// `sibling_list_id`.
     pub visit_literal_binary:
@@ -588,13 +592,21 @@ fn visit_expression_scalar(
                 scale
             )
         }
-        // TODO (#2811): the following is intentional just for this PR, will be addressed
-        // when FFI support for interval types is added
-        Scalar::IntervalYearMonth(_) => {
-            visit_unknown(visitor, sibling_list_id, "interval_year_month_literal")
+        Scalar::IntervalYearMonth(val) => {
+            call!(
+                visitor,
+                visit_literal_interval_year_month,
+                sibling_list_id,
+                *val
+            )
         }
-        Scalar::IntervalDayTime(_) => {
-            visit_unknown(visitor, sibling_list_id, "interval_day_time_literal")
+        Scalar::IntervalDayTime(val) => {
+            call!(
+                visitor,
+                visit_literal_interval_day_time,
+                sibling_list_id,
+                *val
+            )
         }
         Scalar::Struct(struct_data) => {
             visit_expression_struct_literal(visitor, struct_data, sibling_list_id)
@@ -737,4 +749,249 @@ fn visit_predicate_internal(predicate: &Predicate, visitor: &mut EngineExpressio
     let top_level = call!(visitor, make_field_list, 1);
     visit_predicate_impl(visitor, predicate, top_level);
     top_level
+}
+
+#[cfg(test)]
+mod tests {
+    use delta_kernel::expressions::{Expression, Scalar};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum LiteralEvent {
+        IntervalYearMonth { sibling_list_id: usize, value: i32 },
+        IntervalDayTime { sibling_list_id: usize, value: i64 },
+    }
+
+    #[derive(Default)]
+    struct TestExpressionBuilder {
+        next_list_id: usize,
+        events: Vec<LiteralEvent>,
+    }
+
+    extern "C" fn make_field_list(data: *mut c_void, _reserve: usize) -> usize {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        let list_id = builder.next_list_id;
+        builder.next_list_id += 1;
+        list_id
+    }
+
+    extern "C" fn visit_literal_interval_year_month(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        value: i32,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        builder.events.push(LiteralEvent::IntervalYearMonth {
+            sibling_list_id,
+            value,
+        });
+    }
+
+    extern "C" fn visit_literal_interval_day_time(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        value: i64,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        builder.events.push(LiteralEvent::IntervalDayTime {
+            sibling_list_id,
+            value,
+        });
+    }
+
+    macro_rules! ignored_literal_fn {
+        ($fn_name:ident, $value_type:ty) => {
+            extern "C" fn $fn_name(
+                _data: *mut c_void,
+                _sibling_list_id: usize,
+                _value: $value_type,
+            ) {
+            }
+        };
+    }
+
+    ignored_literal_fn!(ignore_i32, i32);
+    ignored_literal_fn!(ignore_i64, i64);
+    ignored_literal_fn!(ignore_i16, i16);
+    ignored_literal_fn!(ignore_i8, i8);
+    ignored_literal_fn!(ignore_f32, f32);
+    ignored_literal_fn!(ignore_f64, f64);
+    ignored_literal_fn!(ignore_bool, bool);
+    ignored_literal_fn!(ignore_string_slice, KernelStringSlice);
+
+    extern "C" fn ignore_binary(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _buffer: *const u8,
+        _len: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_decimal(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _value_ms: i64,
+        _value_ls: u64,
+        _precision: u8,
+        _scale: u8,
+    ) {
+    }
+
+    extern "C" fn ignore_struct_literal(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _child_field_list_id: usize,
+        _child_value_list_id: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_child_list(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _child_list_id: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_map_literal(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _key_list_id: usize,
+        _value_list_id: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_null(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _type_tag: u8,
+        _precision: u8,
+        _scale: u8,
+    ) {
+    }
+
+    extern "C" fn ignore_parse_json(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _child_list_id: usize,
+        _output_schema: Handle<SharedSchema>,
+    ) {
+    }
+
+    extern "C" fn ignore_column(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _name: KernelStringSlice,
+    ) {
+    }
+
+    extern "C" fn ignore_struct_patch(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _input_path_list_id: usize,
+        _prepended_field_list_id: usize,
+        _field_patch_list_id: usize,
+        _appended_field_list_id: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_field_patch(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _field_name: KernelStringSlice,
+        _insertion_expr_list_id: usize,
+        _keep_input: bool,
+        _optional: bool,
+    ) {
+    }
+
+    extern "C" fn ignore_opaque_expr(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _op: Handle<SharedOpaqueExpressionOp>,
+        _child_list_id: usize,
+    ) {
+    }
+
+    extern "C" fn ignore_opaque_pred(
+        _data: *mut c_void,
+        _sibling_list_id: usize,
+        _op: Handle<SharedOpaquePredicateOp>,
+        _child_list_id: usize,
+    ) {
+    }
+
+    fn test_visitor(builder: &mut TestExpressionBuilder) -> EngineExpressionVisitor {
+        EngineExpressionVisitor {
+            data: builder as *mut _ as *mut c_void,
+            make_field_list,
+            visit_literal_int: ignore_i32,
+            visit_literal_long: ignore_i64,
+            visit_literal_short: ignore_i16,
+            visit_literal_byte: ignore_i8,
+            visit_literal_float: ignore_f32,
+            visit_literal_double: ignore_f64,
+            visit_literal_string: ignore_string_slice,
+            visit_literal_bool: ignore_bool,
+            visit_literal_timestamp: ignore_i64,
+            visit_literal_timestamp_ntz: ignore_i64,
+            visit_literal_date: ignore_i32,
+            visit_literal_interval_year_month,
+            visit_literal_interval_day_time,
+            visit_literal_binary: ignore_binary,
+            visit_literal_decimal: ignore_decimal,
+            visit_literal_struct: ignore_struct_literal,
+            visit_literal_array: ignore_child_list,
+            visit_literal_map: ignore_map_literal,
+            visit_literal_null: ignore_null,
+            visit_and: ignore_child_list,
+            visit_or: ignore_child_list,
+            visit_not: ignore_child_list,
+            visit_is_null: ignore_child_list,
+            visit_to_json: ignore_child_list,
+            visit_parse_json: ignore_parse_json,
+            visit_map_to_struct: ignore_child_list,
+            visit_lt: ignore_child_list,
+            visit_gt: ignore_child_list,
+            visit_eq: ignore_child_list,
+            visit_distinct: ignore_child_list,
+            visit_in: ignore_child_list,
+            visit_add: ignore_child_list,
+            visit_minus: ignore_child_list,
+            visit_multiply: ignore_child_list,
+            visit_divide: ignore_child_list,
+            visit_coalesce: ignore_child_list,
+            visit_array: ignore_child_list,
+            visit_column: ignore_column,
+            visit_struct_expr: ignore_child_list,
+            visit_struct_patch_expr: ignore_struct_patch,
+            visit_field_patch: ignore_field_patch,
+            visit_opaque_expr: ignore_opaque_expr,
+            visit_opaque_pred: ignore_opaque_pred,
+            visit_unknown: ignore_column,
+        }
+    }
+
+    #[rstest]
+    #[case(
+        Expression::literal(Scalar::IntervalYearMonth(26)),
+        LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: 26 }
+    )]
+    #[case(
+        Expression::literal(Scalar::IntervalDayTime(987_654)),
+        LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: 987_654 }
+    )]
+    fn visit_expression_uses_interval_literal_callbacks(
+        #[case] expression: Expression,
+        #[case] expected: LiteralEvent,
+    ) {
+        let mut builder = TestExpressionBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+
+        let top_level_id = visit_expression_internal(&expression, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(builder.events, vec![expected]);
+    }
 }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -363,6 +363,28 @@ pub extern "C" fn visit_expression_literal_timestamp_ntz(
     wrap_expression(state, Expression::literal(Scalar::TimestampNtz(value)))
 }
 
+/// Visit an interval year-month literal expression.
+///
+/// The value is a signed count of months.
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_interval_year_month(
+    state: &mut KernelExpressionVisitorState,
+    value: i32,
+) -> usize {
+    wrap_expression(state, Expression::literal(Scalar::IntervalYearMonth(value)))
+}
+
+/// Visit an interval day-time literal expression.
+///
+/// The value is a signed count of microseconds.
+#[no_mangle]
+pub extern "C" fn visit_expression_literal_interval_day_time(
+    state: &mut KernelExpressionVisitorState,
+    value: i64,
+) -> usize {
+    wrap_expression(state, Expression::literal(Scalar::IntervalDayTime(value)))
+}
+
 /// visit a binary literal expression
 ///
 /// # Safety
@@ -411,10 +433,10 @@ fn visit_expression_literal_decimal_impl(
 
 /// Type tag for null literal construction via FFI. Identifies the data type of a typed null.
 ///
-/// Primitive types use fixed discriminants 0-11. Decimal uses 12 and requires additional
-/// precision/scale parameters. Non-primitive types (struct, array, map, variant) use the
-/// [`NonPrimitive`](Self::NonPrimitive) sentinel -- these cannot be reconstructed from a type
-/// tag alone.
+/// Primitive types use fixed discriminants 0-14. Decimal uses 12 and requires additional
+/// precision/scale parameters. Non-primitive types (struct, array, map, variant) and void use
+/// the [`NonPrimitive`](Self::NonPrimitive) sentinel because they cannot be reconstructed from
+/// a type tag alone.
 ///
 /// NOTE: These values are part of the FFI contract. Changing existing discriminants is a breaking
 /// change.
@@ -450,9 +472,14 @@ pub(crate) enum NullTypeTag {
     /// WARNING: This variant MUST remain `= 12`. It is the only tag with special handling
     /// (precision/scale parameters), and C consumers key on the value `12` directly.
     Decimal = 12,
-    /// Sentinel for non-primitive null types (struct, array, map, variant). Emitted by the
-    /// kernel-to-engine visitor when the null's type is not a primitive. Engines that receive
-    /// this tag should use opaque expressions or a schema visitor to obtain full type details.
+    /// Null of type `interval year to month` (signed month count).
+    IntervalYearMonth = 13,
+    /// Null of type `interval day to second` (signed microsecond duration).
+    IntervalDayTime = 14,
+    /// Sentinel for non-primitive null types (struct, array, map, variant) and void. Emitted by
+    /// the kernel-to-engine visitor when the null's type cannot be reconstructed from a compact
+    /// tag. Engines that receive this tag should use opaque expressions or a schema visitor to
+    /// obtain full type details.
     ///
     /// Passing this tag to [`visit_expression_literal_null`] returns an error because the
     /// original complex type cannot be reconstructed from a tag alone.
@@ -477,6 +504,8 @@ impl TryFrom<u8> for NullTypeTag {
             10 => Ok(Self::Timestamp),
             11 => Ok(Self::TimestampNtz),
             12 => Ok(Self::Decimal),
+            13 => Ok(Self::IntervalYearMonth),
+            14 => Ok(Self::IntervalDayTime),
             255 => Ok(Self::NonPrimitive),
             other => Err(delta_kernel::Error::generic(format!(
                 "Unrecognized null type tag: {other}"
@@ -505,10 +534,8 @@ impl NullTypeTag {
                 PrimitiveType::Date => (Self::Date, 0, 0),
                 PrimitiveType::Timestamp => (Self::Timestamp, 0, 0),
                 PrimitiveType::TimestampNtz => (Self::TimestampNtz, 0, 0),
-                PrimitiveType::IntervalYearMonth | PrimitiveType::IntervalDayTime => {
-                    // No FFI null tag for intervals; the sentinel avoids a new discriminant
-                    (Self::NonPrimitive, 0, 0)
-                }
+                PrimitiveType::IntervalYearMonth => (Self::IntervalYearMonth, 0, 0),
+                PrimitiveType::IntervalDayTime => (Self::IntervalDayTime, 0, 0),
                 PrimitiveType::Decimal(dt) => (Self::Decimal, dt.precision(), dt.scale()),
                 // Void has no dedicated FFI tag. The current predicate-construction path is
                 // not expected to produce a void-typed literal null; if one ever reaches this
@@ -550,6 +577,8 @@ impl NullTypeTag {
             Self::Date => Ok(DataType::DATE),
             Self::Timestamp => Ok(DataType::TIMESTAMP),
             Self::TimestampNtz => Ok(DataType::TIMESTAMP_NTZ),
+            Self::IntervalYearMonth => Ok(DataType::INTERVAL_YEAR_MONTH),
+            Self::IntervalDayTime => Ok(DataType::INTERVAL_DAY_TIME),
             Self::Decimal => Ok(DataType::Primitive(PrimitiveType::decimal(
                 precision, scale,
             )?)),
@@ -839,6 +868,8 @@ mod tests {
     #[case(DataType::DATE, NullTypeTag::Date, 0, 0)]
     #[case(DataType::TIMESTAMP, NullTypeTag::Timestamp, 0, 0)]
     #[case(DataType::TIMESTAMP_NTZ, NullTypeTag::TimestampNtz, 0, 0)]
+    #[case(DataType::INTERVAL_YEAR_MONTH, NullTypeTag::IntervalYearMonth, 0, 0)]
+    #[case(DataType::INTERVAL_DAY_TIME, NullTypeTag::IntervalDayTime, 0, 0)]
     fn from_data_type_primitive(
         #[case] dt: DataType,
         #[case] expected_tag: NullTypeTag,
@@ -906,6 +937,8 @@ mod tests {
     #[case(NullTypeTag::Date, DataType::DATE)]
     #[case(NullTypeTag::Timestamp, DataType::TIMESTAMP)]
     #[case(NullTypeTag::TimestampNtz, DataType::TIMESTAMP_NTZ)]
+    #[case(NullTypeTag::IntervalYearMonth, DataType::INTERVAL_YEAR_MONTH)]
+    #[case(NullTypeTag::IntervalDayTime, DataType::INTERVAL_DAY_TIME)]
     fn to_data_type_primitive(#[case] tag: NullTypeTag, #[case] expected: DataType) {
         assert_eq!(tag.to_data_type(0, 0).unwrap(), expected);
     }
@@ -952,13 +985,15 @@ mod tests {
     #[case(10, NullTypeTag::Timestamp)]
     #[case(11, NullTypeTag::TimestampNtz)]
     #[case(12, NullTypeTag::Decimal)]
+    #[case(13, NullTypeTag::IntervalYearMonth)]
+    #[case(14, NullTypeTag::IntervalDayTime)]
     #[case(255, NullTypeTag::NonPrimitive)]
     fn try_from_u8_valid(#[case] value: u8, #[case] expected: NullTypeTag) {
         assert_eq!(NullTypeTag::try_from(value).unwrap(), expected);
     }
 
     #[rstest]
-    #[case(13)]
+    #[case(15)]
     #[case(42)]
     #[case(254)]
     fn try_from_u8_invalid(#[case] value: u8) {
@@ -984,7 +1019,7 @@ mod tests {
     #[test]
     fn visit_null_unrecognized_tag_returns_error() {
         let mut state = KernelExpressionVisitorState::default();
-        assert!(visit_expression_literal_null_impl(&mut state, 13, 0, 0).is_err());
+        assert!(visit_expression_literal_null_impl(&mut state, 15, 0, 0).is_err());
     }
 
     #[test]
@@ -1010,6 +1045,8 @@ mod tests {
     #[case(DataType::DATE)]
     #[case(DataType::TIMESTAMP)]
     #[case(DataType::TIMESTAMP_NTZ)]
+    #[case(DataType::INTERVAL_YEAR_MONTH)]
+    #[case(DataType::INTERVAL_DAY_TIME)]
     fn null_type_round_trips_through_tag_encoding(#[case] data_type: DataType) {
         let (tag, precision, scale) = NullTypeTag::from_data_type(&data_type);
         let mut state = KernelExpressionVisitorState::default();
@@ -1029,6 +1066,24 @@ mod tests {
             visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
         assert_eq!(expr, Expression::literal(Scalar::Null(dt)));
+    }
+
+    #[rstest]
+    #[case(Scalar::IntervalYearMonth(17))]
+    #[case(Scalar::IntervalDayTime(1_234_567))]
+    fn interval_literal_visitors_build_interval_scalars(#[case] expected: Scalar) {
+        let mut state = KernelExpressionVisitorState::default();
+        let id = match expected {
+            Scalar::IntervalYearMonth(value) => {
+                visit_expression_literal_interval_year_month(&mut state, value)
+            }
+            Scalar::IntervalDayTime(value) => {
+                visit_expression_literal_interval_day_time(&mut state, value)
+            }
+            _ => unreachable!(),
+        };
+        let expr = unwrap_kernel_expression(&mut state, id).unwrap();
+        assert_eq!(expr, Expression::literal(expected));
     }
 
     // ============================================================================

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -363,9 +363,7 @@ pub extern "C" fn visit_expression_literal_timestamp_ntz(
     wrap_expression(state, Expression::literal(Scalar::TimestampNtz(value)))
 }
 
-/// Visit an interval year-month literal expression.
-///
-/// The value is a signed count of months.
+/// Visit an interval year-month literal (signed month count).
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_interval_year_month(
     state: &mut KernelExpressionVisitorState,
@@ -374,9 +372,7 @@ pub extern "C" fn visit_expression_literal_interval_year_month(
     wrap_expression(state, Expression::literal(Scalar::IntervalYearMonth(value)))
 }
 
-/// Visit an interval day-time literal expression.
-///
-/// The value is a signed count of microseconds.
+/// Visit an interval day-time literal (signed microsecond count).
 #[no_mangle]
 pub extern "C" fn visit_expression_literal_interval_day_time(
     state: &mut KernelExpressionVisitorState,
@@ -433,10 +429,10 @@ fn visit_expression_literal_decimal_impl(
 
 /// Type tag for null literal construction via FFI. Identifies the data type of a typed null.
 ///
-/// Primitive types use fixed discriminants 0-14. Decimal uses 12 and requires additional
-/// precision/scale parameters. Non-primitive types (struct, array, map, variant) and void use
-/// the [`NonPrimitive`](Self::NonPrimitive) sentinel because they cannot be reconstructed from
-/// a type tag alone.
+/// Most primitive types use fixed discriminants 0-14. Decimal uses 12 and requires additional
+/// precision/scale parameters. Non-primitive types (struct, array, map, variant) and the `void`
+/// primitive use the [`NonPrimitive`](Self::NonPrimitive) sentinel because they cannot be
+/// reconstructed from a type tag alone.
 ///
 /// NOTE: These values are part of the FFI contract. Changing existing discriminants is a breaking
 /// change.
@@ -1071,6 +1067,12 @@ mod tests {
     #[rstest]
     #[case(Scalar::IntervalYearMonth(17))]
     #[case(Scalar::IntervalDayTime(1_234_567))]
+    #[case(Scalar::IntervalYearMonth(-13))]
+    #[case(Scalar::IntervalYearMonth(i32::MIN))]
+    #[case(Scalar::IntervalYearMonth(i32::MAX))]
+    #[case(Scalar::IntervalDayTime(-86_400_000_000))]
+    #[case(Scalar::IntervalDayTime(i64::MIN))]
+    #[case(Scalar::IntervalDayTime(i64::MAX))]
     fn interval_literal_visitors_build_interval_scalars(#[case] expected: Scalar) {
         let mut state = KernelExpressionVisitorState::default();
         let id = match expected {

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -380,6 +380,7 @@ mod tests {
     use delta_kernel::schema::{ArrayType, StructField};
 
     use super::*;
+    use crate::TryFromStringSlice;
 
     #[derive(Debug, PartialEq, Eq)]
     struct VisitedField {
@@ -401,16 +402,6 @@ mod tests {
         list_id
     }
 
-    fn field_name(name: KernelStringSlice) -> String {
-        unsafe {
-            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-                name.ptr as *const u8,
-                name.len,
-            ))
-            .to_string()
-        }
-    }
-
     fn add_field(
         data: *mut c_void,
         sibling_list_id: usize,
@@ -421,66 +412,38 @@ mod tests {
     ) {
         let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
         builder.lists[sibling_list_id].push(VisitedField {
-            name: field_name(name),
+            name: unsafe { String::try_from_slice(&name) }.unwrap(),
             data_type,
             is_nullable,
             children,
         });
     }
 
-    extern "C" fn visit_struct(
-        data: *mut c_void,
-        sibling_list_id: usize,
-        name: KernelStringSlice,
-        is_nullable: bool,
-        _metadata: &CStringMap,
-        child_list_id: usize,
-    ) {
-        add_field(
-            data,
-            sibling_list_id,
-            name,
-            is_nullable,
-            "struct",
-            Some(child_list_id),
-        );
+    macro_rules! visit_nested_type {
+        ($fn_name:ident, $type_name:expr) => {
+            extern "C" fn $fn_name(
+                data: *mut c_void,
+                sibling_list_id: usize,
+                name: KernelStringSlice,
+                is_nullable: bool,
+                _metadata: &CStringMap,
+                child_list_id: usize,
+            ) {
+                add_field(
+                    data,
+                    sibling_list_id,
+                    name,
+                    is_nullable,
+                    $type_name,
+                    Some(child_list_id),
+                );
+            }
+        };
     }
 
-    extern "C" fn visit_array(
-        data: *mut c_void,
-        sibling_list_id: usize,
-        name: KernelStringSlice,
-        is_nullable: bool,
-        _metadata: &CStringMap,
-        child_list_id: usize,
-    ) {
-        add_field(
-            data,
-            sibling_list_id,
-            name,
-            is_nullable,
-            "array",
-            Some(child_list_id),
-        );
-    }
-
-    extern "C" fn visit_map(
-        data: *mut c_void,
-        sibling_list_id: usize,
-        name: KernelStringSlice,
-        is_nullable: bool,
-        _metadata: &CStringMap,
-        child_list_id: usize,
-    ) {
-        add_field(
-            data,
-            sibling_list_id,
-            name,
-            is_nullable,
-            "map",
-            Some(child_list_id),
-        );
-    }
+    visit_nested_type!(visit_struct, "struct");
+    visit_nested_type!(visit_array, "array");
+    visit_nested_type!(visit_map, "map");
 
     extern "C" fn visit_decimal(
         data: *mut c_void,

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -194,6 +194,24 @@ pub struct EngineSchemaVisitor {
         metadata: &CStringMap,
     ),
 
+    /// Visit an `interval year to month` belonging to the list identified by `sibling_list_id`.
+    pub visit_interval_year_month: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        metadata: &CStringMap,
+    ),
+
+    /// Visit an `interval day to second` belonging to the list identified by `sibling_list_id`.
+    pub visit_interval_day_time: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        metadata: &CStringMap,
+    ),
+
     /// Visit a `void` belonging to the list identified by `sibling_list_id`.
     pub visit_void: extern "C" fn(
         data: *mut c_void,
@@ -339,11 +357,9 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::DATE => call!(visit_date),
             &DataType::TIMESTAMP => call!(visit_timestamp),
             &DataType::TIMESTAMP_NTZ => call!(visit_timestamp_ntz),
+            &DataType::INTERVAL_YEAR_MONTH => call!(visit_interval_year_month),
+            &DataType::INTERVAL_DAY_TIME => call!(visit_interval_day_time),
             &DataType::VOID => call!(visit_void),
-            &DataType::INTERVAL_YEAR_MONTH | &DataType::INTERVAL_DAY_TIME => {
-                // TODO(#2811): add visit_interval_* callbacks; skipping silently drops the column
-                tracing::warn!("Skipping unsupported interval field '{name}' in FFI schema visit");
-            }
             #[cfg(feature = "geo-type-in-dev")]
             DataType::Primitive(PrimitiveType::Geometry(_))
             | DataType::Primitive(PrimitiveType::Geography(_)) => {
@@ -355,4 +371,252 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
     }
 
     visit_struct_fields(visitor, schema)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use delta_kernel::schema::{ArrayType, StructField};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct VisitedField {
+        name: String,
+        data_type: &'static str,
+        is_nullable: bool,
+        children: Option<usize>,
+    }
+
+    #[derive(Default)]
+    struct TestSchemaBuilder {
+        lists: Vec<Vec<VisitedField>>,
+    }
+
+    extern "C" fn make_field_list(data: *mut c_void, reserve: usize) -> usize {
+        let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
+        let list_id = builder.lists.len();
+        builder.lists.push(Vec::with_capacity(reserve));
+        list_id
+    }
+
+    fn field_name(name: KernelStringSlice) -> String {
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                name.ptr as *const u8,
+                name.len,
+            ))
+            .to_string()
+        }
+    }
+
+    fn add_field(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        data_type: &'static str,
+        children: Option<usize>,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
+        builder.lists[sibling_list_id].push(VisitedField {
+            name: field_name(name),
+            data_type,
+            is_nullable,
+            children,
+        });
+    }
+
+    extern "C" fn visit_struct(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CStringMap,
+        child_list_id: usize,
+    ) {
+        add_field(
+            data,
+            sibling_list_id,
+            name,
+            is_nullable,
+            "struct",
+            Some(child_list_id),
+        );
+    }
+
+    extern "C" fn visit_array(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CStringMap,
+        child_list_id: usize,
+    ) {
+        add_field(
+            data,
+            sibling_list_id,
+            name,
+            is_nullable,
+            "array",
+            Some(child_list_id),
+        );
+    }
+
+    extern "C" fn visit_map(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CStringMap,
+        child_list_id: usize,
+    ) {
+        add_field(
+            data,
+            sibling_list_id,
+            name,
+            is_nullable,
+            "map",
+            Some(child_list_id),
+        );
+    }
+
+    extern "C" fn visit_decimal(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CStringMap,
+        _precision: u8,
+        _scale: u8,
+    ) {
+        add_field(data, sibling_list_id, name, is_nullable, "decimal", None);
+    }
+
+    macro_rules! visit_simple_type {
+        ($fn_name:ident, $type_name:expr) => {
+            extern "C" fn $fn_name(
+                data: *mut c_void,
+                sibling_list_id: usize,
+                name: KernelStringSlice,
+                is_nullable: bool,
+                _metadata: &CStringMap,
+            ) {
+                add_field(data, sibling_list_id, name, is_nullable, $type_name, None);
+            }
+        };
+    }
+
+    visit_simple_type!(visit_string, "string");
+    visit_simple_type!(visit_long, "long");
+    visit_simple_type!(visit_integer, "integer");
+    visit_simple_type!(visit_short, "short");
+    visit_simple_type!(visit_byte, "byte");
+    visit_simple_type!(visit_float, "float");
+    visit_simple_type!(visit_double, "double");
+    visit_simple_type!(visit_boolean, "boolean");
+    visit_simple_type!(visit_binary, "binary");
+    visit_simple_type!(visit_date, "date");
+    visit_simple_type!(visit_timestamp, "timestamp");
+    visit_simple_type!(visit_timestamp_ntz, "timestamp_ntz");
+    visit_simple_type!(visit_interval_year_month, "interval year to month");
+    visit_simple_type!(visit_interval_day_time, "interval day to second");
+    visit_simple_type!(visit_void, "void");
+    visit_simple_type!(visit_variant, "variant");
+
+    fn test_visitor(builder: &mut TestSchemaBuilder) -> EngineSchemaVisitor {
+        EngineSchemaVisitor {
+            data: builder as *mut _ as *mut c_void,
+            make_field_list,
+            visit_struct,
+            visit_array,
+            visit_map,
+            visit_decimal,
+            visit_string,
+            visit_long,
+            visit_integer,
+            visit_short,
+            visit_byte,
+            visit_float,
+            visit_double,
+            visit_boolean,
+            visit_binary,
+            visit_date,
+            visit_timestamp,
+            visit_timestamp_ntz,
+            visit_interval_year_month,
+            visit_interval_day_time,
+            visit_void,
+            visit_variant,
+        }
+    }
+
+    #[test]
+    fn visit_schema_preserves_interval_fields() {
+        let schema = StructType::try_new(vec![
+            StructField::nullable("ym", DataType::INTERVAL_YEAR_MONTH),
+            StructField::not_null("dt", DataType::INTERVAL_DAY_TIME),
+            StructField::nullable(
+                "nested",
+                StructType::try_new(vec![StructField::nullable(
+                    "inner_ym",
+                    DataType::INTERVAL_YEAR_MONTH,
+                )])
+                .unwrap(),
+            ),
+            StructField::nullable(
+                "intervals",
+                ArrayType::new(DataType::INTERVAL_DAY_TIME, false),
+            ),
+        ])
+        .unwrap();
+
+        let mut builder = TestSchemaBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+        let top_level_id = visit_schema_impl(&schema, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(builder.lists[0].len(), 4);
+        assert_eq!(
+            builder.lists[0][0],
+            VisitedField {
+                name: "ym".to_string(),
+                data_type: "interval year to month",
+                is_nullable: true,
+                children: None,
+            }
+        );
+        assert_eq!(
+            builder.lists[0][1],
+            VisitedField {
+                name: "dt".to_string(),
+                data_type: "interval day to second",
+                is_nullable: false,
+                children: None,
+            }
+        );
+
+        let nested_child_list_id = builder.lists[0][2].children.unwrap();
+        assert_eq!(
+            builder.lists[nested_child_list_id][0],
+            VisitedField {
+                name: "inner_ym".to_string(),
+                data_type: "interval year to month",
+                is_nullable: true,
+                children: None,
+            }
+        );
+
+        let array_child_list_id = builder.lists[0][3].children.unwrap();
+        assert_eq!(
+            builder.lists[array_child_list_id][0],
+            VisitedField {
+                name: "array_element".to_string(),
+                data_type: "interval day to second",
+                is_nullable: false,
+                children: None,
+            }
+        );
+    }
 }

--- a/ffi/src/schema_visitor.rs
+++ b/ffi/src/schema_visitor.rs
@@ -308,6 +308,42 @@ pub unsafe extern "C" fn visit_field_timestamp_ntz(
         .into_extern_result(&allocate_error)
 }
 
+/// Visit an interval year-month field. Values store signed month counts.
+///
+/// # Safety
+///
+/// Caller is responsible for providing a valid `state`, `name` slice with valid UTF-8 data,
+/// and `allocate_error` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_field_interval_year_month(
+    state: &mut KernelSchemaVisitorState,
+    name: KernelStringSlice,
+    nullable: bool,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name_str = unsafe { TryFromStringSlice::try_from_slice(&name) };
+    visit_field_primitive_impl(state, name_str, PrimitiveType::IntervalYearMonth, nullable)
+        .into_extern_result(&allocate_error)
+}
+
+/// Visit an interval day-time field. Values store signed microsecond durations.
+///
+/// # Safety
+///
+/// Caller is responsible for providing a valid `state`, `name` slice with valid UTF-8 data,
+/// and `allocate_error` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_field_interval_day_time(
+    state: &mut KernelSchemaVisitorState,
+    name: KernelStringSlice,
+    nullable: bool,
+    allocate_error: AllocateErrorFn,
+) -> ExternResult<usize> {
+    let name_str = unsafe { TryFromStringSlice::try_from_slice(&name) };
+    visit_field_primitive_impl(state, name_str, PrimitiveType::IntervalDayTime, nullable)
+        .into_extern_result(&allocate_error)
+}
+
 /// Visit a decimal field. Decimal fields store fixed-precision decimal numbers with specified
 /// precision and scale.
 ///
@@ -755,6 +791,8 @@ mod tests {
         //   col_date: date,
         //   col_timestamp: timestamp,
         //   col_timestamp_ntz: timestamp_ntz,
+        //   col_interval_year_month: interval year to month,
+        //   col_interval_day_time: interval day to second,
         //   col_decimal: decimal(10,2),
         //   col_array: array<string>,
         //   col_map: map<string, long>,
@@ -777,6 +815,10 @@ mod tests {
         let col_date = visit_field!(date, state, "col_date", false);
         let col_timestamp = visit_field!(timestamp, state, "col_timestamp", false);
         let col_timestamp_ntz = visit_field!(timestamp_ntz, state, "col_timestamp_ntz", false);
+        let col_interval_year_month =
+            visit_field!(interval_year_month, state, "col_interval_year_month", false);
+        let col_interval_day_time =
+            visit_field!(interval_day_time, state, "col_interval_day_time", false);
         let col_decimal = visit_field!(decimal, state, "col_decimal", 10, 2, false);
 
         // Create array<string>
@@ -821,6 +863,8 @@ mod tests {
             col_date,
             col_timestamp,
             col_timestamp_ntz,
+            col_interval_year_month,
+            col_interval_day_time,
             col_decimal,
             col_array,
             col_map,
@@ -841,7 +885,7 @@ mod tests {
         // Verify the schema
         let schema = extract_kernel_schema(&mut state, schema_id).unwrap();
         let fields: Vec<_> = schema.fields().collect();
-        assert_eq!(fields.len(), 17);
+        assert_eq!(fields.len(), 19);
 
         // Validate the primitive fields
         let primitive_field_expectations = [
@@ -857,6 +901,8 @@ mod tests {
             ("col_date", PrimitiveType::Date),
             ("col_timestamp", PrimitiveType::Timestamp),
             ("col_timestamp_ntz", PrimitiveType::TimestampNtz),
+            ("col_interval_year_month", PrimitiveType::IntervalYearMonth),
+            ("col_interval_day_time", PrimitiveType::IntervalDayTime),
         ];
 
         for (index, (expected_name, expected_type)) in
@@ -870,25 +916,25 @@ mod tests {
             assert!(!fields[index].is_nullable());
         }
 
-        assert_eq!(fields[12].name(), "col_decimal");
-        let DataType::Primitive(PrimitiveType::Decimal(decimal_type)) = fields[12].data_type()
+        assert_eq!(fields[14].name(), "col_decimal");
+        let DataType::Primitive(PrimitiveType::Decimal(decimal_type)) = fields[14].data_type()
         else {
             panic!("Field col_decimal is not a decimal type");
         };
         assert_eq!(decimal_type.precision(), 10);
         assert_eq!(decimal_type.scale(), 2);
 
-        assert_eq!(fields[13].name(), "col_array");
-        assert_array(fields[13], DataType::STRING, false);
+        assert_eq!(fields[15].name(), "col_array");
+        assert_array(fields[15], DataType::STRING, false);
 
-        assert_eq!(fields[14].name(), "col_map");
-        assert_map(fields[14], DataType::STRING, DataType::LONG, false);
+        assert_eq!(fields[16].name(), "col_map");
+        assert_map(fields[16], DataType::STRING, DataType::LONG, false);
 
-        assert_eq!(fields[15].name(), "col_struct");
-        assert_struct(fields[15], DataType::STRING, false);
+        assert_eq!(fields[17].name(), "col_struct");
+        assert_struct(fields[17], DataType::STRING, false);
 
-        assert_eq!(fields[16].name(), "col_variant");
-        let DataType::Variant(variant_type) = fields[16].data_type() else {
+        assert_eq!(fields[18].name(), "col_variant");
+        let DataType::Variant(variant_type) = fields[18].data_type() else {
             panic!("Expected variant type for col_variant");
         };
         let variant_fields: Vec<_> = variant_type.fields().collect();

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -254,6 +254,8 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
         Scalar::Date(19000).into(),
         Scalar::Timestamp(1234567890).into(),
         Scalar::TimestampNtz(9876543210).into(),
+        Scalar::IntervalYearMonth(-13).into(),
+        Scalar::IntervalDayTime(9_876_543_210).into(),
         Expr::null_literal(DataType::INTEGER),
         Expr::null_literal(DataType::decimal(10, 5).unwrap()),
         Expr::binary(

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -179,7 +179,7 @@ And
 === Simple Round-trip Test ===
 This test validates expressions/predicates with full support.
 Supported types: primitives (int, long, float, double, bool, string),
-  temporal (date, timestamp, timestamp_ntz), binary, decimal, null,
+  temporal (date, timestamp, timestamp_ntz), intervals, binary, decimal, null,
   binary operations (+, -, *, /), struct expressions, predicates (eq, ne, lt, le,
   gt, ge, distinct, is_null, is_not_null, not, and, or)
 
@@ -194,6 +194,8 @@ StructExpression
   Date(19000)
   Timestamp(1234567890)
   TimestampNtz(9876543210)
+  IntervalYearMonth(-13)
+  IntervalDayTime(9876543210)
   Null(Integer)
   Null(Decimal(10,5))
   Add


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add interval support across the FFI schema and expression visitors. Includes new callbacks.

Note: this is a breaking FFI change because it adds callback fields to the `#[repr(C)] EngineSchemaVisitor` and `EngineExpressionVisitor` structs. Consumers must rebuild against the updated generated header.

Addresses #2811.

## How was this change tested?

Round-trip tests, unit tests, and extended the C expression visitor test.
