### PR TITLE
feat!: emit P&MLoad metric on every snapshot-load with a source label

### DIFF
--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -111,12 +111,37 @@ pub struct LogSegmentLoadFailure {
     pub table_type: TableType,
 }
 
+/// How a snapshot load resolved Protocol and Metadata.
+///
+/// cbindgen:prefix-with-name=true
+#[repr(C)]
+pub enum ProtocolMetadataSource {
+    CrcAtTarget,
+    CrcAdvancedByReplay,
+    CrcSeededPmOnlyReplay,
+    FullReplay,
+    Unknown,
+}
+
+impl From<kernel::ProtocolMetadataSource> for ProtocolMetadataSource {
+    fn from(s: kernel::ProtocolMetadataSource) -> Self {
+        match s {
+            kernel::ProtocolMetadataSource::CrcAtTarget => Self::CrcAtTarget,
+            kernel::ProtocolMetadataSource::CrcAdvancedByReplay => Self::CrcAdvancedByReplay,
+            kernel::ProtocolMetadataSource::CrcSeededPmOnlyReplay => Self::CrcSeededPmOnlyReplay,
+            kernel::ProtocolMetadataSource::FullReplay => Self::FullReplay,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// Protocol and metadata actions were read from the log.
 #[repr(C)]
 pub struct ProtocolMetadataLoadSuccess {
     pub operation_id: MetricId,
     pub correlation_id: KernelStringSlice,
     pub table_type: TableType,
+    pub source: ProtocolMetadataSource,
     pub duration_ns: u64,
 }
 
@@ -335,11 +360,13 @@ impl MetricEvent {
                 operation_id,
                 correlation_id,
                 table_type,
+                source,
                 duration,
             }) => Self::ProtocolMetadataLoadSuccess(ProtocolMetadataLoadSuccess {
                 operation_id: (*operation_id).into(),
                 correlation_id: correlation_id_slice(correlation_id.as_deref()),
                 table_type: (*table_type).into(),
+                source: (*source).into(),
                 duration_ns: ns(*duration),
             }),
             K::ProtocolMetadataLoadFailure(kernel::ProtocolMetadataLoadFailure {
@@ -676,6 +703,34 @@ mod tests {
             assert_eq!(e.peak_hash_set_size, 41);
             assert_eq!(e.dedup_visitor_time_ns, 43);
             assert_eq!(e.predicate_eval_time_ns, 47);
+        });
+    }
+
+    #[test]
+    fn from_kernel_protocol_metadata_load_success_maps_source() {
+        let id = kernel::MetricId::new();
+        let event =
+            kernel::MetricEvent::ProtocolMetadataLoadSuccess(kernel::ProtocolMetadataLoadSuccess {
+                operation_id: id,
+                correlation_id: Some("pm-req".into()),
+                table_type: kernel::TableType::CatalogManaged,
+                source: kernel::ProtocolMetadataSource::CrcAdvancedByReplay,
+                duration: Duration::from_nanos(53),
+            });
+        with_ffi_event(&event, |ffi| {
+            let MetricEvent::ProtocolMetadataLoadSuccess(e) = ffi else {
+                panic!("expected ProtocolMetadataLoadSuccess");
+            };
+            assert_eq!(e.operation_id.bytes, id.as_bytes());
+            assert!(matches!(e.table_type, TableType::CatalogManaged));
+            let cid: &str =
+                unsafe { TryFromStringSlice::try_from_slice(&e.correlation_id).unwrap() };
+            assert_eq!(cid, "pm-req");
+            assert_eq!(
+                discriminant(&e.source),
+                discriminant(&ProtocolMetadataSource::CrcAdvancedByReplay)
+            );
+            assert_eq!(e.duration_ns, 53);
         });
     }
 

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -28,6 +28,7 @@ use crate::crc::{
     FileSizeHistogram, FileStatsDelta,
 };
 use crate::engine_data::{GetData, TypedGetData as _};
+use crate::metrics::ProtocolMetadataSource;
 use crate::path::ParsedLogPath;
 use crate::schema::{
     column_name, schema, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
@@ -75,18 +76,21 @@ impl LogSegment {
         engine: &dyn Engine,
         base: Option<&Arc<Crc>>,
         incremental_replay: IncrementalReplay,
-    ) -> DeltaResult<Option<Arc<Crc>>> {
+    ) -> DeltaResult<Option<(Arc<Crc>, ProtocolMetadataSource)>> {
         let Some(base) = base else {
             return Ok(None);
         };
         if base.version == self.end_version {
-            return Ok(Some(base.clone()));
+            return Ok(Some((base.clone(), ProtocolMetadataSource::CrcAtTarget)));
         }
         if !incremental_replay.should_advance(base.version, self.end_version)? {
             return Ok(None);
         }
         let advanced = self.build_crc_from_base(engine, base)?;
-        Ok(Some(Arc::new(advanced)))
+        Ok(Some((
+            Arc::new(advanced),
+            ProtocolMetadataSource::CrcAdvancedByReplay,
+        )))
     }
 
     /// Pick the latest CRC to use as an advance base: this segment's on-disk CRC or

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -11,31 +11,27 @@ use super::LogSegment;
 use crate::actions::{Metadata, Protocol, METADATA_FIELD, PROTOCOL_FIELD};
 use crate::crc::Crc;
 use crate::log_replay::ActionsBatch;
-use crate::metrics::events::PROTOCOL_METADATA_LOADED_SPAN;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::ProtocolMetadataSource;
 use crate::schema::schema_ref;
 use crate::{DeltaResult, Engine, Error};
 
 impl LogSegment {
     /// Read the latest Protocol and Metadata from this log segment, using CRC when available.
-    /// Returns an error if either is missing.
+    /// Returns an error if either is missing, and the [`ProtocolMetadataSource`] describing how
+    /// P&M was resolved.
     ///
     /// This is the checked variant of [`Self::read_protocol_metadata_opt`], used for fresh
     /// snapshot creation where both Protocol and Metadata must exist.
-    ///
-    /// Reports metrics: `ProtocolMetadataLoadSuccess` or `ProtocolMetadataLoadFailure`.
-    #[instrument(name = PROTOCOL_METADATA_LOADED_SPAN, err, fields(report, operation_id = %metric_context.operation_id, is_catalog_managed = metric_context.is_catalog_managed, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, crc))]
     pub(crate) fn read_protocol_metadata(
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-        metric_context: SnapshotLoadMetricContext,
-    ) -> DeltaResult<(Metadata, Protocol)> {
+    ) -> DeltaResult<(Metadata, Protocol, ProtocolMetadataSource)> {
         match self.read_protocol_metadata_opt(engine, crc)? {
-            (Some(m), Some(p)) => Ok((m, p)),
-            (None, Some(_)) => Err(Error::MissingMetadata),
-            (Some(_), None) => Err(Error::MissingProtocol),
-            (None, None) => Err(Error::MissingMetadataAndProtocol),
+            (Some(m), Some(p), source) => Ok((m, p, source)),
+            (None, Some(_), _) => Err(Error::MissingMetadata),
+            (Some(_), None, _) => Err(Error::MissingProtocol),
+            (None, None, _) => Err(Error::MissingMetadataAndProtocol),
         }
     }
 
@@ -53,11 +49,15 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
         crc: Option<&Arc<Crc>>,
-    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
+    ) -> DeltaResult<(Option<Metadata>, Option<Protocol>, ProtocolMetadataSource)> {
         // Case 1: If CRC at target version, use it directly and exit early.
         if let Some(crc) = crc.filter(|c| c.version == self.end_version) {
             info!("P&M from CRC at target version {}", self.end_version);
-            return Ok((Some(crc.metadata.clone()), Some(crc.protocol.clone())));
+            return Ok((
+                Some(crc.metadata.clone()),
+                Some(crc.protocol.clone()),
+                ProtocolMetadataSource::CrcAtTarget,
+            ));
         }
 
         // We didn't return above, so we need to do log replay to find P&M.
@@ -80,7 +80,11 @@ impl LogSegment {
 
             if metadata_opt.is_some() && protocol_opt.is_some() {
                 info!("Found P&M from pruned log replay");
-                return Ok((metadata_opt, protocol_opt));
+                return Ok((
+                    metadata_opt,
+                    protocol_opt,
+                    ProtocolMetadataSource::CrcSeededPmOnlyReplay,
+                ));
             }
 
             // Case 2(b): P&M incomplete from pruned replay, use the CRC.
@@ -90,11 +94,17 @@ impl LogSegment {
             return Ok((
                 metadata_opt.or_else(|| Some(crc.metadata.clone())),
                 protocol_opt.or_else(|| Some(crc.protocol.clone())),
+                ProtocolMetadataSource::CrcSeededPmOnlyReplay,
             ));
         }
 
         // Case 3: Full P&M log replay.
-        self.replay_for_pm(engine)
+        let (metadata_opt, protocol_opt) = self.replay_for_pm(engine)?;
+        Ok((
+            metadata_opt,
+            protocol_opt,
+            ProtocolMetadataSource::FullReplay,
+        ))
     }
 
     /// Replays the log segment for Protocol and Metadata, stopping early once both are found.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2466,7 +2466,7 @@ async fn test_latest_commit_file_field_is_captured() {
         log_root.clone(),
         vec![],
         None,
-        SnapshotLoadMetricContext::default(),
+        SnapshotLoadMetricContext::for_test(),
     )
     .unwrap();
 
@@ -2499,7 +2499,7 @@ async fn test_latest_commit_file_with_checkpoint_filtering() {
         log_root.clone(),
         vec![],
         None,
-        SnapshotLoadMetricContext::default(),
+        SnapshotLoadMetricContext::for_test(),
     )
     .unwrap();
 
@@ -2526,7 +2526,7 @@ async fn test_latest_commit_file_with_no_commits() {
         log_root.clone(),
         vec![],
         None,
-        SnapshotLoadMetricContext::default(),
+        SnapshotLoadMetricContext::for_test(),
     )
     .unwrap();
 
@@ -2556,7 +2556,7 @@ async fn test_latest_commit_file_with_checkpoint_at_same_version() {
         log_root.clone(),
         vec![],
         None,
-        SnapshotLoadMetricContext::default(),
+        SnapshotLoadMetricContext::for_test(),
     )
     .unwrap();
 
@@ -2588,7 +2588,7 @@ async fn test_latest_commit_file_edge_case_commit_before_checkpoint() {
         log_root.clone(),
         vec![],
         None,
-        SnapshotLoadMetricContext::default(),
+        SnapshotLoadMetricContext::for_test(),
     )
     .unwrap();
 

--- a/kernel/src/metrics/README.md
+++ b/kernel/src/metrics/README.md
@@ -1,0 +1,35 @@
+# Kernel metrics
+
+Kernel emits metrics as `tracing` spans. A connector installs `ReportGeneratorLayer`
+(`reporter.rs`), which turns each span carrying the `report` field into a `MetricEvent`
+(`events.rs`) and hands it to the connector's `MetricsReporter`. Kernel does no aggregation.
+
+## Two mechanisms
+
+The difference is *when a metric's values are known*:
+
+- **Span-based** (`#[instrument]` on a function): values arrive over the function's life. Some at
+  the start, some mid-call (`Span::current().record(...)`), the duration at the end.
+- **Emit-based** (an `emit_*` helper): all values are known at once, so the helper fires a single
+  `span!` carrying every field (including `duration_ns`) and drops it. Nothing arrives later.
+
+`from_attrs` builds the event from a span's fields. It reads them with a `Visit` (the trait whose
+`record_*` methods receive one field at a time). Emit events run one `Visit` over the whole struct;
+span-based events reuse small per-field helpers like `MetricId::from_attrs`, each a `Visit` inside.
+
+## Failure events
+
+Success and failure are two variants of one event. Emit the success span, then fire `error` on it
+(`#[instrument(err)]` does this on `Err`; an emit helper calls `tracing::info!(error = ...)`). The
+layer sees `error` and flips the event via `MetricEvent::into_failure`.
+
+## Adding an event
+
+1. Define the struct + `SPAN_NAME` in `events.rs`; add a `MetricEvent` variant and its
+   `into_failure` arm.
+2. For emit, add an `emit_*` helper and a `from_attrs`; register the span name in `on_new_span`
+   (`reporter.rs`).
+3. Make each label a strum enum (`serialize_all = "snake_case"`).
+
+The FFI mirror (`ffi/src/ffi_metrics.rs`) and connectors destructure these structs, so adding a
+field or variant is a breaking change.

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -14,7 +14,7 @@
 //! default rather than failing the operation being observed.
 
 use std::fmt;
-use std::str::FromStr as _;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,8 +38,15 @@ pub struct MetricId(pub(crate) Uuid);
 
 impl MetricId {
     /// Generate a new unique `MetricId`.
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
+    }
+
+    /// The nil id (all-zero UUID): the decode seed when a span omits `operation_id`, and the
+    /// sentinel for a malformed one.
+    pub(crate) fn nil() -> Self {
+        Self(Uuid::nil())
     }
 
     /// Return the 16 raw bytes of the underlying UUID. Useful for FFI consumers that want to
@@ -67,12 +74,6 @@ impl MetricId {
         let mut v = V::default();
         attrs.record(&mut v);
         Self(v.0)
-    }
-}
-
-impl Default for MetricId {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -117,28 +118,31 @@ impl MetricEvent {
         match self {
             // Lifecycle success: duration must be set by the tracing layer on span close.
             Self::LogSegmentLoadSuccess(e) => e.set_duration(d),
-            Self::ProtocolMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SnapshotBuildSuccess(e) => e.set_duration(d),
             Self::TransactionCommitSuccess(e) => e.set_duration(d),
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
 
-            // For now, failure events carry no duration; storage/scan events set it at
-            // construction; read events have no duration field.
+            // Emit-based success events set their duration as a creation attribute, so the
+            // span-close hook must not overwrite it.
+            Self::ProtocolMetadataLoadSuccess(_)
+            | Self::ScanMetadataCompleted(_)
+            | Self::StorageListCompleted(_)
+            | Self::StorageReadCompleted(_)
+            | Self::StorageCopyCompleted(_) => {}
+
+            // Failure events carry no duration.
             Self::LogSegmentLoadFailure(_)
             | Self::ProtocolMetadataLoadFailure(_)
             | Self::SnapshotBuildFailure(_)
             | Self::TransactionCommitFailure(_)
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
-            | Self::CrcReadFailure
-            | Self::ScanMetadataCompleted(_)
-            | Self::StorageListCompleted(_)
-            | Self::StorageReadCompleted(_)
-            | Self::StorageCopyCompleted(_)
-            | Self::JsonReadCompleted(_)
-            | Self::ParquetReadCompleted(_) => {}
+            | Self::CrcReadFailure => {}
+
+            // Read events have no duration field.
+            Self::JsonReadCompleted(_) | Self::ParquetReadCompleted(_) => {}
         }
     }
 
@@ -429,34 +433,99 @@ impl fmt::Display for LogSegmentLoadFailure {
 
 pub(crate) const PROTOCOL_METADATA_LOADED_SPAN: &str = "segment.read_metadata";
 
-/// Protocol and metadata actions were read from the log.
+/// How a snapshot load resolved Protocol and Metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, StrumDisplay, AsRefStr, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProtocolMetadataSource {
+    /// A CRC already sat at the target version; used as-is with zero replay.
+    CrcAtTarget,
+    /// A stale CRC was advanced to the target version by reverse replay.
+    CrcAdvancedByReplay,
+    /// A stale CRC seeded a pruned P&M replay of the commits above it (falling back to the
+    /// CRC's own P&M when the pruned replay found no newer Protocol or Metadata).
+    CrcSeededPmOnlyReplay,
+    /// No CRC baseline; P&M came from log replay (full history on a fresh load, or the new
+    /// commits on an incremental load).
+    FullReplay,
+    /// Decode fell back here because the span's `pm_source` field was unset or unrecognized.
+    /// Kernel never emits this deliberately.
+    Unknown,
+}
+
+impl ProtocolMetadataSource {
+    fn parse_or_unknown(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::Unknown;
+        }
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid pm_source '{s}': {e}. Using Unknown.");
+            Self::Unknown
+        })
+    }
+}
+
+/// Protocol and metadata actions were resolved for a snapshot.
+///
+/// All fields are set at emit time (creation attrs).
 #[derive(Debug, Clone)]
 pub struct ProtocolMetadataLoadSuccess {
-    // === Set on span creation ===
     pub operation_id: MetricId,
     /// Opaque, caller-supplied id for joining this operation's metric events to the caller's
     /// own request or operation id.
     pub correlation_id: Option<Arc<str>>,
     pub table_type: TableType,
-
-    // === Set on span close ===
+    pub source: ProtocolMetadataSource,
     pub duration: Duration,
 }
 
 impl ProtocolMetadataLoadSuccess {
     pub(crate) const SPAN_NAME: &'static str = PROTOCOL_METADATA_LOADED_SPAN;
 
-    pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
+    /// The all-unset seed that [`Self::from_attrs`] fills in as span fields arrive. Each field
+    /// here is the value used when its span field is absent.
+    fn empty() -> Self {
         Self {
-            operation_id: MetricId::from_attrs(attrs),
-            table_type: TableType::from_catalog_managed(read_is_catalog_managed(attrs)),
-            correlation_id: correlation_id_from_attrs(attrs),
-            duration: Duration::default(),
+            operation_id: MetricId::nil(),
+            correlation_id: None,
+            table_type: TableType::from_catalog_managed(false),
+            source: ProtocolMetadataSource::Unknown,
+            duration: Duration::ZERO,
         }
     }
 
-    pub(crate) fn set_duration(&mut self, d: Duration) {
-        self.duration = d;
+    pub(crate) fn from_attrs(attrs: &Attributes<'_>) -> Self {
+        let mut event = Self::empty();
+        attrs.record(&mut event);
+        event
+    }
+}
+
+impl Visit for ProtocolMetadataLoadSuccess {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == IS_CATALOG_MANAGED_FIELD {
+            self.table_type = TableType::from_catalog_managed(value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            CORRELATION_ID_FIELD if !value.is_empty() => self.correlation_id = Some(value.into()),
+            "pm_source" => self.source = ProtocolMetadataSource::parse_or_unknown(value),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "duration_ns" {
+            self.duration = Duration::from_nanos(value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if let Some(id) = record_operation_id(field, value, Self::SPAN_NAME) {
+            self.operation_id = id;
+        }
     }
 }
 
@@ -466,12 +535,13 @@ impl fmt::Display for ProtocolMetadataLoadSuccess {
             operation_id,
             table_type,
             correlation_id,
+            source,
             duration,
         } = self;
         write!(
             f,
             "ProtocolMetadataLoadSuccess(id={operation_id}, table_type={table_type}, \
-             correlation_id={correlation_id:?}, duration={duration:?})"
+             correlation_id={correlation_id:?}, source={source}, duration={duration:?})"
         )
     }
 }
@@ -1119,11 +1189,41 @@ impl fmt::Display for TableType {
 }
 
 /// Operation-scoped values threaded through the snapshot-load chain to label its metric events.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SnapshotLoadMetricContext {
     pub(crate) operation_id: MetricId,
     pub(crate) correlation_id: Option<Arc<str>>,
     pub(crate) is_catalog_managed: bool,
+}
+
+#[cfg(test)]
+impl SnapshotLoadMetricContext {
+    /// A context seeded with a nil `operation_id` for tests that exercise the load chain without
+    /// asserting on the id.
+    pub(crate) fn for_test() -> Self {
+        Self {
+            operation_id: MetricId::nil(),
+            correlation_id: None,
+            is_catalog_managed: false,
+        }
+    }
+}
+
+/// Decode the `operation_id` debug-string span field into a [`MetricId`]. Returns `None` when the
+/// field is not `operation_id`; returns the nil id (with a warning) when the value is malformed.
+/// Shared by the self-visiting event decoders.
+pub(crate) fn record_operation_id(
+    field: &Field,
+    value: &dyn fmt::Debug,
+    span_name: &str,
+) -> Option<MetricId> {
+    (field.name() == "operation_id").then(|| {
+        let s = format!("{value:?}");
+        Uuid::from_str(&s).map(MetricId).unwrap_or_else(|e| {
+            warn!("Invalid uuid '{s}' on {span_name}: {e}. Using nil.");
+            MetricId::nil()
+        })
+    })
 }
 
 pub(crate) fn read_is_catalog_managed(attrs: &Attributes<'_>) -> bool {
@@ -1304,17 +1404,10 @@ impl Visit for ScanMetadataCompletedAttrs {
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        let s = format!("{value:?}");
-        match field.name() {
-            "operation_id" => match Uuid::from_str(&s) {
-                Ok(u) => self.operation_id = u,
-                Err(e) => warn!(
-                    "Invalid uuid '{s}' on {}: {e}",
-                    ScanMetadataCompleted::SPAN_NAME
-                ),
-            },
-            "scan_type" => self.scan_type = s,
-            _ => {}
+        if let Some(id) = record_operation_id(field, value, ScanMetadataCompleted::SPAN_NAME) {
+            self.operation_id = id.0;
+        } else if field.name() == "scan_type" {
+            self.scan_type = format!("{value:?}");
         }
     }
 }
@@ -1538,6 +1631,40 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
     );
 }
 
