### PR TITLE
feat: resolve offset-less timestamp partitions via engine session timezone

### DIFF
--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use std::num::NonZero;
 use std::sync::Arc;
 
+use delta_kernel::arrow::array::timezone::Tz;
 use delta_kernel::engine::arrow_conversion::TryFromArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::arrow_expression::ArrowEvaluationHandler;
@@ -18,7 +19,8 @@ use delta_kernel::object_store::DynObjectStore;
 use delta_kernel::schema::Schema;
 use delta_kernel::transaction::WriteContext;
 use delta_kernel::{
-    DeltaResult, Engine, EngineData, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler,
+    DeltaResult, Engine, EngineData, Error, EvaluationHandler, JsonHandler, ParquetHandler,
+    StorageHandler,
 };
 use futures::stream::{BoxStream, StreamExt as _};
 use url::Url;
@@ -133,6 +135,9 @@ pub struct DefaultEngineBuilder<E> {
     /// Read-path I/O concurrency config applied to the JSON and Parquet handlers. `None` fields
     /// fall back to the handlers' defaults.
     io_config: ReadIoConfig,
+    /// Session timezone for the evaluation handler; resolves offset-less `TIMESTAMP` partition
+    /// values. `None` = UTC. See [`DefaultEngineBuilder::with_session_timezone`].
+    session_timezone: Option<Tz>,
 }
 
 /// Read-path I/O tuning for [`DefaultEngine`]'s JSON and Parquet handlers.
@@ -158,13 +163,19 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
             object_store,
             task_executor: DefaultTaskExecutor,
             io_config: ReadIoConfig::default(),
+            session_timezone: None,
         }
     }
 
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
         let task_executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
-        DefaultEngine::new_with_opts(self.object_store, task_executor, self.io_config)
+        DefaultEngine::new_with_opts(
+            self.object_store,
+            task_executor,
+            self.io_config,
+            self.session_timezone,
+        )
     }
 }
 
@@ -180,7 +191,22 @@ impl<E> DefaultEngineBuilder<E> {
             object_store: self.object_store,
             task_executor,
             io_config: self.io_config,
+            session_timezone: self.session_timezone,
         }
+    }
+
+    /// Set the session timezone used to resolve offset-less `TIMESTAMP` partition values (a string
+    /// with no `Z` or explicit offset). Such a value denotes a different instant per zone; the
+    /// engine resolves it here. Unset resolves at UTC.
+    ///
+    /// Errors if `timezone` is not a valid IANA name or fixed offset.
+    pub fn with_session_timezone(mut self, timezone: &str) -> DeltaResult<Self> {
+        self.session_timezone = Some(
+            timezone
+                .parse::<Tz>()
+                .map_err(|_| Error::generic(format!("Invalid session timezone: {timezone}")))?,
+        );
+        Ok(self)
     }
 
     /// Set the maximum number of files read concurrently by the JSON and Parquet handlers in their
@@ -208,7 +234,12 @@ impl<E> DefaultEngineBuilder<E> {
 impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<E> {
-        DefaultEngine::new_with_opts(self.object_store, self.task_executor, self.io_config)
+        DefaultEngine::new_with_opts(
+            self.object_store,
+            self.task_executor,
+            self.io_config,
+            self.session_timezone,
+        )
     }
 }
 
@@ -228,6 +259,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
         object_store: Arc<DynObjectStore>,
         task_executor: Arc<E>,
         io_config: ReadIoConfig,
