### PR TITLE
feat: add retry when data skipping before dedup fails

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -149,7 +149,7 @@ consumed. It provides detailed statistics about the log replay process:
 | `operation_id` | Unique ID for this scan, useful for correlation. |
 | `scan_type` | Which scan path produced the event (see below). |
 | `duration` | Wall-clock time from scan start to iterator exhaustion. |
-| `num_add_files_seen` | Add actions that entered deduplication. Excludes files already eliminated by data skipping. |
+| `num_add_files_seen` | Add files that entered deduplication. This normally excludes data-skipped files; parse-error fallback includes data-skipped files during retry. |
 | `num_active_add_files` | Add files that survived log replay. These are the files your connector reads. |
 | `num_remove_files_seen` | Remove actions encountered in commit files. |
 | `num_non_file_actions` | Non-file actions (protocol, metadata, etc.) seen during replay. |

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -548,7 +548,7 @@ impl ParseJsonExpression {
 /// empty bytes for binary, and to null for every other type.
 ///
 /// - Missing keys produce null values
-/// - Parse errors are propagated (indicating a broken table)
+/// - A value that cannot be parsed as its target field type returns [`Error::ParseError`]
 /// - Duplicate map keys are resolved by taking the rightmost entry
 ///
 /// [`PrimitiveType::parse_scalar`]: crate::schema::PrimitiveType::parse_scalar

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -832,6 +832,7 @@ impl PrimitiveType {
     }
 
     fn parse_decimal(raw: &str, dtype: DecimalType) -> Result<Scalar, Error> {
+        // TODO(#2950): Normalize all decimal parsing failures to Error::ParseError.
         let (base, exp): (&str, i128) = match raw.find(['e', 'E']) {
             None => (raw, 0), // no 'e' or 'E', so there's no exponent
             Some(pos) => {

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1180,7 +1180,10 @@ pub struct ScanMetadataCompleted {
     pub scan_type: ScanType,
     /// Wall-clock time from scan start to iterator exhaustion.
     pub duration: Duration,
-    /// Add files that entered deduplication (excludes files filtered by data skipping).
+    /// Add files that entered deduplication. This normally excludes add files filtered by data
+    /// skipping. During parse-error fallback, deduplication runs first, so add files filtered by
+    /// retry-time data skipping are included. See
+    /// [`LogReplayProcessor::process_actions_batch`](crate::log_replay::LogReplayProcessor::process_actions_batch).
     pub num_add_files_seen: u64,
     /// Add files that survived log replay (the files the connector reads).
     pub num_active_add_files: u64,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -496,6 +496,27 @@ impl ScanLogReplayProcessor {
         );
         Ok((transformed, selection_vector))
     }
+
+    fn record_active_add_files(
+        &self,
+        selection_vector: &[bool],
+        active_add_file_sizes: &[u64],
+    ) -> DeltaResult<()> {
+        require!(
+            selection_vector.len() == active_add_file_sizes.len(),
+            Error::internal_error(format!(
+                "selection vector length {} != active Add file sizes length {}",
+                selection_vector.len(),
+                active_add_file_sizes.len()
+            ))
+        );
+        for (selected, size) in selection_vector.iter().zip(active_add_file_sizes) {
+            if *selected {
+                self.metrics.record_active_add_file(*size);
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A visitor that deduplicates a stream of add and remove actions into a stream of valid adds. Log
@@ -507,6 +528,7 @@ struct AddRemoveDedupVisitor<'a, D: Deduplicator> {
     selection_vector: Vec<bool>,
     state_info: Arc<StateInfo>,
     row_transform_exprs: Vec<Option<ExpressionRef>>,
+    active_add_file_sizes: Vec<u64>,
     metrics: &'a ScanMetrics,
 }
 
@@ -517,11 +539,13 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         state_info: Arc<StateInfo>,
         metrics: &'a ScanMetrics,
     ) -> AddRemoveDedupVisitor<'a, D> {
+        let active_add_file_sizes = vec![0; selection_vector.len()];
         AddRemoveDedupVisitor {
             deduplicator,
             selection_vector,
             state_info,
             row_transform_exprs: Vec::new(),
+            active_add_file_sizes,
             metrics,
         }
     }
@@ -608,7 +632,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
                 self.row_transform_exprs.push(patch_expr);
             }
         }
-        self.metrics.record_active_add_file(size);
+        self.active_add_file_sizes[row] = size;
         Ok(true)
     }
 }
@@ -887,7 +911,7 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
             Self::ADD_SIZE_INDEX,
             Self::ADD_DV_START_INDEX,
         )?;
-        let (dedup_selection, row_transform_exprs) = {
+        let (dedup_selection, row_transform_exprs, active_add_file_sizes) = {
             let mut visitor = AddRemoveDedupVisitor::new(
                 deduplicator,
                 selection_vector,
@@ -895,7 +919,11 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
                 &self.metrics,
             );
             visitor.visit_rows_of(actions.as_ref())?;
-            (visitor.selection_vector, visitor.row_transform_exprs)
+            (
+                visitor.selection_vector,
+                visitor.row_transform_exprs,
+                visitor.active_add_file_sizes,
+            )
         };
 
         // Step 3: Return transformed batch with updated selection vector
@@ -908,11 +936,18 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
                 .filter(|(_, selected)| **selected)
                 .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
                 .collect();
+            let active_add_file_sizes = dedup_selection
+                .iter()
+                .zip(active_add_file_sizes)
+                .filter_map(|(selected, size)| (*selected).then_some(size))
+                .collect::<Vec<_>>();
             let actions = actions.apply_selection_vector(dedup_selection)?;
             let (transformed, selection_vector) =
                 self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
+            self.record_active_add_files(&selection_vector, &active_add_file_sizes)?;
             ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
         } else {
+            self.record_active_add_files(&dedup_selection, &active_add_file_sizes)?;
             ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
         };
         self.metrics
@@ -968,7 +1003,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             Self::ADD_DV_START_INDEX,
             Self::REMOVE_DV_START_INDEX,
         );
