### PR TITLE
feat: label snapshot-load events fresh vs incremental and report CRC staleness

### DIFF
--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -100,7 +100,11 @@ pub struct LogSegmentLoadSuccess {
     pub num_commit_files: u64,
     pub num_checkpoint_files: u64,
     pub num_compaction_files: u64,
-    pub has_latest_crc_file: bool,
+    /// Whether the segment had a CRC file. When false, `crc_versions_behind` is 0 and meaningless.
+    pub has_crc: bool,
+    /// Versions the latest CRC file is behind the loaded version (0 when at the loaded version).
+    /// Only meaningful when `has_crc` is true.
+    pub crc_versions_behind: u64,
 }
 
 /// Listing the log segment failed.
@@ -310,8 +314,9 @@ impl MetricEvent {
                 num_commit_files,
                 num_checkpoint_files,
                 num_compaction_files,
-                has_latest_crc_file,
+                crc_versions_behind,
                 duration,
+                ..
             }) => Self::LogSegmentLoadSuccess(LogSegmentLoadSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -320,12 +325,15 @@ impl MetricEvent {
                 num_commit_files: *num_commit_files,
                 num_checkpoint_files: *num_checkpoint_files,
                 num_compaction_files: *num_compaction_files,
-                has_latest_crc_file: *has_latest_crc_file,
+                // C has no Option: `has_crc` gates `crc_versions_behind` (0 when absent).
+                has_crc: crc_versions_behind.is_some(),
+                crc_versions_behind: crc_versions_behind.unwrap_or(0),
             }),
             K::LogSegmentLoadFailure(kernel::LogSegmentLoadFailure {
                 operation_id,
                 correlation_id,
                 table_type,
+                ..
             }) => Self::LogSegmentLoadFailure(LogSegmentLoadFailure {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -347,6 +355,7 @@ impl MetricEvent {
                 operation_id,
                 correlation_id,
                 table_type,
+                ..
             }) => Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
@@ -687,10 +696,11 @@ mod tests {
             operation_id: id,
             correlation_id: Some("req-42".into()),
             table_type: kernel::TableType::CatalogManaged,
+            load_purpose: kernel::LogSegmentLoadPurpose::FreshSnapshot,
             num_commit_files: 3,
             num_checkpoint_files: 1,
             num_compaction_files: 2,
-            has_latest_crc_file: true,
+            crc_versions_behind: Some(5),
             duration: Duration::from_nanos(61),
         });
         with_ffi_event(&event, |ffi| {
@@ -703,7 +713,8 @@ mod tests {
             assert_eq!(e.num_commit_files, 3);
             assert_eq!(e.num_checkpoint_files, 1);
             assert_eq!(e.num_compaction_files, 2);
-            assert!(e.has_latest_crc_file);
+            assert!(e.has_crc);
+            assert_eq!(e.crc_versions_behind, 5);
             let cid: &str =
                 unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };
             assert_eq!(cid, "req-42");
@@ -716,10 +727,11 @@ mod tests {
             operation_id: kernel::MetricId::new(),
             correlation_id: None,
             table_type: kernel::TableType::PathBased,
+            load_purpose: kernel::LogSegmentLoadPurpose::FreshSnapshot,
             num_commit_files: 0,
             num_checkpoint_files: 0,
             num_compaction_files: 0,
-            has_latest_crc_file: false,
+            crc_versions_behind: None,
             duration: Duration::from_nanos(0),
         });
         with_ffi_event(&event, |ffi| {
@@ -727,6 +739,7 @@ mod tests {
                 panic!("expected LogSegmentLoadSuccess");
             };
             assert!(matches!(e.table_type, TableType::PathBased));
+            assert!(!e.has_crc);
             let cid: &str =
                 unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };
             assert_eq!(cid, "");

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -336,6 +336,7 @@ impl MetricEvent {
                 correlation_id,
                 table_type,
                 duration,
+                ..
             }) => Self::ProtocolMetadataLoadSuccess(ProtocolMetadataLoadSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -28,6 +28,7 @@ use crate::crc::{
     FileSizeHistogram, FileStatsDelta,
 };
 use crate::engine_data::{GetData, TypedGetData as _};
+use crate::metrics::ProtocolMetadataSource;
 use crate::path::ParsedLogPath;
 use crate::schema::{
     column_name, schema, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
@@ -63,30 +64,62 @@ static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(with_file)
 });
 
+/// Outcome of resolving a CRC at a log segment's end version, from
+/// [`LogSegment::try_build_crc_within_budget`].
+pub(crate) enum CrcResolution {
+    /// The base CRC is at the target version.
+    AtTarget(Arc<Crc>),
+    /// A stale base CRC was advanced to the target version.
+    AdvancedByReplay(Arc<Crc>),
+    /// No usable CRC at the target: either no base CRC, or the base was too stale for the replay
+    /// budget.
+    Unresolved,
+}
+
+impl CrcResolution {
+    /// The resolved CRC, or `None` if none was resolved.
+    pub(crate) fn into_crc(self) -> Option<Arc<Crc>> {
+        match self {
+            Self::AtTarget(crc) | Self::AdvancedByReplay(crc) => Some(crc),
+            Self::Unresolved => None,
+        }
+    }
+
+    /// The resolved CRC paired with its P&M source label, or `None` for [`Self::Unresolved`].
+    pub(crate) fn crc_and_source(&self) -> Option<(&Arc<Crc>, ProtocolMetadataSource)> {
+        match self {
+            Self::AtTarget(crc) => Some((crc, ProtocolMetadataSource::CrcAtTarget)),
+            Self::AdvancedByReplay(crc) => Some((crc, ProtocolMetadataSource::CrcAdvancedByReplay)),
+            Self::Unresolved => None,
+        }
+    }
+}
+
 impl LogSegment {
     /// Try to build the CRC at this segment's `end_version` from the caller's resolved `base` CRC.
     /// Handles three cases:
-    /// - Case 1: no base CRC available -> return None
-    /// - Case 2: base CRC at `end_version` -> return it as-is
-    /// - Case 3: stale base CRC older than `end_version` -> advance it to `end_version` when
-    ///   `incremental_replay` permits, else fall back to normal log replay (return None)
+    /// - Case 1: no base CRC available -> [`CrcResolution::Unresolved`]
+    /// - Case 2: base CRC at `end_version` -> [`CrcResolution::AtTarget`]
+    /// - Case 3: stale base CRC older than `end_version` -> [`CrcResolution::AdvancedByReplay`]
+    ///   when `incremental_replay` permits, else fall back to normal log replay
+    ///   ([`CrcResolution::Unresolved`])
     pub(crate) fn try_build_crc_within_budget(
         &self,
         engine: &dyn Engine,
         base: Option<&Arc<Crc>>,
         incremental_replay: IncrementalReplay,
-    ) -> DeltaResult<Option<Arc<Crc>>> {
+    ) -> DeltaResult<CrcResolution> {
         let Some(base) = base else {
-            return Ok(None);
+            return Ok(CrcResolution::Unresolved);
         };
         if base.version == self.end_version {
-            return Ok(Some(base.clone()));
+            return Ok(CrcResolution::AtTarget(base.clone()));
         }
         if !incremental_replay.should_advance(base.version, self.end_version)? {
-            return Ok(None);
+            return Ok(CrcResolution::Unresolved);
         }
         let advanced = self.build_crc_from_base(engine, base)?;
-        Ok(Some(Arc::new(advanced)))
+        Ok(CrcResolution::AdvancedByReplay(Arc::new(advanced)))
     }
 
     /// Pick the latest CRC to use as an advance base: this segment's on-disk CRC or

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, LazyLock};
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
@@ -20,8 +20,9 @@ use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
 #[internal_api]
 use crate::log_segment_files::LogSegmentFiles;
-use crate::metrics::events::LOG_SEGMENT_LOADED_SPAN;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_log_segment_load, emit_log_segment_load_failure, SnapshotLoadMetricContext,
+};
 use crate::path::LogPathFileType::*;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::compare::SchemaComparison;
