### PR TITLE
fix: enable checkpoint row group skipping for partition columns

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
@@ -20,6 +21,7 @@ use crate::scan::log_replay::PARTITION_VALUES_PARSED_NAME;
 use crate::scan::metrics::ScanMetrics;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
+use crate::transforms::{transform_output_type, ExpressionTransform};
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
 
@@ -414,22 +416,29 @@ impl DataSkippingFilter {
 /// Rewrites a predicate for parquet row group skipping in checkpoint/sidecar files.
 /// Returns `None` if the predicate is not eligible for data skipping.
 ///
-/// Adds IS NULL guards on each stat column reference so the parquet RowGroupFilter
-/// conservatively keeps row groups containing files with missing stats (null stat values
-/// are invisible to footer min/max). The rewrite is `stats_parsed.*`-rooted, so `col_a > 100`
-/// becomes:
+/// Data-column references become `stats_parsed.{minValues,maxValues,nullCount}.<col>`. Partition
+/// references become `partitionValues_parsed.<col>`: the partition value is exact, so it serves as
+/// both the min and the max stat, and `col_a = 'x'` prunes a row group whose footer range excludes
+/// `'x'`.
+///
+/// Every generated stat comparison is wrapped in an IS NULL guard, so a row group is kept whenever
+/// the referenced stat is null; scalar-only comparisons fold directly because they have no stat
+/// reference. For data columns a null stat means a file is missing that statistic (footer min/max
+/// ignore nulls, so the aggregate is untrustworthy); for partition values a null leaf means either
+/// a non-Add row (Remove, metadata, ...) or an Add with a null (e.g. Hive-default) partition value.
+/// Guarding both keeps such row groups instead of pruning them. `col_a > 100` becomes:
 /// ```text
 /// OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100)
 /// ```
 ///
-/// Partition columns are excluded since their values live in `add.partitionValues_parsed`,
-/// not `add.stats_parsed`. `physical_partition_columns` is the table's full partition list;
+/// `physical_partition_columns` is the set of physical partition columns available to this rewrite.
+/// It may be narrowed to the predicate's references rather than the table's full partition list;
 /// pass an empty set for unpartitioned tables.
 ///
-/// `physical_stats_columns` restricts rewrites to columns which are expected to have stats
-/// collected; other references fold to NULL (keeps the file). Must match the column set
-/// used to build `physical_stats_schema`, otherwise the row-group filter sees a missing
-/// field.
+/// `physical_stats_columns` is the table-level membership set for expected stats; references
+/// outside it fold to NULL (keeps the file). It is predicate-independent, unlike
+/// `physical_stats_schema` which may be predicate-trimmed. Each rewritten reference must be present
+/// in that schema, otherwise the row-group filter sees a missing field.
 pub(crate) fn as_checkpoint_skipping_predicate(
     pred: &Pred,
     physical_partition_columns: &HashSet<ColumnName>,
@@ -442,6 +451,42 @@ pub(crate) fn as_checkpoint_skipping_predicate(
         },
     }
     .eval(pred)
+}
+
+/// Builds the meta-predicate applied through the parquet row-group filter over checkpoint and
+/// sidecar files. Rewrites `pred` via [`as_checkpoint_skipping_predicate`] and scopes the result
+/// under the `add` action. The skipping form carries `stats_parsed.*` / `partitionValues_parsed.*`
+/// struct paths, so scoping only adds the `add` root to match the checkpoint/sidecar column layout.
+pub(crate) fn as_checkpoint_meta_predicate(
+    pred: &Pred,
+    physical_partition_columns: &HashSet<ColumnName>,
+    physical_stats_columns: &HashSet<ColumnName>,
+) -> Option<Pred> {
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(pred, physical_partition_columns, physical_stats_columns)?;
+    let mut prefixer = PrefixColumns::new(ColumnName::new(["add"]));
+    Some(prefixer.transform_pred(&skipping_pred).into_owned())
+}
+
+/// Prefixes every column reference in a predicate with a fixed root path. Checkpoint skipping uses
+/// it to scope `stats_parsed.*` / `partitionValues_parsed.*` stat expressions under `add`, e.g.
+/// `stats_parsed.minValues.x > 100` becomes `add.stats_parsed.minValues.x > 100`.
+struct PrefixColumns {
+    prefix: ColumnName,
+}
+
+impl PrefixColumns {
+    fn new(prefix: ColumnName) -> Self {
+        Self { prefix }
+    }
+}
+
+impl<'a> ExpressionTransform<'a> for PrefixColumns {
+    transform_output_type!(|'a, T| Cow<'a, T>);
+
+    fn transform_expr_column(&mut self, name: &'a ColumnName) -> Cow<'a, ColumnName> {
+        Cow::Owned(self.prefix.join(name))
+    }
 }
 
 /// Maps an ordering and inversion flag to the corresponding comparison predicate.
@@ -746,9 +791,10 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     }
 }
 
-/// Like [`DataSkippingPredicateCreator`] but adds IS NULL guards on stat column references for safe
-/// parquet row group filtering in checkpoint/sidecar files. Partition columns are excluded since
-/// their values live in `add.partitionValues_parsed`, not `add.stats_parsed`.
+/// Like [`DataSkippingPredicateCreator`] but adds IS NULL guards on every stat reference for safe
+/// parquet row group filtering. Data columns rewrite to `stats_parsed.*` and partition columns to
+/// `partitionValues_parsed.<col>`; in both cases a null stat keeps the row group (a data column's
+/// missing statistic or a non-Add row's null partition value).
 struct CheckpointDataSkippingPredicateCreator<'a> {
     data_skipping_columns: DataSkippingColumns<'a>,
 }
@@ -764,20 +810,20 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
     type Output = Pred;
     type ColumnStat = Expr;
 
-    // The stat methods produce `stats_parsed.*`-rooted references; the checkpoint skipping path
-    // then scopes them under `add`. Partition columns return None since their values live in
-    // `add.partitionValues_parsed`.
+    // The stat methods produce `stats_parsed.*`-rooted references for data columns and
+    // `partitionValues_parsed.*` for partition columns; the checkpoint skipping path then scopes
+    // them under `add`. A partition value is exact per file, so it serves as both min and max.
 
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
-            return None;
+            return Some(partition_value_expr(col));
         }
         self.data_skipping_columns.data_min_stat(col, data_type)
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
-            return None;
+            return Some(partition_value_expr(col));
         }
         self.data_skipping_columns.data_max_stat(col, data_type)
     }
