### PR TITLE
feat: add UC Delta-Tables create-table wire types and staging E2E test

### DIFF
--- a/.github/workflows/unitycatalog_oss_test.yml
+++ b/.github/workflows/unitycatalog_oss_test.yml
@@ -3,7 +3,7 @@ name: unity-catalog-oss-test
 # Runs the gated `unity-catalog-delta-rest-client` live integration tests against a real Unity
 # Catalog OSS server (built from a pinned commit). Exercises the read-only `get_config` handshake
 # (needs no table) and `load_table` against a table seeded via the Delta-Commits (legacy) API
-# before the test step.
+# before the test step, plus the mutating create tests (UC_CREATE) against the ephemeral server.
 on:
   push:
     branches: [main, "release/**"]
@@ -88,6 +88,7 @@ jobs:
           UC_TEST_CATALOG: unity
           UC_TEST_SCHEMA: default
           UC_TEST_TABLE: smoke_test_table
+          UC_CREATE: "1"
         run: cargo nextest run --locked -p unity-catalog-delta-rest-client --features integration-test -E 'test(live_)'
 
       - name: Stop Unity Catalog server

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -34,6 +34,8 @@ pub use credentials::{
 };
 pub use error::{Error, Result};
 pub use models::{
-    CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse, DeltaTableRequirement,
-    DeltaTableUpdate, LoadTableResponse, Protocol, TableMetadata, UpdateTableRequest,
+    CatalogConfig, Commit, CommitRequest, CommitsRequest, CommitsResponse,
+    CreateStagingTableRequest, CreateStagingTableResponse, CreateTableRequest,
+    DeltaTableRequirement, DeltaTableUpdate, LoadTableResponse, Protocol, TableMetadata,
+    UpdateTableRequest,
 };

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::credentials::StorageCredential;
+
 // ============================================================================
 // Delta-Commits API (legacy)
 //
@@ -303,9 +305,6 @@ pub struct CatalogConfig {
 // ============================================================================
 
 /// Typed Delta protocol wire model (mirrors kernel's `Protocol` action).
-///
-/// TODO: introduce `CreateTableRequest` and `CreateStagingTableResponse`, which both carry a
-/// typed `protocol` field.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Protocol {
@@ -319,6 +318,76 @@ pub struct Protocol {
     /// Writer features (Delta's `writerFeatures` list).
     #[serde(default)]
     pub writer_features: Vec<String>,
+}
+
+// ============================================================================
+// create-table: staging-tables and tables (CREATE flow)
+// ============================================================================
+
+/// Body of a `POST /delta/v1/catalogs/{c}/schemas/{s}/staging-tables` request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CreateStagingTableRequest {
+    /// Table name (catalog and schema are in the URL path).
+    pub name: String,
+}
+
+/// Response from the `staging-tables` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CreateStagingTableResponse {
+    /// Allocated table UUID.
+    pub table_id: String,
+    /// Table type (always `"MANAGED"` for staging tables).
+    pub table_type: String,
+    /// Cloud-storage location for the table's `_delta_log/` parent.
+    pub location: String,
+    /// Temporary credentials for the initial commit.
+    pub storage_credentials: Vec<StorageCredential>,
+    /// Required protocol that the v0 commit must satisfy.
+    pub required_protocol: Protocol,
+    /// Suggested protocol the client should consider. Modeled as opaque JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_protocol: Option<serde_json::Value>,
+    /// Required raw configuration entries. Null values mean "any valid value".
+    #[serde(default)]
+    pub required_properties: HashMap<String, Option<String>>,
+    /// Suggested raw configuration entries.
+    #[serde(default)]
+    pub suggested_properties: HashMap<String, Option<String>>,
+}
+
+/// Body of a `POST /delta/v1/catalogs/{c}/schemas/{s}/tables` request, the
+/// typed CREATE finalization payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CreateTableRequest {
+    /// Table name (catalog and schema are in the URL path).
+    pub name: String,
+    /// Cloud-storage location of the table.
+    pub location: String,
+    /// Table type, e.g. `"MANAGED"` or `"EXTERNAL"`.
+    pub table_type: String,
+    /// Optional table comment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    /// Typed Delta schema: a `StructType` JSON value.
+    pub columns: serde_json::Value,
+    /// Partition column names, in declaration order.
+    #[serde(default)]
+    pub partition_columns: Vec<String>,
+    /// Typed Delta protocol.
+    pub protocol: Protocol,
+    /// Raw `metaData.configuration` entries; the server derives all `delta.*`
+    /// properties itself.
+    #[serde(default)]
+    pub properties: HashMap<String, String>,
+    /// Per-domain metadata, keyed by domain name. Each value is opaque JSON.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub domain_metadata: HashMap<String, serde_json::Value>,
+    /// Timestamp of version 0 (the commit the client wrote before calling this
+    /// endpoint), in epoch milliseconds.
+    pub last_commit_timestamp_ms: i64,
 }
 
 #[cfg(test)]