@@ -321,12 +322,6 @@ impl LogSegment {
     /// [`Snapshot`]: crate::snapshot::Snapshot
     ///
     /// Reports metrics: `LogSegmentLoadSuccess` or `LogSegmentLoadFailure`.
-    #[instrument(
-        name = LOG_SEGMENT_LOADED_SPAN,
-        err,
-        skip(storage, time_travel_version),
-        fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or(""), num_commit_files, num_checkpoint_files, num_compaction_files, has_latest_crc_file)
-    )]
     #[internal_api]
     pub(crate) fn for_snapshot(
         storage: &dyn StorageHandler,
@@ -336,37 +331,39 @@ impl LogSegment {
         metric_context: SnapshotLoadMetricContext,
     ) -> DeltaResult<Self> {
         let time_travel_version = time_travel_version.into();
-        let checkpoint_hint = LastCheckpointHint::try_read(storage, &log_root)?;
-        let result = Self::for_snapshot_impl(
-            storage,
-            log_root,
-            log_tail,
-            checkpoint_hint,
-            time_travel_version,
-        );
+        let start = std::time::Instant::now();
+        let build = || {
+            let checkpoint_hint = LastCheckpointHint::try_read(storage, &log_root)?;
+            Self::for_snapshot_impl(
+                storage,
+                log_root,
+                log_tail,
+                checkpoint_hint,
+                time_travel_version,
+            )
+        };
+        let log_segment =
+            build().inspect_err(|_| emit_log_segment_load_failure(&metric_context))?;
 
-        match result {
-            Ok(log_segment) => {
-                tracing::Span::current().record(
-                    "num_commit_files",
-                    log_segment.listed.ascending_commit_files.len() as u64,
-                );
-                tracing::Span::current().record(
-                    "num_checkpoint_files",
-                    log_segment.listed.checkpoint_parts.len() as u64,
-                );
-                tracing::Span::current().record(
-                    "num_compaction_files",
-                    log_segment.listed.ascending_compaction_files.len() as u64,
-                );
-                tracing::Span::current().record(
-                    "has_latest_crc_file",
-                    log_segment.listed.latest_crc_file.is_some(),
-                );
-                Ok(log_segment)
-            }
-            Err(e) => Err(e),
-        }
+        emit_log_segment_load(
+            &metric_context,
+            log_segment.listed.ascending_commit_files.len() as u64,
+            log_segment.listed.checkpoint_parts.len() as u64,
+            log_segment.listed.ascending_compaction_files.len() as u64,
+            log_segment.crc_versions_behind(),
+            start.elapsed(),
+        );
+        Ok(log_segment)
+    }
+
+    /// How many versions behind `end_version` the latest on-disk CRC file is, for the
+    /// `LogSegmentLoad` metric: `None` if there is no CRC file, else `end_version - crc.version`
+    /// (`Some(0)` when a CRC sits at the end version).
+    pub(crate) fn crc_versions_behind(&self) -> Option<u64> {
+        self.listed
+            .latest_crc_file
+            .as_ref()
+            .map(|crc| self.end_version.saturating_sub(crc.version))
     }
 
     // factored out for testing

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -11,31 +11,27 @@ use super::LogSegment;
 use crate::actions::{Metadata, Protocol, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
-use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::ProtocolMetadataSource;
 use crate::schema::schema_ref;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
     /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
-    /// Returns an error if either is missing.
+    /// Returns an error if either is missing, and the [`ProtocolMetadataSource`] describing how
+    /// P&M was resolved.
     ///
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
     /// snapshot creation where both Protocol and Metadata must exist.
-    ///
-    /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, crc))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-        metric_context: SnapshotLoadMetricContext,
-    ) -> DeltaResult<(Metadata, Protocol)> {
+    ) -> DeltaResult<(Metadata, Protocol, ProtocolMetadataSource)> {
         match self.read_protocol_metadata_opt(engine, crc)? {
-            (Some(m), Some(p)) => Ok((m, p)),
-            (None, Some(_)) => Err(Error::MissingMetadata),
-            (Some(_), None) => Err(Error::MissingProtocol),
-            (None, None) => Err(Error::MissingMetadataAndProtocol),
+            (Some(m), Some(p), source) => Ok((m, p, source)),
+            (None, Some(_), _) => Err(Error::MissingMetadata),
+            (Some(_), None, _) => Err(Error::MissingProtocol),
+            (None, None, _) => Err(Error::MissingMetadataAndProtocol),
         }
     }
 
