### PR TITLE
feat: add UC OSS-server live integration test CI for get_config and load_table

### DIFF
--- a/.github/scripts/seed_uc_table.sh
+++ b/.github/scripts/seed_uc_table.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Seed a catalog-managed Delta table in the running UC OSS server via its `bin/uc` CLI,
+# so the gated `load_table` live test has a table to read.
+#
+# Usage: seed_uc_table.sh <catalog> <schema> <table>
+# Overridable via env: UC_DIR.
+set -euo pipefail
+
+UC_DIR="${UC_DIR:-$HOME/unitycatalog}"
+catalog="${1:?catalog required}"
+schema="${2:?schema required}"
+table="${3:?table required}"
+
+cd "$UC_DIR"
+bin/uc table create \
+  --full_name "$catalog.$schema.$table" \
+  --columns "id INT, name STRING" \
+  --table_type MANAGED

--- a/.github/scripts/setup_unitycatalog.sh
+++ b/.github/scripts/setup_unitycatalog.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Clone and build the Unity Catalog OSS server at a pinned commit so the gated
+# unity-catalog-delta-rest-client live integration tests can run against a real server in CI.
+#
+# Pinned to a commit that serves the Delta-Tables API the kernel UC crate targets. The published
+# `:latest` artifacts/images predate these endpoints, so building from this commit is required.
+# Bump UC_COMMIT when the server contract advances.
+#
+# Overridable via env: UC_REPO, UC_COMMIT, UC_DIR.
+set -euo pipefail
+
+UC_REPO="${UC_REPO:-https://github.com/unitycatalog/unitycatalog.git}"
+UC_COMMIT="${UC_COMMIT:-0f1445227bd251b386420c90136515daefa4e03d}"
+UC_DIR="${UC_DIR:-$HOME/unitycatalog}"
+
+if [[ ! -d "$UC_DIR/.git" ]]; then
+  git init -q "$UC_DIR"
+  git -C "$UC_DIR" remote add origin "$UC_REPO"
+fi
+
+git -C "$UC_DIR" fetch --depth 1 origin "$UC_COMMIT"
+git -C "$UC_DIR" checkout -q --force FETCH_HEAD
+
+cd "$UC_DIR"
+# Build the server jar up front so the launch step starts fast and a cache can capture it.
+# `bin/start-uc-server` will reuse this jar instead of rebuilding when present.
+build/sbt -info package