-        let (dedup_selection, row_transform_exprs) = {
+        let (dedup_selection, row_transform_exprs, active_add_file_sizes) = {
             let mut visitor = AddRemoveDedupVisitor::new(
                 deduplicator,
                 selection_vector,
@@ -976,7 +1011,11 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 &self.metrics,
             );
             visitor.visit_rows_of(actions.as_ref())?;
-            (visitor.selection_vector, visitor.row_transform_exprs)
+            (
+                visitor.selection_vector,
+                visitor.row_transform_exprs,
+                visitor.active_add_file_sizes,
+            )
         };
 
         // Step 4: Return transformed batch with updated selection vector
@@ -987,11 +1026,18 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 .filter(|(_, selected)| **selected)
                 .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
                 .collect();
+            let active_add_file_sizes = dedup_selection
+                .iter()
+                .zip(active_add_file_sizes)
+                .filter_map(|(selected, size)| (*selected).then_some(size))
+                .collect::<Vec<_>>();
             let actions = actions.apply_selection_vector(dedup_selection)?;
             let (transformed, selection_vector) =
                 self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
+            self.record_active_add_files(&selection_vector, &active_add_file_sizes)?;
             ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
         } else {
+            self.record_active_add_files(&dedup_selection, &active_add_file_sizes)?;
             ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
         };
         self.metrics

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -130,17 +130,18 @@ pub struct SerializableScanState {
 /// During a table scan, the processor reads batches of log actions (in reverse chronological order)
 /// and performs the following steps:
 ///
-/// - Data Skipping: Applies a predicate-based filter (via [`DataSkippingFilter`]) to quickly skip
-///   files that are irrelevant for the query. This includes both data column stats
-///   (min/max/nullCount) and partition value filtering in a single columnar pass. A secondary
-///   row-level partition filter catches remaining files the columnar pass cannot prune (e.g. null
-///   partition values where null-safety conservatively keeps them).
+/// - Transformation and Data Skipping: Applies a built-in transformation (`log_transform` or
+///   `checkpoint_transform`) to parse action metadata, then applies a predicate-based filter (via
+///   [`DataSkippingFilter`]). This includes both data column stats (min/max/nullCount) and
+///   partition value filtering in a single columnar pass. A secondary row-level partition filter
+///   catches remaining files the columnar pass cannot prune (e.g. null partition values where
+///   null-safety conservatively keeps them).
 /// - Action Deduplication: Leverages the [`FileActionDeduplicator`] to ensure that for each unique
 ///   file (identified by its path and deletion vector unique ID), only the latest valid Add action
 ///   is processed.
-/// - Transformation: Applies a built-in transformation (`log_transform` or `checkpoint_transform`)
-///   to convert selected Add actions into [`ScanMetadata`], the intermediate format passed to the
-///   engine.
+/// - Parse-error fallback: If transformation and data skipping return [`Error::ParseError`],
+///   deduplicates the raw batch first, then retries transformation and data skipping on the
+///   surviving actions.
 /// - Row StructPatch passthrough: Any user-provided row-level transformation expressions (e.g.
 ///   those derived from projection or filters) are preserved and passed through to the engine,
 ///   which applies them as part of its scan execution logic.

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -175,6 +175,13 @@ pub struct ScanLogReplayProcessor {
     metrics: Arc<ScanMetrics>,
 }
 
+struct RetryTransformAndDataSkipOutput {
+    transformed_actions: Box<dyn EngineData>,
+    final_selection: Vec<bool>,
+    row_transform_exprs: Vec<Option<ExpressionRef>>,
+    active_add_file_sizes: Vec<u64>,
+}
+
 impl ScanLogReplayProcessor {
     // These index positions correspond to the order of columns defined in
     // `selected_column_names_and_types()`
@@ -496,6 +503,36 @@ impl ScanLogReplayProcessor {
             ))
         );
         Ok((transformed, selection_vector))
+    }
+
+    fn retry_transform_and_data_skip(
+        &self,
+        actions: Box<dyn EngineData>,
+        is_log_batch: bool,
+        dedup_selection: Vec<bool>,
+        row_transform_exprs: Vec<Option<ExpressionRef>>,
+        active_add_file_sizes: Vec<u64>,
+    ) -> DeltaResult<RetryTransformAndDataSkipOutput> {
+        let row_transform_exprs = dedup_selection
+            .iter()
+            .enumerate()
+            .filter(|(_, selected)| **selected)
+            .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
+            .collect();
+        let active_add_file_sizes = dedup_selection
+            .iter()
+            .zip(active_add_file_sizes)
+            .filter_map(|(selected, size)| (*selected).then_some(size))
+            .collect();
+        let actions = actions.apply_selection_vector(dedup_selection)?;
+        let (transformed_actions, final_selection) =
+            self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
+        Ok(RetryTransformAndDataSkipOutput {
+            transformed_actions,
+            final_selection,
+            row_transform_exprs,
+            active_add_file_sizes,
+        })
     }
 
     fn record_active_add_files(
@@ -889,17 +926,19 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
             Error::generic("Parallel checkpoint processor may only be applied to checkpoint files")
         );
 
-        let mut retry_after_dedup = false;
+        let mut should_retry_transform_and_data_skip = false;
         // Step 1: Apply transform + data skipping. Do this before deduplication to reduce the size
         // of the dedup map and avoid String allocations.
         // This step transforms all Adds, including those superseded by Removes (dead Adds).
         // The transform for a dead Add may fail because it may have a different partition column
         // type. In that case, we get a ParseError and retry after deduplication.
