### PR TITLE
feat!: re-introduce CRC caching

### DIFF
--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -90,8 +90,8 @@ impl LogSegment {
     }
 
     /// Pick the latest CRC to use as an advance base: this segment's on-disk CRC or
-    /// `in_memory_base` (e.g. the CRC an updating snapshot holds), whichever is newer. A failed
-    /// on-disk read falls back to `in_memory_base`. Returns None when neither is available.
+    /// `in_memory_base`, whichever is newer, falling back to `in_memory_base` on a failed on-disk
+    /// read. Drops a base below the checkpoint; returns None when no candidate remains.
     pub(crate) fn pick_latest_base_crc(
         &self,
         engine: &dyn Engine,
@@ -105,6 +105,10 @@ impl LogSegment {
         preferred_disk_crc
             .and_then(|f| read_crc_file_or_none(engine, f))
             .or_else(|| in_memory_base.cloned())
+            .filter(|crc| {
+                self.checkpoint_version
+                    .is_none_or(|ckpt| crc.version >= ckpt)
+            })
     }
 
     /// Read this segment's latest on-disk CRC (`latest_crc_file`), at whatever version it sits.

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -22,7 +22,7 @@ use crate::object_store::ObjectStoreExt as _;
 use crate::path::ParsedLogPath;
 use crate::snapshot::{IncrementalReplay, SnapshotBuilder, SnapshotRef};
 use crate::utils::FoldWithOption as _;
-use crate::{DeltaResult, Engine, Snapshot};
+use crate::{DeltaResult, Engine, Snapshot, Version};
 
 // ============================================================================
 // Expected values
@@ -397,6 +397,20 @@ impl BuiltCrcTest {
         let log_segment =
             LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
         log_segment.build_crc_from_base(&self.engine, base)
+    }
+
+    /// Run `pick_latest_base_crc` against a directly-listed `LogSegment`, using `in_memory_base`.
+    fn pick_latest_base_crc(
+        &self,
+        in_memory_base: Option<&Arc<Crc>>,
+    ) -> DeltaResult<Option<Version>> {
+        let storage = self.engine.storage_handler();
+        let log_root = self.url.join("_delta_log/").unwrap();
+        let log_segment =
+            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
+        Ok(log_segment
+            .pick_latest_base_crc(&self.engine, in_memory_base)
+            .map(|c| c.version))
     }
 
     /// Read the on-disk CRC at `version` from this test's log.
@@ -1213,7 +1227,39 @@ async fn test_stale_crc_advanced_only_within_replay_budget(
         .await;
     let snapshot = built.snapshot_latest_with_replay(mode);
     assert_eq!(snapshot.version(), 3);
-    assert_eq!(snapshot.crc().map(|c| c.version), expected_crc_version);
+    assert_eq!(
+        snapshot.crc_at_version().map(|c| c.version),
+        expected_crc_version
+    );
+}
+
+// A base exactly at the checkpoint version is kept (its tail is (ckpt, end]); a base below it is
+// dropped. Guards the `>=` vs `>` seam in `pick_latest_base_crc`.
+#[tokio::test]
+async fn test_pick_latest_base_crc_keeps_base_at_checkpoint_drops_below() {
+    let built = CrcReadTest::new()
+        .v2_checkpoint(2, protocol_a(), metadata_a())
+        .commit(3, [commit_info(DEFAULT_OPERATION, None)])
+        .build()
+        .await;
+    let base_at_ckpt = Arc::new(Crc {
+        version: 2,
+        ..Default::default()
+    });
+    let base_below_ckpt = Arc::new(Crc {
+        version: 1,
+        ..Default::default()
+    });
+    assert_eq!(
+        built.pick_latest_base_crc(Some(&base_at_ckpt)).unwrap(),
+        Some(2),
+        "a base exactly at the checkpoint version must be retained"
+    );
+    assert_eq!(
+        built.pick_latest_base_crc(Some(&base_below_ckpt)).unwrap(),
+        None,
+        "a base below the checkpoint version must be dropped"
+    );
 }
 
 // ============================================================================

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -295,7 +295,8 @@ impl Snapshot {
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
         // `incremental_replay`.
-        let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
+        let base_crc =
+            combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.base_crc());
         let crc_at_version = combined_log_segment.try_build_crc_within_budget(
             engine,
             base_crc.as_ref(),
@@ -337,7 +338,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            crc_at_version,
+            crc_at_version.or(base_crc),
             built_as_latest,
         )?))
     }
@@ -359,7 +360,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             existing.log_segment.clone(),
             existing.table_configuration.clone(),
-            existing.crc.clone(),
+            existing.base_crc().cloned(),
             true, // reached only when the flag flips false -> true
         )?))
     }
