### PR TITLE
fix: clarify schema JSON recursion limit errors

### DIFF
--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -70,6 +70,7 @@ pub enum KernelError {
     CheckpointWriteError = 41,
     SchemaError = 42,
     LogHistoryError = 43,
+    SchemaNestingDepthExceededError = 44,
 }
 
 impl From<Error> for KernelError {
@@ -131,6 +132,7 @@ impl From<Error> for KernelError {
                 KernelError::LiteralExpressionTransformError
             }
             Error::Schema(_) => KernelError::SchemaError,
+            Error::SchemaNestingDepthExceeded(_) => KernelError::SchemaNestingDepthExceededError,
             Error::LogHistory(_) => KernelError::LogHistoryError,
             _ => KernelError::UnknownError,
         }
@@ -338,7 +340,8 @@ impl From<EngineExecError> for Error {
             | KernelError::ChangeDataFeedUnsupported
             | KernelError::ChangeDataFeedIncompatibleSchema
             | KernelError::LiteralExpressionTransformError
-            | KernelError::LogHistoryError) => {
+            | KernelError::LogHistoryError
+            | KernelError::SchemaNestingDepthExceededError) => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
             #[cfg(feature = "default-engine-base")]
@@ -384,5 +387,16 @@ mod tests {
     ) {
         let err: Error = exec_error(etype, "boom").into();
         assert_eq!(err.to_string(), expected);
+    }
+
+    #[test]
+    fn schema_nesting_depth_error_maps_ffi_error_code() {
+        let source = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+        let error = Error::SchemaNestingDepthExceeded(source);
+
+        assert_eq!(
+            KernelError::from(error),
+            KernelError::SchemaNestingDepthExceededError
+        );
     }
 }

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -70,7 +70,6 @@ pub enum KernelError {
     CheckpointWriteError = 41,
     SchemaError = 42,
     LogHistoryError = 43,
-    SchemaNestingDepthExceededError = 44,
 }
 
 impl From<Error> for KernelError {
@@ -132,7 +131,6 @@ impl From<Error> for KernelError {
                 KernelError::LiteralExpressionTransformError
             }
             Error::Schema(_) => KernelError::SchemaError,
-            Error::SchemaNestingDepthExceeded(_) => KernelError::SchemaNestingDepthExceededError,
             Error::LogHistory(_) => KernelError::LogHistoryError,
             _ => KernelError::UnknownError,
         }
@@ -340,8 +338,7 @@ impl From<EngineExecError> for Error {
             | KernelError::ChangeDataFeedUnsupported
             | KernelError::ChangeDataFeedIncompatibleSchema
             | KernelError::LiteralExpressionTransformError
-            | KernelError::LogHistoryError
-            | KernelError::SchemaNestingDepthExceededError) => {
+            | KernelError::LogHistoryError) => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
             #[cfg(feature = "default-engine-base")]
@@ -387,16 +384,5 @@ mod tests {
     ) {
         let err: Error = exec_error(etype, "boom").into();
         assert_eq!(err.to_string(), expected);
-    }
-
-    #[test]
-    fn schema_nesting_depth_error_maps_ffi_error_code() {
-        let source = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
-        let error = Error::SchemaNestingDepthExceeded(source);
-
-        assert_eq!(
-            KernelError::from(error),
-            KernelError::SchemaNestingDepthExceededError
-        );
     }
 }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1221,10 +1221,14 @@ mod tests {
             schema_string: "{".to_string(),
             ..Default::default()
         };