-        let (transformed_result, selection_vector) =
+        let (pre_dedup_transform_result, pre_dedup_selection) =
             match self.transform_and_data_skip(actions.as_ref(), is_log_batch) {
-                Ok((transformed, selection_vector)) => (Ok(transformed), selection_vector),
+                Ok((transformed_actions, pre_dedup_selection)) => {
+                    (Ok(transformed_actions), pre_dedup_selection)
+                }
                 Err(err @ Error::ParseError(_, _)) => {
-                    retry_after_dedup = true;
+                    should_retry_transform_and_data_skip = true;
                     (Err(err), vec![true; actions.len()])
                 }
                 Err(err) => return Err(err),
@@ -915,7 +954,7 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
         let (dedup_selection, row_transform_exprs, active_add_file_sizes) = {
             let mut visitor = AddRemoveDedupVisitor::new(
                 deduplicator,
-                selection_vector,
+                pre_dedup_selection,
                 self.state_info.clone(),
                 &self.metrics,
             );
@@ -928,29 +967,32 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
         };
 
         // Step 3: Return transformed batch with updated selection vector
-        let scan_metadata = if retry_after_dedup {
+        let RetryTransformAndDataSkipOutput {
+            transformed_actions,
+            final_selection,
+            row_transform_exprs,
+            active_add_file_sizes,
+        } = if should_retry_transform_and_data_skip {
             // If step 1 failed with a parse error, filter out the dead Adds and retry after
             // deduplication.
-            let row_transform_exprs = dedup_selection
-                .iter()
-                .enumerate()
-                .filter(|(_, selected)| **selected)
-                .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
-                .collect();
-            let active_add_file_sizes = dedup_selection
-                .iter()
-                .zip(active_add_file_sizes)
-                .filter_map(|(selected, size)| (*selected).then_some(size))
-                .collect::<Vec<_>>();
-            let actions = actions.apply_selection_vector(dedup_selection)?;
-            let (transformed, selection_vector) =
-                self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
-            self.record_active_add_files(&selection_vector, &active_add_file_sizes)?;
-            ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
+            self.retry_transform_and_data_skip(
+                actions,
+                is_log_batch,
+                dedup_selection,
+                row_transform_exprs,
+                active_add_file_sizes,
+            )?
         } else {
-            self.record_active_add_files(&dedup_selection, &active_add_file_sizes)?;
-            ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
+            RetryTransformAndDataSkipOutput {
+                transformed_actions: pre_dedup_transform_result?,
+                final_selection: dedup_selection,
+                row_transform_exprs,
+                active_add_file_sizes,
+            }
         };
+        self.record_active_add_files(&final_selection, &active_add_file_sizes)?;
+        let scan_metadata =
+            ScanMetadata::try_new(transformed_actions, final_selection, row_transform_exprs)?;
         self.metrics
             .update_peak_hash_set_size(self.seen_file_keys.len());
         Ok(scan_metadata)
@@ -983,12 +1025,14 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
         // with ISNULL guards that keep rows with missing stats. For partition values, the
         // predicate is wrapped with OR(NOT is_add, pred) via guard_for_removes, so non-Add
         // rows always pass the partition filter regardless of null partition values.
-        let mut retry_after_dedup = false;
-        let (transformed_result, selection_vector) =
+        let mut should_retry_transform_and_data_skip = false;
+        let (pre_dedup_transform_result, pre_dedup_selection) =
             match self.transform_and_data_skip(actions.as_ref(), is_log_batch) {
-                Ok((transformed, selection_vector)) => (Ok(transformed), selection_vector),
+                Ok((transformed_actions, pre_dedup_selection)) => {
+                    (Ok(transformed_actions), pre_dedup_selection)
+                }
                 Err(err @ Error::ParseError(_, _)) => {
-                    retry_after_dedup = true;
+                    should_retry_transform_and_data_skip = true;
                     (Err(err), vec![true; actions.len()])
                 }
                 Err(err) => return Err(err),
@@ -1007,7 +1051,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
         let (dedup_selection, row_transform_exprs, active_add_file_sizes) = {
             let mut visitor = AddRemoveDedupVisitor::new(
                 deduplicator,
-                selection_vector,
+                pre_dedup_selection,
                 self.state_info.clone(),
                 &self.metrics,
             );
@@ -1020,27 +1064,30 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
         };
 
         // Step 4: Return transformed batch with updated selection vector
-        let scan_metadata = if retry_after_dedup {
-            let row_transform_exprs = dedup_selection
-                .iter()
-                .enumerate()
-                .filter(|(_, selected)| **selected)
-                .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
-                .collect();
-            let active_add_file_sizes = dedup_selection
-                .iter()
-                .zip(active_add_file_sizes)
-                .filter_map(|(selected, size)| (*selected).then_some(size))
-                .collect::<Vec<_>>();
-            let actions = actions.apply_selection_vector(dedup_selection)?;
-            let (transformed, selection_vector) =
-                self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
-            self.record_active_add_files(&selection_vector, &active_add_file_sizes)?;
-            ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
+        let RetryTransformAndDataSkipOutput {
+            transformed_actions,
+            final_selection,
+            row_transform_exprs,
+            active_add_file_sizes,
+        } = if should_retry_transform_and_data_skip {
+            self.retry_transform_and_data_skip(
+                actions,
+                is_log_batch,
+                dedup_selection,
+                row_transform_exprs,
+                active_add_file_sizes,
+            )?
         } else {
-            self.record_active_add_files(&dedup_selection, &active_add_file_sizes)?;
-            ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
+            RetryTransformAndDataSkipOutput {
+                transformed_actions: pre_dedup_transform_result?,
+                final_selection: dedup_selection,
+                row_transform_exprs,
+                active_add_file_sizes,
+            }
         };
+        self.record_active_add_files(&final_selection, &active_add_file_sizes)?;
+        let scan_metadata =
+            ScanMetadata::try_new(transformed_actions, final_selection, row_transform_exprs)?;
         self.metrics
             .update_peak_hash_set_size(self.seen_file_keys.len());
         Ok(scan_metadata)

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -10,7 +10,7 @@ use super::metrics::ScanMetrics;
 use super::state_info::StateInfo;
 use super::{PhysicalPredicate, ScanMetadata};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
-use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
+use crate::engine_data::{EngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
     column_expr, column_expr_ref, column_name, ColumnName, Expression, ExpressionRef, Predicate,
     PredicateRef, UnaryExpressionOp,
@@ -464,6 +464,38 @@ impl ScanLogReplayProcessor {
             internal_state.partition_values_options,
         )
     }
+
+    fn transform_and_data_skip(
+        &self,
+        actions: &dyn EngineData,
+        is_log_batch: bool,
+    ) -> DeltaResult<(Box<dyn EngineData>, Vec<bool>)> {
+        let transform = if is_log_batch {
+            &self.log_transform
+        } else {
+            &self.checkpoint_transform
+        };
+        let transformed = transform.evaluate(actions)?;
+        require!(
+            transformed.len() == actions.len(),
+            Error::internal_error(format!(
+                "transform output length {} != actions length {}",
+                transformed.len(),
+                actions.len()
+            ))
+        );
+
+        let selection_vector = self.build_selection_vector(transformed.as_ref())?;
+        require!(
+            selection_vector.len() == actions.len(),
+            Error::internal_error(format!(
+                "selection vector length {} != actions length {}",
+                selection_vector.len(),
+                actions.len()
+            ))
+        );
+        Ok((transformed, selection_vector))
+    }
 }
 
 /// A visitor that deduplicates a stream of add and remove actions into a stream of valid adds. Log
@@ -530,11 +562,18 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
             self.metrics.incr_remove_files_seen()
         };
 
+        // Check both adds and removes (skipping already-seen), but only transform and return adds
+        if self.deduplicator.check_and_record_seen(file_key) || !is_add {
+            return Ok(false);
+        }
+
         // Parse partition values for building the per-row transform expression.
         // Partition pruning is handled by DataSkippingFilter in the columnar data skipping phase,
         // so we only need to parse values here for the transform.
+
+        // Only needed for survived addFiles.
         let partition_values = match &self.state_info.transform_spec {
-            Some(transform) if is_add && !self.state_info.skip_row_transforms => {
+            Some(transform) if !self.state_info.skip_row_transforms => {
                 let partition_values = getters[ScanLogReplayProcessor::ADD_PARTITION_VALUES_INDEX]
                     .get(row, "add.partitionValues")?;
                 parse_partition_values(
@@ -547,10 +586,6 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
             _ => Default::default(),
         };
 
-        // Check both adds and removes (skipping already-seen), but only transform and return adds
-        if self.deduplicator.check_and_record_seen(file_key) || !is_add {
-            return Ok(false);
-        }
         if !self.state_info.skip_row_transforms {
             let base_row_id: Option<i64> =
                 getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
@@ -829,59 +864,57 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
             Error::generic("Parallel checkpoint processor may only be applied to checkpoint files")
         );
 
-        // Step 1: Apply transform FIRST (parses JSON once, outputs stats_parsed).
-        // This is done before data skipping so we can read the already-parsed stats.
-        // We use the checkpoint_transform because we checked above that we're reading a checkpoint.
-        let transformed = self.checkpoint_transform.evaluate(actions.as_ref())?;
-        debug_assert_eq!(transformed.len(), actions.len());
-        require!(
-            transformed.len() == actions.len(),
-            Error::internal_error(format!(
-                "checkpoint transform output length {} != actions length {}",
-                transformed.len(),
-                actions.len()
-            ))
-        );
+        let mut retry_after_dedup = false;
+        // Step 1: Apply transform + data skipping. Do this before deduplication to reduce the size
+        // of the dedup map and avoid String allocations.
+        // This step transforms all Adds, including those superseded by Removes (dead Adds).
+        // The transform for a dead Add may fail because it may have a different partition column
+        // type. In that case, we get a ParseError and retry after deduplication.
+        let (transformed_result, selection_vector) =
+            match self.transform_and_data_skip(actions.as_ref(), is_log_batch) {
+                Ok((transformed, selection_vector)) => (Ok(transformed), selection_vector),
+                Err(err @ Error::ParseError(_, _)) => {
+                    retry_after_dedup = true;
+                    (Err(err), vec![true; actions.len()])
+                }
+                Err(err) => return Err(err),
+            };
 
-        // Step 2: Build selection vector from TRANSFORMED batch (reads stats_parsed directly).
-        // This avoids double JSON parsing -- the transform already parsed the stats.
-        // Data skipping is safe for Remove rows: their add-side columns (stats_parsed,
-        // partitionValues_parsed) are null. For stats, the skipping predicate wraps comparisons
-        // with ISNULL guards that keep rows with missing stats. For partition values, the
-        // predicate is wrapped with OR(NOT is_add, pred) via guard_for_removes, so non-Add
-        // rows always pass the partition filter regardless of null partition values.
-        let selection_vector = self.build_selection_vector(transformed.as_ref())?;
-        debug_assert_eq!(selection_vector.len(), actions.len());
-        require!(
-            selection_vector.len() == actions.len(),
-            Error::internal_error(format!(
-                "selection vector length {} != actions length {}",
-                selection_vector.len(),
-                actions.len()
-            ))
-        );
-
-        // Step 3: Run deduplication visitor on RAW batch (needs add.path, remove.path, etc.)
+        // Step 2: Run deduplication visitor on RAW batch (needs add.path, remove.path, etc.)
         let deduplicator = CheckpointDeduplicator::try_new(
             &self.seen_file_keys,
             Self::ADD_PATH_INDEX,
             Self::ADD_SIZE_INDEX,
             Self::ADD_DV_START_INDEX,
         )?;
-        let mut visitor = AddRemoveDedupVisitor::new(
-            deduplicator,
-            selection_vector,
-            self.state_info.clone(),
-            &self.metrics,
-        );
-        visitor.visit_rows_of(actions.as_ref())?;
+        let (dedup_selection, row_transform_exprs) = {
+            let mut visitor = AddRemoveDedupVisitor::new(
+                deduplicator,
+                selection_vector,
+                self.state_info.clone(),
+                &self.metrics,
+            );
+            visitor.visit_rows_of(actions.as_ref())?;
+            (visitor.selection_vector, visitor.row_transform_exprs)
+        };
 
-        // Step 4: Return transformed batch with updated selection vector
-        let scan_metadata = ScanMetadata::try_new(
-            transformed,
-            visitor.selection_vector,
-            visitor.row_transform_exprs,
-        )?;
+        // Step 3: Return transformed batch with updated selection vector
+        let scan_metadata = if retry_after_dedup {
+            // If step 1 failed with a parse error, filter out the dead Adds and retry after
+            // deduplication.
+            let row_transform_exprs = dedup_selection
+                .iter()
+                .enumerate()
+                .filter(|(_, selected)| **selected)
+                .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
+                .collect();
+            let actions = actions.apply_selection_vector(dedup_selection)?;
+            let (transformed, selection_vector) =
+                self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
+            ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
+        } else {
+            ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
+        };
         self.metrics
             .update_peak_hash_set_size(self.seen_file_keys.len());
         Ok(scan_metadata)
@@ -906,20 +939,6 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
         // Use the correct transform based on batch type:
         // - Log batches: parse JSON for stats, MapToStruct for partition values
         // - Checkpoint batches: read pre-parsed columns directly when available
-        let transform = if is_log_batch {
-            &self.log_transform
-        } else {
-            &self.checkpoint_transform
-        };
-        let transformed = transform.evaluate(actions.as_ref())?;
-        require!(
-            transformed.len() == actions.len(),
-            Error::internal_error(format!(
-                "transform output length {} != actions length {}",
-                transformed.len(),
-                actions.len()
-            ))
-        );
 
         // Step 2: Build selection vector from TRANSFORMED batch (reads stats_parsed directly).
         // This avoids double JSON parsing -- the transform already parsed the stats.
@@ -928,16 +947,16 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
         // with ISNULL guards that keep rows with missing stats. For partition values, the
         // predicate is wrapped with OR(NOT is_add, pred) via guard_for_removes, so non-Add
         // rows always pass the partition filter regardless of null partition values.
-        let selection_vector = self.build_selection_vector(transformed.as_ref())?;
-        debug_assert_eq!(selection_vector.len(), actions.len());
-        require!(
-            selection_vector.len() == actions.len(),
-            Error::internal_error(format!(
-                "selection vector length {} != actions length {}",
-                selection_vector.len(),
-                actions.len()
-            ))
-        );
+        let mut retry_after_dedup = false;
+        let (transformed_result, selection_vector) =
+            match self.transform_and_data_skip(actions.as_ref(), is_log_batch) {
+                Ok((transformed, selection_vector)) => (Ok(transformed), selection_vector),
+                Err(err @ Error::ParseError(_, _)) => {
+                    retry_after_dedup = true;
+                    (Err(err), vec![true; actions.len()])
+                }
+                Err(err) => return Err(err),
+            };
 
         // Step 3: Run deduplication visitor on RAW batch (needs add.path, remove.path, etc.)
         let deduplicator = FileActionDeduplicator::new(
@@ -949,20 +968,32 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             Self::ADD_DV_START_INDEX,
             Self::REMOVE_DV_START_INDEX,
         );
-        let mut visitor = AddRemoveDedupVisitor::new(
-            deduplicator,
-            selection_vector,
-            self.state_info.clone(),
-            &self.metrics,
-        );
-        visitor.visit_rows_of(actions.as_ref())?;
+        let (dedup_selection, row_transform_exprs) = {
+            let mut visitor = AddRemoveDedupVisitor::new(
+                deduplicator,
+                selection_vector,
+                self.state_info.clone(),
+                &self.metrics,
+            );
+            visitor.visit_rows_of(actions.as_ref())?;
+            (visitor.selection_vector, visitor.row_transform_exprs)
+        };
 
         // Step 4: Return transformed batch with updated selection vector
-        let scan_metadata = ScanMetadata::try_new(
-            transformed,
-            visitor.selection_vector,
-            visitor.row_transform_exprs,
-        )?;
+        let scan_metadata = if retry_after_dedup {
+            let row_transform_exprs = dedup_selection
+                .iter()
+                .enumerate()
+                .filter(|(_, selected)| **selected)
+                .map(|(row, _)| row_transform_exprs.get(row).cloned().flatten())
+                .collect();
+            let actions = actions.apply_selection_vector(dedup_selection)?;
+            let (transformed, selection_vector) =
+                self.transform_and_data_skip(actions.as_ref(), is_log_batch)?;
+            ScanMetadata::try_new(transformed, selection_vector, row_transform_exprs)?
+        } else {
+            ScanMetadata::try_new(transformed_result?, dedup_selection, row_transform_exprs)?
+        };
         self.metrics
             .update_peak_hash_set_size(self.seen_file_keys.len());
         Ok(scan_metadata)

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1013,19 +1013,21 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             is_log_batch,
         } = actions_batch;
 
-        // Step 1: Apply transform FIRST (outputs stats_parsed and partitionValues_parsed).
-        // Use the correct transform based on batch type:
+        let mut should_retry_transform_and_data_skip = false;
+        // Step 1: Apply transform + data skipping. Do this before deduplication to reduce the size
+        // of the dedup map and avoid String allocations.
+        // This step transforms all Adds, including those superseded by Removes (dead Adds).
+        // The transform for a dead Add may fail because it may have a different partition column
+        // type. In that case, we get a ParseError and retry after deduplication.
+        // The transform depends on the batch type:
         // - Log batches: parse JSON for stats, MapToStruct for partition values
         // - Checkpoint batches: read pre-parsed columns directly when available
-
-        // Step 2: Build selection vector from TRANSFORMED batch (reads stats_parsed directly).
         // This avoids double JSON parsing -- the transform already parsed the stats.
         // Data skipping is safe for Remove rows: their add-side columns (stats_parsed,
         // partitionValues_parsed) are null. For stats, the skipping predicate wraps comparisons
         // with ISNULL guards that keep rows with missing stats. For partition values, the
         // predicate is wrapped with OR(NOT is_add, pred) via guard_for_removes, so non-Add
         // rows always pass the partition filter regardless of null partition values.
-        let mut should_retry_transform_and_data_skip = false;
         let (pre_dedup_transform_result, pre_dedup_selection) =
             match self.transform_and_data_skip(actions.as_ref(), is_log_batch) {
                 Ok((transformed_actions, pre_dedup_selection)) => {
@@ -1038,7 +1040,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 Err(err) => return Err(err),
             };
 
-        // Step 3: Run deduplication visitor on RAW batch (needs add.path, remove.path, etc.)
+        // Step 2: Run deduplication visitor on RAW batch (needs add.path, remove.path, etc.)
         let deduplicator = FileActionDeduplicator::new(
             &mut self.seen_file_keys,
             is_log_batch,
@@ -1063,13 +1065,15 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
             )
         };
 
-        // Step 4: Return transformed batch with updated selection vector
+        // Step 3: Return transformed batch with updated selection vector
         let RetryTransformAndDataSkipOutput {
             transformed_actions,
             final_selection,
             row_transform_exprs,
             active_add_file_sizes,
         } = if should_retry_transform_and_data_skip {
+            // If step 1 failed with a parse error, filter out the dead Adds and retry after
+            // deduplication.
             self.retry_transform_and_data_skip(
                 actions,
                 is_log_batch,

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -11,8 +11,9 @@ use crate::metrics::{MetricId, ScanMetadataCompleted, ScanType, TableType};
 /// Metrics collected during scan log replay. Metrics are updated and read using relaxed ordering
 /// to keep updates fast across parallel executing threads.
 pub(crate) struct ScanMetrics {
-    /// Add files seen during add remove deduplication. This does not include data skipped add
-    /// files.
+    /// Add files that entered deduplication. This normally excludes add files filtered by data
+    /// skipping. During parse-error fallback, deduplication runs first, so add files filtered by
+    /// retry-time data skipping are included.
     num_add_files_seen: AtomicU64,
     /// Add files that survived log replay (files to read). includes files that survived
     /// dataskipping, partition pruning, and add/remove deduplication.

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -16,18 +16,19 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{Int64Array, RecordBatch};
 use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::checkpoint::{CheckpointSpec, V2CheckpointConfig};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{
     column_expr, Expression as Expr, Predicate as Pred, PredicateRef, Scalar,
 };
-use delta_kernel::metrics::MetricEvent;
+use delta_kernel::metrics::{MetricEvent, ScanType};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::{Snapshot, SnapshotRef};
+use delta_kernel::{Error, Snapshot, SnapshotRef};
 use rstest::rstest;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -616,7 +617,7 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     103
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn scan_compatible_with_replace_partition_change(
+async fn scan_with_replace_table_schema_change(
     #[case] predicate: PredicateRef,
     #[case] expected_paths: &[&str],
     #[case] expected_active_files: u64,
@@ -633,6 +634,7 @@ async fn scan_compatible_with_replace_partition_change(
     ])?);
     create_table(&table_path, old_schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["part"]))
+        .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
@@ -680,7 +682,10 @@ async fn scan_compatible_with_replace_partition_change(
 
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     if checkpoint_old_add {
-        snapshot.checkpoint(engine.as_ref(), None)?;
+        let checkpoint_spec = CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+            file_actions_per_sidecar_hint: Some(1),
+        });
+        snapshot.checkpoint(engine.as_ref(), Some(&checkpoint_spec))?;
     }
 
     // Commit 3 replaces the table metadata and removes the addFiles.
@@ -757,26 +762,94 @@ async fn scan_compatible_with_replace_partition_change(
     let reporter = Arc::new(CapturingReporter::default());
     let _guard = install_thread_local_metrics_reporter(reporter.clone());
     assert_eq!(
-        surviving_paths(&table_path, engine, predicate, use_parallel)?,
+        surviving_paths(&table_path, engine.clone(), predicate.clone(), use_parallel)?,
         expected_paths
             .iter()
             .map(|path| (*path).to_string())
             .collect::<Vec<_>>()
     );
-    let (active_files, active_bytes) = reporter
+    let scan_events = reporter
         .events()
         .into_iter()
         .filter_map(|event| match event {
-            MetricEvent::ScanMetadataCompleted(event) => {
-                Some((event.num_active_add_files, event.active_add_files_bytes))
-            }
+            MetricEvent::ScanMetadataCompleted(event) => Some(event),
             _ => None,
         })
-        .fold((0, 0), |(files, bytes), (event_files, event_bytes)| {
-            (files + event_files, bytes + event_bytes)
-        });
-    assert_eq!(active_files, expected_active_files);
-    assert_eq!(active_bytes, expected_active_bytes);
+        .collect::<Vec<_>>();
+    if use_parallel && checkpoint_old_add {
+        assert!(
+            scan_events
+                .iter()
+                .any(|event| event.scan_type == ScanType::ParallelPhase),
+            "the V2 sidecar should be processed by the parallel phase"
+        );
+    }
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.num_add_files_seen)
+            .sum::<u64>(),
+        4
+    );
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.num_active_add_files)
+            .sum::<u64>(),
+        expected_active_files
+    );
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.active_add_files_bytes)
+            .sum::<u64>(),
+        expected_active_bytes
+    );
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.num_remove_files_seen)
+            .sum::<u64>(),
+        3
+    );
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.num_predicate_filtered)
+            .sum::<u64>(),
+        2
+    );
+    // Negative test: a live addFile with incompatible schema should fail the scan.
+    let active_incompatible_add = [
+        json!({
+            "commitInfo": {
+                "timestamp": 1700000003000i64,
+                "operation": "WRITE",
+                "version": 4,
+            }
+        }),
+        add_file_action(
+            "active-incompatible.parquet",
+            301,                               /* size */
+            "not-an-integer-active-partition", /* partition_value */
+            "not-an-integer-active-value",     /* data_value */
+        )?,
+    ];
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        4,
+        active_incompatible_add
+            .map(|action| action.to_string())
+            .join("\n"),
+    )
+    .await?;
+    let error = surviving_paths(&table_path, engine, predicate, use_parallel)
+        .expect_err("an active incompatible add file should fail the scan");
+    assert!(matches!(
+        error.downcast_ref::<Error>(),
+        Some(Error::ParseError(_, _))
+    ));
     Ok(())
 }
 

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -844,6 +844,15 @@ async fn scan_with_replace_table_schema_change(
             .join("\n"),
     )
     .await?;