--- a/.github/scripts/uc_oss_server.sh
+++ b/.github/scripts/uc_oss_server.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Start or stop the Unity Catalog OSS server built by setup_unitycatalog.sh, for the gated
+# unity-catalog-delta-rest-client live integration tests.
+#
+# Usage: uc_oss_server.sh {start|stop}
+# Overridable via env: UC_DIR, UC_HOST, UC_PID_FILE, UC_LOG_FILE.
+set -euo pipefail
+
+UC_DIR="${UC_DIR:-$HOME/unitycatalog}"
+UC_HOST="${UC_HOST:-http://localhost:8080}"
+PID_FILE="${UC_PID_FILE:-$UC_DIR/uc-server.pid}"
+LOG_FILE="${UC_LOG_FILE:-$UC_DIR/uc-server.log}"
+# Used to poll the OSS UC server to see when it is ready to accept requests.
+HEALTH_URL="$UC_HOST/api/2.1/unity-catalog/catalogs"
+
+start() {
+  cd "$UC_DIR"
+
+  # Set a storage root so the server can allocate locations for UC catalog-managed tables; a fresh
+  # server has none, so the staging-tables create endpoint 400s. Point it at a local dir for CI,
+  # kept outside UC_DIR so created tables don't end up in the build cache.
+  local managed_dir="${UC_MANAGED_DIR:-${TMPDIR:-/tmp}/uc-managed-tables}"
+  local props="$UC_DIR/etc/conf/server.properties"
+  mkdir -p "$managed_dir"
+  sed -i '/^storage-root\.tables=/d' "$props"
+  echo "storage-root.tables=file://$managed_dir" >>"$props"
+
+  echo "Starting Unity Catalog server (logs: $LOG_FILE)"
+  # Launch in a new session so stop() can kill the whole process group (the forked JVM child).
+  setsid bash -c 'echo $$ >"'"$PID_FILE"'"; exec bin/start-uc-server >"'"$LOG_FILE"'" 2>&1' &
+
+  # Wait up to ~5 minutes: covers an incremental sbt build on first boot plus JVM startup.
+  for i in $(seq 1 150); do
+    if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+      echo "Unity Catalog server is up (after $((i * 2))s)."
+      return 0
+    fi
+    if [[ -f "$PID_FILE" ]] && ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+      echo "Server process exited before becoming healthy. Logs:" >&2
+      cat "$LOG_FILE" >&2
+      return 1
+    fi
+    sleep 2
+  done
+
+  echo "Server did not become healthy within the timeout. Logs:" >&2
+  cat "$LOG_FILE" >&2
+  return 1
+}
+
+stop() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PID_FILE")"
+    # Kill the whole process group (negative pid) to take down the forked JVM child.
+    kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+    rm -f "$PID_FILE"
+  fi
+}
+
+case "${1:-}" in
+  start) start ;;
+  stop) stop ;;
+  *)
+    echo "usage: $0 {start|stop}" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/unitycatalog_oss_test.yml
+++ b/.github/workflows/unitycatalog_oss_test.yml
@@ -1,0 +1,99 @@
+name: unity-catalog-oss-test
+
+# Runs the gated `unity-catalog-delta-rest-client` live integration tests against a real Unity
+# Catalog OSS server (built from a pinned commit). Exercises the read-only `get_config` handshake
+# (needs no table) and `load_table` against a table seeded via the Delta-Commits (legacy) API
+# before the test step.
+on:
+  push:
+    branches: [main, "release/**"]
+    paths:
+      - "unity-catalog-delta-client-api/**"
+      - "unity-catalog-delta-rest-client/**"
+      - ".github/workflows/unitycatalog_oss_test.yml"
+      - ".github/scripts/setup_unitycatalog.sh"
+      - ".github/scripts/uc_oss_server.sh"
+      - ".github/scripts/seed_uc_table.sh"
+  pull_request:
+    paths:
+      - "unity-catalog-delta-client-api/**"
+      - "unity-catalog-delta-rest-client/**"
+      - ".github/workflows/unitycatalog_oss_test.yml"
+      - ".github/scripts/setup_unitycatalog.sh"
+      - ".github/scripts/uc_oss_server.sh"
+      - ".github/scripts/seed_uc_table.sh"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  UC_COMMIT: 0f1445227bd251b386420c90136515daefa4e03d
+  UC_DIR: ${{ github.workspace }}/.uc-server
+
+jobs:
+  uc-oss-test:
+    name: UC OSS server integration test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Java 17
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        with:
+          distribution: zulu
+          java-version: "17"
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          cache: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
+
+      - name: Cache Unity Catalog build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ${{ env.UC_DIR }}
+            ~/.ivy2
+            ~/.sbt
+            ~/.cache/coursier
+          key: uc-oss-${{ runner.os }}-${{ env.UC_COMMIT }}-${{ hashFiles('.github/scripts/setup_unitycatalog.sh') }}
+
+      - name: Build Unity Catalog server
+        run: bash .github/scripts/setup_unitycatalog.sh
+
+      - name: Start Unity Catalog server
+        run: bash .github/scripts/uc_oss_server.sh start
+
+      # Seed a catalog-managed (MANAGED) Delta table so the load_table live test has a table to read.
+      - name: Seed a managed table
+        run: bash .github/scripts/seed_uc_table.sh unity default smoke_test_table
+
+      - name: Run UC live integration tests
+        env:
+          UC_SERVER_URL: http://localhost:8080
+          UC_TOKEN: not-used
+          # Fresh OSS server seeds the `unity` catalog with a `default` schema.
+          UC_TEST_CATALOG: unity
+          UC_TEST_SCHEMA: default
+          UC_TEST_TABLE: smoke_test_table
+        run: cargo nextest run --locked -p unity-catalog-delta-rest-client --features integration-test -E 'test(live_)'
+
+      - name: Stop Unity Catalog server
+        if: always()
+        run: bash .github/scripts/uc_oss_server.sh stop
+
+      - name: Dump server log on failure
+        if: failure()
+        run: cat "$UC_DIR/uc-server.log" || true

