### PR TITLE
feat!: validate add file partition columns

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1537,7 +1537,10 @@ pub unsafe extern "C" fn snapshot_table_root(
 #[no_mangle]
 pub unsafe extern "C" fn get_partition_column_count(snapshot: Handle<SharedSnapshot>) -> usize {
     let snapshot = unsafe { snapshot.as_ref() };
-    snapshot.table_configuration().partition_columns().len()
+    snapshot
+        .table_configuration()
+        .logical_partition_columns()
+        .len()
 }
 
 /// Get an iterator of the list of partition columns for this snapshot.
@@ -1550,7 +1553,10 @@ pub unsafe extern "C" fn get_partition_columns(
 ) -> Handle<StringSliceIterator> {
     let snapshot = unsafe { snapshot.as_ref() };
     // NOTE: Clippy doesn't like it, but we need to_vec+into_iter to decouple lifetimes
-    let partition_columns = snapshot.table_configuration().partition_columns().to_vec();
+    let partition_columns = snapshot
+        .table_configuration()
+        .logical_partition_columns()
+        .to_vec();
     let iter: Box<StringIter> = Box::new(partition_columns.into_iter());
     iter.into()
 }

--- a/kernel/src/engine_data.rs
+++ b/kernel/src/engine_data.rs
@@ -195,6 +195,13 @@ impl<'a> MapItem<'a> {
         self.values.is_valid(idx).then(|| self.values.value(idx))
     }
 
+    /// Returns the map's keys in storage order, including keys whose value is null. Unlike
+    /// [`MapItem::materialize`], which drops null-valued entries, this exposes the full key set.
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &'a str> + 'a {
+        let keys = self.keys;
+        self.offsets.clone().map(move |idx| keys.value(idx))
+    }
+
     pub fn materialize(&self) -> HashMap<String, String> {
         let mut ret = HashMap::with_capacity(self.offsets.len());
         for idx in self.offsets.clone() {
@@ -836,5 +843,33 @@ mod tests {
         #[case] expected: Vec<usize>,
     ) {
         assert_eq!(collect_indices(row_count, selection), expected);
+    }
+
+    #[test]
+    fn map_item_keys_includes_null_valued_keys() {
+        // Map { "a" => "1", "b" => null }: `keys()` must expose both keys, while `materialize()`
+        // (and `get`) drop the null-valued entry.
+        let keys = StringArray::from(vec!["a", "b"]);
+        let values = StringArray::from(vec![Some("1"), None]);
+        let map = MapItem::new(&keys, &values, 0..2);
+
+        let mut seen: Vec<&str> = map.keys().collect();
+        seen.sort_unstable();
+        assert_eq!(seen, vec!["a", "b"]);
+
+        assert_eq!(map.get("a"), Some("1"));
+        assert_eq!(map.get("b"), None);
+        assert_eq!(
+            map.materialize(),
+            HashMap::from([("a".to_string(), "1".to_string())])
+        );
+    }
+
+    #[test]
+    fn map_item_keys_empty() {
+        let keys = StringArray::from(Vec::<&str>::new());
+        let values = StringArray::from(Vec::<&str>::new());
+        let map = MapItem::new(&keys, &values, 0..0);
+        assert_eq!(map.keys().count(), 0);
     }
 }

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -84,7 +84,7 @@ fn validate_metadata_columns<'a>(
     table_configuration: &'a TableConfiguration,
 ) -> DeltaResult<MetadataInfo<'a>> {
     let mut metadata_info = MetadataInfo::default();
-    let partition_columns = table_configuration.partition_columns();
+    let partition_columns = table_configuration.logical_partition_columns();
     for metadata_column in logical_schema.metadata_columns() {
         // Ensure we don't have a metadata column with same name as a partition column
         if partition_columns.contains(metadata_column.name()) {
@@ -246,7 +246,7 @@ impl StateInfo {
         partition_values: &PartitionValuesOptions,
         classifier: C,
     ) -> DeltaResult<Self> {
-        let partition_columns = table_configuration.partition_columns();
+        let partition_columns = table_configuration.logical_partition_columns();
         let column_mapping_mode = table_configuration.column_mapping_mode();
         let mut read_fields = Vec::with_capacity(logical_read_schema.num_fields());
         let mut transform_spec = Vec::with_capacity(logical_read_schema.num_fields());

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -571,6 +571,8 @@ impl TableConfiguration {
         self.version
     }
 
+    // TODO(#3020): Unify scan-state schema construction and write-context serialization to call
+    // this.
     fn physical_partition_fields(&self) -> impl Iterator<Item = (&StructField, &str)> + '_ {
         let column_mapping_mode = self.column_mapping_mode();
         self.logical_partition_columns()

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -554,10 +554,9 @@ impl TableConfiguration {
     }
 
     /// The physical partition columns of this table (empty if unpartitioned).
-    pub(crate) fn physical_partition_columns(&self) -> Vec<String> {
+    pub(crate) fn physical_partition_columns(&self) -> impl Iterator<Item = String> + '_ {
         self.physical_partition_fields()
             .map(|(_, physical_name)| physical_name.to_owned())
-            .collect()
     }
 
     /// The [`Url`] of the table this [`TableConfiguration`] belongs to
@@ -577,6 +576,9 @@ impl TableConfiguration {
         self.logical_partition_columns()
             .iter()
             .filter_map(move |name| {
+                // SAFETY: Construction already validates that every partition column exists in
+                // the schema. Keep this iterator infallible for a simpler return type, with a
+                // defensive warning if the invariant is violated.
                 let field = self.logical_schema.field(name);
                 if field.is_none() {
                     warn!("Partition column '{name}' not found in table schema");
@@ -2138,7 +2140,10 @@ mod test {
             [],
         );
 
-        assert_eq!(config.physical_partition_columns(), expected);
+        assert_eq!(
+            config.physical_partition_columns().collect::<Vec<_>>(),
+            expected
+        );
     }
 
     #[test]

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -376,24 +376,14 @@ impl TableConfiguration {
     /// and field types are the actual partition column data types with their original nullability.
     /// Returns `None` if the table has no partition columns.
     pub(crate) fn build_partition_values_parsed_schema(&self) -> Option<SchemaRef> {
-        let partition_columns = self.metadata().partition_columns();
-        if partition_columns.is_empty() {
+        if self.logical_partition_columns().is_empty() {
             return None;
         }
-        let logical_schema = self.logical_schema();
-        let column_mapping_mode = self.column_mapping_mode();
-        let partition_fields: Vec<StructField> = partition_columns
-            .iter()
-            .filter_map(|col_name| {
-                let field = logical_schema.field(col_name);
-                if field.is_none() {
-                    warn!("Partition column '{col_name}' not found in table schema");
-                }
-                field
-            })
-            .map(|field: &StructField| {
+        let partition_fields: Vec<StructField> = self
+            .physical_partition_fields()
+            .map(|(field, physical_name)| {
                 StructField::new(
-                    field.physical_name(column_mapping_mode).to_owned(),
+                    physical_name.to_owned(),
                     field.data_type().clone(),
                     field.is_nullable(),
                 )
@@ -557,10 +547,17 @@ impl TableConfiguration {
         self.column_mapping_mode
     }
 
-    /// The partition columns of this table (empty if non-partitioned)
+    /// The logical partition columns of this table (empty if unpartitioned).
     #[internal_api]
-    pub(crate) fn partition_columns(&self) -> &[String] {
+    pub(crate) fn logical_partition_columns(&self) -> &[String] {
         self.metadata().partition_columns()
+    }
+
+    /// The physical partition columns of this table (empty if unpartitioned).
+    pub(crate) fn physical_partition_columns(&self) -> Vec<String> {
+        self.physical_partition_fields()
+            .map(|(_, physical_name)| physical_name.to_owned())
+            .collect()
     }
 
     /// The [`Url`] of the table this [`TableConfiguration`] belongs to
@@ -573,6 +570,19 @@ impl TableConfiguration {
     #[internal_api]
     pub(crate) fn version(&self) -> Version {
         self.version
+    }
+
+    fn physical_partition_fields(&self) -> impl Iterator<Item = (&StructField, &str)> + '_ {
+        let column_mapping_mode = self.column_mapping_mode();
+        self.logical_partition_columns()
+            .iter()
+            .filter_map(move |name| {
+                let field = self.logical_schema.field(name);
+                if field.is_none() {
+                    warn!("Partition column '{name}' not found in table schema");
+                }
+                field.map(|field| (field, field.physical_name(column_mapping_mode)))
+            })
     }
 
     /// Validates that all feature requirements for a given feature are satisfied.
@@ -2103,7 +2113,7 @@ mod test {
             [],
         );
 
-        assert_eq!(config.partition_columns(), ["part_a", "part_b"]);
+        assert_eq!(config.logical_partition_columns(), ["part_a", "part_b"]);
         let partition_schema = config
             .build_partition_values_parsed_schema()
             .expect("partition schema should be present");
@@ -2111,6 +2121,24 @@ mod test {
         assert!(partition_schema.field("phys_part_b").is_some());
         assert!(partition_schema.field("part_a").is_none());
         assert!(partition_schema.field("part_b").is_none());
+    }
+
+    #[rstest]
+    #[case::none("none", ["part_a", "part_b"])]
+    #[case::name("name", ["phys_part_a", "phys_part_b"])]
+    #[case::id("id", ["phys_part_a", "phys_part_b"])]
+    fn test_physical_partition_columns(
+        #[case] column_mapping_mode: &str,
+        #[case] expected: [&str; 2],
+    ) {
+        let config = create_partitioned_table_config_with_column_mapping(
+            partitioned_schema_with_column_mapping(),
+            column_mapping_mode,
+            vec!["part_a".to_string(), "part_b".to_string()],
+            [],
+        );
+
+        assert_eq!(config.physical_partition_columns(), expected);
     }
 
     #[test]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -417,7 +417,7 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        // Validate required fields and partition-column completeness for addFile.
+        // Validate required fields for addFile.
         write_validation::StagedDataValidator::staged_add_file(
             self.effective_table_config.physical_partition_columns(),
         )

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -417,9 +417,11 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        // Validate required fields for addFile.
-        write_validation::StagedDataValidator::staged_add_file()
-            .validate(&self.add_files_metadata)?;
+        // Validate required fields and partition-column completeness for addFile.
+        write_validation::StagedDataValidator::staged_add_file(
+            self.effective_table_config.physical_partition_columns(),
+        )
+        .validate(&self.add_files_metadata)?;
 
         // Step 1: Generate SetTransaction actions
         let set_transaction_actions = self
@@ -957,7 +959,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
         {
             let partition_cols: HashSet<&str> = self
                 .effective_table_config
-                .partition_columns()
+                .logical_partition_columns()
                 .iter()
                 .map(String::as_str)
                 .collect();
@@ -990,7 +992,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
 
     /// Returns the logical partition column names for this table.
     pub fn logical_partition_columns(&self) -> &[String] {
-        self.effective_table_config.partition_columns()
+        self.effective_table_config.logical_partition_columns()
     }
 
     /// Returns the column default for every top-level column in this table's logical schema that
@@ -1054,7 +1056,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
             physical_schema: table_config.physical_write_schema(),
             column_mapping_mode: table_config.column_mapping_mode(),
             stats_columns: self.stats_columns(),
-            logical_partition_columns: table_config.partition_columns().to_vec(),
+            logical_partition_columns: table_config.logical_partition_columns().to_vec(),
             randomize_file_prefixes: props.should_randomize_file_prefixes(),
             random_prefix_length: props.random_prefix_length(),
         }))

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -33,7 +33,8 @@ impl StagedDataValidator {
     }
 }
 
-/// Validates required fields for every staged add-file row.
+/// Validates required-field existence and that each row's `partitionValues` keys match the table's
+/// physical partition columns.
 ///
 /// Required fields: `path`, `partitionValues`, `size`, `modificationTime`, and `dataChange`.
 /// Optional fields: `stats`, `tags`, `deletionVector`, `baseRowId`,

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -20,7 +20,7 @@ static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
 impl StagedDataValidator {
-    /// Creates a validator for required add-file values.
+    /// Creates a validator that validates every staged add-file row.
     pub(crate) fn staged_add_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
     ) -> Self {
@@ -366,13 +366,24 @@ mod tests {
         #[case] invalid_partition_values: &[(&str, Option<&str>)],
         #[case] physical_partition_columns: &[&str],
         #[case] expected_error: &str,
-        #[values(0, 1, 2)] invalid_row_index: usize,
+        #[values(0, 1, 2)] invalid_batch: usize,
+        #[values(0, 1, 2)] invalid_row: usize,
     ) {
-        let mut partition_values = [valid_partition_values; 3];
-        partition_values[invalid_row_index] = invalid_partition_values;
-        let batch = add_files_with_partition_values(&partition_values);
+        const BATCH_COUNT: usize = 3;
+        const ROW_COUNT: usize = 3;
+
+        let adds: Vec<Box<dyn EngineData>> = (0..BATCH_COUNT)
+            .map(|batch_index| {
+                let mut partition_values = [valid_partition_values; ROW_COUNT];
+                if batch_index == invalid_batch {
+                    partition_values[invalid_row] = invalid_partition_values;
+                }
+                let batch = add_files_with_partition_values(&partition_values);
+                Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>
+            })
+            .collect();
         let error = add_file_validator(physical_partition_columns)
-            .validate(&as_engine_data(batch))
+            .validate(&adds)
             .expect_err("invalid partition values should be rejected");
         let Error::InvalidPartitionValues(message) = error else {
             panic!("expected InvalidPartitionValues, got {error:?}");

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -355,6 +355,12 @@ mod tests {
         &["p1", "p2"],
         "partitionValues keys"
     )]
+    #[case::wrong_partition_column_name(
+        &[("p1", Some("a")), ("p2", Some("b"))],
+        &[("p1", Some("a")), ("wrong", Some("b"))],
+        &["p1", "p2"],
+        "partitionValues keys"
+    )]
     #[case::duplicate_partition_column(
         &[("p1", Some("a")), ("p2", Some("b"))],
         &[("p1", Some("a")), ("p1", Some("b")), ("p2", Some("c"))],

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -1,11 +1,13 @@
 //! Add-file validations.
 
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use super::{StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
+use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 /// Column indices, matching the order in [`MANDATORY_ADD_FILE_COLUMNS`].
@@ -18,11 +20,18 @@ static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
 impl StagedDataValidator {
-    /// Creates a validator that validates every staged add-file row.
-    pub(crate) fn staged_add_file() -> Self {
+    /// Creates a validator for required add-file values and `partitionValues` keys.
+    ///
+    /// [`TableConfiguration::physical_partition_columns`]: crate::table_configuration::TableConfiguration::physical_partition_columns
+    pub(crate) fn staged_add_file(physical_partition_columns: Vec<String>) -> Self {
         StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
-            vec![Box::new(AddFileRequiredFields)],
+            vec![
+                Box::new(AddFileRequiredFields),
+                Box::new(AddFilePartitionColumnsValidation {
+                    physical_partition_columns: physical_partition_columns.into_iter().collect(),
+                }),
+            ],
         )
     }
 }
@@ -82,6 +91,47 @@ impl Validation for AddFileRequiredFields {
     }
 }
 
+/// Validates that each staged add-file's `partitionValues` keys exactly match the table's partition
+/// columns (compared as physical names). Both a missing and an unexpected key are rejected.
+pub(crate) struct AddFilePartitionColumnsValidation {
+    physical_partition_columns: HashSet<String>,
+}
+
+impl Validation for AddFilePartitionColumnsValidation {
+    fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        let path: &str = getters[PATH]
+            .get_opt(row, "path")?
+            .ok_or_else(|| Error::missing_data("AddFile is missing required field 'path'"))?;
+
+        let actual_keys_vec: Vec<&str> = getters[PARTITION_VALUES]
+            .get_map(row, "partitionValues")?
+            .map_or_else(Vec::new, |map| map.keys().collect());
+        let actual_keys_set: HashSet<&str> = actual_keys_vec.iter().copied().collect();
+        let expected_keys_set = &self.physical_partition_columns;
+        let keys_match = actual_keys_set.len() == expected_keys_set.len()
+            && actual_keys_set
+                .iter()
+                .all(|key| expected_keys_set.contains(*key));
+
+        require!(
+            actual_keys_vec.len() == actual_keys_set.len(),
+            Error::invalid_partition_values(format!(
+                "AddFile for '{path}' has duplicate partition column names in partitionValues: \
+                 {actual_keys_vec:?}"
+            ))
+        );
+
+        require!(
+            keys_match,
+            Error::invalid_partition_values(format!(
+                "AddFile for '{path}' has partitionValues keys {actual_keys_vec:?}, but the table's \
+                 physical partition columns are {expected_keys_set:?}"
+            ))
+        );
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -89,8 +139,11 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{new_null_array, Array, ArrayRef, Int64Array, StringArray};
+    use crate::arrow::array::{
+        new_null_array, Array, ArrayRef, Int64Array, MapBuilder, StringArray, StringBuilder,
+    };
     use crate::arrow::compute::{concat, concat_batches};
+    use crate::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::expressions::ColumnName;
@@ -141,8 +194,54 @@ mod tests {
             .expect("failed to rebuild add-file batch after replacing a column")
     }
 
-    fn add_validator() -> StagedDataValidator {
-        StagedDataValidator::staged_add_file()
+    /// Returns nullable add-file rows with `partitionValues` replaced by the given values.
+    /// A `None` value stores a present key with a null value.
+    fn add_files_with_partition_values(
+        partition_values: &[&[(&str, Option<&str>)]],
+    ) -> RecordBatch {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        for entries in partition_values {
+            for (key, value) in *entries {
+                builder.keys().append_value(key);
+                match value {
+                    Some(v) => builder.values().append_value(v),
+                    None => builder.values().append_null(),
+                }
+            }
+            builder
+                .append(true)
+                .expect("failed to append partition-values map row");
+        }
+        let map: ArrayRef = Arc::new(builder.finish());
+
+        let batch = nullable_add_files(partition_values.len());
+        let schema = batch.schema();
+        let index = schema
+            .index_of("partitionValues")
+            .expect("add-file schema should contain partitionValues");
+        let mut fields = schema.fields().to_vec();
+        fields[index] = Arc::new(ArrowField::new(
+            "partitionValues",
+            map.data_type().clone(),
+            true,
+        ));
+        let mut columns = batch.columns().to_vec();
+        columns[index] = map;
+        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
+            .expect("failed to rebuild add-file batch with partition values")
+    }
+
+    fn add_file_validator(physical_partition_columns: &[&str]) -> StagedDataValidator {
+        StagedDataValidator::staged_add_file(
+            physical_partition_columns
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        )
+    }
+
+    fn as_engine_data(batch: RecordBatch) -> [Box<dyn EngineData>; 1] {
+        [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>]
     }
 
     /// Guards the invariant that the column-index consts match the leaf order of
@@ -191,7 +290,7 @@ mod tests {
             })
             .collect();
         assert_result_error_with_message(
-            add_validator().validate(&adds),
+            add_file_validator(&[] /* physical_partition_columns */).validate(&adds),
             &format!("missing required field '{field}'"),
         );
     }
@@ -245,12 +344,80 @@ mod tests {
             Arc::new(Int64Array::from(vec![modification_time])),
         );
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        let result = add_validator().validate(&adds);
+        let result = add_file_validator(&[] /* physical_partition_columns */).validate(&adds);
 
         if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);
         } else {
             result.unwrap();
         }
+    }
+
+    #[test]
+    fn partition_values_exact_match_ok() {
+        let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", Some("b"))]]);
+        add_file_validator(&["p1", "p2"] /* physical_partition_columns */)
+            .validate(&as_engine_data(batch))
+            .unwrap();
+    }
+
+    #[test]
+    fn partition_value_null_still_counts_as_present() {
+        // A partition column present with a null value satisfies the key-set check.
+        let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", None)]]);
+        add_file_validator(&["p1", "p2"] /* physical_partition_columns */)
+            .validate(&as_engine_data(batch))
+            .unwrap();
+    }
+
+    #[rstest]
+    #[case::missing_second_partition_column(
+        &[("p1", Some("a")), ("p2", Some("b")), ("p3", Some("c"))],
+        &[("p1", Some("a")), ("p3", Some("c"))],
+        &["p1", "p2", "p3"],
+        "partitionValues keys"
+    )]
+    #[case::missing_third_partition_column(
+        &[("p1", Some("a")), ("p2", Some("b")), ("p3", Some("c"))],
+        &[("p1", Some("a")), ("p2", Some("b"))],
+        &["p1", "p2", "p3"],
+        "partitionValues keys"
+    )]
+    #[case::extra_partition_columns(
+        &[("p1", Some("a")), ("p2", Some("b"))],
+        &[("p1", Some("a")), ("p2", Some("b")), ("p3", Some("c"))],
+        &["p1", "p2"],
+        "partitionValues keys"
+    )]
+    #[case::duplicate_partition_column(
+        &[("p1", Some("a")), ("p2", Some("b"))],
+        &[("p1", Some("a")), ("p1", Some("b")), ("p2", Some("c"))],
+        &["p1", "p2"],
+        "duplicate partition column names"
+    )]
+    fn partition_column_mismatch_rejected(
+        #[case] valid_partition_values: &[(&str, Option<&str>)],
+        #[case] invalid_partition_values: &[(&str, Option<&str>)],
+        #[case] physical_partition_columns: &[&str],
+        #[case] expected_error: &str,
+        #[values(0, 1, 2)] invalid_row_index: usize,
+    ) {
+        let mut partition_values = [valid_partition_values; 3];
+        partition_values[invalid_row_index] = invalid_partition_values;
+        let batch = add_files_with_partition_values(&partition_values);
+        assert_result_error_with_message(
+            add_file_validator(physical_partition_columns).validate(&as_engine_data(batch)),
+            expected_error,
+        );
+    }
+
+    #[test]
+    fn unpartitioned_table_rejects_partition_values() {
+        let batch = add_files_with_partition_values(&[&[("stray", Some("x"))]]);
+        assert_result_error_with_message(
+            add_file_validator(&[] /* physical_partition_columns */)
+                .validate(&as_engine_data(batch)),
+            "partitionValues keys",
+        );
     }
 }

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use super::{StagedDataValidator, Validation};
-use crate::engine_data::{GetData, TypedGetData as _};
+use crate::engine_data::{GetData, MapItem, TypedGetData as _};
 use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
 use crate::utils::require;