@@ -53,11 +49,15 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
+    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>, ProtocolMetadataSource)> {
         // Case 1: If CRC at target version, use it directly and exit early.
         if let Some(crc) = crc.filter(|c| c.version == self.end_version) {
             info!("P&M from CRC at target version {}", self.end_version);
-            return Ok((Some(crc.metadata.clone()), Some(crc.protocol.clone())));
+            return Ok((
+                Some(crc.metadata.clone()),
+                Some(crc.protocol.clone()),
+                ProtocolMetadataSource::CrcAtTarget,
+            ));
         }
 
         // We didn't return above, so we need to do log replay to find P&M.
@@ -80,7 +80,11 @@ impl LogSegment {
 
             if metadata_opt.is_some() && protocol_opt.is_some() {
                 info!("Found P&M from pruned log replay");
-                return Ok((metadata_opt, protocol_opt));
+                return Ok((
+                    metadata_opt,
+                    protocol_opt,
+                    ProtocolMetadataSource::CrcSeededPmOnlyReplay,
+                ));
             }
 
             // Case 2(b): P&M incomplete from pruned replay, use the CRC.
@@ -90,11 +94,17 @@ impl LogSegment {
             return Ok((
                 metadata_opt.or_else(|| Some(crc.metadata.clone())),
                 protocol_opt.or_else(|| Some(crc.protocol.clone())),
+                ProtocolMetadataSource::CrcSeededPmOnlyReplay,
             ));
         }
 
         // Case 3: Full P&M log replay.
-        self.replay_for_pm(engine)
+        let (metadata_opt, protocol_opt) = self.replay_for_pm(engine)?;
+        Ok((
+            metadata_opt,
+            protocol_opt,
+            ProtocolMetadataSource::FullReplay,
+        ))
     }
 
     /// Replays the log segment for Protocol and Metadata, stopping early once both are found.

--- a/kernel/src/metrics/README.md
+++ b/kernel/src/metrics/README.md
@@ -1,0 +1,70 @@
+# Kernel metrics
+
+Kernel emits metrics as `tracing` spans. A connector installs [`ReportGeneratorLayer`]
+(`reporter.rs`), which turns each span into a [`MetricEvent`] (`events.rs`) and hands it to the
+connector's [`MetricsReporter`]. Kernel does no aggregation; the connector does.
+
+## Terms
+
+- **Span-based (instrument-based)**: the span *is* a function. `#[instrument]` opens it on entry
+  and closes it on return. The event fires because the function ran; its duration is the function's
+  wall-clock. Data fields arrive via the runtime-record channel during the call.
+- **Emit-based**: the span is a one-shot marker fired by an `emit_*` helper at an arbitrary point,
+  then dropped (never entered). The event fires because you called `emit_*`; all fields, including
+  `duration_ns`, are passed as creation attrs. There is no function boundary and no runtime-record.
+- An event type is **fully emit-based** when every one of its instances is produced by `emit_*` (so
+  it needs no `record_*` / `set_duration` methods), and **span-based** when produced by
+  `#[instrument]`. An event filled by *both* mechanisms (some call sites instrument, others emit) is
+  **hybrid**: it must support both channels, which is more machinery; avoid unless a call site
+  genuinely can't use the other.
+
+## How a span becomes an event
+
+Every metric span carries a `report` field (the sentinel the layer keys on) plus its data fields.
+In `on_new_span` the layer matches the span name to its event and builds it via that event's
+`from_attrs` (storage events share one span name, dispatched by `storage_metric_from_attrs`), then
+reports it in `on_close`. Two channels fill an event's fields:
+
+- **Creation attrs**: `span!(NAME, field = value, ...)`. Read once, at construction, by a
+  `Visit`or in `from_attrs`. All fields must be known up front.
+- **Runtime record**: `Span::current().record("field", value)` while the span is open. Routed to
+  the event's `record_*` methods. For fields not known until mid-span.
+
+Duration: the layer stamps it in `on_close` from the time the span was **entered**, but only if it
+was entered. A span that is created and dropped without `.enter()` has no duration unless you pass
+one as a `duration_ns` creation attr.
+
+## Which mechanism to use
+
+| You want to... | Use | Why |
+|---|---|---|
+| Time one function, event fires when it runs | `#[instrument(name = SPAN, fields(report, ...))]` | The macro enters/exits the fn; duration = fn wall-clock. Fields via `record()` during the call. |
+| Fire an event from a point that is **not** a whole function (a match arm, a convergence of several branches) | an `emit_*` helper that fires a one-shot `span!` with all fields as creation attrs | No function boundary to annotate; the branches are the point. See `emit_protocol_metadata_load`. |
+| Fire the **same** event from **several** call sites | one `emit_*` helper, called from each | One event definition, many callers. Instrument can't span two functions. |
+| Record a diagnostic log line, not a metric | `info!` / `warn!` / `debug!` (no `report` field) | The layer ignores spans/events without `report`; these stay pure logging. |
+| Add a field to an open instrumented span | `Span::current().record("field", v)` + a `record_*` arm on the event | Runtime channel; only meaningful on an entered (`#[instrument]`) span. |
+
+## Failure events
+
+Success and failure are two variants of one event. Emit the **success**-named span, then signal
+failure by firing `error` on it: `#[instrument(err)]` does this automatically on `Err`; an emit
+helper does it by entering the span and calling `tracing::info!(error = ...)`. The layer's
+`on_event` sees `error` and flips the built event via `MetricEvent::into_failure`. A bare creation
+attr does **not** flip it; the `error` event is what triggers the flip (see
+`emit_protocol_metadata_load_failure`).
+
+## Adding an event
+
+1. Define the struct + `SPAN_NAME` in `events.rs`; add a `MetricEvent` variant and its
+   `into_failure` mapping (the match is exhaustive, so a missing arm fails to compile).
+2. Pick a mechanism from the table. For emit, add an `emit_*` helper and a `from_attrs` `Visit`or.
+3. Add the span-name arm to `on_new_span` in `reporter.rs`.
+4. Keep every label a typed enum with the strum derives (`EnumString`, `Display`, `AsRefStr`,
+   `IntoStaticStr`, `serialize_all = "snake_case"`) so the wire string and the parse stay in sync.
+
+The FFI mirror (`ffi/src/ffi_metrics.rs`) and connector consumers destructure these structs, so
+adding a field or variant is a breaking change for them.
+
+[`ReportGeneratorLayer`]: reporter.rs
+[`MetricEvent`]: events.rs
+[`MetricsReporter`]: reporter.rs

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -14,7 +14,7 @@
 //! default rather than failing the operation being observed.
 
 use std::fmt;
-use std::str::FromStr as _;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,6 +40,12 @@ impl MetricId {
     /// Generate a new unique `MetricId`.
     pub fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    /// The nil id (all-zero UUID). The [`Default`] value and the decode seed when a span omits
+    /// `operation_id`.
+    pub(crate) fn nil() -> Self {
+        Self(Uuid::nil())
     }
 
     /// Return the 16 raw bytes of the underlying UUID. Useful for FFI consumers that want to
@@ -71,8 +77,10 @@ impl MetricId {
 }
 
 impl Default for MetricId {
+    /// The nil (all-zero) id. A real operation id comes from [`MetricId::new`]; `Default` is the
+    /// zero value used as a decode seed and in zero-initialized metric structs.
     fn default() -> Self {
-        Self::new()
+        Self::nil()
     }
 }
 
@@ -117,28 +125,31 @@ impl MetricEvent {
         match self {
             // Lifecycle success: duration must be set by the tracing layer on span close.
             Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
-            Self::ProtocolMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SnapshotBuildSuccess(e) => e.set_duration(d),
             Self::TransactionCommitSuccess(e) => e.set_duration(d),
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
 
-            // For now, failure events carry no duration; storage/scan events set it at
-            // construction; read events have no duration field.
+            // Emit-based success events set their duration as a creation attribute, so the
+            // span-close hook must not overwrite it.
+            Self::ProtocolMetadataLoadSuccess(_)
+            | Self::ScanMetadataCompleted(_)
+            | Self::StorageListCompleted(_)
+            | Self::StorageReadCompleted(_)
+            | Self::StorageCopyCompleted(_) => {}
+
+            // Failure events carry no duration.
             Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
             | Self::TransactionCommitFailure(_)
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
-            | Self::CrcReadFailure
-            | Self::ScanMetadataCompleted(_)
-            | Self::StorageListCompleted(_)
-            | Self::StorageReadCompleted(_)
-            | Self::StorageCopyCompleted(_)
-            | Self::JsonReadCompleted(_)
-            | Self::ParquetReadCompleted(_) => {}
+            | Self::CrcReadFailure => {}
+
+            // Read events have no duration field.
+            Self::JsonReadCompleted(_) | Self::ParquetReadCompleted(_) => {}
         }
     }
 
@@ -260,8 +271,6 @@ impl MetricEvent {
             Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
             Self::CrcReadSuccess(_) => Self::CrcReadFailure,
             // Events with no failure form pass through unchanged.
-            // Note: here we list explicitly so adding a lifecycle event without a failure mapping
-            //       fails to compile.
             e @ (Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
@@ -304,6 +313,22 @@ impl fmt::Display for MetricEvent {
             Self::StorageCopyCompleted(e) => e.fmt(f),
         }
     }
+}
+
+/// Parse a snake_case label span field into its enum, defaulting on an empty (unset) or
+/// unrecognized value. An unrecognized value warns; an empty value is the expected "field unset"
+/// case (e.g. a failure-emit span) and does not.
+fn parse_label_or_default<T: FromStr<Err = strum::ParseError> + Default>(
+    value: &str,
+    field: &str,
+) -> T {
+    if value.is_empty() {
+        return T::default();
+    }
+    T::from_str(value).unwrap_or_else(|e| {
+        warn!("Invalid {field} '{value}' on span: {e}. Using default.");
+        T::default()
+    })
 }
 
 // ====================================================================
@@ -429,17 +454,43 @@ impl fmt::Display for LogSegmentLoadFailure {
 
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
-/// Protocol and metadata actions were read from the log.
-#[derive(Debug, Clone)]
+/// How a snapshot load resolved Protocol and Metadata: served directly by a CRC, derived by
+/// advancing or seeding a replay from a stale CRC, or from full log replay when no CRC applies.
+/// New variants may be added as more resolution paths appear.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProtocolMetadataSource {
+    /// A CRC already sat at the target version; used as-is with zero replay.
+    CrcAtTarget,
+    /// A stale CRC was advanced to the target version by reverse replay.
+    CrcAdvancedByReplay,
+    /// A stale CRC seeded a pruned P&M replay of the commits above it (falling back to the
+    /// CRC's own P&M when the pruned replay found no newer Protocol or Metadata).
+    CrcSeededPmOnlyReplay,
+    /// No CRC baseline; P&M came from log replay (full history on a fresh load, or the new
+    /// commits on an incremental load).
+    #[default]
+    FullReplay,
+}
+
+impl ProtocolMetadataSource {
+    fn parse_lenient(s: &str) -> Self {
+        parse_label_or_default(s, "pm_source")
+    }
+}
+
+/// Protocol and metadata actions were resolved for a snapshot.
+#[derive(Debug, Clone, Default)]
 pub struct ProtocolMetadataLoadSuccess {
-    // === Set on span creation ===
     pub operation_id: MetricId,
     /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-
-    // === Set on span close ===
+    pub source: ProtocolMetadataSource,
     pub duration: Duration,
 }
 
@@ -447,16 +498,37 @@ impl ProtocolMetadataLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = PROTOCOL_METADATA_LOADED_SPAN;
 
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
-        Self {
-            operation_id: MetricId::from_attrs(attrs),
-            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
-            correlation_id: correlation_id_from_attrs(attrs),
-            duration: Duration::default(),
+        let mut event = Self::default();
+        attrs.record(&mut event);
+        event
+    }
+}
+
+impl Visit for ProtocolMetadataLoadSuccess {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == IS_CATALOG_MANAGED_FIELD {
+            self.table_type = TableType::from_catalog_managed(value);
         }
     }
 
-    pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            CORRELATION_ID_FIELD if !value.is_empty() => self.correlation_id = Some(value.into()),
+            "pm_source" => self.source = ProtocolMetadataSource::parse_lenient(value),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "duration_ns" {
+            self.duration = Duration::from_nanos(value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if let Some(id) = record_operation_id(field, value, Self::SPAN_NAME) {
+            self.operation_id = id;
+        }
     }
 }
 
@@ -466,12 +538,13 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            source,
             duration,
         } = self;
         write!(
             f,
             "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, duration={duration:?})"
+             correlation_id={correlation_id:?}, source={source}, duration={duration:?})"
         )
     }
 }
@@ -1126,6 +1199,23 @@ pub struct SnapshotLoadMetricContext {
     pub(crate) is_catalog_managed: bool,
 }
 
+/// Decode the `operation_id` debug-string span field into a [`MetricId`]. Returns `None` when the
+/// field is not `operation_id`; returns the nil id (with a warning) when the value is malformed.
+/// Shared by the self-visiting event decoders.
+pub(crate) fn record_operation_id(
+    field: &Field,
+    value: &dyn fmt::Debug,
+    span_name: &str,
+) -> Option<MetricId> {
+    (field.name() == "operation_id").then(|| {
+        let s = format!("{value:?}");
+        Uuid::from_str(&s).map(MetricId).unwrap_or_else(|e| {
+            warn!("Invalid uuid '{s}' on {span_name}: {e}. Using nil.");
+            MetricId::nil()
+        })
+    })
+}
+
 pub(crate) fn read_is_catalog_managed(attrs: &Attributes<'_>) -> bool {
     #[derive(Default)]
     struct V(bool);
@@ -1538,6 +1628,40 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
     );
 }
 
