### PR TITLE
feat: send User-Agent header on UC Delta-Tables API requests

### DIFF
--- a/unity-catalog-delta-client-api/src/clients/mod.rs
+++ b/unity-catalog-delta-client-api/src/clients/mod.rs
@@ -1,11 +1,21 @@
 use crate::error::Result;
-use crate::models::{CommitRequest, CommitsRequest, CommitsResponse};
+use crate::models::{CommitRequest, CommitsRequest, CommitsResponse, UpdateTableRequest};
 
 #[cfg(any(test, feature = "test-utils"))]
 mod in_memory;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use in_memory::{InMemoryCommitsClient, TableData};
+
+/// Trait for committing new versions to a UC-managed Delta table via the
+/// `update_table` endpoint.
+///
+/// Implementations are responsible for any retry logic on transient failures.
+#[allow(async_fn_in_trait)]
+pub trait UpdateTableClient: Send + Sync {
+    /// Apply the typed `requirements + updates` payload atomically against the catalog.
+    async fn update_table(&self, request: UpdateTableRequest) -> Result<()>;
+}
 
 /// Trait for committing new versions to a UC-managed Delta table.
 ///

--- a/unity-catalog-delta-client-api/src/clients/mod.rs
+++ b/unity-catalog-delta-client-api/src/clients/mod.rs
@@ -17,6 +17,10 @@ pub trait UpdateTableClient: Send + Sync {
     async fn update_table(&self, request: UpdateTableRequest) -> Result<()>;
 }
 
+// The `CommitClient` and `GetCommitsClient` traits below back the legacy Delta-Commits path and
+// are superseded by `UpdateTableClient` (above). They will be deleted once the read and commit
+// paths are swapped onto the new Delta-Tables API.
+
 /// Trait for committing new versions to a UC-managed Delta table.
 ///
 /// Implementations of this trait are responsible for performing any necessary

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -24,9 +24,12 @@ pub mod credentials;
 pub mod error;
 pub mod models;
 
-pub use clients::{CommitClient, GetCommitsClient};
+pub use clients::{CommitClient, GetCommitsClient, UpdateTableClient};
 #[cfg(any(test, feature = "test-utils"))]
 pub use clients::{InMemoryCommitsClient, TableData};
 pub use credentials::{AwsTempCredentials, Operation, TemporaryTableCredentials};
 pub use error::{Error, Result};
-pub use models::{Commit, CommitRequest, CommitsRequest, CommitsResponse};
+pub use models::{
+    CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse, LoadTableResponse,
+    Protocol, Requirement, TableMetadata, Update, UpdateTableRequest,
+};

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! # Traits
 //!
+//! - [`UpdateTableClient`] -- apply typed requirements + updates to a UC-managed Delta table
 //! - [`CommitClient`] -- commit a new version to a UC-managed Delta table
 //! - [`GetCommitsClient`] -- retrieve commits from a UC-managed Delta table
 //!
