### PR TITLE
feat: decouple data skipping from stats, add DataSkippingOptions

### DIFF
--- a/docs/user-guide/src/reading/filter_pushdown.md
+++ b/docs/user-guide/src/reading/filter_pushdown.md
@@ -218,7 +218,7 @@ connector. To override the default, call `ScanBuilder::with_stats` with a
 `StatsOptions` value. The named constructors cover the common shapes; you can also
 build the struct directly for any combination.
 
-### Disabling data skipping entirely
+### Disabling data-column skipping
 
 If your compute engine performs its own data skipping, you can tell Kernel to skip reading
 statistics altogether. This avoids the cost of parsing statistics from checkpoint files.
@@ -245,13 +245,19 @@ let scan = snapshot
 
 With `StatsOptions::none()`:
 
-- Kernel skips the stats column entirely during checkpoint reads.
-- No statistics-based or partition-value-based file pruning occurs (row-level
-  partition filtering still applies).
+- Kernel reads no statistics columns from checkpoint files, so no statistics-based (data-column)
+  file pruning occurs.
+- Partition pruning still applies when your predicate references a partition column. Partition
+  values come from each file's partition map, not from statistics, so Kernel can still drop files
+  whose partition values cannot match the predicate.
 - The `stats` field on each `ScanFile` is `None`.
 
-Use this when your connector or compute engine already handles file pruning and you want to
-avoid the overhead of parsing statistics you won't use.
+Use this when your connector or compute engine handles data-column pruning itself and you want to
+avoid the overhead of reading statistics you won't use, while still letting Kernel prune partitions.
+
+> [!NOTE]
+> `StatsOptions::struct_columns([])` (an empty column projection) behaves the same as
+> `StatsOptions::none()`: projecting statistics to zero columns reads no statistics.
 
 ### Including all statistics in scan metadata
 
@@ -326,7 +332,7 @@ Only the named columns appear in `stats_parsed`.
 | Goal | Constructor |
 |------|-------------|
 | Default behavior (Kernel skips files internally, no stats exposed) | No call needed (or `StatsOptions::json_only()`) |
-| Disable all stats reading for performance | `StatsOptions::none()` |
+| Skip stats reading but keep partition pruning | `StatsOptions::none()` |
 | Expose all struct stats to your connector for custom pruning (cheap path) | `StatsOptions::all_struct()` |
 | Expose both struct stats and the JSON `stats` column | `StatsOptions::all()` |
 | Expose stats for specific columns only | `StatsOptions::struct_columns(cols)` |

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -130,9 +130,9 @@ impl DataSkippingFilter {
     ///   rewrites so non-Add rows are never filtered out.
     /// - `input_schema`: Schema of the batch that will be passed to [`apply()`](Self::apply)
     /// - `stats_columns`: Physical leaf paths whose stats are in `stats_schema`. References to
-    ///   other data columns fold to NULL (keeping the file). Must line up with `stats_schema` --
-    ///   otherwise the rewritten predicate references columns the unified schema doesn't have and
-    ///   evaluator construction fails.
+    ///   other data columns fold to NULL (keeping the file). When `stats_schema` is `None` the set
+    ///   is treated as empty regardless of what the caller passes, since no data-column stat is
+    ///   available to compare against; only partition arms can then prune.
     /// - `metrics`: Optional metrics to record data skipping statistics.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -158,6 +158,15 @@ impl DataSkippingFilter {
 
         let predicate = predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);
+
+        // With no stats schema there is no data-column stat to compare against, so any
+        // `stats_columns` the caller passed cannot line up with the (absent) schema. Force the set
+        // empty: data-column arms then fold to NULL (keep) and only partition arms prune.
+        let empty_stats_columns = HashSet::new();
+        let stats_columns = match stats_schema {
+            Some(_) => stats_columns,
+            None => &empty_stats_columns,
+        };
 
         // Build the unified evaluation schema and extraction expression. Data stats and partition
         // values are conceptually separate, but the evaluator needs a single schema/expression.

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -245,20 +245,41 @@ impl ScanLogReplayProcessor {
             _ => None,
         };
 
-        // When skip_stats is enabled, disable both data column skipping and partition pruning.
-        // Both rely on the same DataSkippingFilter columnar pass, so they are controlled together.
+        // `skip_stats` suppresses data-column skipping (no stats are read), but partition pruning
+        // survives it: partition values come from the Add action's partition map, not
+        // `stats_parsed`, so a predicate on partition columns can still prune files with no
+        // stats read at all. When `skip_stats` holds and the predicate references a
+        // partition column, we keep a partition-only filter alive (data stats stay off).
+        //
+        // The reference check is what gates this: a present `physical_partition_schema` does not
+        // imply the predicate touches partitions (requesting `parsed_struct` output populates it
+        // with all partition columns), so gate on the reference to avoid a per-batch all-keep
+        // filter.
+        let predicate_references_partition = || {
+            let (Some((predicate, _)), Some(partition_schema)) =
+                (&physical_predicate, &state_info.physical_partition_schema)
+            else {
+                return false;
+            };
+            let refs = predicate.references();
+            partition_schema
+                .fields()
+                .any(|f| refs.contains(&ColumnName::new([f.name()])))
+        };
+        let partition_only_skip = skip_stats && predicate_references_partition();
+
         let stats_schema_for_transform = if skip_stats {
             None
         } else {
             state_info.physical_stats_schema.clone()
         };
 
-        // The partition schema feeds two consumers: the DataSkippingFilter (predicate
-        // pruning, disabled by skip_stats together with stats) and the engine-facing
-        // `partitionValues_parsed` output column (requested via `parsed_struct`, independent
-        // of skip_stats). Either consumer keeps the transform emitting the column.
+        // The partition schema feeds two consumers: the DataSkippingFilter (partition pruning,
+        // which survives `skip_stats` via `partition_only_skip`) and the engine-facing
+        // `partitionValues_parsed` output column (requested via `parsed_struct`). Either consumer
+        // keeps the transform emitting the column.
         let partition_schema_for_transform =