+/// Emit a [`MetricEvent::ProtocolMetadataLoadSuccess`]. Call once per snapshot load on the P&M
+/// resolution path, on success.
+pub(crate) fn emit_protocol_metadata_load(
+    ctx: &SnapshotLoadMetricContext,
+    source: ProtocolMetadataSource,
+    duration: Duration,
+) {
+    let _span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        pm_source = source.as_ref(),
+        duration_ns = duration.as_nanos() as u64,
+    );
+}
+
+/// Emit a [`MetricEvent::ProtocolMetadataLoadFailure`] on the load error path (the flipped
+/// `...Success` span, per the README's failure-events pattern).
+pub(crate) fn emit_protocol_metadata_load_failure(ctx: &SnapshotLoadMetricContext) {
+    let span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+    );
+    let _enter = span.enter();
+    tracing::info!(error = tracing::field::debug("protocol/metadata load failed"));
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -1637,6 +1761,34 @@ mod tests {
         #[case] expected: ScanType,
     ) {
         assert_eq!(ScanType::parse_lenient(value), expected);
+    }
+
+    #[rstest]
+    #[case::crc_at_target(ProtocolMetadataSource::CrcAtTarget, "crc_at_target")]
+    #[case::crc_advanced(ProtocolMetadataSource::CrcAdvancedByReplay, "crc_advanced_by_replay")]
+    #[case::crc_seeded(
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay,
+        "crc_seeded_pm_only_replay"
+    )]
+    #[case::full_replay(ProtocolMetadataSource::FullReplay, "full_replay")]
+    fn protocol_metadata_source_serializes_to_wire_name_and_parses_back(
+        #[case] source: ProtocolMetadataSource,
+        #[case] wire: &str,
+    ) {
+        let serialized: &'static str = source.into();
+        assert_eq!(serialized, wire);
+        assert_eq!(ProtocolMetadataSource::from_str(wire).unwrap(), source);
+    }
+
+    #[rstest]
+    #[case::known("crc_at_target", ProtocolMetadataSource::CrcAtTarget)]
+    #[case::empty_defaults_to_full_replay("", ProtocolMetadataSource::FullReplay)]
+    #[case::unknown_defaults_to_full_replay("totally_unknown", ProtocolMetadataSource::FullReplay)]
+    fn protocol_metadata_source_parse_lenient(
+        #[case] value: &str,
+        #[case] expected: ProtocolMetadataSource,
+    ) {
+        assert_eq!(ProtocolMetadataSource::parse_lenient(value), expected);
     }
 
     #[test]

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -124,7 +124,6 @@ impl MetricEvent {
     pub(crate) fn set_duration_if_applicable(&mut self, d: Duration) {
         match self {
             // Lifecycle success: duration must be set by the tracing layer on span close.
-            Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
             Self::SnapshotBuildSuccess(e) => e.set_duration(d),
             Self::TransactionCommitSuccess(e) => e.set_duration(d),
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
@@ -133,7 +132,8 @@ impl MetricEvent {
 
             // Emit-based success events set their duration as a creation attribute, so the
             // span-close hook must not overwrite it.
-            Self::ProtocolMetadataLoadSuccess(_)
+            Self::LogSegmentLoadSuccess(_)
+            | Self::ProtocolMetadataLoadSuccess(_)
             | Self::ScanMetadataCompleted(_)
             | Self::StorageListCompleted(_)
             | Self::StorageReadCompleted(_)
@@ -156,13 +156,12 @@ impl MetricEvent {
     pub(crate) fn record_u64(&mut self, name: &str, value: u64) -> Result<(), &'static str> {
         match self {
             // Variants with u64 fields set during span lifetime.
-            Self::LogSegmentLoadSuccess(e) => e.record_u64(name, value),
             Self::SnapshotBuildSuccess(e) => e.record_u64(name, value),
             Self::TransactionCommitSuccess(e) => e.record_u64(name, value),
             Self::DomainMetadataLoadSuccess(e) => e.record_u64(name, value),
             Self::CrcReadSuccess(e) => e.record_u64(name, value),
 
-            // No u64 fields set during span lifetime — a runtime record() on these is a bug.
+            Self::LogSegmentLoadSuccess(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadSuccess::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
@@ -186,12 +185,12 @@ impl MetricEvent {
     pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
         match self {
             // Variants with bool fields set during span lifetime.
-            Self::LogSegmentLoadSuccess(e) => e.record_bool(name, value),
             Self::TransactionCommitSuccess(e) => e.record_bool(name, value),
             Self::DomainMetadataLoadSuccess(e) => e.record_bool(name, value),
             Self::SetTransactionLoadSuccess(e) => e.record_bool(name, value),
 
             // No bool fields set during span lifetime — a runtime record() on these is a bug.
+            Self::LogSegmentLoadSuccess(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
             Self::CrcReadSuccess(_) => Err(CrcReadSuccess::SPAN_NAME),
@@ -246,12 +245,14 @@ impl MetricEvent {
                 operation_id: e.operation_id,
                 table_type: e.table_type,
                 correlation_id: e.correlation_id,
+                load_purpose: e.load_purpose,
             }),
             Self::ProtocolMetadataLoadSuccess(e) => {
                 Self::ProtocolMetadataLoadFailure(ProtocolMetadataLoadFailure {
                     operation_id: e.operation_id,
                     table_type: e.table_type,
                     correlation_id: e.correlation_id,
+                    load_purpose: e.load_purpose,
                 })
             }
             Self::SnapshotBuildSuccess(e) => Self::SnapshotBuildFailure(SnapshotBuildFailure {
@@ -338,70 +339,95 @@ fn parse_label_or_default<T: FromStr<Err = strum::ParseError> + Default>(
 // Canonical example for the per-event block pattern. Other events below follow the same
 // shape; detailed `///` docs on `from_attrs` and `record_*` live here only.
 
-// Module-scope span name. `#[instrument(name = ...)]` only accepts a bare identifier here,
-// not a multi-segment path like `Type::SPAN_NAME`.
 pub(crate) const LOG_SEGMENT_LOADED_SPAN: &str = "segment.for_snapshot";
 
+/// Whether a snapshot load built from scratch or updated an existing snapshot. New variants may
+/// be added as more log-segment load purposes appear (e.g. table-changes or streaming).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum LogSegmentLoadPurpose {
+    /// A fresh snapshot built from a freshly-listed log segment.
+    #[default]
+    FreshSnapshot,
+    /// An incremental update of an existing snapshot to a newer version.
+    IncrementalSnapshot,
+}
+
+impl LogSegmentLoadPurpose {
+    fn parse_lenient(s: &str) -> Self {
+        parse_label_or_default(s, "load_purpose")
+    }
+}
+
 /// A log segment was listed and assembled for a snapshot.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LogSegmentLoadSuccess {
-    // === Set on span creation ===
     pub operation_id: MetricId,
     /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-
-    // === Set during span lifetime ===
+    pub load_purpose: LogSegmentLoadPurpose,
     pub num_commit_files: u64,
     pub num_checkpoint_files: u64,
     pub num_compaction_files: u64,
-    pub has_latest_crc_file: bool,
-
-    // === Set on span close ===
+    /// How many versions behind the segment's end version the latest on-disk CRC file is:
+    /// `None` if there is no CRC file, `Some(0)` if one sits at the end version, `Some(n)` if it
+    /// is `n` versions stale.
+    pub crc_versions_behind: Option<u64>,
     pub duration: Duration,
 }
 
 impl LogSegmentLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = LOG_SEGMENT_LOADED_SPAN;
 
-    /// Construction-time channel. Extracts fields bound at span creation via
-    /// `#[instrument(fields(X = expr))]` or `tracing::span!(..., X = expr)`.
     pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
-        Self {
-            operation_id: MetricId::from_attrs(attrs),
-            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
-            correlation_id: correlation_id_from_attrs(attrs),
-            num_commit_files: 0,
-            num_checkpoint_files: 0,
-            num_compaction_files: 0,
-            has_latest_crc_file: false,
-            duration: Duration::default(),
+        let mut event = Self::default();
+        attrs.record(&mut event);
+        event
+    }
+}
+
+impl Visit for LogSegmentLoadSuccess {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == IS_CATALOG_MANAGED_FIELD {
+            self.table_type = TableType::from_catalog_managed(value);
         }
     }
 
-    /// Runtime channel. Dispatches a u64 field update from `Span::current().record(name, value)`
-    /// to the matching field.
-    pub(crate) fn record_u64(&mut self, name: &str, value: u64) -> Result<(), &'static str> {
-        match name {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            CORRELATION_ID_FIELD if !value.is_empty() => self.correlation_id = Some(value.into()),
+            "load_purpose" => self.load_purpose = LogSegmentLoadPurpose::parse_lenient(value),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "duration_ns" => self.duration = Duration::from_nanos(value),
             "num_commit_files" => self.num_commit_files = value,
             "num_checkpoint_files" => self.num_checkpoint_files = value,
             "num_compaction_files" => self.num_compaction_files = value,
-            _ => return Err(Self::SPAN_NAME),
+            _ => {}
         }
-        Ok(())
     }
 
-    pub(crate) fn record_bool(&mut self, name: &str, value: bool) -> Result<(), &'static str> {
-        match name {
-            "has_latest_crc_file" => self.has_latest_crc_file = value,
-            _ => return Err(Self::SPAN_NAME),
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        // `crc_versions_behind` rides the span as an i64 so its `None` (no CRC file) can be a
+        // negative sentinel; any negative value decodes back to `None`.
+        if field.name() == "crc_versions_behind" {
+            self.crc_versions_behind = u64::try_from(value).ok();
         }
-        Ok(())
     }
 
-    pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if let Some(id) = record_operation_id(field, value, Self::SPAN_NAME) {
+            self.operation_id = id;
+        }
     }
 }
 
@@ -411,19 +437,20 @@ impl fmt::Display for LogSegmentLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            load_purpose,
             duration,
             num_commit_files,
             num_checkpoint_files,
             num_compaction_files,
-            has_latest_crc_file,
+            crc_versions_behind,
         } = self;
         write!(
             f,
             "LogSegmentLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, \
+             correlation_id={correlation_id:?}, load_purpose={load_purpose}, \
              duration={duration:?}, commits={num_commit_files}, \
              checkpoints={num_checkpoint_files}, compactions={num_compaction_files}, \
-             has_latest_crc={has_latest_crc_file})"
+             crc_versions_behind={crc_versions_behind:?})"
         )
     }
 }
@@ -436,14 +463,15 @@ pub struct LogSegmentLoadFailure {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    pub load_purpose: LogSegmentLoadPurpose,
 }
 
 impl fmt::Display for LogSegmentLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "LogSegmentLoadFailure(id={}, table_type={}, correlation_id={:?})",
-            self.operation_id, self.table_type, self.correlation_id
+            "LogSegmentLoadFailure(id={}, table_type={}, correlation_id={:?}, load_purpose={})",
+            self.operation_id, self.table_type, self.correlation_id, self.load_purpose
         )
     }
 }
@@ -490,6 +518,7 @@ pub struct ProtocolMetadataLoadSuccess {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    pub load_purpose: LogSegmentLoadPurpose,
     pub source: ProtocolMetadataSource,
     pub duration: Duration,
 }
