### PR TITLE
feat: expose several internal apis for connectors to do log cleanup

### DIFF
--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -30,7 +30,7 @@ use tracing::{info, trace, warn};
 use url::Url;
 
 use crate::log_segment::LogSegment;
-use crate::log_segment_files::{list_from_storage, should_process_log_file};
+use crate::log_segment_files::{list_delta_log_from_storage, should_process_log_file};
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::snapshot::Snapshot;
 use crate::table_configuration::InCommitTimestampEnablement;
@@ -718,7 +718,7 @@ fn get_earliest_published_commit_version(
     log_root: &Url,
     earliest_ratified_commit_version: Option<Version>,
 ) -> DeltaResult<Version> {
-    list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
+    list_delta_log_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
         .filter_ok(|f| f.file_type == LogPathFileType::Commit)
         .next()
         .transpose()?
@@ -768,7 +768,8 @@ fn get_earliest_recreatable_commit(
     let mut multi_part_checkpoint_progress = HashMap::<(Version, u32), HashSet<u32>>::new();
     let mut earliest_commit_version: Option<Version> = None;
 
-    let listing = list_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?;
+    let listing =
+        list_delta_log_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?;
     for parsed_result in listing {
         let parsed_log_path = parsed_result?;
         if !should_process_log_file(&parsed_log_path) {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -168,6 +168,9 @@ pub mod last_checkpoint_hint;
 #[cfg(not(feature = "internal-api"))]
 pub(crate) mod last_checkpoint_hint;
 
+#[cfg(feature = "internal-api")]
+pub mod log_segment_files;
+#[cfg(not(feature = "internal-api"))]
 pub(crate) mod log_segment_files;
 
 pub mod history_manager;

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -1,19 +1,14 @@
 //! [`LogSegmentFiles`] is a struct holding the result of listing the delta log. Currently, it
 //! exposes four APIs for listing:
-//! 1. [`list_commits`]: Lists all commit files between the provided start and end versions.
-//! 2. [`list`]: Lists all commit and checkpoint files between the provided start and end versions.
-//! 3. [`list_with_checkpoint_hint`]: Lists all commit and checkpoint files after the provided
+//! 1. `list_commits`: Lists all commit files between the provided start and end versions.
+//! 2. `list`: Lists all commit and checkpoint files between the provided start and end versions.
+//! 3. `list_with_checkpoint_hint`: Lists all commit and checkpoint files after the provided
 //!    checkpoint hint.
-//! 4. [`list_with_backward_checkpoint_scan`]: Scans backward from an end version in 1000-version
+//! 4. `list_with_backward_checkpoint_scan`: Scans backward from an end version in 1000-version
 //!    windows until a complete checkpoint is found or the log is exhausted.
 //!
 //! After listing, one can leverage the [`LogSegmentFiles`] to construct a [`LogSegment`].
 //!
-//! [`list_with_backward_checkpoint_scan`]: Self::list_with_backward_checkpoint_scan
-//!
-//! [`list_commits`]: Self::list_commits
-//! [`list`]: Self::list
-//! [`list_with_checkpoint_hint`]: Self::list_with_checkpoint_hint
 //! [`LogSegment`]: crate::log_segment::LogSegment
 
 use std::collections::HashMap;
@@ -66,8 +61,7 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
-/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
-/// not for common use.
+/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
 pub(crate) fn list_from_storage(
     storage: &dyn StorageHandler,
@@ -112,8 +106,7 @@ pub(crate) fn list_from_storage(
 ///
 /// NOTE: There could be a single-part and/or any number of uuid-based checkpoints. They
 /// are all equivalent, and this routine keeps only one of them (arbitrarily chosen).
-/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
-/// not for common use.
+/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
 fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedLogPath>> {
     let mut checkpoints: HashMap<u32, Vec<ParsedLogPath>> = HashMap::new();
@@ -180,8 +173,7 @@ fn find_complete_checkpoint_version(ascending_files: &[ParsedLogPath]) -> Option
 /// Compaction and checkpoint files are skipped when empty -- they have fallbacks
 /// (individual commits, older checkpoints). Commit and CRC files are kept even
 /// if empty; the warning ensures the corrupt file is identifiable in logs.
-/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
-/// not for common use.
+/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
 pub(crate) fn should_process_log_file(file: &ParsedLogPath) -> bool {
     if file.location.size > 0 {

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -61,9 +61,8 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
-/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
-pub(crate) fn list_from_storage(
+pub(crate) fn list_delta_log_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,
@@ -106,7 +105,6 @@ pub(crate) fn list_from_storage(
 ///
 /// NOTE: There could be a single-part and/or any number of uuid-based checkpoints. They
 /// are all equivalent, and this routine keeps only one of them (arbitrarily chosen).
-/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
 fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedLogPath>> {
     let mut checkpoints: HashMap<u32, Vec<ParsedLogPath>> = HashMap::new();
@@ -173,7 +171,6 @@ fn find_complete_checkpoint_version(ascending_files: &[ParsedLogPath]) -> Option
 /// Compaction and checkpoint files are skipped when empty -- they have fallbacks
 /// (individual commits, older checkpoints). Commit and CRC files are kept even
 /// if empty; the warning ensures the corrupt file is identifiable in logs.
-/// Exposed as internal-api for connectors to do log cleanup.
 #[internal_api]
 pub(crate) fn should_process_log_file(file: &ParsedLogPath) -> bool {
     if file.location.size > 0 {
@@ -493,7 +490,7 @@ impl LogSegmentFiles {
         );
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
-        let fs_iter = list_from_storage(storage, log_root, start, end)?;
+        let fs_iter = list_delta_log_from_storage(storage, log_root, start, end)?;
 
         let log_tail_start_version = log_tail.first().map(|f| f.version);
         let mut listed_commits = Vec::new();
@@ -555,7 +552,7 @@ impl LogSegmentFiles {
     ) -> DeltaResult<Self> {
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
-        let fs_iter = list_from_storage(storage, log_root, start, end)?;
+        let fs_iter = list_delta_log_from_storage(storage, log_root, start, end)?;
         Self::build_log_segment_files(fs_iter, log_tail, start, end_version)
     }
 
@@ -630,13 +627,13 @@ impl LogSegmentFiles {
         let mut windows: Vec<Vec<ParsedLogPath>> = Vec::new();
         let mut found_checkpoint_version: Option<Version> = None;
         // upper is the exclusive upper bound of the next window; adding 1 includes end_version
-        // in the first window. The inclusive range passed to list_from_storage is [lower, upper -
-        // 1].
+        // in the first window. The inclusive range passed to list_delta_log_from_storage is
+        // [lower, upper - 1].
         let mut upper = end_version + 1;
         while upper > 0 {
             let lower = upper.saturating_sub(BACKWARD_SCAN_WINDOW_SIZE);
             let window_files: Vec<_> =
-                list_from_storage(storage, log_root, lower, upper - 1)?.try_collect()?;
+                list_delta_log_from_storage(storage, log_root, lower, upper - 1)?.try_collect()?;
 
             found_checkpoint_version = find_complete_checkpoint_version(&window_files);
             windows.push(window_files);

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -66,6 +66,9 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
+/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
+/// not for common use.
+#[internal_api]
 pub(crate) fn list_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
@@ -109,6 +112,9 @@ pub(crate) fn list_from_storage(
 ///
 /// NOTE: There could be a single-part and/or any number of uuid-based checkpoints. They
 /// are all equivalent, and this routine keeps only one of them (arbitrarily chosen).
+/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
+/// not for common use.
+#[internal_api]
 fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedLogPath>> {
     let mut checkpoints: HashMap<u32, Vec<ParsedLogPath>> = HashMap::new();
     for part_file in parts {
@@ -174,6 +180,9 @@ fn find_complete_checkpoint_version(ascending_files: &[ParsedLogPath]) -> Option
 /// Compaction and checkpoint files are skipped when empty -- they have fallbacks
 /// (individual commits, older checkpoints). Commit and CRC files are kept even
 /// if empty; the warning ensures the corrupt file is identifiable in logs.
+/// Low-level helper exposed as internal-api for connectors doing customized log cleanup only;
+/// not for common use.
+#[internal_api]
 pub(crate) fn should_process_log_file(file: &ParsedLogPath) -> bool {
     if file.location.size > 0 {
         return true;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose several internal apis for connectors to do log cleanup

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
n/a