+/// Emit a [`MetricEvent::ProtocolMetadataLoadSuccess`]. Call once per snapshot load on the P&M
+/// resolution path, on success.
+pub(crate) fn emit_protocol_metadata_load(
+    ctx: &SnapshotLoadMetricContext,
+    source: ProtocolMetadataSource,
+    duration: Duration,
+) {
+    let _span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+        pm_source = source.as_ref(),
+        duration_ns = duration.as_nanos() as u64,
+    );
+}
+
+/// Emit a [`MetricEvent::ProtocolMetadataLoadFailure`]. Call once per snapshot load on the P&M
+/// resolution path, on failure.
+pub(crate) fn emit_protocol_metadata_load_failure(ctx: &SnapshotLoadMetricContext) {
+    let span = tracing::span!(
+        tracing::Level::INFO,
+        ProtocolMetadataLoadSuccess::SPAN_NAME,
+        report = tracing::field::Empty,
+        operation_id = %ctx.operation_id,
+        is_catalog_managed = ctx.is_catalog_managed,
+        correlation_id = ctx.correlation_id.as_deref().unwrap_or(""),
+    );
+    let _enter = span.enter();
+    tracing::info!(error = tracing::field::debug("protocol/metadata load failed"));
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -1637,6 +1764,35 @@ mod tests {
         #[case] expected: ScanType,
     ) {
         assert_eq!(ScanType::parse_lenient(value), expected);
+    }
+
+    #[rstest]
+    #[case::crc_at_target(ProtocolMetadataSource::CrcAtTarget, "crc_at_target")]
+    #[case::crc_advanced(ProtocolMetadataSource::CrcAdvancedByReplay, "crc_advanced_by_replay")]
+    #[case::crc_seeded(
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay,
+        "crc_seeded_pm_only_replay"
+    )]
+    #[case::full_replay(ProtocolMetadataSource::FullReplay, "full_replay")]
+    #[case::unknown(ProtocolMetadataSource::Unknown, "unknown")]
+    fn protocol_metadata_source_serializes_to_wire_name_and_parses_back(
+        #[case] source: ProtocolMetadataSource,
+        #[case] wire: &str,
+    ) {
+        let serialized: &'static str = source.into();
+        assert_eq!(serialized, wire);
+        assert_eq!(ProtocolMetadataSource::from_str(wire).unwrap(), source);
+    }
+
+    #[rstest]
+    #[case::known("crc_at_target", ProtocolMetadataSource::CrcAtTarget)]
+    #[case::empty_maps_to_unknown("", ProtocolMetadataSource::Unknown)]
+    #[case::unrecognized_maps_to_unknown("totally_unknown", ProtocolMetadataSource::Unknown)]
+    fn protocol_metadata_source_parse_or_unknown(
+        #[case] value: &str,
+        #[case] expected: ProtocolMetadataSource,
+    ) {
+        assert_eq!(ProtocolMetadataSource::parse_or_unknown(value), expected);
     }
 
     #[test]

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -87,11 +87,12 @@ pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
     DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
     MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess,