@@ -514,6 +543,7 @@ impl Visit for ProtocolMetadataLoadSuccess {
     fn record_str(&mut self, field: &Field, value: &str) {
         match field.name() {
             CORRELATION_ID_FIELD if !value.is_empty() => self.correlation_id = Some(value.into()),
+            "load_purpose" => self.load_purpose = LogSegmentLoadPurpose::parse_lenient(value),
             "pm_source" => self.source = ProtocolMetadataSource::parse_lenient(value),
             _ => {}
         }
@@ -538,13 +568,15 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            load_purpose,
             source,
             duration,
         } = self;
         write!(
             f,
             "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, source={source}, duration={duration:?})"
+             correlation_id={correlation_id:?}, load_purpose={load_purpose}, source={source}, \
+             duration={duration:?})"
         )
     }
 }
@@ -557,14 +589,16 @@ pub struct ProtocolMetadataLoadFailure {
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
+    pub load_purpose: LogSegmentLoadPurpose,
 }
 
 impl fmt::Display for ProtocolMetadataLoadFailure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "ProtocolMetadataLoadFailure(id={}, table_type={}, correlation_id={:?})",
-            self.operation_id, self.table_type, self.correlation_id
+            "ProtocolMetadataLoadFailure(id={}, table_type={}, correlation_id={:?}, \
+             load_purpose={})",
+            self.operation_id, self.table_type, self.correlation_id, self.load_purpose
         )
     }
 }
@@ -1197,6 +1231,7 @@ pub struct SnapshotLoadMetricContext {
     pub(crate) operation_id: MetricId,
     pub(crate) correlation_id: Option<Arc<str>>,
     pub(crate) is_catalog_managed: bool,
+    pub(crate) load_purpose: LogSegmentLoadPurpose,
 }
 
 /// Decode the `operation_id` debug-string span field into a [`MetricId`]. Returns `None` when the
@@ -1628,6 +1663,50 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
     );
 }
 
+/// Emit a [`MetricEvent::LogSegmentLoadSuccess`]. Used where a log segment is listed inline
+/// rather than through an instrumented listing.
+pub(crate) fn emit_log_segment_load(
+    ctx: &SnapshotLoadMetricContext,
+    num_commit_files: u64,
+    num_checkpoint_files: u64,
+    num_compaction_files: u64,
+    crc_versions_behind: Option<u64>,
+    duration: Duration,
+) {
+    tracing::span!(
+        tracing::Level::INFO,
+        LogSegmentLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        load_purpose = ctx.load_purpose.as_ref(),
+        num_commit_files,
+        num_checkpoint_files,
+        num_compaction_files,
+        // Rides the span as an i64 so `None` (no CRC file) is a negative sentinel that decodes
+        // back to `None`.
+        crc_versions_behind = crc_versions_behind.map_or(-1, |n| n as i64),
+        duration_ns = duration.as_nanos() as u64,
+    );
+}
+
+/// Emit a [`MetricEvent::LogSegmentLoadFailure`] on the load error path (the flipped `...Success`
+/// span, per the README's failure-events pattern).
+pub(crate) fn emit_log_segment_load_failure(ctx: &SnapshotLoadMetricContext) {
+    let span = tracing::span!(
+        tracing::Level::INFO,
+        LogSegmentLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        load_purpose = ctx.load_purpose.as_ref(),
+    );
+    let _enter = span.enter();
+    tracing::info!(error = tracing::field::debug("log segment load failed"));
+}
+
 /// Emit a [`MetricEvent::ProtocolMetadataLoadSuccess`]. Call once per snapshot load on the P&M
 /// resolution path, on success.
 pub(crate) fn emit_protocol_metadata_load(
@@ -1642,6 +1721,7 @@ pub(crate) fn emit_protocol_metadata_load(
         operation_id = %ctx.operation_id,
         is_catalog_managed = ctx.is_catalog_managed,
         correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        load_purpose = ctx.load_purpose.as_ref(),
         pm_source = source.as_ref(),
         duration_ns = duration.as_nanos() as u64,
     );
@@ -1657,6 +1737,7 @@ pub(crate) fn emit_protocol_metadata_load_failure(ctx: &SnapshotLoadMetricContex
         operation_id = %ctx.operation_id,
         is_catalog_managed = ctx.is_catalog_managed,
         correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        load_purpose = ctx.load_purpose.as_ref(),
     );
     let _enter = span.enter();
     tracing::info!(error = tracing::field::debug("protocol/metadata load failed"));
@@ -1761,6 +1842,29 @@ mod tests {
         #[case] expected: ScanType,
     ) {
         assert_eq!(ScanType::parse_lenient(value), expected);
+    }
+
+    #[rstest]
+    #[case::fresh(LogSegmentLoadPurpose::FreshSnapshot, "fresh_snapshot")]
+    #[case::incremental(LogSegmentLoadPurpose::IncrementalSnapshot, "incremental_snapshot")]
+    fn log_segment_load_purpose_serializes_to_wire_name_and_parses_back(
+        #[case] purpose: LogSegmentLoadPurpose,
+        #[case] wire: &str,
+    ) {
+        let serialized: &'static str = purpose.into();
+        assert_eq!(serialized, wire);
+        assert_eq!(LogSegmentLoadPurpose::from_str(wire).unwrap(), purpose);
+    }
+
+    #[rstest]
+    #[case::known("incremental_snapshot", LogSegmentLoadPurpose::IncrementalSnapshot)]
+    #[case::empty_defaults_to_fresh("", LogSegmentLoadPurpose::FreshSnapshot)]
+    #[case::unknown_defaults_to_fresh("totally_unknown", LogSegmentLoadPurpose::FreshSnapshot)]
+    fn log_segment_load_purpose_parse_lenient(
+        #[case] value: &str,
+        #[case] expected: LogSegmentLoadPurpose,
+    ) {
+        assert_eq!(LogSegmentLoadPurpose::parse_lenient(value), expected);
     }
 
     #[rstest]

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -85,14 +85,17 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
-    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
-    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
-    SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-    TableType, TransactionCommitFailure, TransactionCommitSuccess,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadPurpose,
+    LogSegmentLoadSuccess, MetricEvent, MetricId, ParquetReadCompleted,
+    ProtocolMetadataLoadFailure, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+    ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess, SnapshotBuildFailure,
+    SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted,
+    StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
 };
-pub(crate) use events::{emit_protocol_metadata_load, emit_protocol_metadata_load_failure};
+pub(crate) use events::{
+    emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,
+    emit_protocol_metadata_load_failure,
+};
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;
 pub use metered_parquet::MeteredParquetHandler;

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -87,11 +87,12 @@ pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
     DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
     MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
-    SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted,
-    StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
-    TransactionCommitSuccess,
+    ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
+    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
+    SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+    TableType, TransactionCommitFailure, TransactionCommitSuccess,
 };
+pub(crate) use events::{emit_protocol_metadata_load, emit_protocol_metadata_load_failure};
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;
 pub use metered_parquet::MeteredParquetHandler;

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -7,7 +7,7 @@ use tracing::{info, instrument};
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-use crate::metrics::{MetricId, SnapshotLoadMetricContext};
+use crate::metrics::{LogSegmentLoadPurpose, MetricId, SnapshotLoadMetricContext};
 use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
@@ -48,6 +48,9 @@ pub struct SnapshotBuilder {
     /// Opaque, caller-supplied id recorded on this build's metric events. Not interpreted by
     /// kernel; set via [`with_correlation_id`](Self::with_correlation_id).
     correlation_id: Option<Arc<str>>,
+    /// Whether this builds a fresh snapshot or updates an existing one. Set by the constructor
+    /// and recorded on the load metric events.
+    load_purpose: LogSegmentLoadPurpose,
 }
 
 /// Controls whether kernel replays commits to advance a stale base CRC (the existing snapshot's
@@ -109,6 +112,7 @@ impl SnapshotBuilder {
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
             correlation_id: None,
+            load_purpose: LogSegmentLoadPurpose::FreshSnapshot,
         }
     }
 
@@ -122,6 +126,7 @@ impl SnapshotBuilder {
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
             correlation_id: None,
+            load_purpose: LogSegmentLoadPurpose::IncrementalSnapshot,
         }
     }
 
@@ -241,12 +246,14 @@ impl SnapshotBuilder {
             incremental_replay,
             operation_id,
             correlation_id,
+            load_purpose,
         } = self;
 
         let metric_context = SnapshotLoadMetricContext {
             operation_id,
             is_catalog_managed: max_catalog_version.is_some(),
             correlation_id,
+            load_purpose,
         };
 
         let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -10,7 +10,9 @@ use tracing::instrument;
 use super::{IncrementalReplay, Snapshot};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_protocol_metadata_load, emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