@@ -520,5 +589,122 @@ mod tests {
         .unwrap();
         assert_eq!(config.protocol_version, "1.0");
         assert_eq!(config.endpoints.len(), 1);
+    }
+
+    #[test]
+    fn create_staging_table_request_wire_shape() {
+        let v = serde_json::to_value(CreateStagingTableRequest {
+            name: "t".to_string(),
+        })
+        .unwrap();
+        assert_eq!(v["name"], "t");
+    }
+
+    #[test]
+    fn create_staging_table_response_decodes_renamed_fields() {
+        // Pin the `table-id` rename and that storage-credentials / optional advertisement
+        // fields decode.
+        let body = r#"{
+            "table-id": "abc",
+            "table-type": "MANAGED",
+            "location": "s3://bucket/t",
+            "storage-credentials": [
+                {"prefix": "s3://bucket/t/", "operation": "READ_WRITE",
+                 "expiration-time-ms": 123, "config": {"s3.access-key-id": "ak"}}
+            ],
+            "required-protocol": {"min-reader-version": 3, "min-writer-version": 7}
+        }"#;
+        let resp: CreateStagingTableResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(resp.table_id, "abc");
+        assert_eq!(resp.location, "s3://bucket/t");
+        assert_eq!(resp.storage_credentials.len(), 1);
+        assert_eq!(resp.required_protocol.min_reader_version, 3);
+        // Absent advertisement fields default rather than fail to decode.
+        assert!(resp.suggested_protocol.is_none());
+        assert!(resp.required_properties.is_empty());
+    }
+
+    #[test]
+    fn create_staging_table_response_decodes_property_maps_and_suggested_protocol() {
+        let body = r#"{
+            "table-id": "abc",
+            "table-type": "MANAGED",
+            "location": "s3://bucket/t",
+            "storage-credentials": [],
+            "required-protocol": {"min-reader-version": 3, "min-writer-version": 7},
+            "suggested-protocol": {"min-reader-version": 1, "min-writer-version": 2},
+            "required-properties": {"delta.appendOnly": "true", "delta.columnMapping.mode": null},
+            "suggested-properties": {"delta.checkpointInterval": null}
+        }"#;
+        let resp: CreateStagingTableResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(
+            resp.required_properties["delta.appendOnly"],
+            Some("true".to_string())
+        );
+        assert_eq!(resp.required_properties["delta.columnMapping.mode"], None);
+        assert_eq!(resp.suggested_properties["delta.checkpointInterval"], None);
+        assert!(resp.suggested_protocol.is_some());
+    }
+
+    #[test]
+    fn create_table_request_wire_shape() {
+        let req = CreateTableRequest {
+            name: "t".to_string(),
+            location: "s3://bucket/t".to_string(),
+            table_type: "MANAGED".to_string(),
+            comment: None,
+            columns: serde_json::json!({"type": "struct", "fields": []}),
+            partition_columns: vec![],
+            protocol: Protocol {
+                min_reader_version: 3,
+                min_writer_version: 7,
+                reader_features: vec!["catalogManaged".to_string()],
+                writer_features: vec!["catalogManaged".to_string()],
+            },
+            properties: HashMap::from([("delta.appendOnly".to_string(), "true".to_string())]),
+            domain_metadata: HashMap::new(),
+            last_commit_timestamp_ms: 42,
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        // Field renames.
+        assert_eq!(v["location"], "s3://bucket/t");
+        assert_eq!(v["table-type"], "MANAGED");
+        assert_eq!(v["last-commit-timestamp-ms"], 42);
+        // Protocol is sent typed and separate; properties carry only raw configuration (the server
+        // derives `delta.feature.*` / versions itself), so no derived keys leak into `properties`.
+        assert_eq!(v["protocol"]["min-reader-version"], 3);
+        assert_eq!(v["properties"]["delta.appendOnly"], "true");
+        assert!(v["properties"].get("delta.minReaderVersion").is_none());
+        assert!(v["properties"]
+            .get("delta.feature.catalogManaged")
+            .is_none());
+        // Empty domain metadata is omitted from the wire body.
+        assert!(v.get("domain-metadata").is_none());
+    }
+
+    #[test]
+    fn create_table_request_serializes_optional_fields_when_present() {
+        let req = CreateTableRequest {
+            name: "t".to_string(),
+            location: "s3://bucket/t".to_string(),
+            table_type: "MANAGED".to_string(),
+            comment: Some("hello".to_string()),
+            columns: serde_json::json!({"type": "struct", "fields": []}),
+            partition_columns: vec!["p1".to_string(), "p2".to_string()],
+            protocol: Protocol::default(),
+            properties: HashMap::new(),
+            domain_metadata: HashMap::from([(
+                "delta.clustering".to_string(),
+                serde_json::json!({"clusteringColumns": ["c1"]}),
+            )]),
+            last_commit_timestamp_ms: 42,
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["comment"], "hello");
+        assert_eq!(v["partition-columns"], serde_json::json!(["p1", "p2"]));
+        assert_eq!(
+            v["domain-metadata"]["delta.clustering"]["clusteringColumns"][0],
+            "c1"
+        );
     }
 }

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -350,7 +350,6 @@ pub struct CreateStagingTableResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub suggested_protocol: Option<serde_json::Value>,
     /// Required raw configuration entries. Null values mean "any valid value".