-        assert!(matches!(
-            malformed_metadata.parse_schema(),
-            Err(Error::MalformedJson(_))
-        ));
+        let malformed_error = malformed_metadata.parse_schema().unwrap_err();
+        // Error conversion captures a backtrace only when enabled, so normalize both forms before
+        // checking the underlying error.
+        let malformed_error = match malformed_error {
+            Error::Backtraced { source, .. } => *source,
+            error => error,
+        };
+        assert!(matches!(malformed_error, Error::MalformedJson(_)));
     }
 
     #[test]

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -351,11 +351,12 @@ impl Metadata {
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
         // TODO(#1896): Increase the supported nesting depth or use non-recursive schema decoding.
         serde_json::from_str(&self.schema_string).map_err(|error| {
-            // serde_json keeps ErrorCode::RecursionLimitExceeded private, so its display text is
-            // the only available discriminator.
-            if error
-                .to_string()
-                .starts_with(SERDE_JSON_RECURSION_LIMIT_EXCEEDED)
+            // serde_json keeps ErrorCode::RecursionLimitExceeded private, so we use string
+            // matching.
+            if error.is_syntax()
+                && error
+                    .to_string()
+                    .starts_with(SERDE_JSON_RECURSION_LIMIT_EXCEEDED)
             {
                 Error::SchemaNestingDepthExceeded(error)
             } else {

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -347,6 +347,12 @@ impl Metadata {
         &self.schema_string
     }
 
+    /// Parses the table schema from its JSON representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth, or
+    /// [`Error::MalformedJson`] for other JSON decoding failures.
     #[internal_api]
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
         // TODO(#1896): Increase the supported nesting depth or use non-recursive schema decoding.

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
-const SERDE_JSON_RECURSION_LIMIT_EXCEEDED: &str = "recursion limit exceeded";
+const SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX: &str = "recursion limit exceeded";
 const UNKNOWN_OPERATION: &str = "UNKNOWN";
 
 pub mod deletion_vector;
@@ -356,9 +356,13 @@ impl Metadata {
             if error.is_syntax()
                 && error
                     .to_string()
-                    .starts_with(SERDE_JSON_RECURSION_LIMIT_EXCEEDED)
+                    .starts_with(SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX)
             {
-                Error::SchemaNestingDepthExceeded(error)
+                Error::schema(format!(
+                    "Table schema is too deeply nested: decoding metaData.schemaString exceeded \
+                     serde_json's recursion limit: {error}"
+                ))
+                .with_backtrace()
             } else {
                 error.into()
             }
@@ -1201,23 +1205,37 @@ mod tests {
         assert_eq!(schema, expected);
     }
 
-    #[test]
-    fn parse_schema_distinguishes_excessive_nesting_from_malformed_json() {
-        let deeply_nested_schema = (0..42).fold(
-            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
-            |schema, depth| {
-                StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
-            },
-        );
-        let deeply_nested_metadata = Metadata {
-            schema_string: serde_json::to_string(&deeply_nested_schema).unwrap(),
+    #[rstest]
+    #[case::supported(41, false)]
+    #[case::exceeded(42, true)]
+    fn parse_schema_nesting_boundary(#[case] depth: usize, #[case] exceeds_limit: bool) {
+        let metadata = Metadata {
+            schema_string: serde_json::to_string(&nested_schema(depth)).unwrap(),
             ..Default::default()
         };
-        assert!(matches!(
-            deeply_nested_metadata.parse_schema(),
-            Err(Error::SchemaNestingDepthExceeded(_))
-        ));
 
+        let result = metadata.parse_schema();
+        if exceeds_limit {
+            assert_result_error_with_message(
+                result.as_ref(),
+                concat!(
+                    "Schema error: Table schema is too deeply nested: decoding ",
+                    "metaData.schemaString exceeded serde_json's ",
+                    "recursion limit: recursion limit exceeded"
+                ),
+            );
+            let error = match result.unwrap_err() {
+                Error::Backtraced { source, .. } => *source,
+                error => error,
+            };
+            assert!(matches!(error, Error::Schema(_)));
+        } else {
+            result.unwrap();
+        }
+    }
+
+    #[test]
+    fn parse_schema_malformed_json_returns_malformed_json() {
         let malformed_metadata = Metadata {
             schema_string: "{".to_string(),
             ..Default::default()
@@ -1230,6 +1248,15 @@ mod tests {
             error => error,
         };
         assert!(matches!(malformed_error, Error::MalformedJson(_)));
+    }
+
+    fn nested_schema(depth: usize) -> StructType {
+        (0..depth).fold(
+            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
+            |schema, depth| {
+                StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
+            },
+        )
     }
 
     #[test]

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -27,6 +27,7 @@ use crate::{
 };
 
 const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
+const SERDE_JSON_RECURSION_LIMIT_EXCEEDED: &str = "recursion limit exceeded";
 const UNKNOWN_OPERATION: &str = "UNKNOWN";
 
 pub mod deletion_vector;
@@ -348,7 +349,19 @@ impl Metadata {
 
     #[internal_api]
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
-        Ok(serde_json::from_str(&self.schema_string)?)
+        // TODO(#1896): Increase the supported nesting depth or use non-recursive schema decoding.
+        serde_json::from_str(&self.schema_string).map_err(|error| {
+            // serde_json keeps ErrorCode::RecursionLimitExceeded private, so its display text is
+            // the only available discriminator.
+            if error
+                .to_string()
+                .starts_with(SERDE_JSON_RECURSION_LIMIT_EXCEEDED)
+            {
+                Error::SchemaNestingDepthExceeded(error)
+            } else {
+                error.into()
+            }
+        })
     }
 
     #[internal_api]
@@ -1185,6 +1198,33 @@ mod tests {
             ]),
         )]));
         assert_eq!(schema, expected);
+    }
+
+    #[test]
+    fn parse_schema_distinguishes_excessive_nesting_from_malformed_json() {
+        let deeply_nested_schema = (0..42).fold(
+            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
+            |schema, depth| {
+                StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
+            },
+        );
+        let deeply_nested_metadata = Metadata {
+            schema_string: serde_json::to_string(&deeply_nested_schema).unwrap(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            deeply_nested_metadata.parse_schema(),
+            Err(Error::SchemaNestingDepthExceeded(_))
+        ));
+
+        let malformed_metadata = Metadata {
+            schema_string: "{".to_string(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            malformed_metadata.parse_schema(),
+            Err(Error::MalformedJson(_))
+        ));
     }
 
     #[test]

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -232,6 +232,10 @@ pub enum Error {
     #[error("Schema error: {0}")]
     Schema(String),
 
+    /// The table schema exceeds the JSON parser's supported nesting depth
+    #[error("Table schema nesting exceeds the supported depth: {0}")]
+    SchemaNestingDepthExceeded(#[source] serde_json::Error),
+
     /// Validation error for file statistics (e.g., missing required clustering column stats)
     #[error("Stats validation error: {0}")]
     StatsValidation(String),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -232,7 +232,10 @@ pub enum Error {
     #[error("Schema error: {0}")]
     Schema(String),
 
-    /// The table schema exceeds the JSON parser's supported nesting depth
+    /// The table schema exceeds `serde_json`'s supported nesting depth.
+    ///
+    /// The Delta protocol does not define a schema nesting limit; this is a Delta Kernel
+    /// limitation inherited from `serde_json`.
     #[error("Table schema nesting exceeds the supported depth: {0}")]
     SchemaNestingDepthExceeded(#[source] serde_json::Error),
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -228,16 +228,9 @@ pub enum Error {
         #[from] crate::expressions::literal_expression_transform::Error,
     ),
 
-    /// Schema mismatch has occurred or invalid schema used somewhere
+    /// Schema mismatch has occurred or invalid/not-kernel-supported schema used somewhere
     #[error("Schema error: {0}")]
     Schema(String),
-
-    /// The table schema exceeds `serde_json`'s supported nesting depth.
-    ///
-    /// The Delta protocol does not define a schema nesting limit; this is a Delta Kernel
-    /// limitation inherited from `serde_json`.
-    #[error("Table schema nesting exceeds the supported depth: {0}")]
-    SchemaNestingDepthExceeded(#[source] serde_json::Error),
 
     /// Validation error for file statistics (e.g., missing required clustering column stats)
     #[error("Stats validation error: {0}")]

--- a/kernel/tests/integration/log/snapshot_build.rs
+++ b/kernel/tests/integration/log/snapshot_build.rs
@@ -4,16 +4,19 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::{Committer, FileSystemCommitter};
-use delta_kernel::schema::schema_ref;
+use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::snapshot::{
     CheckpointWriteResult, ChecksumWriteResult, IncrementalReplay, SnapshotBuilder,
 };
 use delta_kernel::transaction::create_table::create_table;
-use delta_kernel::{DeltaResult, Snapshot, Version};
+use delta_kernel::{DeltaResult, Error, Snapshot, Version};
 use rstest::rstest;
+use serde_json::json;
 use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
-use test_utils::{insert_data_with, test_table_setup_mt, TestCatalogCommitter};
+use test_utils::{
+    add_commit, engine_store_setup, insert_data_with, test_table_setup_mt, TestCatalogCommitter,
+};
 
 /// The newest version of the table built by [`setup_multi_version_table`].
 const LATEST_VERSION: Version = 3;
@@ -95,6 +98,40 @@ async fn setup_multi_version_table<E: TaskExecutor>(
     for value in 1..=LATEST_VERSION as i32 {
         snap = append_row(snap, engine, kind, value).await?;
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn deeply_nested_schema_snapshot_load_returns_specific_error(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let deeply_nested_schema = (0..42).fold(
+        StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
+        |schema, depth| {
+            StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
+        },
+    );
+    let (store, engine, table_url) = engine_store_setup("deeply_nested_schema", None);
+    let commit = [
+        json!({"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}}),
+        json!({
+            "metaData": {
+                "id": "deeply-nested-schema",
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": serde_json::to_string(&deeply_nested_schema)?,
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 0
+            }
+        }),
+    ]
+    .map(|action| action.to_string())
+    .join("\n");
+    add_commit(table_url.as_str(), store.as_ref(), 0, commit).await?;
+
+    assert!(matches!(
+        Snapshot::builder_for(table_url).build(&engine),
+        Err(Error::SchemaNestingDepthExceeded(_))
+    ));
     Ok(())
 }
 

--- a/kernel/tests/integration/log/snapshot_build.rs
+++ b/kernel/tests/integration/log/snapshot_build.rs
@@ -15,7 +15,8 @@ use serde_json::json;
 use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    add_commit, engine_store_setup, insert_data_with, test_table_setup_mt, TestCatalogCommitter,
+    add_commit, assert_result_error_with_message, engine_store_setup, insert_data_with,
+    test_table_setup_mt, TestCatalogCommitter,
 };
 
 /// The newest version of the table built by [`setup_multi_version_table`].
@@ -102,7 +103,7 @@ async fn setup_multi_version_table<E: TaskExecutor>(
 }
 
 #[tokio::test]
-async fn deeply_nested_schema_snapshot_load_returns_specific_error(
+async fn deeply_nested_schema_snapshot_load_returns_schema_error(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let deeply_nested_schema = (0..42).fold(
         StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
@@ -128,10 +129,20 @@ async fn deeply_nested_schema_snapshot_load_returns_specific_error(
     .join("\n");
     add_commit(table_url.as_str(), store.as_ref(), 0, commit).await?;
 
-    assert!(matches!(
-        Snapshot::builder_for(table_url).build(&engine),
-        Err(Error::SchemaNestingDepthExceeded(_))
-    ));
+    let result = Snapshot::builder_for(table_url).build(&engine);
+    assert_result_error_with_message(
+        result.as_ref(),
+        concat!(
+            "Schema error: Table schema is too deeply nested: decoding ",
+            "metaData.schemaString exceeded serde_json's ",
+            "recursion limit: recursion limit exceeded"
+        ),
+    );
+    let error = match result.unwrap_err() {
+        Error::Backtraced { source, .. } => *source,
+        error => error,
+    };
+    assert!(matches!(error, Error::Schema(_)));
     Ok(())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Kernel cannot decode too deeply nested, protocol-valid `metaData.schemaString` values because serde_json enforces a recursion limit. This PR returns the existing `SchemaError` category with an actionable message for such case. #1896 for more context. The doesn't fundamentally resolved the problem. Long term solutions includes(like 1896 mentioned)
- Benchmark the memory and set a higher bar, current depth > 41 schemas are rejected, probably too low
- Parse the schema in non-dfs way

## How was this change tested?

- Added unit coverage for the last supported and first rejected struct nesting depths.
- Added a malformed-JSON control and an assertion for the user-visible error message.
- Added an integration test verifying snapshot loading returns the improved schema error.