### PR TITLE
feat: Add base Structs for modelling AMT

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -4,8 +4,8 @@ use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, Data, DataStruct, DeriveInput, Error, Expr, ExprLit, Fields, Item, Lit,
-    Meta, PathArguments, Token, Type, Visibility,
+    parse_macro_input, Attribute, Data, DataStruct, DeriveInput, Error, Expr, ExprLit, Field,
+    Fields, Item, Lit, Meta, PathArguments, Token, Type, Visibility,
 };
 
 mod schema_macro;
@@ -122,7 +122,19 @@ fn validate_single_segment(segment: &str, span: Span) -> Result<(), Error> {
 /// the values of the container (i.e. a `key` -> `null` in a `HashMap`). Therefore the schema should
 /// mark the value field as nullable, but those mappings will be dropped when converting to an
 /// actual rust `HashMap`. Currently this can _only_ be set on `HashMap` fields.
-#[proc_macro_derive(ToSchema, attributes(allow_null_container_values))]
+///
+/// Supported field attributes:
+/// - `#[field_id = N]`: Sets the Parquet field ID for this field.
+/// - `#[element_field_id = N]`: Sets the Parquet field ID for the element of a list field. Stored
+///   as `ColumnMappingNestedIds` metadata (`{"fieldName.element": N}`) on the parent `StructField`
+///   and propagated to the inner Arrow list element during schema conversion. The generated code
+///   references `serde_json::json!`, which must be available at the expansion site.
+/// - `#[allow_null_container_values]`: Marks the value field of a `HashMap` as nullable.
+/// - `#[skip_schema]`: Excludes this field from the generated schema.
+#[proc_macro_derive(
+    ToSchema,
+    attributes(allow_null_container_values, field_id, element_field_id, skip_schema)
+)]
 pub fn derive_to_schema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let struct_ident = input.ident;
@@ -166,6 +178,46 @@ fn get_schema_name(name: &Ident) -> Ident {
     Ident::new(&ret, name.span())
 }
 
