### PR TITLE
feat: enable reading tables with geospatial columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
 - `interval-type-in-dev` -- ANSI interval type support (experimental, in development). With the
   cargo feature off, creating or writing tables with interval columns is blocked; reads are
   unaffected.
+- `geo-type-in-dev` -- geospatial type support (geometry and geography columns) (experimental,
+  in development). Gates `KernelSupport` for the `geospatial` reader+writer feature: with the
+  cargo feature off, any table listing it is rejected; with it on, scans and CDF are supported
+  but writes are still blocked.
 - `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
 - `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost
@@ -264,9 +268,9 @@ is the source of truth. Key concepts:
   `clustering`, `domainMetadata`, `generatedColumns`, `icebergCompatV1`, `icebergCompatV2`,
   `icebergCompatV3`, `identityColumns`, `inCommitTimestamp`, `invariants`, `rowTracking`
 - Reader + writer: `adaptiveMetadata-preview`, `catalogManaged`, `catalogOwned-preview`,
-  `columnMapping`, `deletionVectors`, `timestampNtz`, `typeWidening`, `v2Checkpoint`,
-  `vacuumProtocolCheck`, `variantShredding`, `variantShredding-preview`, `variantType`,
-  `variantType-preview`
+  `columnMapping`, `deletionVectors`, `geospatial`, `timestampNtz`,
+  `typeWidening`, `v2Checkpoint`, `vacuumProtocolCheck`, `variantShredding`,
+  `variantShredding-preview`, `variantType`, `variantType-preview`
 
 Keep this list updated when new protocol features are added to kernel.
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -26,6 +26,8 @@ use crate::schema::void_utils::strip_void_from_schema;
 use crate::schema::{
     schema_has_invariants, validate_column_defaults_metadata, SchemaRef, StructField, StructType,
 };