+        session_timezone: Option<Tz>,
     ) -> Self {
         let raw_storage: Arc<dyn StorageHandler> = Arc::new(ObjectStoreStorageHandler::new(
             object_store.clone(),
@@ -251,7 +283,7 @@ impl<E: TaskExecutor> DefaultEngine<E> {
             raw_parquet,
             object_store,
             task_executor,
-            evaluation: Arc::new(ArrowEvaluationHandler {}),
+            evaluation: Arc::new(ArrowEvaluationHandler::new(session_timezone)),
         }
     }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1094,7 +1094,7 @@ mod tests {
 
     impl ExprEngine {
         fn new() -> Self {
-            ExprEngine(Arc::new(ArrowEvaluationHandler))
+            ExprEngine(Arc::new(ArrowEvaluationHandler::default()))
         }
     }
 

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -714,7 +714,7 @@ fn dummy_struct() -> DataType {
 )]
 fn test_splitter_rejects_invalid_schema(#[case] schema: StructType, #[case] expected_msg: &str) {
     let iter = ActionReconciliationIterator::new(Box::new(std::iter::empty()));
-    let result = SidecarSplitter::new(iter, &ArrowEvaluationHandler, Arc::new(schema));
+    let result = SidecarSplitter::new(iter, &ArrowEvaluationHandler::default(), Arc::new(schema));
     assert!(result.is_err(), "should reject invalid schema");
     let err = result.err().unwrap();
     assert!(
@@ -731,7 +731,8 @@ fn test_single_sidecar_data_iterator_rejects_zero_max_file_actions_hint() {
     ])
     .into();
     let iter = ActionReconciliationIterator::new(Box::new(std::iter::empty()));
-    let splitter = SidecarSplitter::new_mut_shared(iter, &ArrowEvaluationHandler, schema).unwrap();
+    let splitter =
+        SidecarSplitter::new_mut_shared(iter, &ArrowEvaluationHandler::default(), schema).unwrap();
     let result = SingleSidecarDataIterator::new(splitter, 0);
     assert!(result.is_err());
     let err = result.err().unwrap();

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -7,6 +7,7 @@ use chrono::Utc;
 use itertools::Itertools;
 use tracing::warn;
 
+use crate::arrow::array::timezone::Tz;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
@@ -109,6 +110,7 @@ fn evaluate_struct_expression(
     batch: &RecordBatch,
     output_schema: &StructType,
     nullability_predicate: Option<&ExpressionRef>,
+    session_tz: Option<&Tz>,
 ) -> DeltaResult<ArrayRef> {
     if fields.len() != output_schema.num_fields() {
         return Err(Error::generic(format!(
@@ -121,7 +123,9 @@ fn evaluate_struct_expression(
     let output_cols: Vec<ArrayRef> = fields
         .iter()
         .zip(output_schema.fields())
-        .map(|(expr, field)| evaluate_expression(expr, batch, Some(field.data_type())))
+        .map(|(expr, field)| {
+            evaluate_expression_impl(expr, batch, Some(field.data_type()), session_tz)
+        })
         .try_collect()?;
     let output_fields: Vec<ArrowField> = output_cols
         .iter()
@@ -136,7 +140,8 @@ fn evaluate_struct_expression(
         })
         .collect();
     let null_buffer = if let Some(predicate_expr) = nullability_predicate {
-        let predicate_array = evaluate_expression(predicate_expr, batch, Some(&DataType::BOOLEAN))?;
+        let predicate_array =
+            evaluate_expression_impl(predicate_expr, batch, Some(&DataType::BOOLEAN), session_tz)?;
         let bool_array = predicate_array
             .as_any()
             .downcast_ref::<BooleanArray>()
@@ -159,6 +164,7 @@ fn evaluate_struct_patch_expression(
     patch: &ExpressionStructPatch,
     batch: &RecordBatch,
     output_schema: &StructType,
+    session_tz: Option<&Tz>,
 ) -> DeltaResult<ArrayRef> {
     let mut used_field_patches = 0;
 
@@ -176,7 +182,12 @@ fn evaluate_struct_patch_expression(
 
     // Handle prepends (insertions before any field)
     for expr in &patch.prepended_fields {
-        output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
+        output_cols.push(evaluate_expression_impl(
+            expr,
+            batch,
+            Some(next_output_type()?),
+            session_tz,
+        )?);
     }
 
     // Extract the input path, if any
@@ -206,7 +217,12 @@ fn evaluate_struct_patch_expression(
         // Process any insertions that come at or after this field's output position.
         if let Some(field_patch) = field_patch {
             for expr in &field_patch.insertions {
-                output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
+                output_cols.push(evaluate_expression_impl(
+                    expr,
+                    batch,
+                    Some(next_output_type()?),
+                    session_tz,
+                )?);
             }
             used_field_patches += 1;
         }
@@ -226,7 +242,12 @@ fn evaluate_struct_patch_expression(
 
     // Handle appends (insertions after all input fields and field-specific insertions)
     for expr in &patch.appended_fields {
-        output_cols.push(evaluate_expression(expr, batch, Some(next_output_type()?))?);
+        output_cols.push(evaluate_expression_impl(
+            expr,
+            batch,
+            Some(next_output_type()?),
+            session_tz,
+        )?);
     }
 
     // Verify we consumed all output schema fields
@@ -258,11 +279,30 @@ fn evaluate_struct_patch_expression(
     Ok(Arc::new(data))
 }
 
-/// Evaluates a kernel expression over a record batch
+/// Evaluates a kernel expression over a record batch.
+///
+/// Offset-less `TIMESTAMP` partition values (inside `MAP_TO_STRUCT`) resolve at UTC. Engines that
+/// supply a session zone use [`ArrowEvaluationHandler`], which routes through
+/// [`evaluate_expression_impl`] with the zone.
+///
+/// [`ArrowEvaluationHandler`]: super::ArrowEvaluationHandler
 pub fn evaluate_expression(
     expression: &Expression,
     batch: &RecordBatch,
     result_type: Option<&DataType>,
+) -> DeltaResult<ArrayRef> {
+    evaluate_expression_impl(expression, batch, result_type, None)
+}
+
+/// Evaluates a kernel expression, resolving offset-less `TIMESTAMP` partition values in
+/// `session_tz` (`None` = UTC). The zone is applied only at the `MAP_TO_STRUCT` leaf parse; every
+/// other expression ignores it. Threaded down the recursion so a `MAP_TO_STRUCT` nested inside a
+/// struct or coalesce still sees the zone.
+pub(super) fn evaluate_expression_impl(
+    expression: &Expression,
+    batch: &RecordBatch,
+    result_type: Option<&DataType>,
+    session_tz: Option<&Tz>,
 ) -> DeltaResult<ArrayRef> {
     use BinaryExpressionOp::*;
     use Expression::*;
@@ -274,13 +314,19 @@ pub fn evaluate_expression(
         }
         (Column(name), _) => validate_array_type(extract_column(batch, name)?, result_type),
         (Struct(fields, nullability), Some(DataType::Struct(output_schema))) => {
-            evaluate_struct_expression(fields, batch, output_schema, nullability.as_ref())
+            evaluate_struct_expression(
+                fields,
+                batch,
+                output_schema,
+                nullability.as_ref(),
+                session_tz,
+            )
         }
         (Struct(..), dt) => Err(Error::Generic(format!(
             "Struct expression expects a DataType::Struct result, but got {dt:?}"
         ))),
         (StructPatch(patch), Some(DataType::Struct(output_schema))) => {
-            evaluate_struct_patch_expression(patch, batch, output_schema)
+            evaluate_struct_patch_expression(patch, batch, output_schema, session_tz)
         }
         (StructPatch(_), _) => Err(Error::generic(
             "Data type is required to evaluate struct patch expressions",
@@ -294,7 +340,7 @@ pub fn evaluate_expression(
         ))),
         (Unary(UnaryExpression { op: ToJson, expr }), result_type) => match result_type {
             None | Some(&DataType::STRING) => {
-                let input = evaluate_expression(expr, batch, None)?;
+                let input = evaluate_expression_impl(expr, batch, None, session_tz)?;
                 Ok(to_json(&input)?)
             }
             Some(data_type) => Err(Error::generic(format!(
@@ -302,8 +348,8 @@ pub fn evaluate_expression(
             ))),
         },
         (Binary(BinaryExpression { op, left, right }), _) => {
-            let left_arr = evaluate_expression(left.as_ref(), batch, None)?;
-            let right_arr = evaluate_expression(right.as_ref(), batch, None)?;
+            let left_arr = evaluate_expression_impl(left.as_ref(), batch, None, session_tz)?;
+            let right_arr = evaluate_expression_impl(right.as_ref(), batch, None, session_tz)?;
 
             type Operation = fn(&dyn Datum, &dyn Datum) -> Result<ArrayRef, ArrowError>;
             let eval: Operation = match op {
@@ -325,7 +371,7 @@ pub fn evaluate_expression(
             let mut arrays: Vec<ArrayRef> = Vec::with_capacity(exprs.len());
 
             for expr in exprs {
-                let array = evaluate_expression(expr, batch, result_type)?;
+                let array = evaluate_expression_impl(expr, batch, result_type, session_tz)?;
                 let null_count = array.null_count();
                 arrays.push(array);
                 // Short-circuit: if this array has no nulls, we can stop evaluating
@@ -339,7 +385,7 @@ pub fn evaluate_expression(
             Ok(coalesce_arrays(&arrays, result_type)?)
         }
         (Variadic(VariadicExpression { op: Array, exprs }), result_type) => {
-            evaluate_array_expression(exprs, batch, result_type)
+            evaluate_array_expression(exprs, batch, result_type, session_tz)
         }
         (Opaque(OpaqueExpression { op, exprs }), _) => {
             match op
@@ -353,7 +399,8 @@ pub fn evaluate_expression(
             }
         }
         (ParseJson(p), _) => {
-            let json_arr = evaluate_expression(&p.json_expr, batch, Some(&DataType::STRING))?;
+            let json_arr =
+                evaluate_expression_impl(&p.json_expr, batch, Some(&DataType::STRING), session_tz)?;
             // Coarser backstop for genuinely malformed JSON (incomplete records, unmatched
             // braces, etc.). Cell-level type-parse failures in failure-prone leaves
             // (Timestamp/Date/Decimal) are handled inside `parse_json_impl` itself, which
@@ -374,8 +421,8 @@ pub fn evaluate_expression(
             }
         }
         (MapToStruct(m), Some(DataType::Struct(output_schema))) => {
-            let map_arr = evaluate_expression(&m.map_expr, batch, None)?;
-            let result = evaluate_map_to_struct(&map_arr, output_schema)?;
+            let map_arr = evaluate_expression_impl(&m.map_expr, batch, None, session_tz)?;
+            let result = evaluate_map_to_struct(&map_arr, output_schema, session_tz)?;
             Ok(Arc::new(result) as ArrayRef)
         }
         (MapToStruct(_), dt) => Err(Error::Generic(format!(
@@ -401,6 +448,7 @@ fn evaluate_array_expression(
     exprs: &[Expression],
     batch: &RecordBatch,
     result_type: Option<&DataType>,
+    session_tz: Option<&Tz>,
 ) -> DeltaResult<ArrayRef> {
     let num_rows = batch.num_rows();
 
@@ -418,7 +466,7 @@ fn evaluate_array_expression(
 
     let element_arrays: Vec<ArrayRef> = exprs
         .iter()
-        .map(|expr| evaluate_expression(expr, batch, element_kernel_type))
+        .map(|expr| evaluate_expression_impl(expr, batch, element_kernel_type, session_tz))
         .try_collect()?;
 
     let element_type = element_arrays
@@ -902,29 +950,43 @@ pub fn coalesce_arrays(
 /// Date and timestamp use arrow's `Date32Type::parse` / `string_to_datetime`, which are much
 /// faster than `parse_scalar`'s chrono path and yield the same value for valid Delta partition
 /// values. These arrow parsers accept a superset of the canonical formats (e.g. `20240115`, or a
-/// timestamp carrying an explicit offset) and interpret no-offset timestamps as UTC, matching
-/// `parse_scalar`; spec-compliant writers only emit canonical values, so the extra leniency is
-/// harmless on the read path. All other types go through `parse_scalar`.
-fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
+/// timestamp carrying an explicit offset); spec-compliant writers only emit canonical values, so
+/// the extra leniency is harmless on the read path. All other types go through `parse_scalar`.
+///
+/// `session_tz` sets the zone used to resolve an offset-less `TIMESTAMP` value (one with no `Z` or
+/// explicit offset). `None` resolves at UTC (today's behavior). A string carrying an explicit
+/// offset ignores the zone, and `TIMESTAMP_NTZ` is a zoneless wall-clock that always resolves at
+/// UTC. This is the point where the engine's session-timezone capability is applied.
+fn parse_partition_scalar(
+    prim: &PrimitiveType,
+    raw: &str,
+    session_tz: Option<&Tz>,
+) -> DeltaResult<Option<Scalar>> {
     if raw.is_empty() {
         return Ok(prim.empty_string_partition_cast());
     }
+    let parse_err = || Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone()));
     match prim {
         PrimitiveType::Date => {
-            let days = Date32Type::parse(raw).ok_or_else(|| {
-                Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone()))
-            })?;
+            let days = Date32Type::parse(raw).ok_or_else(parse_err)?;
             return Ok(Some(Scalar::Date(days)));
         }
         PrimitiveType::Timestamp => {
-            let micros = string_to_datetime(&Utc, raw)
-                .map_err(|_| Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone())))?
-                .timestamp_micros();
+            // Resolve an offset-less string in the engine's session zone when supplied; a string
+            // with an explicit offset pins its own instant regardless.
+            let micros = match session_tz {
+                Some(tz) => string_to_datetime(tz, raw)
+                    .map_err(|_| parse_err())?
+                    .timestamp_micros(),
+                None => string_to_datetime(&Utc, raw)
+                    .map_err(|_| parse_err())?
+                    .timestamp_micros(),
+            };
             return Ok(Some(Scalar::Timestamp(micros)));
         }
         PrimitiveType::TimestampNtz => {
             let micros = string_to_datetime(&Utc, raw)
-                .map_err(|_| Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone())))?
+                .map_err(|_| parse_err())?
                 .timestamp_micros();
             return Ok(Some(Scalar::TimestampNtz(micros)));
         }
@@ -944,6 +1006,7 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 fn evaluate_map_to_struct(
     map_arr: &ArrayRef,
     output_schema: &StructType,
+    session_tz: Option<&Tz>,
 ) -> DeltaResult<StructArray> {
     let map_array = map_arr
         .as_any()
@@ -1024,7 +1087,7 @@ fn evaluate_map_to_struct(
             // and where the value is non-null.
             if entry_idx >= entry_start && map_values.is_valid(entry_idx as usize) {
                 let raw = map_values.value(entry_idx as usize);
-                match parse_partition_scalar(target_types[i], raw)? {
+                match parse_partition_scalar(target_types[i], raw, session_tz)? {
                     Some(scalar) => scalar.append_to(builder, 1)?,
                     None => Scalar::append_null(builder, field.data_type(), 1)?,
                 }
@@ -2359,6 +2422,93 @@ mod tests {
             .downcast_ref::<TimestampMicrosecondArray>()
             .unwrap();
         assert_eq!(ts.value(0), 1718443800000000); // 2024-06-15T09:30:00Z
+    }
+
+    /// An offset-less `TIMESTAMP` map value resolves in the engine-supplied session zone, while a
+    /// value carrying an explicit `Z` pins its own instant. With no zone (`None`), the offset-less
+    /// value resolves at UTC. This is the engine-capability path: the zone reaches
+    /// `evaluate_map_to_struct` as a parameter threaded from the handler, not from schema metadata.
+    #[rstest]
+    // Offset-less `2024-01-15 16:00:00` under America/New_York (UTC-5 in January) is 21:00Z.
+    #[case::offset_less_in_zone(
+        "2024-01-15 16:00:00",
+        Some("America/New_York"),
+        1_705_352_400_000_000
+    )]
+    // Offset-less resolves at UTC when no zone is supplied: 16:00:00 -> 16:00Z.
+    #[case::offset_less_no_zone("2024-01-15 16:00:00", None, 1_705_334_400_000_000)]
+    // Explicit `Z` ignores the session zone: 16:00Z stays 16:00Z.
+    #[case::explicit_z_ignores_zone(
+        "2024-01-15T16:00:00Z",
+        Some("America/New_York"),
+        1_705_334_400_000_000
+    )]
+    fn map_to_struct_timestamp_resolves_in_session_timezone(
+        #[case] raw: &str,
+        #[case] session_tz: Option<&str>,
+        #[case] expected_micros: i64,
+    ) {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("ts");
+        builder.values().append_value(raw);
+        builder.append(true).unwrap();
+        let map_array = builder.finish();
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "pv",
+            map_array.data_type().clone(),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
+
+        let output_schema =
+            StructType::new_unchecked(vec![StructField::nullable("ts", DataType::TIMESTAMP)]);
+        let result_type = DataType::from(output_schema);
+        let expr = Expr::map_to_struct(column_expr!("pv"));
+        let tz = session_tz.map(|t| t.parse::<Tz>().unwrap());
+        let result =
+            evaluate_expression_impl(&expr, &batch, Some(&result_type), tz.as_ref()).unwrap();
+        let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let ts = structs
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(ts.value(0), expected_micros);
+    }
+
+    /// `TIMESTAMP_NTZ` is a zoneless wall-clock: it must ignore the session zone entirely and
+    /// resolve at UTC even when one is supplied.
+    #[test]
+    fn map_to_struct_timestamp_ntz_ignores_session_timezone() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("ts");
+        builder.values().append_value("2024-01-15 16:00:00");
+        builder.append(true).unwrap();
+        let map_array = builder.finish();
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "pv",
+            map_array.data_type().clone(),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
+
+        let output_schema = StructType::new_unchecked(vec![StructField::nullable(
+            "ts",
+            DataType::Primitive(PrimitiveType::TimestampNtz),
+        )]);
+        let result_type = DataType::from(output_schema);
+        let expr = Expr::map_to_struct(column_expr!("pv"));
+        let tz = "America/New_York".parse::<Tz>().unwrap();
+        let result =
+            evaluate_expression_impl(&expr, &batch, Some(&result_type), Some(&tz)).unwrap();
+        let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let ts = structs
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        // 16:00 wall-clock, zone ignored -> 16:00Z.
+        assert_eq!(ts.value(0), 1_705_334_400_000_000);
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -1,11 +1,12 @@
 //! Expression handling based on arrow-rs compute kernels.
 use std::sync::Arc;
 
-use evaluate_expression::{evaluate_expression, evaluate_predicate, extract_column};
+use evaluate_expression::{evaluate_expression_impl, evaluate_predicate, extract_column};
 use itertools::Itertools;
 use tracing::debug;
 
 use super::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
+use crate::arrow::array::timezone::Tz;
 use crate::arrow::array::{self, ArrayBuilder, ArrayRef, RecordBatch, StructArray};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
@@ -238,8 +239,34 @@ impl ArrayData {
     }
 }
 
-#[derive(Debug)]
-pub struct ArrowEvaluationHandler;
+/// Arrow-backed [`EvaluationHandler`].
+///
+/// # Session timezone
+///
+/// An offset-less `TIMESTAMP` partition value (a string with no `Z` or explicit offset, e.g.
+/// `"2024-01-15 12:00:00"`) denotes a different instant per session zone; the Delta protocol reads
+/// it in the writer's zone, which a reader cannot recover. This handler resolves such values in
+/// `session_timezone` when it evaluates `MAP_TO_STRUCT` over a partition map. `None` resolves at
+/// UTC, matching the pre-existing behavior; a string carrying an explicit offset and
+/// `TIMESTAMP_NTZ` always ignore the zone.
+///
+/// The zone is a property of the handler because it is the engine's session state: an engine that
+/// wants session-aware partition resolution builds its handler with
+/// [`ArrowEvaluationHandler::new`]. Since the handler is typically long-lived and shared, an engine
+/// serving multiple sessions must build a fresh handler per session rather than mutating one in
+/// place.
+#[derive(Debug, Default)]
+pub struct ArrowEvaluationHandler {
+    session_timezone: Option<Tz>,
+}
+
+impl ArrowEvaluationHandler {
+    /// Builds a handler that resolves offset-less `TIMESTAMP` partition values in
+    /// `session_timezone` (`None` = UTC).
+    pub fn new(session_timezone: Option<Tz>) -> Self {
+        Self { session_timezone }
+    }
+}
 
 impl EvaluationHandler for ArrowEvaluationHandler {
     fn new_expression_evaluator(
@@ -252,6 +279,7 @@ impl EvaluationHandler for ArrowEvaluationHandler {
             _input_schema: schema,
             expression,
             output_type,
+            session_timezone: self.session_timezone,
         }))
     }
 
@@ -339,6 +367,9 @@ pub struct DefaultExpressionEvaluator {
     _input_schema: SchemaRef,
     expression: ExpressionRef,
     output_type: DataType,
+    /// Session zone for resolving offset-less `TIMESTAMP` partition values; carried from the
+    /// [`ArrowEvaluationHandler`] that produced this evaluator. See its docs.
+    session_timezone: Option<Tz>,
 }
 
 impl ExpressionEvaluator for DefaultExpressionEvaluator {
@@ -365,11 +396,21 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
                 apply_schema(&array, &self.output_type)?
             }
             (expr, output_type @ DataType::Struct(_)) => {
-                let array_ref = evaluate_expression(expr, batch, Some(output_type))?;
+                let array_ref = evaluate_expression_impl(
+                    expr,
+                    batch,
+                    Some(output_type),
+                    self.session_timezone.as_ref(),
+                )?;
                 apply_schema(&array_ref, output_type)?
             }
             (expr, output_type) => {
-                let array_ref = evaluate_expression(expr, batch, Some(output_type))?;
+                let array_ref = evaluate_expression_impl(
+                    expr,
+                    batch,
+                    Some(output_type),
+                    self.session_timezone.as_ref(),
+                )?;
                 let array_ref = apply_schema_to(&array_ref, output_type)?;
                 let arrow_type = ArrowDataType::try_from_kernel(output_type)?;
                 let schema = ArrowSchema::new(vec![ArrowField::new("output", arrow_type, true)]);

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -14,7 +14,7 @@ use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
 use crate::arrow::datatypes::{DataType, Field, Fields, Schema};
 use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt as _};
-use crate::engine::arrow_expression::evaluate_expression::to_json;
+use crate::engine::arrow_expression::evaluate_expression::{evaluate_expression, to_json};
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpression as _, ArrowOpaqueExpressionOp, ArrowOpaquePredicate as _,
     ArrowOpaquePredicateOp,
@@ -802,7 +802,7 @@ fn test_null_row() {
         ),
         StructField::nullable("c", KernelDataType::STRING),
     ]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let result = handler.null_row(schema.clone()).unwrap();
     let expected = RecordBatch::try_new(
         Arc::new(schema.as_ref().try_into_arrow().unwrap()),
@@ -830,7 +830,7 @@ fn test_null_row_err() {
         "a",
         KernelDataType::STRING,
     )]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     assert_result_error_with_message(
         handler.null_row(not_null_schema),
         "Invalid argument error: Column 'a' is declared as non-nullable but contains null values",
@@ -839,7 +839,7 @@ fn test_null_row_err() {
 
 // helper to take values/schema to pass to `create_one` and assert the result = expected
 fn assert_create_one(values: &[Scalar], schema: SchemaRef, expected: RecordBatch) {
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let actual = handler.create_one(schema, values).unwrap();
     let actual_rb = actual.try_into_record_batch().unwrap();
     assert_eq!(actual_rb, expected);
@@ -963,7 +963,7 @@ fn test_create_one_mismatching_scalar_types() {
         "version",
         KernelDataType::INTEGER,
     )]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     assert_result_error_with_message(
         handler.create_one(schema, values),
         "Schema error: Mismatched scalar type while creating Expression: expected Integer, got Long",
@@ -985,7 +985,7 @@ fn test_create_one_not_null_struct() {
             StructField::nullable("c", KernelDataType::INTEGER),
         ]),
     )]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     assert_result_error_with_message(
         handler.create_one(schema, values),
         "Column 'a' is declared as non-nullable but contains null values",
@@ -997,7 +997,7 @@ fn test_create_one_top_level_null() {
     // Creating a NOT NULL field with null value should error.
     // The error comes from Arrow's RecordBatch validation.
     let values = &[Scalar::Null(KernelDataType::INTEGER)];
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
 
     let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
         "col_1",
@@ -1283,7 +1283,7 @@ fn test_evaluator_mixed_string_types_identity_transform() {
     let input_schema = Arc::new(StructType::new_unchecked(fields.clone()));
     let output_type = KernelDataType::from(StructType::new_unchecked(fields));
 
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let expression: ExpressionRef =
         Arc::new(Expression::struct_patch(ExpressionStructPatchBuilder::new()).unwrap());
     handler
@@ -1314,7 +1314,7 @@ fn test_evaluator_mixed_string_types_struct_expression() {
     )]));
     let output_type = KernelDataType::from(StructType::new_unchecked(fields));
 
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let expression: ExpressionRef = Arc::new(column_expr!("st"));
     handler
         .new_expression_evaluator(input_schema, expression, output_type)
@@ -1325,7 +1325,7 @@ fn test_evaluator_mixed_string_types_struct_expression() {
 
 // helper to build a RecordBatch via `create_many` and assert it equals `expected`
 fn assert_create_many(rows: &[&[Scalar]], schema: SchemaRef, expected: RecordBatch) {
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let actual = handler.create_many(schema, rows).unwrap();
     let actual_rb = actual.try_into_record_batch().unwrap();
     assert_eq!(actual_rb, expected);
@@ -1361,7 +1361,7 @@ fn test_create_many_empty_rows_returns_zero_row_batch() {
         StructField::nullable("a", KernelDataType::INTEGER),
         StructField::nullable("b", KernelDataType::STRING),
     ]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let result = handler.create_many(schema.clone(), &[]).unwrap();
     assert_eq!(result.len(), 0);
     let rb = result.try_into_record_batch().unwrap();
@@ -1377,7 +1377,7 @@ fn test_create_many_wrong_field_count_returns_error() {
     ]));
     // Row has 3 scalars but schema has 2 fields
     let bad_row: &[Scalar] = &[1.into(), "x".into(), 99.into()];
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     assert_result_error_with_message(
         handler.create_many(schema, &[bad_row]),
         "Row 0 has 3 scalars but schema has 2 fields",
@@ -1393,7 +1393,7 @@ fn test_create_many_wrong_field_type_returns_error() {
     // Row 1 passes a Long where an Integer is expected for field "a"
     let good_row: &[Scalar] = &[1.into(), "x".into()];
     let bad_row: &[Scalar] = &[1i64.into(), "y".into()];
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     assert_result_error_with_message(
         handler.create_many(schema, &[good_row, bad_row]),
         "Row 1, field 'a' (expected type integer, got long): Invalid expression evaluation: Invalid builder for long",
@@ -1413,7 +1413,7 @@ fn test_create_many_single_row_matches_create_one() {
         StructField::nullable("b", KernelDataType::STRING),
         StructField::nullable("c", KernelDataType::INTEGER),
     ]));
-    let handler = ArrowEvaluationHandler;
+    let handler = ArrowEvaluationHandler::default();
     let from_one = handler
         .create_one(schema.clone(), values)
         .unwrap()

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -63,7 +63,7 @@ impl SyncEngine {
             storage_handler: Arc::new(storage::SyncStorageHandler::new(store.clone())),
             json_handler: Arc::new(json::SyncJsonHandler::new(store.clone())),
             parquet_handler: Arc::new(parquet::SyncParquetHandler::new(store)),
-            evaluation_handler: Arc::new(ArrowEvaluationHandler {}),
+            evaluation_handler: Arc::new(ArrowEvaluationHandler::default()),
         }
     }
 }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -24,8 +24,8 @@ use crate::log_segment::CheckpointReadInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
 use crate::scan::Scalar;
 use crate::schema::{
-    schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
-    StructField, StructType, ToSchema as _,
+    schema_ref, ColumnNamesAndTypes, DataType, MapType, PrimitiveType, SchemaRef,
+    SchemaStructPatchBuilder, StructField, StructType, ToSchema as _,
 };
 use crate::table_features::ColumnMappingMode;
 use crate::utils::{require, FoldWithOption as _};
@@ -269,6 +269,16 @@ impl ScanLogReplayProcessor {
             partition_schema_for_transform.clone(),
         )?;
 
+        // A native checkpoint `partitionValues_parsed` column bakes a `TIMESTAMP` partition value
+        // at the writer's zone, which a reader cannot recover from the frozen instant.
+        // Trusting it would make a checkpoint read disagree with a JSON-commit read of the
+        // same table. So when a `TIMESTAMP` partition column exists, bypass the frozen
+        // column and reconstruct partition values from the raw `partitionValues` string
+        // map. Every other partition type is zone-independent and keeps the native fast
+        // path.
+        let checkpoint_has_partition_values_parsed = has_partition_values_parsed
+            && !should_reparse_partition_values_from_map(partition_schema_for_transform.as_ref());
+
         // Create data skipping filter that reads stats_parsed and partitionValues_parsed
         // from the transformed batch. This avoids double JSON parsing -- the transform parses
         // JSON once, then data skipping reads the already-parsed columns from the output.
@@ -319,7 +329,7 @@ impl ScanLogReplayProcessor {
                     skip_stats,
                     synthesize_json,
                     partition_schema_for_transform,
-                    has_partition_values_parsed,
+                    checkpoint_has_partition_values_parsed,
                 ),
                 output_schema.into(),
             )?,
@@ -698,6 +708,29 @@ fn scan_row_schema_with_parsed_columns(
     Ok(Arc::new(patch.build(&SCAN_ROW_SCHEMA)?))
 }
 
+/// Whether `partition_schema` has a `TIMESTAMP` column. Partition columns are flat primitives, so
+/// only top-level leaves are inspected.
+fn partition_schema_has_timestamp(partition_schema: Option<&SchemaRef>) -> bool {
+    partition_schema.is_some_and(|schema| {
+        schema
+            .fields()
+            .any(|field| field.data_type() == &DataType::Primitive(PrimitiveType::Timestamp))
+    })
+}
+
+/// Whether a native checkpoint's frozen `partitionValues_parsed` column must be bypassed and
+/// reconstructed from the raw `partitionValues` string map.
+///
+/// A `TIMESTAMP` partition value is serialized without a zone, so its frozen instant was resolved
+/// in the writer's zone, which a reader cannot recover. Trusting the frozen column would make a
+/// checkpoint read disagree with a JSON-commit read of the same table (which always reconstructs
+/// from the map). So whenever a `TIMESTAMP` partition column exists, always reconstruct from the
+/// raw map. Every other partition type (date, int, string, `TIMESTAMP_NTZ`) is zone-independent and
+/// keeps the native fast path.
+fn should_reparse_partition_values_from_map(partition_schema: Option<&SchemaRef>) -> bool {
+    partition_schema_has_timestamp(partition_schema)
+}
+
 /// Build the add transform expression with optional stats and partition value parsing.
 ///
 /// # Parameters
@@ -1018,8 +1051,9 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState,
+        get_add_transform_expr, scan_action_iter, should_reparse_partition_values_from_map,
+        InternalScanState, ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+        SerializableScanState,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
@@ -1927,5 +1961,36 @@ mod tests {
             0,
             "expected no ToJson nodes anywhere in the transform when synthesis is skipped"
         );
+    }
+
+    /// A native checkpoint's frozen `partitionValues_parsed` must be reparsed from the raw map
+    /// whenever a `TIMESTAMP` partition column exists (its frozen instant carries the writer's
+    /// unrecoverable zone), and trusted for every zone-independent type.
+    #[test]
+    fn reparse_gate_forces_reparse_only_for_timestamp_partition() {
+        use crate::schema::PrimitiveType;
+
+        let ts: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
+            "p",
+            DataType::TIMESTAMP,
+        )]));
+        assert!(should_reparse_partition_values_from_map(Some(&ts)));
+
+        // A TIMESTAMP among other columns still forces reparse.
+        let mixed: SchemaRef = Arc::new(StructType::new_unchecked([
+            StructField::nullable("d", DataType::DATE),
+            StructField::nullable("n", DataType::Primitive(PrimitiveType::TimestampNtz)),
+            StructField::nullable("t", DataType::TIMESTAMP),
+        ]));
+        assert!(should_reparse_partition_values_from_map(Some(&mixed)));
+
+        // Zone-independent types (including TIMESTAMP_NTZ) keep the native fast path.
+        let no_ts: SchemaRef = Arc::new(StructType::new_unchecked([
+            StructField::nullable("d", DataType::DATE),
+            StructField::nullable("n", DataType::Primitive(PrimitiveType::TimestampNtz)),
+            StructField::nullable("i", DataType::INTEGER),
+        ]));
+        assert!(!should_reparse_partition_values_from_map(Some(&no_ts)));
+        assert!(!should_reparse_partition_values_from_map(None));
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2297,7 +2297,7 @@ mod tests {
         let physical_schema = wc.physical_schema();
         let l2p = wc.logical_to_physical();
 
-        let handler = ArrowEvaluationHandler;
+        let handler = ArrowEvaluationHandler::default();
         let evaluator = handler.new_expression_evaluator(
             input_schema.into(),
             l2p,
@@ -2907,7 +2907,8 @@ mod tests {
                 Scalar::Array(ArrayData::try_new(score_type, [30i32])?),
             ],
         )?);
-        ArrowEvaluationHandler.create_many(schema, &[&[1i64.into(), info1], &[2i64.into(), info2]])
+        ArrowEvaluationHandler::default()
+            .create_many(schema, &[&[1i64.into(), info1], &[2i64.into(), info2]])
     }
 
     /// Validates that [`WriteContext::logical_to_physical`] correctly renames fields at all nesting
@@ -2933,7 +2934,7 @@ mod tests {
 
         // Evaluate the logical_to_physical expression
         let input_schema: SchemaRef = logical_schema.clone();
-        let handler = ArrowEvaluationHandler;
+        let handler = ArrowEvaluationHandler::default();
         let evaluator = handler.new_expression_evaluator(
             input_schema,
             logical_to_physical_expression.clone(),
@@ -3059,7 +3060,7 @@ mod tests {
             })
             .collect();
         let row_refs: Vec<&[Scalar]> = rows.iter().map(|r| r.as_slice()).collect();
-        ArrowEvaluationHandler
+        ArrowEvaluationHandler::default()
             .create_many(schema, &row_refs)
             .unwrap()
     }

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -402,9 +402,14 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
 // end-to-end counterpart to the unit tests in `evaluate_expression`.
 
 /// Writes a `p_ts`-TIMESTAMP-partition foreign table, one `add` per `(path, raw_ts)`, and returns
-/// its URL. `writeStatsAsStruct=false` so the JSON commit reconstructs `partitionValues_parsed`
-/// from the string map on read (the tz-aware path).
-async fn write_ts_partition_table(table_path: &std::path::Path, files: &[(&str, &str)]) -> Url {
+/// its URL. With `write_stats_as_struct = false` a JSON commit reconstructs
+/// `partitionValues_parsed` from the string map on read; with `true` a later kernel checkpoint
+/// writes a native `partitionValues_parsed` column, exercising the reparse-vs-passthrough branch.
+async fn write_ts_partition_table(
+    table_path: &std::path::Path,
+    files: &[(&str, &str)],
+    write_stats_as_struct: bool,
+) -> Url {
     std::fs::create_dir_all(table_path).unwrap();
     let url = Url::from_directory_path(table_path).unwrap();
     let table_root = url.to_string();
@@ -418,6 +423,11 @@ async fn write_ts_partition_table(table_path: &std::path::Path, files: &[(&str, 
         ],
     })
     .to_string();
+    let configuration = if write_stats_as_struct {
+        serde_json::json!({"delta.checkpoint.writeStatsAsStruct": "true"})
+    } else {
+        serde_json::json!({})
+    };
     let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
     let metadata = serde_json::json!({
         "metaData": {
@@ -425,7 +435,7 @@ async fn write_ts_partition_table(table_path: &std::path::Path, files: &[(&str, 
             "format": {"provider": "parquet", "options": {}},
             "schemaString": schema_string,
             "partitionColumns": ["p_ts"],
-            "configuration": {},
+            "configuration": configuration,
             "createdTime": 1700000000000_i64,
         },
     })
@@ -499,7 +509,8 @@ async fn engine_session_timezone_resolves_offset_less_timestamp_partition(
 ) {
     let temp_dir = tempfile::tempdir().unwrap();
     let table_path = temp_dir.path().join("engine-tz-offset-less");
-    let url = write_ts_partition_table(&table_path, &[("f.parquet", "2024-01-15 16:00:00")]).await;
+    let url =
+        write_ts_partition_table(&table_path, &[("f.parquet", "2024-01-15 16:00:00")], false).await;
     let engine = zoned_engine(&url, session_tz);
 
     let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
@@ -550,6 +561,7 @@ async fn engine_session_timezone_prunes_offset_less_timestamp_partition() {
             ("a.parquet", "2024-01-15 16:00:00"),
             ("b.parquet", "2024-01-15 17:00:00"),
         ],
+        false,
     )
     .await;
     let engine = zoned_engine(&url, Some("America/New_York"));
@@ -578,4 +590,64 @@ async fn engine_session_timezone_prunes_offset_less_timestamp_partition() {
         vec!["a.parquet".to_string()],
         "only the file whose session-zone instant equals the predicate survives"
     );
+}
+
+/// A native checkpoint's frozen `partitionValues_parsed` for a TIMESTAMP partition column is always
+/// bypassed and reparsed from the raw map, even with NO session zone. A foreign writer froze
+/// `2024-01-15 16:00:00` at some non-UTC instant, but a zoneless kernel read must reconstruct it
+/// from the raw string at UTC (16:00Z), proving the frozen column was not trusted. This is the
+/// commit-vs-checkpoint consistency guarantee: the same table reads identically before and after a
+/// checkpoint.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_checkpoint_timestamp_partition_always_reparses_without_zone() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let table_path = temp_dir.path().join("forced-reparse-no-zone");
+    // `writeStatsAsStruct=true` so the kernel checkpoint writes a native `partitionValues_parsed`
+    // column, exercising the reparse-vs-passthrough branch.
+    let url =
+        write_ts_partition_table(&table_path, &[("f.parquet", "2024-01-15 16:00:00")], true).await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+
+    // Force a checkpoint so the read sees a native frozen column, not a JSON commit.
+    Snapshot::builder_for(url.clone())
+        .build(engine.as_ref())
+        .unwrap()
+        .checkpoint(engine.as_ref(), None)
+        .unwrap();
+
+    // Zoneless engine (no session timezone). The frozen column must still be bypassed and the raw
+    // map reparsed at UTC: "2024-01-15 16:00:00" -> 16:00Z.
+    let utc_micros = 1_705_334_400_000_000_i64;
+    let snapshot = Snapshot::builder_for(url.clone())
+        .build(engine.as_ref())
+        .unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()
+        .unwrap();
+
+    let mut found = false;
+    for scan_metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let (data, selection) = scan_metadata.unwrap().scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data).unwrap().into();
+        let batch = filter_record_batch(&batch, &BooleanArray::from(selection)).unwrap();
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let pv = get_column!(batch, "partitionValues_parsed", StructArray);
+        let p_ts = pv
+            .column_by_name("p_ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(
+            p_ts.value(0),
+            utc_micros,
+            "TIMESTAMP partition must reparse from the raw map even with no session zone"
+        );
+        found = true;
+    }
+    assert!(found, "expected one surviving file");
 }

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
     Array, BinaryArray, BooleanArray, Int32Array, RecordBatch, StringArray, StructArray,
+    TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -390,4 +391,129 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
         vec![other.clone()],
         "empty-bytes file must be pruned under p_bin = X'6f74686572'"
     );
+}
+
+// === Engine-supplied session timezone (Option 6) ===
+//
+// The engine's `ArrowEvaluationHandler` carries the session zone. When it evaluates the
+// `MAP_TO_STRUCT` that reconstructs `partitionValues_parsed`, offset-less TIMESTAMP values resolve
+// in that zone. Kernel emits a generic `MAP_TO_STRUCT` and never sees the timezone; a
+// `DefaultEngine` built via `DefaultEngineBuilder::with_session_timezone` supplies it. This is the
+// end-to-end counterpart to the unit tests in `evaluate_expression`.
+
+/// Writes a single-`p_ts`-TIMESTAMP-partition foreign table with one offset-less add, and returns
+/// its URL. `writeStatsAsStruct=false` so the JSON commit reconstructs `partitionValues_parsed`
+/// from the string map on read (the tz-aware path).
+async fn write_ts_partition_table(table_path: &std::path::Path, raw_ts: &str) -> Url {
+    std::fs::create_dir_all(table_path).unwrap();
+    let url = Url::from_directory_path(table_path).unwrap();
+    let table_root = url.to_string();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+
+    let schema_string = serde_json::json!({
+        "type": "struct",
+        "fields": [
+            {"name": "p_ts", "type": "timestamp", "nullable": true, "metadata": {}},
+            {"name": "value", "type": "integer", "nullable": true, "metadata": {}},
+        ],
+    })
+    .to_string();
+    let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+    let metadata = serde_json::json!({
+        "metaData": {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": ["p_ts"],
+            "configuration": {},
+            "createdTime": 1700000000000_i64,
+        },
+    })
+    .to_string();
+    let add = serde_json::json!({
+        "add": {
+            "path": "f.parquet",
+            "partitionValues": {"p_ts": raw_ts},
+            "size": 100,
+            "modificationTime": 1700000000000_i64,
+            "dataChange": true,
+            "stats": "{\"numRecords\":1}",
+        },
+    })
+    .to_string();
+
+    add_commit(
+        &table_root,
+        store.as_ref(),
+        0,
+        format!("{protocol}\n{metadata}"),
+    )
+    .await
+    .unwrap();
+    add_commit(&table_root, store.as_ref(), 1, add)
+        .await
+        .unwrap();
+    url
+}
+
+/// An engine built with a session zone resolves an offset-less TIMESTAMP partition value in that
+/// zone; a default (zoneless) engine resolves it at UTC. This exercises the full Option-6 path:
+/// `DefaultEngineBuilder::with_session_timezone` -> zoned `ArrowEvaluationHandler` ->
+/// `evaluate_map_to_struct`.
+#[rstest]
+// Offset-less `2024-01-15 16:00:00` under America/New_York (UTC-5 in January) is 21:00Z.
+#[case::in_zone(Some("America/New_York"), 1_705_352_400_000_000)]
+// A zoneless engine resolves the same string at UTC: 16:00Z.
+#[case::no_zone(None, 1_705_334_400_000_000)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_session_timezone_resolves_offset_less_timestamp_partition(
+    #[case] session_tz: Option<&str>,
+    #[case] expected_micros: i64,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let table_path = temp_dir.path().join("engine-tz-offset-less");
+    let url = write_ts_partition_table(&table_path, "2024-01-15 16:00:00").await;
+
+    let store = test_utils::delta_kernel_default_engine::storage::store_from_url(&url).unwrap();
+    let task_executor = Arc::new(
+        test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor::new(
+            tokio::runtime::Handle::current(),
+        ),
+    );
+    let mut builder = DefaultEngineBuilder::new(store).with_task_executor(task_executor);
+    if let Some(tz) = session_tz {
+        builder = builder.with_session_timezone(tz).unwrap();
+    }
+    let engine = builder.build();
+
+    let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()
+        .unwrap();
+
+    let mut found = false;
+    for scan_metadata in scan.scan_metadata(&engine).unwrap() {
+        let (data, selection) = scan_metadata.unwrap().scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data).unwrap().into();
+        let batch = filter_record_batch(&batch, &BooleanArray::from(selection)).unwrap();
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let pv = get_column!(batch, "partitionValues_parsed", StructArray);
+        let p_ts = pv
+            .column_by_name("p_ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(
+            p_ts.value(0),
+            expected_micros,
+            "offset-less TIMESTAMP must resolve in the engine's session zone"
+        );
+        found = true;
+    }
+    assert!(found, "expected one surviving file");
 }

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -8,7 +8,7 @@ use delta_kernel::arrow::array::{
 };
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::expressions::{col, lit, ColumnName, Predicate};
+use delta_kernel::expressions::{col, lit, ColumnName, Predicate, Scalar};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::DynObjectStore;
 use delta_kernel::scan::state::ScanFile;
@@ -401,10 +401,10 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
 // `DefaultEngine` built via `DefaultEngineBuilder::with_session_timezone` supplies it. This is the
 // end-to-end counterpart to the unit tests in `evaluate_expression`.
 
-/// Writes a single-`p_ts`-TIMESTAMP-partition foreign table with one offset-less add, and returns
+/// Writes a `p_ts`-TIMESTAMP-partition foreign table, one `add` per `(path, raw_ts)`, and returns
 /// its URL. `writeStatsAsStruct=false` so the JSON commit reconstructs `partitionValues_parsed`
 /// from the string map on read (the tz-aware path).
-async fn write_ts_partition_table(table_path: &std::path::Path, raw_ts: &str) -> Url {
+async fn write_ts_partition_table(table_path: &std::path::Path, files: &[(&str, &str)]) -> Url {
     std::fs::create_dir_all(table_path).unwrap();
     let url = Url::from_directory_path(table_path).unwrap();
     let table_root = url.to_string();
@@ -430,17 +430,23 @@ async fn write_ts_partition_table(table_path: &std::path::Path, raw_ts: &str) ->
         },
     })
     .to_string();
-    let add = serde_json::json!({
-        "add": {
-            "path": "f.parquet",
-            "partitionValues": {"p_ts": raw_ts},
-            "size": 100,
-            "modificationTime": 1700000000000_i64,
-            "dataChange": true,
-            "stats": "{\"numRecords\":1}",
-        },
-    })
-    .to_string();
+    let adds = files
+        .iter()
+        .map(|(path, raw_ts)| {
+            serde_json::json!({
+                "add": {
+                    "path": path,
+                    "partitionValues": {"p_ts": raw_ts},
+                    "size": 100,
+                    "modificationTime": 1700000000000_i64,
+                    "dataChange": true,
+                    "stats": "{\"numRecords\":1}",
+                },
+            })
+            .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
 
     add_commit(
         &table_root,
@@ -450,10 +456,31 @@ async fn write_ts_partition_table(table_path: &std::path::Path, raw_ts: &str) ->
     )
     .await
     .unwrap();
-    add_commit(&table_root, store.as_ref(), 1, add)
+    add_commit(&table_root, store.as_ref(), 1, adds)
         .await
         .unwrap();
     url
+}
+
+/// Builds a multi-threaded `DefaultEngine` over `url`, optionally carrying a session zone.
+/// `session_tz = None` resolves offset-less TIMESTAMP partition values at UTC.
+fn zoned_engine(
+    url: &Url,
+    session_tz: Option<&str>,
+) -> test_utils::delta_kernel_default_engine::DefaultEngine<
+    test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor,
+> {
+    let store = test_utils::delta_kernel_default_engine::storage::store_from_url(url).unwrap();
+    let task_executor = Arc::new(
+        test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor::new(
+            tokio::runtime::Handle::current(),
+        ),
+    );
+    let mut builder = DefaultEngineBuilder::new(store).with_task_executor(task_executor);
+    if let Some(tz) = session_tz {
+        builder = builder.with_session_timezone(tz).unwrap();
+    }
+    builder.build()
 }
 
 /// An engine built with a session zone resolves an offset-less TIMESTAMP partition value in that
@@ -472,19 +499,8 @@ async fn engine_session_timezone_resolves_offset_less_timestamp_partition(
 ) {
     let temp_dir = tempfile::tempdir().unwrap();
     let table_path = temp_dir.path().join("engine-tz-offset-less");
-    let url = write_ts_partition_table(&table_path, "2024-01-15 16:00:00").await;
-
-    let store = test_utils::delta_kernel_default_engine::storage::store_from_url(&url).unwrap();
-    let task_executor = Arc::new(
-        test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor::new(
-            tokio::runtime::Handle::current(),
-        ),
-    );
-    let mut builder = DefaultEngineBuilder::new(store).with_task_executor(task_executor);
-    if let Some(tz) = session_tz {
-        builder = builder.with_session_timezone(tz).unwrap();
-    }
-    let engine = builder.build();
+    let url = write_ts_partition_table(&table_path, &[("f.parquet", "2024-01-15 16:00:00")]).await;
+    let engine = zoned_engine(&url, session_tz);
 
     let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
     let scan = snapshot
@@ -516,4 +532,50 @@ async fn engine_session_timezone_resolves_offset_less_timestamp_partition(
         found = true;
     }
     assert!(found, "expected one surviving file");
+}
+
+/// The engine's session zone actually eliminates files: a partition predicate written as an
+/// absolute instant keeps only the file whose offset-less TIMESTAMP resolves (in that zone) to the
+/// same instant, and prunes the other. Under UTC the same predicate would keep the other file, so
+/// this proves the pruning acts on the zone-resolved value, not a fixed-UTC one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engine_session_timezone_prunes_offset_less_timestamp_partition() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let table_path = temp_dir.path().join("engine-tz-pruning");
+    // Two offset-less values one hour apart. Under America/New_York (UTC-5) they denote
+    // 2024-01-15T21:00:00Z (a.parquet) and 2024-01-15T22:00:00Z (b.parquet).
+    let url = write_ts_partition_table(
+        &table_path,
+        &[
+            ("a.parquet", "2024-01-15 16:00:00"),
+            ("b.parquet", "2024-01-15 17:00:00"),
+        ],
+    )
+    .await;
+    let engine = zoned_engine(&url, Some("America/New_York"));
+
+    let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
+    // 16:00 in America/New_York is 21:00Z. The predicate written as that instant keeps a.parquet
+    // (21:00Z) and prunes b.parquet (22:00Z). Under UTC, a.parquet would resolve to 16:00Z and be
+    // pruned instead, so a surviving `a.parquet` proves the zone was applied.
+    let target = lit(Scalar::Timestamp(1_705_352_400_000_000)); // 2024-01-15T21:00:00Z
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .with_predicate(Arc::new(Predicate::eq(col!("p_ts"), target)))
+        .build()
+        .unwrap();
+
+    let mut paths = Vec::new();
+    for scan_metadata in scan.scan_metadata(&engine).unwrap() {
+        paths = scan_metadata
+            .unwrap()
+            .visit_scan_files(paths, collect_path)
+            .unwrap();
+    }
+    assert_eq!(
+        paths,
+        vec!["a.parquet".to_string()],
+        "only the file whose session-zone instant equals the predicate survives"
+    );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is an **alternative implementation** to #2894, opened as a draft for side-by-side comparison. Both resolve offset-less `TIMESTAMP` partition values (a string with no `Z`/offset, e.g. `"2024-01-15 12:00:00"`, which denotes a different instant per session zone) in a caller-supplied session timezone. They differ only in **how the zone reaches the leaf parse**.

This PR takes the **engine-capability** approach (Option 6 in the design doc): the engine's `EvaluationHandler` carries the session timezone, and kernel emits a generic `MAP_TO_STRUCT` with no timezone awareness of its own.

- `ArrowEvaluationHandler` gains an `Option<Tz>` (`ArrowEvaluationHandler::new(tz)`), defaulting to `None` = UTC.
- The zone threads from the handler through `evaluate_expression` into `evaluate_map_to_struct` / `parse_partition_scalar`, applied only at the `TIMESTAMP` leaf parse. `TIMESTAMP_NTZ` and offset-bearing strings ignore it.
- `DefaultEngineBuilder::with_session_timezone(tz)` builds a zoned engine.

#2894 instead rides the zone on **field metadata of the output schema** (which already crosses the `Engine` trait as `output_type`), keeping the handler a stateless unit struct.

### Tradeoff vs #2894

| | #2894 (output-schema metadata) | This PR (engine capability) |
|---|---|---|
| Where the zone rides | Field metadata on the output schema — a channel already crossing the trait | New `Option<Tz>` on `ArrowEvaluationHandler` |
| Zone lifetime | Per-evaluation (per-scan), naturally scoped | Per-handler — long-lived and shared |
| Cross-session safety | Safe by construction | Hazard: `DefaultEngine` (and connectors like Reyden that delegate to `ArrowEvaluationHandler`) build the handler once; a baked-in zone bleeds across queries unless the handler is rebuilt per session |
| Blast radius | `evaluate_map_to_struct` reads per-field metadata; scan stamps it | `evaluate_expression` signature threaded with `Tz` through the recursion; handler fielded; construction sites updated |
| Extra surface | Needs a `ColumnMetadataKey::SessionTimezone` key + a strip step so internal metadata never leaks to engine output | None — no schema metadata to strip |
| Ergonomics | Zone attached to exactly the `TIMESTAMP` leaves it applies to | Zone rides an object that also evaluates stats JSON, predicates, `create_many` — none of which use it |

Net: #2894 keeps the mechanism localized and per-scan-scoped at the cost of a metadata key + strip; this PR keeps the schema clean at the cost of relocating per-session state onto a shared handler and threading a timezone through the whole evaluator surface.

Checkpoint reparse policy (bypassing a native `partitionValues_parsed` column under a session zone) is out of scope for this draft; it is orthogonal to where the zone lives and can be layered on either approach.

## How was this change tested?

- Unit tests in `evaluate_expression`: offset-less `TIMESTAMP` resolves in the supplied zone, an explicit `Z` ignores it, `None` resolves at UTC, and `TIMESTAMP_NTZ` ignores the zone.
- Integration test: a `DefaultEngine` built with `with_session_timezone` resolves an offset-less `TIMESTAMP` partition value in-zone end-to-end, and a zoneless engine resolves it at UTC.
- Integration test proving **file elimination**: a partition predicate written as an absolute instant keeps only the file whose offset-less `TIMESTAMP` resolves (in the session zone) to that instant and prunes the other; under UTC the same predicate would keep the other file, so a surviving match proves pruning acts on the zone-resolved value.

Tested against synthetic foreign-writer tables (raw-JSON commits), not against real DBR/Spark-written tables; that end-to-end validation is a follow-up.