@@ -20,25 +20,20 @@ static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
 impl StagedDataValidator {
-    /// Creates a validator for required add-file values and `partitionValues` keys.
-    ///
-    /// [`TableConfiguration::physical_partition_columns`]: crate::table_configuration::TableConfiguration::physical_partition_columns
+    /// Creates a validator for required add-file values.
     pub(crate) fn staged_add_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
     ) -> Self {
         StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
-            vec![
-                Box::new(AddFileRequiredFields),
-                Box::new(AddFilePartitionColumnsValidation {
-                    physical_partition_columns: physical_partition_columns.into_iter().collect(),
-                }),
-            ],
+            vec![Box::new(AddFileRequiredFields {
+                physical_partition_columns: physical_partition_columns.into_iter().collect(),
+            })],
         )
     }
 }
 
-/// Validates that every staged add-file row has its protocol-required fields.
+/// Validates required fields for every staged add-file row.
 ///
 /// Required fields: `path`, `partitionValues`, `size`, `modificationTime`, and `dataChange`.
 /// Optional fields: `stats`, `tags`, `deletionVector`, `baseRowId`,
@@ -46,7 +41,9 @@ impl StagedDataValidator {
 ///
 /// NOTE: Currently, Kernel doesn't require connectors to set dataChange for staged addFile.
 /// TODO(2869): Add intent-based validation for dataChange.
-pub(crate) struct AddFileRequiredFields;
+pub(crate) struct AddFileRequiredFields {
+    physical_partition_columns: HashSet<String>,
+}
 
 fn validate_required_add_file_field_exist<T>(
     value: Option<T>,
@@ -60,6 +57,36 @@ fn validate_required_add_file_field_exist<T>(
     })
 }
 
