### PR TITLE
refactor: make StorageHandler::list_from single-directory

### DIFF
--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use delta_kernel::object_store::list::{PaginatedListOptions, PaginatedListStore};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{self, DynObjectStore, ObjectStoreExt as _, PutMode};
 use delta_kernel::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
@@ -11,17 +12,35 @@ use url::Url;
 use crate::executor::TaskExecutor;
 use crate::UrlExt;
 
-#[derive(Debug)]
 pub struct ObjectStoreStorageHandler<E: TaskExecutor> {
     inner: Arc<DynObjectStore>,
+    /// Present only for backends implementing [`PaginatedListStore`] (S3/GCS/Azure), which push
+    /// the single-directory delimiter into the listing request. `None` for local/memory/http and
+    /// custom stores, which fall back to a client-side direct-children filter.
+    paginated: Option<Arc<dyn PaginatedListStore>>,
     task_executor: Arc<E>,
     readahead: usize,
 }
 
+impl<E: TaskExecutor> std::fmt::Debug for ObjectStoreStorageHandler<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectStoreStorageHandler")
+            .field("inner", &self.inner)
+            .field("paginated", &self.paginated.is_some())
+            .field("readahead", &self.readahead)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
-    pub(crate) fn new(store: Arc<DynObjectStore>, task_executor: Arc<E>) -> Self {
+    pub(crate) fn new(
+        store: Arc<DynObjectStore>,
+        paginated: Option<Arc<dyn PaginatedListStore>>,
+        task_executor: Arc<E>,
+    ) -> Self {
         Self {
             inner: store,
+            paginated,
             task_executor,
             readahead: 10,
         }
@@ -34,21 +53,13 @@ impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
     }
 }
 
-/// Native async implementation for list_from.
+/// Derives the `(prefix, offset)` pair for a `list_from` request from `path`.
 ///
