### PR TITLE
[WIP] fix: force partition schema fields nullable

### DIFF
--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -391,7 +391,7 @@ impl TableConfiguration {
                 StructField::new(
                     field.physical_name(column_mapping_mode).to_owned(),
                     field.data_type().clone(),
-                    field.is_nullable(),
+                    true,
                 )
             })
             .collect();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Spark writes every checkpoint with a fully-nullable schema by calling
`StructType.asNullable`


## How was this change tested?

Generated two checkpoints (with and without the fix) using the following harness:
```
#[tokio::test(flavor = "multi_thread")]
async fn dump_checkpoint_nonnullable_partition() -> Result<(), Box<dyn std::error::Error>> {
    let out = std::env::var("CKPT_OUT").expect("set CKPT_OUT");
    let schema = Arc::new(StructType::try_new(vec![
        StructField::nullable("value", DataType::INTEGER),
        StructField::not_null("p", DataType::STRING),
    ])?);

    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
    let snapshot = create_partitioned_table(
        &table_path,
        engine.as_ref(),
        schema,
        &["p"],
        ColumnMappingMode::None,
        true, // write_partition_values_parsed
    )?;

    let data_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
        "value",
        DataType::INTEGER,
    )])?);
    let arrow_data_schema: Arc<ArrowSchema> = Arc::new(data_schema.as_ref().try_into_arrow()?);
    let batch = RecordBatch::try_new(
        arrow_data_schema,
        vec![Arc::new(Int32Array::from(vec![1]))],
    )?;
    let partition_values = HashMap::from([("p".to_string(), Scalar::from("a"))]);
    let snapshot = write_batch_to_table(
        &snapshot,
        engine.as_ref(),
        batch,
        partition_values,
    )
    .await?;

    snapshot.checkpoint(engine.as_ref(), None)?;

    // Copy the checkpoint parquet out to a stable path for external inspection.
    let log_dir = format!("{table_path}/_delta_log");
    let ckpt = std::fs::read_dir(&log_dir)?
        .filter_map(|e| e.ok())
        .map(|e| e.path())
        .find(|p| {
            p.file_name()
                .and_then(|n| n.to_str())
                .is_some_and(|n| n.ends_with(".checkpoint.parquet"))
        })
        .expect("checkpoint parquet should exist");
    std::fs::copy(&ckpt, &out)?;
    eprintln!("wrote checkpoint {ckpt:?} -> {out}");
    Ok(())
}
```

Verified the schema with duckdb:
```
duckdb -c "SELECT name, type, repetition_type
FROM parquet_schema('without_fix.checkpoint.parquet')
WHERE name IN ('partitionValues_parsed','p');"
┌────────────────────────┬────────────┬─────────────────┐
│          name          │    type    │ repetition_type │
│        varchar         │  varchar   │     varchar     │
├────────────────────────┼────────────┼─────────────────┤
│ partitionValues_parsed │ NULL       │ OPTIONAL        │
│ p                      │ BYTE_ARRAY │ REQUIRED        │
└────────────────────────┴────────────┴─────────────────┘
duckdb -c "SELECT name, type, repetition_type
FROM parquet_schema('with_fix.checkpoint.parquet') 
WHERE name IN ('partitionValues_parsed','p');"
┌────────────────────────┬────────────┬─────────────────┐
│          name          │    type    │ repetition_type │
│        varchar         │  varchar   │     varchar     │
├────────────────────────┼────────────┼─────────────────┤
│ partitionValues_parsed │ NULL       │ OPTIONAL        │
│ p                      │ BYTE_ARRAY │ OPTIONAL        │
└────────────────────────┴────────────┴─────────────────┘
```