+
+    if use_parallel {
+        // Put the active incompatible Add in a sidecar so the parallel processor rejects it.
+        let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+        let checkpoint_spec = CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+            file_actions_per_sidecar_hint: Some(1),
+        });
+        snapshot.checkpoint(engine.as_ref(), Some(&checkpoint_spec))?;
+    }
     let error = surviving_paths(&table_path, engine, predicate, use_parallel)
         .expect_err("an active incompatible add file should fail the scan");
     assert!(matches!(

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -28,10 +28,12 @@ use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{Snapshot, SnapshotRef};
 use rstest::rstest;
+use serde_json::json;
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    add_commit, create_table_and_load_snapshot, test_table_setup_mt, write_batch_to_table,
+    add_commit, create_table_and_load_snapshot, read_add_infos, test_table_setup_mt,
+    write_batch_to_table,
 };
 use url::Url;
 
@@ -582,6 +584,127 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     assert_eq!(
         surviving_files(&table_path, engine, predicate, use_parallel)?,
         2
+    );
+    Ok(())
+}
+
+/// Replace table may change a partition column's type. A scan after replacement should remain
+/// compatible with the old addFiles.
+#[rstest]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_compatible_with_replace_partition_change(
+    #[values(false, true)] use_parallel: bool,
+    #[values(false, true)] checkpoint_old_add: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+
+    // Commit 1 creates the table with a string partition column.
+    let old_schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("part", DataType::STRING),
+        StructField::nullable("value", DataType::LONG),
+    ])?);
+    let snapshot = create_table(&table_path, old_schema, "Test/1.0")
+        .with_data_layout(DataLayout::partitioned(["part"]))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+
+    // Commit 2 writes an addFile with `old_schema`.
+    let physical_data_schema: ArrowSchema =
+        (&StructType::try_new([StructField::nullable("value", DataType::LONG)])?)
+            .try_into_arrow()?;
+    let physical_data_schema = Arc::new(physical_data_schema);
+    let data = RecordBatch::try_new(
+        physical_data_schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1i64]))],
+    )?;
+    let snapshot = write_batch_to_table(
+        &snapshot,
+        engine.as_ref(),
+        data,
+        HashMap::from([(
+            "part".to_string(),
+            Scalar::String("not-an-integer".to_string()),
+        )]),
+    )
+    .await?;
+    let old_path = read_add_infos(&snapshot, engine.as_ref())?
+        .into_iter()
+        .next()
+        .ok_or("commit 2 should contain an addFile")?
+        .path;
+
+    if checkpoint_old_add {
+        snapshot.checkpoint(engine.as_ref(), None)?;
+    }
+
+    // Commit 3 replaces the table metadata and removes the old addFile without adding data.
+    let replacement_schema = StructType::try_new(vec![
+        StructField::nullable("part", DataType::LONG),
+        StructField::nullable("value", DataType::LONG),
+    ])?;
+    let replacement = [
+        json!({
+            "commitInfo": {
+                "timestamp": 1700000001000i64,
+                "operation": "CREATE OR REPLACE TABLE",
+                "version": 2,
+            }
+        }),
+        json!({
+            "metaData": {
+                "id": "replacement-table",
+                "format": { "provider": "parquet", "options": {} },
+                "schemaString": serde_json::to_string(&replacement_schema)?,
+                "partitionColumns": ["part"],
+                "configuration": {},
+                "createdTime": 1700000001000i64,
+            }
+        }),
+        json!({
+            "remove": {
+                "path": old_path.clone(),
+                "deletionTimestamp": 1700000001000i64,
+                "dataChange": true,
+                "extendedFileMetadata": false,
+            }
+        }),
+    ];
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        2,
+        replacement.map(|action| action.to_string()).join("\n"),
+    )
+    .await?;
+
+    // Commit 4 writes an addFile using the replacement LONG partition type.
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    let data = RecordBatch::try_new(
+        physical_data_schema,
+        vec![Arc::new(Int64Array::from(vec![2i64]))],
+    )?;
+    let snapshot = write_batch_to_table(
+        &snapshot,
+        engine.as_ref(),
+        data,
+        HashMap::from([("part".to_string(), Scalar::Long(1))]),
+    )
+    .await?;
+    let new_path = read_add_infos(&snapshot, engine.as_ref())?
+        .into_iter()
+        .find(|add| add.path != old_path)
+        .ok_or("commit 4 should contain an addFile")?
+        .path;
+
+    let predicate = Arc::new(Pred::eq(column_expr!("part"), Expr::literal(1i64)));
+    assert_eq!(
+        surviving_paths(&table_path, engine, predicate, use_parallel)?,
+        vec![new_path]
     );
     Ok(())
 }

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -21,6 +21,7 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{
     column_expr, Expression as Expr, Predicate as Pred, PredicateRef, Scalar,
 };
