### PR TITLE
feat!: support a fallback on PlanBasedEngine

### DIFF
--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -43,7 +43,10 @@ pub unsafe extern "C" fn free_plan_executor(executor: Handle<SharedPlanExecutor>
     executor.drop_handle();
 }
 
-/// Construct a [`PlanBasedEngine`] from the given [`SharedPlanExecutor`].
+/// Construct a [`PlanBasedEngine`] from the given [`SharedPlanExecutor`], with no fallback engine.
+///
+/// Operations not yet implemented on the plan-execution path return an unsupported error. Use
+/// [`get_plan_based_engine_with_fallback`] to delegate those operations to another engine instead.
 ///
 /// This method consumes the [`SharedPlanExecutor`] handle, which should be freed when the engine
 /// is dropped via `free_engine` (caller responsibility).
@@ -63,35 +66,82 @@ pub unsafe extern "C" fn get_plan_based_engine(
     engine_to_handle(engine, allocate_error)
 }
 
+/// Construct a [`PlanBasedEngine`] backed by `plan_executor`, delegating operations not yet
+/// implemented on the plan-execution path to `fallback_engine`.
+///
+/// This method consumes BOTH the [`SharedPlanExecutor`] and [`SharedExternEngine`] handles.
+/// Ownership of the fallback engine transfers into the returned engine: dropping the returned
+/// engine (via `free_engine`) also drops the embedded fallback engine.
+///
+/// # Safety
+///
+/// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`], a
+/// valid [`SharedExternEngine`] handle, and a valid [`AllocateErrorFn`].
+#[no_mangle]
+pub unsafe extern "C" fn get_plan_based_engine_with_fallback(
+    plan_executor: Handle<SharedPlanExecutor>,
+    fallback_engine: Handle<SharedExternEngine>,
+    allocate_error: AllocateErrorFn,
+) -> Handle<SharedExternEngine> {
+    let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
+    let fallback: Arc<dyn Engine> = unsafe { fallback_engine.into_inner() }.engine();
+    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::with_fallback(fallback, executor));
+    engine_to_handle(engine, allocate_error)
+}
+
 #[cfg(test)]
 mod tests {
+    use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel_default_engine::DefaultEngineBuilder;
+
     use super::*;
     use crate::error::EngineExecResult;
     use crate::ffi_test_utils::allocate_err;
     use crate::free_engine;
     use crate::plans::result::CPlanResult;
 
-    #[test]
-    fn get_plan_based_engine_returns_plan_based_engine() {
-        extern "C" fn unreachable_callback(
-            _context: NullableCvoid,
-            _plan_proto: crate::KernelBytesSlice,
-            _out: *mut EngineExecResult<CPlanResult>,
-        ) {
-            unreachable!("callback should not run -- this test only constructs the engine");
-        }
+    extern "C" fn unreachable_callback(
+        _context: NullableCvoid,
+        _plan_proto: crate::KernelBytesSlice,
+        _out: *mut EngineExecResult<CPlanResult>,
+    ) {
+        unreachable!("callback should not run -- this test only constructs the engine");
+    }
 
-        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
-        let engine_handle = unsafe { get_plan_based_engine(executor, allocate_err) };
-
-        // Confirm we got back a real `PlanBasedEngine`, not e.g. an accidental DefaultEngine.
+    /// Assert that the given engine handle wraps a `PlanBasedEngine` (not e.g. a DefaultEngine).
+    fn assert_is_plan_based_engine(engine_handle: &Handle<SharedExternEngine>) {
         let extern_engine = unsafe { engine_handle.as_ref() };
         let engine = extern_engine.engine();
         assert!(
             engine.any_ref().downcast_ref::<PlanBasedEngine>().is_some(),
             "engine handle must wrap a PlanBasedEngine",
         );
+    }
 
+    #[test]
+    fn get_plan_based_engine_returns_plan_based_engine() {
+        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
+        let engine_handle = unsafe { get_plan_based_engine(executor, allocate_err) };
+
+        assert_is_plan_based_engine(&engine_handle);
+
+        unsafe { free_engine(engine_handle) };
+    }
+
+    #[test]
+    fn get_plan_based_engine_with_fallback_returns_plan_based_engine() {
+        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
+
+        // Build a fallback engine handle whose ownership will transfer into the plan-based engine.
+        let fallback = DefaultEngineBuilder::new(Arc::new(InMemory::new())).build();
+        let fallback_handle = engine_to_handle(Arc::new(fallback), allocate_err);
+
+        let engine_handle =
+            unsafe { get_plan_based_engine_with_fallback(executor, fallback_handle, allocate_err) };
+
+        assert_is_plan_based_engine(&engine_handle);
+
+        // Freeing the plan-based engine also frees the embedded fallback
         unsafe { free_engine(engine_handle) };
     }
 }

--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -3,9 +3,8 @@
 
 use std::sync::Arc;
 
-use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
 use delta_kernel::engine::plans::PlanBasedEngine;
-use delta_kernel::{Engine, EvaluationHandler, PlanExecutor};
+use delta_kernel::{Engine, PlanExecutor};
 
 use crate::handle::Handle;
 use crate::plans::executor::{CExecuteOpFn, FfiPlanExecutor, SharedPlanExecutor};
@@ -43,29 +42,6 @@ pub unsafe extern "C" fn free_plan_executor(executor: Handle<SharedPlanExecutor>
     executor.drop_handle();
 }
 
-/// Construct a [`PlanBasedEngine`] from the given [`SharedPlanExecutor`], with no fallback engine.
-///
-/// Operations not yet implemented on the plan-execution path return an unsupported error. Use
-/// [`get_plan_based_engine_with_fallback`] to delegate those operations to another engine instead.
-///
-/// This method consumes the [`SharedPlanExecutor`] handle, which should be freed when the engine
-/// is dropped via `free_engine` (caller responsibility).
-///
-/// # Safety
-///
-/// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`] and
-/// a valid [`AllocateErrorFn`].
-#[no_mangle]
-pub unsafe extern "C" fn get_plan_based_engine(
-    plan_executor: Handle<SharedPlanExecutor>,
-    allocate_error: AllocateErrorFn,
-) -> Handle<SharedExternEngine> {
-    let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
-    let evaluation_handler: Arc<dyn EvaluationHandler> = Arc::new(ArrowEvaluationHandler);
-    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new(evaluation_handler, executor));
-    engine_to_handle(engine, allocate_error)
-}
-
 /// Construct a [`PlanBasedEngine`] backed by `plan_executor`, delegating operations not yet
 /// implemented on the plan-execution path to `fallback_engine`.
 ///
