### PR TITLE
feat: add UC Delta-Tables credential-vending wire types and client method

### DIFF
--- a/unity-catalog-delta-client-api/src/credentials.rs
+++ b/unity-catalog-delta-client-api/src/credentials.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,7 +34,7 @@ pub struct AwsTempCredentials {
     pub session_token: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Operation {
     Read,
@@ -48,5 +50,102 @@ impl std::fmt::Display for Operation {
             Operation::Write => write!(f, "WRITE"),
             Operation::ReadWrite => write!(f, "READ_WRITE"),
         }
+    }
+}
+
+// === Delta-Tables API credential-vending wire types ===
+//
+// Served by `GET .../tables/{table}/credentials`.
+// TODO: delete the legacy Delta-Commits `TemporaryTableCredentials` / `AwsTempCredentials` types
+// above once the read path swaps onto the Delta-Tables API.
+
+/// Response from a credential-vending endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialsResponse {
+    #[serde(rename = "storage-credentials")]
+    pub storage_credentials: Vec<StorageCredential>,
+}
+
+/// A single temporary cloud-storage credential scoped to a storage prefix.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct StorageCredential {
+    /// Storage path prefix this credential applies to, e.g. `"s3://bucket/path/"`.
+    pub prefix: String,
+    /// Permission level granted by this credential.
+    pub operation: Operation,
+    /// Credential expiration time in epoch milliseconds, or `None` when the server omits it.
+    #[serde(rename = "expiration-time-ms")]
+    pub expiration_time_ms: Option<i64>,
+    /// Cloud provider-specific credential configuration (e.g. `s3.access-key-id`,
+    /// `s3.secret-access-key`, `s3.session-token`, `azure.sas-token`, `gcs.oauth-token`).
+    pub config: HashMap<String, String>,
+}
+
+// Manual `Debug` that redacts `config`: it holds live secrets (`s3.secret-access-key`,
+// `azure.sas-token`, `gcs.oauth-token`) that must not leak into logs or error output.
+impl std::fmt::Debug for StorageCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageCredential")
+            .field("prefix", &self.prefix)
+            .field("operation", &self.operation)
+            .field("expiration_time_ms", &self.expiration_time_ms)
+            .field(
+                "config",
+                &format_args!("<{} redacted entries>", self.config.len()),
+            )
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_credential_decodes_empty_config_and_absent_expiration() {
+        // Local `file://` storage: the server sends an empty `config` object (no cloud keys
+        // apply) and omits the nullable `expiration-time-ms`.
+        let json = r#"{"prefix":"file:///tmp/t/","operation":"READ_WRITE","config":{}}"#;
+        let cred: StorageCredential = serde_json::from_str(json).unwrap();
+        assert_eq!(cred.operation, Operation::ReadWrite);
+        assert_eq!(cred.expiration_time_ms, None);
+        assert!(cred.config.is_empty());
+    }
+
+    #[test]
+    fn storage_credential_debug_redacts_config_secrets() {
+        let cred = StorageCredential {
+            prefix: "s3://b/t/".to_string(),
+            operation: Operation::Read,
+            expiration_time_ms: Some(123),
+            config: HashMap::from([(
+                "s3.secret-access-key".to_string(),
+                "supersecret".to_string(),
+            )]),
+        };
+        let debug = format!("{cred:?}");
+        assert!(
+            !debug.contains("supersecret"),
+            "secret leaked in Debug: {debug}"
+        );
+        assert!(debug.contains("redacted"));
+    }
+
+    #[test]
+    fn credentials_response_decodes_populated_body() {
+        let json = r#"{"storage-credentials":[{
+            "prefix":"s3://b/t/",
+            "operation":"READ",
+            "expiration-time-ms":123,
+            "config":{"s3.access-key-id":"ak","s3.secret-access-key":"sk"}
+        }]}"#;
+        let resp: CredentialsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.storage_credentials.len(), 1);
+        let cred = &resp.storage_credentials[0];
+        assert_eq!(cred.prefix, "s3://b/t/");
+        assert_eq!(cred.operation, Operation::Read);
+        assert_eq!(cred.expiration_time_ms, Some(123));
+        assert_eq!(cred.config["s3.access-key-id"], "ak");
+        assert_eq!(cred.config["s3.secret-access-key"], "sk");
     }
 }

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -28,7 +28,10 @@ pub mod models;
 pub use clients::{CommitClient, GetCommitsClient, UpdateTableClient};
 #[cfg(any(test, feature = "test-utils"))]
 pub use clients::{InMemoryCommitsClient, TableData};