+};
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -292,24 +294,24 @@ impl Snapshot {
 
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
-        // `incremental_replay`.
+        // `incremental_replay`. Time from here so the CRC-advance cost lands in the P&M duration,
+        // matching the fresh path.
+        let pm_start = std::time::Instant::now();
         let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
-        let crc_at_version = combined_log_segment.try_build_crc_within_budget(
-            engine,
-            base_crc.as_ref(),
-            incremental_replay,
-        )?;
+        let crc_resolution = combined_log_segment
+            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
+            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
 
         let existing_table_config = existing_snapshot.table_configuration();
-        let (new_metadata, new_protocol) = match &crc_at_version {
-            Some(crc) => {
+        let (new_metadata, new_protocol, source) = match crc_resolution.crc_and_source() {
+            Some((crc, source)) => {
                 // If we were able to build a new CRC, then re-use it for TableConfiguration
                 // creation.
                 let new_metadata = (crc.metadata != *existing_table_config.metadata())
                     .then(|| crc.metadata.clone());
                 let new_protocol = (crc.protocol != *existing_table_config.protocol())
                     .then(|| crc.protocol.clone());
-                (new_metadata, new_protocol)
+                (new_metadata, new_protocol, source)
             }
             None => {
                 // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
@@ -321,9 +323,12 @@ impl Snapshot {
                     .filter(|c| c.version > existing_snapshot_version);
                 combined_log_segment
                     .segment_after_version(existing_snapshot_version)
-                    .read_protocol_metadata_opt(engine, newer_base)?
+                    .read_protocol_metadata_opt(engine, newer_base)
+                    .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?
             }
         };
+        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
+
         let table_configuration = TableConfiguration::try_new_from(
             existing_table_config,
             new_metadata,
@@ -335,7 +340,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            crc_at_version,
+            crc_resolution.into_crc(),
         )?))
     }
 
@@ -402,12 +407,17 @@ mod tests {
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
+    use crate::metrics::{
+        MetricEvent, MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+    };
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStoreExt as _;
     use crate::parquet::arrow::ArrowWriter;
     use crate::path::LogPathFileType;
     use crate::snapshot::commit;
-    use crate::utils::test_utils::string_array_to_engine_data;
+    use crate::utils::test_utils::{
+        install_thread_local_metrics_reporter, string_array_to_engine_data, CapturingReporter,
+    };
 
     // ============================================================================
     // Helpers
@@ -1791,6 +1801,188 @@ mod tests {
             .collect();
         assert_eq!(versions_and_his, vec![(1, 2), (2, 2)]);
 
+        Ok(())
+    }
+
+    // ============================================================================
+    // ProtocolMetadataLoad source classification
+    // ============================================================================
+
+    fn protocol_metadata_load(events: &[MetricEvent]) -> ProtocolMetadataLoadSuccess {
+        let mut it = events.iter().filter_map(|e| match e {
+            MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+            _ => None,
+        });
+        let found = it.next().expect("expected a ProtocolMetadataLoadSuccess");
+        assert!(it.next().is_none(), "expected exactly one matching event");
+        found.clone()
+    }
+
+    #[rstest]
+    #[case::no_crc(None, IncrementalReplay::Disabled, ProtocolMetadataSource::FullReplay)]
+    #[case::crc_at_target(
+        Some(3),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcAtTarget
+    )]
+    #[case::stale_crc_advanced(
+        Some(1),
+        IncrementalReplay::Unlimited,
+        ProtocolMetadataSource::CrcAdvancedByReplay
+    )]
+    #[case::stale_crc_seeds_replay(
+        Some(1),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_fresh_build_classifies_protocol_metadata_source(
+        #[case] planted_crc_version: Option<u64>,
+        #[case] mode: IncrementalReplay,
+        #[case] expected_source: ProtocolMetadataSource,
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+        if let Some(v) = planted_crc_version {
+            ctx.store
+                .put(
+                    &delta_path_for_version(v, "crc"),
+                    make_test_crc_json(200, 2).to_string().into(),
+                )
+                .await?;
+        }
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let corr = "req-abc";
+        let _snapshot = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .with_incremental_crc_replay(mode)
+            .with_correlation_id(corr)
+            .build(ctx.engine.as_ref())?;
+
+        let events = reporter.events();
+        let pm = protocol_metadata_load(&events);
+        assert_eq!(pm.source, expected_source);
+
+        // The operation_id and correlation_id survive the emit->decode round-trip.
+        assert_eq!(pm.correlation_id.as_deref(), Some(corr));
+        assert_ne!(pm.operation_id, MetricId::nil());
+
+        // The CRC-advance replay cost is folded into the P&M duration on the advanced case.
+        if expected_source == ProtocolMetadataSource::CrcAdvancedByReplay {
+            assert!(pm.duration > std::time::Duration::ZERO);
+        }
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::no_crc(None, IncrementalReplay::Disabled, ProtocolMetadataSource::FullReplay)]
+    #[case::crc_at_target(
+        Some(5),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcAtTarget
+    )]
+    #[case::stale_crc_advanced(
+        Some(1),
+        IncrementalReplay::Unlimited,
+        ProtocolMetadataSource::CrcAdvancedByReplay
+    )]
+    // A CRC newer than the existing snapshot (v3) but below the target (v5), with advance
+    // disabled, seeds a pruned replay rather than being used at target or advanced.
+    #[case::stale_crc_seeds_replay(
+        Some(4),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_build_classifies_protocol_metadata_source(
+        #[case] planted_crc_version: Option<u64>,
+        #[case] mode: IncrementalReplay,
+        #[case] expected_source: ProtocolMetadataSource,
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        if let Some(v) = planted_crc_version {
+            ctx.store
+                .put(
+                    &delta_path_for_version(v, "crc"),
+                    make_test_crc_json(200, 2).to_string().into(),
+                )
+                .await?;
+        }
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let updated = Snapshot::builder_from(base)
+            .at_version(5)
+            .with_incremental_crc_replay(mode)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 5);
+
+        let pm = protocol_metadata_load(&reporter.events());
+        assert_eq!(pm.source, expected_source);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_build_no_pm_change_classifies_full_replay() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let updated = Snapshot::builder_from(base).build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 3);
+
+        // No P&M change in the new commits, no newer CRC: the replay finds nothing above the
+        // existing snapshot, so the source is the not-CRC-rooted `FullReplay`.
+        let pm = protocol_metadata_load(&reporter.events());
+        assert_eq!(pm.source, ProtocolMetadataSource::FullReplay);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_fresh_build_missing_protocol_metadata_emits_failure() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        // A commit with only an add action: no protocol or metadata anywhere in the log.
+        commit(
+            ctx.url.as_str(),
+            &ctx.store,
+            0,
+            vec![add_action("f0.parquet")],
+        )
+        .await;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let result = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref());
+        assert!(result.is_err());
+
+        let events = reporter.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadFailure(_))),
+            "expected a ProtocolMetadataLoadFailure"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadSuccess(_))),
+            "no success event should fire on the failure path"
+        );
         Ok(())
     }
 }

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -11,11 +11,30 @@ use super::{IncrementalReplay, Snapshot};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::{
-    emit_protocol_metadata_load, emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
+    emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,
+    emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
 };
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Engine, Error, Version};
+
+/// Outcome of listing and assembling the new log segment during an incremental update. Listing and
+/// assembly run as one fallible unit returning this enum, so a genuine load failure (a propagated
+/// `Err`) emits the load-failure metric at exactly one call site, while these non-failure outcomes
+/// do not.
+enum NewSegment {
+    /// The requested version is not in the log; the caller errors (case C.1).
+    Unavailable { requested_version: Version },
+    /// No new segment to build; the caller returns the existing snapshot unchanged (cases C.2, E).
+    Unchanged,
+    /// A checkpoint ahead of the existing snapshot requires a full rebuild from it (case D.1).
+    Rebuild(LogSegment),
+    /// New commits merged into the existing segment; ready for incremental P&M (case F, D.2 -> F).
+    Combined {
+        combined_log_segment: LogSegment,
+        new_end_version: Version,
+    },
+}
 
 impl Snapshot {
     // ============================================================================
@@ -113,13 +132,131 @@ impl Snapshot {
             tracing::Span::current().record("version", existing_snapshot_version);
         }
 
+        // Check for new commits (and CRC).
+        let segment_load_start = std::time::Instant::now();
+        let emit_segment_load = |ctx: &SnapshotLoadMetricContext, segment: &LogSegment| {
+            emit_log_segment_load(
+                ctx,
+                segment.listed.ascending_commit_files.len() as u64,
+                segment.listed.checkpoint_parts.len() as u64,
+                segment.listed.ascending_compaction_files.len() as u64,
+                segment.crc_versions_behind(),
+                segment_load_start.elapsed(),
+            );
+        };
+
+        // List and assemble the new segment as one fallible unit so a load failure emits exactly
+        // once here. A propagated `Err` is a genuine load failure; the returned `NewSegment` is
+        // not.
+        let (combined_log_segment, new_end_version) = match Self::build_new_segment(
+            engine,
+            existing_log_segment,
+            existing_snapshot_version,
+            log_tail,
+            requested_version,
+        )
+        .inspect_err(|_| emit_log_segment_load_failure(&metric_context))?
+        {
+            NewSegment::Unavailable { requested_version } => {
+                return Err(Error::Generic(format!(
+                    "Requested snapshot version {requested_version} is not available: \
+                     no new commits were found after existing snapshot version \
+                     {existing_snapshot_version}"
+                )));
+            }
+            NewSegment::Unchanged => return Ok(existing_snapshot.clone()),
+            NewSegment::Rebuild(new_log_segment) => {
+                emit_segment_load(&metric_context, &new_log_segment);
+                let snapshot = Self::try_new_from_log_segment(
+                    existing_snapshot.table_root().clone(),
+                    new_log_segment,
+                    engine,
+                    metric_context,
+                    incremental_replay,
+                );
+                return Ok(Arc::new(snapshot?));
+            }
+            NewSegment::Combined {
+                combined_log_segment,
+                new_end_version,
+            } => {
+                emit_segment_load(&metric_context, &combined_log_segment);
+                (combined_log_segment, new_end_version)
+            }
+        };
+
+        // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
+        // on-disk CRC the combined segment carries) to the new end version, subject to
+        // `incremental_replay`. Time from here so the CRC-advance cost lands in the P&M duration,
+        // matching the fresh path.
+        let pm_start = std::time::Instant::now();
+        let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
+        let crc_resolution = combined_log_segment
+            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
+            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
+
+        let existing_table_config = existing_snapshot.table_configuration();
+        let (new_metadata, new_protocol, source) = match crc_resolution.crc_and_source() {
+            Some((crc, source)) => {
+                // If we were able to build a new CRC, then re-use it for TableConfiguration
+                // creation.
+                let new_metadata = (crc.metadata != *existing_table_config.metadata())
+                    .then(|| crc.metadata.clone());
+                let new_protocol = (crc.protocol != *existing_table_config.protocol())
+                    .then(|| crc.protocol.clone());
+                (new_metadata, new_protocol, source)
+            }
+            None => {
+                // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
+                // scanned any log files). Replay the new commits `(existing_snapshot_version, end]`
+                // for P&M, rooted at the base CRC when it is newer than the existing snapshot
+                // (else the existing snapshot is the baseline).
+                let newer_base = base_crc
+                    .as_ref()
+                    .filter(|c| c.version > existing_snapshot_version);
+                combined_log_segment
+                    .segment_after_version(existing_snapshot_version)
+                    .read_protocol_metadata_opt(engine, newer_base)
+                    .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?
+            }
+        };
+        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
+
+        let table_configuration = TableConfiguration::try_new_from(
+            existing_table_config,
+            new_metadata,
+            new_protocol,
+            new_end_version,
+        )?;
+
+        tracing::Span::current().record("version", table_configuration.version());
+        Ok(Arc::new(Snapshot::new_with_crc(
+            combined_log_segment,
+            table_configuration,
+            crc_resolution.into_crc(),
+        )?))
+    }
+
+    // ============================================================================
+    // Helpers
+    // ============================================================================
+
+    /// List the log after the existing snapshot and assemble the new [`NewSegment`] for this
+    /// incremental update. Returns a non-failure [`NewSegment`] on the C/D.1/E/F cases; a
+    /// propagated `Err` is a genuine listing/assembly failure.
+    fn build_new_segment(
+        engine: &dyn Engine,
+        existing_log_segment: &LogSegment,
+        existing_snapshot_version: Version,
+        log_tail: Vec<ParsedLogPath>,
+        requested_version: Option<Version>,
+    ) -> DeltaResult<NewSegment> {
         let log_root = existing_log_segment.log_root.clone();
         let storage = engine.storage_handler();
 
         // Start listing just after the previous segment's checkpoint, if any.
         let listing_start = existing_log_segment.checkpoint_version.unwrap_or(0) + 1;
 
-        // Check for new commits (and CRC)
         let new_listed_files = LogSegmentFiles::list(
             storage.as_ref(),
             &log_root,
@@ -134,22 +271,14 @@ impl Snapshot {
         if new_listed_files.ascending_commit_files().is_empty()
             && new_listed_files.checkpoint_parts().is_empty()
         {
-            match requested_version {
+            return Ok(match requested_version {
                 // Case C.1: caller requested a specific version (necessarily >
                 // existing_snapshot_version since cases A and B were handled above), but
                 // no such commit exists in the log.
-                Some(requested_version) => {
-                    return Err(Error::Generic(format!(
-                        "Requested snapshot version {requested_version} is not available: \
-                         no new commits were found after existing snapshot version \
-                         {existing_snapshot_version}"
-                    )));
-                }
+                Some(requested_version) => NewSegment::Unavailable { requested_version },
                 // Case C.2: no new commits and no explicit target; latest is existing.
-                None => {
-                    return Ok(existing_snapshot.clone());
-                }
-            }
+                None => NewSegment::Unchanged,
+            });
         }
 
         // create a log segment just from existing_checkpoint.version -> new_version
@@ -179,14 +308,7 @@ impl Snapshot {
                 // of the listing, so a full rebuild is required. The existing snapshot's CRC
                 // is older than the new checkpoint and cannot apply, but a fresh on-disk CRC
                 // at or above the new checkpoint still advances per `incremental_replay`.
-                let snapshot = Self::try_new_from_log_segment(
-                    existing_snapshot.table_root().clone(),
-                    new_log_segment,
-                    engine,
-                    metric_context,
-                    incremental_replay,
-                );
-                return Ok(Arc::new(snapshot?));
+                return Ok(NewSegment::Rebuild(new_log_segment));
             }
             // Case D.2: checkpoint at or below existing snapshot; fall through to case F to
             // replay only the new commits and advance the checkpoint base.
@@ -199,7 +321,7 @@ impl Snapshot {
             // We must check checkpoint_version here: if a checkpoint at or below the existing
             // snapshot version was discovered, we still need to fall through to advance the
             // checkpoint base even though the version did not change.
-            return Ok(existing_snapshot.clone());
+            return Ok(NewSegment::Unchanged);
         }
 
         // Case F: lightweight P+M replay on new commits, merge with existing segment.
@@ -292,61 +414,11 @@ impl Snapshot {
             new_checkpoint_hint,
         )?;
 
-        // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
-        // on-disk CRC the combined segment carries) to the new end version, subject to
-        // `incremental_replay`. Time from here so the CRC-advance cost lands in the P&M duration,
-        // matching the fresh path.
-        let pm_start = std::time::Instant::now();
-        let base_crc = combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.crc());
-        let crc_resolution = combined_log_segment
-            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
-            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
-
-        let existing_table_config = existing_snapshot.table_configuration();
-        let (new_metadata, new_protocol, source) = match crc_resolution.crc_and_source() {
-            Some((crc, source)) => {
-                // If we were able to build a new CRC, then re-use it for TableConfiguration
-                // creation.
-                let new_metadata = (crc.metadata != *existing_table_config.metadata())
-                    .then(|| crc.metadata.clone());
-                let new_protocol = (crc.protocol != *existing_table_config.protocol())
-                    .then(|| crc.protocol.clone());
-                (new_metadata, new_protocol, source)
-            }
-            None => {
-                // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
-                // scanned any log files). Replay the new commits `(existing_snapshot_version, end]`
-                // for P&M, rooted at the base CRC when it is newer than the existing snapshot
-                // (else the existing snapshot is the baseline).
-                let newer_base = base_crc
-                    .as_ref()
-                    .filter(|c| c.version > existing_snapshot_version);
-                combined_log_segment
-                    .segment_after_version(existing_snapshot_version)
-                    .read_protocol_metadata_opt(engine, newer_base)
-                    .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?
-            }
-        };
-        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
-
-        let table_configuration = TableConfiguration::try_new_from(
-            existing_table_config,
-            new_metadata,
-            new_protocol,
-            new_end_version,
-        )?;
-
-        tracing::Span::current().record("version", table_configuration.version());
-        Ok(Arc::new(Snapshot::new_with_crc(
+        Ok(NewSegment::Combined {
             combined_log_segment,
-            table_configuration,
-            crc_resolution.into_crc(),
-        )?))
+            new_end_version,
+        })
     }
-
-    // ============================================================================
-    // Helpers
-    // ============================================================================
 
     /// Determine the on-disk CRC file the combined segment should carry.
     ///
@@ -408,7 +480,8 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
     use crate::metrics::{
-        MetricEvent, MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+        LogSegmentLoadPurpose, LogSegmentLoadSuccess, MetricEvent, MetricId,
+        ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
     };
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStoreExt as _;
@@ -1808,14 +1881,28 @@ mod tests {
     // ProtocolMetadataLoad source classification
     // ============================================================================
 
-    fn protocol_metadata_load(events: &[MetricEvent]) -> ProtocolMetadataLoadSuccess {
-        let mut it = events.iter().filter_map(|e| match e {
-            MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
-            _ => None,
-        });
-        let found = it.next().expect("expected a ProtocolMetadataLoadSuccess");
+    fn single_event<T: Clone>(
+        events: &[MetricEvent],
+        extract: impl Fn(&MetricEvent) -> Option<&T>,
+    ) -> T {
+        let mut it = events.iter().filter_map(&extract);
+        let found = it.next().expect("expected an event of this type");
         assert!(it.next().is_none(), "expected exactly one matching event");
         found.clone()
+    }
+
+    fn protocol_metadata_load(events: &[MetricEvent]) -> ProtocolMetadataLoadSuccess {
+        single_event(events, |e| match e {
+            MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+            _ => None,
+        })
+    }
+
+    fn log_segment_load(events: &[MetricEvent]) -> LogSegmentLoadSuccess {
+        single_event(events, |e| match e {
+            MetricEvent::LogSegmentLoadSuccess(s) => Some(s),
+            _ => None,
+        })
     }
 
     #[rstest]
@@ -1865,10 +1952,23 @@ mod tests {
         let events = reporter.events();
         let pm = protocol_metadata_load(&events);
         assert_eq!(pm.source, expected_source);
+        assert_eq!(pm.load_purpose, LogSegmentLoadPurpose::FreshSnapshot);
 
-        // The operation_id and correlation_id survive the emit->decode round-trip.
-        assert_eq!(pm.correlation_id.as_deref(), Some(corr));
-        assert_ne!(pm.operation_id, MetricId::nil());
+        let seg = log_segment_load(&events);
+        assert_eq!(seg.load_purpose, LogSegmentLoadPurpose::FreshSnapshot);
+        // The v0-v3 table has 4 commits, no checkpoint or compaction.
+        assert_eq!(seg.num_commit_files, 4);
+        assert_eq!(seg.num_checkpoint_files, 0);
+        assert_eq!(seg.num_compaction_files, 0);
+        // No CRC decodes to None; a CRC planted at version v is `3 - v` versions behind the
+        // loaded version 3.
+        assert_eq!(seg.crc_versions_behind, planted_crc_version.map(|v| 3 - v));
+
+        // The operation_id and correlation_id survive the emit->decode round-trip and one
+        // operation_id joins both events.
+        assert_eq!(seg.correlation_id.as_deref(), Some(corr));
+        assert_ne!(seg.operation_id, MetricId::nil());
+        assert_eq!(seg.operation_id, pm.operation_id);
 
         // The CRC-advance replay cost is folded into the P&M duration on the advanced case.
         if expected_source == ProtocolMetadataSource::CrcAdvancedByReplay {
@@ -1925,8 +2025,12 @@ mod tests {
             .build(ctx.engine.as_ref())?;
         assert_eq!(updated.version(), 5);
 
-        let pm = protocol_metadata_load(&reporter.events());
+        let events = reporter.events();
+        let pm = protocol_metadata_load(&events);
         assert_eq!(pm.source, expected_source);
+        assert_eq!(pm.load_purpose, LogSegmentLoadPurpose::IncrementalSnapshot);
+        let seg = log_segment_load(&events);
+        assert_eq!(seg.load_purpose, LogSegmentLoadPurpose::IncrementalSnapshot);
         Ok(())
     }
 
@@ -1982,6 +2086,79 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadSuccess(_))),
             "no success event should fire on the failure path"
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_version_regression_emits_log_segment_load_failure() -> DeltaResult<()>
+    {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?; // v0..=v5
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(5)
+            .build(ctx.engine.as_ref())?;
+
+        // Simulate commits incorrectly deleted from the log: re-listing now tops out below v5, so
+        // the new segment's end version is older than the base and the regression branch fires.
+        ctx.store.delete(&delta_path_for_version(5, "json")).await?;
+        ctx.store.delete(&delta_path_for_version(4, "json")).await?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let result = Snapshot::builder_from(base).build(ctx.engine.as_ref());
+        assert!(result.is_err());
+
+        let events = reporter.events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::LogSegmentLoadFailure(_))),
+            "expected a LogSegmentLoadFailure"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::LogSegmentLoadSuccess(_))),
+            "no success event should fire on the failure path"
+        );
+        Ok(())
+    }
+
+    // Case D.1 (checkpoint strictly ahead of the base) rebuilds via the fresh emitter, but the
+    // load was requested incrementally, so both events must still report IncrementalSnapshot.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_rebuild_reports_incremental_purpose() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?;
+
+        // Checkpoint at v3, strictly ahead of the base at v1: the incremental update takes the
+        // Case D.1 rebuild path.
+        Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?
+            .checkpoint(ctx.engine.as_ref(), None)?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let updated = Snapshot::builder_from(base).build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 3);
+        assert_eq!(updated.log_segment.checkpoint_version, Some(3));
+
+        let events = reporter.events();
+        assert_eq!(
+            log_segment_load(&events).load_purpose,
+            LogSegmentLoadPurpose::IncrementalSnapshot
+        );
+        assert_eq!(
+            protocol_metadata_load(&events).load_purpose,
+            LogSegmentLoadPurpose::IncrementalSnapshot
         );
         Ok(())
     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -24,7 +24,9 @@ use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
 use crate::metrics::events::{DOMAIN_METADATA_LOADED_SPAN, SET_TRANSACTION_LOADED_SPAN};
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_protocol_metadata_load, emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
+};
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::SchemaRef;
@@ -189,32 +191,31 @@ impl Snapshot {
         metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
     ) -> DeltaResult<Self> {
+        let pm_start = std::time::Instant::now();
+
         // Step 1: read the latest on-disk CRC and, if usable, advance it to the end version
         //         (or use it as-is when already there) per `incremental_replay`.
         let base_crc = log_segment.read_latest_crc(engine);
-        let crc_at_version = log_segment.try_build_crc_within_budget(
-            engine,
-            base_crc.as_ref(),
-            incremental_replay,
-        )?;
+        let crc_resolution = log_segment
+            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
+            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
 
         // Step 2: P&M from that CRC, else log replay rooted at the base CRC, checkpoint, or
-        //         first commit.
-        // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
-        //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
-        let (metadata, protocol) = match crc_at_version.as_deref() {
-            Some(c) => (c.metadata.clone(), c.protocol.clone()),
-            None => {
-                log_segment.read_protocol_metadata(engine, base_crc.as_ref(), metric_context)?
-            }
+        //         first commit. The replay reports its own source (seeded vs full).
+        let (metadata, protocol, source) = match crc_resolution.crc_and_source() {
+            Some((crc, source)) => (crc.metadata.clone(), crc.protocol.clone(), source),
+            None => log_segment
+                .read_protocol_metadata(engine, base_crc.as_ref())
+                .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?,
         };
+        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
 
         let table_configuration =
             TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
 
         tracing::Span::current().record("version", table_configuration.version());
 
-        Self::new_with_crc(log_segment, table_configuration, crc_at_version)
+        Self::new_with_crc(log_segment, table_configuration, crc_resolution.into_crc())
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -319,7 +319,7 @@ impl MetricsReporter for CountingReporter {
                 self.checkpoint_files.add(e.num_checkpoint_files);
                 self.compaction_files.add(e.num_compaction_files);
                 self.latest_crc_files_found
-                    .add(e.has_latest_crc_file as u64);
+                    .add(e.crc_versions_behind.is_some() as u64);
             }
             MetricEvent::CrcReadSuccess(e) => {
                 self.crc_read_calls.inc();
@@ -397,8 +397,8 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
-        ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
+        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadPurpose, LogSegmentLoadSuccess,
+        MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
         SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
         StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
@@ -466,11 +466,12 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: None,
+            load_purpose: LogSegmentLoadPurpose::FreshSnapshot,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
-            has_latest_crc_file: true,
+            crc_versions_behind: Some(0),
         }));
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.commit_files.get(), 7);
@@ -486,11 +487,12 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: None,
+            load_purpose: LogSegmentLoadPurpose::FreshSnapshot,
             duration: dur(),
             num_commit_files: 3,
             num_checkpoint_files: 1,
             num_compaction_files: 0,