-    #[serde(default)]
     pub required_properties: HashMap<String, Option<String>>,
     /// Suggested raw configuration entries.
     #[serde(default)]
@@ -364,7 +363,7 @@ pub struct CreateStagingTableResponse {
 pub struct CreateTableRequest {
     /// Table name (catalog and schema are in the URL path).
     pub name: String,
-    /// Cloud-storage location of the table.
+    /// Cloud-storage location of the table root, e.g. `"s3://bucket/path/to/table"`.
     pub location: String,
     /// Table type, e.g. `"MANAGED"` or `"EXTERNAL"`.
     pub table_type: String,
@@ -378,9 +377,9 @@ pub struct CreateTableRequest {
     pub partition_columns: Vec<String>,
     /// Typed Delta protocol.
     pub protocol: Protocol,
-    /// Raw `metaData.configuration` entries; the server derives all `delta.*`
-    /// properties itself.
-    #[serde(default)]
+    /// Raw `metaData.configuration` entries. The server derives the *protocol* properties
+    /// (`delta.minReaderVersion`/`minWriterVersion`, `delta.feature.*`) from the typed `protocol`,
+    /// so those must not appear here.
     pub properties: HashMap<String, String>,
     /// Per-domain metadata, keyed by domain name. Each value is opaque JSON.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
@@ -612,14 +611,14 @@ mod tests {
                 {"prefix": "s3://bucket/t/", "operation": "READ_WRITE",
                  "expiration-time-ms": 123, "config": {"s3.access-key-id": "ak"}}
             ],
-            "required-protocol": {"min-reader-version": 3, "min-writer-version": 7}
+            "required-protocol": {"min-reader-version": 3, "min-writer-version": 7},
+            "required-properties": {}
         }"#;
         let resp: CreateStagingTableResponse = serde_json::from_str(body).unwrap();
         assert_eq!(resp.table_id, "abc");
         assert_eq!(resp.location, "s3://bucket/t");
         assert_eq!(resp.storage_credentials.len(), 1);
         assert_eq!(resp.required_protocol.min_reader_version, 3);
-        // Absent advertisement fields default rather than fail to decode.
         assert!(resp.suggested_protocol.is_none());
         assert!(resp.required_properties.is_empty());
     }
@@ -695,7 +694,7 @@ mod tests {
             properties: HashMap::new(),
             domain_metadata: HashMap::from([(
                 "delta.clustering".to_string(),
-                serde_json::json!({"clusteringColumns": ["c1"]}),
+                serde_json::json!({"clusteringColumns": [["c1"]]}),
             )]),
             last_commit_timestamp_ms: 42,
         };
@@ -704,7 +703,7 @@ mod tests {
         assert_eq!(v["partition-columns"], serde_json::json!(["p1", "p2"]));
         assert_eq!(
             v["domain-metadata"]["delta.clustering"]["clusteringColumns"][0],
-            "c1"
+            serde_json::json!(["c1"])
         );
     }
 }

--- a/unity-catalog-delta-rest-client/tests/integration_live_server.rs
+++ b/unity-catalog-delta-rest-client/tests/integration_live_server.rs
@@ -9,8 +9,12 @@
 //! 'test(live_)'
 #![cfg(feature = "integration-test")]
 