+#[cfg(feature = "geo-type-in-dev")]
+use crate::table_features::validate_geospatial_feature_support;
 use crate::table_features::{
     check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
     get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
@@ -222,6 +224,9 @@ impl TableConfiguration {
         // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a non-`NULL`
         // default on a Variant column).
         validate_column_defaults_metadata(&table_config.logical_schema)?;
+        // Reject tables with geo-typed columns that don't declare the `geospatial` feature.
+        #[cfg(feature = "geo-type-in-dev")]
+        validate_geospatial_feature_support(&table_config)?;
         validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
 
         Ok(table_config)
@@ -1695,6 +1700,13 @@ mod test {
             7,
         );
         assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+
+        #[cfg(feature = "geo-type-in-dev")]
+        {
+            let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+            assert!(config.ensure_operation_supported(Operation::Scan).is_ok());
+            assert!(config.ensure_operation_supported(Operation::Cdf).is_ok());
+        }
     }
 
     #[test]
@@ -1716,6 +1728,28 @@ mod test {
         assert_result_error_with_message(
             config.ensure_operation_supported(Operation::Write),
             r#"Feature 'typeWidening' is not supported for writes"#,
+        );
+
+        #[cfg(feature = "geo-type-in-dev")]
+        {
+            let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+            assert_result_error_with_message(
+                config.ensure_operation_supported(Operation::Write),
+                r#"Feature 'geospatial' is not supported for writes"#,
+            );
+        }
+    }
+
+    #[cfg(not(feature = "geo-type-in-dev"))]
+    #[rstest]
+    #[case::scan(Operation::Scan)]
+    #[case::cdf(Operation::Cdf)]
+    #[case::write(Operation::Write)]
+    fn test_geospatial_not_supported_without_cargo_feature(#[case] operation: Operation) {
+        let config = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+        assert_result_error_with_message(
+            config.ensure_operation_supported(operation),
+            "Feature 'geospatial' is not supported",
         );
     }
 

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -1,0 +1,120 @@
+//! Validation logic for the `geospatial` table feature.
+
+use super::TableFeature;
+use crate::schema::{PrimitiveType, Schema};
+use crate::table_configuration::TableConfiguration;
+use crate::transforms::{transform_output_type, SchemaTransform};
+use crate::utils::require;
+use crate::{DeltaResult, Error};
+
+/// Returns `true` if the schema contains at least one geometry or geography column,
+/// including nested structs, arrays, and maps.
+fn schema_contains_geospatial(schema: &Schema) -> bool {
+    UsesGeo.transform_struct(schema).is_err()
+}
+
+struct UsesGeo;
+
+impl<'a> SchemaTransform<'a> for UsesGeo {
+    transform_output_type!(|'a, T| Result<(), ()>);
+
+    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Result<(), ()> {
+        match ptype {
+            PrimitiveType::Geometry(_) | PrimitiveType::Geography(_) => Err(()),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Validates that if a table schema contains geometry or geography columns, the table must have
+/// the `geospatial` feature in both reader and writer features.
+pub(crate) fn validate_geospatial_feature_support(tc: &TableConfiguration) -> DeltaResult<()> {
+    if schema_contains_geospatial(&tc.logical_schema()) {
+        require!(
+            tc.protocol().has_table_feature(&TableFeature::GeospatialType),
+            Error::unsupported(
+                "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features"
+            )
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::actions::Protocol;
+    use crate::schema::{
+        ArrayType, DataType, EdgeInterpolationAlgorithm, MapType, StructField, StructType,
+    };
+    use crate::utils::test_utils::{
+        assert_schema_feature_validation, geography_type, geometry_type,
+    };
+
+    fn schema_with_field(dt: DataType) -> StructType {
+        StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("g", dt, true),
+        ])
+    }
+
+    #[rstest]
+    #[case::top_level_geometry(schema_with_field(geometry_type("EPSG:4326")), true)]
+    #[case::nested_struct(
+        schema_with_field(DataType::Struct(Box::new(StructType::new_unchecked([
+            StructField::new("inner_geo", geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical), true),
+        ])))),
+        true
+    )]
+    #[case::in_array(schema_with_field(ArrayType::new(geometry_type("EPSG:4326"), true).into()), true)]
+    #[case::in_map(
+        schema_with_field(MapType::new(DataType::STRING, geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical), true).into()),
+        true
+    )]
+    #[case::no_geo(schema_with_field(DataType::STRING), false)]
+    fn test_schema_contains_geospatial(#[case] schema: StructType, #[case] expected: bool) {
+        assert_eq!(schema_contains_geospatial(&schema), expected);
+    }
+
+    #[test]
+    fn test_geospatial_feature_validation() {
+        let schema_with_geotype = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("geom", geometry_type("EPSG:4326"), true),
+        ]);
+        let schema_without_geotype = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new("name", DataType::STRING, true),
+        ]);
+        let nested_schema_with_geotype = StructType::new_unchecked([
+            StructField::new("id", DataType::INTEGER, false),
+            StructField::new(
+                "nested",
+                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
+                    "inner_geo",
+                    geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical),
+                    true,
+                )]))),
+                true,
+            ),
+        ]);
+        let protocol_with_geotype = Protocol::try_new_modern(
+            [TableFeature::GeospatialType],
+            [TableFeature::GeospatialType],
+        )
+        .unwrap();
+        let protocol_without_geotype =
+            Protocol::try_new_modern(TableFeature::EMPTY_LIST, TableFeature::EMPTY_LIST).unwrap();
+
+        assert_schema_feature_validation(
+            &schema_with_geotype,
+            &schema_without_geotype,
+            &protocol_with_geotype,
+            &protocol_without_geotype,
+            &[&nested_schema_with_geotype],
+            "Table contains geometry or geography columns but does not have the required 'geospatial' feature in reader and writer features",
+        );
+    }
+}

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -12,6 +12,8 @@ pub(crate) use column_mapping::{
     validate_column_mapping_id, StaleAnnotationPolicy,
 };
 use delta_kernel_derive::internal_api;