-    SnapshotBuildFailure, SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted,
-    StorageListCompleted, StorageReadCompleted, TableType, TransactionCommitFailure,
-    TransactionCommitSuccess,
+    ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
+    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
+    SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+    TableType, TransactionCommitFailure, TransactionCommitSuccess,
 };
+pub(crate) use events::{emit_protocol_metadata_load, emit_protocol_metadata_load_failure};
 pub use metered_engine::MeteredDeltaEngine;
 pub use metered_json::MeteredJsonHandler;
 pub use metered_parquet::MeteredParquetHandler;

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -10,7 +10,9 @@ use tracing::instrument;
 use super::{IncrementalReplay, Snapshot};
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_protocol_metadata_load, emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
+};
 use crate::path::ParsedLogPath;
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -292,27 +294,29 @@ impl Snapshot {
             new_checkpoint_hint,
         )?;
 
+        // Start the P&M-load timer before the CRC read/advance below, so their cost is counted in
+        // the reported P&M-resolution duration.
+        let pm_start = std::time::Instant::now();
+
         // Advance the latest available base (the existing snapshot's in-memory CRC, or a newer
         // on-disk CRC the combined segment carries) to the new end version, subject to
         // `incremental_replay`.
         let base_crc =
             combined_log_segment.pick_latest_base_crc(engine, existing_snapshot.base_crc());
