### PR TITLE
feat: add benchmark registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,9 +1383,11 @@ dependencies = [
  "flate2",
  "object_store 0.12.5",
  "rayon",
+ "serde",
  "serde_json",
  "sha2",
  "tar",
+ "tempfile",
  "test_utils",
  "tokio",
  "unity-catalog-delta-client-api",
@@ -1486,6 +1488,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlparser",
+ "tempfile",
  "url",
 ]
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -28,6 +28,7 @@ delta-kernel-unity-catalog = { path = "../delta-kernel-unity-catalog" }
 object_store = { version = "0.12.3", features = ["aws"] }
 test_utils = { path = "../test-utils" }
 rayon = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
@@ -36,6 +37,7 @@ url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.5"
+tempfile = "3"
 
 [[bench]]
 name = "workload_bench"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,43 +23,43 @@ samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench "som
 
 #### By benchmark name
 
-Benchmark names follow a hierarchical path structure assembled from the table name, the spec file name, the operation, and (for `Read` workloads) the read config name:
+Benchmark names use the human-readable table name and spec file name. Read benchmarks also
+include the harness config name:
 
 ```
-{table_name}/{spec_file_name}/{operation}/{config_name}
+{table_name}/{spec_file_name}               # snapshot construction
+{table_name}/{spec_file_name}/{config_name} # read
 ```
 
-- `{table_name}` — the `name` field from `tableInfo.json`
+- `{table_name}` — the human-readable `name` from the table's `tableInfo.json`
 - `{spec_file_name}` — the spec filename without its `.json` extension (the `case_name`)