@@ -78,14 +54,14 @@ pub unsafe extern "C" fn get_plan_based_engine(
 /// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`], a
 /// valid [`SharedExternEngine`] handle, and a valid [`AllocateErrorFn`].
 #[no_mangle]
-pub unsafe extern "C" fn get_plan_based_engine_with_fallback(
+pub unsafe extern "C" fn get_plan_based_engine(
     plan_executor: Handle<SharedPlanExecutor>,
     fallback_engine: Handle<SharedExternEngine>,
     allocate_error: AllocateErrorFn,
 ) -> Handle<SharedExternEngine> {
     let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
     let fallback: Arc<dyn Engine> = unsafe { fallback_engine.into_inner() }.engine();
-    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::with_fallback(fallback, executor));
+    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new(fallback, executor));
     engine_to_handle(engine, allocate_error)
 }
 
@@ -121,23 +97,13 @@ mod tests {
     #[test]
     fn get_plan_based_engine_returns_plan_based_engine() {
         let executor = unsafe { get_plan_executor(None, unreachable_callback) };
-        let engine_handle = unsafe { get_plan_based_engine(executor, allocate_err) };
-
-        assert_is_plan_based_engine(&engine_handle);
-
-        unsafe { free_engine(engine_handle) };
-    }
-
-    #[test]
-    fn get_plan_based_engine_with_fallback_returns_plan_based_engine() {
-        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
 
         // Build a fallback engine handle whose ownership will transfer into the plan-based engine.
         let fallback = DefaultEngineBuilder::new(Arc::new(InMemory::new())).build();
         let fallback_handle = engine_to_handle(Arc::new(fallback), allocate_err);
 
         let engine_handle =
-            unsafe { get_plan_based_engine_with_fallback(executor, fallback_handle, allocate_err) };
+            unsafe { get_plan_based_engine(executor, fallback_handle, allocate_err) };
 
         assert_is_plan_based_engine(&engine_handle);
 

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -2,42 +2,32 @@
 
 use std::sync::Arc;
 
+use tracing::debug;
 use url::Url;
 
 use crate::engine::arrow_utils;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
+    DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator, FileMeta,
     FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
 ///
-/// Operations not yet implemented on the plan-execution path delegate to `fallback` when present,
-/// and otherwise return an unsupported error.
+/// Operations not yet implemented on the plan-execution path delegate to the required `fallback`
+/// handler.
 pub struct PlanBasedJsonHandler {
     executor: Arc<dyn PlanExecutor>,
-    fallback: Option<Arc<dyn JsonHandler>>,
+    fallback: Arc<dyn JsonHandler>,
 }
 
 impl PlanBasedJsonHandler {
-    /// Construct a handler with no fallback.
-    pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
-        Self {
-            executor: plan_executor,
-            fallback: None,
-        }
-    }
-
     /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
-    pub fn with_fallback(
-        plan_executor: Arc<dyn PlanExecutor>,
-        fallback: Arc<dyn JsonHandler>,
-    ) -> Self {
+    pub fn new(plan_executor: Arc<dyn PlanExecutor>, fallback: Arc<dyn JsonHandler>) -> Self {
         Self {
             executor: plan_executor,
-            fallback: Some(fallback),
+            fallback,
         }
     }
 }
@@ -71,12 +61,8 @@ impl JsonHandler for PlanBasedJsonHandler {
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()> {
-        match &self.fallback {
-            Some(fallback) => fallback.write_json_file(path, data, overwrite),
-            None => Err(Error::unsupported(
-                "PlanBasedJsonHandler does not support write_json_file yet",
-            )),
-        }
+        debug!(%path, "PlanBasedJsonHandler delegating write_json_file to fallback handler");
+        self.fallback.write_json_file(path, data, overwrite)
     }
 }
 
@@ -100,16 +86,12 @@ mod tests {
     use crate::engine_data::FilteredEngineData;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
     use crate::{
-        DeltaResult, Engine as _, EngineData, Error, FileDataReadResultIterator, FileMeta,
+        DeltaResult, Engine as _, EngineData, FileDataReadResultIterator, FileMeta,
         JsonHandler as _, ParquetHandler as _,
     };
 
     fn make_handler() -> PlanBasedJsonHandler {
-        PlanBasedJsonHandler::new(Arc::new(SyncPlanExecutor::new()))
-    }
-
-    fn make_handler_with_fallback() -> PlanBasedJsonHandler {
-        PlanBasedJsonHandler::with_fallback(
+        PlanBasedJsonHandler::new(
             Arc::new(SyncPlanExecutor::new()),
             SyncEngine::new().json_handler(),
         )
@@ -125,19 +107,6 @@ mod tests {
     }
 
     #[test]
-    fn test_write_json_file_without_fallback_is_unsupported() {
-        let dir = tempdir().unwrap();
-        let url = Url::from_file_path(dir.path().join("out.json")).unwrap();
-        let filtered = Ok(FilteredEngineData::with_all_rows_selected(
-            single_column_data(vec!["a"]),
-        ));
-        let err = make_handler()
-            .write_json_file(&url, Box::new(std::iter::once(filtered)), false)
-            .unwrap_err();
-        assert!(matches!(err, Error::Unsupported(_)));
-    }
-
-    #[test]
     fn test_write_json_file_delegates_to_fallback() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("out.json");
@@ -145,7 +114,7 @@ mod tests {
         let filtered = Ok(FilteredEngineData::with_all_rows_selected(
             single_column_data(vec!["a", "b"]),
         ));
-        make_handler_with_fallback()
+        make_handler()
             .write_json_file(&url, Box::new(std::iter::once(filtered)), false)
             .unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -153,7 +122,10 @@ mod tests {
     }
 
     fn make_parquet_handler() -> PlanBasedParquetHandler {
-        PlanBasedParquetHandler::new(Arc::new(SyncPlanExecutor::new()))
+        PlanBasedParquetHandler::new(
+            Arc::new(SyncPlanExecutor::new()),
+            SyncEngine::new().parquet_handler(),
+        )
     }
 
     fn temp_json_file(lines: &[&str]) -> (NamedTempFile, FileMeta) {

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -13,14 +13,31 @@ use crate::{
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
+///
+/// Operations not yet implemented on the plan-execution path delegate to `fallback` when present,
+/// and otherwise return an unsupported error.
 pub struct PlanBasedJsonHandler {
     executor: Arc<dyn PlanExecutor>,
+    fallback: Option<Arc<dyn JsonHandler>>,
 }
 
 impl PlanBasedJsonHandler {
+    /// Construct a handler with no fallback.
     pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
         Self {
             executor: plan_executor,
+            fallback: None,
+        }
+    }
+
+    /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
+    pub fn with_fallback(
+        plan_executor: Arc<dyn PlanExecutor>,
+        fallback: Arc<dyn JsonHandler>,
+    ) -> Self {
+        Self {
+            executor: plan_executor,
+            fallback: Some(fallback),
         }
     }
 }
@@ -50,13 +67,16 @@ impl JsonHandler for PlanBasedJsonHandler {
 
     fn write_json_file(
         &self,
-        _path: &Url,
-        _data: DeltaResultIterator<'_, FilteredEngineData>,
-        _overwrite: bool,
+        path: &Url,
+        data: DeltaResultIterator<'_, FilteredEngineData>,
+        overwrite: bool,
     ) -> DeltaResult<()> {
-        Err(Error::unsupported(
-            "PlanBasedJsonHandler does not support write_json_file yet",
-        ))
+        match &self.fallback {
+            Some(fallback) => fallback.write_json_file(path, data, overwrite),
+            None => Err(Error::unsupported(
+                "PlanBasedJsonHandler does not support write_json_file yet",
+            )),
+        }
     }
 }
 
@@ -68,22 +88,68 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
-    use tempfile::NamedTempFile;
+    use tempfile::{tempdir, NamedTempFile};
     use url::Url;
 
     use super::PlanBasedJsonHandler;
-    use crate::arrow::array::{Int32Array, RecordBatch, StringArray};
+    use crate::arrow::array::{Array, Int32Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::plans::parquet::PlanBasedParquetHandler;
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::sync::SyncEngine;
+    use crate::engine_data::FilteredEngineData;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
     use crate::{
-        DeltaResult, EngineData, FileDataReadResultIterator, FileMeta, JsonHandler as _,
-        ParquetHandler as _,
+        DeltaResult, Engine as _, EngineData, Error, FileDataReadResultIterator, FileMeta,
+        JsonHandler as _, ParquetHandler as _,
     };
 
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(Arc::new(SyncPlanExecutor::new()))
+    }
+
+    fn make_handler_with_fallback() -> PlanBasedJsonHandler {
+        PlanBasedJsonHandler::with_fallback(
+            Arc::new(SyncPlanExecutor::new()),
+            SyncEngine::new().json_handler(),
+        )
+    }
+
+    fn single_column_data(values: Vec<&str>) -> Box<dyn EngineData> {
+        let batch = RecordBatch::try_from_iter(vec![(
+            "x",
+            Arc::new(StringArray::from(values)) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        Box::new(ArrowEngineData::new(batch))
+    }
+
+    #[test]
+    fn test_write_json_file_without_fallback_is_unsupported() {
+        let dir = tempdir().unwrap();
+        let url = Url::from_file_path(dir.path().join("out.json")).unwrap();
+        let filtered = Ok(FilteredEngineData::with_all_rows_selected(
+            single_column_data(vec!["a"]),
+        ));
+        let err = make_handler()
+            .write_json_file(&url, Box::new(std::iter::once(filtered)), false)
+            .unwrap_err();
+        assert!(matches!(err, Error::Unsupported(_)));
+    }
+
+    #[test]
+    fn test_write_json_file_delegates_to_fallback() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("out.json");
+        let url = Url::from_file_path(&path).unwrap();
+        let filtered = Ok(FilteredEngineData::with_all_rows_selected(
+            single_column_data(vec!["a", "b"]),
+        ));
+        make_handler_with_fallback()
+            .write_json_file(&url, Box::new(std::iter::once(filtered)), false)
+            .unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(contents, "{\"x\":\"a\"}\n{\"x\":\"b\"}\n");
     }
 
     fn make_parquet_handler() -> PlanBasedParquetHandler {

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -28,8 +28,8 @@ use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandl
 /// Storage, JSON file reads, and Parquet file reads are converted into
 /// [`Operation`](crate::plans::Operation)s and delegated to the plan executor.
 ///
-/// EvaluationHandler capabilities are not supported under plan execution,
-/// so the engine must provide an EvaluationHandler as well.
+/// EvaluationHandler capabilities are not supported under plan execution, so the engine is always
+/// constructed with an [`EvaluationHandler`].
 pub struct PlanBasedEngine {
     executor: Arc<dyn PlanExecutor>,
     evaluation: Arc<dyn EvaluationHandler>,
@@ -39,6 +39,10 @@ pub struct PlanBasedEngine {
 }
 
 impl PlanBasedEngine {
+    /// Construct a `PlanBasedEngine` with no fallback engine.
+    ///
+    /// Not-yet-implemented operations return an unsupported error.
+    /// Use [`PlanBasedEngine::with_fallback`] to delegate them to another engine instead.
     pub fn new(
         evaluation_handler: Arc<dyn EvaluationHandler>,
         plan_executor: Arc<dyn PlanExecutor>,
@@ -48,6 +52,27 @@ impl PlanBasedEngine {
             storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
             json: Arc::new(PlanBasedJsonHandler::new(plan_executor.clone())),
             parquet: Arc::new(PlanBasedParquetHandler::new(plan_executor.clone())),
+            executor: plan_executor,
+        }
+    }
+
+    /// Construct a `PlanBasedEngine` that delegates not-yet-implemented operations to `fallback`.
+    ///
+    /// The fallback's [`EvaluationHandler`] is used for evaluation, and each plan-based handler
+    /// falls back to the fallback's corresponding handler for operations the plan-execution path
+    /// does not yet implement.
+    pub fn with_fallback(fallback: Arc<dyn Engine>, plan_executor: Arc<dyn PlanExecutor>) -> Self {
+        Self {
+            evaluation: fallback.evaluation_handler(),
+            storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
+            json: Arc::new(PlanBasedJsonHandler::with_fallback(
+                plan_executor.clone(),
+                fallback.json_handler(),
+            )),
+            parquet: Arc::new(PlanBasedParquetHandler::with_fallback(
+                plan_executor.clone(),
+                fallback.parquet_handler(),
+            )),
             executor: plan_executor,
         }
     }

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -28,8 +28,8 @@ use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandl
 /// Storage, JSON file reads, and Parquet file reads are converted into
 /// [`Operation`](crate::plans::Operation)s and delegated to the plan executor.
 ///
-/// EvaluationHandler capabilities are not supported under plan execution, so the engine is always
-/// constructed with an [`EvaluationHandler`].
+/// Operations not yet implemented on the plan-execution path (e.g. `write_json_file`,
+/// `write_parquet_file`) and evaluation are delegated to the required `fallback` [`Engine`].
 pub struct PlanBasedEngine {
     executor: Arc<dyn PlanExecutor>,
     evaluation: Arc<dyn EvaluationHandler>,
@@ -39,37 +39,21 @@ pub struct PlanBasedEngine {
 }
 
 impl PlanBasedEngine {
-    /// Construct a `PlanBasedEngine` with no fallback engine.
-    ///
-    /// Not-yet-implemented operations return an unsupported error.
-    /// Use [`PlanBasedEngine::with_fallback`] to delegate them to another engine instead.
-    pub fn new(
-        evaluation_handler: Arc<dyn EvaluationHandler>,
-        plan_executor: Arc<dyn PlanExecutor>,
-    ) -> Self {
-        Self {
-            evaluation: evaluation_handler,
-            storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
-            json: Arc::new(PlanBasedJsonHandler::new(plan_executor.clone())),
-            parquet: Arc::new(PlanBasedParquetHandler::new(plan_executor.clone())),
-            executor: plan_executor,
-        }
-    }
-
-    /// Construct a `PlanBasedEngine` that delegates not-yet-implemented operations to `fallback`.
+    /// Construct a `PlanBasedEngine` backed by `plan_executor`, delegating operations not yet
+    /// implemented on the plan-execution path to `fallback`.
     ///
     /// The fallback's [`EvaluationHandler`] is used for evaluation, and each plan-based handler
     /// falls back to the fallback's corresponding handler for operations the plan-execution path
     /// does not yet implement.
-    pub fn with_fallback(fallback: Arc<dyn Engine>, plan_executor: Arc<dyn PlanExecutor>) -> Self {
+    pub fn new(fallback: Arc<dyn Engine>, plan_executor: Arc<dyn PlanExecutor>) -> Self {
         Self {
             evaluation: fallback.evaluation_handler(),
             storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
-            json: Arc::new(PlanBasedJsonHandler::with_fallback(
+            json: Arc::new(PlanBasedJsonHandler::new(
                 plan_executor.clone(),
                 fallback.json_handler(),
             )),
-            parquet: Arc::new(PlanBasedParquetHandler::with_fallback(
+            parquet: Arc::new(PlanBasedParquetHandler::new(
                 plan_executor.clone(),
                 fallback.parquet_handler(),
             )),

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -2,41 +2,31 @@
 
 use std::sync::Arc;
 
+use tracing::debug;
 use url::Url;
 
 use crate::plans::{IoOperation, Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
-    FileMeta, ParquetFooter, ParquetHandler, PredicateRef,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, FileDataReadResultIterator, FileMeta,
+    ParquetFooter, ParquetHandler, PredicateRef,
 };
 
 /// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
 ///
-/// Operations not yet implemented on the plan-execution path delegate to `fallback` when present,
-/// and otherwise return an unsupported error.
+/// Operations not yet implemented on the plan-execution path delegate to the required `fallback`
+/// handler.
 pub struct PlanBasedParquetHandler {
     executor: Arc<dyn PlanExecutor>,
-    fallback: Option<Arc<dyn ParquetHandler>>,
+    fallback: Arc<dyn ParquetHandler>,
 }
 
 impl PlanBasedParquetHandler {
-    /// Construct a handler with no fallback.
-    pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
-        Self {
-            executor: plan_executor,
-            fallback: None,
-        }
-    }
-
     /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
-    pub fn with_fallback(
-        plan_executor: Arc<dyn PlanExecutor>,
-        fallback: Arc<dyn ParquetHandler>,
-    ) -> Self {
+    pub fn new(plan_executor: Arc<dyn PlanExecutor>, fallback: Arc<dyn ParquetHandler>) -> Self {
         Self {
             executor: plan_executor,
-            fallback: Some(fallback),
+            fallback,
         }
     }
 }
@@ -61,12 +51,8 @@ impl ParquetHandler for PlanBasedParquetHandler {
         location: Url,
         data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
-        match &self.fallback {
-            Some(fallback) => fallback.write_parquet_file(location, data),
-            None => Err(Error::unsupported(
-                "PlanBasedParquetHandler does not support write_parquet_file yet",
-            )),
-        }
+        debug!(%location, "PlanBasedParquetHandler delegating write_parquet_file to fallback handler");
+        self.fallback.write_parquet_file(location, data)
     }
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
@@ -95,14 +81,10 @@ mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
-    use crate::{Engine as _, EngineData, Error, FileMeta, ParquetHandler as _};
+    use crate::{Engine as _, EngineData, FileMeta, ParquetHandler as _};
 
     fn make_handler() -> PlanBasedParquetHandler {
-        PlanBasedParquetHandler::new(Arc::new(SyncPlanExecutor::new()))
-    }
-
-    fn make_handler_with_fallback() -> PlanBasedParquetHandler {
-        PlanBasedParquetHandler::with_fallback(
+        PlanBasedParquetHandler::new(
             Arc::new(SyncPlanExecutor::new()),
             SyncEngine::new().parquet_handler(),
         )
@@ -117,23 +99,12 @@ mod tests {
     }
 
     #[test]
-    fn test_write_parquet_file_without_fallback_is_unsupported() {
-        let temp_dir = tempdir().unwrap();
-        let url = Url::from_file_path(temp_dir.path().join("out.parquet")).unwrap();
-        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(single_column_batch()));
-        let err = make_handler()
-            .write_parquet_file(url, Box::new(std::iter::once(Ok(data))))
-            .unwrap_err();
-        assert!(matches!(err, Error::Unsupported(_)));
-    }
-
-    #[test]
     fn test_write_parquet_file_delegates_to_fallback() {
         let temp_dir = tempdir().unwrap();
         let path = temp_dir.path().join("out.parquet");
         let url = Url::from_file_path(&path).unwrap();
         let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(single_column_batch()));
-        make_handler_with_fallback()
+        make_handler()
             .write_parquet_file(url.clone(), Box::new(std::iter::once(Ok(data))))
             .unwrap();
 
@@ -146,7 +117,7 @@ mod tests {
             last_modified: 0,
             size: std::fs::metadata(&path).unwrap().len(),
         };
-        let rows: usize = make_handler_with_fallback()
+        let rows: usize = make_handler()
             .read_parquet_files(&[file_meta], schema, None)
             .unwrap()
             .map(|batch| batch.unwrap().len())

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -12,14 +12,31 @@ use crate::{
 };
 
 /// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
+///
+/// Operations not yet implemented on the plan-execution path delegate to `fallback` when present,
+/// and otherwise return an unsupported error.
 pub struct PlanBasedParquetHandler {
     executor: Arc<dyn PlanExecutor>,
+    fallback: Option<Arc<dyn ParquetHandler>>,
 }
 
 impl PlanBasedParquetHandler {
+    /// Construct a handler with no fallback.
     pub fn new(plan_executor: Arc<dyn PlanExecutor>) -> Self {
         Self {
             executor: plan_executor,
+            fallback: None,
+        }
+    }
+
+    /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
+    pub fn with_fallback(
+        plan_executor: Arc<dyn PlanExecutor>,
+        fallback: Arc<dyn ParquetHandler>,
+    ) -> Self {
+        Self {
+            executor: plan_executor,
+            fallback: Some(fallback),
         }
     }
 }
@@ -41,12 +58,15 @@ impl ParquetHandler for PlanBasedParquetHandler {
 
     fn write_parquet_file(
         &self,
-        _location: Url,
-        _data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+        location: Url,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
-        Err(Error::unsupported(
-            "PlanBasedParquetHandler does not support write_parquet_file yet",
-        ))
+        match &self.fallback {
+            Some(fallback) => fallback.write_parquet_file(location, data),
+            None => Err(Error::unsupported(
+                "PlanBasedParquetHandler does not support write_parquet_file yet",
+            )),
+        }
     }
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
@@ -72,12 +92,66 @@ mod tests {
     use crate::engine::arrow_conversion::TryIntoKernel as _;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::sync::SyncEngine;
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
-    use crate::{FileMeta, ParquetHandler as _};
+    use crate::{Engine as _, EngineData, Error, FileMeta, ParquetHandler as _};
 
     fn make_handler() -> PlanBasedParquetHandler {
         PlanBasedParquetHandler::new(Arc::new(SyncPlanExecutor::new()))
+    }
+
+    fn make_handler_with_fallback() -> PlanBasedParquetHandler {
+        PlanBasedParquetHandler::with_fallback(
+            Arc::new(SyncPlanExecutor::new()),
+            SyncEngine::new().parquet_handler(),
+        )
+    }
+
+    fn single_column_batch() -> RecordBatch {
+        RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![1, 2, 3])) as Arc<dyn Array>,
+        )])
+        .unwrap()
+    }
+
+    #[test]
+    fn test_write_parquet_file_without_fallback_is_unsupported() {
+        let temp_dir = tempdir().unwrap();
+        let url = Url::from_file_path(temp_dir.path().join("out.parquet")).unwrap();
+        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(single_column_batch()));
+        let err = make_handler()
+            .write_parquet_file(url, Box::new(std::iter::once(Ok(data))))
+            .unwrap_err();
+        assert!(matches!(err, Error::Unsupported(_)));
+    }
+
+    #[test]
+    fn test_write_parquet_file_delegates_to_fallback() {
+        let temp_dir = tempdir().unwrap();
+        let path = temp_dir.path().join("out.parquet");
+        let url = Url::from_file_path(&path).unwrap();
+        let data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(single_column_batch()));
+        make_handler_with_fallback()
+            .write_parquet_file(url.clone(), Box::new(std::iter::once(Ok(data))))
+            .unwrap();
+
+        // Read it back to confirm the fallback actually wrote the rows.
+        let schema: SchemaRef = Arc::new(
+            StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
+        );
+        let file_meta = FileMeta {
+            location: url,
+            last_modified: 0,
+            size: std::fs::metadata(&path).unwrap().len(),
+        };
+        let rows: usize = make_handler_with_fallback()
+            .read_parquet_files(&[file_meta], schema, None)
+            .unwrap()
+            .map(|batch| batch.unwrap().len())
+            .sum();
+        assert_eq!(rows, 3);
     }
 
     fn file_meta_for(path: &Path) -> FileMeta {

--- a/kernel/src/engine/plans/storage.rs
+++ b/kernel/src/engine/plans/storage.rs
@@ -62,7 +62,11 @@ impl StorageHandler for PlanBasedStorageHandler {
 
     fn delete(&self, _path: &Url) -> DeltaResult<()> {
         // TODO(#2820): implement here once supported as IoOperation.
-        unimplemented!("PlanBasedStorageHandler does not yet implement delete")
+        // Intentionally do not use a fallback because we expect this SHOULD be implemented via
+        // plan-execution.
+        Err(Error::unsupported(
+            "PlanBasedStorageHandler does not yet implement delete",
+        ))
     }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR adds fallback capability to PlanBasedEngine. Specifically, it updates the constructor on `PlanBasedEngine` (and associated handlers) such that callers can embed a separate `Engine` impl that will handle any operations which we do not support via plan-based execution.

This serves as a compatibility layer such that the existing Engine interfaces all continue to work even when declarative-plans is used for certain APIs. 

## How was this change tested?
Unit tests.