+#[cfg(feature = "geo-type-in-dev")]
+pub(crate) use geospatial::validate_geospatial_feature_support;
 pub(crate) use iceberg_compat::v3::{iceberg_compat_v3_column_defaults_validation, V3_VALIDATOR};
 pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
@@ -30,6 +32,8 @@ use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 mod column_mapping;
+#[cfg(feature = "geo-type-in-dev")]
+mod geospatial;
 mod iceberg_compat;
 mod timestamp_ntz;
 
@@ -169,6 +173,10 @@ pub(crate) enum TableFeature {
     #[strum(serialize = "adaptiveMetadata-preview")]
     #[serde(rename = "adaptiveMetadata-preview")]
     AdaptiveMetadataPreview,
+    /// Geospatial type support (geometry and geography columns)
+    #[strum(serialize = "geospatial")]
+    #[serde(rename = "geospatial")]
+    GeospatialType,
 
     #[serde(untagged)]
     #[strum(default)]
@@ -658,6 +666,23 @@ static ADAPTIVE_METADATA_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
+// TODO(#2949): drop the `geo-type-in-dev` gate once full geospatial support ships.
+static GEOSPATIAL_TYPE_INFO: FeatureInfo = FeatureInfo {
+    feature_type: FeatureType::ReaderWriter,
+    min_legacy_version: None,
+    feature_requirements: &[],
+    #[cfg(feature = "geo-type-in-dev")]
+    kernel_support: KernelSupport::Custom(|_, _, op| match op {
+        Operation::Scan | Operation::Cdf => Ok(()),
+        Operation::Write => Err(Error::unsupported(
+            "Feature 'geospatial' is not supported for writes",
+        )),
+    }),
+    #[cfg(not(feature = "geo-type-in-dev"))]
+    kernel_support: KernelSupport::NotSupported,
+    enablement_check: EnablementCheck::AlwaysIfSupported,
+};
+
 /// By definition, kernel cannot know how to handle unknown features and must assume they're always
 /// enabled if supported in protocol. However, the read path ignores all writer-only features,
 /// including unknown ones. Unknown features are never inferred from legacy protocol versions.
@@ -690,7 +715,8 @@ impl TableFeature {
             | TableFeature::VariantTypePreview
             | TableFeature::VariantShredding
             | TableFeature::VariantShreddingPreview
-            | TableFeature::AdaptiveMetadataPreview => FeatureType::ReaderWriter,
+            | TableFeature::AdaptiveMetadataPreview
+            | TableFeature::GeospatialType => FeatureType::ReaderWriter,
             TableFeature::AppendOnly
             | TableFeature::DomainMetadata
             | TableFeature::Invariants
@@ -758,6 +784,7 @@ impl TableFeature {
             TableFeature::VariantShredding => &VARIANT_SHREDDING_INFO,
             TableFeature::VariantShreddingPreview => &VARIANT_SHREDDING_PREVIEW_INFO,
             TableFeature::AdaptiveMetadataPreview => &ADAPTIVE_METADATA_PREVIEW_INFO,
+            TableFeature::GeospatialType => &GEOSPATIAL_TYPE_INFO,
 
             // Unknown features: not supported by kernel, no legacy version inference.
             TableFeature::Unknown(_) => &UNKNOWN_FEATURE_INFO,
@@ -1072,6 +1099,7 @@ mod tests {
                 TableFeature::VariantShreddingPreview => "variantShredding-preview",
                 TableFeature::AdaptiveMetadataPreview => "adaptiveMetadata-preview",
                 TableFeature::AllowColumnDefaults => "allowColumnDefaults",
+                TableFeature::GeospatialType => "geospatial",
                 TableFeature::Unknown(_) => continue, // tested in test_unknown_features
             };
 


### PR DESCRIPTION

## What changes are proposed in this pull request?

-  Added a Geospatial table feature for GeoType. Without enabling feature flag, read and write is not supported for the GeoType. Under the feature flag, the kernel support Read and CDF while not supporting write.
- Added a schema visitor, verifying that table having Geography or Geometry columns without Geospatial feature will be rejected to read.

## How was this change tested?
- New unit test was added.