-- `{operation}` — `snapshotConstruction` or `readMetadata`
-- `{config_name}` — only present for `Read` workloads; e.g. `serial`, `parallel2`, `parallel4`
-
-All path components use camelCase to match the JSON keys used throughout the workload spec format.
+- `{config_name}` — the read harness config from
+  [`bench-registry.json`](#registry-bench-registryjson), such as `serial` or `parallel2`
 
 Examples:
 ```
-101kAdds1000CommitsSinceChkpt1Chkpt/snapshotLatest/snapshotConstruction
-101kAdds1000CommitsSinceChkpt1Chkpt/snapshotLatest/readMetadata/serial
-10kAdds0CommitsSinceChkpt1V2Chkpt/snapshotLatest/readMetadata/parallel2
+crcVeryStale/snapshotLatest
+v1Checkpoint/readMetadataLatest/serial
+v2Checkpoint/readMetadataLatest/parallel2
 ```
 
 The filter argument is a regular expression, so you can create patterns to target the benchmarks that you want:
 
 ```bash
 # all benchmarks for a specific table name
-cargo bench -p delta_kernel_benchmarks --bench workload_bench "101kAdds1000CommitsSinceChkpt1Chkpt"
+cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale"
 
 # all benchmarks for either of two tables (| for OR)
-cargo bench -p delta_kernel_benchmarks --bench workload_bench "101kAdds1000CommitsSinceChkpt1Chkpt|10kAdds0Chkpts"
+cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale|crcLatest"
 
-# all snapshotConstruction benchmarks
-cargo bench -p delta_kernel_benchmarks --bench workload_bench "snapshotConstruction"
+# all snapshot-construction benchmarks (the snapshotLatest spec)
+cargo bench -p delta_kernel_benchmarks --bench workload_bench "snapshotLatest"
 
-# snapshotConstruction workloads for a specific table (.* to AND two parts of the name)
-cargo bench -p delta_kernel_benchmarks --bench workload_bench "101kAdds1000CommitsSinceChkpt1Chkpt.*snapshotConstruction"
+# snapshot-construction workloads for a specific table (.* to AND two parts of the name)
+cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale.*snapshotLatest"
 
 # profile a specific benchmark with samply
-samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench "101kAdds1000CommitsSinceChkpt1Chkpt/snapshotLatest/snapshotConstruction"
+samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale/snapshotLatest"
 ```
 
 #### By tag (`BENCH_TAGS`)
@@ -129,13 +129,50 @@ Examples:
 ```
 /bench                                                  # BENCH_TAGS=base, all benchmark names
 /bench --tags base,my-tag                               # BENCH_TAGS=base,my-tag, all benchmark names
-/bench --filter snapshotConstruction                    # no BENCH_TAGS set, only snapshotConstruction benchmarks
-/bench --tags base --filter 101kAdds.*snapshotConstruction  # only snapshotConstruction benchmarks from tables tagged "base"
-/bench --filter 101kAdds|10kAdds                        # no BENCH_TAGS set, OR two table names
+/bench --filter snapshotLatest                          # no BENCH_TAGS set, only snapshot-construction benchmarks
+/bench --tags base --filter crcVeryStale.*snapshotLatest  # only snapshot-construction benchmarks from tables tagged "base"
+/bench --filter crcVeryStale|crcLatest                    # no BENCH_TAGS set, OR two table names
 ```
 
 See [By tag (`BENCH_TAGS`)](#by-tag-bench_tags) for how tags work and [By benchmark name](#by-benchmark-name) for regex pattern examples. Results are posted automatically as a PR comment, comparing the PR branch against the base branch.
 CI timings are noisy and tend to run higher than on dedicated hardware, but proportional differences between branches are a rough signal for performance changes.
+
+## Registry (`bench-registry.json`)
+
+[`bench-registry.json`](bench-registry.json) maps read benchmarks to the harness configs they run.
+Each registered read workload expands into one Criterion benchmark per config, and the config
+`name` becomes the trailing path segment of the benchmark name (see
+[By benchmark name](#by-benchmark-name)). Snapshot-construction workloads construct a new snapshot
+each iteration and are not configured through the registry.
+
+The registry is a checked-in file under the crate root, separate from the spec files: the
+workload archive (`benchmarks/workloads/`) is downloaded at build time and gitignored, so configs
+that belong with the source live here and reference benchmarks by name.
+
+```json
+{
+  "10kAdds0CommitsSinceChkpt1V2Chkpt": {
+    "readMetadataLatest": [
+      { "name": "serial",    "parallelScan": "disabled" },
+      { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
+    ]
+  }
+}
+```
+
+- The file nests read config lists by table directory name then case name
+  (`{ table: { case: [configs] } }`).
+- A read benchmark whose `(table, case)` key is absent from the registry falls back to the built-in
+  serial config. An explicit but empty config list is rejected at load rather than silently
+  dropping the benchmark.
+- Config `name`s within a list must be unique and non-empty (they form the benchmark name's last
+  segment).
+
+Config-field value forms:
+
+- `parallelScan` (read configs): `"disabled"` or `{ "enabled": { "numThreads": <n> } }` — serde
+  externally-tagged, so the fieldless variant is a bare string and the parameterized variant a
+  single-key object.
 
 ## Workload data layout
 
@@ -156,7 +193,7 @@ benchmarks/workloads/
 
 Workloads are downloaded from the DAT GitHub release and extracted to `benchmarks/workloads/` automatically by `build.rs` when the crate is built. A `.done` marker file is written on success to skip re-downloading on subsequent builds. To force a fresh download, delete `benchmarks/workloads/.done`.
 
-Workloads are discovered automatically by path. `load_all_workloads()` scans every subdirectory of `benchmarks/workloads/benchmarks/`, loading `tableInfo.json` and every spec file under `specs/`. The spec filename (without extension) becomes the `case_name`.
+Workloads are discovered automatically by path. `load_all_workloads()` scans every subdirectory of `benchmarks/workloads/benchmarks/`, loading `tableInfo.json` and every spec file under `specs/`. The subdirectory name becomes the registry table key, the human-readable `name` from `tableInfo.json` becomes the benchmark identifier's first segment, and the spec filename (without extension) becomes the `case_name`.
 
 ## Current benchmarking workloads
 
@@ -226,7 +263,7 @@ KERNEL_BENCH_WORKLOAD_DIR=/path/to/my/tables \
 
 ### `TableInfo`
 
-Deserialized from `tableInfo.json`. Captures the table's identity (`name`, `description`), Delta schema and protocol, log statistics (`logInfo`), physical data layout, table properties, and benchmark tags. See [`workloads/src/models.rs`](../workloads/src/models.rs) for field-level documentation.
+Deserialized from `tableInfo.json`. Captures a human label (`name`) and `description`, Delta schema and protocol, log statistics (`logInfo`), physical data layout, table properties, and benchmark tags. The `name` field becomes the benchmark identifier's table segment, while the registry table key comes from the table's directory name. See [`workloads/src/models.rs`](../workloads/src/models.rs) for field-level documentation.
 
 #### Example
 
@@ -301,29 +338,31 @@ Or with a specific version:
 
 ### `Workload`
 
-The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
+The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table, which carries its directory name as `TableInfo::dir_name`) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
 
 ### `ReadConfig`
 
-Specifies runtime parameters for `Read` workloads that are not part of the spec JSON — currently whether to scan serially or in parallel, and how many threads to use. Multiple configs can be applied to the same workload to compare modes. By default all workloads run serial log replay; workloads with sidecar files additionally run parallel configs to benchmark parallel scanning.
+Specifies runtime parameters for `Read` workloads that are not part of the spec JSON — currently whether to scan serially or in parallel, and how many threads to use. Multiple configs can be applied to the same workload to compare modes. Which configs run for a given benchmark is determined by the [registry](#registry-bench-registryjson).
 
 ### `WorkloadRunner`
 
-Owns all pre-built state for a workload (e.g. a pre-constructed `Snapshot`) so that `execute()` measures only the target operation. Each runner corresponds to one `Workload` plus whatever additional configuration that workload type requires — `Read` workloads take a `ReadConfig`, while `SnapshotConstruction` workloads require no extra configuration.
+Owns all pre-built state for a workload (e.g. a pre-constructed `Snapshot`) so that `execute()` measures only the target operation. Read runners also carry the `ReadConfig` selected by the registry. Snapshot-construction runners always construct a new snapshot each iteration.
 
 
 ## Source Layout
 
-The workload spec data types (`TableInfo`, `Spec`, `Workload`, `ReadConfig`, …) and the SQL
-predicate parser live in the shared [`delta_kernel_workloads`](../workloads/) crate, since they
-are also used by the `acceptance` crate.
+The workload spec data types (`TableInfo`, `Spec`, `Workload`, …) live in the shared
+[`delta_kernel_workloads`](../workloads/) crate, since the spec types are also used by the
+`acceptance` crate. The read harness config types (`ReadConfig`, `ParallelScan`) and the registry
+that maps read benchmarks to them are benchmark-specific and live in this crate.
 
 | File | Purpose |
 |------|---------|
-| `../workloads/src/models.rs` | Data types: `TableInfo`, `Spec`, `Workload`, `ReadConfig`, `ReadOperation` |
+| `../workloads/src/models.rs` | Workload spec types: `TableInfo`, `Spec`, `Workload`, `ReadOperation` |
 | `../workloads/src/predicate_parser.rs` | SQL WHERE clause to kernel `Predicate` parser |
+| `src/registry.rs` | Read harness config types and registry loader: `ReadConfig`, `ParallelScan`, `BenchRegistry` |
+| `bench-registry.json` | Checked-in registry mapping read benchmarks to their harness configs |
 | `src/runners.rs` | `WorkloadRunner` trait and implementations: `ReadMetadataRunner`, `SnapshotConstructionRunner` |
 | `src/utils.rs` | Workload loading: deserializes workloads from the extracted data directory |
-| `benches/workload_bench.rs` | Criterion entry point — loads workloads, builds runners, drives benchmarks |
+| `benches/workload_bench.rs` | Criterion entry point — loads workloads + registry, builds runners, drives benchmarks |
 | `build.rs` | Downloads and extracts benchmark workloads from the DAT GitHub release at build time |
-

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -338,7 +338,7 @@ Or with a specific version:
 
 ### `Workload`
 
-The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table, which carries its directory name as `TableInfo::dir_name`) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
+The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table, whose directory determines `TableInfo::registry_table_key()`) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
 
 ### `ReadConfig`
 

--- a/benchmarks/bench-registry.json
+++ b/benchmarks/bench-registry.json
@@ -1,0 +1,8 @@
+{
+  "10kAdds0CommitsSinceChkpt1V2Chkpt": {
+    "readMetadataLatest": [
+      { "name": "serial",    "parallelScan": "disabled" },
+      { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
+    ]
+  }
+}

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -1,15 +1,21 @@
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use delta_kernel_benchmarks::registry::BenchRegistry;
 use delta_kernel_benchmarks::runners::{
-    create_read_runner, SnapshotConstructionRunner, WorkloadRunner,
+    benchmark_name, configured_benchmark_name, create_read_runner, SnapshotConstructionRunner,
+    WorkloadRunner,
 };
 use delta_kernel_benchmarks::utils::load_all_workloads;
-use delta_kernel_workloads::models::{
-    default_read_configs, ParallelScan, ReadConfig, ReadOperation, Spec,
-};
+use delta_kernel_workloads::models::{ReadOperation, Spec};
 use test_utils::CountingReporter;
+
+// Checked-in registry mapping each benchmark to its harness configs. Lives under the crate root
+// (not the gitignored, downloaded `workloads/` dir), so it is loaded relative to
+// CARGO_MANIFEST_DIR.
+const REGISTRY_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/bench-registry.json");
 
 // Loads all workloads and sets up a shared runtime, then registers each as a top-level benchmark.
 // For each workload, builds a runner that encapsulates the state (table info, engine, config, etc.)
@@ -22,20 +28,31 @@ fn workload_benchmarks(c: &mut Criterion) {
         Err(e) => panic!("Failed to load workloads: {e}"),
     };
 
+    let registry = BenchRegistry::load_from_path(Path::new(REGISTRY_PATH))
+        .expect("Failed to load bench-registry.json");
+
     let reporter = Arc::new(CountingReporter::new());
     let runtime = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
 
     for workload in &workloads {
+        let table_key = &workload.table_info.dir_name;
+        let case_name = &workload.case_name;
         match &workload.spec {
             Spec::Read(read_spec) => {
+                let configs = registry.read_configs(table_key, case_name);
                 for operation in [ReadOperation::ReadMetadata] {
-                    for config in build_read_configs(&workload.table_info.name) {
-                        let runner = create_read_runner(
+                    for config in &configs {
+                        let name = configured_benchmark_name(
                             &workload.table_info,
-                            &workload.case_name,
+                            case_name,
+                            &config.name,
+                        );
+                        let runner = create_read_runner(
+                            name,
                             read_spec,
                             operation,
-                            config,
+                            config.clone(),
+                            &workload.table_info,
                             runtime.clone(),
                         )
                         .expect("Failed to create read runner");
@@ -44,10 +61,11 @@ fn workload_benchmarks(c: &mut Criterion) {
                 }
             }
             Spec::SnapshotConstruction(snapshot_construction_spec) => {
+                let name = benchmark_name(&workload.table_info, case_name);
                 let runner = SnapshotConstructionRunner::setup(
-                    &workload.table_info,
-                    &workload.case_name,
+                    name,
                     snapshot_construction_spec,
+                    &workload.table_info,
                     runtime.clone(),
                 )
                 .expect("Failed to create snapshot construction runner");
@@ -72,20 +90,6 @@ fn run_benchmark(c: &mut Criterion, runner: &dyn WorkloadRunner, reporter: &Coun
         runner.execute().expect("IO profiling iteration failed");
         reporter.print_summary(runner.name());
     }
-}
-
-fn build_read_configs(table_name: &str) -> Vec<ReadConfig> {
-    // Choose which benchmark configurations to run for a given table
-    // TODO: This function will take in table info to choose the appropriate configs for a given
-    // table
-    let mut configs = default_read_configs();
-    if table_name.contains("V2Chkpt") {
-        configs.push(ReadConfig {
-            name: "parallel2".into(),
-            parallel_scan: ParallelScan::Enabled { num_threads: 2 },
-        });
-    }
-    configs
 }
 
 criterion_group!(benches, workload_benchmarks);

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -35,11 +35,12 @@ fn workload_benchmarks(c: &mut Criterion) {
     let runtime = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));
 
     for workload in &workloads {
-        let table_key = &workload.table_info.dir_name;
         let case_name = &workload.case_name;
         match &workload.spec {
             Spec::Read(read_spec) => {
-                let configs = registry.read_configs(table_key, case_name);
+                let configs = registry
+                    .read_configs(workload)
+                    .expect("loaded workload must have a registry table key");
                 for operation in [ReadOperation::ReadMetadata] {
                     for config in &configs {
                         let name = configured_benchmark_name(

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -30,6 +30,9 @@ fn workload_benchmarks(c: &mut Criterion) {
 
     let registry = BenchRegistry::load_from_path(Path::new(REGISTRY_PATH))
         .expect("Failed to load bench-registry.json");
+    registry
+        .validate(&workloads)
+        .expect("bench-registry.json must match the loaded workload types");
 
     let reporter = Arc::new(CountingReporter::new());
     let runtime = Arc::new(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"));

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod registry;
 pub mod runners;
 pub mod utils;

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -1,25 +1,12 @@
 //! Benchmark harness-config registry.
 //!
-//! Defines the read harness config types (`ReadConfig`, `ParallelScan`) and the registry that maps
-//! read benchmarks to them. These are benchmark-harness concepts (how to run a benchmark, not what
-//! the workload is).
-//!
-//! The registry is a checked-in JSON file (`benchmarks/bench-registry.json`) nesting each
-//! benchmark's harness configs by table name then case name: `{ table: { case: [configs] } }`.
-//! The table key is the table's directory name and the case key is the spec filename. Benchmark
-//! output uses the human-readable table name from `tableInfo.json` instead of the directory key.
-//!
-//! Each registered read benchmark expands into one Criterion benchmark per config; the config
-//! `name` becomes the trailing path segment of the benchmark name. A read benchmark whose
-//! `(table, case)` key is absent from the registry falls back to the built-in serial config.
-//!
-//! The `parallelScan` config field uses serde's externally-tagged form: the fieldless variant is
-//! a bare string (`"disabled"`) and the parameterized variant a single-key object
-//! (`{"enabled": {"numThreads": 2}}`).
+//! Defines benchmark harness parameters and maps workloads to the configurations used to run them.
+//! These parameters control how a benchmark runs rather than what operation it performs.
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use delta_kernel_workloads::models::Workload;
 use serde::Deserialize;
 
 // === Harness configs ===
@@ -41,8 +28,10 @@ pub fn default_read_configs() -> Vec<ReadConfig> {
     }]
 }
 
-/// Scan parallelism. Serialized externally-tagged: `"disabled"` or
-/// `{ "enabled": { "numThreads": <n> } }`.
+/// Scan parallelism configuration.
+///
+/// In registry JSON, disabled scans use the string `"disabled"`. Enabled scans use an object that
+/// specifies the thread count: `{ "enabled": { "numThreads": <n> } }`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ParallelScan {
@@ -55,8 +44,24 @@ pub enum ParallelScan {
 /// Error type for registry loading and lookup.
 pub type RegistryResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-/// Registry deserialized from `benchmarks/bench-registry.json`: read harness configs nested by
-/// table name then case name.
+/// Read harness configs keyed by table directory name and workload spec filename.
+///
+/// For example, this entry runs `readMetadataLatest` against the table in the
+/// `10kAdds0CommitsSinceChkpt1V2Chkpt` directory once serially and once with two scan threads:
+///
+/// ```json
+/// {
+///   "10kAdds0CommitsSinceChkpt1V2Chkpt": {
+///     "readMetadataLatest": [
+///       { "name": "serial", "parallelScan": "disabled" },
+///       { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
+///     ]
+///   }
+/// }
+/// ```
+///
+/// Each configuration creates a separate Criterion benchmark whose final name segment is the
+/// configuration `name`. Read workloads absent from the registry use the built-in serial config.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(transparent)]
 pub struct BenchRegistry {
@@ -74,11 +79,20 @@ impl BenchRegistry {
         Ok(registry)
     }
 
-    /// Configs for the read benchmark `"{table}/{case}"`: the registry entry if present, else the
-    /// built-in serial config.
-    pub fn read_configs(&self, table: &str, case: &str) -> Vec<ReadConfig> {
-        self.lookup(table, case)
-            .map_or_else(default_read_configs, ToOwned::to_owned)
+    /// Returns the registry configs for a read workload, or the built-in serial config when the
+    /// workload is not registered.
+    ///
+    /// Returns an error when the workload's table directory has no valid registry key.
+    pub fn read_configs(&self, workload: &Workload) -> RegistryResult<Vec<ReadConfig>> {
+        let table = workload.table_info.registry_table_key().ok_or_else(|| {
+            format!(
+                "could not derive a registry table key for workload '{}'",
+                workload.case_name
+            )
+        })?;
+        Ok(self
+            .lookup(table, &workload.case_name)
+            .map_or_else(default_read_configs, ToOwned::to_owned))
     }
 
     /// All `(table, case)` keys in the registry. Lets the harness cross-check every entry against
@@ -129,12 +143,36 @@ fn check_config_names<'a>(names: impl Iterator<Item = &'a str>, ctx: &str) -> Re
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use delta_kernel_workloads::models::{Spec, TableInfo, Workload};
+
     use super::*;
 
     fn registry_from_str(json: &str) -> BenchRegistry {
         let registry: BenchRegistry = serde_json::from_str(json).expect("failed to parse registry");
         registry.validate().expect("registry should validate");
         registry
+    }
+
+    fn read_workload(table: &str, case: &str) -> Workload {
+        let mut table_info: TableInfo = serde_json::from_str(
+            r#"{
+                "name": "test", "description": "test", "tablePath": "s3://bucket/table",
+                "schema": {"type": "struct", "fields": []},
+                "protocol": {"minReaderVersion": 1, "minWriterVersion": 2},
+                "logInfo": {"numAddFiles": 0, "numRemoveFiles": 0, "sizeInBytes": 0,
+                    "numCommits": 1, "numActions": 1},
+                "properties": {}, "dataLayout": {}, "tags": []
+            }"#,
+        )
+        .unwrap();
+        table_info.table_info_dir = PathBuf::from(table);
+        Workload {
+            table_info,
+            case_name: case.to_string(),
+            spec: serde_json::from_str::<Spec>(r#"{"type": "read"}"#).unwrap(),
+        }
     }
 
     const FULL_REGISTRY: &str = r#"{
@@ -156,7 +194,9 @@ mod tests {
     #[test]
     fn read_configs_use_explicit_entry() {
         let registry = registry_from_str(FULL_REGISTRY);
-        let configs = registry.read_configs("v2", "readMetadataLatest");
+        let configs = registry
+            .read_configs(&read_workload("v2", "readMetadataLatest"))
+            .unwrap();
         let names: Vec<_> = configs.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, vec!["serial", "parallel2"]);
         assert_eq!(configs[0].parallel_scan, ParallelScan::Disabled);
@@ -171,10 +211,22 @@ mod tests {
         // An unlisted read benchmark in a populated registry and any lookup against an empty
         // registry both fall back to the built-in serial config.
         for registry in [registry_from_str(FULL_REGISTRY), registry_from_str("{}")] {
-            let read = registry.read_configs("other", "readMetadataLatest");
+            let read = registry
+                .read_configs(&read_workload("other", "readMetadataLatest"))
+                .unwrap();
             assert_eq!(read.len(), 1);
             assert_eq!(read[0].name, "serial");
         }
+    }
+
+    #[test]
+    fn read_configs_errors_without_registry_table_key() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let mut workload = read_workload("v2", "readMetadataLatest");
+        workload.table_info.table_info_dir.clear();
+
+        let error = registry.read_configs(&workload).unwrap_err().to_string();
+        assert!(error.contains("could not derive a registry table key"));
     }
 
     #[test]

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -1,0 +1,225 @@
+//! Benchmark harness-config registry.
+//!
+//! Defines the read harness config types (`ReadConfig`, `ParallelScan`) and the registry that maps
+//! read benchmarks to them. These are benchmark-harness concepts (how to run a benchmark, not what
+//! the workload is).
+//!
+//! The registry is a checked-in JSON file (`benchmarks/bench-registry.json`) nesting each
+//! benchmark's harness configs by table name then case name: `{ table: { case: [configs] } }`.
+//! The table key is the table's directory name and the case key is the spec filename. Benchmark
+//! output uses the human-readable table name from `tableInfo.json` instead of the directory key.
+//!
+//! Each registered read benchmark expands into one Criterion benchmark per config; the config
+//! `name` becomes the trailing path segment of the benchmark name. A read benchmark whose
+//! `(table, case)` key is absent from the registry falls back to the built-in serial config.
+//!
+//! The `parallelScan` config field uses serde's externally-tagged form: the fieldless variant is
+//! a bare string (`"disabled"`) and the parameterized variant a single-key object
+//! (`{"enabled": {"numThreads": 2}}`).
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use serde::Deserialize;
+
+// === Harness configs ===
+
+/// A read-operation config: benchmark parameters not carried in the spec JSON. Deserialized
+/// directly from a `bench-registry.json` entry.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReadConfig {
+    pub name: String,
+    pub parallel_scan: ParallelScan,
+}
+
+/// The built-in default read configs (a single serial config).
+pub fn default_read_configs() -> Vec<ReadConfig> {
+    vec![ReadConfig {
+        name: "serial".into(),
+        parallel_scan: ParallelScan::Disabled,
+    }]
+}
+
+/// Scan parallelism. Serialized externally-tagged: `"disabled"` or
+/// `{ "enabled": { "numThreads": <n> } }`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum ParallelScan {
+    Disabled,
+    Enabled { num_threads: usize },
+}
+
+// === Registry ===
+
+/// Error type for registry loading and lookup.
+pub type RegistryResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Registry deserialized from `benchmarks/bench-registry.json`: read harness configs nested by
+/// table name then case name.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(transparent)]
+pub struct BenchRegistry {
+    tables: HashMap<String, HashMap<String, Vec<ReadConfig>>>,
+}
+
+impl BenchRegistry {
+    /// Load and validate a registry from `path`.
+    pub fn load_from_path(path: &Path) -> RegistryResult<Self> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("reading registry {}: {e}", path.display()))?;
+        let registry: BenchRegistry = serde_json::from_str(&content)
+            .map_err(|e| format!("parsing registry {}: {e}", path.display()))?;
+        registry.validate()?;
+        Ok(registry)
+    }
+
+    /// Configs for the read benchmark `"{table}/{case}"`: the registry entry if present, else the
+    /// built-in serial config.
+    pub fn read_configs(&self, table: &str, case: &str) -> Vec<ReadConfig> {
+        self.lookup(table, case)
+            .map_or_else(default_read_configs, ToOwned::to_owned)
+    }
+
+    /// All `(table, case)` keys in the registry. Lets the harness cross-check every entry against
+    /// the loaded workloads so a stale/typo'd key (which would otherwise silently fall back to
+    /// defaults) is caught.
+    pub fn keys(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.tables.iter().flat_map(|(table, cases)| {
+            cases
+                .keys()
+                .map(move |case| (table.as_str(), case.as_str()))
+        })
+    }
+
+    /// Looks up the config list for `"{table}/{case}"`, if the registry lists it.
+    fn lookup(&self, table: &str, case: &str) -> Option<&[ReadConfig]> {
+        self.tables
+            .get(table)
+            .and_then(|cases| cases.get(case))
+            .map(Vec::as_slice)
+    }
+
+    /// Validate every read config list independently of which benchmarks are later looked up.
+    fn validate(&self) -> RegistryResult<()> {
+        for (table, cases) in &self.tables {
+            for (case, configs) in cases {
+                let key = format!("{table}/{case}");
+                check_config_names(configs.iter().map(|c| c.name.as_str()), &key)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Errors if `names` is empty or contains a repeat. `ctx` identifies the offending list. An empty
+/// list would otherwise expand to zero benchmarks, silently dropping the benchmark.
+fn check_config_names<'a>(names: impl Iterator<Item = &'a str>, ctx: &str) -> RegistryResult<()> {
+    let mut seen = HashSet::new();
+    for name in names {
+        if !seen.insert(name) {
+            return Err(format!("duplicate config name '{name}' in '{ctx}'").into());
+        }
+    }
+    if seen.is_empty() {
+        return Err(format!("registry entry '{ctx}' has an empty config list").into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry_from_str(json: &str) -> BenchRegistry {
+        let registry: BenchRegistry = serde_json::from_str(json).expect("failed to parse registry");
+        registry.validate().expect("registry should validate");
+        registry
+    }
+
+    const FULL_REGISTRY: &str = r#"{
+        "v2": {
+            "readMetadataLatest": [
+                { "name": "serial",    "parallelScan": "disabled" },
+                { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
+            ]
+        }
+    }"#;
+
+    #[test]
+    fn parses_full_registry() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        assert_eq!(registry.tables.len(), 1);
+        assert_eq!(registry.tables["v2"]["readMetadataLatest"].len(), 2);
+    }
+
+    #[test]
+    fn read_configs_use_explicit_entry() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let configs = registry.read_configs("v2", "readMetadataLatest");
+        let names: Vec<_> = configs.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["serial", "parallel2"]);
+        assert_eq!(configs[0].parallel_scan, ParallelScan::Disabled);
+        assert_eq!(
+            configs[1].parallel_scan,
+            ParallelScan::Enabled { num_threads: 2 }
+        );
+    }
+
+    #[test]
+    fn unlisted_read_benchmark_falls_back_to_serial() {
+        // An unlisted read benchmark in a populated registry and any lookup against an empty
+        // registry both fall back to the built-in serial config.
+        for registry in [registry_from_str(FULL_REGISTRY), registry_from_str("{}")] {
+            let read = registry.read_configs("other", "readMetadataLatest");
+            assert_eq!(read.len(), 1);
+            assert_eq!(read[0].name, "serial");
+        }
+    }
+
+    #[test]
+    fn duplicate_config_names_error_at_load() {
+        let json = r#"{
+            "t": { "readMetadataLatest": [
+                { "name": "dup", "parallelScan": "disabled" },
+                { "name": "dup", "parallelScan": "disabled" }
+            ] }
+        }"#;
+        let registry: BenchRegistry = serde_json::from_str(json).unwrap();
+        let err = registry.validate().unwrap_err().to_string();
+        assert!(err.contains("duplicate config name 'dup'"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_config_list_errors_at_load() {
+        // An explicit `[]` would expand to zero benchmarks, silently dropping the benchmark, so it
+        // is rejected at load rather than accepted like a missing key (which falls back to
+        // default).
+        let json = r#"{ "t": { "readMetadataLatest": [] } }"#;
+        let registry: BenchRegistry = serde_json::from_str(json).unwrap();
+        let err = registry.validate().unwrap_err().to_string();
+        assert!(err.contains("empty config list"), "got: {err}");
+    }
+
+    #[test]
+    fn malformed_entry_errors_at_load() {
+        // `parallelScn` is a typo, so the entry is not a valid read config.
+        let json = r#"{
+            "t": { "c": [ { "name": "x", "parallelScn": "disabled" } ] }
+        }"#;
+        assert!(serde_json::from_str::<BenchRegistry>(json).is_err());
+    }
+
+    #[test]
+    fn non_object_table_entry_errors() {
+        // Each table key must map to an object of case -> config list, not a scalar.
+        let result: Result<BenchRegistry, _> = serde_json::from_str(r#"{ "t": 1 }"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_from_path_missing_file_errors() {
+        let result = BenchRegistry::load_from_path(Path::new("/nonexistent/bench-registry.json"));
+        assert!(result.is_err());
+    }
+}

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use delta_kernel_workloads::models::Workload;
+use delta_kernel_workloads::models::{Spec, Workload};
 use serde::Deserialize;
 
 // === Harness configs ===
@@ -69,14 +69,15 @@ pub struct BenchRegistry {
 }
 
 impl BenchRegistry {
-    /// Load and validate a registry from `path`.
+    /// Loads a registry from `path`.
+    ///
+    /// Returns an error when the file cannot be read or deserialized. Call [`Self::validate`]
+    /// before using the registry.
     pub fn load_from_path(path: &Path) -> RegistryResult<Self> {
         let content = std::fs::read_to_string(path)
             .map_err(|e| format!("reading registry {}: {e}", path.display()))?;
-        let registry: BenchRegistry = serde_json::from_str(&content)
-            .map_err(|e| format!("parsing registry {}: {e}", path.display()))?;
-        registry.validate()?;
-        Ok(registry)
+        serde_json::from_str(&content)
+            .map_err(|e| format!("parsing registry {}: {e}", path.display()).into())
     }
 
     /// Returns the registry configs for a read workload, or the built-in serial config when the
@@ -93,6 +94,47 @@ impl BenchRegistry {
         Ok(self
             .lookup(table, &workload.case_name)
             .map_or_else(default_read_configs, ToOwned::to_owned))
+    }
+
+    /// Validates the registry structure and its relationship to `workloads`.
+    ///
+    /// Only registry entries matching a workload in `workloads` receive workload-type validation,
+    /// allowing callers to validate a tag-filtered workload set. Returns an error for empty config
+    /// lists, duplicate config names, invalid workload registry keys, or read configs targeting a
+    /// non-read workload.
+    pub fn validate(&self, workloads: &[Workload]) -> RegistryResult<()> {
+        for (table, cases) in &self.tables {
+            for (case, configs) in cases {
+                let key = format!("{table}/{case}");
+                if configs.is_empty() {
+                    return Err(format!("registry entry '{key}' has an empty config list").into());
+                }
+                let names: HashSet<_> = configs.iter().map(|config| config.name.as_str()).collect();
+                if names.len() != configs.len() {
+                    return Err(format!("registry entry '{key}' has duplicate config names").into());
+                }
+            }
+        }
+
+        for workload in workloads {
+            let table = workload.table_info.registry_table_key().ok_or_else(|| {
+                format!(
+                    "could not derive a registry table key for workload '{}'",
+                    workload.case_name
+                )
+            })?;
+            if self.lookup(table, &workload.case_name).is_some() {
+                if let Spec::SnapshotConstruction(_) = &workload.spec {
+                    return Err(format!(
+                        "registry entry '{table}/{}' provides read configs for a {} workload",
+                        workload.case_name,
+                        workload.spec.as_str()
+                    )
+                    .into());
+                }
+            }
+        }
+        Ok(())
     }
 
     /// All `(table, case)` keys in the registry. Lets the harness cross-check every entry against
@@ -113,32 +155,6 @@ impl BenchRegistry {
             .and_then(|cases| cases.get(case))
             .map(Vec::as_slice)
     }
-
-    /// Validate every read config list independently of which benchmarks are later looked up.
-    fn validate(&self) -> RegistryResult<()> {
-        for (table, cases) in &self.tables {
-            for (case, configs) in cases {
-                let key = format!("{table}/{case}");
-                check_config_names(configs.iter().map(|c| c.name.as_str()), &key)?;
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Errors if `names` is empty or contains a repeat. `ctx` identifies the offending list. An empty
-/// list would otherwise expand to zero benchmarks, silently dropping the benchmark.
-fn check_config_names<'a>(names: impl Iterator<Item = &'a str>, ctx: &str) -> RegistryResult<()> {
-    let mut seen = HashSet::new();
-    for name in names {
-        if !seen.insert(name) {
-            return Err(format!("duplicate config name '{name}' in '{ctx}'").into());
-        }
-    }
-    if seen.is_empty() {
-        return Err(format!("registry entry '{ctx}' has an empty config list").into());
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -151,7 +167,7 @@ mod tests {
 
     fn registry_from_str(json: &str) -> BenchRegistry {
         let registry: BenchRegistry = serde_json::from_str(json).expect("failed to parse registry");
-        registry.validate().expect("registry should validate");
+        registry.validate(&[]).expect("registry should validate");
         registry
     }
 
@@ -230,7 +246,28 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_config_names_error_at_load() {
+    fn workload_validation_accepts_read_configs_for_read_workload() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        registry
+            .validate(&[read_workload("v2", "readMetadataLatest")])
+            .unwrap();
+    }
+
+    #[test]
+    fn workload_validation_rejects_read_configs_for_snapshot_workload() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let mut workload = read_workload("v2", "readMetadataLatest");
+        workload.spec = serde_json::from_str(r#"{"type":"snapshotConstruction"}"#).unwrap();
+
+        let error = registry.validate(&[workload]).unwrap_err().to_string();
+        assert!(
+            error.contains("provides read configs for a snapshotConstruction workload"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn duplicate_config_names_error_at_validation() {
         let json = r#"{
             "t": { "readMetadataLatest": [
                 { "name": "dup", "parallelScan": "disabled" },
@@ -238,18 +275,18 @@ mod tests {
             ] }
         }"#;
         let registry: BenchRegistry = serde_json::from_str(json).unwrap();
-        let err = registry.validate().unwrap_err().to_string();
-        assert!(err.contains("duplicate config name 'dup'"), "got: {err}");
+        let err = registry.validate(&[]).unwrap_err().to_string();
+        assert!(err.contains("duplicate config names"), "got: {err}");
     }
 
     #[test]
-    fn empty_config_list_errors_at_load() {
+    fn empty_config_list_errors_at_validation() {
         // An explicit `[]` would expand to zero benchmarks, silently dropping the benchmark, so it
         // is rejected at load rather than accepted like a missing key (which falls back to
         // default).
         let json = r#"{ "t": { "readMetadataLatest": [] } }"#;
         let registry: BenchRegistry = serde_json::from_str(json).unwrap();
-        let err = registry.validate().unwrap_err().to_string();
+        let err = registry.validate(&[]).unwrap_err().to_string();
         assert!(err.contains("empty config list"), "got: {err}");
     }
 

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -419,9 +419,10 @@ impl WorkloadRunner for SnapshotConstructionRunner {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::LazyLock;
 
-    use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel};
+    use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
 
     use super::*;
 
@@ -494,7 +495,6 @@ mod tests {
     fn configured_benchmark_name_uses_human_readable_table_name() {
         let mut table_info = test_table_info();
         table_info.name = "Human readable table".to_string();
-        table_info.dir_name = "registry-key".to_string();
 
         assert_eq!(
             configured_benchmark_name(&table_info, "testCase", "serial"),
@@ -581,7 +581,14 @@ mod tests {
         let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
         let registry = BenchRegistry::load_from_path(std::path::Path::new(&path))
             .expect("checked-in bench-registry.json must load and validate");
-        let read = registry.read_configs("10kAdds0CommitsSinceChkpt1V2Chkpt", "readMetadataLatest");
+        let mut table_info = test_table_info();
+        table_info.table_info_dir = PathBuf::from("10kAdds0CommitsSinceChkpt1V2Chkpt");
+        let workload = Workload {
+            table_info,
+            case_name: "readMetadataLatest".to_string(),
+            spec: Spec::Read(test_read_spec()),
+        };
+        let read = registry.read_configs(&workload).unwrap();
         assert_eq!(
             read.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["serial", "parallel2"]
@@ -601,12 +608,17 @@ mod tests {
         let Ok(workloads) = load_all_workloads() else {
             return; // workload archive not downloaded -- nothing to cross-check
         };
-        let spec_by_key: HashMap<(&str, &str), &Spec> = workloads
+        let workload_by_key: HashMap<(&str, &str), &Workload> = workloads
             .iter()
             .map(|w| {
                 (
-                    (w.table_info.dir_name.as_str(), w.case_name.as_str()),
-                    &w.spec,
+                    (
+                        w.table_info
+                            .registry_table_key()
+                            .expect("loaded workloads must have a registry table key"),
+                        w.case_name.as_str(),
+                    ),
+                    w,
                 )
             })
             .collect();
@@ -616,11 +628,11 @@ mod tests {
             .expect("checked-in bench-registry.json must load and validate");
 
         for (table, case) in registry.keys() {
-            let spec = spec_by_key.get(&(table, case)).unwrap_or_else(|| {
+            let workload = workload_by_key.get(&(table, case)).unwrap_or_else(|| {
                 panic!("registry key '{table}/{case}' matches no workload (stale or typo'd?)")
             });
-            let resolved = match spec {
-                Spec::Read(_) => registry.read_configs(table, case).len(),
+            let resolved = match &workload.spec {
+                Spec::Read(_) => registry.read_configs(workload).unwrap().len(),
                 Spec::SnapshotConstruction(_) => panic!(
                     "registry key '{table}/{case}' refers to a snapshot-construction workload"
                 ),

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -419,12 +419,16 @@ impl WorkloadRunner for SnapshotConstructionRunner {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::slice;
     use std::sync::LazyLock;
 
     use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
 
     use super::*;
+    use crate::registry::BenchRegistry;
+    use crate::utils::load_all_workloads;
 
     fn test_runtime() -> Arc<tokio::runtime::Runtime> {
         static RT: LazyLock<Arc<tokio::runtime::Runtime>> = LazyLock::new(|| {
@@ -576,11 +580,9 @@ mod tests {
     /// fails fast in `cargo test` rather than only when the harness runs.
     #[test]
     fn checked_in_registry_loads_and_validates() {
-        use crate::registry::BenchRegistry;
-
         let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
-        let registry = BenchRegistry::load_from_path(std::path::Path::new(&path))
-            .expect("checked-in bench-registry.json must load and validate");
+        let registry = BenchRegistry::load_from_path(Path::new(&path))
+            .expect("checked-in bench-registry.json must load");
         let mut table_info = test_table_info();
         table_info.table_info_dir = PathBuf::from("10kAdds0CommitsSinceChkpt1V2Chkpt");
         let workload = Workload {
@@ -588,6 +590,9 @@ mod tests {
             case_name: "readMetadataLatest".to_string(),
             spec: Spec::Read(test_read_spec()),
         };
+        registry
+            .validate(slice::from_ref(&workload))
+            .expect("checked-in bench-registry.json must validate");
         let read = registry.read_configs(&workload).unwrap();
         assert_eq!(
             read.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
@@ -600,11 +605,6 @@ mod tests {
     /// Skips when the downloaded workload archive is absent (e.g. offline unit runs).
     #[test]
     fn checked_in_registry_keys_match_real_workloads() {
-        use std::collections::HashMap;
-
-        use crate::registry::BenchRegistry;
-        use crate::utils::load_all_workloads;
-
         let Ok(workloads) = load_all_workloads() else {
             return; // workload archive not downloaded -- nothing to cross-check
         };
@@ -624,20 +624,16 @@ mod tests {
             .collect();
 
         let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
-        let registry = BenchRegistry::load_from_path(std::path::Path::new(&path))
-            .expect("checked-in bench-registry.json must load and validate");
+        let registry = BenchRegistry::load_from_path(Path::new(&path))
+            .expect("checked-in bench-registry.json must load");
+        registry
+            .validate(&workloads)
+            .expect("registry configs must match workload types");
 
         for (table, case) in registry.keys() {
-            let workload = workload_by_key.get(&(table, case)).unwrap_or_else(|| {
+            workload_by_key.get(&(table, case)).unwrap_or_else(|| {
                 panic!("registry key '{table}/{case}' matches no workload (stale or typo'd?)")
             });
-            let resolved = match &workload.spec {
-                Spec::Read(_) => registry.read_configs(workload).unwrap().len(),
-                Spec::SnapshotConstruction(_) => panic!(
-                    "registry key '{table}/{case}' refers to a snapshot-construction workload"
-                ),
-            };
-            assert_ne!(resolved, 0);
         }
     }
 

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -21,8 +21,7 @@ use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
 use delta_kernel_default_engine::DefaultEngine;
 use delta_kernel_unity_catalog::UCKernelClient;
 use delta_kernel_workloads::models::{
-    ParallelScan, ReadConfig, ReadOperation, ReadSpec, SnapshotConstructionSpec, TableInfo,
-    TimeTravel,
+    ReadOperation, ReadSpec, SnapshotConstructionSpec, TableInfo, TimeTravel,
 };
 use delta_kernel_workloads::predicate_parser::parse_predicate;
 use unity_catalog_delta_client_api::{Error as UcApiError, Operation};
@@ -31,12 +30,28 @@ use unity_catalog_delta_rest_client::{
 };
 use url::Url;
 
+use crate::registry::{ParallelScan, ReadConfig};
+
 /// Delta table property indicating catalog-managed support.
 const CATALOG_MANAGED_PROPERTY: &str = "delta.feature.catalogManaged";
 
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
     fn name(&self) -> &str;
+}
+
+/// Builds `{table}/{case}` from `table_info.name` and `case_name`.
+pub fn benchmark_name(table_info: &TableInfo, case_name: &str) -> String {
+    format!("{}/{case_name}", table_info.name)
+}
+
+/// Builds `{table}/{case}/{config}` from `table_info.name`, `case_name`, and `config_name`.
+pub fn configured_benchmark_name(
+    table_info: &TableInfo,
+    case_name: &str,
+    config_name: &str,
+) -> String {
+    format!("{}/{case_name}/{config_name}", table_info.name)
 }
 
 fn build_engine(
@@ -216,10 +231,10 @@ pub struct ReadMetadataRunner {
 
 impl ReadMetadataRunner {
     pub fn setup(
-        table_info: &TableInfo,
-        case_name: &str,
+        name: String,
         read_spec: &ReadSpec,
         config: ReadConfig,
+        table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let (engine, strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
@@ -232,8 +247,6 @@ impl ReadMetadataRunner {
             .map(|sql| parse_predicate(sql, &snapshot.schema()))
             .transpose()?
             .map(Arc::new);
-
-        let name = format!("{}/{}/{}", table_info.name, case_name, config.name,);
 
         let thread_pool = match &config.parallel_scan {
             ParallelScan::Enabled { num_threads } => {
@@ -343,18 +356,19 @@ impl WorkloadRunner for ReadMetadataRunner {
     }
 }
 
-/// Factory function that creates the appropriate read runner for a given operation and config
+/// Factory function that creates the appropriate read runner for a given operation and config.
+/// `name` is the full benchmark identifier (`{table_name}/{case}/{config}`).
 pub fn create_read_runner(
-    table_info: &TableInfo,
-    case_name: &str,
+    name: String,
     read_spec: &ReadSpec,
     operation: ReadOperation,
     config: ReadConfig,
+    table_info: &TableInfo,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> Result<Box<dyn WorkloadRunner>, Box<dyn std::error::Error>> {
     match operation {
         ReadOperation::ReadMetadata => Ok(Box::new(ReadMetadataRunner::setup(
-            table_info, case_name, read_spec, config, runtime,
+            name, read_spec, config, table_info, runtime,
         )?)),
         ReadOperation::ReadData => Err("ReadDataRunner not yet implemented".into()),
     }
@@ -370,13 +384,11 @@ pub struct SnapshotConstructionRunner {
 
 impl SnapshotConstructionRunner {
     pub fn setup(
-        table_info: &TableInfo,
-        case_name: &str,
+        name: String,
         snapshot_spec: &SnapshotConstructionSpec,
+        table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let name = format!("{}/{}", table_info.name, case_name,);
-
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
 
         Ok(Self {
@@ -409,9 +421,7 @@ impl WorkloadRunner for SnapshotConstructionRunner {
 mod tests {
     use std::sync::LazyLock;
 
-    use delta_kernel_workloads::models::{
-        ParallelScan, ReadConfig, ReadSpec, TableInfo, TimeTravel,
-    };
+    use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel};
 
     use super::*;
 
@@ -481,12 +491,24 @@ mod tests {
     }
 
     #[test]
+    fn configured_benchmark_name_uses_human_readable_table_name() {
+        let mut table_info = test_table_info();
+        table_info.name = "Human readable table".to_string();
+        table_info.dir_name = "registry-key".to_string();
+
+        assert_eq!(
+            configured_benchmark_name(&table_info, "testCase", "serial"),
+            "Human readable table/testCase/serial"
+        );
+    }
+
+    #[test]
     fn test_read_metadata_runner_serial() {
         let runner = ReadMetadataRunner::setup(
-            &test_table_info(),
-            "testCase",
+            configured_benchmark_name(&test_table_info(), "testCase", "serial"),
             &test_read_spec(),
             serial_config(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
@@ -497,10 +519,10 @@ mod tests {
     #[test]
     fn test_read_metadata_runner_parallel() {
         let runner = ReadMetadataRunner::setup(
-            &test_table_info(),
-            "testCase",
+            configured_benchmark_name(&test_table_info(), "testCase", "parallel2"),
             &test_read_spec(),
             parallel_config(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
@@ -518,9 +540,9 @@ mod tests {
     #[test]
     fn test_snapshot_construction_runner_setup() {
         let runner = SnapshotConstructionRunner::setup(
-            &test_table_info(),
-            "testCase",
+            benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            &test_table_info(),
             test_runtime(),
         );
         assert!(runner.is_ok());
@@ -529,9 +551,9 @@ mod tests {
     #[test]
     fn test_snapshot_construction_runner_name() {
         let runner = SnapshotConstructionRunner::setup(
-            &test_table_info(),
-            "testCase",
+            benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
@@ -541,23 +563,80 @@ mod tests {
     #[test]
     fn test_snapshot_construction_runner_execute() {
         let runner = SnapshotConstructionRunner::setup(
-            &test_table_info(),
-            "testCase",
+            benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
         assert!(runner.execute().is_ok());
     }
 
+    /// Guards the checked-in `bench-registry.json` so a malformed edit or a duplicate config name
+    /// fails fast in `cargo test` rather than only when the harness runs.
+    #[test]
+    fn checked_in_registry_loads_and_validates() {
+        use crate::registry::BenchRegistry;
+
+        let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
+        let registry = BenchRegistry::load_from_path(std::path::Path::new(&path))
+            .expect("checked-in bench-registry.json must load and validate");
+        let read = registry.read_configs("10kAdds0CommitsSinceChkpt1V2Chkpt", "readMetadataLatest");
+        assert_eq!(
+            read.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["serial", "parallel2"]
+        );
+    }
+
+    /// Every registry key must name a real read workload. A key miss silently falls back to the
+    /// serial default, so a stale/typo'd key would otherwise be invisible until the harness runs.
+    /// Skips when the downloaded workload archive is absent (e.g. offline unit runs).
+    #[test]
+    fn checked_in_registry_keys_match_real_workloads() {
+        use std::collections::HashMap;
+
+        use crate::registry::BenchRegistry;
+        use crate::utils::load_all_workloads;
+
+        let Ok(workloads) = load_all_workloads() else {
+            return; // workload archive not downloaded -- nothing to cross-check
+        };
+        let spec_by_key: HashMap<(&str, &str), &Spec> = workloads
+            .iter()
+            .map(|w| {
+                (
+                    (w.table_info.dir_name.as_str(), w.case_name.as_str()),
+                    &w.spec,
+                )
+            })
+            .collect();
+
+        let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
+        let registry = BenchRegistry::load_from_path(std::path::Path::new(&path))
+            .expect("checked-in bench-registry.json must load and validate");
+
+        for (table, case) in registry.keys() {
+            let spec = spec_by_key.get(&(table, case)).unwrap_or_else(|| {
+                panic!("registry key '{table}/{case}' matches no workload (stale or typo'd?)")
+            });
+            let resolved = match spec {
+                Spec::Read(_) => registry.read_configs(table, case).len(),
+                Spec::SnapshotConstruction(_) => panic!(
+                    "registry key '{table}/{case}' refers to a snapshot-construction workload"
+                ),
+            };
+            assert_ne!(resolved, 0);
+        }
+    }
+
     #[test]
     fn test_create_read_runner_read_metadata() {
         let runner = create_read_runner(
-            &test_table_info(),
-            "testCase",
+            configured_benchmark_name(&test_table_info(), "testCase", "serial"),
             &test_read_spec(),
             ReadOperation::ReadMetadata,
             serial_config(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("create_read_runner should succeed");
@@ -569,10 +648,10 @@ mod tests {
         let mut spec = test_read_spec();
         spec.predicate = Some("letter = 'a'".to_string());
         let runner = ReadMetadataRunner::setup(
-            &test_table_info(),
-            "test_case",
+            configured_benchmark_name(&test_table_info(), "test_case", "serial"),
             &spec,
             serial_config(),
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
@@ -584,10 +663,10 @@ mod tests {
         let mut spec = test_read_spec();
         spec.predicate = Some("a LIKE '%foo'".to_string());
         let result = ReadMetadataRunner::setup(
-            &test_table_info(),
-            "test_case",
+            configured_benchmark_name(&test_table_info(), "test_case", "serial"),
             &spec,
             serial_config(),
+            &test_table_info(),
             test_runtime(),
         );
         assert!(result.is_err());
@@ -596,11 +675,11 @@ mod tests {
     #[test]
     fn test_create_read_runner_read_data_unimplemented() {
         let result = create_read_runner(
-            &test_table_info(),
-            "testCase",
+            configured_benchmark_name(&test_table_info(), "testCase", "serial"),
             &test_read_spec(),
             ReadOperation::ReadData,
             serial_config(),
+            &test_table_info(),
             test_runtime(),
         );
         assert!(result.is_err());
@@ -620,9 +699,9 @@ mod tests {
             expected: None,
         };
         let runner = SnapshotConstructionRunner::setup(
-            &test_table_info(),
-            "testCase",
+            benchmark_name(&test_table_info(), "testCase"),
             &spec,
+            &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -121,9 +121,7 @@ fn load_specs_from_table(
         }
     }
 
-    // `from_json_path` derives the registry key (`TableInfo::dir_name`) from the directory
-    // basename; a table whose directory has no usable basename cannot be registered.
-    if table_info.dir_name.is_empty() {
+    if table_info.registry_table_key().is_none() {
         return Err(format!(
             "could not derive table name from directory {}",
             table_dir.display()
@@ -238,7 +236,10 @@ mod tests {
 
         let workloads = load_specs_from_table(&table_dir, None).unwrap();
         assert_eq!(workloads.len(), 1);
-        assert_eq!(workloads[0].table_info.dir_name, "dirBasename");
+        assert_eq!(
+            workloads[0].table_info.registry_table_key(),
+            Some("dirBasename")
+        );
         assert_eq!(workloads[0].table_info.name, "humanLabel");
         assert_eq!(workloads[0].case_name, "readMetadataLatest");
     }

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -114,12 +114,21 @@ fn load_specs_from_table(
         let delta_dir = table_dir.join(DELTA_DIR_NAME);
         if !delta_dir.is_dir() {
             return Err(format!(
-                "Table data not found for '{}'. Expected a 'delta' directory in {}",
-                table_info.name,
+                "Table data not found. Expected a 'delta' directory in {}",
                 table_dir.display()
             )
             .into());
         }
+    }
+
+    // `from_json_path` derives the registry key (`TableInfo::dir_name`) from the directory
+    // basename; a table whose directory has no usable basename cannot be registered.
+    if table_info.dir_name.is_empty() {
+        return Err(format!(
+            "could not derive table name from directory {}",
+            table_dir.display()
+        )
+        .into());
     }
 
     let spec_files = find_spec_files(&specs_dir)?;
@@ -199,5 +208,38 @@ mod tests {
         assert_eq!(get_required_tags().unwrap(), vec!["ci", "checkpoints"]);
 
         std::env::remove_var(BENCH_TAGS_ENV_VAR);
+    }
+
+    #[test]
+    fn load_specs_from_table_uses_directory_basename_not_table_info_name() {
+        // A remote `tablePath` skips the local `delta/` requirement, so only `tableInfo.json` and
+        // `specs/` are needed.
+        let root = tempfile::tempdir().unwrap();
+        let table_dir = root.path().join("dirBasename");
+        std::fs::create_dir_all(table_dir.join(SPECS_DIR_NAME)).unwrap();
+        std::fs::write(
+            table_dir.join(TABLE_INFO_FILE_NAME),
+            r#"{
+                "name": "humanLabel", "description": "d", "tablePath": "s3://b/t",
+                "schema": {"type": "struct", "fields": []},
+                "protocol": {"minReaderVersion": 1, "minWriterVersion": 2},
+                "logInfo": {"numAddFiles": 0, "numRemoveFiles": 0, "sizeInBytes": 0, "numCommits": 1, "numActions": 1},
+                "properties": {}, "dataLayout": {}, "tags": []
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            table_dir
+                .join(SPECS_DIR_NAME)
+                .join("readMetadataLatest.json"),
+            r#"{"type": "read"}"#,
+        )
+        .unwrap();
+
+        let workloads = load_specs_from_table(&table_dir, None).unwrap();
+        assert_eq!(workloads.len(), 1);
+        assert_eq!(workloads[0].table_info.dir_name, "dirBasename");
+        assert_eq!(workloads[0].table_info.name, "humanLabel");
+        assert_eq!(workloads[0].case_name, "readMetadataLatest");
     }
 }

--- a/workloads/Cargo.toml
+++ b/workloads/Cargo.toml
@@ -28,3 +28,4 @@ url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.23"
+tempfile = "3"

--- a/workloads/src/models.rs
+++ b/workloads/src/models.rs
@@ -63,10 +63,6 @@ pub struct TableInfo {
     /// Path to the directory containing the `tableInfo.json` file
     #[serde(skip, default)]
     pub table_info_dir: PathBuf,
-    /// Basename of [`Self::table_info_dir`], used as the registry table key. Populated by
-    /// [`Self::from_json_path`]; empty for a `TableInfo` deserialized without directory context.
-    #[serde(skip, default)]
-    pub dir_name: String,
 }
 
 impl TableInfo {
@@ -85,6 +81,14 @@ impl TableInfo {
         })
     }
 
+    /// Returns the basename of [`Self::table_info_dir`] used as the benchmark registry table key.
+    ///
+    /// Returns `None` when the table info has no directory context or the basename is not valid
+    /// UTF-8.
+    pub fn registry_table_key(&self) -> Option<&str> {
+        self.table_info_dir.file_name()?.to_str()
+    }
+
     pub fn from_json_path<P: AsRef<Path>>(path: P) -> Result<Self, serde_json::Error> {
         let content = std::fs::read_to_string(path.as_ref()).map_err(serde_json::Error::io)?;
         let mut table_info: TableInfo = serde_json::from_str(&content)?;
@@ -94,12 +98,7 @@ impl TableInfo {
                 "catalog_info and table_path are mutually exclusive",
             )));
         }
-        // Stores the parent directory of the `tableInfo.json` file and its basename, which is the
-        // table's registry key (see `dir_name`).
         if let Some(parent) = path.as_ref().parent() {
-            if let Some(name) = parent.file_name().and_then(|n| n.to_str()) {
-                table_info.dir_name = name.to_string();
-            }
             table_info.table_info_dir = parent.to_path_buf();
         }
         Ok(table_info)
@@ -535,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn from_json_path_derives_dir_name_from_directory_not_name_field() {
+    fn registry_table_key_uses_directory_basename_not_name_field() {
         // The registry key is the directory basename, not the JSON `name` field.
         let dir = tempfile::tempdir().unwrap();
         let table_dir = dir.path().join("dirBasename");
@@ -550,15 +549,13 @@ mod tests {
         std::fs::write(table_dir.join("tableInfo.json"), json).unwrap();
 
         let table_info = TableInfo::from_json_path(table_dir.join("tableInfo.json")).unwrap();
-        assert_eq!(table_info.dir_name, "dirBasename");
+        assert_eq!(table_info.registry_table_key(), Some("dirBasename"));
         assert_eq!(table_info.name, "humanLabel");
     }
 
     #[test]
-    fn dir_name_is_empty_without_directory_context() {
-        // A `TableInfo` deserialized directly (no `from_json_path`) has no directory, so `dir_name`
-        // is the empty default -- registry callers must route through `from_json_path`.
+    fn registry_table_key_is_none_without_directory_context() {
         let info = make_table_info(&[]);
-        assert_eq!(info.dir_name, "");
+        assert_eq!(info.registry_table_key(), None);
     }
 }

--- a/workloads/src/models.rs
+++ b/workloads/src/models.rs
@@ -8,29 +8,6 @@ use delta_kernel::schema::Schema;
 use serde::Deserialize;
 use url::Url;
 
-/// ReadConfig represents a specific configuration for a read operation
-/// A config represents configurations for a specific benchmark that aren't specified in the spec
-/// JSON file
-#[derive(Clone, Debug)]
-pub struct ReadConfig {
-    pub name: String,
-    pub parallel_scan: ParallelScan,
-}
-
-/// Provides a default set of read configs for a given table, read spec, and operation
-pub fn default_read_configs() -> Vec<ReadConfig> {
-    vec![ReadConfig {
-        name: "serial".into(),
-        parallel_scan: ParallelScan::Disabled,
-    }]
-}
-
-#[derive(Clone, Debug)]
-pub enum ParallelScan {
-    Disabled,
-    Enabled { num_threads: usize },
-}
-
 /// Info needed to access a UC-managed table via credential vending.
 /// This covers both catalog-managed and non-catalog-managed UC tables.
 #[derive(Clone, Debug, Deserialize)]
@@ -44,8 +21,7 @@ pub struct CatalogInfo {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TableInfo {
-    /// Table name is a short identifier for the table (part of the final benchmark name), e.g.
-    /// 100Adds0Chkpts
+    /// Human-readable label used in benchmark output.
     pub name: String,
     /// Human-readable description of the table. Use this to capture context that the name alone
     /// doesn't convey (e.g. "A table with 1 commit with 1M add actions. This includes a commit
@@ -87,6 +63,10 @@ pub struct TableInfo {
     /// Path to the directory containing the `tableInfo.json` file
     #[serde(skip, default)]
     pub table_info_dir: PathBuf,
+    /// Basename of [`Self::table_info_dir`], used as the registry table key. Populated by
+    /// [`Self::from_json_path`]; empty for a `TableInfo` deserialized without directory context.
+    #[serde(skip, default)]
+    pub dir_name: String,
 }
 
 impl TableInfo {
@@ -114,8 +94,12 @@ impl TableInfo {
                 "catalog_info and table_path are mutually exclusive",
             )));
         }
-        // Stores the parent directory of the `tableInfo.json` file
+        // Stores the parent directory of the `tableInfo.json` file and its basename, which is the
+        // table's registry key (see `dir_name`).
         if let Some(parent) = path.as_ref().parent() {
+            if let Some(name) = parent.file_name().and_then(|n| n.to_str()) {
+                table_info.dir_name = name.to_string();
+            }
             table_info.table_info_dir = parent.to_path_buf();
         }
         Ok(table_info)
@@ -548,5 +532,33 @@ mod tests {
     fn test_deserialize_spec_errors(#[case] json: &str, #[case] expected_msg: &str) {
         let error = serde_json::from_str::<Spec>(json).unwrap_err();
         assert!(error.to_string().contains(expected_msg));
+    }
+
+    #[test]
+    fn from_json_path_derives_dir_name_from_directory_not_name_field() {
+        // The registry key is the directory basename, not the JSON `name` field.
+        let dir = tempfile::tempdir().unwrap();
+        let table_dir = dir.path().join("dirBasename");
+        std::fs::create_dir(&table_dir).unwrap();
+        let json = r#"{
+            "name": "humanLabel", "description": "d", "tablePath": "s3://b/t",
+            "schema": {"type": "struct", "fields": []},
+            "protocol": {"minReaderVersion": 1, "minWriterVersion": 2},
+            "logInfo": {"numAddFiles": 0, "numRemoveFiles": 0, "sizeInBytes": 0, "numCommits": 1, "numActions": 1},
+            "properties": {}, "dataLayout": {}, "tags": []
+        }"#;
+        std::fs::write(table_dir.join("tableInfo.json"), json).unwrap();
+
+        let table_info = TableInfo::from_json_path(table_dir.join("tableInfo.json")).unwrap();
+        assert_eq!(table_info.dir_name, "dirBasename");
+        assert_eq!(table_info.name, "humanLabel");
+    }
+
+    #[test]
+    fn dir_name_is_empty_without_directory_context() {
+        // A `TableInfo` deserialized directly (no `from_json_path`) has no directory, so `dir_name`
+        // is the empty default -- registry callers must route through `from_json_path`.
+        let info = make_table_info(&[]);
+        assert_eq!(info.dir_name, "");
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adds a benchmark registry which consists of a json configuration file and a parser which together enable developers to specify benchmark configurations for specific benchmark specs. Currently our CI only runs benchmarks with default options (serial scans, full p&m replay, etc.). This change will allow us to run benchmarks with custom configurations defined in the benchmark registry.

## How was this change tested?
Added unit tests and tested on this pull request.

## Common user journey (CUJ)
1. Identify the read workload using its table directory name and spec case name.
2. Add one or more harness configurations to `benchmarks/bench-registry.json`. Each configuration has a unique name and its runtime parameters, such as serial or parallel scan settings.
3. Run the benchmark locally and select a specific configuration using its generated name:
   ```bash
   cargo bench -p delta_kernel_benchmarks --bench workload_bench "<table>/<case>/<config>"
   ```
4. CI runs the registered configurations and posts benchmark comparisons on the pull request. Read workloads without a registry entry continue to use the built-in serial configuration.