-        let crc_at_version = combined_log_segment.try_build_crc_within_budget(
-            engine,
-            base_crc.as_ref(),
-            incremental_replay,
-        )?;
+        let crc_at_version = combined_log_segment
+            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
+            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
 
         let existing_table_config = existing_snapshot.table_configuration();
-        let (new_metadata, new_protocol) = match &crc_at_version {
-            Some(crc) => {
+        let (new_metadata, new_protocol, source) = match &crc_at_version {
+            Some((crc, source)) => {
                 // If we were able to build a new CRC, then re-use it for TableConfiguration
                 // creation.
                 let new_metadata = (crc.metadata != *existing_table_config.metadata())
                     .then(|| crc.metadata.clone());
                 let new_protocol = (crc.protocol != *existing_table_config.protocol())
                     .then(|| crc.protocol.clone());
-                (new_metadata, new_protocol)
+                (new_metadata, new_protocol, *source)
             }
             None => {
                 // Incremental CRC replay wasn't applicable or failed (note: we have *not* yet
@@ -324,9 +328,12 @@ impl Snapshot {
                     .filter(|c| c.version > existing_snapshot_version);
                 combined_log_segment
                     .segment_after_version(existing_snapshot_version)
-                    .read_protocol_metadata_opt(engine, newer_base)?
+                    .read_protocol_metadata_opt(engine, newer_base)
+                    .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?
             }
         };
+        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
+
         let table_configuration = TableConfiguration::try_new_from(
             existing_table_config,
             new_metadata,
@@ -338,7 +345,7 @@ impl Snapshot {
         Ok(Arc::new(Snapshot::new_with_crc(
             combined_log_segment,
             table_configuration,
-            crc_at_version.or(base_crc),
+            crc_at_version.map(|(crc, _)| crc).or(base_crc),
             built_as_latest,
         )?))
     }
@@ -424,12 +431,17 @@ mod tests {
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::SyncEngine;
+    use crate::metrics::{
+        MetricEvent, MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+    };
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStoreExt as _;
     use crate::parquet::arrow::ArrowWriter;
     use crate::path::LogPathFileType;
     use crate::snapshot::commit;
-    use crate::utils::test_utils::string_array_to_engine_data;
+    use crate::utils::test_utils::{
+        install_thread_local_metrics_reporter, string_array_to_engine_data, CapturingReporter,
+    };
 
     // ============================================================================
     // Helpers
@@ -570,7 +582,7 @@ mod tests {
             vec![],
             &engine,
             None,
-            SnapshotLoadMetricContext::default(),
+            SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             true, /* built_as_latest */
         )?;
@@ -650,7 +662,7 @@ mod tests {
             log_tail,
             &engine,
             Some(2),
-            SnapshotLoadMetricContext::default(),
+            SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
         )?;
@@ -709,7 +721,7 @@ mod tests {
             vec![],
             &engine,
             Some(1),
-            SnapshotLoadMetricContext::default(),
+            SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
         )?;
@@ -721,7 +733,7 @@ mod tests {
             vec![],
             &engine,
             Some(0),
-            SnapshotLoadMetricContext::default(),
+            SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
         );
@@ -1819,6 +1831,229 @@ mod tests {
             .collect();
         assert_eq!(versions_and_his, vec![(1, 2), (2, 2)]);
 
+        Ok(())
+    }
+
+    // ============================================================================
+    // ProtocolMetadataLoad source classification
+    // ============================================================================
+
+    fn protocol_metadata_load(events: &[MetricEvent]) -> ProtocolMetadataLoadSuccess {
+        let mut it = events.iter().filter_map(|e| match e {
+            MetricEvent::ProtocolMetadataLoadSuccess(s) => Some(s),
+            _ => None,
+        });
+        let found = it.next().expect("expected a ProtocolMetadataLoadSuccess");
+        assert!(it.next().is_none(), "expected exactly one matching event");
+        found.clone()
+    }
+
+    #[rstest]
+    #[case::no_crc(None, IncrementalReplay::Disabled, ProtocolMetadataSource::FullReplay)]
+    #[case::crc_at_target(
+        Some(3),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcAtTarget
+    )]
+    #[case::stale_crc_advanced(
+        Some(1),
+        IncrementalReplay::Unlimited,
+        ProtocolMetadataSource::CrcAdvancedByReplay
+    )]
+    #[case::stale_crc_seeds_replay(
+        Some(1),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_fresh_build_classifies_protocol_metadata_source(
+        #[case] planted_crc_version: Option<u64>,
+        #[case] mode: IncrementalReplay,
+        #[case] expected_source: ProtocolMetadataSource,
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+        if let Some(v) = planted_crc_version {
+            ctx.store
+                .put(
+                    &delta_path_for_version(v, "crc"),
+                    make_test_crc_json(200, 2).to_string().into(),
+                )
+                .await?;
+        }
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let corr = "req-abc";
+        let _snapshot = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .with_incremental_crc_replay(mode)
+            .with_correlation_id(corr)
+            .build(ctx.engine.as_ref())?;
+
+        let events = reporter.events();
+        let pm = protocol_metadata_load(&events);
+        assert_eq!(pm.source, expected_source);
+
+        // The operation_id and correlation_id survive the emit->decode round-trip.
+        assert_eq!(pm.correlation_id.as_deref(), Some(corr));
+        assert_ne!(pm.operation_id, MetricId::nil());
+
+        // The CRC-advance replay cost is folded into the P&M duration on the advanced case.
+        if expected_source == ProtocolMetadataSource::CrcAdvancedByReplay {
+            assert!(pm.duration > std::time::Duration::ZERO);
+        }
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::no_crc(None, IncrementalReplay::Disabled, ProtocolMetadataSource::FullReplay)]
+    #[case::crc_at_target(
+        Some(5),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcAtTarget
+    )]
+    #[case::stale_crc_advanced(
+        Some(1),
+        IncrementalReplay::Unlimited,
+        ProtocolMetadataSource::CrcAdvancedByReplay
+    )]
+    // A CRC newer than the existing snapshot (v3) but below the target (v5), with advance
+    // disabled, seeds a pruned replay rather than being used at target or advanced.
+    #[case::stale_crc_seeds_replay(
+        Some(4),
+        IncrementalReplay::Disabled,
+        ProtocolMetadataSource::CrcSeededPmOnlyReplay
+    )]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_build_classifies_protocol_metadata_source(
+        #[case] planted_crc_version: Option<u64>,
+        #[case] mode: IncrementalReplay,
+        #[case] expected_source: ProtocolMetadataSource,
+    ) -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+        if let Some(v) = planted_crc_version {
+            ctx.store
+                .put(
+                    &delta_path_for_version(v, "crc"),
+                    make_test_crc_json(200, 2).to_string().into(),
+                )
+                .await?;
+        }
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let updated = Snapshot::builder_from(base)
+            .at_version(5)
+            .with_incremental_crc_replay(mode)
+            .build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 5);
+
+        let pm = protocol_metadata_load(&reporter.events());
+        assert_eq!(pm.source, expected_source);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_build_no_pm_change_classifies_full_replay() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?;
+
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(1)
+            .build(ctx.engine.as_ref())?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let updated = Snapshot::builder_from(base).build(ctx.engine.as_ref())?;
+        assert_eq!(updated.version(), 3);
+
+        // No P&M change in the new commits, no newer CRC: the replay finds nothing above the
+        // existing snapshot, so the source is the not-CRC-rooted `FullReplay`.
+        let pm = protocol_metadata_load(&reporter.events());
+        assert_eq!(pm.source, ProtocolMetadataSource::FullReplay);
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_fresh_build_missing_protocol_metadata_emits_failure() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        // A commit with only an add action: no protocol or metadata anywhere in the log.
+        commit(
+            ctx.url.as_str(),
+            &ctx.store,
+            0,
+            vec![add_action("f0.parquet")],
+        )
+        .await;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let result = Snapshot::builder_for(ctx.url.as_str()).build(ctx.engine.as_ref());
+        assert!(result.is_err());
+
+        let events = reporter.events();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, MetricEvent::ProtocolMetadataLoadFailure(_)))
+                .count(),
+            1,
+            "expected exactly one ProtocolMetadataLoadFailure"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadSuccess(_))),
+            "no success event should fire on the failure path"
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_incremental_build_replay_error_emits_failure() -> DeltaResult<()> {
+        let ctx = setup_incremental_snapshot_test()?;
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 6).await?;
+        let base = Snapshot::builder_for(ctx.url.as_str())
+            .at_version(3)
+            .build(ctx.engine.as_ref())?;
+
+        // Corrupt a commit above the base so the incremental P&M replay of `(3, 5]` errors.
+        ctx.store
+            .put(&delta_path_for_version(4, "json"), "{ not json".into())
+            .await?;
+
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let result = Snapshot::builder_from(base)
+            .at_version(5)
+            .build(ctx.engine.as_ref());
+        assert!(result.is_err());
+
+        let events = reporter.events();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, MetricEvent::ProtocolMetadataLoadFailure(_)))
+                .count(),
+            1,
+            "expected exactly one ProtocolMetadataLoadFailure"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, MetricEvent::ProtocolMetadataLoadSuccess(_))),
+            "no success event should fire on the failure path"
+        );
         Ok(())
     }
 }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -24,7 +24,9 @@ use crate::expressions::ColumnName;
 use crate::incremental_scan::IncrementalScanBuilder;
 use crate::log_segment::{DomainMetadataMap, LogSegment};
 use crate::metrics::events::{DOMAIN_METADATA_LOADED_SPAN, SET_TRANSACTION_LOADED_SPAN};