-use unity_catalog_delta_client_api::Operation;
+use unity_catalog_delta_client_api::{
+    CreateStagingTableRequest, CreateStagingTableResponse, Operation,
+};
+use unity_catalog_delta_rest_client::http::build_http_client;
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
+use url::Url;
 
 /// Reads the server URL + token from the environment, or `None` to skip the test.
 fn server_env() -> Option<(String, String)> {
@@ -24,6 +28,22 @@ fn client(url: &str, token: &str) -> UCClient {
         .build()
         .expect("failed to build ClientConfig");
     UCClient::new(config).expect("failed to build UCClient")
+}
+
+/// Returns the Delta-Tables base URL (`<workspace>/delta/v1/catalogs/{c}/schemas/{s}/`) plus an
+/// authed `reqwest::Client` for the hand-rolled staging-tables POST.
+///
+/// TODO(remove): fold into UCClient once it exposes a typed staging-tables method.
+fn raw_delta_client(url: &str, token: &str, catalog: &str, schema: &str) -> (Url, reqwest::Client) {
+    let config = ClientConfig::build(url, token)
+        .build()
+        .expect("failed to build ClientConfig");
+    let base = config
+        .workspace_url
+        .join(&format!("delta/v1/catalogs/{catalog}/schemas/{schema}/"))
+        .expect("failed to join delta/v1 path onto workspace URL");
+    let http = build_http_client(&config).expect("failed to build reqwest client");
+    (base, http)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -147,4 +167,52 @@ async fn live_get_table_credentials() {
             location
         );
     }
+}
+
+/// Validates the `CreateStagingTableRequest` / `CreateStagingTableResponse` wire types against a
+/// real server.
+#[tokio::test(flavor = "multi_thread")]
+async fn live_create_staging_table() {
+    let Some((url, token)) = server_env() else {
+        eprintln!("UC_SERVER_URL unset; skipping live_create_staging_table");
+        return;
+    };
+    if std::env::var("UC_CREATE").is_err() {
+        eprintln!("UC_CREATE unset; skipping mutating live_create_staging_table");
+        return;
+    }
+    let catalog = std::env::var("UC_TEST_CATALOG").unwrap_or_else(|_| "unity".to_string());
+    let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
+    let table = "delta_rest_client_staging_test";
+
+    let (base, http) = raw_delta_client(&url, &token, &catalog, &schema);
+
+    let req = CreateStagingTableRequest {
+        name: table.to_string(),
+    };
+    let resp = http
+        .post(base.join("staging-tables").expect("staging-tables URL"))
+        .json(&req)
+        .send()
+        .await
+        .expect("staging-tables POST failed");
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "staging-tables POST returned {status}: {body}"
+    );
+
+    let staging: CreateStagingTableResponse =
+        serde_json::from_str(&body).expect("failed to deserialize CreateStagingTableResponse");
+    assert!(
+        !staging.table_id.is_empty(),
+        "expected an allocated table id"
+    );
+    assert!(
+        staging.location.starts_with("file:") || staging.location.starts_with("s3"),
+        "expected an absolute storage location, got {:?}",
+        staging.location
+    );
+    assert_eq!(staging.table_type, "MANAGED", "staging tables are managed");
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2941/files) to review incremental changes.
- [**stack/uc-create-wire-types**](https://github.com/delta-io/delta-kernel-rs/pull/2941) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2941/files)] ← _this PR_
  - [stack/uc-core](https://github.com/delta-io/delta-kernel-rs/pull/2855) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2855/files/211b0b270483ae5074d2c181ed45d495b21b4b9b..35f5faa85363bd9197b1448044ceebc2164a5ffb)]
    - [stack/uc-api-v2](https://github.com/delta-io/delta-kernel-rs/pull/2826) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2826/files/35f5faa85363bd9197b1448044ceebc2164a5ffb..230e34740947162d6e3af061a82eb6d7678cfeb4)]
      - [stack/uc-metrics](https://github.com/delta-io/delta-kernel-rs/pull/2956) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2956/files/230e34740947162d6e3af061a82eb6d7678cfeb4..15e9fc658bd43e8f23f51c99742fdb8417cd6274)]

---------
## What changes are proposed in this pull request?

This change adds the UC Delta-Tables create table wire models to unity-catalog-delta-client-api to account for the new Delta-Tables API. StagingTable wire models are included so that we can E2E test the create table flow against the OSS UC server in a follow-up PR.

## How was this change tested?

New UTs, new staging table wire tests against the OSS UC server. Existing UC tests pass.