+fn validate_partition_keys(
+    path: &str,
+    actual_partition_values: MapItem<'_>,
+    expected_physical_partition_columns: &HashSet<String>,
+) -> DeltaResult<()> {
+    let actual_keys_vec: Vec<&str> = actual_partition_values.keys().collect();
+    let actual_keys_set: HashSet<&str> = actual_keys_vec.iter().copied().collect();
+    let keys_match = actual_keys_set.len() == expected_physical_partition_columns.len()
+        && actual_keys_set
+            .iter()
+            .all(|key| expected_physical_partition_columns.contains(*key));
+
+    require!(
+        actual_keys_vec.len() == actual_keys_set.len(),
+        Error::invalid_partition_values(format!(
+            "AddFile for '{path}' has duplicate partition column names in partitionValues: \
+             {actual_keys_vec:?}"
+        ))
+    );
+
+    require!(
+        keys_match,
+        Error::invalid_partition_values(format!(
+            "AddFile for '{path}' has partitionValues keys {actual_keys_vec:?}, but the table's \
+             physical partition columns are {expected_physical_partition_columns:?}"
+        ))
+    );
+    Ok(())
+}
+
 impl Validation for AddFileRequiredFields {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
@@ -69,11 +96,12 @@ impl Validation for AddFileRequiredFields {
             return Err(Error::generic("AddFile path must not be empty"));
         }
 
-        validate_required_add_file_field_exist(
+        let partition_values = validate_required_add_file_field_exist(
             getters[PARTITION_VALUES].get_map(row, "partitionValues")?,
             path,
             "partitionValues",
         )?;
+        validate_partition_keys(path, partition_values, &self.physical_partition_columns)?;
         let size = validate_required_add_file_field_exist::<i64>(
             getters[SIZE].get_opt(row, "size")?,
             path,
@@ -89,47 +117,7 @@ impl Validation for AddFileRequiredFields {
             path,
             "modificationTime",
         )?;
-        Ok(())
-    }
-}
 
-/// Validates that each staged add-file's `partitionValues` keys exactly match the table's partition
-/// columns (compared as physical names). Missing, unexpected, and duplicate keys are rejected.
-pub(crate) struct AddFilePartitionColumnsValidation {
-    physical_partition_columns: HashSet<String>,
-}
-
-impl Validation for AddFilePartitionColumnsValidation {
-    fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
-        let path: &str = getters[PATH]
-            .get_opt(row, "path")?
-            .ok_or_else(|| Error::missing_data("AddFile is missing required field 'path'"))?;
-
-        let actual_keys_vec: Vec<&str> = getters[PARTITION_VALUES]
-            .get_map(row, "partitionValues")?
-            .map_or_else(Vec::new, |map| map.keys().collect());
-        let actual_keys_set: HashSet<&str> = actual_keys_vec.iter().copied().collect();
-        let expected_keys_set = &self.physical_partition_columns;
-        let keys_match = actual_keys_set.len() == expected_keys_set.len()
-            && actual_keys_set
-                .iter()
-                .all(|key| expected_keys_set.contains(*key));
-
-        require!(
-            actual_keys_vec.len() == actual_keys_set.len(),
-            Error::invalid_partition_values(format!(
-                "AddFile for '{path}' has duplicate partition column names in partitionValues: \
-                 {actual_keys_vec:?}"
-            ))
-        );
-
-        require!(
-            keys_match,
-            Error::invalid_partition_values(format!(
-                "AddFile for '{path}' has partitionValues keys {actual_keys_vec:?}, but the table's \
-                 physical partition columns are {expected_keys_set:?}"
-            ))
-        );
         Ok(())
     }
 }