-pub use credentials::{AwsTempCredentials, Operation, TemporaryTableCredentials};
+pub use credentials::{
+    AwsTempCredentials, CredentialsResponse, Operation, StorageCredential,
+    TemporaryTableCredentials,
+};
 pub use error::{Error, Result};
 pub use models::{
     CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse, DeltaTableRequirement,

--- a/unity-catalog-delta-rest-client/src/clients/uc_client.rs
+++ b/unity-catalog-delta-rest-client/src/clients/uc_client.rs
@@ -4,7 +4,7 @@
 use reqwest::StatusCode;
 use tracing::instrument;
 use unity_catalog_delta_client_api::{
-    CatalogConfig, LoadTableResponse, Operation, TemporaryTableCredentials,
+    CatalogConfig, CredentialsResponse, LoadTableResponse, Operation, TemporaryTableCredentials,
 };
 use url::Url;
 
@@ -13,6 +13,13 @@ use crate::error::Result;
 use crate::http::{build_http_client, execute_with_retry, handle_response};
 use crate::models::credentials::CredentialsRequest;
 use crate::models::tables::TablesResponse;
+
+/// Builds the Delta-Tables per-table resource path
+/// (`delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`) that the `load_table` and
+/// credential-vending endpoints share.
+fn table_path(catalog: &str, schema: &str, table: &str) -> String {
+    format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+}
 
 /// An HTTP client for interacting with the Unity Catalog API.
 #[derive(Debug, Clone)]
@@ -67,8 +74,7 @@ impl UCClient {
         schema: &str,
         table: &str,
     ) -> Result<LoadTableResponse> {
-        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}");
-        let url = self.base_url.join(&path)?;
+        let url = self.base_url.join(&table_path(catalog, schema, table))?;
 
         let response =
             execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;
@@ -99,6 +105,28 @@ impl UCClient {
         })
         .await?;
 
+        handle_response(response).await
+    }
+
+    /// Vend temporary cloud-storage credentials for the table via the Delta-Tables
+    /// `GET .../catalogs/{catalog}/schemas/{schema}/tables/{table}/credentials?operation=...`
+    /// endpoint.
+    // TODO: remove `get_credentials` once the read path swaps onto this Delta-Tables endpoint.
+    #[instrument(skip(self))]
+    pub async fn get_table_credentials(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        operation: Operation,
+    ) -> Result<CredentialsResponse> {
+        let path = format!("{}/credentials", table_path(catalog, schema, table));
+        let mut url = self.base_url.join(&path)?;
+        url.query_pairs_mut()
+            .append_pair("operation", &operation.to_string());
+
+        let response =
+            execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;
         handle_response(response).await
     }
 

--- a/unity-catalog-delta-rest-client/tests/integration_live_server.rs
+++ b/unity-catalog-delta-rest-client/tests/integration_live_server.rs
@@ -9,6 +9,7 @@
 //! 'test(live_)'
 #![cfg(feature = "integration-test")]
 
+use unity_catalog_delta_client_api::Operation;
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
 
 /// Reads the server URL + token from the environment, or `None` to skip the test.
@@ -93,4 +94,57 @@ async fn live_load_table_reads_metadata() {
         Some(0),
         "expected latest_table_version 0 for a freshly created table"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn live_get_table_credentials() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_get_table_credentials");
+        return;
+    };
+    let Some(table) = std::env::var("UC_TEST_TABLE").ok() else {
+        eprintln!("UC_TEST_TABLE unset; skipping live_get_table_credentials");
+        return;
+    };
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+    let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
+
+    let client = client(&url, &token);
+
+    let location = client
+        .load_table(&catalog, &schema, &table)
+        .await
+        .expect("load_table failed")
+        .metadata
+        .location;
+
+    let resp = client
+        .get_table_credentials(&catalog, &schema, &table, Operation::Read)
+        .await
+        .expect("get_table_credentials failed");
+
+    assert!(
+        !resp.storage_credentials.is_empty(),
+        "expected the server to vend at least one credential"
+    );
+    for cred in &resp.storage_credentials {
+        assert!(
+            cred.prefix.contains("://"),
+            "expected a storage-URL prefix, got {:?}",
+            cred.prefix
+        );
+        assert_eq!(
+            cred.operation,
+            Operation::Read,
+            "expected the vended credential to echo the requested operation"
+        );
+        let prefix = cred.prefix.trim_end_matches('/');
+        let table_location = location.trim_end_matches('/');
+        assert!(
+            table_location == prefix || table_location.starts_with(&format!("{prefix}/")),
+            "vended prefix {:?} should scope the table location {:?}",
+            cred.prefix,
+            location
+        );
+    }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2934/files) to review incremental changes.
- [**stack/uc-credentials**](https://github.com/delta-io/delta-kernel-rs/pull/2934) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2934/files)] ← _this PR_
  - [stack/uc-create-wire-types](https://github.com/delta-io/delta-kernel-rs/pull/2941) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2941/files/f16e03fe0ff66ec92b98517a1d98d3b12b44ad71..f384c8318061a9212f0ae6c5cf3d9817a9af620b)]
    - [stack/uc-core](https://github.com/delta-io/delta-kernel-rs/pull/2855) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2855/files/f384c8318061a9212f0ae6c5cf3d9817a9af620b..72270d2f0e9e614a661d4797a955c527b5147d8f)]
      - [stack/uc-api-v2](https://github.com/delta-io/delta-kernel-rs/pull/2826) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2826/files/72270d2f0e9e614a661d4797a955c527b5147d8f..7f3143cb0a1ad4b2368ceabd4729120bf6197a7b)]

---------
## What changes are proposed in this pull request?

Adds the Delta Tables API credential surface to the UC client crates. Once the read path swaps with the legacy UC API, we will delete the old credential equivalents.

## How was this change tested?

New UT, new integration test against the OSS UC server, existing UC client/kernel tests pass.