@@ -793,11 +839,8 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         Some(self.data_skipping_columns.rowcount_stat())
     }
 
-    /// Compares a column's max stat against a literal value, adjusting for timestamp
-    /// truncation. See [`adjust_scalar_for_max_stat_truncation`].
-    ///
-    /// No partition column guard needed: `get_max_stat` returns `None` for partition columns,
-    /// so their exact values never reach the adjustment.
+    /// Compares a column's max stat against a literal value, adjusting for timestamp truncation on
+    /// data columns. Partition values are exact (never truncated), so they skip the adjustment.
     fn partial_cmp_max_stat(
         &self,
         col: &ColumnName,
@@ -806,21 +849,16 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         inverted: bool,
     ) -> Option<Pred> {
         let max = self.get_max_stat(col, &val.data_type())?;
+        if self.is_partition_column(col) {
+            return self.eval_partial_cmp(ord, max, val, inverted);
+        }
         let adjusted = adjust_scalar_for_max_stat_truncation(val);
         self.eval_partial_cmp(ord, max, &adjusted, inverted)
     }
 
-    /// Wraps a stat column comparison with an IS NULL guard.
-    ///
-    /// `col > 100` → `OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col > 100)`
-    ///
-    /// `col = 100` (calls this twice, once per stat):
-    /// ```text
-    /// AND(
-    ///   OR(stats_parsed.minValues.col IS NULL, stats_parsed.minValues.col <= 100),
-    ///   OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col >= 100)
-    /// )
-    /// ```
+    /// Wraps a stat column comparison with an IS NULL guard, so a null stat keeps the row group.
+    /// `col > 100` becomes
+    /// `OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col > 100)`.
     fn eval_partial_cmp(
         &self,
         ord: Ordering,
@@ -832,24 +870,28 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         Some(Pred::or(Pred::is_null(col), comparison))
     }
 
-    /// No guard needed — no stat column reference. `TRUE` → `Some(true)`.
+    /// Scalar-only, so no stat reference to guard.
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Pred> {
         KernelPredicateEvaluatorDefaults::eval_pred_scalar(val, inverted).map(Pred::literal)
     }
 
-    /// No guard needed — no stat column reference. `NULL IS NULL` → `Some(true)`.
+    /// Scalar-only, so no stat reference to guard.
     fn eval_pred_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<Pred> {
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
     }
 
-    /// IS NULL guard on nullCount stat.
+    /// IS NULL skipping. IS NOT NULL never prunes here and returns `None`.
     ///
-    /// `IS NULL` → `OR(nullCount.col IS NULL, nullCount.col != 0)`:
-    /// column vs literal — RowGroupFilter can evaluate via footer stats.
+    /// A partition column checks `partitionValues_parsed.<col> IS NULL` directly: a row group with
+    /// no null partition value holds only Add rows with real values, so `IS NULL` can prune it.
+    /// `IS NOT NULL` can't: a non-Add row also has a null partition value, so proving the value is
+    /// non-null would drop those rows.
     ///
-    /// `IS NOT NULL` → returns `None`. The unguarded version produces
-    /// `nullCount.col != numRecords`, which is column vs column. The RowGroupFilter can
-    /// only resolve one column at a time, so it can never prune with this predicate.
+    /// A data column uses the `nullCount` stat. `IS NULL` becomes
+    /// `OR(stats_parsed.nullCount.col IS NULL, stats_parsed.nullCount.col != 0)`, which
+    /// RowGroupFilter can evaluate against footer stats. `IS NOT NULL` returns `None`: its
+    /// unguarded form compares nullCount against numRecords (column vs column), which
+    /// RowGroupFilter can't prune since it resolves one column at a time.
     // TODO(#1873): IS NOT NULL pruning requires cross-column range comparison in RowGroupFilter.
     // Skippable when the nullCount and numRecords ranges don't overlap (e.g. nullCount in
     // [0, 0] vs numRecords in [500, 2000] proves all files have non-null values).
@@ -857,12 +899,15 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         if inverted {
             return None; // IS NOT NULL: column vs column, can't prune (#1873)
         }
+        if self.is_partition_column(col) {
+            return Some(Pred::is_null(partition_value_expr(col)));
+        }
         let nullcount = self.get_nullcount_stat(col)?;
         let comparison = Pred::ne(nullcount.clone(), Expr::literal(0i64));
         Some(Pred::or(Pred::is_null(nullcount), comparison))
     }
 
-    /// No guard needed — no stat column reference. `5 < 10` → `Some(true)`.
+    /// Scalar-only, so no stat reference to guard.
     fn eval_pred_binary_scalars(
         &self,
         op: BinaryPredicateOp,
@@ -886,7 +931,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         None
     }
 
-    /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` →
+    /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` becomes
     /// ```text
     /// AND(
     ///   OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -413,33 +413,16 @@ impl DataSkippingFilter {
     }
 }
 
-/// Rewrites a predicate for parquet row group skipping in checkpoint/sidecar files.
-/// Returns `None` if the predicate is not eligible for data skipping.
+/// Rewrites `pred` for checkpoint row-group skipping. Data references become IS NULL guarded
+/// `stats_parsed.{minValues,maxValues,nullCount}.<col>` comparisons; partition references become
+/// exact `partitionValues_parsed.<col>` values (serving as both min and max). Returns `None` when
+/// the predicate cannot be rewritten safely. The null-guard invariant is documented on
+/// [`CheckpointDataSkippingPredicateCreator`].
 ///