@@ -139,13 +127,11 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
+    use test_utils::{modify_add_file_partition_keys, AddFilePartitionKeyModify};
 
     use super::*;
-    use crate::arrow::array::{
-        new_null_array, Array, ArrayRef, Int64Array, MapBuilder, StringArray, StringBuilder,
-    };
+    use crate::arrow::array::{new_null_array, Array, ArrayRef, Int64Array, StringArray};
     use crate::arrow::compute::{concat, concat_batches};
-    use crate::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::expressions::ColumnName;
@@ -201,36 +187,18 @@ mod tests {
     fn add_files_with_partition_values(
         partition_values: &[&[(&str, Option<&str>)]],
     ) -> RecordBatch {
-        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        for entries in partition_values {
-            for (key, value) in *entries {
-                builder.keys().append_value(key);
-                match value {
-                    Some(v) => builder.values().append_value(v),
-                    None => builder.values().append_null(),
-                }
-            }
-            builder
-                .append(true)
-                .expect("failed to append partition-values map row");
-        }
-        let map: ArrayRef = Arc::new(builder.finish());
-
-        let batch = nullable_add_files(partition_values.len());
-        let schema = batch.schema();
-        let index = schema
-            .index_of("partitionValues")
-            .expect("add-file schema should contain partitionValues");
-        let mut fields = schema.fields().to_vec();
-        fields[index] = Arc::new(ArrowField::new(
-            "partitionValues",
-            map.data_type().clone(),
-            true,
-        ));
-        let mut columns = batch.columns().to_vec();
-        columns[index] = map;
-        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
-            .expect("failed to rebuild add-file batch with partition values")
+        let batches: Vec<_> = partition_values
+            .iter()
+            .map(|entries| {
+                let modifications: Vec<_> = entries
+                    .iter()
+                    .map(|(key, value)| AddFilePartitionKeyModify::Insert { key, value: *value })
+                    .collect();
+                modify_add_file_partition_keys(nullable_add_file(), &modifications)
+            })
+            .collect();
+        concat_batches(&batches[0].schema(), &batches)
+            .expect("failed to concatenate add-file rows with partition values")
     }
 
     fn add_file_validator(physical_partition_columns: &[&str]) -> StagedDataValidator {

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -23,7 +23,9 @@ impl StagedDataValidator {
     /// Creates a validator for required add-file values and `partitionValues` keys.
     ///
     /// [`TableConfiguration::physical_partition_columns`]: crate::table_configuration::TableConfiguration::physical_partition_columns
-    pub(crate) fn staged_add_file(physical_partition_columns: Vec<String>) -> Self {
+    pub(crate) fn staged_add_file(
+        physical_partition_columns: impl IntoIterator<Item = String>,
+    ) -> Self {
         StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
             vec![
@@ -92,7 +94,7 @@ impl Validation for AddFileRequiredFields {
 }
 
 /// Validates that each staged add-file's `partitionValues` keys exactly match the table's partition
-/// columns (compared as physical names). Both a missing and an unexpected key are rejected.
+/// columns (compared as physical names). Missing, unexpected, and duplicate keys are rejected.
 pub(crate) struct AddFilePartitionColumnsValidation {
     physical_partition_columns: HashSet<String>,
 }
@@ -233,10 +235,7 @@ mod tests {
 
     fn add_file_validator(physical_partition_columns: &[&str]) -> StagedDataValidator {
         StagedDataValidator::staged_add_file(
-            physical_partition_columns
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+            physical_partition_columns.iter().map(|s| s.to_string()),
         )
     }
 
@@ -363,7 +362,6 @@ mod tests {
 
     #[test]
     fn partition_value_null_still_counts_as_present() {
-        // A partition column present with a null value satisfies the key-set check.
         let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", None)]]);
         add_file_validator(&["p1", "p2"] /* physical_partition_columns */)
             .validate(&as_engine_data(batch))
@@ -405,9 +403,15 @@ mod tests {
         let mut partition_values = [valid_partition_values; 3];
         partition_values[invalid_row_index] = invalid_partition_values;
         let batch = add_files_with_partition_values(&partition_values);
-        assert_result_error_with_message(
-            add_file_validator(physical_partition_columns).validate(&as_engine_data(batch)),
-            expected_error,
+        let error = add_file_validator(physical_partition_columns)
+            .validate(&as_engine_data(batch))
+            .expect_err("invalid partition values should be rejected");
+        let Error::InvalidPartitionValues(message) = error else {
+            panic!("expected InvalidPartitionValues, got {error:?}");
+        };
+        assert!(
+            message.contains(expected_error),
+            "expected error message to contain {expected_error:?}, got {message:?}"
         );
     }
 

--- a/kernel/tests/integration/create_table/partitioned.rs
+++ b/kernel/tests/integration/create_table/partitioned.rs
@@ -29,7 +29,7 @@ fn test_create_table_partitioned_basic(#[case] partition_col: &str) -> DeltaResu
     assert_eq!(snapshot.version(), 0);
 
     // Partition column should be stored matching the casing in the schema
-    let partition_cols = snapshot.table_configuration().partition_columns();
+    let partition_cols = snapshot.table_configuration().logical_partition_columns();
     assert_eq!(partition_cols, &["date"]);
 
     let clustering = snapshot.get_physical_clustering_columns(engine.as_ref())?;

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -4,21 +4,31 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{new_null_array, Int32Array, StringArray};
+use delta_kernel::arrow::array::{
+    new_null_array, Array, ArrayRef, AsArray as _, Int32Array, MapBuilder, StringArray,
+    StringBuilder,
+};
 use delta_kernel::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
+use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
-use delta_kernel::{DeltaResult, Error as KernelError};
+use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::transaction::create_table::create_table;
+use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::Transaction;
+use delta_kernel::{DeltaResult, Error as KernelError, Snapshot};
 use itertools::Itertools;
+use rstest::rstest;
 use serde_json::{json, Deserializer};
 use test_utils::{
-    into_record_batch, load_and_begin_transaction, set_json_value, setup_test_tables, test_read,
+    assert_result_error_with_message, into_record_batch, load_and_begin_transaction,
+    set_json_value, setup_test_tables, test_read,
 };
 
 use crate::common::write_utils::{
@@ -432,4 +442,159 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
         );
     }
     Ok(())
+}
+
+#[rstest]
+#[case::missing(None, &[AddFilePartitionKeyModify::Drop { key: "p2" }])]
+#[case::extra(None, &[AddFilePartitionKeyModify::Insert {
+    key: "p3",
+    value: "extra",
+}])]
+#[case::incorrect_name(None, &[
+    AddFilePartitionKeyModify::Drop { key: "p2" },
+    AddFilePartitionKeyModify::Insert {
+        key: "partition_2",
+        value: "6",
+    },
+])]
+#[case::logical_partition_name_when_cm_name_mode(
+    Some("name"),
+    &[
+        AddFilePartitionKeyModify::Drop { key: "p2" },
+        AddFilePartitionKeyModify::Insert { key: "p2", value: "6" },
+    ],
+)]
+#[case::logical_partition_name_when_cm_id_mode(
+    Some("id"),
+    &[
+        AddFilePartitionKeyModify::Drop { key: "p2" },
+        AddFilePartitionKeyModify::Insert { key: "p2", value: "6" },
+    ],
+)]
+#[tokio::test(flavor = "multi_thread")]
+async fn commit_rejects_add_with_invalid_partition_keys(
+    #[case] column_mapping_mode: Option<&str>,
+    #[case] modifications: &[AddFilePartitionKeyModify<'_>],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let table_schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("d", DataType::INTEGER),
+        StructField::nullable("p1", DataType::STRING),
+        StructField::nullable("p2", DataType::INTEGER),
+    ])?);
+    let (_tmp_dir, table_path, engine) = test_utils::test_table_setup_mt()?;
+    let mut builder = create_table(&table_path, table_schema, "test/1.0")
+        .with_data_layout(DataLayout::partitioned(["p1", "p2"]));
+    if let Some(mode) = column_mapping_mode {
+        builder = builder.with_table_properties([("delta.columnMapping.mode", mode)]);
+    }
+    builder
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    let data_schema: Arc<ArrowSchema> = Arc::new(
+        (&StructType::try_new(vec![StructField::nullable("d", DataType::INTEGER)])?)
+            .try_into_arrow()?,
+    );
+    let make_add = |txn: &Transaction, p1: &str, p2: i32| {
+        let wc = txn.partitioned_write_context(HashMap::from([
+            ("p1".to_string(), Scalar::String(p1.into())),
+            ("p2".to_string(), Scalar::Integer(p2)),
+        ]))?;
+        let data = RecordBatch::try_new(
+            data_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )?;
+        futures::executor::block_on(engine.write_parquet(&ArrowEngineData::new(data), &wc))
+    };
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let mode = snapshot
+        .table_properties()
+        .column_mapping_mode
+        .unwrap_or(ColumnMappingMode::None);
+    let logical_schema = snapshot.schema();
+    // Translate the `modifications` to the physical partition column names.
+    let modifications: Vec<_> = modifications
+        .iter()
+        .map(|modification| match *modification {
+            AddFilePartitionKeyModify::Drop { key } => {
+                let key = logical_schema
+                    .field(key)
+                    .map(|field| field.physical_name(mode))
+                    .unwrap_or(key);
+                AddFilePartitionKeyModify::Drop { key }
+            }
+            insertion => insertion,
+        })
+        .collect();
+    let mut txn = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .with_data_change(true);
+    let add = make_add(&txn, "b", 6)?;
+    let corrupted = modify_add_file_partition_keys(into_record_batch(add), &modifications);
+    txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
+    assert_result_error_with_message(txn.commit(engine.as_ref()), "partitionValues keys");
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum AddFilePartitionKeyModify<'a> {
+    Drop { key: &'a str },
+    Insert { key: &'a str, value: &'a str },
+}
+
+/// Rebuilds `batch` after applying the partition-key modifications.
+fn modify_add_file_partition_keys(
+    batch: RecordBatch,
+    modifications: &[AddFilePartitionKeyModify<'_>],
+) -> RecordBatch {
+    let index = batch
+        .schema()
+        .index_of("partitionValues")
+        .expect("partitionValues field in add-file batch");
+    let map = batch.column(index).as_map();
+    let entries = map.entries();
+    let keys = entries.column(0).as_string::<i32>();
+    let values = entries.column(1).as_string::<i32>();
+    let mut partition_values: Vec<(&str, Option<&str>)> = (0..keys.len())
+        .map(|i| (keys.value(i), values.is_valid(i).then(|| values.value(i))))
+        .collect();
+    for modification in modifications {
+        match *modification {
+            AddFilePartitionKeyModify::Drop { key } => {
+                partition_values.retain(|(existing_key, _)| *existing_key != key);
+            }
+            AddFilePartitionKeyModify::Insert { key, value } => {
+                partition_values.push((key, Some(value)));
+            }
+        }
+    }
+
+    let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+    for (key, value) in partition_values {
+        builder.keys().append_value(key);
+        match value {
+            Some(v) => builder.values().append_value(v),
+            None => builder.values().append_null(),
+        }
+    }
+    builder
+        .append(true)
+        .expect("failed to append partition-values map row");
+    let new_map: ArrayRef = Arc::new(builder.finish());
+
+    let mut fields: Vec<ArrowField> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.as_ref().clone())
+        .collect();
+    fields[index] = ArrowField::new("partitionValues", new_map.data_type().clone(), true);
+    let mut columns = batch.columns().to_vec();
+    columns[index] = new_map;
+    RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
+        .expect("failed to rebuild add-file batch after modifying a partition key")
 }

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -4,10 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{
-    new_null_array, Array, ArrayRef, AsArray as _, Int32Array, MapBuilder, StringArray,
-    StringBuilder,
-};
+use delta_kernel::arrow::array::{new_null_array, Int32Array, StringArray};
 use delta_kernel::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use delta_kernel::arrow::error::ArrowError;
 use delta_kernel::arrow::record_batch::RecordBatch;