@@ -30,6 +31,6 @@ pub use clients::{InMemoryCommitsClient, TableData};
 pub use credentials::{AwsTempCredentials, Operation, TemporaryTableCredentials};
 pub use error::{Error, Result};
 pub use models::{
-    CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse, LoadTableResponse,
-    Protocol, Requirement, TableMetadata, Update, UpdateTableRequest,
+    CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse, DeltaTableRequirement,
+    DeltaTableUpdate, LoadTableResponse, Protocol, TableMetadata, UpdateTableRequest,
 };

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -2,6 +2,15 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+// ============================================================================
+// Delta-Commits API (legacy)
+//
+// These types back the current Delta-Commits read/commit path. They are superseded by the
+// Delta-Tables types below (update_table / load_table) and will be deleted once the read and
+// commit paths are swapped onto the new API. Kept here so the crate and its downstream consumers
+// keep compiling during the migration.
+// ============================================================================
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitsRequest {
     pub table_id: String,
@@ -121,7 +130,7 @@ impl CommitRequest {
 /// commit.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "kebab-case")]
-pub enum Requirement {
+pub enum DeltaTableRequirement {
     /// Assert that the table being updated has the given UUID. Used to detect
     /// the case where a table has been dropped and recreated under the same
     /// name between the client's last read and this update.
@@ -134,7 +143,7 @@ pub enum Requirement {
 /// A typed update to apply atomically as part of an `update_table` call.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "action", rename_all = "kebab-case")]
-pub enum Update {
+pub enum DeltaTableUpdate {
     /// Register a new staged commit with the catalog.
     AddCommit { commit: Commit },
     /// Inform the catalog of the latest published version.
@@ -148,19 +157,19 @@ pub enum Update {
 /// (`update_table`) request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UpdateTableRequest {
-    /// Catalog name. Used for URL path only; not serialized.
+    /// Catalog name. Used for URL routing.
     #[serde(skip)]
     pub catalog: String,
-    /// Schema name. Used for URL path only; not serialized.
+    /// Schema name. Used for URL routing.
     #[serde(skip)]
     pub schema: String,
-    /// Table name. Used for URL path only; not serialized.
+    /// Table name. Used for URL routing.
     #[serde(skip)]
     pub table_name: String,
     /// Preconditions the catalog must validate.
-    pub requirements: Vec<Requirement>,
+    pub requirements: Vec<DeltaTableRequirement>,
     /// Updates to apply atomically.
-    pub updates: Vec<Update>,
+    pub updates: Vec<DeltaTableUpdate>,
 }
 
 impl UpdateTableRequest {
@@ -168,31 +177,47 @@ impl UpdateTableRequest {
         catalog: impl Into<String>,
         schema: impl Into<String>,
         table_name: impl Into<String>,
-        requirements: Vec<Requirement>,
-        updates: Vec<Update>,
-    ) -> Self {
-        Self {
+        requirements: Vec<DeltaTableRequirement>,
+        updates: Vec<DeltaTableUpdate>,
+    ) -> crate::error::Result<Self> {
+        let count = |is_variant: fn(&DeltaTableRequirement) -> bool| {
+            requirements.iter().filter(|r| is_variant(r)).count()
+        };
+        if count(|r| matches!(r, DeltaTableRequirement::AssertTableUuid { .. })) > 1 {
+            return Err(crate::error::Error::Generic(
+                "update_table request must not contain more than one AssertTableUuid requirement"
+                    .to_string(),
+            ));
+        }
+        if count(|r| matches!(r, DeltaTableRequirement::AssertEtag { .. })) > 1 {
+            return Err(crate::error::Error::Generic(
+                "update_table request must not contain more than one AssertEtag requirement"
+                    .to_string(),
+            ));
+        }
+        Ok(Self {
             catalog: catalog.into(),
             schema: schema.into(),
             table_name: table_name.into(),
             requirements,
             updates,
-        }
+        })
     }
 
     /// The table UUID asserted by this request's `AssertTableUuid` requirement, if present.
+    /// [`new`](Self::new) guarantees at most one such requirement.
     pub fn table_uuid(&self) -> Option<&str> {
         self.requirements.iter().find_map(|r| match r {
-            Requirement::AssertTableUuid { uuid } => Some(uuid.as_str()),
-            Requirement::AssertEtag { .. } => None,
+            DeltaTableRequirement::AssertTableUuid { uuid } => Some(uuid.as_str()),
+            _ => None,
         })
     }
 
     /// The `AddCommit` staged-commit reference in this request's updates, if present.
-    pub fn add_commit(&self) -> Option<&Commit> {
+    pub fn staged_commit(&self) -> Option<&Commit> {
         self.updates.iter().find_map(|u| match u {
-            Update::AddCommit { commit } => Some(commit),
-            Update::SetLatestBackfilledVersion { .. } => None,
+            DeltaTableUpdate::AddCommit { commit } => Some(commit),
+            _ => None,
         })
     }
 }
@@ -215,6 +240,7 @@ pub struct LoadTableResponse {
     #[serde(default)]
     pub commits: Vec<Commit>,
     /// Optional UniForm conversion metadata. Modeled as opaque JSON.
+    // TODO: decode into a typed struct once a consumer needs UniForm metadata.
     #[serde(default)]
     pub uniform: Option<serde_json::Value>,
     /// Highest version the catalog knows about, including data-only commits.
@@ -276,9 +302,10 @@ pub struct CatalogConfig {
 // Protocol wire type
 // ============================================================================
 
-/// Typed protocol fields used in read responses and credential vending.
+/// Typed Delta protocol wire model (mirrors kernel's `Protocol` action).
 ///
-/// Mirrors Delta's `Protocol` action.
+/// TODO: introduce `CreateTableRequest` and `CreateStagingTableResponse`, which both carry a
+/// typed `protocol` field.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Protocol {
@@ -334,7 +361,7 @@ mod tests {
 
     #[test]
     fn update_add_commit_wire_shape() {
-        let v = serde_json::to_value(Update::AddCommit {
+        let v = serde_json::to_value(DeltaTableUpdate::AddCommit {
             commit: sample_commit(),
         })
         .unwrap();
@@ -344,7 +371,7 @@ mod tests {
 
     #[test]
     fn update_set_latest_backfilled_version_wire_shape() {
-        let v = serde_json::to_value(Update::SetLatestBackfilledVersion {
+        let v = serde_json::to_value(DeltaTableUpdate::SetLatestBackfilledVersion {
             latest_published_version: 9,
         })
         .unwrap();
@@ -354,7 +381,7 @@ mod tests {
 
     #[test]
     fn requirement_assert_table_uuid_wire_shape() {
-        let v = serde_json::to_value(Requirement::AssertTableUuid {
+        let v = serde_json::to_value(DeltaTableRequirement::AssertTableUuid {
             uuid: "abc".to_string(),
         })
         .unwrap();
@@ -364,7 +391,7 @@ mod tests {
 
     #[test]
     fn requirement_assert_etag_wire_shape() {
-        let v = serde_json::to_value(Requirement::AssertEtag {
+        let v = serde_json::to_value(DeltaTableRequirement::AssertEtag {
             etag: "e1".to_string(),
         })
         .unwrap();
@@ -384,7 +411,7 @@ mod tests {
 
     #[test]
     fn update_table_request_skips_routing_fields() {
-        let req = UpdateTableRequest::new("cat", "sch", "tbl", vec![], vec![]);
+        let req = UpdateTableRequest::new("cat", "sch", "tbl", vec![], vec![]).unwrap();
         let v = serde_json::to_value(&req).unwrap();
         let obj = v.as_object().unwrap();
         for key in ["catalog", "schema", "table_name", "table-name"] {
@@ -395,6 +422,94 @@ mod tests {
         }
         assert!(obj.contains_key("requirements"));
         assert!(obj.contains_key("updates"));
+    }
+
+    #[test]
+    fn table_uuid_returns_none_when_only_etag_requirement_present() {
+        let req = UpdateTableRequest::new(
+            "c",
+            "s",
+            "t",
+            vec![DeltaTableRequirement::AssertEtag { etag: "e1".into() }],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(req.table_uuid(), None);
+    }
+
+    #[test]
+    fn table_uuid_returns_uuid_when_assert_table_uuid_present() {
+        let req = UpdateTableRequest::new(
+            "c",
+            "s",
+            "t",
+            vec![DeltaTableRequirement::AssertTableUuid { uuid: "abc".into() }],
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(req.table_uuid(), Some("abc"));
+    }
+
+    #[test]
+    fn new_rejects_duplicate_requirements() {
+        for dup in [
+            vec![
+                DeltaTableRequirement::AssertTableUuid { uuid: "a".into() },
+                DeltaTableRequirement::AssertTableUuid { uuid: "b".into() },
+            ],
+            vec![
+                DeltaTableRequirement::AssertEtag { etag: "e1".into() },
+                DeltaTableRequirement::AssertEtag { etag: "e2".into() },
+            ],
+        ] {
+            assert!(
+                UpdateTableRequest::new("c", "s", "t", dup, vec![]).is_err(),
+                "duplicate requirement of the same type must be rejected"
+            );
+        }
+
+        // One of each type is allowed.
+        assert!(UpdateTableRequest::new(
+            "c",
+            "s",
+            "t",
+            vec![
+                DeltaTableRequirement::AssertTableUuid { uuid: "a".into() },
+                DeltaTableRequirement::AssertEtag { etag: "e1".into() },
+            ],
+            vec![],
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn staged_commit_returns_commit_when_add_commit_present() {
+        let req = UpdateTableRequest::new(
+            "c",
+            "s",
+            "t",
+            vec![],
+            vec![DeltaTableUpdate::AddCommit {
+                commit: sample_commit(),
+            }],
+        )
+        .unwrap();
+        assert_eq!(req.staged_commit(), Some(&sample_commit()));
+    }
+
+    #[test]
+    fn staged_commit_returns_none_when_no_add_commit_present() {
+        let req = UpdateTableRequest::new(
+            "c",
+            "s",
+            "t",
+            vec![],
+            vec![DeltaTableUpdate::SetLatestBackfilledVersion {
+                latest_published_version: 9,
+            }],
+        )
+        .unwrap();
+        assert_eq!(req.staged_commit(), None);
     }
 
     #[test]

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,7 +40,8 @@ pub struct CommitsResponse {
     pub latest_table_version: i64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Commit {
     pub version: i64,
     pub timestamp: i64,
@@ -108,4 +111,299 @@ impl CommitRequest {
     }
 
     // TODO: expose metadata/protocol (with_metadata, with_protocol)
+}
+
+// ============================================================================
+// update_table: typed requirements + updates
+// ============================================================================
+
+/// A precondition that the catalog server must validate before applying a
+/// commit.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum Requirement {
+    /// Assert that the table being updated has the given UUID. Used to detect
+    /// the case where a table has been dropped and recreated under the same
+    /// name between the client's last read and this update.
+    AssertTableUuid { uuid: String },
+    /// Assert that the table's etag matches the expected value. Used for
+    /// optimistic-concurrency control on metadata-only updates.
+    AssertEtag { etag: String },
+}
+
+/// A typed update to apply atomically as part of an `update_table` call.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "kebab-case")]
+pub enum Update {
+    /// Register a new staged commit with the catalog.
+    AddCommit { commit: Commit },
+    /// Inform the catalog of the latest published version.
+    SetLatestBackfilledVersion {
+        #[serde(rename = "latest-published-version")]
+        latest_published_version: i64,
+    },
+}
+
+/// Body of a `POST /delta/v1/catalogs/{c}/schemas/{s}/tables/{t}`
+/// (`update_table`) request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UpdateTableRequest {
+    /// Catalog name. Used for URL path only; not serialized.
+    #[serde(skip)]
+    pub catalog: String,
+    /// Schema name. Used for URL path only; not serialized.
+    #[serde(skip)]
+    pub schema: String,
+    /// Table name. Used for URL path only; not serialized.
+    #[serde(skip)]
+    pub table_name: String,
+    /// Preconditions the catalog must validate.
+    pub requirements: Vec<Requirement>,
+    /// Updates to apply atomically.
+    pub updates: Vec<Update>,
+}
+
+impl UpdateTableRequest {
+    pub fn new(
+        catalog: impl Into<String>,
+        schema: impl Into<String>,
+        table_name: impl Into<String>,
+        requirements: Vec<Requirement>,
+        updates: Vec<Update>,
+    ) -> Self {
+        Self {
+            catalog: catalog.into(),
+            schema: schema.into(),
+            table_name: table_name.into(),
+            requirements,
+            updates,
+        }
+    }
+
+    /// The table UUID asserted by this request's `AssertTableUuid` requirement, if present.
+    pub fn table_uuid(&self) -> Option<&str> {
+        self.requirements.iter().find_map(|r| match r {
+            Requirement::AssertTableUuid { uuid } => Some(uuid.as_str()),
+            Requirement::AssertEtag { .. } => None,
+        })
+    }
+
+    /// The `AddCommit` staged-commit reference in this request's updates, if present.
+    pub fn add_commit(&self) -> Option<&Commit> {
+        self.updates.iter().find_map(|u| match u {
+            Update::AddCommit { commit } => Some(commit),
+            Update::SetLatestBackfilledVersion { .. } => None,
+        })
+    }
+}
+
+// ============================================================================
+// load_table: read-side response
+// ============================================================================
+
+/// Response from `GET /delta/v1/catalogs/{c}/schemas/{s}/tables/{t}`
+/// (`load_table`).
+///
+/// The server returns the table's full metadata plus any unpublished commits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct LoadTableResponse {
+    /// Full table metadata.
+    pub metadata: TableMetadata,
+    /// Unpublished commits known to the catalog at this read, in descending
+    /// version order (newest first).
+    #[serde(default)]
+    pub commits: Vec<Commit>,
+    /// Optional UniForm conversion metadata. Modeled as opaque JSON.
+    #[serde(default)]
+    pub uniform: Option<serde_json::Value>,
+    /// Highest version the catalog knows about, including data-only commits.
+    /// Compare with `metadata.last_commit_version`, which only tracks
+    /// metadata-changing commits.
+    #[serde(default)]
+    pub latest_table_version: Option<i64>,
+}
+
+/// Full table metadata returned by `load_table`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TableMetadata {
+    /// Entity tag for optimistic-concurrency control.
+    pub etag: String,
+    /// Table type, e.g. `"MANAGED"` or `"EXTERNAL"`.
+    pub table_type: String,
+    /// Stable table UUID, matching `Metadata.id` in the Delta log.
+    pub table_uuid: String,
+    /// Cloud-storage location of the table's `_delta_log/` parent.
+    pub location: String,
+    /// Creation time in epoch milliseconds.
+    pub created_time: i64,
+    /// Last update time in epoch milliseconds.
+    pub updated_time: i64,
+    /// Schema as a Delta `StructType` JSON value.
+    pub columns: serde_json::Value,
+    /// Partition column names, in declaration order.
+    #[serde(default)]
+    pub partition_columns: Vec<String>,
+    /// Raw `metaData.configuration` properties.
+    pub properties: HashMap<String, String>,
+    /// Version of the last commit that changed table metadata.
+    #[serde(default)]
+    pub last_commit_version: Option<i64>,
+    /// Timestamp of the last metadata-changing commit, in epoch milliseconds.
+    #[serde(default)]
+    pub last_commit_timestamp_ms: Option<i64>,
+}
+
+// ============================================================================
+// /config: protocol negotiation
+// ============================================================================
+
+/// Response from `GET /delta/v1/config`.
+///
+/// The server returns the list of versioned endpoints the client should use
+/// for subsequent calls, plus the negotiated protocol version.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct CatalogConfig {
+    /// Supported endpoints, e.g. `"POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables"`.
+    pub endpoints: Vec<String>,
+    /// Negotiated protocol version, e.g. `"1.0"`.
+    pub protocol_version: String,
+}
+
+// ============================================================================
+// Protocol wire type
+// ============================================================================
+
+/// Typed protocol fields used in read responses and credential vending.
+///
+/// Mirrors Delta's `Protocol` action.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct Protocol {
+    /// Minimum reader version required to read the table.
+    pub min_reader_version: i32,
+    /// Minimum writer version required to write to the table.
+    pub min_writer_version: i32,
+    /// Reader features (Delta's `readerFeatures` list).
+    #[serde(default)]
+    pub reader_features: Vec<String>,
+    /// Writer features (Delta's `writerFeatures` list).
+    #[serde(default)]
+    pub writer_features: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_table_response_decodes_full_body() {
+        // Both load_table and update_table return this full table-state body. Decode a
+        // representative one and pin the kebab-case field renames on TableMetadata.
+        let body = r#"{
+            "metadata": {
+                "etag": "e1",
+                "table-type": "MANAGED",
+                "table-uuid": "abc",
+                "location": "s3://bucket/t",
+                "created-time": 1,
+                "updated-time": 2,
+                "columns": {"type": "struct", "fields": []},
+                "partition-columns": ["p"],
+                "properties": {},
+                "last-commit-version": 5,
+                "last-commit-timestamp-ms": 6
+            },
+            "commits": [],
+            "latest-table-version": 7
+        }"#;
+        let resp: LoadTableResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(resp.metadata.table_type, "MANAGED");
+        assert_eq!(resp.metadata.table_uuid, "abc");
+        assert_eq!(resp.metadata.last_commit_timestamp_ms, Some(6));
+        assert_eq!(resp.latest_table_version, Some(7));
+    }
+
+    // === Serde golden tests: pin the wire tag + renamed keys for the tagged enums. ===
+
+    fn sample_commit() -> Commit {
+        Commit::new(7, 1234, "00000000000000000007.uuid.json", 100, 5678)
+    }
+
+    #[test]
+    fn update_add_commit_wire_shape() {
+        let v = serde_json::to_value(Update::AddCommit {
+            commit: sample_commit(),
+        })
+        .unwrap();
+        assert_eq!(v["action"], "add-commit");
+        assert!(v.get("commit").is_some());
+    }
+
+    #[test]
+    fn update_set_latest_backfilled_version_wire_shape() {
+        let v = serde_json::to_value(Update::SetLatestBackfilledVersion {
+            latest_published_version: 9,
+        })
+        .unwrap();
+        assert_eq!(v["action"], "set-latest-backfilled-version");
+        assert_eq!(v["latest-published-version"], 9);
+    }
+
+    #[test]
+    fn requirement_assert_table_uuid_wire_shape() {
+        let v = serde_json::to_value(Requirement::AssertTableUuid {
+            uuid: "abc".to_string(),
+        })
+        .unwrap();
+        assert_eq!(v["type"], "assert-table-uuid");
+        assert_eq!(v["uuid"], "abc");
+    }
+
+    #[test]
+    fn requirement_assert_etag_wire_shape() {
+        let v = serde_json::to_value(Requirement::AssertEtag {
+            etag: "e1".to_string(),
+        })
+        .unwrap();
+        assert_eq!(v["type"], "assert-etag");
+        assert_eq!(v["etag"], "e1");
+    }
+
+    #[test]
+    fn commit_wire_shape() {
+        let v = serde_json::to_value(sample_commit()).unwrap();
+        assert_eq!(v["version"], 7);
+        assert_eq!(v["timestamp"], 1234);
+        assert_eq!(v["file-name"], "00000000000000000007.uuid.json");
+        assert_eq!(v["file-size"], 100);
+        assert_eq!(v["file-modification-timestamp"], 5678);
+    }
+
+    #[test]
+    fn update_table_request_skips_routing_fields() {
+        let req = UpdateTableRequest::new("cat", "sch", "tbl", vec![], vec![]);
+        let v = serde_json::to_value(&req).unwrap();
+        let obj = v.as_object().unwrap();
+        for key in ["catalog", "schema", "table_name", "table-name"] {
+            assert!(
+                !obj.contains_key(key),
+                "routing field {key} must not be serialized"
+            );
+        }
+        assert!(obj.contains_key("requirements"));
+        assert!(obj.contains_key("updates"));
+    }
+
+    #[test]
+    fn catalog_config_decodes_kebab_protocol_version() {
+        let config: CatalogConfig = serde_json::from_str(
+            r#"{"endpoints": ["POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables"], "protocol-version": "1.0"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.protocol_version, "1.0");
+        assert_eq!(config.endpoints.len(), 1);
+    }
 }

--- a/unity-catalog-delta-rest-client/src/clients/commits.rs
+++ b/unity-catalog-delta-rest-client/src/clients/commits.rs
@@ -13,6 +13,9 @@ use crate::http::{build_http_client, execute_with_retry, handle_response};
 struct EmptyResponse {}
 
 /// REST implementation of [CommitClient] and [GetCommitsClient].
+///
+/// Backs the legacy Delta-Commits path and will be deleted once the read and commit paths are
+/// swapped onto the new Delta-Tables API.
 #[derive(Debug, Clone)]
 pub struct UCCommitsRestClient {
     http_client: reqwest::Client,

--- a/unity-catalog-delta-rest-client/src/config.rs
+++ b/unity-catalog-delta-rest-client/src/config.rs
@@ -4,15 +4,41 @@ use url::Url;
 
 use crate::error::Result;
 
-#[derive(Debug, Clone)]
+/// Default `User-Agent` identifying this client. Override via
+/// [`ClientConfigBuilder::with_user_agent`] if UC expects a particular value.
+fn default_user_agent() -> String {
+    format!(
+        "Delta/{v} delta-kernel-rs/{v}",
+        v = env!("CARGO_PKG_VERSION")
+    )
+}
+
+#[derive(Clone)]
 pub struct ClientConfig {
     pub workspace_url: Url,
     pub token: String,
+    pub user_agent: String,
     pub timeout: Duration,
     pub connect_timeout: Duration,
     pub max_retries: u32,
     pub retry_base_delay: Duration,
     pub retry_max_delay: Duration,
+}
+
+// Manual Debug to avoid leaking the bearer token.
+impl std::fmt::Debug for ClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientConfig")
+            .field("workspace_url", &self.workspace_url)
+            .field("token", &"***")
+            .field("user_agent", &self.user_agent)
+            .field("timeout", &self.timeout)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("max_retries", &self.max_retries)
+            .field("retry_base_delay", &self.retry_base_delay)
+            .field("retry_max_delay", &self.retry_max_delay)
+            .finish()
+    }
 }
 
 impl ClientConfig {
@@ -36,6 +62,7 @@ impl ClientConfig {
         Ok(Self {
             workspace_url,
             token: token.into(),
+            user_agent: default_user_agent(),
             timeout: Duration::from_secs(30),
             connect_timeout: Duration::from_secs(10),
             max_retries: 3,
@@ -52,6 +79,7 @@ impl ClientConfig {
 pub struct ClientConfigBuilder {
     workspace: String,
     token: String,
+    user_agent: String,
     timeout: Duration,
     connect_timeout: Duration,
     max_retries: u32,
@@ -64,12 +92,19 @@ impl ClientConfigBuilder {
         Self {
             workspace: workspace.into(),
             token: token.into(),
+            user_agent: default_user_agent(),
             timeout: Duration::from_secs(30),
             connect_timeout: Duration::from_secs(10),
             max_retries: 3,
             retry_base_delay: Duration::from_millis(500),
             retry_max_delay: Duration::from_secs(10),
         }
+    }
+
+    /// Override the `User-Agent` header with the value the catalog expects for your connector.
+    pub fn with_user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = user_agent.into();
+        self
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
@@ -95,6 +130,7 @@ impl ClientConfigBuilder {
 
     pub fn build(self) -> Result<ClientConfig> {
         let mut config = ClientConfig::new(self.workspace, self.token)?;
+        config.user_agent = self.user_agent;
         config.timeout = self.timeout;
         config.connect_timeout = self.connect_timeout;
         config.max_retries = self.max_retries;
@@ -138,5 +174,30 @@ mod tests {
             .as_str()
             .contains("api/2.1/unity-catalog"));
         assert_eq!(config.token, "token");
+    }
+
+    #[test]
+    fn with_user_agent_overrides_default() {
+        let default = ClientConfig::build("example.com", "t").build().unwrap();
+        assert_eq!(default.user_agent, default_user_agent());
+
+        let overridden = ClientConfig::build("example.com", "t")
+            .with_user_agent("MyConnector/1.2.3")
+            .build()
+            .unwrap();
+        assert_eq!(overridden.user_agent, "MyConnector/1.2.3");
+    }
+
+    #[test]
+    fn debug_redacts_bearer_token() {
+        let config = ClientConfig::build("example.com", "super-secret-token")
+            .build()
+            .unwrap();
+        let debug = format!("{config:?}");
+        assert!(
+            !debug.contains("super-secret-token"),
+            "token leaked: {debug}"
+        );
+        assert!(debug.contains("***"), "redaction marker missing: {debug}");
     }
 }

--- a/unity-catalog-delta-rest-client/src/http.rs
+++ b/unity-catalog-delta-rest-client/src/http.rs
@@ -17,6 +17,11 @@ pub fn build_http_client(config: &ClientConfig) -> Result<Client> {
             header::CONTENT_TYPE,
             header::HeaderValue::from_static("application/json"),
         ),
+        // Identifies the calling client to UC.
+        (
+            header::USER_AGENT,
+            header::HeaderValue::from_str(&config.user_agent)?,
+        ),
     ]);
 
     let client = Client::builder()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2909/files/ea47f4056ad37feff943e939a62f06c2e96b984d..95b2f21c16273531af03afb3478c8a1915a8097a) to review incremental changes.
- [stack/uc-client-models](https://github.com/delta-io/delta-kernel-rs/pull/2906) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2906/files)]
  - [**stack/uc-user-agent**](https://github.com/delta-io/delta-kernel-rs/pull/2909) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2909/files/ea47f4056ad37feff943e939a62f06c2e96b984d..95b2f21c16273531af03afb3478c8a1915a8097a)] ← _this PR_
    - [stack/uc-e2e-smoke](https://github.com/delta-io/delta-kernel-rs/pull/2925) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2925/files/95b2f21c16273531af03afb3478c8a1915a8097a..7f22ffb456761b0ff2d956382bb6a2a657b7500c)]
      - [stack/uc-core](https://github.com/delta-io/delta-kernel-rs/pull/2855) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2855/files/7f22ffb456761b0ff2d956382bb6a2a657b7500c..96781da6094eec3bebd7a1dfd86fa30065af3abe)]
        - [stack/uc-api-v2](https://github.com/delta-io/delta-kernel-rs/pull/2826) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2826/files/96781da6094eec3bebd7a1dfd86fa30065af3abe..f981f90fefd45b33cfc59bfbfcadf9c06c4173ff)]

---------
## What changes are proposed in this pull request?

This change adds a `User-Agent` header to requests made by the UC REST client. `ClientConfig` gains a `user_agent` field defaulting to `Delta/<ver> delta-kernel-rs/<ver>`, with a `ClientConfigBuilder::with_user_agent` override. This change replaces the derived `Debug` on `ClientConfig` with a manual impl that redacts the bearer token so it can't leak into logs.

## How was this change tested?
New unit tests, existing UC tests pass. This change was also tested E2E on the OSS UC server at the top of the PR stack.