-/// Data-column references become `stats_parsed.{minValues,maxValues,nullCount}.<col>`. Partition
-/// references become `partitionValues_parsed.<col>`: the partition value is exact, so it serves as
-/// both the min and the max stat, and `col_a = 'x'` prunes a row group whose footer range excludes
-/// `'x'`.
-///
-/// Every generated stat comparison is wrapped in an IS NULL guard, so a row group is kept whenever
-/// the referenced stat is null; scalar-only comparisons fold directly because they have no stat
-/// reference. For data columns a null stat means a file is missing that statistic (footer min/max
-/// ignore nulls, so the aggregate is untrustworthy); for partition values a null leaf means either
-/// a non-Add row (Remove, metadata, ...) or an Add with a null (e.g. Hive-default) partition value.
-/// Guarding both keeps such row groups instead of pruning them. `col_a > 100` becomes:
-/// ```text
-/// OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100)
-/// ```
-///
-/// `physical_partition_columns` is the set of physical partition columns available to this rewrite.
-/// It may be narrowed to the predicate's references rather than the table's full partition list;
-/// pass an empty set for unpartitioned tables.
-///
-/// `physical_stats_columns` is the table-level membership set for expected stats; references
-/// outside it fold to NULL (keeps the file). It is predicate-independent, unlike
-/// `physical_stats_schema` which may be predicate-trimmed. Each rewritten reference must be present
-/// in that schema, otherwise the row-group filter sees a missing field.
-pub(crate) fn as_checkpoint_skipping_predicate(
+/// `physical_partition_columns` may be narrowed to the predicate's references; pass an empty set
+/// for unpartitioned tables. `physical_stats_columns` is the table-level stats membership set;
+/// references outside it fold to NULL (keeping the file).
+fn as_checkpoint_skipping_predicate(
     pred: &Pred,
     physical_partition_columns: &HashSet<ColumnName>,
     physical_stats_columns: &HashSet<ColumnName>,
@@ -584,24 +567,49 @@ impl DataSkippingColumns<'_> {
         self.physical_stats_columns.contains(col)
     }
 
-    /// Data column -> `stats_parsed.minValues.<col>`, or `None` when unindexed or not
-    /// min/max-eligible.
-    fn data_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        (self.is_stats_column(col) && has_min_max_stats(data_type))
-            .then(|| Expr::from(column_name!("stats_parsed", MIN_VALUES).join(col)))
+    /// Min stat for `col`: the exact `partitionValues_parsed.<col>` value for partition columns
+    /// (it serves as both min and max), else `stats_parsed.minValues.<col>` (`None` when unindexed
+    /// or not min/max-eligible).
+    fn min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            Some(partition_value_expr(col))
+        } else {
+            (self.is_stats_column(col) && has_min_max_stats(data_type))
+                .then(|| Expr::from(column_name!("stats_parsed", MIN_VALUES).join(col)))
+        }
     }
 
-    /// Data column -> `stats_parsed.maxValues.<col>`, or `None` when unindexed or not
-    /// min/max-eligible.
-    fn data_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        (self.is_stats_column(col) && has_min_max_stats(data_type))
-            .then(|| Expr::from(column_name!("stats_parsed", MAX_VALUES).join(col)))
+    /// Max stat for `col`: the exact `partitionValues_parsed.<col>` value for partition columns,
+    /// else `stats_parsed.maxValues.<col>` (`None` when unindexed or not min/max-eligible).
+    fn max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            Some(partition_value_expr(col))
+        } else {
+            (self.is_stats_column(col) && has_min_max_stats(data_type))
+                .then(|| Expr::from(column_name!("stats_parsed", MAX_VALUES).join(col)))
+        }
     }
 
-    /// Data column -> `stats_parsed.nullCount.<col>`, or `None` when unindexed.
-    fn data_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        self.is_stats_column(col)
-            .then(|| Expr::from(column_name!("stats_parsed", NULL_COUNT).join(col)))
+    /// The comparison value for a max-stat check. Data-column max stats may be JSON-truncated, so
+    /// the value is widened by [`adjust_scalar_for_max_stat_truncation`]; partition values are
+    /// exact and pass through unchanged.
+    fn max_stat_comparison_value(&self, col: &ColumnName, val: &Scalar) -> Scalar {
+        if self.is_partition_column(col) {
+            val.clone()
+        } else {
+            adjust_scalar_for_max_stat_truncation(val)
+        }
+    }
+
+    /// Null count stat for `col`: `None` for partition columns (their values are exact, not
+    /// aggregated) and for data columns outside the stats set, else `stats_parsed.nullCount.<col>`.
+    fn nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
+        if self.is_partition_column(col) {
+            None
+        } else {
+            self.is_stats_column(col)
+                .then(|| Expr::from(column_name!("stats_parsed", NULL_COUNT).join(col)))
+        }
     }
 
     fn rowcount_stat(&self) -> Expr {
@@ -650,32 +658,14 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     type Output = Pred;
     type ColumnStat = Expr;
 
-    /// Retrieves the minimum value of a column. For partition columns, returns the exact
-    /// partition value (which serves as both min and max). Returns `None` for data columns
-    /// outside the stat-columns set or whose type is not min/max-eligible.
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            Some(partition_value_expr(col))
-        } else {
-            self.data_skipping_columns.data_min_stat(col, data_type)
-        }
+        self.data_skipping_columns.min_stat(col, data_type)
     }
 
-    /// Retrieves the maximum value of a column. For partition columns, returns the exact
-    /// partition value. Returns `None` for data columns outside the stat-columns set or whose
-    /// type is not min/max-eligible.
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            Some(partition_value_expr(col))
-        } else {
-            self.data_skipping_columns.data_max_stat(col, data_type)
-        }
+        self.data_skipping_columns.max_stat(col, data_type)
     }
 
-    /// Compares a column's max stat against a literal value, adjusting for timestamp
-    /// truncation on non-partition columns. Partition values are exact and not subject to
-    /// JSON stats truncation, so no adjustment is needed. For data columns, the comparison
-    /// value is adjusted by [`adjust_scalar_for_max_stat_truncation`].
     fn partial_cmp_max_stat(
         &self,
         col: &ColumnName,
@@ -684,24 +674,16 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         inverted: bool,
     ) -> Option<Pred> {
         let max = self.get_max_stat(col, &val.data_type())?;
-        if self.is_partition_column(col) {
-            return self.eval_partial_cmp(ord, max, val, inverted);
-        }
-        let adjusted = adjust_scalar_for_max_stat_truncation(val);
+        let adjusted = self
+            .data_skipping_columns
+            .max_stat_comparison_value(col, val);
         self.eval_partial_cmp(ord, max, &adjusted, inverted)
     }
 
-    /// Retrieves the null count of a column. Partition columns don't have nullCount stats,
-    /// nor do data columns outside the stat-columns set.
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            None
-        } else {
-            self.data_skipping_columns.data_nullcount_stat(col)
-        }
+        self.data_skipping_columns.nullcount_stat(col)
     }
 
-    /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
         Some(self.data_skipping_columns.rowcount_stat())
     }
@@ -810,37 +792,27 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
     type Output = Pred;
     type ColumnStat = Expr;
 