--- a/unity-catalog-delta-rest-client/Cargo.toml
+++ b/unity-catalog-delta-rest-client/Cargo.toml
@@ -28,6 +28,10 @@ chrono = { version = "0.4", features = ["serde"] }
 [features]
 default = []
 test-utils = ["unity-catalog-delta-client-api/test-utils"]
+# Gates live integration tests that hit a real Unity Catalog OSS server. Off by default so normal
+# `cargo test` never compiles or runs them; the dedicated CI job enables it. See
+# tests/integration_live_server.rs.
+integration-test = []
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/unity-catalog-delta-rest-client/src/clients/uc_client.rs
+++ b/unity-catalog-delta-rest-client/src/clients/uc_client.rs
@@ -3,7 +3,9 @@
 // to unity-catalog-delta-client-api.
 use reqwest::StatusCode;
 use tracing::instrument;
-use unity_catalog_delta_client_api::{Operation, TemporaryTableCredentials};
+use unity_catalog_delta_client_api::{
+    CatalogConfig, LoadTableResponse, Operation, TemporaryTableCredentials,
+};
 use url::Url;
 
 use crate::config::ClientConfig;
@@ -56,6 +58,29 @@ impl UCClient {
         }
     }
 
+    /// `GET /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}` (`load_table`): reads a
+    /// catalog-managed table's full metadata plus any unpublished commits. Read-only.
+    #[instrument(skip(self))]
+    pub async fn load_table(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<LoadTableResponse> {
+        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}");
+        let url = self.base_url.join(&path)?;
+
+        let response =
+            execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;
+        match response.status() {
+            StatusCode::NOT_FOUND => Err(unity_catalog_delta_client_api::Error::TableNotFound(
+                format!("{catalog}.{schema}.{table}"),
+            )
+            .into()),
+            _ => handle_response(response).await,
+        }
+    }
+
     /// Get temporary cloud storage credentials for accessing a table.
     #[instrument(skip(self))]
     pub async fn get_credentials(
@@ -74,6 +99,25 @@ impl UCClient {
         })
         .await?;
 
+        handle_response(response).await
+    }
+
+    /// `GET /delta/v1/config?catalog={catalog}&protocol-versions={csv}`: session-start handshake.
+    /// `protocol_versions` is a list of version strings such as `["1.1", "2.3"]` indicating the
+    /// highest version per major version the client supports.
+    #[instrument(skip(self))]
+    pub async fn get_config(
+        &self,
+        catalog: &str,
+        protocol_versions: &[&str],
+    ) -> Result<CatalogConfig> {
+        let mut url = self.base_url.join("delta/v1/config")?;
+        url.query_pairs_mut().append_pair("catalog", catalog);
+        url.query_pairs_mut()
+            .append_pair("protocol-versions", &protocol_versions.join(","));
+
+        let response =
+            execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;
         handle_response(response).await
     }
 }