+use delta_kernel::metrics::MetricEvent;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
 use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
@@ -28,12 +29,13 @@ use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{Snapshot, SnapshotRef};
 use rstest::rstest;
-use serde_json::json;
+use serde::Serialize;
+use serde_json::{json, Value};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    add_commit, create_table_and_load_snapshot, read_add_infos, test_table_setup_mt,
-    write_batch_to_table,
+    add_commit, create_table_and_load_snapshot, install_thread_local_metrics_reporter,
+    test_table_setup_mt, write_batch_to_table, CapturingReporter,
 };
 use url::Url;
 
@@ -142,6 +144,7 @@ fn selected_paths(
                     paths = sm?.visit_scan_files(paths, push_path)?;
                 }
             }
+            state.log_metrics();
         }
     } else {
         for sm in scan.scan_metadata(engine.as_ref())? {
@@ -588,11 +591,36 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     Ok(())
 }
 
-/// Replace table may change a partition column's type. A scan after replacement should remain
-/// compatible with the old addFiles.
+/// Replace table may change partition and data column types. A scan after replacement should
+/// remain compatible with the old addFiles.
 #[rstest]
+#[case::partition(
+    Arc::new(Pred::eq(column_expr!("part"), Expr::literal(1i64))),
+    &["new-1.parquet"],
+    1,
+    101
+)]
+#[case::stats(
+    Arc::new(Pred::eq(column_expr!("value"), Expr::literal(20i64))),
+    &["new-2.parquet"],
+    1,
+    102
+)]
+#[case::partition_and_stats(
+    Arc::new(Pred::and(
+        Pred::eq(column_expr!("part"), Expr::literal(3i64)),
+        Pred::eq(column_expr!("value"), Expr::literal(30i64)),
+    )),
+    &["new-3.parquet"],
+    1,
+    103
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn scan_compatible_with_replace_partition_change(
+    #[case] predicate: PredicateRef,
+    #[case] expected_paths: &[&str],
+    #[case] expected_active_files: u64,
+    #[case] expected_active_bytes: u64,
     #[values(false, true)] use_parallel: bool,
     #[values(false, true)] checkpoint_old_add: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -601,9 +629,9 @@ async fn scan_compatible_with_replace_partition_change(
     // Commit 1 creates the table with a string partition column.
     let old_schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("part", DataType::STRING),
-        StructField::nullable("value", DataType::LONG),
+        StructField::nullable("value", DataType::STRING),
     ])?);