-    // The stat methods produce `stats_parsed.*`-rooted references for data columns and
-    // `partitionValues_parsed.*` for partition columns; the checkpoint skipping path then scopes
-    // them under `add`. A partition value is exact per file, so it serves as both min and max.
+    // Stat selection (partition value vs `stats_parsed.*`, and the max-stat truncation policy) is
+    // shared with the in-memory creator via `DataSkippingColumns`. Only the guards below differ:
+    // this creator wraps every comparison in an IS NULL check so the row-group filter keeps a group
+    // whenever the stat is null.
 
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            return Some(partition_value_expr(col));
-        }
-        self.data_skipping_columns.data_min_stat(col, data_type)
+        self.data_skipping_columns.min_stat(col, data_type)
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            return Some(partition_value_expr(col));
-        }
-        self.data_skipping_columns.data_max_stat(col, data_type)
+        self.data_skipping_columns.max_stat(col, data_type)
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) {
-            return None;
-        }
-        self.data_skipping_columns.data_nullcount_stat(col)
+        self.data_skipping_columns.nullcount_stat(col)
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
         Some(self.data_skipping_columns.rowcount_stat())
     }
 
-    /// Compares a column's max stat against a literal value, adjusting for timestamp truncation on
-    /// data columns. Partition values are exact (never truncated), so they skip the adjustment.
     fn partial_cmp_max_stat(
         &self,
         col: &ColumnName,
@@ -849,10 +821,9 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         inverted: bool,
     ) -> Option<Pred> {
         let max = self.get_max_stat(col, &val.data_type())?;
-        if self.is_partition_column(col) {
-            return self.eval_partial_cmp(ord, max, val, inverted);
-        }
-        let adjusted = adjust_scalar_for_max_stat_truncation(val);
+        let adjusted = self
+            .data_skipping_columns
+            .max_stat_comparison_value(col, val);
         self.eval_partial_cmp(ord, max, &adjusted, inverted)
     }
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -500,31 +500,6 @@ fn test_checkpoint_skipping_semantic(
     expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
 }
 
-// A partition-only equality resolves against the exact `partitionValues_parsed` value: a matching
-// value keeps the row group, an out-of-range value prunes it.
-#[rstest]
-#[case::below("A", FALSE, "part='A', pred part='B' -> skip")]
-#[case::match_("B", TRUE, "part='B', pred part='B' -> keep")]
-#[case::above("C", FALSE, "part='C', pred part='B' -> skip")]
-fn test_checkpoint_skipping_partition_column(
-    #[case] part_val: &str,
-    #[case] expected: Option<bool>,
-    #[case] description: &str,
-) {
-    let partition_columns = HashSet::from([column_name!("part_col")]);
-    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("B"));
-    // Partition columns are not part of the stats-columns set.
-    let stats = HashSet::new();
-    let skipping_pred =
-        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
-    let resolver = HashMap::from_iter([(
-        column_name!("partitionValues_parsed.part_col"),
-        Scalar::from(part_val),
-    )]);
-    let filter = DefaultKernelPredicateEvaluator::from(resolver);
-    expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
-}
-
 // The IS NULL guard on a partition comparison keeps a row group whose partition value is null (a
 // non-Add row such as a Remove). Without the guard, `part_col = 'B'` would resolve to FALSE against
 // a null value and wrongly prune the row group, dropping the tombstone from log replay.
@@ -546,15 +521,14 @@ fn test_checkpoint_skipping_partition_null_value_kept() {
     );
 }
 
-// Checkpoint partition skipping across comparison operators, modeling a row group whose add files
-// all share one partition value (min == max -- the canonical partition case). The rewrite reads
-// `partitionValues_parsed.part_col` as both min and max, so a single resolved value drives an exact
-// verdict. (Range footers where min != max are exercised by the real-parquet
-// CheckpointRowGroupFilter tests and the e2e integration tests.) Skip (FALSE) exactly when the
-// value cannot match.
+// Checkpoint partition skipping across comparison operators. Each case resolves one exact per-file
+// partition value from `partitionValues_parsed.part_col`, which serves as both min and max. The
+// rewritten comparison returns FALSE exactly when that value cannot satisfy the original predicate.
 #[rstest]
-#[case::eq_miss(Pred::eq(column_expr!("part_col"), Scalar::from("m")), "b", FALSE)]
+// Value fixed at "b"; the literal sits below, on, or above it.
+#[case::eq_lit_above(Pred::eq(column_expr!("part_col"), Scalar::from("m")), "b", FALSE)]
 #[case::eq_hit(Pred::eq(column_expr!("part_col"), Scalar::from("b")), "b", TRUE)]
+#[case::eq_lit_below(Pred::eq(column_expr!("part_col"), Scalar::from("a")), "b", FALSE)]
 #[case::neq_miss(Pred::ne(column_expr!("part_col"), Scalar::from("b")), "b", FALSE)]
 #[case::neq_hit(Pred::ne(column_expr!("part_col"), Scalar::from("m")), "b", TRUE)]
 #[case::lt_miss(Pred::lt(column_expr!("part_col"), Scalar::from("a")), "b", FALSE)]
@@ -633,10 +607,9 @@ fn test_checkpoint_skipping_partition_missing_stats_keeps_all() {
     }
 }
 
-// Mixed partition + data predicates. Each arm prunes independently against its own stats
-// (`partitionValues_parsed.part_col` = "b", footer range ['a','c'];
-// `stats_parsed.maxValues.data_col`). AND skips when EITHER arm proves no match; OR skips only when
-// BOTH prove no match.
+// Mixed partition + data predicates. Each arm prunes independently against its own stat: the exact
+// `partitionValues_parsed.part_col` value and the `stats_parsed.maxValues.data_col` range. AND
+// skips when EITHER arm proves no match; OR skips only when BOTH prove no match.
 #[rstest]
 // part_col = 'b' AND data_col > 100
 #[case::and_partition_prunes(true, "z", 500, FALSE)] // partition out of range -> skip

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -4,7 +4,9 @@ use rstest::rstest;
 
 use super::*;
 use crate::expressions::column_name;
-use crate::kernel_predicates::{DefaultKernelPredicateEvaluator, UnimplementedColumnResolver};
+use crate::kernel_predicates::{
+    DefaultKernelPredicateEvaluator, EmptyColumnResolver, UnimplementedColumnResolver,
+};
 
 const TRUE: Option<bool> = Some(true);
 const FALSE: Option<bool> = Some(false);