-            if partition_values_options.parsed_struct || !skip_stats {
+            if partition_values_options.parsed_struct || !skip_stats || partition_only_skip {
                 state_info.physical_partition_schema.clone()
             } else {
                 None
@@ -269,14 +290,18 @@ impl ScanLogReplayProcessor {
             partition_schema_for_transform.clone(),
         )?;
 
-        // Create data skipping filter that reads stats_parsed and partitionValues_parsed
-        // from the transformed batch. This avoids double JSON parsing -- the transform parses
-        // JSON once, then data skipping reads the already-parsed columns from the output.
+        // Create data skipping filter that reads stats_parsed and partitionValues_parsed from the
+        // transformed batch. This avoids double JSON parsing: the transform parses JSON once, then
+        // data skipping reads the already-parsed columns from the output.
         //
-        // When partition columns are referenced by the predicate, the filter receives a
-        // partition schema + expression to extract typed partition values. Since the transform
-        // already produces `partitionValues_parsed`, the filter reads that column directly.
-        let data_skipping_filter = if skip_stats {
+        // When partition columns are referenced by the predicate, the filter receives a partition
+        // schema + expression to extract typed partition values. Since the transform already
+        // produces `partitionValues_parsed`, the filter reads that column directly.
+        //
+        // Under `partition_only_skip` the filter runs with `stats_schema_for_transform = None`, so
+        // it ignores the stats columns entirely: data-column arms fold to NULL (keep) and only
+        // partition arms prune.
+        let data_skipping_filter = if skip_stats && !partition_only_skip {
             None
         } else {
             DataSkippingFilter::new(
@@ -982,9 +1007,10 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
 /// Each row that is selected in the returned `engine_data` _must_ be processed to complete the
 /// scan. Non-selected rows _must_ be ignored.
 ///
-/// When `stats_options.skip_stats` is true, file statistics are not read from checkpoint parquet
-/// files and columnar data skipping is disabled (no stats-based or partition-value-based
-/// pruning), but row-level partition filtering still applies.
+/// When `stats_options.skip_stats` is true, no stats columns are read from checkpoint parquet
+/// files and data-column skipping is off. Partition-value-based pruning still applies when the
+/// predicate references a partition column (partition values come from the Add action's partition
+/// map, not stats), and row-level partition filtering still applies.
 ///
 /// Note: The iterator of [`ActionsBatch`]s ('action_iter' parameter) must be sorted by the order of
 /// the actions in the log from most recent to least recent.

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -42,6 +42,11 @@ pub(crate) struct ScanStatsOptions {
     /// is left null on such checkpoints; engines that consume `stats_parsed` directly
     /// avoid the per-batch `ToJson` cost.
     pub(crate) synthesize_json: bool,
+    /// Whether kernel builds an in-memory [`DataSkippingFilter`]. When false, no in-memory
+    /// pruning happens even with a predicate and stats present; the engine is expected to prune
+    /// (the predicate is still pushed to it). Independent of `skip_stats`: stats can be read and
+    /// emitted while in-memory pruning is off.
+    pub(crate) internal_data_skipping: bool,
 }
 
 impl Default for ScanStatsOptions {
@@ -49,6 +54,7 @@ impl Default for ScanStatsOptions {
         Self {
             skip_stats: false,
             synthesize_json: true,
+            internal_data_skipping: true,
         }
     }
 }
@@ -233,6 +239,7 @@ impl ScanLogReplayProcessor {
         let ScanStatsOptions {
             skip_stats,
             synthesize_json,
+            internal_data_skipping,
         } = stats_options;
 
         // Create metrics first so we can pass them to DataSkippingFilter
@@ -266,7 +273,11 @@ impl ScanLogReplayProcessor {
                 .fields()
                 .any(|f| refs.contains(&ColumnName::new([f.name()])))
         };
-        let partition_only_skip = skip_stats && predicate_references_partition();
+        // `internal_data_skipping = false` turns off all kernel in-memory pruning (data-column
+        // and partition), even when stats are read and a predicate is present. The engine prunes
+        // instead; the predicate is still pushed to it upstream in `create_checkpoint_stream`.
+        let partition_only_skip =
+            internal_data_skipping && skip_stats && predicate_references_partition();
 
         let stats_schema_for_transform = if skip_stats {
             None
@@ -277,13 +288,15 @@ impl ScanLogReplayProcessor {
         // The partition schema feeds two consumers: the DataSkippingFilter (partition pruning,
         // which survives `skip_stats` via `partition_only_skip`) and the engine-facing
         // `partitionValues_parsed` output column (requested via `parsed_struct`). Either consumer
-        // keeps the transform emitting the column.
-        let partition_schema_for_transform =
-            if partition_values_options.parsed_struct || !skip_stats || partition_only_skip {
-                state_info.physical_partition_schema.clone()
-            } else {
-                None
-            };
+        // keeps the transform emitting the column. When in-memory skipping is off the filter is
+        // not built, so only the output request keeps the column.
+        let partition_schema_for_transform = if partition_values_options.parsed_struct
+            || (internal_data_skipping && (!skip_stats || partition_only_skip))
+        {
+            state_info.physical_partition_schema.clone()
+        } else {
+            None
+        };
 
         let output_schema = scan_row_schema_with_parsed_columns(
             stats_schema_for_transform.clone(),
@@ -300,10 +313,10 @@ impl ScanLogReplayProcessor {
         //
         // Under `partition_only_skip` the filter runs with `stats_schema_for_transform = None`, so
         // it ignores the stats columns entirely: data-column arms fold to NULL (keep) and only
-        // partition arms prune.
-        let data_skipping_filter = if skip_stats && !partition_only_skip {
-            None
-        } else {
+        // partition arms prune. When `internal_data_skipping` is off the filter is never built --
+        // the engine prunes instead.
+        let build_filter = internal_data_skipping && (!skip_stats || partition_only_skip);
+        let data_skipping_filter = if build_filter {
             DataSkippingFilter::new(
                 engine,
                 physical_predicate.as_ref().map(|(p, _)| p.clone()),
@@ -318,6 +331,8 @@ impl ScanLogReplayProcessor {
                 &state_info.physical_stats_columns,
                 Some(metrics.clone()),
             )
+        } else {
+            None
         };
 
         Ok(Self {
@@ -1061,14 +1076,15 @@ mod tests {
     use crate::log_segment::CheckpointReadInfo;
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::{
-        assert_transform_spec, get_simple_state_info, get_state_info, ROW_TRACKING_FEATURES,
+        assert_transform_spec, get_simple_state_info, get_state_info, get_state_info_with_stats,
+        ROW_TRACKING_FEATURES,
     };
     use crate::scan::state_info::StateInfo;
     use crate::scan::test_utils::{
         add_batch_for_row_id, add_batch_simple, add_batch_with_partition_col,
         add_batch_with_remove, add_batch_with_remove_and_partition, run_with_validate_callback,
     };
-    use crate::scan::PhysicalPredicate;
+    use crate::scan::{PhysicalPredicate, StatsOptions};
     use crate::schema::{
         schema_ref, DataType, MetadataColumnSpec, SchemaRef, StructField, StructType,
     };
@@ -1250,6 +1266,43 @@ mod tests {
             validate_patch(transforms[1].as_ref(), 17511);
             validate_patch(transforms[3].as_ref(), 17510);
         }
+    }
+
+    // With a predicate and stats requested, `internal_data_skipping` controls whether kernel
+    // builds an in-memory `DataSkippingFilter`: enabled -> Some (kernel prunes), disabled -> None
+    // (the engine prunes; the predicate is still pushed to the reader upstream).
+    #[rstest]
+    #[case::enabled(true, true)]
+    #[case::disabled(false, false)]
+    fn internal_data_skipping_gates_the_filter(
+        #[case] internal_data_skipping: bool,
+        #[case] expect_filter: bool,
+    ) {
+        let schema: SchemaRef = schema_ref! { nullable "value": INTEGER };
+        let predicate = Arc::new(Predicate::gt(Expr::column(["value"]), Scalar::from(5)));
+        // `all_struct` keeps stats on (so `skip_stats` is false); the new flag is the only lever.
+        let state_info = get_state_info_with_stats(
+            schema,
+            vec![],
+            Some(predicate),
+            &[],
+            HashMap::new(),
+            vec![],
+            StatsOptions::all_struct(),
+        )
+        .unwrap();
+        let processor = ScanLogReplayProcessor::new(
+            &SyncEngine::new(),
+            Arc::new(state_info),
+            test_checkpoint_info(),
+            ScanStatsOptions {
+                internal_data_skipping,
+                ..Default::default()
+            },
+            ScanPartitionValuesOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(processor.data_skipping_filter.is_some(), expect_filter);
     }
 
     #[test]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -95,7 +95,7 @@ pub use crate::parallel::parallel_scan_metadata::{
 ///   `stats_parsed` directly; avoids the per-batch `ToJson` cost.
 /// - [`Self::struct_columns`] -- struct stats projected to a subset of columns, no JSON.
 /// - [`Self::all`] -- both representations.
-/// - [`Self::none`] neither, and turns off data-column skipping. Unlike the other four
+/// - [`Self::none`] -- neither, and turns off data-column skipping. Unlike the other four
 ///   constructors, this one reads no stats columns from parquet; partition pruning still applies
 ///   when the predicate references a partition column (partition values need no stats read).
 #[derive(Clone, Debug)]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -193,6 +193,46 @@ impl StatsOptions {
     }
 }
 
+/// Engine-facing control over kernel's internal data skipping. Pass to
+/// [`ScanBuilder::with_data_skipping`].
+///
+/// This is orthogonal to [`StatsOptions`]: `StatsOptions` decides which statistics the scan
+/// *emits*, while this decides whether kernel *prunes* files itself during log replay. An engine
+/// with its own pruning (e.g. one that applies the pushed predicate as a row-group filter or an
+/// exact row filter) can turn kernel's in-memory pruning off while still requesting stats output
+/// and still receiving the pushed checkpoint predicate.
+#[derive(Clone, Debug)]
+pub struct DataSkippingOptions {
+    /// Whether kernel builds an in-memory
+    /// [`DataSkippingFilter`](self::data_skipping::DataSkippingFilter) to prune files during
+    /// log replay. When false, kernel performs no in-memory pruning even if the scan has a
+    /// predicate; the predicate is still pushed to the engine's parquet reader so the engine
+    /// can prune at read time.
+    pub(crate) internal: bool,
+}
+
+impl DataSkippingOptions {
+    /// Kernel prunes files in-memory using the scan predicate (the default).
+    pub fn enabled() -> Self {
+        Self { internal: true }
+    }
+
+    /// Kernel performs no in-memory pruning. The scan predicate is still pushed to the engine's
+    /// parquet reader (so the engine can prune at read time), and stats output still follows
+    /// [`StatsOptions`]. Use when the engine handles its own pruning and kernel's row-by-row
+    /// filtering would be redundant (or, for a differing cast/comparison implementation, unsound).
+    pub fn disabled() -> Self {
+        Self { internal: false }
+    }
+}
+
+impl Default for DataSkippingOptions {
+    /// Kernel prunes in-memory (backward-compatible default).
+    fn default() -> Self {
+        Self::enabled()
+    }
+}
+
 /// Engine-facing partition value options. Pass to [`ScanBuilder::with_partition_values`] to
 /// declare whether scan metadata output includes the typed `partitionValues_parsed` struct
 /// alongside the raw string map (`fileConstantValues.partitionValues`), which is always present.
@@ -229,6 +269,7 @@ pub struct ScanBuilder {
     logical_read_schema: Option<SchemaRef>,
     predicate: Option<PredicateRef>,
     stats: StatsOptions,
+    data_skipping: DataSkippingOptions,
     correlation_id: Option<Arc<str>>,
     without_row_transforms: bool,
     partition_values: PartitionValuesOptions,
@@ -240,6 +281,7 @@ impl std::fmt::Debug for ScanBuilder {
             .field("logical_read_schema", &self.logical_read_schema)
             .field("predicate", &self.predicate)
             .field("stats", &self.stats)
+            .field("data_skipping", &self.data_skipping)
             .field("correlation_id", &self.correlation_id)
             .field("without_row_transforms", &self.without_row_transforms)
             .field("partition_values", &self.partition_values)
@@ -255,6 +297,7 @@ impl ScanBuilder {
             logical_read_schema: None,
             predicate: None,
             stats: StatsOptions::default(),
+            data_skipping: DataSkippingOptions::default(),
             correlation_id: None,
             without_row_transforms: false,
             partition_values: PartitionValuesOptions::default(),
@@ -309,6 +352,18 @@ impl ScanBuilder {
     /// per-batch `ToJson` synthesis on parsed-stats checkpoints.
     pub fn with_stats(mut self, stats: StatsOptions) -> Self {
         self.stats = stats;
+        self
+    }
+
+    /// Configure kernel's internal data skipping. See [`DataSkippingOptions`].
+    ///
+    /// Defaults to [`DataSkippingOptions::enabled`] (kernel prunes in-memory using the scan
+    /// predicate). Pass [`DataSkippingOptions::disabled`] when the engine handles its own
+    /// pruning; kernel then does no in-memory pruning but still pushes the predicate to the
+    /// engine's parquet reader. Orthogonal to [`with_stats`](Self::with_stats): stats output is
+    /// controlled separately, so an engine can request `stats_parsed` while pruning itself.
+    pub fn with_data_skipping(mut self, data_skipping: DataSkippingOptions) -> Self {
+        self.data_skipping = data_skipping;
         self
     }
 
@@ -400,6 +455,7 @@ impl ScanBuilder {
             snapshot: self.snapshot,
             state_info: Arc::new(state_info),
             stats: self.stats,
+            data_skipping: self.data_skipping,
             correlation_id: self.correlation_id,
             partition_values: self.partition_values,
         })
@@ -661,6 +717,7 @@ pub struct Scan {
     snapshot: SnapshotRef,
     state_info: Arc<StateInfo>,
     stats: StatsOptions,
+    data_skipping: DataSkippingOptions,
     correlation_id: Option<Arc<str>>,
     partition_values: PartitionValuesOptions,
 }
@@ -695,6 +752,7 @@ impl Scan {
         log_replay::ScanStatsOptions {
             skip_stats: self.skip_stats(),
             synthesize_json: self.stats.synthesize_json,
+            internal_data_skipping: self.data_skipping.internal,
         }
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -95,8 +95,9 @@ pub use crate::parallel::parallel_scan_metadata::{
 ///   `stats_parsed` directly; avoids the per-batch `ToJson` cost.
 /// - [`Self::struct_columns`] -- struct stats projected to a subset of columns, no JSON.
 /// - [`Self::all`] -- both representations.
-/// - [`Self::none`] -- neither, AND disables internal data skipping. Unlike the other four
-///   constructors, this is the only one that stops kernel from reading stats from parquet at all.
+/// - [`Self::none`] neither, and turns off data-column skipping. Unlike the other four
+///   constructors, this one reads no stats columns from parquet; partition pruning still applies
+///   when the predicate references a partition column (partition values need no stats read).
 #[derive(Clone, Debug)]
 pub struct StatsOptions {
     /// Whether to surface JSON stats on parsed-stats checkpoints (where the
@@ -117,8 +118,8 @@ pub struct StatsOptions {
 #[derive(Clone, Debug)]
 pub enum StructStats {
     /// Don't emit `stats_parsed`. Kernel still reads predicate-referenced stats for
-    /// internal data skipping unless the caller picked [`StatsOptions::none`], which
-    /// disables stats reading entirely.
+    /// data-column skipping unless the caller picked [`StatsOptions::none`], which
+    /// reads no stats columns (partition pruning is unaffected).
     None,
     /// Emit all indexed stats columns.
     All,
@@ -154,7 +155,14 @@ impl StatsOptions {
 
     /// Struct stats projected to the specified columns, no JSON. Like
     /// [`Self::all_struct`] but narrowed to a subset of indexed columns.
+    ///
+    /// An empty `cols` is normalized to [`Self::none`]: projecting stats to zero columns is the
+    /// same as reading no stats, so data-column skipping is off while partition pruning still
+    /// applies when the predicate references a partition column.
     pub fn struct_columns(cols: Vec<ColumnName>) -> Self {
+        if cols.is_empty() {
+            return Self::none();
+        }
         Self {
             synthesize_json: false,
             struct_stats: StructStats::Columns(cols),
@@ -169,11 +177,13 @@ impl StatsOptions {
         }
     }
 
-    /// **Disables all stats work**: no stats output, no internal data skipping (even
-    /// when a predicate is set). Kernel reads no stats columns from parquet at all.
-    /// Use when the engine handles its own pruning.
+    /// **Disables data-column stats work**: no stats output, and no stats columns are read from
+    /// parquet, so data-column skipping is off. Partition pruning still applies when the predicate
+    /// references a partition column (partition values come from the Add action's partition map,
+    /// not `stats_parsed`, so they need no stats read). Use when the engine handles its own
+    /// data-column pruning but still wants kernel to prune partitions.
     ///
-    /// To get internal predicate-based skipping without `stats_parsed` output, use
+    /// To also get data-column predicate skipping without `stats_parsed` output, use
     /// [`StatsOptions::default`] (JSON only) or set `struct_stats` to `All`/`Columns(_)`.
     pub fn none() -> Self {
         Self {
@@ -667,9 +677,17 @@ impl std::fmt::Debug for Scan {
 }
 
 impl Scan {
-    /// Whether stats reading is entirely skipped, disabling internal data skipping.
+    /// Whether stats reading is entirely skipped, disabling data-column skipping. An empty
+    /// `StructStats::Columns` projection reads no stats, so it is equivalent to `StructStats::None`
+    /// here (the public [`StatsOptions::struct_columns`] normalizes it, but internal construction
+    /// can still produce it).
     fn skip_stats(&self) -> bool {
-        !self.stats.synthesize_json && matches!(self.stats.struct_stats, StructStats::None)
+        let no_struct_stats = match &self.stats.struct_stats {
+            StructStats::None => true,
+            StructStats::Columns(cols) => cols.is_empty(),
+            StructStats::All => false,
+        };
+        !self.stats.synthesize_json && no_struct_stats
     }
 
     /// Build the read-options bundle passed to [`ScanLogReplayProcessor`].
@@ -882,12 +900,20 @@ impl Scan {
 
         // For incremental reads, new_log_segment has no checkpoint but we use the
         // checkpoint schema returned by the function for consistency.
-        let (checkpoint_schema, meta_predicate) = if self.skip_stats() {
-            (CHECKPOINT_READ_SCHEMA_NO_STATS.clone(), None)
+        //
+        // `skip_stats` also drops the stats schema: leaving it set would project `stats_parsed`
+        // out of any checkpoint that carries it, only for the transform to discard it (stats
+        // output is off). Passing `None` keeps `none()` honest -- no stats columns are read.
+        let (checkpoint_schema, meta_predicate, stats_schema) = if self.skip_stats() {
+            (CHECKPOINT_READ_SCHEMA_NO_STATS.clone(), None, None)
         } else {
             (
                 CHECKPOINT_READ_SCHEMA.clone(),
                 self.build_actions_meta_predicate(),
+                self.state_info
+                    .physical_stats_schema
+                    .as_ref()
+                    .map(|s| s.as_ref()),
             )
         };
         let result = new_log_segment.read_actions_with_projected_checkpoint_actions(
@@ -895,10 +921,7 @@ impl Scan {
             COMMIT_READ_SCHEMA.clone(),
             checkpoint_schema,
             meta_predicate,
-            self.state_info
-                .physical_stats_schema
-                .as_ref()
-                .map(|s| s.as_ref()),
+            stats_schema,
             None,
         )?;
         let actions_with_checkpoint_info = ActionsWithCheckpointInfo {
@@ -965,12 +988,21 @@ impl Scan {
     ) -> DeltaResult<
         ActionsWithCheckpointInfo<impl Iterator<Item = DeltaResult<ActionsBatch>> + Send>,
     > {
-        let (checkpoint_schema, meta_predicate) = if self.skip_stats() {
-            (CHECKPOINT_READ_SCHEMA_NO_STATS.clone(), None)
+        // `skip_stats` drops the stats schema alongside the checkpoint schema: leaving it set
+        // would project `stats_parsed` out of any checkpoint that carries it, only for the
+        // transform to discard it (stats output is off). Passing `None` keeps `none()` honest --
+        // no stats columns are read. The partition schema still flows through so partition pruning
+        // survives (see `partition_only_skip` in the log-replay processor).
+        let (checkpoint_schema, meta_predicate, stats_schema) = if self.skip_stats() {
+            (CHECKPOINT_READ_SCHEMA_NO_STATS.clone(), None, None)
         } else {
             (
                 CHECKPOINT_READ_SCHEMA.clone(),
                 self.build_actions_meta_predicate(),
+                self.state_info
+                    .physical_stats_schema
+                    .as_ref()
+                    .map(|s| s.as_ref()),
             )
         };
         self.snapshot
@@ -980,10 +1012,7 @@ impl Scan {
                 COMMIT_READ_SCHEMA.clone(),
                 checkpoint_schema,
                 meta_predicate,
-                self.state_info
-                    .physical_stats_schema
-                    .as_ref()
-                    .map(|s| s.as_ref()),
+                stats_schema,
                 self.state_info
                     .physical_partition_schema
                     .as_ref()

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1394,8 +1394,11 @@ fn test_checkpoint_row_group_skipping(
     }
 }
 
+/// `StatsOptions::none()` disables data-column skipping (no stats are read). Partition pruning is
+/// a separate path that survives `none()`, but this table is unpartitioned and the predicate is on
+/// a data column, so no skipping applies and every file is kept.
 #[test]
-fn test_skip_stats_disables_data_skipping() {
+fn test_skip_stats_disables_data_column_skipping() {
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = Arc::new(SyncEngine::new());

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::vec;
 
 use delta_kernel::actions::deletion_vector::split_vector;
@@ -24,8 +24,14 @@ use delta_kernel::scan::state::{transform_to_logical, ScanFile};
 use delta_kernel::scan::{
     AfterSequentialScanMetadata, ParallelScanMetadata, PartitionValuesOptions, Scan, StatsOptions,
 };
-use delta_kernel::schema::{DataType, MetadataColumnSpec, Schema, StructField, StructType};
-use delta_kernel::{Engine, FileMeta, Snapshot};
+use delta_kernel::schema::{
+    DataType, MetadataColumnSpec, Schema, SchemaRef, StructField, StructType,
+};
+use delta_kernel::{
+    DeltaResult, DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler,
+    FileDataReadResultIterator, FileMeta, JsonHandler, ParquetFooter, ParquetHandler, Snapshot,
+    StorageHandler,
+};
 use itertools::Itertools;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
@@ -1045,6 +1051,138 @@ async fn null_partition_pruning_matches_across_stats_options(
         .build()?;
 
     assert_eq!(surviving_file_count(engine.as_ref(), &scan)?, 1);
+    Ok(())
+}
+
+/// A `ParquetHandler` that records the physical read schema of every `read_parquet_files` call and
+/// otherwise delegates to an inner handler. Used to observe which columns a scan projects out of
+/// checkpoint parquet.
+struct RecordingParquetHandler {
+    inner: Arc<dyn ParquetHandler>,
+    read_schemas: Arc<Mutex<Vec<SchemaRef>>>,
+}
+
+impl ParquetHandler for RecordingParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.read_schemas
+            .lock()
+            .unwrap()
+            .push(physical_schema.clone());
+        self.inner
+            .read_parquet_files(files, physical_schema, predicate)
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: url::Url,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+    ) -> DeltaResult<()> {
+        self.inner.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        self.inner.read_parquet_footer(file)
+    }
+}
+
+/// Delegates every handler to an inner engine except `parquet_handler`, which records read schemas.
+struct RecordingEngine {
+    inner: Arc<dyn Engine>,
+    parquet: Arc<RecordingParquetHandler>,
+}
+
+impl Engine for RecordingEngine {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.inner.storage_handler()
+    }
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.inner.json_handler()
+    }
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet.clone()
+    }
+}
+
+/// Returns true if `schema` (or any nested struct field) contains a field named `name`.
+fn schema_contains_field(schema: &StructType, name: &str) -> bool {
+    schema.fields().any(|f| {
+        f.name() == name
+            || match f.data_type() {
+                DataType::Struct(s) => schema_contains_field(s, name),
+                _ => false,
+            }
+    })
+}
+
+/// Ground-truth for the stats-off optimization: under `StatsOptions::none()` the checkpoint parquet
+/// read must project neither the JSON `stats` field nor the native `stats_parsed` struct, while the
+/// default (stats-on) path still reads `stats`. Surviving file COUNT is invariant to whether stats
+/// are read, so this asserts on the physical read schema directly -- the observable proof that the
+/// wide per-column stats are no longer read from the checkpoint.
+///
+/// The predicate references the data column `value`, so `physical_stats_schema` is `Some`. That is
+/// the case the read-path gating must suppress under `none()`: without it, `stats_parsed` would be
+/// projected from the checkpoint (and discarded), which is exactly the wasteful read `none()`
+/// avoids.
+#[rstest::rstest]
+#[case::stats_none(StatsOptions::none(), false)]
+#[case::stats_default(StatsOptions::default(), true)]
+fn stats_none_does_not_read_stats_from_checkpoint(
+    #[case] stats: StatsOptions,
+    #[case] expect_stats_read: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint"))?;
+    let url = url::Url::from_directory_path(path).unwrap();
+    let inner = test_utils::create_default_engine(&url)?;
+    let read_schemas = Arc::new(Mutex::new(Vec::new()));
+    let engine = RecordingEngine {
+        parquet: Arc::new(RecordingParquetHandler {
+            inner: inner.parquet_handler(),
+            read_schemas: read_schemas.clone(),
+        }),
+        inner,
+    };
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
+
+    // A predicate on the data column `value` makes `physical_stats_schema` Some, so the read-path
+    // gating is what suppresses the stats projection under `none()`.
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(
+            column_expr!("value").gt(Expr::literal(1_000_000i32)),
+        ))
+        .with_stats(stats)
+        .build()?;
+    surviving_file_count(&engine, &scan)?;
+
+    // The checkpoint read is the one whose schema carries the `add` action.
+    let schemas = read_schemas.lock().unwrap();
+    let checkpoint_reads: Vec<_> = schemas
+        .iter()
+        .filter(|s| schema_contains_field(s, "add"))
+        .collect();
+    assert!(
+        !checkpoint_reads.is_empty(),
+        "expected at least one checkpoint parquet read"
+    );
+    for schema in checkpoint_reads {
+        let reads_stats = schema_contains_field(schema, "stats");
+        let reads_stats_parsed = schema_contains_field(schema, "stats_parsed");
+        assert_eq!(
+            reads_stats || reads_stats_parsed,
+            expect_stats_read,
+            "checkpoint read schema stats presence mismatch (stats={reads_stats}, \
+             stats_parsed={reads_stats_parsed}), expected_stats_read={expect_stats_read}"
+        );
+    }
     Ok(())
 }
 

--- a/kernel/tests/integration/read.rs
+++ b/kernel/tests/integration/read.rs
@@ -21,7 +21,9 @@ use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::parquet::file::properties::{EnabledStatistics, WriterProperties};
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::scan::state::{transform_to_logical, ScanFile};
-use delta_kernel::scan::{Scan, StatsOptions};
+use delta_kernel::scan::{
+    AfterSequentialScanMetadata, ParallelScanMetadata, PartitionValuesOptions, Scan, StatsOptions,
+};
 use delta_kernel::schema::{DataType, MetadataColumnSpec, Schema, StructField, StructType};
 use delta_kernel::{Engine, FileMeta, Snapshot};
 use itertools::Itertools;
@@ -882,6 +884,170 @@ fn partition_pruning_with_checkpoint_parsed_values(
     Ok(())
 }
 
+/// Counts the files surviving data skipping (selected rows across `scan_metadata`) for `scan`.
+fn surviving_file_count(
+    engine: &dyn Engine,
+    scan: &Scan,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut count = 0;
+    for res in scan.scan_metadata(engine)? {
+        count = res?.visit_scan_files(count, |acc, _scan_file| *acc += 1)?;
+    }
+    Ok(count)
+}
+
+/// Like [`surviving_file_count`] but drives the two-phase `parallel_scan_metadata` path, rebuilding
+/// the worker `DataSkippingFilter` from the serialized `InternalScanState`. Dispatches one file per
+/// `ParallelScanMetadata` to maximize coverage of the worker rebuild.
+fn surviving_file_count_parallel(
+    engine: Arc<dyn Engine>,
+    scan: &Scan,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let mut count = 0;
+    let mut sequential = scan.parallel_scan_metadata(engine.clone())?;
+    for res in sequential.by_ref() {
+        count = res?.visit_scan_files(count, |acc, _scan_file| *acc += 1)?;
+    }
+    if let AfterSequentialScanMetadata::Parallel { state, files } = sequential.finish()? {
+        let state = Arc::from(state);
+        for file in files {
+            let parallel =
+                ParallelScanMetadata::try_new(engine.clone(), Arc::clone(&state), vec![file])?;
+            for res in parallel {
+                count = res?.visit_scan_files(count, |acc, _scan_file| *acc += 1)?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// Partition pruning survives a stats-off scan on both the sequential and parallel scan paths, for
+/// both `StatsOptions::none()` and the empty `struct_columns([])` projection (which normalizes to
+/// the same stats-off behavior). The `app-txn-checkpoint` table has 4 files (2 per `modified`
+/// partition) behind a checkpoint carrying `partitionValues_parsed`; `modified = '2021-02-02'`
+/// matches 2 of them, and partition values come from the Add action's partition map rather than
+/// `stats_parsed`, so the count drops to 2 with no stats read.
+///
+/// The mixed case (`modified = '2021-02-02' AND value > 1000000`, matched by no row) shows the
+/// stats-off divergence: with stats off the data-column arm can't prune (keeps 2), while default
+/// stats prune it to 0.
+///
+/// The `use_parallel` axis guards the serialization round-trip: the parallel worker recomputes
+/// `partition_only_skip` from the serialized options, so it must match the sequential count.
+#[rstest::rstest]
+#[case::stats_off(StatsOptions::none(), false)]
+#[case::stats_on(StatsOptions::default(), true)]
+#[case::empty_struct_columns(StatsOptions::struct_columns(vec![]), false)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn partition_pruning_survives_stats_none(
+    #[case] stats: StatsOptions,
+    #[case] stats_on: bool,
+    #[values(false, true)] mixed_with_data_col: bool,
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint"))?;
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = test_utils::create_default_engine_mt_executor(&url)?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
+
+    let partition_pred = column_expr!("modified").eq(Expr::literal("2021-02-02"));
+    let predicate = if mixed_with_data_col {
+        Pred::and(
+            partition_pred,
+            Pred::gt(column_expr!("value"), Expr::literal(1_000_000i32)),
+        )
+    } else {
+        partition_pred
+    };
+
+    // Partition arm always narrows to 2. With stats on, the data arm additionally prunes the mixed
+    // case to 0; with stats off, the data arm can't prune, so the mixed case stays at 2.
+    let expected = if mixed_with_data_col && stats_on {
+        0
+    } else {
+        2
+    };
+
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(predicate))
+        .with_stats(stats)
+        .build()?;
+
+    let count = if use_parallel {
+        surviving_file_count_parallel(engine.clone(), &scan)?
+    } else {
+        surviving_file_count(engine.as_ref(), &scan)?
+    };
+    assert_eq!(count, expected);
+    Ok(())
+}
+
+/// A data-only predicate under `none()` gains no partition pruning even when `parsed_struct` output
+/// is requested. Requesting the typed struct populates the internal partition schema with all
+/// partition columns, so pruning must key off whether the predicate references a partition column,
+/// not off schema presence. Here `value > 0` references none, so all 4 files survive.
+#[test]
+fn data_only_predicate_under_none_with_parsed_struct_does_not_prune(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint"))?;
+    let url = url::Url::from_directory_path(path).unwrap();
+    let engine = test_utils::create_default_engine(&url)?;
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
+
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(Pred::gt(
+            column_expr!("value"),
+            Expr::literal(0i32),
+        )))
+        .with_stats(StatsOptions::none())
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()?;
+
+    assert_eq!(surviving_file_count(engine.as_ref(), &scan)?, 4);
+    Ok(())
+}
+
+/// A NULL partition value under `StatsOptions::none()` must yield the same surviving set as the
+/// default (stats-on) path -- decoupling partition pruning from stats must not shift NULL-partition
+/// semantics. This is a JSON-only table (no checkpoint), so `partitionValues_parsed` comes from
+/// `map_to_struct(partitionValues)`; a null partition value parses to a NULL scalar. Of the three
+/// files (id=1, id=2, id=NULL), `id = 2` keeps exactly the id=2 file on both paths: id=1 mismatches
+/// and the id=NULL file holds only `id IS NULL` rows, none of which can equal 2.
+#[rstest::rstest]
+#[case::stats_none(StatsOptions::none())]
+#[case::stats_default(StatsOptions::default())]
+#[tokio::test]
+async fn null_partition_pruning_matches_across_stats_options(
+    #[case] stats: StatsOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(InMemory::new());
+    let table_root = "memory:///";
+    let actions = [
+        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#.to_string(),
+        r#"{"metaData":{"id":"5fba94ed-9794-4965-ba6e-6ee3c0d22af9","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"val\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}}]}","partitionColumns":["id"],"configuration":{},"createdTime":1587968585495}}"#.to_string(),
+        format!(r#"{{"add":{{"path":"id=1/{PARQUET_FILE1}","partitionValues":{{"id":"1"}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#),
+        format!(r#"{{"add":{{"path":"id=2/{PARQUET_FILE2}","partitionValues":{{"id":"2"}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#),
+        // A null partition value is serialized as JSON null in the partition map.
+        format!(r#"{{"add":{{"path":"id=__HIVE_DEFAULT_PARTITION__/{PARQUET_FILE3}","partitionValues":{{"id":null}},"size":0,"modificationTime":1587968586000,"dataChange":true}}}}"#),
+    ];
+
+    add_commit(table_root, storage.as_ref(), 0, actions.iter().join("\n")).await?;
+
+    let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
+    let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
+
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(Arc::new(Pred::eq(column_expr!("id"), Expr::literal(2))))
+        .with_stats(stats)
+        .build()?;
+
+    assert_eq!(surviving_file_count(engine.as_ref(), &scan)?, 1);
+    Ok(())
+}
+
 /// Test mixed predicates (partition + data stats) on a checkpoint with both
 /// `partitionValues_parsed` and `stats_parsed`. This exercises the unified columnar data skipping
 /// pass that evaluates both partition values and data column statistics together.
@@ -1013,12 +1179,15 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
 /// Test partition pruning on a table with column mapping (name mode). The logical partition
 /// column "category" has physical name "phys_category". With column mapping, `partitionValues`
 /// in the log uses physical column names, and the partition schema + predicate must also use
-/// physical names for `MapToStruct` extraction and data skipping to work correctly.
+/// physical names for `MapToStruct` extraction and data skipping to work correctly. The
+/// `StatsOptions::none()` cases pin that physical-name partition pruning survives the stats-off
+/// path, where the filter is kept alive only by the predicate's partition reference.
 #[rstest::rstest]
 #[case::partition_only(
     // Partition-only predicate: category = 'A' prunes the category=B file
     Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
     None,
+    StatsOptions::default(),
     1
 )]
 #[case::mixed_partition_and_data(
@@ -1029,6 +1198,7 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
         Pred::gt(column_expr!("val"), Expr::literal("z")),
     )),
     None,
+    StatsOptions::default(),
     1
 )]
 #[case::predicate_on_unprojected_data_column(
@@ -1037,6 +1207,7 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     // schema and prune both files: max(phys_val)='z' is NOT > 'z'.
     Arc::new(Pred::gt(column_expr!("val"), Expr::literal("z"))),
     Some(vec!["category"]),
+    StatsOptions::default(),
     0
 )]
 #[case::predicate_on_unprojected_partition_column(
@@ -1045,12 +1216,31 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     // using the physical partition name, keeping only the category=A file.
     Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
     Some(vec!["val"]),
+    StatsOptions::default(),
+    1
+)]
+#[case::partition_only_stats_none(
+    // Same partition-only predicate under `none()`: the filter is kept alive only because the
+    // predicate references a partition column, and pruning must still resolve `category` to its
+    // physical name `phys_category` with no stats read.
+    Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
+    None,
+    StatsOptions::none(),
+    1
+)]
+#[case::unprojected_partition_stats_none(
+    // Partition predicate on an unprojected column under `none()`: exercises physical-name
+    // partition pruning on the stats-off path.
+    Arc::new(Pred::eq(column_expr!("category"), Expr::literal("A"))),
+    Some(vec!["val"]),
+    StatsOptions::none(),
     1
 )]
 #[tokio::test]
 async fn test_partition_pruning_with_column_mapping(
     #[case] predicate: Arc<Pred>,
     #[case] select_cols: Option<Vec<&'static str>>,
+    #[case] stats: StatsOptions,
     #[case] expected_files: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let batch = generate_batch(vec![("phys_val", vec!["x", "y", "z"].into_arrow_array())])?;
@@ -1106,6 +1296,7 @@ async fn test_partition_pruning_with_column_mapping(
         .scan_builder()
         .with_schema_opt(projection)
         .with_predicate(predicate)
+        .with_stats(stats)
         .build()?;
 
     let stream = scan.execute(engine)?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Decouples kernel's internal data skipping from stats output, on two axes.

**1. Partition pruning no longer requires reading data stats.** Previously `StatsOptions::none()` disabled the entire `DataSkippingFilter`, so a partition-column predicate under `none()` pruned nothing. When stats are off but the predicate references a partition column, kernel now keeps a partition-only filter alive (partition values come from the Add action's partition map, not `stats_parsed`, so no stats read is needed). `none()` also stops projecting `stats_parsed` from checkpoints entirely, and `struct_columns([])` is normalized to `none()`.

**2. New `DataSkippingOptions` to turn off kernel's in-memory pruning while keeping the pushed predicate.** `StatsOptions` decides which statistics the scan *emits*; `DataSkippingOptions` (a peer, set via `ScanBuilder::with_data_skipping`) decides whether kernel *prunes* files itself during log replay. An engine with its own pruning can pass `DataSkippingOptions::disabled()`: kernel builds no in-memory `DataSkippingFilter`, but the predicate is still pushed to the engine's parquet reader (so the engine can prune at read time) and stats output still follows `StatsOptions`. Defaults to `enabled()` -- existing behavior is unchanged.

### This PR affects the following public APIs

- New `DataSkippingOptions` type and `ScanBuilder::with_data_skipping`.
- `StatsOptions::none()` / `struct_columns([])` semantics refined (partition pruning now survives stats-off). New public APIs are not breaking.

## How was this change tested?

- Integration tests for partition pruning under `none()` and for `none()` reading no stats columns.
- A parameterized unit test asserting `DataSkippingOptions` gates whether the in-memory `DataSkippingFilter` is built (enabled -> built, disabled -> not built) while a predicate and stats are present.
- Full `delta_kernel` lib suite, fmt, clippy, and doc pass.

Note: for a consumer that applies the pushed predicate as an exact row filter, pair this with #2989 (folding unsupported checkpoint-predicate arms to TRUE), which keeps the pushed predicate sound under two-valued evaluation.