-    let snapshot = create_table(&table_path, old_schema, "Test/1.0")
+    create_table(&table_path, old_schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["part"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
@@ -613,36 +641,49 @@ async fn scan_compatible_with_replace_partition_change(
     let table_url = Url::from_directory_path(&table_path)
         .map_err(|_| "table_path should be a valid file URL")?;
 
-    // Commit 2 writes an addFile with `old_schema`.
-    let physical_data_schema: ArrowSchema =
-        (&StructType::try_new([StructField::nullable("value", DataType::LONG)])?)
-            .try_into_arrow()?;
-    let physical_data_schema = Arc::new(physical_data_schema);
-    let data = RecordBatch::try_new(
-        physical_data_schema.clone(),
-        vec![Arc::new(Int64Array::from(vec![1i64]))],
-    )?;
-    let snapshot = write_batch_to_table(
-        &snapshot,
-        engine.as_ref(),
-        data,
-        HashMap::from([(
-            "part".to_string(),
-            Scalar::String("not-an-integer".to_string()),
-        )]),
+    // Commit 2 writes addFiles using `old_schema`.
+    let old_paths = ["old-1.parquet", "old-2.parquet", "old-3.parquet"];
+    let old_adds = [
+        json!({
+            "commitInfo": {
+                "timestamp": 1700000000000i64,
+                "operation": "WRITE",
+                "version": 1,
+            }
+        }),
+        add_file_action(
+            old_paths[0],
+            201,                           /* size */
+            "not-an-integer-partition-1",  /* partition_value */
+            "not-an-integer-data-value-1", /* data_value */
+        )?,
+        add_file_action(
+            old_paths[1],
+            202,                           /* size */
+            "not-an-integer-partition-2",  /* partition_value */
+            "not-an-integer-data-value-2", /* data_value */
+        )?,
+        add_file_action(
+            old_paths[2],
+            203,                           /* size */
+            "not-an-integer-partition-3",  /* partition_value */
+            "not-an-integer-data-value-3", /* data_value */
+        )?,
+    ];
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        1,
+        old_adds.map(|action| action.to_string()).join("\n"),
     )
     .await?;
-    let old_path = read_add_infos(&snapshot, engine.as_ref())?
-        .into_iter()
-        .next()
-        .ok_or("commit 2 should contain an addFile")?
-        .path;
 
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     if checkpoint_old_add {
         snapshot.checkpoint(engine.as_ref(), None)?;
     }
 
-    // Commit 3 replaces the table metadata and removes the old addFile without adding data.
+    // Commit 3 replaces the table metadata and removes the addFiles.
     let replacement_schema = StructType::try_new(vec![
         StructField::nullable("part", DataType::LONG),
         StructField::nullable("value", DataType::LONG),
@@ -665,14 +706,9 @@ async fn scan_compatible_with_replace_partition_change(
                 "createdTime": 1700000001000i64,
             }
         }),
-        json!({
-            "remove": {
-                "path": old_path.clone(),
-                "deletionTimestamp": 1700000001000i64,
-                "dataChange": true,
-                "extendedFileMetadata": false,
-            }
-        }),
+        remove_file_action(old_paths[0])?,
+        remove_file_action(old_paths[1])?,
+        remove_file_action(old_paths[2])?,
     ];
     add_commit(
         table_url.as_str(),
@@ -682,30 +718,65 @@ async fn scan_compatible_with_replace_partition_change(
     )
     .await?;
 
-    // Commit 4 writes an addFile using the replacement LONG partition type.
-    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let data = RecordBatch::try_new(
-        physical_data_schema,
-        vec![Arc::new(Int64Array::from(vec![2i64]))],
-    )?;
-    let snapshot = write_batch_to_table(
-        &snapshot,
-        engine.as_ref(),
-        data,
-        HashMap::from([("part".to_string(), Scalar::Long(1))]),
+    // Commit 4 writes addFiles with distinct partition values and statistics.
+    let new_adds = [
+        json!({
+            "commitInfo": {
+                "timestamp": 1700000002000i64,
+                "operation": "WRITE",
+                "version": 3,
+            }
+        }),
+        add_file_action(
+            "new-1.parquet",
+            101, /* size */
+            "1", /* partition_value */
+            10,  /* data_value */
+        )?,
+        add_file_action(
+            "new-2.parquet",
+            102, /* size */
+            "2", /* partition_value */
+            20,  /* data_value */
+        )?,
+        add_file_action(
+            "new-3.parquet",
+            103, /* size */
+            "3", /* partition_value */
+            30,  /* data_value */
+        )?,
+    ];
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        3,
+        new_adds.map(|action| action.to_string()).join("\n"),
     )
     .await?;
-    let new_path = read_add_infos(&snapshot, engine.as_ref())?
-        .into_iter()
-        .find(|add| add.path != old_path)
-        .ok_or("commit 4 should contain an addFile")?
-        .path;
 
-    let predicate = Arc::new(Pred::eq(column_expr!("part"), Expr::literal(1i64)));
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
     assert_eq!(
         surviving_paths(&table_path, engine, predicate, use_parallel)?,
-        vec![new_path]
+        expected_paths
+            .iter()
+            .map(|path| (*path).to_string())
+            .collect::<Vec<_>>()
     );
+    let (active_files, active_bytes) = reporter
+        .events()
+        .into_iter()
+        .filter_map(|event| match event {
+            MetricEvent::ScanMetadataCompleted(event) => {
+                Some((event.num_active_add_files, event.active_add_files_bytes))
+            }
+            _ => None,
+        })
+        .fold((0, 0), |(files, bytes), (event_files, event_bytes)| {
+            (files + event_files, bytes + event_bytes)
+        });
+    assert_eq!(active_files, expected_active_files);
+    assert_eq!(active_bytes, expected_active_bytes);
     Ok(())
 }
 
@@ -942,4 +1013,85 @@ async fn all_null_files_pruned_regardless_of_source(
         "unexpected survivors for source {source:?} (use_parallel={use_parallel})"
     );
     Ok(())
+}
+
+#[derive(Serialize)]
+struct AddActionFixture {
+    add: AddFileFixture,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AddFileFixture {
+    path: String,
+    size: i64,
+    modification_time: i64,
+    data_change: bool,
+    partition_values: HashMap<String, String>,
+    stats: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatsFixture<T> {
+    num_records: i64,
+    min_values: ValueFixture<T>,
+    max_values: ValueFixture<T>,
+    null_count: ValueFixture<i64>,
+}
+
+#[derive(Clone, Serialize)]
+struct ValueFixture<T> {
+    value: T,
+}
+
+fn add_file_action<T: Clone + Serialize>(
+    path: &str,
+    size: i64,
+    partition_value: &str,
+    data_value: T,
+) -> serde_json::Result<Value> {
+    let stats = serde_json::to_string(&StatsFixture {
+        num_records: 1,
+        min_values: ValueFixture {
+            value: data_value.clone(),
+        },
+        max_values: ValueFixture { value: data_value },
+        null_count: ValueFixture { value: 0 },
+    })?;
+    serde_json::to_value(AddActionFixture {
+        add: AddFileFixture {
+            path: path.to_string(),
+            size,
+            modification_time: 1700000000000,
+            data_change: true,
+            partition_values: HashMap::from([("part".to_string(), partition_value.to_string())]),
+            stats,
+        },
+    })
+}
+
+#[derive(Serialize)]
+struct RemoveActionFixture {
+    remove: RemoveFileFixture,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoveFileFixture {
+    path: String,
+    deletion_timestamp: i64,
+    data_change: bool,
+    extended_file_metadata: bool,
+}
+
+fn remove_file_action(path: &str) -> serde_json::Result<Value> {
+    serde_json::to_value(RemoveActionFixture {
+        remove: RemoveFileFixture {
+            path: path.to_string(),
+            deletion_timestamp: 1700000001000,
+            data_change: true,
+            extended_file_metadata: false,
+        },
+    })
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Kernel does data skipping before add-remove dedup in scan_metadata. When `REPLACE TABLE` happens, partition column types may change and the data skipping may fail. This PR adds a fallback to dedup before data skipping, when data skipping meets an `ParseError`
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Positive + negative tests over different predicates