@@ -498,6 +500,200 @@ fn test_checkpoint_skipping_semantic(
     expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
 }
 
+// A partition-only equality resolves against the exact `partitionValues_parsed` value: a matching
+// value keeps the row group, an out-of-range value prunes it.
+#[rstest]
+#[case::below("A", FALSE, "part='A', pred part='B' -> skip")]
+#[case::match_("B", TRUE, "part='B', pred part='B' -> keep")]
+#[case::above("C", FALSE, "part='C', pred part='B' -> skip")]
+fn test_checkpoint_skipping_partition_column(
+    #[case] part_val: &str,
+    #[case] expected: Option<bool>,
+    #[case] description: &str,
+) {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("B"));
+    // Partition columns are not part of the stats-columns set.
+    let stats = HashSet::new();
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
+    let resolver = HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from(part_val),
+    )]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
+}
+
+// The IS NULL guard on a partition comparison keeps a row group whose partition value is null (a
+// non-Add row such as a Remove). Without the guard, `part_col = 'B'` would resolve to FALSE against
+// a null value and wrongly prune the row group, dropping the tombstone from log replay.
+#[test]
+fn test_checkpoint_skipping_partition_null_value_kept() {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let pred = Pred::eq(column_expr!("part_col"), Scalar::from("B"));
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &HashSet::new()).unwrap();
+    let resolver = HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::Null(DataType::STRING),
+    )]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    expect_eq!(
+        filter.eval(&skipping_pred),
+        TRUE,
+        "null partition value (non-Add row) must be kept by the IS NULL guard"
+    );
+}
+
+// Checkpoint partition skipping across comparison operators, modeling a row group whose add files
+// all share one partition value (min == max -- the canonical partition case). The rewrite reads
+// `partitionValues_parsed.part_col` as both min and max, so a single resolved value drives an exact
+// verdict. (Range footers where min != max are exercised by the real-parquet
+// CheckpointRowGroupFilter tests and the e2e integration tests.) Skip (FALSE) exactly when the
+// value cannot match.
+#[rstest]
+#[case::eq_miss(Pred::eq(column_expr!("part_col"), Scalar::from("m")), "b", FALSE)]
+#[case::eq_hit(Pred::eq(column_expr!("part_col"), Scalar::from("b")), "b", TRUE)]
+#[case::neq_miss(Pred::ne(column_expr!("part_col"), Scalar::from("b")), "b", FALSE)]
+#[case::neq_hit(Pred::ne(column_expr!("part_col"), Scalar::from("m")), "b", TRUE)]
+#[case::lt_miss(Pred::lt(column_expr!("part_col"), Scalar::from("a")), "b", FALSE)]
+#[case::lt_hit(Pred::lt(column_expr!("part_col"), Scalar::from("c")), "b", TRUE)]
+#[case::le_boundary(Pred::le(column_expr!("part_col"), Scalar::from("b")), "b", TRUE)]
+#[case::gt_miss(Pred::gt(column_expr!("part_col"), Scalar::from("z")), "b", FALSE)]
+#[case::gt_hit(Pred::gt(column_expr!("part_col"), Scalar::from("a")), "b", TRUE)]
+#[case::ge_boundary(Pred::ge(column_expr!("part_col"), Scalar::from("b")), "b", TRUE)]
+fn test_checkpoint_skipping_partition_range_ops(
+    #[case] pred: Pred,
+    #[case] value: &str,
+    #[case] expected: Option<bool>,
+) {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let stats = HashSet::new();
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from(value),
+    )]));
+    expect_eq!(
+        resolver.eval(&skipping_pred),
+        expected,
+        "value={value} {pred:?}"
+    );
+}
+
+// Partition `IS NULL` reads `partitionValues_parsed.part_col IS NULL` directly: a row group with no
+// null partition value holds only Add rows with real values, so a non-null value prunes it (FALSE).
+#[test]
+fn test_checkpoint_skipping_partition_is_null() {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let pred = Pred::is_null(column_expr!("part_col"));
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &HashSet::new()).unwrap();
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from("x"),
+    )]));
+    expect_eq!(resolver.eval(&skipping_pred), FALSE, "{pred:?}");
+}
+
+// Partition `IS NOT NULL` can't prune: a non-Add row also has a null partition value, so proving
+// the value is non-null would drop those rows. It produces no skipping predicate (#1873).
+#[test]
+fn test_checkpoint_skipping_partition_is_not_null_never_prunes() {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let pred = Pred::not(Pred::is_null(column_expr!("part_col")));
+    assert!(
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &HashSet::new()).is_none(),
+        "partition IS NOT NULL must not produce a skipping predicate"
+    );
+}
+
+// When the checkpoint lacks `partitionValues_parsed` (older writer), the meta-predicate still
+// references it, but every stat resolves to unavailable -> the predicate is NULL/unknown -> the
+// row group is KEPT, never pruned. Simulated with a resolver that has no columns at all.
+#[test]
+fn test_checkpoint_skipping_partition_missing_stats_keeps_all() {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let stats = HashSet::new();
+    for pred in [
+        Pred::eq(column_expr!("part_col"), Scalar::from("B")),
+        Pred::lt(column_expr!("part_col"), Scalar::from("B")),
+        Pred::is_null(column_expr!("part_col")),
+    ] {
+        let skipping_pred =
+            as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
+        let filter = DefaultKernelPredicateEvaluator::from(EmptyColumnResolver);
+        expect_eq!(
+            filter.eval(&skipping_pred),
+            NULL,
+            "missing partition stats must never prune: {pred:?}"
+        );
+    }
+}
+
+// Mixed partition + data predicates. Each arm prunes independently against its own stats
+// (`partitionValues_parsed.part_col` = "b", footer range ['a','c'];
+// `stats_parsed.maxValues.data_col`). AND skips when EITHER arm proves no match; OR skips only when
+// BOTH prove no match.
+#[rstest]
+// part_col = 'b' AND data_col > 100
+#[case::and_partition_prunes(true, "z", 500, FALSE)] // partition out of range -> skip
+#[case::and_data_prunes(true, "b", 40, FALSE)] // data max below threshold -> skip
+#[case::and_both_keep(true, "b", 500, TRUE)] // both match -> keep
+// part_col = 'b' OR data_col > 100
+#[case::or_both_miss(false, "z", 40, FALSE)] // both miss -> skip
+#[case::or_partition_keeps(false, "b", 40, TRUE)] // partition matches -> keep
+#[case::or_data_keeps(false, "z", 500, TRUE)] // data matches -> keep
+fn test_checkpoint_skipping_mixed_partition_and_data(
+    #[case] is_and: bool,
+    #[case] part_val: &str,
+    #[case] data_max: i64,
+    #[case] expected: Option<bool>,
+) {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let stats: HashSet<ColumnName> = [column_name!("data_col")].into_iter().collect();
+    let part = Pred::eq(column_expr!("part_col"), Scalar::from("b"));
+    let data = Pred::gt(column_expr!("data_col"), Scalar::from(100i64));
+    let pred = if is_and {
+        Pred::and(part, data)
+    } else {
+        Pred::or(part, data)
+    };
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([
+        (
+            column_name!("partitionValues_parsed.part_col"),
+            Scalar::from(part_val),
+        ),
+        (
+            column_name!("stats_parsed.maxValues.data_col"),
+            Scalar::from(data_max),
+        ),
+    ]));
+    expect_eq!(resolver.eval(&skipping_pred), expected, "{pred:?}");
+}
+
+// Partition timestamp columns are exact (never truncated), so unlike data-column timestamps they
+// get NO 999us max-stat adjustment. `part_ts > T` compares against the exact value T (not T-999),
+// under the IS NULL guard that keeps non-Add rows.
+#[test]
+fn test_checkpoint_skipping_partition_timestamp_no_truncation_adjustment() {
+    let partition_columns = HashSet::from([column_name!("part_ts")]);
+    let stats = HashSet::new();
+    let pred = Pred::gt(column_expr!("part_ts"), Scalar::Timestamp(1_000_000));
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).unwrap();
+    assert_eq!(
+        skipping_pred.to_string(),
+        "OR(Column(partitionValues_parsed.part_ts) IS NULL, \
+         Column(partitionValues_parsed.part_ts) > 1000000)",
+        "partition timestamp must not get the 999us data-column truncation adjustment"
+    );
+}
+
 // Verifies that the IS NULL guard changes behavior compared to a regular data skipping predicate:
 // without the guard, null stats produce NULL (unknown); with the guard, they produce TRUE (keep).
 #[test]