-/// Storage metrics are emitted by the outer [`MeteredStorageHandler`] wrapping this
-/// handler (e.g. inside `DefaultEngine`'s `storage_handler()`), so this function just
-/// returns the raw stream.
-///
-/// [`MeteredStorageHandler`]: delta_kernel::metrics::MeteredStorageHandler
-async fn list_from_impl(
-    store: Arc<DynObjectStore>,
-    path: Url,
-) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
-    // The offset is used for list-after; the prefix is used to restrict the listing to a specific
-    // directory. Unfortunately, `Path` provides no easy way to check whether a name is
-    // directory-like, because it strips trailing /, so we're reduced to manually checking the
-    // original URL.
+/// The offset is the list-after lower bound; the prefix restricts the listing to a single
+/// directory. `Path` strips trailing slashes, so directory-vs-file is decided from the original
+/// URL: a directory-like `path` (ends with `/`) lists its own contents, otherwise the parent
+/// directory is listed after `path`.
+fn list_scope(path: &Url) -> DeltaResult<(Path, Path)> {
     let offset = Path::from_url_path(path.path())?;
     let prefix = if path.path().ends_with('/') {
         offset.clone()
@@ -61,20 +72,68 @@ async fn list_from_impl(
         }
         Path::from_iter(parts)
     };
+    Ok((prefix, offset))
+}
+
+/// Builds a [`FileMeta`] URL from a listed object's store-relative [`Path`], reusing `base`'s
+/// scheme and authority.
+fn file_meta_from_object(base: &Url, location: &Path, last_modified: i64, size: u64) -> FileMeta {
+    let mut url = base.clone();
+    url.set_path(&format!("/{}", location.as_ref()));
+    FileMeta {
+        location: url,
+        last_modified,
+        size,
+    }
+}
+
+/// Native async implementation for list_from.
+///
+/// [`StorageHandler::list_from`] is single-directory: only the direct children of the listed
+/// directory are returned. Two paths deliver this:
+/// - Path A ([`list_one_level_paginated`]): when a [`PaginatedListStore`] handle is present, the
+///   `/` delimiter is pushed into the request so the store never descends into subdirectories.
+/// - Path B: otherwise, the recursive `list_with_offset` stream is filtered client-side to direct
+///   children only.
+///
+/// Storage metrics are emitted by the outer [`MeteredStorageHandler`] wrapping this
+/// handler (e.g. inside `DefaultEngine`'s `storage_handler()`), so this function just
+/// returns the raw stream.
+///
+/// [`MeteredStorageHandler`]: delta_kernel::metrics::MeteredStorageHandler
+async fn list_from_impl(
+    store: Arc<DynObjectStore>,
+    paginated: Option<Arc<dyn PaginatedListStore>>,
+    path: Url,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    let (prefix, offset) = list_scope(&path)?;
+
+    if let Some(paginated) = paginated {
+        let files = list_one_level_paginated(paginated, path, prefix, offset).await?;
+        return Ok(Box::pin(stream::iter(files.into_iter().map(Ok))));
+    }
 
     let has_ordered_listing = supports_ordered_listing(&path);
-
+    let filter_prefix = prefix.clone();
     let stream = store
         .list_with_offset(Some(&prefix), &offset)
+        // Single-directory contract: drop entries nested below `prefix`. `prefix_match` yields the
+        // path parts after `prefix`; a direct child has exactly one remaining part (its filename).
+        .try_filter(move |meta| {
+            let is_direct_child = meta
+                .location
+                .prefix_match(&filter_prefix)
+                .is_some_and(|parts| parts.count() == 1);
+            futures::future::ready(is_direct_child)
+        })
         .map(move |meta| {
             let meta = meta?;
-            let mut location = path.clone();
-            location.set_path(&format!("/{}", meta.location.as_ref()));
-            Ok(FileMeta {
-                location,
-                last_modified: meta.last_modified.timestamp_millis(),
-                size: meta.size,
-            })
+            Ok(file_meta_from_object(
+                &path,
+                &meta.location,
+                meta.last_modified.timestamp_millis(),
+                meta.size,
+            ))
         });
 
     if !has_ordered_listing {
@@ -87,6 +146,54 @@ async fn list_from_impl(
     } else {
         Ok(Box::pin(stream))
     }
+}
+
+/// Path A: list a single directory level via [`PaginatedListStore`], starting after `offset`.
+///
+/// The `/` delimiter makes the store return direct children in `objects` and subdirectories in
+/// `common_prefixes` (ignored here), so nested files are never fetched. `list_paginated` does not
+/// guarantee ordering, so the collected results are sorted before returning to satisfy the
+/// sorted-listing contract that [`StorageHandler::list_from`] callers rely on.
+async fn list_one_level_paginated(
+    paginated: Arc<dyn PaginatedListStore>,
+    base_url: Url,
+    prefix: Path,
+    offset: Path,
+) -> DeltaResult<Vec<FileMeta>> {
+    // `list_paginated` does not append a trailing delimiter to the prefix (unlike
+    // `ObjectStore::list`), so a slash-less prefix would roll every direct child into a
+    // `common_prefix` and return no objects. Append it here, treating an empty prefix as a root
+    // listing (no prefix).
+    let prefix = (!prefix.as_ref().is_empty()).then(|| format!("{}/", prefix.as_ref()));
+    let mut out = Vec::new();
+    let mut page_token = None;
+    loop {
+        let result = paginated
+            .list_paginated(
+                prefix.as_deref(),
+                PaginatedListOptions {
+                    offset: Some(offset.to_string()),
+                    delimiter: Some("/".into()),
+                    page_token,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        for meta in result.result.objects {
+            out.push(file_meta_from_object(
+                &base_url,
+                &meta.location,
+                meta.last_modified.timestamp_millis(),
+                meta.size,
+            ));
+        }
+        match result.page_token {
+            Some(token) => page_token = Some(token),
+            None => break,
+        }
+    }
+    out.sort_unstable();
+    Ok(out)
 }
 
 /// Native async implementation for read_files
@@ -192,7 +299,7 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
         &self,
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
-        let future = list_from_impl(self.inner.clone(), path.clone());
+        let future = list_from_impl(self.inner.clone(), self.paginated.clone(), path.clone());
         let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
         Ok(iter) // type coercion drops the unneeded Send bound
     }
@@ -290,7 +397,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = Arc::new(LocalFileSystem::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
-        let handler = ObjectStoreStorageHandler::new(store.clone(), executor);
+        let handler = ObjectStoreStorageHandler::new(store.clone(), None, executor);
         (tmp, store, handler)
     }
 
@@ -337,7 +444,7 @@ mod tests {
 
         let store = Arc::new(LocalFileSystem::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
-        let storage = ObjectStoreStorageHandler::new(store, executor);
+        let storage = ObjectStoreStorageHandler::new(store, None, executor);
 
         let mut slices: Vec<FileSlice> = Vec::new();
 
@@ -371,7 +478,7 @@ mod tests {
         let engine = DefaultEngineBuilder::new(store).build();
         let files: Vec<_> = engine
             .storage_handler()
-            .list_from(&table_root.join("_delta_log").unwrap().join("0").unwrap())
+            .list_from(&table_root.join("_delta_log/").unwrap().join("0").unwrap())
             .unwrap()
             .try_collect()
             .unwrap();
@@ -401,7 +508,7 @@ mod tests {
         let engine = DefaultEngineBuilder::new(store).build();
         let files = engine
             .storage_handler()
-            .list_from(&url.join("_delta_log").unwrap().join("0").unwrap())
+            .list_from(&url.join("_delta_log/").unwrap().join("0").unwrap())
             .unwrap();
         let mut len = 0;
         for (file, expected) in files.zip(expected_names.iter()) {
@@ -556,5 +663,115 @@ mod tests {
             Err(Error::FileNotFound(_))
         ));
         handler.delete(&missing_url).unwrap();
+    }
+
+    // === single-directory listing ===
+
+    /// A [`PaginatedListStore`] over an in-memory store that reproduces real cloud (S3/GCS/Azure)
+    /// semantics: raw-string prefix matching plus `/` delimiter grouping, where every key with a
+    /// further `/` after the prefix rolls into a `common_prefix` and is excluded from `objects`.
+    /// This differs from [`InMemory::list_with_delimiter`], which matches on `Path` segments and so
+    /// would tolerate a prefix missing its trailing slash. Returns objects reverse-sorted to verify
+    /// the paginated path sorts its results.
+    #[derive(Debug)]
+    struct ReverseSortedPaginatedStore(Arc<InMemory>);
+
+    #[async_trait::async_trait]
+    impl PaginatedListStore for ReverseSortedPaginatedStore {
+        async fn list_paginated(
+            &self,
+            prefix: Option<&str>,
+            opts: PaginatedListOptions,
+        ) -> object_store::Result<delta_kernel::object_store::list::PaginatedListResult> {
+            use delta_kernel::object_store::ObjectStore as _;
+            use futures::TryStreamExt as _;
+            assert_eq!(opts.delimiter.as_deref(), Some("/"), "Path A must pass '/'");
+            let prefix = prefix.unwrap_or("");
+            let all: Vec<_> = self.0.list(None).try_collect().await?;
+            let mut objects: Vec<_> = all
+                .into_iter()
+                .filter(|meta| {
+                    let key = meta.location.as_ref();
+                    // Raw-string prefix match, then exclude keys nested below a delimiter (they
+                    // roll into a common prefix on real cloud stores).
+                    key.strip_prefix(prefix)
+                        .is_some_and(|rest| !rest.contains('/'))
+                })
+                .filter(|meta| {
+                    opts.offset
+                        .as_deref()
+                        .is_none_or(|offset| meta.location.as_ref() > offset)
+                })
+                .collect();
+            objects.sort_unstable_by(|a, b| b.location.cmp(&a.location));
+            let result = delta_kernel::object_store::ListResult {
+                objects,
+                common_prefixes: Vec::new(),
+            };
+            Ok(delta_kernel::object_store::list::PaginatedListResult {
+                result,
+                page_token: None,
+            })
+        }
+    }
+
+    /// Seeds a `_delta_log/` with three commits, a checkpoint at v2, and `staged_count` staged
+    /// commits under `_staged_commits/`. Returns the store and the table root URL.
+    async fn seed_log_with_staged_commits(staged_count: u64) -> (Arc<InMemory>, Url) {
+        let store = Arc::new(InMemory::new());
+        let data = Bytes::from("x");
+        for v in 0..3 {
+            store
+                .put(&delta_path_for_version(v, "json"), data.clone().into())
+                .await
+                .unwrap();
+        }
+        store
+            .put(
+                &delta_path_for_version(2, "checkpoint.parquet"),
+                data.clone().into(),
+            )
+            .await
+            .unwrap();
+        for v in 0..staged_count {
+            let uuid = uuid::Uuid::new_v4();
+            let path = Path::from(format!("_delta_log/_staged_commits/{v:020}.{uuid}.json"));
+            store.put(&path, data.clone().into()).await.unwrap();
+        }
+        (store, Url::parse("memory:///").unwrap())
+    }
+
+    #[rstest::rstest]
+    #[case::path_a_paginated(true)]
+    #[case::path_b_fallback(false)]
+    #[tokio::test]
+    async fn list_from_single_directory_omits_staged_commits(#[case] use_paginated: bool) {
+        let (store, table_root) = seed_log_with_staged_commits(20).await;
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let paginated: Option<Arc<dyn PaginatedListStore>> =
+            use_paginated.then(|| Arc::new(ReverseSortedPaginatedStore(store.clone())) as _);
+        let handler = ObjectStoreStorageHandler::new(store, paginated, executor);
+
+        let start = table_root.join("_delta_log/").unwrap().join("0").unwrap();
+        let files: Vec<_> = handler.list_from(&start).unwrap().try_collect().unwrap();
+
+        let names: Vec<_> = files
+            .iter()
+            .map(|f| f.location.path().to_string())
+            .collect();
+        // Only direct children of _delta_log/ are listed, sorted; no _staged_commits/ files.
+        assert_eq!(
+            names,
+            vec![
+                "/_delta_log/00000000000000000000.json",
+                "/_delta_log/00000000000000000001.json",
+                "/_delta_log/00000000000000000002.checkpoint.parquet",
+                "/_delta_log/00000000000000000002.json",
+            ]
+        );
+        assert!(
+            names.iter().all(|n| !n.contains("_staged_commits")),
+            "staged commits must never be listed: {names:?}"
+        );
     }
 }

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -14,6 +14,7 @@ use delta_kernel::engine::arrow_conversion::TryFromArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
 use delta_kernel::metrics::{MeteredJsonHandler, MeteredParquetHandler, MeteredStorageHandler};
+use delta_kernel::object_store::list::PaginatedListStore;
 use delta_kernel::object_store::DynObjectStore;
 use delta_kernel::schema::Schema;
 use delta_kernel::transaction::WriteContext;
@@ -124,14 +125,27 @@ pub struct DefaultEngine<E: TaskExecutor> {
 ///     .with_task_executor(Arc::new(TokioBackgroundExecutor::new()))
 ///     .build();
 /// ```
-#[derive(Debug)]
 pub struct DefaultEngineBuilder<E> {
     object_store: Arc<DynObjectStore>,
+    /// Optional [`PaginatedListStore`] handle enabling single-directory log listing (delimiter
+    /// pushdown) on backends that support it. `None` uses the client-side fallback.
+    paginated: Option<Arc<dyn PaginatedListStore>>,
     /// The state is either [`DefaultTaskExecutor`] or `Arc<E>` with a custom task executor.
     task_executor: E,
     /// Read-path I/O concurrency config applied to the JSON and Parquet handlers. `None` fields
     /// fall back to the handlers' defaults.
     io_config: ReadIoConfig,
+}
+
+impl<E: std::fmt::Debug> std::fmt::Debug for DefaultEngineBuilder<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultEngineBuilder")
+            .field("object_store", &self.object_store)
+            .field("paginated", &self.paginated.is_some())
+            .field("task_executor", &self.task_executor)
+            .field("io_config", &self.io_config)
+            .finish()
+    }
 }
 
 /// Read-path I/O tuning for [`DefaultEngine`]'s JSON and Parquet handlers.
@@ -155,6 +169,7 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
     pub fn new(object_store: Arc<DynObjectStore>) -> Self {
         Self {
             object_store,
+            paginated: None,
             task_executor: DefaultTaskExecutor,
             io_config: ReadIoConfig::default(),
         }
@@ -163,7 +178,12 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
         let task_executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
-        DefaultEngine::new_with_opts(self.object_store, task_executor, self.io_config)
+        DefaultEngine::new_with_opts(
+            self.object_store,
+            self.paginated,
+            task_executor,
+            self.io_config,
+        )
     }
 }
 
@@ -177,9 +197,22 @@ impl<E> DefaultEngineBuilder<E> {
     ) -> DefaultEngineBuilder<Arc<F>> {
         DefaultEngineBuilder {
             object_store: self.object_store,
+            paginated: self.paginated,
             task_executor,
             io_config: self.io_config,
         }
+    }
+
+    /// Enable single-level log listing (delimiter pushdown) for a store that also
+    /// implements [`PaginatedListStore`]. This is typically the same concrete
+    /// `Arc<AmazonS3>` / `Arc<GoogleCloudStorage>` / `Arc<MicrosoftAzure>` passed to [`Self::new`],
+    /// which coerces to both trait objects independently.
+    ///
+    /// Without this, log listing falls back to a recursive listing filtered to direct children
+    /// client-side, which is correct but pages through subdirectories.
+    pub fn with_paginated_list_store(mut self, paginated: Arc<dyn PaginatedListStore>) -> Self {
+        self.paginated = Some(paginated);
+        self
     }
 
     /// Set the maximum number of files read concurrently by the JSON and Parquet handlers in their
@@ -207,7 +240,12 @@ impl<E> DefaultEngineBuilder<E> {
 impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<E> {
-        DefaultEngine::new_with_opts(self.object_store, self.task_executor, self.io_config)
+        DefaultEngine::new_with_opts(
+            self.object_store,
+            self.paginated,
+            self.task_executor,
+            self.io_config,
+        )
     }
 }
 
@@ -225,11 +263,13 @@ impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
 impl<E: TaskExecutor> DefaultEngine<E> {
     fn new_with_opts(
         object_store: Arc<DynObjectStore>,
+        paginated: Option<Arc<dyn PaginatedListStore>>,
         task_executor: Arc<E>,
         io_config: ReadIoConfig,
     ) -> Self {
         let raw_storage: Arc<dyn StorageHandler> = Arc::new(ObjectStoreStorageHandler::new(
             object_store.clone(),
+            paginated,
             task_executor.clone(),
         ));
 

--- a/default-engine/src/storage.rs
+++ b/default-engine/src/storage.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, RwLock};
 
+use delta_kernel::object_store::aws::AmazonS3Builder;
+use delta_kernel::object_store::azure::MicrosoftAzureBuilder;
+use delta_kernel::object_store::gcp::GoogleCloudStorageBuilder;
+use delta_kernel::object_store::list::PaginatedListStore;
 use delta_kernel::object_store::path::Path;
-use delta_kernel::object_store::{self, Error, ObjectStore};
+use delta_kernel::object_store::{self, DynObjectStore, Error, ObjectStore, ObjectStoreScheme};
 use delta_kernel::Error as DeltaError;
 use url::Url;
 
@@ -18,6 +22,10 @@ type HandlerClosure = Arc<dyn Fn(&Url, HashMap<String, String>) -> ClosureReturn
 type Handlers = HashMap<String, HandlerClosure>;
 /// The URL_REGISTRY contains the custom URL scheme handlers that will parse URL options
 static URL_REGISTRY: LazyLock<RwLock<Handlers>> = LazyLock::new(|| RwLock::new(HashMap::default()));
+
+/// An object store paired with an optional [`PaginatedListStore`] handle for the same backend.
+/// The handle is `Some` only for backends supporting single-level listing (delimiter pushdown).
+pub type StoreWithPaginated = (Arc<DynObjectStore>, Option<Arc<dyn PaginatedListStore>>);
 
 /// Insert a new URL handler for [store_from_url_opts] with the given `scheme`. This allows
 /// users to provide their own custom URL handler to plug new
@@ -107,6 +115,121 @@ where
 
     Ok(Arc::new(store))
 }
+
+/// Like [`store_from_url_opts`], but also returns a [`PaginatedListStore`] handle for backends
+/// that support single-level listing (delimiter pushdown) (S3/GCS/Azure). Pass the handle to
+/// [`DefaultEngineBuilder::with_paginated_list_store`] to enable delimiter-pushdown log listing.
+///
+/// The returned handle is `None` for local/memory/http and any scheme registered via
+/// [`insert_url_handler`], which use the client-side one-level fallback. Because a paginated
+/// backend must be constructed as its concrete type (the handle is unreachable through
+/// `Arc<dyn ObjectStore>`), this bypasses [`store_from_url_opts`] for cloud schemes and builds the
+/// concrete store directly.
+///
+/// [`DefaultEngineBuilder::with_paginated_list_store`]: crate::DefaultEngineBuilder::with_paginated_list_store
+pub fn paginated_store_from_url_opts<I, K, V>(
+    url: &Url,
+    options: I,
+) -> delta_kernel::DeltaResult<StoreWithPaginated>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: Into<String>,
+{
+    // A custom handler for this scheme takes precedence and yields no paginated handle.
+    if let Ok(handlers) = URL_REGISTRY.read() {
+        if handlers.contains_key(url.scheme()) {
+            return Ok((store_from_url_opts(url, options)?, None));
+        }
+    }
+
+    let (scheme, _path) = ObjectStoreScheme::parse(url).map_err(object_store::Error::from)?;
+    let opts = options
+        .into_iter()
+        .map(|(k, v)| (k.as_ref().to_string(), v.into()));
+    Ok(match scheme {
+        ObjectStoreScheme::AmazonS3 => {
+            let store = Arc::new(build_cloud_store(AmazonS3Builder::new(), url, opts)?);
+            (store.clone(), Some(store))
+        }
+        ObjectStoreScheme::GoogleCloudStorage => {
+            let store = Arc::new(build_cloud_store(
+                GoogleCloudStorageBuilder::new(),
+                url,
+                opts,
+            )?);
+            (store.clone(), Some(store))
+        }
+        ObjectStoreScheme::MicrosoftAzure => {
+            let store = Arc::new(build_cloud_store(MicrosoftAzureBuilder::new(), url, opts)?);
+            (store.clone(), Some(store))
+        }
+        // Local / Memory / Http / unknown: no PaginatedListStore, use the client-side fallback.
+        _ => (store_from_url_opts(url, opts)?, None),
+    })
+}
+
+/// Builds a concrete cloud store from `url` and string `options`, mirroring
+/// `object_store::parse_url_opts`: options whose key does not parse into the builder's config-key
+/// type are ignored.
+fn build_cloud_store<B: CloudBuilder>(
+    builder: B,
+    url: &Url,
+    options: impl IntoIterator<Item = (String, String)>,
+) -> delta_kernel::DeltaResult<B::Store> {
+    let builder = options.into_iter().fold(
+        builder.with_url(url.to_string()),
+        |builder, (key, value)| match key.to_ascii_lowercase().parse() {
+            Ok(config_key) => builder.with_config(config_key, value),
+            Err(_) => builder,
+        },
+    );
+    Ok(builder.build()?)
+}
+
+/// The subset of a cloud object-store builder used by [`build_cloud_store`]: seed a URL, set typed
+/// config keys parsed from strings, and build.
+trait CloudBuilder: Sized {
+    type ConfigKey: std::str::FromStr;
+    type Store: ObjectStore + PaginatedListStore;
+    fn with_url(self, url: String) -> Self;
+    fn with_config(self, key: Self::ConfigKey, value: String) -> Self;
+    fn build(self) -> object_store::Result<Self::Store>;
+}
+
+macro_rules! impl_cloud_builder {
+    ($builder:ty, $key:ty, $store:ty) => {
+        impl CloudBuilder for $builder {
+            type ConfigKey = $key;
+            type Store = $store;
+            fn with_url(self, url: String) -> Self {
+                self.with_url(url)
+            }
+            fn with_config(self, key: Self::ConfigKey, value: String) -> Self {
+                self.with_config(key, value)
+            }
+            fn build(self) -> object_store::Result<Self::Store> {
+                self.build()
+            }
+        }
+    };
+}
+
+impl_cloud_builder!(
+    AmazonS3Builder,
+    delta_kernel::object_store::aws::AmazonS3ConfigKey,
+    delta_kernel::object_store::aws::AmazonS3
+);
+impl_cloud_builder!(
+    GoogleCloudStorageBuilder,
+    delta_kernel::object_store::gcp::GoogleConfigKey,
+    delta_kernel::object_store::gcp::GoogleCloudStorage
+);
+impl_cloud_builder!(
+    MicrosoftAzureBuilder,
+    delta_kernel::object_store::azure::AzureConfigKey,
+    delta_kernel::object_store::azure::MicrosoftAzure
+);
 
 #[cfg(test)]
 mod tests {

--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -49,8 +49,9 @@ pub trait StorageHandler {
 ### Key contracts
 
 - **`list_from`**: Results must be sorted lexicographically by path. If the path ends with
-  `/`, list all files in that directory. Otherwise, list files lexicographically greater than
-  the given path in the same directory.
+  `/`, list files within that directory. Otherwise, list files lexicographically greater than
+  the given path in the same directory. The listing is a single directory level: files in nested
+  subdirectories must not be returned, and subdirectories must not appear as entries.
 
 - **`copy_atomic`**: Must fail with `Error::FileAlreadyExists` if the destination exists.
   This is used for commit publishing in catalog-managed tables.

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -45,7 +45,14 @@ impl StorageHandler for SyncStorageHandler {
                 .collect::<Vec<_>>(),
         )
         .into_iter()
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
+        // Single-directory contract: keep only direct children of `prefix`. `prefix_match` yields
+        // the path parts after `prefix`; a direct child has exactly one remaining part.
+        metas.retain(|meta| {
+            meta.location
+                .prefix_match(&prefix)
+                .is_some_and(|parts| parts.count() == 1)
+        });
         metas.sort_unstable_by(|a, b| a.location.cmp(&b.location));
 
         let iter = metas.into_iter().map(move |meta| {
@@ -213,10 +220,9 @@ mod tests {
         Ok(())
     }
 
-    /// `list_from` against an [`ObjectStore`] must walk subdirectories, matching the local FS
-    /// implementation that uses `read_dir` recursively.
+    /// `list_from` is single-directory: files in nested subdirectories are excluded.
     #[tokio::test]
-    async fn list_from_store_is_recursive() {
+    async fn list_from_store_is_single_directory() {
         let store = std::sync::Arc::new(InMemory::new());
         store
             .put(
@@ -245,7 +251,7 @@ mod tests {
             .iter()
             .map(|f| f.location.path().to_string())
             .collect();
-        assert_eq!(names, vec!["/a/file1.json", "/a/sub/file2.json"]);
+        assert_eq!(names, vec!["/a/file1.json"]);
     }
 
     #[test]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -591,20 +591,20 @@ pub(crate) trait IntoEngineData {
 /// file system where the Delta table is present. Connector implementation of
 /// this trait can hide filesystem specific details from Delta Kernel.
 pub trait StorageHandler: AsAny {
-    /// Recursively list files whose full path is lexicographically greater than (UTF-8 sorting)
-    /// the given `path`, restricted to descendants of `path`'s parent directory. The result must
-    /// be sorted by the full path (UTF-8 byte order).
+    /// List files directly within the parent directory of `path` whose full path is
+    /// lexicographically greater than (UTF-8 sorting) `path`. The result must be sorted by
+    /// the full path (UTF-8 byte order).
     ///
-    /// The listing is **recursive**: files in nested subdirectories are included, not just files
-    /// directly under the parent. For example, listing from `dir/0001.json` may return
-    /// `dir/0002.json`, `dir/sub/0003.json`, and `dir/sub/nested/0004.json`, all interleaved
-    /// in lexicographic order.
+    /// The listing is a SINGLE directory level: files in nested subdirectories are NOT included,
+    /// and subdirectories are not returned as entries. For example, listing from
+    /// `dir/0001.json` may return `dir/0002.json` and `dir/0003.checkpoint.parquet`, but nothing
+    /// under `dir/sub/`.
     ///
     /// The parent directory is derived from `path`:
     /// - If `path` is directory-like (ends with `/`), the parent is `path` itself and the result
-    ///   contains all files at or below that directory.
-    /// - Otherwise, the parent is the directory containing `path`, and only files (at any depth
-    ///   under that parent) whose full path sorts strictly greater than `path` are returned.
+    ///   contains the files directly within it.
+    /// - Otherwise, the parent is the directory containing `path`, and only files directly within
+    ///   that parent whose full path sorts strictly greater than `path` are returned.
     fn list_from(&self, path: &Url)
         -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>>;
 

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -25,7 +25,7 @@ use url::Url;
 
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
-use crate::path::{may_begin_listable_log_path, LogPathFileType, ParsedLogPath};
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::{DeltaResult, Error, StorageHandler, Version};
 
 #[cfg(test)]
@@ -59,12 +59,12 @@ pub(crate) struct LogSegmentFiles {
 
 /// Returns a lazy iterator of [`ParsedLogPath`]s from the filesystem over versions
 /// `[start_version, end_version]`. The iterator handles parsing, filtering out non-listable
-/// files (e.g. dot-prefixed files), and stopping at `end_version`. It stops consuming the
-/// underlying listing at the first path past the version-named region, so directories like
-/// `_staged_commits/` and `_sidecars/` are never paged through.
+/// files (e.g. dot-prefixed files), and stopping at `end_version`.
 ///
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
-/// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
+/// Delta log file discovery pipeline. Because `list_from` is single-directory, the listing
+/// covers only the direct children of `_delta_log/`; subdirectories like `_staged_commits/`
+/// and `_sidecars/` are never traversed. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
 pub(crate) fn list_from_storage(
     storage: &dyn StorageHandler,
@@ -73,22 +73,8 @@ pub(crate) fn list_from_storage(
     end_version: Version,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_from = log_root.join(&format!("{start_version:020}"))?;
-    let log_root_str = log_root.to_string();
     let files = storage
         .list_from(&start_from)?
-        // The listing is sorted by full path, so nothing relevant follows the first relative path
-        // past the version-named region (see `may_begin_listable_log_path`). Stopping there avoids
-        // paging through `_staged_commits/` and `_sidecars/`, which can hold thousands of files.
-        // A path that doesn't strip the log_root prefix is kept; parsing discards it.
-        // TODO(#2740): push the bound into the listing request itself.
-        .take_while(move |meta_res| match meta_res {
-            Ok(meta) => meta
-                .location
-                .as_str()
-                .strip_prefix(&log_root_str)
-                .is_none_or(may_begin_listable_log_path),
-            Err(_) => true,
-        })
         .map(|meta| ParsedLogPath::try_from(meta?))
         // NOTE: this filters out .crc files etc which start with "." - some engines
         // produce `.something.parquet.crc` corresponding to `something.parquet`. Kernel

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -135,7 +135,7 @@ fn assert_source(commit: &ParsedLogPath, expected_source: CommitSource) {
 /// A [`StorageHandler`] wrapper that counts the number of `list_from` calls and the number of
 /// items consumed from the returned iterators. Used to verify that
 /// `list_with_backward_checkpoint_scan` issues the expected number of storage listing requests,
-/// and that listing terminates without consuming files past the version-named region.
+/// and that single-directory listing never yields files from subdirectories.
 struct CountingStorageHandler {
     inner: Arc<dyn StorageHandler>,
     list_from_count: AtomicU32,
@@ -473,14 +473,14 @@ async fn test_listing_omits_staged_commits() {
 }
 
 #[tokio::test]
-async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() {
+async fn test_listing_never_consumes_staged_commits_in_subdirectory() {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
         (2, LogPathFileType::Commit, CommitSource::Filesystem),
     ];
-    // Staged commits sort after every version-named file ('_' > '9'), so a sorted listing
-    // reaches them only after all relevant files. None should be consumed beyond the first.
+    // Staged commits live under `_delta_log/_staged_commits/`. Single-directory listing never
+    // descends into that subdirectory, so none are ever consumed.
     log_files
         .extend((0..100).map(|v| (v, LogPathFileType::StagedCommit, CommitSource::Filesystem)));
 
@@ -493,19 +493,19 @@ async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() 
     assert_eq!(commits.len(), 3);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 3 commits plus the single staged commit that stops the listing
-    assert_eq!(storage.items_listed(), 4);
+    // Only the 3 direct-child commits are listed; the 100 staged commits in the subdirectory
+    // are never consumed.
+    assert_eq!(storage.items_listed(), 3);
 }
 
-// Any path past the version-named region stops the listing, not just `_staged_commits/`:
-// checkpoint sidecars under `_sidecars/` and non-underscore names whose first byte sorts
-// past '9' (e.g. 'Z'). Both sentinels sort before `_staged_commits/`, so no staged commit
-// is ever consumed.
+// Direct-child paths that are not version-named log files (e.g. checkpoint sidecar references
+// mistakenly at the top level, or `_last_checkpoint`) are listed but discarded by parsing, and
+// do not affect the commit/checkpoint set.
 #[rstest]
-#[case::sidecar("_delta_log/_sidecars/016ae953-37a9-438e-8683-9a9a4a79a395.parquet")]
+#[case::last_checkpoint("_delta_log/_last_checkpoint")]
 #[case::non_underscore_sentinel("_delta_log/Zsentinel")]
 #[tokio::test]
-async fn test_listing_stops_at_first_non_version_named_path(#[case] sentinel_path: &str) {
+async fn test_listing_ignores_direct_child_non_log_files(#[case] sentinel_path: &str) {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -522,14 +522,12 @@ async fn test_listing_stops_at_first_non_version_named_path(#[case] sentinel_pat
     assert_eq!(commits.len(), 3);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 3 commits plus the sentinel that stops the listing
+    // 3 direct-child commits plus the sentinel; the 50 staged commits are never consumed.
     assert_eq!(storage.items_listed(), 4);
 }
 
 #[tokio::test]
-async fn test_listing_stops_at_last_checkpoint_marker() {
-    // In a real table `_last_checkpoint` sorts before `_staged_commits/` ('_la' < '_st'), so
-    // it is the path that stops the listing.
+async fn test_listing_with_checkpoint_and_crc_omits_staged_commits() {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -557,8 +555,8 @@ async fn test_listing_stops_at_last_checkpoint_marker() {
     assert_eq!(latest_crc.unwrap().version, 2);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 5 version-named files plus the `_last_checkpoint` that stops the listing; no staged
-    // commit is ever consumed
+    // 5 version-named direct children (3 commits + checkpoint + crc) plus `_last_checkpoint`;
+    // the 50 staged commits in the subdirectory are never consumed.
     assert_eq!(storage.items_listed(), 6);
 }
 

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -108,23 +108,6 @@ fn path_contains_delta_log_dir(mut path_segments: std::str::Split<'_, char>) -> 
     path_segments.any(|p| p == DELTA_LOG_DIR)
 }
 
-/// Returns whether `rel_path`, a path relative to the `_delta_log/` directory, could still be
-/// within the version-named region of a lexicographically sorted log listing.
-///
-/// Every listable log file begins with a 20-digit version, so its first byte is an ASCII digit.
-/// Paths like `_staged_commits/`, `_sidecars/`, and `_last_checkpoint` sort after every
-/// version-named file because `'_'` (0x5F) > `'9'` (0x39), so a sorted listing can stop at the
-/// first relative path whose first byte sorts past `'9'`.
-///
-/// This is a scan bound, not a log-file filter, so it must not require a digit first byte: a
-/// path sorting before `'0'` (e.g. a dot-prefixed `.{version}.json.crc` written by some engines)
-/// can still be followed by version-named files, and stopping there would silently drop them.
-/// Such paths are kept here and discarded by [`ParsedLogPath`] parsing instead. An empty
-/// `rel_path` is conservatively kept.
-pub(crate) fn may_begin_listable_log_path(rel_path: &str) -> bool {
-    rel_path.as_bytes().first().is_none_or(|b| *b <= b'9')
-}
-
 impl<Location: AsUrl> ParsedLogPath<Location> {
     /// Estimated heap size in bytes, best-effort estimate.
     ///
@@ -577,23 +560,6 @@ pub(crate) mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         assert!(url.path().ends_with('/'));
         url
-    }
-
-    #[test]
-    fn test_may_begin_listable_log_path() {
-        // version-named files, and anything sorting before them, keep the scan going
-        assert!(may_begin_listable_log_path("00000000000000000010.json"));
-        assert!(may_begin_listable_log_path(
-            ".00000000000000000010.json.crc"
-        ));
-        assert!(may_begin_listable_log_path(""));
-        // paths sorting past '9' end the version-named region
-        assert!(!may_begin_listable_log_path("_last_checkpoint"));
-        assert!(!may_begin_listable_log_path("_sidecars/3a0d65cd.parquet"));
-        assert!(!may_begin_listable_log_path(
-            "_staged_commits/00000000000000000010.3a0d65cd.json"
-        ));
-        assert!(!may_begin_listable_log_path("Zsentinel"));
     }
 
     #[test]

--- a/kernel/src/plans/ir/operation.rs
+++ b/kernel/src/plans/ir/operation.rs
@@ -37,7 +37,7 @@ impl Operation {
 /// is documented on the variant in terms of [`PlanResult`](crate::plans::PlanResult).
 #[derive(Debug)]
 pub enum IoOperation {
-    /// Recursively list files at the given URL.
+    /// List files directly within the parent directory of the given URL.
     ///
     /// Should return a [`PlanResult::FileMeta`](crate::plans::PlanResult::FileMeta) with one entry
     /// per file. See [`StorageHandler::list_from`] for more details on the ordering contract.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `StorageHandler::list_from` single-directory instead of recursive.

- Flip the `list_from` contract doc to single-directory.
- Delete the recursive-listing mitigation (`may_begin_listable_log_path` + the STAGE-1 `take_while`).
- Default engine lists one level via `PaginatedListStore` delimiter pushdown on S3/GCS/Azure, and a client-side direct-children filter otherwise.
- Add `paginated_store_from_url_opts` + `DefaultEngineBuilder::with_paginated_list_store` to thread the paginated handle through.
- Sync engine filters to direct children the same way.

`PaginatedListStore::list_paginated` is the only `object_store` API that combines the `/` delimiter (one directory level) with `offset` (start-after) in a single request. The base-trait methods each hardcode two of the three knobs:

| Method | prefix | delimiter (one-level) | offset (start-after) | Recursive? | Returns |
|---|:---:|:---:|:---:|:---:|---|
| `list(prefix)` | yes | no | no | recursive | `Stream<ObjectMeta>` |
| `list_with_offset(prefix, offset)` | yes | no | yes | recursive | `Stream<ObjectMeta>` |
| `list_with_delimiter(prefix)` | yes | yes | no | one level | `ListResult` (buffered) |
| `PaginatedListStore::list_paginated(prefix, opts)` | yes | optional | optional | caller's choice | one page + `page_token` |

### This PR affects the following public APIs

- `StorageHandler::list_from` now returns a single directory level. Behavioral breaking change for external implementers that returned recursive listings; kernel still classifies and drops any nested entries, so results are unchanged.
- New: `DefaultEngineBuilder::with_paginated_list_store`, `storage::paginated_store_from_url_opts`.

## How was this change tested?

- Updated unit tests: single-directory listing omits `_staged_commits/` on both the paginated and fallback paths; sync engine excludes nested files.
- `cargo +nightly fmt`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo doc`, and `cargo nextest run --workspace --all-features` all pass.