-use crate::metrics::SnapshotLoadMetricContext;
+use crate::metrics::{
+    emit_protocol_metadata_load, emit_protocol_metadata_load_failure, SnapshotLoadMetricContext,
+};
 use crate::path::ParsedLogPath;
 use crate::scan::ScanBuilder;
 use crate::schema::SchemaRef;
@@ -198,37 +200,32 @@ impl Snapshot {
         incremental_replay: IncrementalReplay,
         built_as_latest: bool,
     ) -> DeltaResult<Self> {
+        let pm_start = std::time::Instant::now();
+
         // Step 1: read the latest on-disk CRC and, if usable, advance it to the end version
         //         (or use it as-is when already there) per `incremental_replay`.
         let base_crc = log_segment.read_latest_crc(engine);
-        let crc_at_version = log_segment.try_build_crc_within_budget(
-            engine,
-            base_crc.as_ref(),
-            incremental_replay,
-        )?;
+        let crc_at_version = log_segment
+            .try_build_crc_within_budget(engine, base_crc.as_ref(), incremental_replay)
+            .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?;
 
         // Step 2: P&M from that CRC, else log replay rooted at the base CRC, checkpoint, or
-        //         first commit.
-        // TODO(#2677): emit an `IncrementalCrcLoad` metric on the CRC branch; the
-        //              `ProtocolMetadataLoaded` span only fires on the replay branch below.
-        let (metadata, protocol) = match crc_at_version.as_deref() {
-            Some(c) => (c.metadata.clone(), c.protocol.clone()),
-            None => {
-                log_segment.read_protocol_metadata(engine, base_crc.as_ref(), metric_context)?
-            }
+        //         first commit. The replay reports its own source (seeded vs full).
+        let (metadata, protocol, source) = match &crc_at_version {
+            Some((crc, source)) => (crc.metadata.clone(), crc.protocol.clone(), *source),
+            None => log_segment
+                .read_protocol_metadata(engine, base_crc.as_ref())
+                .inspect_err(|_| emit_protocol_metadata_load_failure(&metric_context))?,
         };
+        emit_protocol_metadata_load(&metric_context, source, pm_start.elapsed());
 
         let table_configuration =
             TableConfiguration::try_new(metadata, protocol, location, log_segment.end_version)?;
 
         tracing::Span::current().record("version", table_configuration.version());
 
-        Self::new_with_crc(
-            log_segment,
-            table_configuration,
-            crc_at_version.or(base_crc),
-            built_as_latest,
-        )
+        let crc = crc_at_version.map(|(crc, _)| crc).or(base_crc);
+        Self::new_with_crc(log_segment, table_configuration, crc, built_as_latest)
     }
 
     /// Creates a new [`Snapshot`] representing the table state immediately after a commit.

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -398,9 +398,9 @@ mod tests {
 
     use delta_kernel::metrics::{
         CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, MetricId,
-        ProtocolMetadataLoadSuccess, SetTransactionLoadSuccess, SnapshotBuildFailure,
-        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-        TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
+        SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
+        StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
 
     use super::*;
@@ -615,6 +615,7 @@ mod tests {
                 operation_id: MetricId::new(),
                 table_type: TableType::PathBased,
                 correlation_id: None,
+                source: ProtocolMetadataSource::FullReplay,
                 duration: dur(),
             },
         ));


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2915/files) to review incremental changes.
- [**stack/snapshot_better_crc_metrics**](https://github.com/delta-io/delta-kernel-rs/pull/2915) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2915/files)] ← _this PR_
  - [stack/snapshot_better_logsegment_metrics](https://github.com/delta-io/delta-kernel-rs/pull/2916) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2916/files/c6328eb3a3ebb8cfd7d44da22c49edf1b5fad76b..ef7b3fc991f74cf149c88fe92d69f8e774c3829a)]

---------
## What changes are proposed in this pull request?

This PR ensures that the `ProtocolMetadataLoad` metric event does fire on every snapshot load path (both fresh and incremental Snapshot builds). Previously it was only fresh.

Further, this PR adds a `source` label so that metric consumers know in what way was the P & M loaded. Variants include: `crc_at_target`, `crc_advanced_by_replay`, `crc_seeded_pm_only_replay`, and `full_replay`.

FFI excluded for now.

## How was this change tested?

New UTs.