@@ -529,8 +725,8 @@ fn test_checkpoint_skipping_null_guard_vs_regular() {
 // column's stats are sufficient. For `col_a > 100 AND col_b < 50`, the guarded predicate is:
 //
 //   AND(
-//     OR(maxValues.col_a IS NULL, maxValues.col_a > 100),
-//     OR(minValues.col_b IS NULL, minValues.col_b < 50)
+//     OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
+//     OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
 //   )
 //
 // Even if col_a's stats are null, col_b's stats alone can prune the row group.
@@ -612,7 +808,8 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
-        "OR(Column(stats_parsed.maxValues.ts_col) IS NULL, Column(stats_parsed.maxValues.ts_col) > 999001)"
+        "OR(Column(stats_parsed.maxValues.ts_col) IS NULL, \
+         Column(stats_parsed.maxValues.ts_col) > 999001)"
     );
 
     // EQ: max stat leg should use adjusted literal
@@ -621,8 +818,10 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
-        "AND(OR(Column(stats_parsed.minValues.ts_col) IS NULL, NOT(Column(stats_parsed.minValues.ts_col) > 1000000)), \
-         OR(Column(stats_parsed.maxValues.ts_col) IS NULL, NOT(Column(stats_parsed.maxValues.ts_col) < 999001)))"
+        "AND(OR(Column(stats_parsed.minValues.ts_col) IS NULL, \
+         NOT(Column(stats_parsed.minValues.ts_col) > 1000000)), \
+         OR(Column(stats_parsed.maxValues.ts_col) IS NULL, \
+         NOT(Column(stats_parsed.maxValues.ts_col) < 999001)))"
     );
 }
 
@@ -1561,6 +1760,18 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
     let result = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         result.to_string(),
-        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, Column(stats_parsed.maxValues.stat) > 100), null)"
+        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, \
+         Column(stats_parsed.maxValues.stat) > 100), null)"
     );
+}
+
+#[test]
+fn prefix_columns_scopes_reference_under_root() {
+    let mut prefixer = PrefixColumns::new(column_name!("add", "stats_parsed"));
+    let pred = Pred::gt(column_expr!("x"), Expr::literal(100i64));
+    let result = prefixer.transform_pred(&pred).into_owned();
+
+    let refs: Vec<_> = result.references().into_iter().collect();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(*refs[0], column_name!("add.stats_parsed.x"));
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use tracing::{debug, info};
 use url::Url;
 
-use self::data_skipping::as_checkpoint_skipping_predicate;
+use self::data_skipping::as_checkpoint_meta_predicate;
 use self::log_replay::{get_scan_metadata_transform_expr, scan_action_iter};
 use crate::actions::deletion_vector::{
     deletion_treemap_to_bools, split_vector, DeletionVectorDescriptor,
@@ -536,21 +536,6 @@ impl<'a> SchemaTransform<'a> for GetReferencedFields<'a> {
     }
 }
 