@@ -1183,7 +1184,7 @@ mod tests {
         // A fresh build advances the stale CRC via reverse-replay to a CRC at v3 (file stats
         // Indeterminate, since these synthetic commits carry no commitInfo). The segment's
         // latest CRC file still points at the on-disk CRC version.
-        assert_eq!(snapshot_v3.crc().map(|c| c.version), Some(3));
+        assert_eq!(snapshot_v3.crc_at_version().map(|c| c.version), Some(3));
         assert_eq!(
             snapshot_v3
                 .log_segment
@@ -1226,7 +1227,7 @@ mod tests {
                 .map(|f| f.version),
             expected_crc_file_v
         );
-        assert_eq!(updated.crc().map(|c| c.version), Some(3));
+        assert_eq!(updated.crc_at_version().map(|c| c.version), Some(3));
 
         Ok(())
     }
@@ -1255,13 +1256,13 @@ mod tests {
             .at_version(3)
             .with_incremental_crc_replay(IncrementalReplay::Unlimited)
             .build(ctx.engine.as_ref())?;
-        assert_eq!(snapshot_a.crc().map(|c| c.version), Some(3));
+        assert_eq!(snapshot_a.crc_at_version().map(|c| c.version), Some(3));
 
         let updated = Snapshot::builder_from(snapshot_a)
             .with_incremental_crc_replay(mode)
             .build(ctx.engine.as_ref())?;
         assert_eq!(updated.version(), 5);
-        assert_eq!(updated.crc().map(|c| c.version), expected_crc_v);
+        assert_eq!(updated.crc_at_version().map(|c| c.version), expected_crc_v);
         assert_eq!(
             updated
                 .log_segment
@@ -1473,7 +1474,7 @@ mod tests {
         let snapshot_v0 = Snapshot::builder_for(ctx.url.as_str())
             .at_version(0)
             .build(ctx.engine.as_ref())?;
-        assert!(snapshot_v0.crc().is_none());
+        assert!(snapshot_v0.crc_at_version().is_none());
 
         // Hop 2: incremental v0 -> v5 (new commits, no checkpoint -> P+M replay). This picks up
         // CRC@v5 from the listing, which is at the snapshot version.
@@ -1481,7 +1482,7 @@ mod tests {
             .at_version(5)
             .build(ctx.engine.as_ref())?;
         assert_eq!(snapshot_v5.log_segment.checkpoint_version, None);
-        assert_eq!(snapshot_v5.crc().map(|c| c.version), Some(5));
+        assert_eq!(snapshot_v5.crc_at_version().map(|c| c.version), Some(5));
 
         // Write checkpoint at v7.
         Snapshot::builder_for(ctx.url.as_str())
@@ -1497,7 +1498,7 @@ mod tests {
         compare_snapshots(&snapshot_v10, &fresh_v10);
         assert_eq!(snapshot_v10.version(), 10);
         assert_eq!(snapshot_v10.log_segment.checkpoint_version, Some(7));
-        assert!(snapshot_v10.crc().is_none());
+        assert!(snapshot_v10.crc_at_version().is_none());
 
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -38,7 +38,9 @@ use crate::{DeltaResult, Engine, Error, LogCompactionWriter, Version};
 
 mod builder;
 mod incremental;
+mod snapshot_crc;
 pub use builder::{IncrementalReplay, SnapshotBuilder};
+use snapshot_crc::SnapshotCrc;
 
 /// A shared, thread-safe reference to a [`Snapshot`].
 pub type SnapshotRef = Arc<Snapshot>;
@@ -71,10 +73,10 @@ pub struct Snapshot {
     span: tracing::Span,
     log_segment: LogSegment,
     table_configuration: TableConfiguration,
-    /// CRC at this snapshot's version, eagerly resolved at construction time. `Some(crc)`
-    /// means `crc.version == self.version()` and the CRC can be queried at zero I/O. `None`
-    /// means no CRC was loadable (no CRC on disk at this version, or the read failed).
-    crc: Option<Arc<Crc>>,
+    /// The newest CRC resolved at construction, kept so later queries and CRC writes reuse it
+    /// instead of re-reading from disk. Queried via [`Snapshot::crc_at_version`] (authoritative,
+    /// zero-I/O) or [`Snapshot::base_crc`] (possibly stale). See [`SnapshotCrc`].
+    crc: SnapshotCrc,
     /// Best-effort "confirmed latest at build time" flag. See [`Snapshot::built_as_latest`].
     built_as_latest: bool,
 }
@@ -153,9 +155,6 @@ impl Snapshot {
 
     /// Internal constructor that accepts an explicit pre-resolved CRC.
     ///
-    /// A `Some(crc)` must be at the table configuration's version; otherwise this returns an
-    /// internal error.
-    ///
     /// `built_as_latest` records whether the build confirmed this is the latest version
     /// (best-effort). See [`Snapshot::built_as_latest`].
     pub(crate) fn new_with_crc(
@@ -164,16 +163,12 @@ impl Snapshot {
         crc: Option<Arc<Crc>>,
         built_as_latest: bool,
     ) -> DeltaResult<Self> {
-        if let Some(crc) = crc.as_ref() {
-            require!(
-                crc.version == table_configuration.version(),
-                Error::internal_error(format!(
-                    "CRC version {} does not match snapshot version {}",
-                    crc.version,
-                    table_configuration.version()
-                ))
-            );
-        }
+        // Will perform version validations.
+        let crc = SnapshotCrc::try_new(
+            crc,
+            table_configuration.version(),
+            log_segment.checkpoint_version,
+        )?;
         let span = tracing::info_span!(
             parent: tracing::Span::none(),
             "snap",
@@ -231,7 +226,7 @@ impl Snapshot {
         Self::new_with_crc(
             log_segment,
             table_configuration,
-            crc_at_version,
+            crc_at_version.or(base_crc),
             built_as_latest,
         )
     }
@@ -244,8 +239,8 @@ impl Snapshot {
     /// The `crc_delta` captures the CRC-relevant changes from the committed transaction
     /// (file stats, domain metadata, ICT, etc.). If this snapshot had a CRC at its version,
     /// the delta is applied to produce a precomputed in-memory CRC for the new version,
-    /// avoiding re-reading metadata from storage. If no CRC was available, the new snapshot
-    /// has no CRC either. CREATE TABLE handles CRC construction separately in
+    /// avoiding re-reading metadata from storage. A stale base is carried forward unchanged;
+    /// no CRC stays no CRC. CREATE TABLE handles CRC construction separately in
     /// `Transaction::into_committed`.
     pub(crate) fn new_post_commit(
         &self,
@@ -279,10 +274,14 @@ impl Snapshot {
 
         let new_log_segment = self.log_segment.new_with_commit_appended(commit)?;
 
-        let new_crc = self
-            .crc
-            .as_deref()
-            .map(|base| Arc::new(base.clone().apply(crc_delta, new_version)));
+        // `crc_delta` covers what the transaction committed, so it advances an at-version CRC;
+        // a stale base is carried forward unadvanced.
+        let new_crc = match self.crc_at_version() {
+            Some(base) => Some(Arc::new(
+                base.as_ref().clone().apply(crc_delta, new_version),
+            )),
+            None => self.base_crc().cloned(),
+        };
 
         // A successful commit means the post-commit snapshot is the latest version.
         Snapshot::new_with_crc(
@@ -303,13 +302,18 @@ impl Snapshot {
         &self.log_segment
     }
 
-    /// Returns the CRC for this snapshot, if one is resolved.
-    ///
-    /// When `Some(crc)`, `crc.version == self.version()` and queries backed by the CRC hit
-    /// cache at zero I/O.
+    /// The CRC iff it sits exactly at this snapshot's version. When `Some`, queries backed by the
+    /// CRC hit cache at zero I/O. Returns `None` when no CRC was resolved or the resolved CRC is
+    /// stale.
     #[internal_api]
-    pub(crate) fn crc(&self) -> Option<&Arc<Crc>> {
-        self.crc.as_ref()
+    pub(crate) fn crc_at_version(&self) -> Option<&Arc<Crc>> {
+        self.crc.at_version()
+    }
+
+    /// The held CRC regardless of version, for reuse that does not require an at-version CRC
+    /// (e.g. checksum writes). Prefer [`Self::crc_at_version`] for authoritative queries.
+    fn base_crc(&self) -> Option<&Arc<Crc>> {
+        self.crc.base()
     }
 
     pub fn table_root(&self) -> &Url {
@@ -461,7 +465,7 @@ impl Snapshot {
             calculate_transaction_expiration_timestamp(self.table_properties())?;
 
         // Fast path: serve from CRC if available at this version.
-        if let Some(crc) = self.crc.as_deref() {
+        if let Some(crc) = self.crc_at_version() {
             match &crc.set_transaction_state {
                 SetTransactionState::Complete(map) => {
                     // Complete is authoritative: a miss means the app_id has no transaction.
@@ -608,7 +612,7 @@ impl Snapshot {
         }
 
         // Fast path: serve from CRC if it tracks domain metadata at this version.
-        if let Some(crc) = self.crc.as_deref() {
+        if let Some(crc) = self.crc_at_version() {
             match &crc.domain_metadata_state {
                 DomainMetadataState::Complete(map) => {
                     let hits: DomainMetadataMap = match domains {
@@ -687,10 +691,12 @@ impl Snapshot {
             .collect())
     }
 
-    /// Returns file-level statistics, or `None` if this snapshot has no CRC, or its CRC does
-    /// not have `Complete` file stats. Performs no I/O (the CRC is resolved at construction).
+    /// Returns file-level statistics, or `None` if this snapshot has no CRC at its version (none
+    /// resolved, or the resolved CRC is stale), or its CRC does not have `Complete` file stats.
+    /// Performs no I/O.
     pub fn get_file_stats_if_present(&self) -> Option<FileStats> {
-        self.crc.as_ref().and_then(|crc| crc.file_stats().cloned())
+        self.crc_at_version()
+            .and_then(|crc| crc.file_stats().cloned())
     }
 
     /// Get the In-Commit Timestamp (ICT) for this snapshot.
@@ -731,7 +737,7 @@ impl Snapshot {
         }
 
         // Fast path: serve ICT from CRC if available at this version.
-        if let Some(crc) = self.crc.as_deref() {
+        if let Some(crc) = self.crc_at_version() {
             match crc.in_commit_timestamp_opt {
                 Some(ict) => return Ok(Some(ict)),
                 None => {
@@ -969,7 +975,7 @@ impl Snapshot {
     fn resolve_crc_for_write(&self, engine: &dyn Engine) -> DeltaResult<Arc<Crc>> {
         let span = tracing::Span::current();
         // Case 1: an in-memory CRC at this version is ready to write as-is.
-        if let Some(crc) = &self.crc {
+        if let Some(crc) = self.crc_at_version() {
             span.record("root", "in_memory");
             return Ok(crc.clone());
         }
@@ -977,15 +983,11 @@ impl Snapshot {
         let end = self.version();
         let log_segment = &self.log_segment;
 
-        // Case 2: a stale on-disk CRC, older than this version. An on-disk CRC at exactly this
-        // version would have short-circuited to `AlreadyExists` in `write_checksum`. Advance it
-        // over the tail commits.
-        // TODO(#2889): `read_latest_crc` re-reads the CRC from disk. `LazyCrc` was deleted in the
-        //              pivot to incremental CRC being optional; reintroduce something like it so a
-        //              CRC already read during snapshot load is reused here instead of re-read.
-        if let Some(base) = log_segment.read_latest_crc(engine) {
+        // Case 2: a stale base CRC, older than this version. Advance the retained base over the
+        // tail commits (a held base is always at or above the checkpoint, so a tail exists).
+        if let Some(base) = self.base_crc() {
             span.record("root", "stale_crc");
-            let crc = log_segment.build_crc_from_base(engine, &base)?;
+            let crc = log_segment.build_crc_from_base(engine, base)?;
             return Ok(Arc::new(crc));
         }
 
@@ -1151,12 +1153,14 @@ impl Snapshot {
         let new_log_segment = self
             .log_segment
             .try_new_with_checkpoint(checkpoint_log_path)?;
+        // Carry only an at-version CRC forward: the checkpoint drops the commits below it, so a
+        // stale base could no longer be advanced over them.
         Ok((
             CheckpointWriteResult::Written,
             Arc::new(Snapshot::new_with_crc(
                 new_log_segment,
                 self.table_configuration().clone(),
-                self.crc.clone(),
+                self.crc_at_version().cloned(),
                 self.built_as_latest,
             )?),
         ))
@@ -1226,7 +1230,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             self.log_segment().new_as_published()?,
             self.table_configuration().clone(),
-            self.crc.clone(),
+            self.base_crc().cloned(),
             self.built_as_latest,
         )?))
     }
@@ -2159,6 +2163,47 @@ mod tests {
         // THEN
         assert_eq!(post_commit_snapshot.version(), next_version);
         assert_eq!(post_commit_snapshot.log_segment().end_version, next_version);
+    }
+
+    // A post-commit snapshot built from a parent holding a stale base (not an at-version CRC)
+    // keeps that base rather than dropping it: the single-commit delta can't advance it, but
+    // retaining it lets a later write reuse the parsed CRC.
+    #[test]
+    fn test_new_post_commit_from_stale_base_keeps_base() {
+        let path =
+            std::fs::canonicalize(PathBuf::from("./tests/data/table-with-dv-small/")).unwrap();
+        let url = url::Url::from_directory_path(path).unwrap();
+        let engine = SyncEngine::new();
+
+        // Rebuild the v1 snapshot so it holds a stale CRC@0 (base only, not at-version).
+        let built = Snapshot::builder_for(url.clone())
+            .at_version(1)
+            .build(&engine)
+            .unwrap();
+        let stale_crc = Arc::new(Crc {
+            version: 0,
+            ..Default::default()
+        });
+        let parent = Snapshot::new_with_crc(
+            built.log_segment().clone(),
+            built.table_configuration().clone(),
+            Some(stale_crc),
+            false, /* built_as_latest */
+        )
+        .unwrap();
+        assert!(parent.crc_at_version().is_none());
+        assert_eq!(parent.base_crc().map(|c| c.version), Some(0));
+
+        let commit = ParsedLogPath::create_parsed_published_commit(&url, 2);
+        let post = parent.new_post_commit(commit, CrcDelta::default()).unwrap();
+
+        assert_eq!(post.version(), 2);
+        assert!(post.crc_at_version().is_none());
+        assert_eq!(
+            post.base_crc().map(|c| c.version),
+            Some(0),
+            "the stale base must be carried forward, not dropped"
+        );
     }
 
     #[test]

--- a/kernel/src/snapshot/snapshot_crc.rs
+++ b/kernel/src/snapshot/snapshot_crc.rs
@@ -1,0 +1,130 @@
+//! The CRC a [`Snapshot`] holds, and the version semantics gating how it may be used.
+//!
+//! [`Snapshot`]: super::Snapshot
+
+use std::sync::Arc;
+
+use crate::crc::Crc;
+use crate::utils::require;
+use crate::{DeltaResult, Error, Version};
+
+/// The newest [`Crc`] a snapshot resolved, at or before the snapshot's version. It is one CRC,
+/// read from disk (or computed) at most once; keeping it lets later queries and CRC writes reuse
+/// the already-parsed state instead of re-reading it. A `Some(crc)` is one of:
+/// - at the snapshot version: authoritative, servable at zero I/O via [`Self::at_version`];
+/// - stale (older): kept only as a base for [`Self::base`], never served as authoritative.
+///
+/// [`Snapshot`]: super::Snapshot
+#[derive(Debug)]
+pub(super) struct SnapshotCrc {
+    crc: Option<Arc<Crc>>,
+    snapshot_version: Version,
+}
+
+impl SnapshotCrc {
+    /// Wrap the CRC a snapshot at `snapshot_version` resolved. A `Some(crc)` must sit in
+    /// `[checkpoint_version, snapshot_version]`.
+    pub(super) fn try_new(
+        crc: Option<Arc<Crc>>,
+        snapshot_version: Version,
+        checkpoint_version: Option<Version>,
+    ) -> DeltaResult<Self> {
+        if let Some(crc) = crc.as_ref() {
+            require!(
+                crc.version <= snapshot_version,
+                Error::internal_error(format!(
+                    "CRC version {} is ahead of snapshot version {snapshot_version}",
+                    crc.version
+                ))
+            );
+            require!(
+                checkpoint_version.is_none_or(|ckpt| crc.version >= ckpt),
+                Error::internal_error(format!(
+                    "CRC version {} is below checkpoint version {checkpoint_version:?}",
+                    crc.version
+                ))
+            );
+        }
+        Ok(Self {
+            crc,
+            snapshot_version,
+        })
+    }
+
+    /// The CRC iff it sits exactly at the snapshot version, so its cached values are authoritative
+    /// at zero I/O. Returns `None` for a stale CRC.
+    pub(super) fn at_version(&self) -> Option<&Arc<Crc>> {
+        self.crc
+            .as_ref()
+            .filter(|crc| crc.version == self.snapshot_version)
+    }
+
+    /// The held CRC, at-version or stale, for callers that reuse it regardless of version
+    /// (e.g. checksum writes).
+    pub(super) fn base(&self) -> Option<&Arc<Crc>> {
+        self.crc.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_utils::assert_result_error_with_message;
+
+    use super::*;
+    use crate::crc::{FileStats, FileStatsState};
+
+    fn crc_at(version: Version) -> Arc<Crc> {
+        Arc::new(Crc {
+            version,
+            file_stats_state: FileStatsState::Complete(FileStats {
+                num_files: 1,
+                table_size_bytes: 100,
+                file_size_histogram: None,
+            }),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn new_rejects_crc_ahead_of_snapshot() {
+        assert_result_error_with_message(
+            SnapshotCrc::try_new(Some(crc_at(6)), 5, None),
+            "is ahead of snapshot version",
+        );
+    }
+
+    #[test]
+    fn new_rejects_crc_below_checkpoint() {
+        assert_result_error_with_message(
+            SnapshotCrc::try_new(Some(crc_at(2)), 5, Some(3)),
+            "is below checkpoint version",
+        );
+    }
+
+    #[test]
+    fn new_accepts_crc_at_checkpoint() {
+        let holder = SnapshotCrc::try_new(Some(crc_at(3)), 5, Some(3)).unwrap();
+        assert_eq!(holder.base().map(|c| c.version), Some(3));
+    }
+
+    #[test]
+    fn at_version_serves_crc_matching_snapshot_version() {
+        let holder = SnapshotCrc::try_new(Some(crc_at(5)), 5, None).unwrap();
+        assert_eq!(holder.at_version().map(|c| c.version), Some(5));
+        assert_eq!(holder.base().map(|c| c.version), Some(5));
+    }
+
+    #[test]
+    fn stale_crc_is_base_but_not_at_version() {
+        let holder = SnapshotCrc::try_new(Some(crc_at(3)), 5, None).unwrap();
+        assert!(holder.at_version().is_none());
+        assert_eq!(holder.base().map(|c| c.version), Some(3));
+    }
+
+    #[test]
+    fn none_holder_serves_nothing() {
+        let holder = SnapshotCrc::try_new(None, 5, None).unwrap();
+        assert!(holder.at_version().is_none());
+        assert!(holder.base().is_none());
+    }
+}

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -20,7 +20,8 @@ use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
-    add_commit, begin_transaction, insert_data, test_table_setup, test_table_setup_mt,
+    add_commit, begin_transaction, copy_directory, insert_data, test_table_setup,
+    test_table_setup_mt,
 };
 use url::Url;
 
@@ -72,8 +73,6 @@ async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
 
 #[tokio::test]
 async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -> DeltaResult<()> {
-    use test_utils::copy_directory;
-
     // ===== GIVEN =====
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
@@ -100,7 +99,7 @@ async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -
         .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 1);
-    assert_eq!(snapshot.crc().unwrap().version, 1);
+    assert_eq!(snapshot.crc_at_version().unwrap().version, 1);
     let stats = snapshot.get_file_stats_if_present().unwrap();
     assert_eq!(stats.num_files(), 10);
     assert_eq!(stats.table_size_bytes(), 5259);
@@ -150,7 +149,7 @@ async fn test_incremental_update_advances_crc_with_real_file_stats(
         .at_version(3)
         .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
-    assert_eq!(base_snapshot.crc().unwrap().version, 3);
+    assert_eq!(base_snapshot.crc_at_version().unwrap().version, 3);
 
     // ===== AND: conditionally write a CRC and/or checkpoint =====
     if let Some(v) = crc_version {
@@ -177,13 +176,15 @@ async fn test_incremental_update_advances_crc_with_real_file_stats(
     assert_eq!(updated_snapshot.version(), 5);
     match expected_num_files {
         Some(num_files) => {
-            let crc = updated_snapshot.crc().expect("expected an in-memory CRC");
+            let crc = updated_snapshot
+                .crc_at_version()
+                .expect("expected an in-memory CRC");
             assert_eq!(crc.version, updated_snapshot.version());
             let stats = updated_snapshot.get_file_stats_if_present().unwrap();
             assert_eq!(stats.num_files(), num_files);
         }
         None => {
-            assert!(updated_snapshot.crc().is_none());
+            assert!(updated_snapshot.crc_at_version().is_none());
             assert!(updated_snapshot.get_file_stats_if_present().is_none());
         }
     }
@@ -209,7 +210,7 @@ async fn test_snapshot_loads_when_crc_at_version_is_corrupt() -> DeltaResult<()>
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
-    assert!(snapshot.crc().is_none());
+    assert!(snapshot.crc_at_version().is_none());
     assert!(snapshot.get_file_stats_if_present().is_none());
 
     Ok(())
@@ -232,7 +233,7 @@ async fn test_crc_returns_resolved_crc_at_snapshot_version() -> DeltaResult<()> 
     assert_eq!(snapshot.version(), 0);
 
     // ===== WHEN =====
-    let crc = snapshot.crc().unwrap();
+    let crc = snapshot.crc_at_version().unwrap();
 
     // ===== THEN =====
     let file_stats = crc.file_stats().unwrap();
@@ -267,8 +268,7 @@ async fn test_crc_returns_none_when_no_crc() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
 
-    // No CRC file exists, so crc() should return None
-    assert!(snapshot.crc().is_none());
+    assert!(snapshot.crc_at_version().is_none());
 
     Ok(())
 }
@@ -299,7 +299,7 @@ async fn test_create_table_produces_post_commit_crc() -> DeltaResult<()> {
     // ===== THEN: should have CRC at v0 =====
     assert_eq!(committed.commit_version(), 0);
     let snapshot = committed.post_commit_snapshot().unwrap();
-    let crc = snapshot.crc().unwrap();
+    let crc = snapshot.crc_at_version().unwrap();
 
     let file_stats = crc.file_stats().unwrap();
     assert_eq!(file_stats.num_files(), 0);
@@ -329,7 +329,10 @@ async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
         // Fresh-from-disk snapshot has no CRC (no .crc file on disk).
         Snapshot::builder_for(table_path).build(engine.as_ref())?
     };
-    assert_eq!(read_snapshot.crc().is_some(), use_post_commit_snapshot);
+    assert_eq!(
+        read_snapshot.crc_at_version().is_some(),
+        use_post_commit_snapshot
+    );
 
     let committed = begin_transaction(read_snapshot, engine.as_ref())?
         .with_operation("WRITE".to_string())
@@ -340,7 +343,11 @@ async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
     // The new post-commit snapshot should only have a CRC if the read snapshot had one.
     assert_eq!(committed.commit_version(), 1);
     assert_eq!(
-        committed.post_commit_snapshot().unwrap().crc().is_some(),
+        committed
+            .post_commit_snapshot()
+            .unwrap()
+            .crc_at_version()
+            .is_some(),
         use_post_commit_snapshot
     );
 
@@ -358,11 +365,11 @@ fn write_and_verify_crc(
     table_path: &str,
     engine: &dyn delta_kernel::Engine,
 ) -> Crc {
-    let crc_in_memory = snapshot.crc().unwrap();
+    let crc_in_memory = snapshot.crc_at_version().unwrap();
     snapshot.write_checksum(engine).unwrap();
 
     let snapshot_fresh = Snapshot::builder_for(table_path).build(engine).unwrap();
-    let crc_from_disk = snapshot_fresh.crc().unwrap();
+    let crc_from_disk = snapshot_fresh.crc_at_version().unwrap();
     assert_eq!(crc_in_memory, crc_from_disk);
     crc_from_disk.as_ref().clone()
 }
@@ -491,7 +498,7 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     // ===== THEN: CRC at v2 has indeterminate file stats =====
     assert_eq!(committed.commit_version(), 2);
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
-    let crc_v2 = snapshot_v2.crc().unwrap();
+    let crc_v2 = snapshot_v2.crc_at_version().unwrap();
     assert!(crc_v2.file_stats_state().is_indeterminate());
 
     Ok(())
@@ -512,7 +519,7 @@ async fn test_write_checksum_success_simple() -> DeltaResult<()> {
 
     // Verify the CRC file is readable by loading a fresh snapshot from disk
     let fresh_snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_snapshot.crc().is_some());
+    assert!(fresh_snapshot.crc_at_version().is_some());
 
     Ok(())
 }
@@ -650,7 +657,7 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
     let fresh = Snapshot::builder_for(&table_path)
         .with_incremental_crc_replay(replay)
         .build(engine.as_ref())?;
-    assert_eq!(fresh.crc().is_some(), incremental_build);
+    assert_eq!(fresh.crc_at_version().is_some(), incremental_build);
 
     // Confirm the load actually reached the intended resolution root, so a mis-resolution that
     // still produced correct contents cannot pass silently.
@@ -672,7 +679,7 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
 
     // Reload from disk so the assertions below run against the persisted CRC.
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    let crc = reloaded.crc().unwrap();
+    let crc = reloaded.crc_at_version().unwrap();
 
     assert_eq!(crc.version as i64, latest);
     assert_eq!(crc.in_commit_timestamp_opt.is_some(), ict_enabled);
@@ -700,6 +707,183 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
     for v in 1..=latest {
         assert!(txns.contains_key(&format!("app{v}")));
     }
+
+    Ok(())
+}
+
+/// A `Disabled`-mode load over a stale on-disk CRC retains it as a base: `base_crc()` is
+/// `Some(stale)` while `crc_at_version()` is `None`. Asserting only `crc_at_version().is_none()`
+/// would pass even if retention regressed to a full discard, so this drives the retained base
+/// through the observable write path.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disabled_load_retains_stale_crc_as_base() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    // crc-full has a CRC at version 0.
+    let source_path = std::fs::canonicalize(PathBuf::from("./tests/data/crc-full/")).unwrap();
+    copy_directory(&source_path, _temp_dir.path()).unwrap();
+
+    // Safe WRITE commit advances to v1 without writing a new CRC; the newest on-disk CRC stays v0.
+    let snap0 = Snapshot::builder_for(table_path.clone()).build(engine.as_ref())?;
+    begin_transaction(snap0, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Default Disabled load at v1: the stale CRC@0 is not advanced, but it is retained as a base.
+    let snap1 = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    assert_eq!(snap1.version(), 1);
+    assert!(
+        snap1.crc_at_version().is_none(),
+        "a stale CRC must not be served as at-version"
+    );
+    assert_eq!(
+        snap1.get_file_stats_if_present(),
+        None,
+        "file stats come from an at-version CRC only"
+    );
+    // `write_checksum` observably advances the retained base over v1.
+    assert_eq!(
+        snap1.write_checksum(engine.as_ref())?.0,
+        ChecksumWriteResult::Written
+    );
+    let reloaded = Snapshot::builder_for(snap1.table_root().clone()).build(engine.as_ref())?;
+    assert_eq!(reloaded.crc_at_version().map(|c| c.version), Some(1));
+
+    Ok(())
+}
+
+/// Regression: a stale base carried through `checkpoint()` must not break a later `write_checksum`.
+/// The checkpoint drops the commits below it, so the stale base can no longer be advanced over
+/// them; resolution must fall back to the checkpoint root instead of erroring on a missing commit.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_checksum_after_checkpoint_with_stale_base_resolves_from_checkpoint(
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let source_path = std::fs::canonicalize(PathBuf::from("./tests/data/crc-full/")).unwrap();
+    copy_directory(&source_path, _temp_dir.path()).unwrap();
+
+    // v0 has CRC@0; a safe WRITE commit advances to v1 with no new CRC.
+    let snap0 = Snapshot::builder_for(table_path.clone()).build(engine.as_ref())?;
+    begin_transaction(snap0, engine.as_ref())?
+        .with_operation("WRITE".to_string())
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Disabled load retains stale CRC@0 as base; checkpoint at v1 carries state forward and drops
+    // the v1 commit.
+    let snap1 = Snapshot::builder_for(table_path).build(engine.as_ref())?;
+    assert!(snap1.crc_at_version().is_none());
+    let (_, checkpointed) = snap1.checkpoint(engine.as_ref(), None)?;
+    assert_eq!(checkpointed.log_segment().checkpoint_version, Some(1));
+
+    // Resolution must not trip the below-checkpoint base on the emptied commit tail.
+    assert_eq!(
+        checkpointed.write_checksum(engine.as_ref())?.0,
+        ChecksumWriteResult::Written
+    );
+    let reloaded =
+        Snapshot::builder_for(checkpointed.table_root().clone()).build(engine.as_ref())?;
+    assert_eq!(reloaded.crc_at_version().map(|c| c.version), Some(1));
+
+    Ok(())
+}
+
+/// Builds a table with commits 0..=3 (one file each) and a stale CRC written at v1, then returns a
+/// base snapshot at v3 that still holds the un-advanced in-memory CRC@1 (loaded `Disabled` so the
+/// base is NOT advanced to v3), plus a checkpoint written at v2. An incremental update from this
+/// base discovers checkpoint@2 and trims the combined segment's commits above v2, leaving the
+/// retained base@1 BELOW the checkpoint.
+async fn setup_incremental_below_checkpoint_base<E: TaskExecutor>(
+    engine: &Arc<DefaultEngine<E>>,
+    table_path: &str,
+) -> DeltaResult<SnapshotRef> {
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let mut snap = create_table(table_path, schema, "test_engine")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    for v in 1..=3i32 {
+        let arrow_schema = TryFromKernel::try_from_kernel(snap.schema().as_ref())?;
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![Arc::new(Int32Array::from(vec![v]))],
+        )
+        .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
+        let mut txn = snap
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("WRITE".to_string())
+            .with_data_change(true);
+        let write_context = txn.unpartitioned_write_context()?;
+        let adds = engine
+            .write_parquet(&ArrowEngineData::new(batch), &write_context)
+            .await?;
+        txn.add_files(adds);
+        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        if v == 1 {
+            snap.write_checksum(engine.as_ref())?;
+        }
+    }
+
+    // Disabled load at v3 retains the un-advanced CRC@1 (Unlimited would advance it to v3 and
+    // defeat the below-checkpoint scenario).
+    let base = Snapshot::builder_for(table_path)
+        .at_version(3)
+        .build(engine.as_ref())?;
+
+    // Checkpoint at v2, above the base's CRC@1 but below the base version.
+    Snapshot::builder_for(table_path)
+        .at_version(2)
+        .build(engine.as_ref())?
+        .checkpoint(engine.as_ref(), None)?;
+
+    Ok(base)
+}
+
+/// Regression (incremental load-advance path): an incremental update under `Unlimited` must not
+/// try to advance a retained base that sits below a newly-listed checkpoint. `pick_latest_base_crc`
+/// would otherwise feed CRC@1 into `build_crc_from_base` on a segment whose checkpoint@2 dropped
+/// commit 2, erroring on the missing commit. The below-checkpoint base must be skipped, so the
+/// build falls back to log replay.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_incremental_unlimited_skips_below_checkpoint_base() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let base = setup_incremental_below_checkpoint_base(&engine, &table_path).await?;
+
+    let updated = Snapshot::builder_from(base)
+        .with_incremental_crc_replay(IncrementalReplay::Unlimited)
+        .build(engine.as_ref())?;
+    assert_eq!(updated.version(), 3);
+    assert_eq!(updated.log_segment().checkpoint_version, Some(2));
+
+    Ok(())
+}
+
+/// Regression (incremental write path): after an incremental update retains a base below a
+/// newly-listed checkpoint, `write_checksum` must skip that below-checkpoint base and resolve from
+/// the checkpoint root rather than erroring on the commits the checkpoint subsumed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_write_checksum_incremental_stale_base_below_new_checkpoint_resolves(
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let base = setup_incremental_below_checkpoint_base(&engine, &table_path).await?;
+
+    // Disabled update keeps the below-checkpoint base@1 un-advanced on the combined segment.
+    let updated = Snapshot::builder_from(base).build(engine.as_ref())?;
+    assert_eq!(updated.log_segment().checkpoint_version, Some(2));
+
+    // Case 2 must skip the below-checkpoint base and resolve from the checkpoint root.
+    assert_eq!(
+        updated.write_checksum(engine.as_ref())?.0,
+        ChecksumWriteResult::Written
+    );
+
+    // The checkpoint-root fallback must count every live file, not just the post-checkpoint tail.
+    // The fixture writes one file per commit (v1..=3), checked against disk ground truth.
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let stats = reloaded.get_file_stats_if_present().unwrap();
+    let disk = parquet_file_sizes_on_disk(&table_path);
+    assert_eq!(stats.num_files() as usize, disk.len());
+    assert_eq!(stats.table_size_bytes(), disk.iter().sum::<i64>());
 
     Ok(())
 }
@@ -738,7 +922,7 @@ async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_p
     std::fs::write(&commit, b"}}} not valid commit json").unwrap();
 
     let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh.crc().is_none());
+    assert!(fresh.crc_at_version().is_none());
     // The failure is the propagated ICT read error, not a laundered `ChecksumWriteUnsupported`.
     assert!(matches!(
         fresh.write_checksum(engine.as_ref()),
@@ -773,7 +957,7 @@ async fn test_write_checksum_no_crc_with_non_incremental_tail_returns_unsupporte
         .unwrap_committed();
 
     let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh.crc().is_none());
+    assert!(fresh.crc_at_version().is_none());
     assert!(matches!(
         fresh.write_checksum(engine.as_ref()),
         Err(delta_kernel::Error::ChecksumWriteUnsupported(_))
@@ -787,7 +971,7 @@ async fn test_in_memory_crc_chains_across_multiple_commits_then_writes() -> Delt
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let committed = create_table_and_commit(&table_path, engine.as_ref())?;
     let mut snapshot = committed.post_commit_snapshot().unwrap().clone();
-    assert!(snapshot.crc().is_some());
+    assert!(snapshot.crc_at_version().is_some());
 
     // Chain several commits without writing CRC to disk
     for i in 0..5 {
@@ -797,7 +981,7 @@ async fn test_in_memory_crc_chains_across_multiple_commits_then_writes() -> Delt
             .unwrap_committed();
         snapshot = committed.post_commit_snapshot().unwrap().clone();
         assert!(
-            snapshot.crc().is_some(),
+            snapshot.crc_at_version().is_some(),
             "in-memory CRC lost at commit {}",
             committed.commit_version()
         );
@@ -850,9 +1034,9 @@ async fn test_incremental_snapshot_preserves_loaded_crc() -> DeltaResult<()> {
     assert_eq!(incremental_v1.version(), 1);
 
     // The CRC at v1 should be loaded from the incremental update (not discarded)
-    assert_eq!(incremental_v1.crc().map(|c| c.version), Some(1));
+    assert_eq!(incremental_v1.crc_at_version().map(|c| c.version), Some(1));
     assert!(
-        incremental_v1.crc().is_some(),
+        incremental_v1.crc_at_version().is_some(),
         "CRC should be loaded at v1 after incremental snapshot update"
     );
 
@@ -865,7 +1049,7 @@ async fn test_incremental_snapshot_preserves_loaded_crc() -> DeltaResult<()> {
     assert_eq!(committed_v2.commit_version(), 2);
     let snapshot_v2 = committed_v2.post_commit_snapshot().unwrap();
     assert!(
-        snapshot_v2.crc().is_some(),
+        snapshot_v2.crc_at_version().is_some(),
         "Post-commit CRC should chain from incremental snapshot's CRC"
     );
 
@@ -902,7 +1086,7 @@ async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
         .at_version(0)
         .build(engine.as_ref())?;
     assert!(
-        fresh_v0.crc().is_some(),
+        fresh_v0.crc_at_version().is_some(),
         "Fresh v0 snapshot should have CRC loaded from 0.crc"
     );
 
@@ -914,7 +1098,7 @@ async fn test_incremental_snapshot_old_crc_no_new_crc() -> DeltaResult<()> {
     // builder_from defaults to IncrementalReplay::Disabled, so the v0 CRC is not advanced to
     // v1 and the snapshot carries no CRC. (With Unlimited it would advance to v1.)
     assert!(
-        incremental_v1.crc().is_none(),
+        incremental_v1.crc_at_version().is_none(),
         "CRC at v0 should not be stored on the v1 snapshot (replay disabled)"
     );
 
@@ -1032,12 +1216,12 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
     // Case 1: Post-commit snapshot with in-memory CRC => DM loaded from CRC (fast path).
     //         Use NoJsonReadsEngine to prove no log replay occurs.
     let post_commit_snapshot = committed.post_commit_snapshot().unwrap();
-    assert!(post_commit_snapshot.crc().is_some());
+    assert!(post_commit_snapshot.crc_at_version().is_some());
     assert_domain_metadata(post_commit_snapshot, &FailingEngine);
 
     // Case 2: Fresh snapshot loaded from disk, no CRC file => DM loaded via log replay (slow path)
     let fresh_snapshot_no_crc = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_snapshot_no_crc.crc().is_none());
+    assert!(fresh_snapshot_no_crc.crc_at_version().is_none());
     assert_domain_metadata(&fresh_snapshot_no_crc, engine.as_ref());
 
     // Case 3: Write CRC to disk, then reload fresh snapshot => DM loaded from CRC (fast path)
@@ -1045,7 +1229,7 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
     let _ = post_commit_snapshot.write_checksum(engine.as_ref())?;
 
     let fresh_snapshot_with_crc = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_snapshot_with_crc.crc().is_some());
+    assert!(fresh_snapshot_with_crc.crc_at_version().is_some());
     assert_domain_metadata(&fresh_snapshot_with_crc, &FailingEngine);
 
     Ok(())
@@ -1088,7 +1272,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
     strip_field_from_crc(&table_path, 0, "domainMetadata");
     let snapshot_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(
-        snapshot_v0.crc().unwrap().domain_metadata_state,
+        snapshot_v0.crc_at_version().unwrap().domain_metadata_state,
         DomainMetadataState::Partial(HashMap::new())
     );
 
@@ -1100,7 +1284,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
 
-    let crc_v1 = snapshot_v1.crc().unwrap();
+    let crc_v1 = snapshot_v1.crc_at_version().unwrap();
     let map = crc_v1.domain_metadata_state.expect_partial();
     assert!(map.contains_key("foo"));
 
@@ -1169,7 +1353,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
 
     // Fresh snapshot with CRC on disk serves queries via fast path (no log replay)
     let fresh_v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_v0.crc().is_some());
+    assert!(fresh_v0.crc_at_version().is_some());
     assert_eq!(
         fresh_v0
             .get_app_id_version("my-app", &FailingEngine)
@@ -1206,7 +1390,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     assert!(txns_v1.contains_key("my-app"));
 
     let fresh_v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_v1.crc().is_some());
+    assert!(fresh_v1.crc_at_version().is_some());
     assert_eq!(
         fresh_v1
             .get_app_id_version("my-app", &FailingEngine)
@@ -1249,7 +1433,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     assert_eq!(txns_v2.len(), 2);
 
     let fresh_v2 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert!(fresh_v2.crc().is_some());
+    assert!(fresh_v2.crc_at_version().is_some());
     assert_eq!(
         fresh_v2
             .get_app_id_version("my-app", &FailingEngine)
@@ -1286,7 +1470,10 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
 
     let snapshot_v1_reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(
-        snapshot_v1_reloaded.crc().unwrap().set_transaction_state,
+        snapshot_v1_reloaded
+            .crc_at_version()
+            .unwrap()
+            .set_transaction_state,
         SetTransactionState::Partial(HashMap::new())
     );
 
@@ -1299,7 +1486,7 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
 
     let map = snapshot_v2
-        .crc()
+        .crc_at_version()
         .unwrap()
         .set_transaction_state
         .expect_partial();
@@ -1383,7 +1570,7 @@ async fn test_set_txn_expiration_via_crc_fast_path(
     assert_eq!(snapshot.version(), 1);
 
     // Verify CRC was loaded from disk
-    assert!(snapshot.crc().is_some());
+    assert!(snapshot.crc_at_version().is_some());
 
     // FailingEngine proves the CRC fast path is used (no log replay)
     assert_eq!(
@@ -1439,7 +1626,7 @@ async fn test_partial_set_txn_expired_hit_returns_none_via_fast_path() -> DeltaR
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
 
     let map = snapshot_v2
-        .crc()
+        .crc_at_version()
         .unwrap()
         .set_transaction_state
         .expect_partial();
@@ -1696,7 +1883,7 @@ async fn test_file_histogram_survives_disk_round_trip_then_delta_merge() -> Delt
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     let v1_bytes = snapshot_v1
-        .crc()
+        .crc_at_version()
         .unwrap()
         .file_stats()
         .unwrap()
@@ -1706,7 +1893,7 @@ async fn test_file_histogram_survives_disk_round_trip_then_delta_merge() -> Delt
     // Load a FRESH snapshot from disk at v1 (CRC deserialized from JSON, not in-memory)
     let fresh_v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(fresh_v1.version(), 1);
-    assert!(fresh_v1.crc().is_some());
+    assert!(fresh_v1.crc_at_version().is_some());
 
     // v2: insert using the fresh (disk-loaded) snapshot -- the post-commit CRC at v2
     // is computed by applying the v2 delta to the deserialized v1 CRC
@@ -1791,7 +1978,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     // Load fresh snapshot from disk (reads the possibly-modified CRC)
     let fresh_v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(fresh_v1.version(), 1);
-    assert!(fresh_v1.crc().is_some());
+    assert!(fresh_v1.crc_at_version().is_some());
 
     // ===== WHEN: perform the operation =====
     let snapshot_v2 = if incremental {
@@ -1811,7 +1998,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     };
 
     // ===== THEN: verify histogram state =====
-    let crc_v2 = snapshot_v2.crc().unwrap();
+    let crc_v2 = snapshot_v2.crc_at_version().unwrap();
 
     if !incremental {
         // Non-incremental operations drop the histogram regardless of bin type
@@ -1970,7 +2157,7 @@ async fn test_stale_crc_fresh_build_advance_matrix(
 
     // === Check: CRC presence ===
     assert_eq!(
-        fresh.crc().map(|c| c.version as i64),
+        fresh.crc_at_version().map(|c| c.version as i64),
         expect_crc_present.then_some(LATEST_VERSION)
     );
 
@@ -2067,7 +2254,11 @@ async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> 
         .with_incremental_crc_replay(IncrementalReplay::Unlimited)
         .build(engine.as_ref())?;
     assert_eq!(fresh.version(), 2);
-    assert!(fresh.crc().unwrap().file_stats_state().is_indeterminate());
+    assert!(fresh
+        .crc_at_version()
+        .unwrap()
+        .file_stats_state()
+        .is_indeterminate());
     assert_eq!(fresh.get_file_stats_if_present(), None);
     assert!(matches!(
         fresh.write_checksum(engine.as_ref()),

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -296,7 +296,10 @@ async fn crc_at_prior_version_roots_replay_at_crc_for_both_modes(
     let snap = Snapshot::builder_for(table_url)
         .with_incremental_crc_replay(mode)
         .build(&measure_engine)?;
-    assert_eq!(snap.crc().map(|c| c.version), expected_crc_version);
+    assert_eq!(
+        snap.crc_at_version().map(|c| c.version),
+        expected_crc_version
+    );
 
     assert_eq!(reporter.snapshot_completions.get(), 1);
     assert_eq!(reporter.log_segment_loads.get(), 1);


### PR DESCRIPTION
## What changes are proposed in this pull request?

While building incremental CRC, we had removed the LazyCrc construct. However, that was premature, as we ended up deciding to making incremental CRC replaying during Snapshot construction optional.

This PR re-introduces the cached CRC construct.

A Snapshot can have a CRC, and that CRC can be at-latest, incrementally-dervived-to-latest, or stale.

This PR introduced `SnapshotCrc` which is a wrapper that guards access to the CRC so that callers always know if they are accessing the latest CRC or a potentially-stale one.

This is a building block for DomainMetadata and SetTxn queries that are rooted in CRC and in Snapshots that were not built via incremental state replay.

## How was this change tested?

New UTs.