@@ -28,7 +25,8 @@ use rstest::rstest;
 use serde_json::{json, Deserializer};
 use test_utils::{
     assert_result_error_with_message, into_record_batch, load_and_begin_transaction,
-    set_json_value, setup_test_tables, test_read,
+    modify_add_file_partition_keys, set_json_value, setup_test_tables, test_read,
+    AddFilePartitionKeyModify,
 };
 
 use crate::common::write_utils::{
@@ -448,27 +446,27 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
 #[case::missing(None, &[AddFilePartitionKeyModify::Drop { key: "p2" }])]
 #[case::extra(None, &[AddFilePartitionKeyModify::Insert {
     key: "p3",
-    value: "extra",
+    value: Some("extra"),
 }])]
 #[case::incorrect_name(None, &[
     AddFilePartitionKeyModify::Drop { key: "p2" },
     AddFilePartitionKeyModify::Insert {
         key: "partition_2",
-        value: "6",
+        value: Some("6"),
     },
 ])]
 #[case::logical_partition_name_when_cm_name_mode(
     Some("name"),
     &[
         AddFilePartitionKeyModify::Drop { key: "p2" },
-        AddFilePartitionKeyModify::Insert { key: "p2", value: "6" },
+        AddFilePartitionKeyModify::Insert { key: "p2", value: Some("6") },
     ],
 )]
 #[case::logical_partition_name_when_cm_id_mode(
     Some("id"),
     &[
         AddFilePartitionKeyModify::Drop { key: "p2" },
-        AddFilePartitionKeyModify::Insert { key: "p2", value: "6" },
+        AddFilePartitionKeyModify::Insert { key: "p2", value: Some("6") },
     ],
 )]
 #[tokio::test(flavor = "multi_thread")]