+fn get_named_attr_id(
+    field_attributes: &[Attribute],
+    attr_name: &str,
+) -> Result<Option<i64>, Error> {
+    field_attributes
+        .iter()
+        .filter_map(|attr| match &attr.meta {
+            Meta::NameValue(nv) => Some(nv),
+            _ => None,
+        })
+        .find(|nv| matches!(nv.path.get_ident(), Some(ident) if ident == attr_name))
+        .map(|nv| {
+            let span = nv.value.span();
+            match &nv.value {
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: Lit::Int(lit_int),
+                    ..
+                }) => lit_int.base10_parse().map_err(|e| {
+                    Error::new(
+                        lit_int.span(),
+                        format!("{} error: Failed to parse integer: {}", attr_name, e),
+                    )
+                }),
+                _ => Err(Error::new(
+                    span,
+                    format!("{} error: Expected an integer", attr_name),
+                )),
+            }
+        })
+        .transpose() // Convert Option<Result<T, E>> to Result<Option<T>, E>
+}
+
+fn get_field_id(field_attributes: &[Attribute]) -> Result<Option<i64>, Error> {
+    get_named_attr_id(field_attributes, "field_id")
+}
+
+fn get_element_field_id(field_attributes: &[Attribute]) -> Result<Option<i64>, Error> {
+    get_named_attr_id(field_attributes, "element_field_id")
+}
+
 /// Check if a path segment is `Option<HashMap<K, V>>`.
 fn is_option_of_hashmap(seg: &syn::PathSegment) -> bool {
     if seg.ident != "Option" {
@@ -186,6 +238,99 @@ fn is_option_of_hashmap(seg: &syn::PathSegment) -> bool {
         .is_some_and(|seg| seg.ident == "HashMap")
 }
 
+fn gen_schema_field(field: &Field) -> TokenStream {
+    let name = get_schema_name(field.ident.as_ref().unwrap());
+    let have_schema_null = field.attrs.iter().any(|attr| {
+        // check if we have allow_null_container_values attr
+        match &attr.meta {
+            Meta::Path(path) => path
+                .get_ident()
+                .is_some_and(|ident| ident == "allow_null_container_values"),
+            _ => false,
+        }
+    });
+
+    match field.ty {
+        Type::Path(ref type_path) => {
+            // Convert the type path segments into a single quoted string
+            let type_path_quoted = type_path.path.segments.iter().map(|segment| {
+                let segment_ident = &segment.ident;
+                match &segment.arguments {
+                    PathArguments::None => quote! { #segment_ident :: },
+                    PathArguments::AngleBracketed(angle_args) => {
+                        quote! { #segment_ident::#angle_args :: }
+                    }
+                    _ => Error::new(
+                        segment.arguments.span(),
+                        "Can only handle <> type path args",
+                    )
+                    .to_compile_error(),
+                }
+            });
+
+            // First, determine which base function to call based on schema_null setting
+            let base_call = if have_schema_null {
+                if let Some(last_seg) = type_path.path.segments.last() {
+                    let is_valid = last_seg.ident == "HashMap" || is_option_of_hashmap(last_seg);
+                    if !is_valid {
+                        return Error::new(
+                            last_seg.ident.span(),
+                            format!(
+                                "Can only use allow_null_container_values on HashMap or \
+                                 Option<HashMap> fields, not {}",
+                                last_seg.ident
+                            ),
+                        )
+                        .to_compile_error();
+                    }
+                }
+                quote_spanned! { field.span() => #(#type_path_quoted)* get_nullable_container_struct_field(stringify!(#name)) }
+            } else {
+                quote_spanned! { field.span() => #(#type_path_quoted)* get_struct_field(stringify!(#name)) }
+            };
+
+            // Then, add field-id and element-field-id metadata if present
+            let field_id = match get_field_id(&field.attrs) {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error(),
+            };
+            let element_field_id = match get_element_field_id(&field.attrs) {
+                Ok(v) => v,
+                Err(e) => return e.to_compile_error(),
+            };
+
+            let with_field_id = if let Some(id) = field_id {
+                quote_spanned! { field.span() => #base_call.add_metadata([(delta_kernel::schema::ColumnMetadataKey::ParquetFieldId.as_ref(), #id)]) }
+            } else {
+                quote_spanned! { field.span() => #base_call }
+            };
+
+            if let Some(elem_id) = element_field_id {
+                let nested_key = format!("{}.element", name);
+                quote_spanned! { field.span() =>
+                    #with_field_id.add_metadata([(
+                        delta_kernel::schema::ColumnMetadataKey::ColumnMappingNestedIds.as_ref().to_string(),
+                        delta_kernel::schema::MetadataValue::Other(
+                            serde_json::json!({ #nested_key: #elem_id })
+                        )
+                    )])
+                }
+            } else {
+                with_field_id
+            }
+        }
+        _ => Error::new(field.span(), format!("Can't handle type: {:?}", field.ty))
+            .to_compile_error(),
+    }
+}
+
+fn has_skip_schema(field: &Field) -> bool {
+    field.attrs.iter().any(|attr| match &attr.meta {
+        Meta::Path(path) => path.get_ident().is_some_and(|ident| ident == "skip_schema"),
+        _ => false,
+    })
+}
+
 fn gen_schema_fields(data: &Data) -> TokenStream {
     let fields = match data {
         Data::Struct(DataStruct {
@@ -201,46 +346,10 @@ fn gen_schema_fields(data: &Data) -> TokenStream {
         }
     };
 
-    let schema_fields = fields.iter().map(|field| {
-        let name = field.ident.as_ref().unwrap(); // we know these are named fields
-        let name = get_schema_name(name);
-        let have_schema_null = field.attrs.iter().any(|attr| {
-            // check if we have allow_null_container_values attr
-            match &attr.meta {
-                Meta::Path(path) => path.get_ident().is_some_and(|ident| ident == "allow_null_container_values"),
-                _ => false,
-            }
-        });
-
-        match field.ty {
-            Type::Path(ref type_path) => {
-                let type_path_quoted = type_path.path.segments.iter().map(|segment| {
-                    let segment_ident = &segment.ident;
-                    match &segment.arguments {
-                        PathArguments::None => quote! { #segment_ident :: },
-                        PathArguments::AngleBracketed(angle_args) => quote! { #segment_ident::#angle_args :: },
-                        _ => Error::new(segment.arguments.span(), "Can only handle <> type path args").to_compile_error()
-                    }
-                });
-                if have_schema_null {
-                    if let Some(last_seg) = type_path.path.segments.last() {
-                        let is_valid =
-                            last_seg.ident == "HashMap" || is_option_of_hashmap(last_seg);
-                        if !is_valid {
-                            return Error::new(
-                                last_seg.ident.span(),
-                                format!("Can only use allow_null_container_values on HashMap or Option<HashMap> fields, not {}", last_seg.ident)
-                            ).to_compile_error()
-                        }
-                    }
-                    quote_spanned! { field.span() => #(#type_path_quoted)* get_nullable_container_struct_field(stringify!(#name))}
-                } else {
-                    quote_spanned! { field.span() => #(#type_path_quoted)* get_struct_field(stringify!(#name))}
-                }
-            }
-            _ => Error::new(field.span(), format!("Can't handle type: {:?}", field.ty)).to_compile_error()
-        }
-    });
+    let schema_fields = fields
+        .iter()
+        .filter(|f| !has_skip_schema(f))
+        .map(gen_schema_field);
     quote! { #(#schema_fields),* }
 }
 

--- a/kernel/src/content_tree/mod.rs
+++ b/kernel/src/content_tree/mod.rs
@@ -1,3 +1,329 @@
 //! Adaptive Metadata Tree (AMT) support.
+// TODO: remove these allows once the AMT read/write paths consume these types and the public
+// types are re-exported from the crate root.
+#![allow(dead_code)]
+#![allow(unreachable_pub)]
 
 pub(crate) mod stats;
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use delta_kernel_derive::{IntoEngineData, ToSchema};
+use url::Url;
+
+use crate::engine_data::EngineData;
+use crate::expressions::{Scalar, StructData};
+use crate::schema::derive_macro_utils::ToDataType;
+use crate::schema::DataType;
+use crate::Version;
+
+/// Field names in the [`ContentTreeNodeEntry`] schema.
+pub(crate) const CONTENT_TYPE: &str = "contentType";
+pub(crate) const LOCATION: &str = "location";
+pub(crate) const FILE_FORMAT: &str = "fileFormat";
+pub(crate) const TRACKING: &str = "tracking";
+pub(crate) const DV_INFO: &str = "deletionVector";
+pub(crate) const PARTITION_SPEC_ID: &str = "specId";
+pub(crate) const PARTITION: &str = "partition";
+pub(crate) const SORT_ORDER_ID: &str = "sortOrderId";
+pub(crate) const RECORD_COUNT: &str = "recordCount";
+pub(crate) const FILE_SIZE_IN_BYTES: &str = "fileSizeInBytes";
+pub(crate) const CONTENT_STATS_FIELD_NAME: &str = "content_stats";
+pub(crate) const MANIFEST_INFO: &str = "manifestInfo";
+pub(crate) const KEY_METADATA: &str = "keyMetadata";
+pub(crate) const SPLIT_OFFSETS: &str = "splitOffsets";
+pub(crate) const EQUALITY_IDS: &str = "equalityIds";
+pub(crate) const TAGS: &str = "tags";
+
+/// Field names for the different fields within content_stats.
+pub(crate) const LOWER_BOUND: &str = "lower_bound";
+pub(crate) const UPPER_BOUND: &str = "upper_bound";
+pub(crate) const TIGHT_BOUNDS: &str = "tight_bounds";
+pub(crate) const VALUE_COUNT: &str = "value_count";
+pub(crate) const NULL_VALUE_COUNT: &str = "null_value_count";
+pub(crate) const NAN_VALUE_COUNT: &str = "nan_value_count";
+pub(crate) const AVG_VALUE_SIZE_IN_BYTES: &str = "avg_value_size_in_bytes";
+
+/// In memory reprsentation of a node in the Adaptive Metadata Tree (AMT) format.
+///
+/// This used as an intermediate structure for both reading and writing AMT nodes.
+pub(super) struct ContentTreeNode {
+    // Collection of EngineData in the node. For root nodes this can contain
+    // both data files and manifest references.
+    data: Vec<Box<dyn EngineData>>,
+    // The delta table version this tree was constructed at.
+    version: Version,
+    /// URL that paths stored in this node are relative to.
+    table_root: Url,
+    /// The exact path string as it appears in the Delta log (from contentRoot action) or manifest
+    /// location field in the AMT root. This is NOT normalized or converted - it flows through
+    /// exactly as stored in the log. Empty string for newly built metadata that hasn't been
+    /// written yet.
+    path_in_log: String,
+}
+
+/// Sub-struct of ContentTreeNodeEnty that hold information about
+/// deletion vector applied to data files.
+#[derive(Debug, Clone, ToSchema, IntoEngineData)]
+pub(crate) struct DeletionVectorInfo {
+    /// Path to location that DV is stored in.
+    #[field_id = 155]
+    pub(crate) location: String,
+
+    /// The offset in the file where the content starts.
+    #[field_id = 144]
+    pub(crate) offset: i64,
+
+    /// The length of the referenced content stored in the file;
+    /// required if content_offset is present.
+    #[field_id = 145]
+    pub(crate) size_in_bytes: i64,
+
+    /// Number of set bits (deleted rows) in the deletion vector.
+    #[field_id = 156]
+    pub(crate) cardinality: i64,
+}
+
+/// Sub-struct of ContentTreeNodeEntry that tracks details
+/// of the history of a file in the AMT (its current state,
+/// a sequence number for when it was added, etc).
+#[derive(Debug, Clone, ToSchema, IntoEngineData)]
+pub struct TrackingInfo {
+    /// Whether this entry is added, existing, or deleted.
+    #[field_id = 0]
+    pub(crate) status: TrackingStatus,
+
+    /// Snapshot ID where the file was added, or deleted if status is 2. Inherited when null.
+    /// Must be written in the root file.
+    #[field_id = 1]
+    pub snapshot_id: Option<i64>,
+
+    /// Snapshot ID in which this entry's deletion vector last changed. Set on Modified entries.
+    #[field_id = 5]
+    pub(crate) dv_snapshot_id: Option<i64>,
+
+    /// Data sequence number of the file. Inherited in when null and status is 1 (added).
+    /// Must be equal to file_sequence_number if content_type is {Data,Delete}Manifest.
+    /// Must be written in the root file.
+    #[field_id = 3]
+    pub(crate) sequence_number: Option<i64>,
+
+    /// File sequence number indicating when the file was added. Inherited when null and status is
+    /// added. Must be equal to sequence_number if content_type is {Data,Delete}Manifest.
+    #[field_id = 4]
+    pub(crate) file_sequence_number: Option<i64>,
+
+    /// The _row_id for the first row in the data file if content_type is Data.
+    /// If content_type is DataManifest, this is the starting _row_id to assign to rows added by
+    /// ADDED data files.
+    #[field_id = 142]
+    pub(crate) first_row_id: Option<i64>,
+
+    /// Positions deleted from this manifest in the current commit. Cleared between commits.
+    #[field_id = 6]
+    pub(crate) deleted_positions: Option<Bytes>,
+
+    /// Positions replaced (DV changed) in this manifest in the current commit. Cleared between
+    /// commits.
+    // TODO: always null until DvCache tracks replaced positions in a later change.
+    #[field_id = 7]
+    pub(crate) replaced_positions: Option<Bytes>,
+}
+
+/// Represents the an entry/row in a ContentTree node.
+#[derive(Debug, Clone, ToSchema)]
+pub(super) struct ContentTreeNodeEntry {
+    /// Type of content stored by the entry.
+    /// DataManifest, DeleteManifest or ManifestDV can only be defined in the root manifest.
+    #[field_id = 134]
+    pub content_type: DataContentType,
+
+    /// Location of the file. Required for most content types.
+    #[field_id = 100]
+    pub location: Option<String>,
+
+    /// avro, orc, parquet or puffin
+    #[field_id = 101]
+    pub(crate) file_format: DataFileFormat,
+
+    #[field_id = 147]
+    pub tracking: TrackingInfo,
+
+    #[field_id = 148]
+    pub(crate) deletion_vector: Option<DeletionVectorInfo>,
+
+    /// ID of partition spec used to write manifest or data/delete files.
+    #[field_id = 141]
+    pub(crate) spec_id: i32,
+
+    /// Partition data tuple, schema based on the partition spec. Required (non-nullable)
+    /// when present in the schema. The schema is dynamically generated based on the
+    /// partition spec via [`Self::to_schema_with_content_stats`]. When `None` in Rust,
+    /// a struct with null-valued fields is produced during serialization.
+    #[skip_schema]
+    #[field_id = 102]
+    pub(crate) partition: Option<StructData>,
+
+    /// ID representing sort order for this file. Can only be set if content_type is Data.
+    #[field_id = 140]
+    pub(crate) sort_order_id: Option<i32>,
+
+    /// Number of records in this file, or the cardinality of a deletion vector
+    #[field_id = 103]
+    pub(crate) record_count: i64,
+
+    /// Total file size in bytes. Must be defined if location is defined
+    #[field_id = 104]
+    pub(crate) file_size_in_bytes: Option<i64>,
+
+    /// Column-level statistics for the data file.
+    /// The schema of this struct is dynamically generated based on the table schema
+    /// using [`stats::stats_schema`]. When `None`, no statistics are available.
+    /// See: <https://docs.google.com/document/d/1uvbrwwAJW2TgsnoaIcwAFpjbhHkBUL5wY_24nKgtt9I/>
+    // Skip the schema since we don't know the type here, use to_schema_with_content_stats instead
+    #[skip_schema]
+    #[field_id = 146]
+    pub(crate) content_stats: Option<StructData>,
+
+    /// Must be set if content_type is {Data,Delete}Manifest, otherwise null.
+    #[field_id = 150]
+    pub(crate) manifest_info: Option<ManifestInfo>,
+
+    /// Location of the data file if the content_type is  PositionDeletes
+    /// Location of affiliated data manifest if content_type is or DeleteManifest or null if delete
+    /// manifest is unaffiliated. TODO: place holder for referenced file which is no longer
+    /// necessary. #[field_id = 143]
+    /// pub referenced_file: `Option<String>`,
+
+    /// Implementation-specific key metadata for encryption
+    #[field_id = 131]
+    pub(crate) key_metadata: Option<Bytes>,
+
+    /// Split offsets for the data file. For example, all row group offsets in a Parquet file. Must
+    /// be sorted ascending
+    #[field_id = 132]
+    #[element_field_id = 133]
+    pub(crate) split_offsets: Option<Vec<i64>>,
+
+    /// Field ids used to determine row equality in equality delete files.
+    /// Required when content is EqualityDeletes and must be null otherwise.
+    /// Fields with ids listed in this column must be present in the delete file
+    #[field_id = 135]
+    #[element_field_id = 136]
+    pub(crate) equality_ids: Option<Vec<i32>>,
+
+    /// Metadata tags for this file, propagated from the Add action. Map values can be null.
+    ///
+    /// Unlike other entry fields, `tags` carries no Parquet field ID. It was added after the
+    /// initial Iceberg AMF schema was fixed, so it is matched by column name when reading.
+    /// TODO: assign a Parquet field ID dynamically based on Iceberg expressions once they are
+    /// supported in the AMF spec.
+    pub(crate) tags: Option<HashMap<String, Option<String>>>,
+}
+
+/// Type of content stored by the manifest entry
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum DataContentType {
+    Data = 0,
+    PositionDeletes = 1,
+    EqualityDeletes = 2,
+    // Types below are only allowed in the root
+    DataManifest = 3,   // manifest of data files with inline DV info
+    DeleteManifest = 4, // kept for backwards compat reading only
+}
+
+impl ToDataType for DataContentType {
+    fn to_data_type() -> DataType {
+        DataType::INTEGER
+    }
+}
+
+impl From<DataContentType> for Scalar {
+    fn from(value: DataContentType) -> Self {
+        Scalar::Integer(value as i32)
+    }
+}
+
+/// Format of this data.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum DataFileFormat {
+    /// Parquet file format: <https://parquet.apache.org/>
+    Parquet,
+    /// Puffin file format: <https://iceberg.apache.org/puffin-spec/>
+    Puffin,
+}
+
+impl ToDataType for DataFileFormat {
+    fn to_data_type() -> DataType {
+        DataType::STRING
+    }
+}
+
+impl From<DataFileFormat> for Scalar {
+    fn from(value: DataFileFormat) -> Self {
+        match value {
+            DataFileFormat::Parquet => Scalar::String("parquet".to_string()),
+            DataFileFormat::Puffin => Scalar::String("puffin".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TrackingStatus {
+    Existing = 0,
+    Added = 1,
+    Deleted = 2,
+    Replaced = 3,
+    Modified = 4,
+}
+
+impl ToDataType for TrackingStatus {
+    fn to_data_type() -> DataType {
+        DataType::INTEGER
+    }
+}
+
+impl From<TrackingStatus> for Scalar {
+    fn from(value: TrackingStatus) -> Self {
+        Scalar::Integer(value as i32)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, ToSchema, IntoEngineData)]
+pub(crate) struct ManifestInfo {
+    /// Number of entries with ADDED status in the manifest.
+    #[field_id = 504]
+    pub(crate) added_files_count: i32,
+    /// Number of entries with EXISTING status in the manifest.
+    #[field_id = 505]
+    pub(crate) existing_files_count: i32,
+    /// Number of entries with DELETED status in the manifest.
+    #[field_id = 506]
+    pub(crate) deleted_files_count: i32,
+    /// Number of entries with REPLACED status in the manifest.
+    #[field_id = 520]
+    pub(crate) replaced_files_count: i32,
+
+    /// Total row count across all ADDED entries in the manifest.
+    #[field_id = 512]
+    pub(crate) added_rows_count: i64,
+    /// Total row count across all EXISTING entries in the manifest.
+    #[field_id = 513]
+    pub(crate) existing_rows_count: i64,
+    /// Total row count across all DELETED entries in the manifest.
+    #[field_id = 514]
+    pub(crate) deleted_rows_count: i64,
+    /// Total row count across all REPLACED entries in the manifest.
+    #[field_id = 521]
+    pub(crate) replaced_rows_count: i64,
+
+    /// Minimum data sequence number of all entries in the manifest.
+    #[field_id = 516]
+    pub(crate) min_sequence_number: i64,
+
+    #[field_id = 522]
+    pub(crate) dv: Option<Bytes>,
+    #[field_id = 523]
+    pub(crate) dv_cardinality: Option<i64>,
+}

--- a/kernel/src/content_tree/mod.rs
+++ b/kernel/src/content_tree/mod.rs
@@ -217,7 +217,7 @@ pub(super) struct ContentTreeNodeEntry {
     #[nested_field_id = 136]
     pub(crate) equality_ids: Option<Vec<i32>>,
 
-    /// The AMT/Iceberg format version this entry was written at (Iceberg field id 157).
+    /// The AMT/Iceberg format version this entry was written at.
     #[field_id = 157]
     pub(crate) format_version: i32,
 

--- a/kernel/src/content_tree/mod.rs
+++ b/kernel/src/content_tree/mod.rs
@@ -34,6 +34,7 @@ pub(crate) const MANIFEST_INFO: &str = "manifestInfo";
 pub(crate) const KEY_METADATA: &str = "keyMetadata";
 pub(crate) const SPLIT_OFFSETS: &str = "splitOffsets";
 pub(crate) const EQUALITY_IDS: &str = "equalityIds";
+pub(crate) const FORMAT_VERSION: &str = "formatVersion";
 pub(crate) const TAGS: &str = "tags";
 
 /// Field names for the different fields within content_stats.
@@ -63,7 +64,7 @@ pub(super) struct ContentTreeNode {
     path_in_log: String,
 }
 
-/// Sub-struct of ContentTreeNodeEnty that hold information about
+/// Sub-struct of ContentTreeNodeEntry that hold information about
 /// deletion vector applied to data files.
 #[derive(Debug, Clone, ToSchema, IntoEngineData)]
 pub(crate) struct DeletionVectorInfo {
@@ -94,7 +95,7 @@ pub struct TrackingInfo {
     #[field_id = 0]
     pub(crate) status: TrackingStatus,
 
-    /// Snapshot ID where the file was added, or deleted if status is 2. Inherited when null.
+    /// Snapshot ID where the file was added, or deleted if status is 2. Inherited when `None`.
     /// Must be written in the root file.
     #[field_id = 1]
     pub snapshot_id: Option<i64>,
@@ -103,14 +104,14 @@ pub struct TrackingInfo {
     #[field_id = 5]
     pub(crate) dv_snapshot_id: Option<i64>,
 
-    /// Data sequence number of the file. Inherited in when null and status is 1 (added).
+    /// Data sequence number of the file. Inherited when `None` and status is 1 (added).
     /// Must be equal to file_sequence_number if content_type is {Data,Delete}Manifest.
     /// Must be written in the root file.
     #[field_id = 3]
     pub(crate) sequence_number: Option<i64>,
 
-    /// File sequence number indicating when the file was added. Inherited when null and status is
-    /// added. Must be equal to sequence_number if content_type is {Data,Delete}Manifest.
+    /// File sequence number indicating when the file was added. Inherited when `None` and status
+    /// is added. Must be equal to sequence_number if content_type is {Data,Delete}Manifest.
     #[field_id = 4]
     pub(crate) file_sequence_number: Option<i64>,
 
@@ -121,21 +122,23 @@ pub struct TrackingInfo {
     pub(crate) first_row_id: Option<i64>,
 
     /// Positions deleted from this manifest in the current commit. Cleared between commits.
+    /// Encoded as a serialized `RoaringBitmapArray` (the same portable RoaringBitmap framing used
+    /// for inline deletion vectors, see [`crate::actions::deletion_vector`]).
     #[field_id = 6]
     pub(crate) deleted_positions: Option<Bytes>,
 
     /// Positions replaced (DV changed) in this manifest in the current commit. Cleared between
-    /// commits.
-    // TODO: always null until DvCache tracks replaced positions in a later change.
+    /// commits. Encoded as a serialized `RoaringBitmapArray`, matching `deleted_positions`.
+    // TODO: always `None` until DvCache tracks replaced positions in a later change.
     #[field_id = 7]
     pub(crate) replaced_positions: Option<Bytes>,
 }
 
-/// Represents the an entry/row in a ContentTree node.
+/// Represents an entry/row in a ContentTree node.
 #[derive(Debug, Clone, ToSchema)]
 pub(super) struct ContentTreeNodeEntry {
     /// Type of content stored by the entry.
-    /// DataManifest, DeleteManifest or ManifestDV can only be defined in the root manifest.
+    /// DataManifest and DeleteManifest can only be defined in the root manifest.
     #[field_id = 134]
     pub content_type: DataContentType,
 
@@ -143,7 +146,8 @@ pub(super) struct ContentTreeNodeEntry {
     #[field_id = 100]
     pub location: Option<String>,
 
-    /// avro, orc, parquet or puffin
+    /// File format of the entry: `parquet` for data files or `puffin` for deletion vectors (the
+    /// only formats kernel supports). See [`DataFileFormat`].
     #[field_id = 101]
     pub(crate) file_format: DataFileFormat,
 
@@ -186,13 +190,13 @@ pub(super) struct ContentTreeNodeEntry {
     #[field_id = 146]
     pub(crate) content_stats: Option<StructData>,
 
-    /// Must be set if content_type is {Data,Delete}Manifest, otherwise null.
+    /// Must be set if content_type is {Data,Delete}Manifest, otherwise `None`.
     #[field_id = 150]
     pub(crate) manifest_info: Option<ManifestInfo>,
 
     /// Location of the data file if the content_type is  PositionDeletes
-    /// Location of affiliated data manifest if content_type is or DeleteManifest or null if delete
-    /// manifest is unaffiliated. TODO: place holder for referenced file which is no longer
+    /// Location of affiliated data manifest if content_type is or DeleteManifest or `None` if
+    /// delete manifest is unaffiliated. TODO: place holder for referenced file which is no longer
     /// necessary. #[field_id = 143]
     /// pub referenced_file: `Option<String>`,
 
@@ -207,11 +211,15 @@ pub(super) struct ContentTreeNodeEntry {
     pub(crate) split_offsets: Option<Vec<i64>>,
 
     /// Field ids used to determine row equality in equality delete files.
-    /// Required when content is EqualityDeletes and must be null otherwise.
+    /// Required when content is EqualityDeletes and must be `None` otherwise.
     /// Fields with ids listed in this column must be present in the delete file
     #[field_id = 135]
     #[element_field_id = 136]
     pub(crate) equality_ids: Option<Vec<i32>>,
+
+    /// The AMT/Iceberg format version this entry was written at (Iceberg field id 157).
+    #[field_id = 157]
+    pub(crate) format_version: i32,
 
     /// Metadata tags for this file, propagated from the Add action. Map values can be null.
     ///
@@ -322,8 +330,12 @@ pub(crate) struct ManifestInfo {
     #[field_id = 516]
     pub(crate) min_sequence_number: i64,
 
+    /// Serialized deletion vector covering the manifest's entries, or `None` when the manifest has
+    /// no associated deletion vector. Encoded as a serialized `RoaringBitmapArray`, matching the
+    /// framing used for [`TrackingInfo::deleted_positions`].
     #[field_id = 522]
     pub(crate) dv: Option<Bytes>,
+    /// Number of set bits (deleted rows) in [`Self::dv`], or `None` when `dv` is absent.
     #[field_id = 523]
     pub(crate) dv_cardinality: Option<i64>,
 }

--- a/kernel/src/schema/derive_macro_utils.rs
+++ b/kernel/src/schema/derive_macro_utils.rs
@@ -3,6 +3,7 @@
 /// Not intended for use by normal code.
 use std::collections::{HashMap, HashSet};
 
+use bytes::Bytes;
 use delta_kernel_derive::internal_api;
 
 use crate::schema::{ArrayType, DataType, MapType, StructField, ToSchema};
@@ -36,6 +37,7 @@ macro_rules! impl_to_data_type {
 
 impl_to_data_type!(
     (String, DataType::STRING),
+    (Bytes, DataType::BINARY),
     (i64, DataType::LONG),
     (i32, DataType::INTEGER),
     (i16, DataType::SHORT),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds basic structs for modelling the Adaptive metadata tree.  


## How was this change tested?

No functionality is added (outside of macro changes see code below).  So no tests are added future PRs will add test coverage as functionality is added.


Note: This relies on PR (https://github.com/delta-io/delta-kernel-rs/pull/2932) where the basic functionality is duplicated here.  The intent is to merge https://github.com/delta-io/delta-kernel-rs/pull/2932 first and remove related code from this PR.  Therefore reviewer should focus on content_tree code in this PR.