-/// Prefixes all column references in a predicate with a fixed path. The checkpoint path prefixes
-/// stat expressions that already carry their `stats_parsed.*` root (e.g. `stats_parsed.minValues.x
-/// > 100`) with `add`, yielding `add.stats_parsed.minValues.x > 100`.
-struct PrefixColumns {
-    prefix: ColumnName,
-}
-
-impl<'a> ExpressionTransform<'a> for PrefixColumns {
-    transform_output_type!(|'a, T| Cow<'a, T>);
-
-    fn transform_expr_column(&mut self, name: &'a ColumnName) -> Cow<'a, ColumnName> {
-        Cow::Owned(self.prefix.join(name))
-    }
-}
-
 struct ApplyColumnMappings {
     column_mappings: HashMap<ColumnName, ColumnName>,
 }
@@ -993,25 +978,28 @@ impl Scan {
 
     /// Builds a predicate for row group skipping in checkpoint and sidecar parquet files.
     ///
-    /// The scan predicate is first transformed into a data-skipping form with IS NULL guards
-    /// (e.g., `x > 100` becomes `OR(stats_parsed.maxValues.x IS NULL, stats_parsed.maxValues.x >
-    /// 100)`), then column references are prefixed with `add` to match the physical column layout
-    /// of checkpoint/sidecar files. The parquet reader's row group filter can then use
-    /// parquet-level statistics on these nested columns to skip entire row groups that cannot
-    /// contain matching files.
+    /// The scan predicate is rewritten into a data-skipping form scoped under the `add` action:
+    /// data-column references become `add.stats_parsed.{minValues,maxValues,nullCount}.<col>` and
+    /// partition references become `add.partitionValues_parsed.<col>`, so the parquet reader's row
+    /// group filter can use footer statistics to skip row groups that cannot contain matching
+    /// files. See [`as_checkpoint_meta_predicate`] for the rewrite and its IS NULL guards.
     ///
-    /// The IS NULL guards are necessary because parquet footer min/max statistics ignore null
-    /// values. Without them, row groups containing files with missing stats (null stat columns)
-    /// could be incorrectly pruned, since the footer min/max wouldn't reflect those files.
-    ///
-    /// Returns `None` if the scan has no predicate, no stats schema, or if the predicate is a
-    /// bare unsupported expression (e.g. column-column comparison). Junctions with unsupported
-    /// arms replace them with TRUE to conservatively prevent pruning.
+    /// Returns `None` if the scan has no predicate, if neither a data-column stats schema nor a
+    /// partition schema is available, or if the predicate is a bare unsupported expression (e.g.
+    /// column-column comparison). Junctions with unsupported arms replace them with a NULL literal
+    /// to conservatively prevent pruning.
     fn build_actions_meta_predicate(&self) -> Option<PredicateRef> {
         let PhysicalPredicate::Some(ref predicate, _) = self.state_info.physical_predicate else {
             return None;
         };
-        self.state_info.physical_stats_schema.as_ref()?;
+        // Skipping needs either data-column stats or partition values to rewrite against; a
+        // partition-only predicate has no `stats_parsed` schema, a data-only predicate on an
+        // unpartitioned table has no partition schema.
+        if self.state_info.physical_stats_schema.is_none()
+            && self.state_info.physical_partition_schema.is_none()
+        {
+            return None;
+        }
 
         // `partitionValues_parsed` is keyed by PHYSICAL partition name, and (under column mapping)
         // the predicate also references physical columns, so partition detection reads the physical
@@ -1022,17 +1010,12 @@ impl Scan {
             .as_ref()
             .map(|s| s.fields().map(|f| ColumnName::new([f.name()])).collect())
             .unwrap_or_default();
-        let skipping_pred = as_checkpoint_skipping_predicate(
+        let meta_predicate = as_checkpoint_meta_predicate(
             predicate,
             &partition_columns,
             &self.state_info.physical_stats_columns,
         )?;
-
-        let mut prefixer = PrefixColumns {
-            prefix: ColumnName::new(["add"]),
-        };
-        let prefixed = prefixer.transform_pred(&skipping_pred);
-        Some(Arc::new(prefixed.into_owned()))
+        Some(Arc::new(meta_predicate))
     }
 
     /// Start a parallel scan metadata processing for the table.

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -16,12 +16,12 @@ use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::engine::sync::SyncEngine;
 use crate::expressions::{
-    column_expr, column_name, column_pred, ColumnName, Expression as Expr, Predicate as Pred,
+    column_expr, column_name, column_pred, Expression as Expr, Predicate as Pred,
 };
 use crate::object_store::memory::InMemory;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
-use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
+use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_meta_predicate};
 use crate::scan::state::ScanFile;
 use crate::schema::{
     self, schema_ref, ColumnMetadataKey, DataType, MetadataColumnSpec, StructField, StructType,
@@ -1096,21 +1096,6 @@ fn test_scan_metadata_stats_columns_with_predicate() {
 }
 
 #[test]
-fn test_prefix_columns_simple() {
-    let mut prefixer = PrefixColumns {
-        prefix: ColumnName::new(["add", "stats_parsed"]),
-    };
-    // A simple binary predicate: x > 100
-    let pred = Pred::gt(column_expr!("x"), Expr::literal(100i64));
-    let result = prefixer.transform_pred(&pred).into_owned();
-
-    // The column reference should now be add.stats_parsed.x
-    let refs: Vec<_> = result.references().into_iter().collect();
-    assert_eq!(refs.len(), 1);
-    assert_eq!(*refs[0], column_name!("add.stats_parsed.x"));
-}
-
-#[test]
 fn test_build_actions_meta_predicate_with_predicate() {
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
@@ -1181,6 +1166,90 @@ fn test_build_actions_meta_predicate_static_skip_all() {
     assert!(
         scan.build_actions_meta_predicate().is_none(),
         "StaticSkipAll predicate should return None"
+    );
+}
+
+// A partition-only predicate must still produce a checkpoint meta-predicate that references
+// `add.partitionValues_parsed.<col>`, so partition values can drive checkpoint row-group skipping.
+// Regression: a partition-only predicate has no `stats_parsed` schema (partitions have no data
+// stats), so the meta-predicate must not be gated off just because data stats are absent.
+#[test]
+fn test_build_actions_meta_predicate_partition_only() {
+    // `app-txn-checkpoint` is partitioned by `modified` (string), no column mapping.
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+    let predicate = Arc::new(Pred::eq(
+        column_expr!("modified"),
+        Expr::literal("2021-02-01"),
+    ));
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(predicate)
+        .build()
+        .unwrap();
+
+    let meta_pred = scan.build_actions_meta_predicate();
+    assert!(
+        meta_pred.is_some(),
+        "partition-only predicate should still produce a checkpoint meta-predicate"
+    );
+    let refs: Vec<String> = meta_pred
+        .unwrap()
+        .references()
+        .into_iter()
+        .map(|c| c.to_string())
+        .collect();
+    assert!(
+        refs.iter()
+            .any(|r| r.starts_with("add.partitionValues_parsed.modified")),
+        "expected a reference to add.partitionValues_parsed.modified, got {refs:?}"
+    );
+}
+
+// Under column mapping (both name and id modes), the checkpoint meta-predicate must reference the
+// PHYSICAL partition column name (partitionValues_parsed is keyed by physical name in the
+// checkpoint), not the logical name. Regression: partition detection used logical
+// `metadata().partition_columns()` against a physical predicate, so it never matched under column
+// mapping and partition skipping silently disabled.
+#[rstest]
+#[case::name_mode("name")]
+#[case::id_mode("id")]
+fn test_build_actions_meta_predicate_partition_column_mapping(#[case] mode: &str) {
+    // `partition_cm/{name,id}` use column mapping, partitioned by `category`
+    // (physical name col-6dc68f07-711d-4f00-8bd6-1f5bc698e8ad in both fixtures).
+    let path =
+        std::fs::canonicalize(PathBuf::from(format!("./tests/data/partition_cm/{mode}/"))).unwrap();
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = SyncEngine::new();
+    let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+    let predicate = Arc::new(Pred::eq(column_expr!("category"), Expr::literal("a")));
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(predicate)
+        .build()
+        .unwrap();
+
+    let meta_pred = scan.build_actions_meta_predicate();
+    assert!(
+        meta_pred.is_some(),
+        "partition predicate under column mapping should produce a meta-predicate"
+    );
+    let refs: Vec<String> = meta_pred
+        .unwrap()
+        .references()
+        .into_iter()
+        .map(|c| c.to_string())
+        .collect();
+    // The hyphenated physical name is backtick-quoted in the column display.
+    assert!(
+        refs.iter().any(|r| r.contains("partitionValues_parsed")
+            && r.contains("col-6dc68f07-711d-4f00-8bd6-1f5bc698e8ad")),
+        "expected a reference to the PHYSICAL partition column under partitionValues_parsed, \
+         got {refs:?}"
     );
 }
 
@@ -1294,14 +1363,9 @@ impl CheckpointParquetBuilder {
     }
 }
 
-/// Builds a checkpoint skipping predicate and prefixes column references with `add.stats_parsed`.
-fn build_prefixed_checkpoint_predicate(pred: &Pred) -> Option<Pred> {
-    let stats = all_referenced_columns(pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(pred, &HashSet::new(), &stats)?;
-    let mut prefixer = PrefixColumns {
-        prefix: ColumnName::new(["add"]),
-    };
-    Some(prefixer.transform_pred(&skipping_pred).into_owned())
+/// Builds a checkpoint meta-predicate scoped under `add`, mirroring `build_actions_meta_predicate`.
+fn build_checkpoint_meta_predicate(pred: &Pred) -> Option<Pred> {
+    as_checkpoint_meta_predicate(pred, &HashSet::new(), &all_referenced_columns(pred))
 }
 
 /// Applies a meta predicate as a row group filter and returns the total rows read.
@@ -1342,7 +1406,7 @@ fn apply_row_group_filter(parquet_bytes: Bytes, meta_predicate: &Pred) -> usize 
 #[case::is_not_null(
     Pred::not(Pred::is_null(column_expr!("id"))),
     None,
-    "IS NOT NULL produces no skipping predicate — column vs column (#1873)"
+    "IS NOT NULL produces no skipping predicate (column vs column, #1873)"
 )]
 fn test_checkpoint_row_group_skipping(
     #[case] pred: Pred,
@@ -1371,7 +1435,7 @@ fn test_checkpoint_row_group_skipping(
     );
     let parquet_bytes = builder.finish();
 
-    let meta_predicate = build_prefixed_checkpoint_predicate(&pred);
+    let meta_predicate = build_checkpoint_meta_predicate(&pred);
 
     match expected_rows {
         Some(expected) => {

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1169,10 +1169,10 @@ fn test_build_actions_meta_predicate_static_skip_all() {
     );
 }
 
-// A partition-only predicate must still produce a checkpoint meta-predicate that references
-// `add.partitionValues_parsed.<col>`, so partition values can drive checkpoint row-group skipping.
-// Regression: a partition-only predicate has no `stats_parsed` schema (partitions have no data
-// stats), so the meta-predicate must not be gated off just because data stats are absent.
+// A partition-only predicate has no `stats_parsed` schema (partitions carry no data stats), yet it
+// must still produce a checkpoint meta-predicate referencing `add.partitionValues_parsed.<col>` so
+// partition values can drive checkpoint row-group skipping. The rewrite is gated on having either a
+// stats or a partition schema, not on data stats alone.
 #[test]
 fn test_build_actions_meta_predicate_partition_only() {
     // `app-txn-checkpoint` is partitioned by `modified` (string), no column mapping.
@@ -1209,11 +1209,9 @@ fn test_build_actions_meta_predicate_partition_only() {
     );
 }
 
-// Under column mapping (both name and id modes), the checkpoint meta-predicate must reference the
-// PHYSICAL partition column name (partitionValues_parsed is keyed by physical name in the
-// checkpoint), not the logical name. Regression: partition detection used logical
-// `metadata().partition_columns()` against a physical predicate, so it never matched under column
-// mapping and partition skipping silently disabled.
+// Under column mapping, `partitionValues_parsed` is keyed by the physical partition name, so the
+// checkpoint meta-predicate must reference that physical name (not the logical one) in both name
+// and id mapping modes.
 #[rstest]
 #[case::name_mode("name")]
 #[case::id_mode("id")]


### PR DESCRIPTION
## Stacked PR

- **fix: enable checkpoint row group skipping for partition columns** (this PR)
  - [test: end-to-end checkpoint row-group skipping](https://github.com/delta-io/delta-kernel-rs/pull/2967)

Builds on [#2976](https://github.com/delta-io/delta-kernel-rs/pull/2976) (merged).

## What changes are proposed in this pull request?

Checkpoint parquet row-group skipping ignored partition columns, so a partition-only predicate like `part = '2026-07-12'` read the whole checkpoint even though `add.partitionValues_parsed.<col>` carries per-row-group min/max. This wires partition columns into that skipping path.

- The checkpoint predicate creator rewrites a partition column to `partitionValues_parsed.<col>`, using the exact partition value as both min and max, the same treatment the in-memory data-skipping path already uses. It also handles `IS [NOT] NULL` on partition columns directly, and emits fully struct-qualified paths so the downstream prefixer only has to add `add`.
- Every checkpoint comparison, partition and data-stat alike, is wrapped in `OR(<stat> IS NULL, cmp)`. A checkpoint interleaves Add rows with non-Add rows (Remove tombstones, metadata), and a non-Add row has a null `partitionValues_parsed`. Since parquet footer min/max ignore nulls, an unguarded `part = v` could skip a row group and drop a Remove, so the guard keeps any group whose referenced stat is null. For the same reason, partition `IS NOT NULL` is made non-pruning.
- `build_actions_meta_predicate` no longer requires a data-stats schema (a partition-only predicate has none).

## How was this change tested?

Added coverage at the predicate-creator layer (rewrite, null guards, column-mapping name resolution) and the scan meta-predicate builder. The end-to-end reader test driven through the production rewrite lands in the stacked tests PR.