@@ -538,63 +536,4 @@ async fn commit_rejects_add_with_invalid_partition_keys(
     txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
     assert_result_error_with_message(txn.commit(engine.as_ref()), "partitionValues keys");
     Ok(())
-}
-
-#[derive(Clone, Copy)]
-enum AddFilePartitionKeyModify<'a> {
-    Drop { key: &'a str },
-    Insert { key: &'a str, value: &'a str },
-}
-
-/// Rebuilds `batch` after applying the partition-key modifications.
-fn modify_add_file_partition_keys(
-    batch: RecordBatch,
-    modifications: &[AddFilePartitionKeyModify<'_>],
-) -> RecordBatch {
-    let index = batch
-        .schema()
-        .index_of("partitionValues")
-        .expect("partitionValues field in add-file batch");
-    let map = batch.column(index).as_map();
-    let entries = map.entries();
-    let keys = entries.column(0).as_string::<i32>();
-    let values = entries.column(1).as_string::<i32>();
-    let mut partition_values: Vec<(&str, Option<&str>)> = (0..keys.len())
-        .map(|i| (keys.value(i), values.is_valid(i).then(|| values.value(i))))
-        .collect();
-    for modification in modifications {
-        match *modification {
-            AddFilePartitionKeyModify::Drop { key } => {
-                partition_values.retain(|(existing_key, _)| *existing_key != key);
-            }
-            AddFilePartitionKeyModify::Insert { key, value } => {
-                partition_values.push((key, Some(value)));
-            }
-        }
-    }
-
-    let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-    for (key, value) in partition_values {
-        builder.keys().append_value(key);
-        match value {
-            Some(v) => builder.values().append_value(v),
-            None => builder.values().append_null(),
-        }
-    }
-    builder
-        .append(true)
-        .expect("failed to append partition-values map row");
-    let new_map: ArrayRef = Arc::new(builder.finish());
-
-    let mut fields: Vec<ArrowField> = batch
-        .schema()
-        .fields()
-        .iter()
-        .map(|f| f.as_ref().clone())
-        .collect();
-    fields[index] = ArrowField::new("partitionValues", new_map.data_type().clone(), true);
-    let mut columns = batch.columns().to_vec();
-    columns[index] = new_map;
-    RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
-        .expect("failed to rebuild add-file batch after modifying a partition key")
 }

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -53,7 +53,13 @@ async fn test_write_partitioned_normal_values_roundtrip(
         normal_partition_values()?,
     )
     .await?;
-    assert_eq!(snapshot.table_configuration().partition_columns().len(), 13);
+    assert_eq!(
+        snapshot
+            .table_configuration()
+            .logical_partition_columns()
+            .len(),
+        13
+    );
 
     // ===== Step 2: Validate add.path structure in the commit log JSON. =====
     let (add, rel_path) = read_single_add(&table_path, 1)?;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -533,6 +533,10 @@ pub fn modify_add_file_partition_keys(
     batch: RecordBatch,
     modifications: &[AddFilePartitionKeyModify<'_>],
 ) -> RecordBatch {
+    if modifications.is_empty() {
+        return batch;
+    }
+
     assert_eq!(batch.num_rows(), 1, "add-file batch must contain one row");
     let index = batch
         .schema()
@@ -556,7 +560,14 @@ pub fn modify_add_file_partition_keys(
         }
     }
 
-    let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+    let (entry_field, ordered) = match map.data_type() {
+        ArrowDataType::Map(entry_field, ordered) => (entry_field.clone(), *ordered),
+        _ => unreachable!("partitionValues column must be a map"),
+    };
+    let (key_field, value_field) = map.entries_fields();
+    let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new())
+        .with_keys_field(key_field.clone())
+        .with_values_field(value_field.clone());
     for (key, value) in partition_values {
         builder.keys().append_value(key);
         match value {
@@ -567,18 +578,15 @@ pub fn modify_add_file_partition_keys(
     builder
         .append(true)
         .expect("failed to append partition-values map row");
-    let new_map: ArrayRef = Arc::new(builder.finish());
+    let (_, offsets, entries, nulls, _) = builder.finish().into_parts();
+    let new_map: ArrayRef = Arc::new(
+        MapArray::try_new(entry_field, offsets, entries, nulls, ordered)
+            .expect("failed to rebuild partition-values map"),
+    );
 
-    let mut fields: Vec<Field> = batch
-        .schema()
-        .fields()
-        .iter()
-        .map(|f| f.as_ref().clone())
-        .collect();
-    fields[index] = Field::new("partitionValues", new_map.data_type().clone(), true);
     let mut columns = batch.columns().to_vec();
     columns[index] = new_map;
-    RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
+    RecordBatch::try_new(batch.schema(), columns)
         .expect("failed to rebuild add-file batch after modifying a partition key")
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -523,6 +523,12 @@ pub enum AddFilePartitionKeyModify<'a> {
     },
 }
 
+/// Applies `modifications` in order to a single-row add-file batch.
+///
+/// # Panics
+///
+/// Panics when `batch` does not have exactly one row with a string-keyed and string-valued
+/// `partitionValues` map, or when the modified batch cannot be constructed.
 pub fn modify_add_file_partition_keys(
     batch: RecordBatch,
     modifications: &[AddFilePartitionKeyModify<'_>],
@@ -533,7 +539,7 @@ pub fn modify_add_file_partition_keys(
         .index_of("partitionValues")
         .expect("partitionValues field in add-file batch");
     let map = batch.column(index).as_map();
-    let entries = map.entries();
+    let entries = map.value(0);
     let keys = entries.column(0).as_string::<i32>();
     let values = entries.column(1).as_string::<i32>();
     let mut partition_values: Vec<(&str, Option<&str>)> = (0..keys.len())

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -172,7 +172,7 @@ use delta_kernel::actions::{
 };
 use delta_kernel::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray,
-    RecordBatch, StringArray, StructArray,
+    MapBuilder, RecordBatch, StringArray, StringBuilder, StructArray,
 };
 use delta_kernel::arrow::buffer::OffsetBuffer;
 use delta_kernel::arrow::datatypes::{
@@ -509,6 +509,71 @@ pub fn into_record_batch(engine_data: Box<dyn EngineData>) -> RecordBatch {
     ArrowEngineData::try_from_engine_data(engine_data)
         .unwrap()
         .into()
+}
+
+/// A modification to an add-file batch's `partitionValues` keys.
+#[derive(Clone, Copy)]
+pub enum AddFilePartitionKeyModify<'a> {
+    Drop {
+        key: &'a str,
+    },
+    Insert {
+        key: &'a str,
+        value: Option<&'a str>,
+    },
+}
+
+pub fn modify_add_file_partition_keys(
+    batch: RecordBatch,
+    modifications: &[AddFilePartitionKeyModify<'_>],
+) -> RecordBatch {
+    assert_eq!(batch.num_rows(), 1, "add-file batch must contain one row");
+    let index = batch
+        .schema()
+        .index_of("partitionValues")
+        .expect("partitionValues field in add-file batch");
+    let map = batch.column(index).as_map();
+    let entries = map.entries();
+    let keys = entries.column(0).as_string::<i32>();
+    let values = entries.column(1).as_string::<i32>();
+    let mut partition_values: Vec<(&str, Option<&str>)> = (0..keys.len())
+        .map(|i| (keys.value(i), values.is_valid(i).then(|| values.value(i))))
+        .collect();
+    for modification in modifications {
+        match *modification {
+            AddFilePartitionKeyModify::Drop { key } => {
+                partition_values.retain(|(existing_key, _)| *existing_key != key);
+            }
+            AddFilePartitionKeyModify::Insert { key, value } => {
+                partition_values.push((key, value));
+            }
+        }
+    }
+
+    let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+    for (key, value) in partition_values {
+        builder.keys().append_value(key);
+        match value {
+            Some(v) => builder.values().append_value(v),
+            None => builder.values().append_null(),
+        }
+    }
+    builder
+        .append(true)
+        .expect("failed to append partition-values map row");
+    let new_map: ArrayRef = Arc::new(builder.finish());
+
+    let mut fields: Vec<Field> = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.as_ref().clone())
+        .collect();
+    fields[index] = Field::new("partitionValues", new_map.data_type().clone(), true);
+    let mut columns = batch.columns().to_vec();
+    columns[index] = new_map;
+    RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
+        .expect("failed to rebuild add-file batch after modifying a partition key")
 }
 
 /// Helper to create a DefaultEngine with the default executor for tests.


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2939/files) to review incremental changes.
- [stack/validate-require-field](https://github.com/delta-io/delta-kernel-rs/pull/2856) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2856/files)] [MERGED]
  - [**stack/addFile-part-val**](https://github.com/delta-io/delta-kernel-rs/pull/2939) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2939/files)] ← _this PR_
    - [stack/dv-val](https://github.com/delta-io/delta-kernel-rs/pull/3026) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3026/files/6d5e30b476b3bfad0ac59f4341c0fd370cb4995a..3dbc9881b7cffac7efafeb0a84822633bbb2aead)]
  - [stack/validate-required-field-removeFile](https://github.com/delta-io/delta-kernel-rs/pull/2974) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2974/files)]

---------
## What changes are proposed in this pull request?

Validate that staged AddFile partitionValues keys match the table's physical partition columns.
## How was this change tested?

- Focused unit tests for matching, missing, extra, and null-valued partition keys.
- Integration tests for commit-time rejection of missing and extra partition keys.

### Perf bench:

Perf bench for `txn.commit`, TL;DR is: approximately 7% slower at 100k files locally; S3 difference remains within run-to-run variance

Local FS (plain 10-column table, one partition column):

| N | baseline | partition val-on |
|---|---:|---:|
| 1 | 298 µs | ~0 |
| 10 | 327 µs | +5 µs |
| 100 | 454 µs | +11 µs |
| 1,000 | 1.96 ms | +0.11 ms |
| 100,000 | 199.2 ms | +13.3 ms |

S3 (plain 10-column table, one partition column; middle of three fresh-process Criterion mean estimates):

| N | validate_off | partition val-on |
|---|---:|---:|
| 1 | 32.7 ms | 29.9 ms |
| 10 | 31.1 ms | 31.9 ms |
| 100 | 34.2 ms | 35.1 ms |
| 1,000 | 74.4 ms | 71.4 ms |
| 10,000 | 135.6 ms | 135.8 ms |