-            has_latest_crc_file: false,
+            crc_versions_behind: None,
         }));
         assert_eq!(reporter.log_segment_loads.get(), 1);
         assert_eq!(reporter.latest_crc_files_found.get(), 0);
@@ -615,6 +617,7 @@ mod tests {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
                 correlation_id: None,
+                load_purpose: LogSegmentLoadPurpose::FreshSnapshot,
                 source: ProtocolMetadataSource::FullReplay,
                 duration: dur(),
             },
@@ -646,11 +649,12 @@ mod tests {
             operation_id: MetricId::new(),
             table_type: TableType::PathBased,
             correlation_id: None,
+            load_purpose: LogSegmentLoadPurpose::FreshSnapshot,
             duration: dur(),
             num_commit_files: 7,
             num_checkpoint_files: 2,
             num_compaction_files: 1,
-            has_latest_crc_file: true,
+            crc_versions_behind: Some(0),
         }));
         reporter.report(MetricEvent::CrcReadSuccess(CrcReadSuccess {
             duration: dur(),

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -398,9 +398,9 @@ mod tests {
 
     use delta_kernel::metrics::{
         CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
-        ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
-        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-        TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
+        SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
+        StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
 
     use super::*;
@@ -615,6 +615,7 @@ mod tests {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
                 correlation_id: None,
+                source: ProtocolMetadataSource::FullReplay,
                 duration: dur(),
             },
         ));


### PR DESCRIPTION
## What changes are proposed in this pull request?

Stacked on #2907. Label every snapshot-load event with its load purpose, report how stale the CRC is, and fire `LogSegmentLoad` on the incremental path (previously only fresh).

- Add `LogSegmentLoadPurpose` (`fresh_snapshot` / `incremental_snapshot`) on both `LogSegmentLoad` and `ProtocolMetadataLoad`, set once in the builder.
- Replace `has_latest_crc_file: bool` with `crc_versions_behind: Option<u64>` (`None` = no CRC, `Some(0)` = at the loaded version, `Some(n)` = `n` versions stale), carried on the span as an i64 with a negative sentinel for `None`.
- `LogSegmentLoad` is emit-based; `for_snapshot` times and emits explicitly, giving the incremental path a `LogSegmentLoadFailure` it previously lacked.
- Collapse the incremental load-failure emits through a single `NewSegment` outcome enum via an extracted `build_new_segment`.
- FFI mirrors `has_crc` + `crc_versions_behind` and ignores `load_purpose`.

## How was this change tested?

New unit tests assert the load purpose and CRC-staleness distance on both events across fresh and incremental loads, the version-regression `LogSegmentLoadFailure` path, and the Case D.1 rebuild carrying `IncrementalSnapshot`. Existing metrics, snapshot, and FFI tests pass.