--- a/unity-catalog-delta-rest-client/tests/integration_live_server.rs
+++ b/unity-catalog-delta-rest-client/tests/integration_live_server.rs
@@ -1,0 +1,96 @@
+//! Live integration tests that exercise the UC REST client against a real Unity Catalog OSS
+//! server.
+//!
+//! These are gated behind the `integration-test` feature so they are never compiled or run by a
+//! normal `cargo test`. The dedicated CI workflow (`.github/workflows/unitycatalog_oss_test.yml`)
+//! builds + starts a UC OSS server and runs them:
+//!
+//!   cargo nextest run -p unity-catalog-delta-rest-client --features integration-test -E
+//! 'test(live_)'
+#![cfg(feature = "integration-test")]
+
+use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
+
+/// Reads the server URL + token from the environment, or `None` to skip the test.
+fn server_env() -> Option<(String, String)> {
+    let url = std::env::var("UC_SERVER_URL").ok()?;
+    let token = std::env::var("UC_TOKEN").unwrap_or_else(|_| "not-used".to_string());
+    Some((url, token))
+}
+
+fn client(url: &str, token: &str) -> UCClient {
+    let config = ClientConfig::build(url, token)
+        .build()
+        .expect("failed to build ClientConfig");
+    UCClient::new(config).expect("failed to build UCClient")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn live_get_config_round_trips() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_get_config_round_trips");
+        return;
+    };
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+
+    let resp = client(&url, &token)
+        .get_config(&catalog, &["1.0"])
+        .await
+        .expect("get_config failed");
+
+    assert!(
+        !resp.protocol_version.is_empty(),
+        "expected a protocol version from the server"
+    );
+    assert!(
+        !resp.endpoints.is_empty(),
+        "expected the server to advertise at least one endpoint"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn live_load_table_reads_metadata() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_load_table_reads_metadata");
+        return;
+    };
+    let Some(table) = std::env::var("UC_TEST_TABLE").ok() else {
+        eprintln!("UC_TEST_TABLE unset; skipping live_load_table_reads_metadata");
+        return;
+    };
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+    let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
+
+    let resp = client(&url, &token)
+        .load_table(&catalog, &schema, &table)
+        .await
+        .expect("load_table failed");
+    let meta = &resp.metadata;
+
+    assert!(
+        !meta.table_uuid.is_empty(),
+        "expected a table_uuid in the load_table response"
+    );
+    assert_eq!(meta.table_type, "MANAGED", "expected a managed table");
+    assert!(
+        meta.location.starts_with("file:") || meta.location.starts_with("s3"),
+        "expected an absolute storage location, got {:?}",
+        meta.location
+    );
+    let columns = meta
+        .columns
+        .get("fields")
+        .and_then(|f| f.as_array())
+        .expect("expected columns to decode as a StructType with a `fields` array");
+    let names: Vec<&str> = columns
+        .iter()
+        .filter_map(|f| f.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert_eq!(names, ["id", "name"], "expected the seeded columns");
+
+    assert_eq!(
+        resp.latest_table_version,
+        Some(0),
+        "expected latest_table_version 0 for a freshly created table"
+    );
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2925/files) to review incremental changes.
- [**stack/uc-e2e-smoke**](https://github.com/delta-io/delta-kernel-rs/pull/2925) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2925/files)] ← _this PR_
  - [stack/uc-log-tail](https://github.com/delta-io/delta-kernel-rs/pull/2927) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2927/files/44b31cfc4b08b2452cee7bf63cfa27549949d413..e69233252f7036ff9a0f4174a1794663276a6af0)]
    - [stack/uc-core](https://github.com/delta-io/delta-kernel-rs/pull/2855) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2855/files/e69233252f7036ff9a0f4174a1794663276a6af0..911fa4d66bb4446a8eeb827cd196e61ddaccb4e9)]
      - [stack/uc-api-v2](https://github.com/delta-io/delta-kernel-rs/pull/2826) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2826/files/911fa4d66bb4446a8eeb827cd196e61ddaccb4e9..f3a93309bbd18c365d4a2a7dad06665d4f08be66)]

---------
## What changes are proposed in this pull request?
This change adds get_config (protocol handshake) and load_table (catalog-managed table metadata + unpublished commits) to UCClient. This change also adds an E2E test against the OSS UC server, which is now a new CI workflow.

## How was this change tested?
New CI tests against OSS UC server, new unit tests for added functions.
