### PR TITLE
perf: skip checkpoint remove tombstones in scan checkpoint read

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -62,6 +62,23 @@ pub(crate) const DOMAIN_METADATA_NAME: &str = "domainMetadata";
 
 pub(crate) const INTERNAL_DOMAIN_PREFIX: &str = "delta.";
 
+/// Returns the required leaf used to identify rows containing `action_name`.
+///
+/// Returns `None` for unknown actions and actions without a required leaf. The table covers every
+/// checkpoint-projectable action, not just those a caller projects today, so callers passing any
+/// subset of the checkpoint action schema derive a correct presence predicate.
+pub(crate) fn action_presence_leaf(action_name: &str) -> Option<&'static str> {
+    match action_name {
+        ADD_NAME | REMOVE_NAME | CDC_NAME | SIDECAR_NAME => Some("path"),
+        METADATA_NAME => Some("id"),
+        PROTOCOL_NAME => Some("minReaderVersion"),
+        SET_TRANSACTION_NAME => Some("appId"),
+        DOMAIN_METADATA_NAME => Some("domain"),
+        CHECKPOINT_METADATA_NAME => Some("version"),
+        _ => None,
+    }
+}
+
 // === Sub-fields of an AddFile's `stats` struct ===
 // See the Delta protocol spec, "Per-file Statistics", and `expected_stats_schema` in
 // `scan/data_skipping/stats_schema/mod.rs` for the full semantics.
@@ -1088,6 +1105,22 @@ mod tests {
     use crate::{
         Engine, EvaluationHandler, IntoEngineData, JsonHandler, ParquetHandler, StorageHandler,
     };
+
+    #[rstest]
+    #[case::add(ADD_NAME, Some("path"))]
+    #[case::remove(REMOVE_NAME, Some("path"))]
+    #[case::metadata(METADATA_NAME, Some("id"))]
+    #[case::protocol(PROTOCOL_NAME, Some("minReaderVersion"))]
+    #[case::transaction(SET_TRANSACTION_NAME, Some("appId"))]
+    #[case::cdc(CDC_NAME, Some("path"))]
+    #[case::domain_metadata(DOMAIN_METADATA_NAME, Some("domain"))]
+    #[case::checkpoint_metadata(CHECKPOINT_METADATA_NAME, Some("version"))]
+    #[case::sidecar(SIDECAR_NAME, Some("path"))]
+    #[case::witnessless_action(COMMIT_INFO_NAME, None)]
+    #[case::unknown_action("futureAction", None)]
+    fn test_action_presence_leaf(#[case] action_name: &str, #[case] expected_leaf: Option<&str>) {
+        assert_eq!(action_presence_leaf(action_name), expected_leaf);
+    }
 
     // duplicated
     struct ExprEngine(Arc<dyn EvaluationHandler>);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -858,6 +858,8 @@ pub trait ParquetHandler: AsAny {
     /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list and order of columns to read from the Parquet file.
     /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
+    ///   Implementations may apply it at any granularity, including only skipping row groups, so
+    ///   callers must tolerate rows that do not satisfy the predicate.
     ///
     /// # Returns
     /// A [`DeltaResult`] containing a [`FileDataReadResultIterator`].

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -677,7 +677,9 @@ pub trait JsonHandler: AsAny {
     ///
     /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list of columns to read from the JSON file.
-    /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
+    /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it or
+    ///   omit only rows they can determine do not satisfy it. Returned data may include rows that
+    ///   do not satisfy the predicate.
     fn read_json_files(
         &self,
         files: &[FileMeta],
@@ -857,14 +859,15 @@ pub trait ParquetHandler: AsAny {
     ///
     /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list and order of columns to read from the Parquet file.
-    /// - `predicate` - Optional push-down predicate hint (engine is free to ignore it).
-    ///   Implementations may apply it at any granularity, including only skipping row groups, so
-    ///   callers must tolerate rows that do not satisfy the predicate.
+    /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it or
+    ///   apply it at any granularity, but may omit only rows they can determine do not satisfy it.
+    ///   Returned data may include rows that do not satisfy the predicate.
     ///
     /// # Returns
     /// A [`DeltaResult`] containing a [`FileDataReadResultIterator`].
     /// Each element of the iterator is a [`DeltaResult`] of [`EngineData`]. The [`EngineData`]
-    /// has the contents of `files` and must match the provided `physical_schema`.
+    /// contains rows from `files` after any predicate push-down and must match the provided
+    /// `physical_schema`.
     ///
     /// Note: The [`FileDataReadResultIterator`] must emit data from files in the order that `files`
     /// is given. For example if files ["a", "b"] is provided, then the engine data iterator must

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -129,10 +129,9 @@ pub(crate) struct LogSegment {
 ///
 /// For `add`, an `add.path IS NOT NULL` predicate drops a checkpoint's Remove tombstones, which
 /// project to a null `add` under an add-only read schema. This is safe because scan log replay
-/// already discards checkpoint removes without deduplicating on them (`skip_removes =
-/// !is_log_batch`), so skipping all-remove row groups changes no survivor. A schema that also
-/// names `remove` (checkpoint write, log compaction) has no identifying column for it and
-/// short-circuits to `None` below, preserving tombstones.
+/// discards checkpoint removes without deduplicating on them, so skipping all-remove row groups
+/// changes no survivor. A schema that also names `remove` (checkpoint write, log compaction) has
+/// no identifying column for it and short-circuits to `None` below, preserving tombstones.
 fn action_identifying_column(action_name: &str) -> Option<ColumnName> {
     match action_name {
         ADD_NAME => Some(column_name!(ADD_NAME, "path")),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -128,14 +128,11 @@ pub(crate) struct LogSegment {
 /// worthwhile since all app ids share one part with a large min/max range (typically UUIDs).
 ///
 /// For `add`, an `add.path IS NOT NULL` predicate drops a checkpoint's Remove tombstones, which
-/// project to a null `add` under an add-only read schema. Scan log replay already discards
-/// checkpoint removes without deduplicating on them (`skip_removes = !is_log_batch`), so filtering
-/// them out at the parquet layer changes no survivor and lets the reader skip all-remove row
-/// groups. This makes the predicate safe only for a reader that ignores checkpoint removes: it is
-/// emitted for an add-only checkpoint read schema, while a multi-action schema that also names
-/// `remove` (checkpoint write, log compaction) has no identifying column for `remove` and
-/// short-circuits to `None` below, preserving tombstones. Commit reads use a separate schema, so
-/// removes in commits are unaffected.
+/// project to a null `add` under an add-only read schema. This is safe because scan log replay
+/// already discards checkpoint removes without deduplicating on them (`skip_removes =
+/// !is_log_batch`), so skipping all-remove row groups changes no survivor. A schema that also
+/// names `remove` (checkpoint write, log compaction) has no identifying column for it and
+/// short-circuits to `None` below, preserving tombstones.
 fn action_identifying_column(action_name: &str) -> Option<ColumnName> {
     match action_name {
         ADD_NAME => Some(column_name!(ADD_NAME, "path")),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,12 +10,11 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    schema_contains_file_actions, Sidecar, ADD_NAME, CDC_NAME, CHECKPOINT_METADATA_NAME,
-    DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, PROTOCOL_NAME,
-    REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    action_presence_leaf, schema_contains_file_actions, Sidecar, LOG_ADD_SCHEMA, MAX_VALUES,
+    MIN_VALUES, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
-use crate::expressions::{column_name, ColumnName};
+use crate::expressions::ColumnName;
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
@@ -121,30 +120,16 @@ pub(crate) struct LogSegment {
     pub(crate) last_checkpoint_metadata: Option<LastCheckpointHint>,
 }
 
-/// Returns a required leaf whose non-nullness identifies a row containing `action_name`.
-///
-/// Actions without a required leaf cannot provide a reliable presence witness. For example, every
-/// `commitInfo` leaf is optional, so a valid action could have no non-null leaf.
+/// Returns the column whose non-nullness identifies a row containing `action_name`.
 fn action_presence_witness(action_name: &str) -> Option<ColumnName> {
-    match action_name {
-        ADD_NAME => Some(column_name!(ADD_NAME, "path")),
-        REMOVE_NAME => Some(column_name!(REMOVE_NAME, "path")),
-        METADATA_NAME => Some(column_name!(METADATA_NAME, "id")),
-        PROTOCOL_NAME => Some(column_name!(PROTOCOL_NAME, "minReaderVersion")),
-        SET_TRANSACTION_NAME => Some(column_name!(SET_TRANSACTION_NAME, "appId")),
-        CDC_NAME => Some(column_name!(CDC_NAME, "path")),
-        DOMAIN_METADATA_NAME => Some(column_name!(DOMAIN_METADATA_NAME, "domain")),
-        CHECKPOINT_METADATA_NAME => Some(column_name!(CHECKPOINT_METADATA_NAME, "version")),
-        SIDECAR_NAME => Some(column_name!(SIDECAR_NAME, "path")),
-        _ => None,
-    }
+    action_presence_leaf(action_name).map(|leaf| ColumnName::new([action_name, leaf]))
 }
 
 /// Builds a checkpoint row-group predicate that retains every action requested by `schema`.
 ///
 /// Each requested action contributes an `IS NOT NULL` presence witness, and the witnesses are
-/// joined with `OR`. Returns `None` if any field lacks a reliable witness because such an action
-/// could occupy a row group that the resulting predicate would otherwise skip.
+/// joined with `OR`. Returns `None` if the schema is empty, or if any field lacks a reliable
+/// witness (an action that could occupy a row group the resulting predicate would otherwise skip).
 fn checkpoint_action_projection_predicate(schema: &StructType) -> Option<PredicateRef> {
     let columns: Vec<ColumnName> = schema
         .fields()
@@ -702,6 +687,8 @@ impl LogSegment {
     /// files. It is _NOT_ the query's data predicate, but a hint for skipping irrelevant data.
     /// IS NOT NULL predicates are automatically derived from `checkpoint_read_schema` and combined
     /// (AND) with `meta_predicate`, so callers only need to supply query-based skipping predicates.
+    /// The combined predicate is only a skipping hint: the reader may return rows that do not
+    /// satisfy it, so downstream log replay must tolerate them.
     #[internal_api]
     pub(crate) fn read_actions_with_projected_checkpoint_actions(
         &self,
@@ -717,9 +704,9 @@ impl LogSegment {
         // Combine schema-derived IS NOT NULL predicate with any caller-supplied predicate so
         // checkpoint parquet row groups without any relevant action type can be skipped.
         // TODO: The semantics of `meta_predicate` will change in a follow-up PR.
-        let is_not_null_pred = checkpoint_action_projection_predicate(&checkpoint_read_schema);
-        let effective_predicate = match (is_not_null_pred, meta_predicate) {
-            (None, x) | (x, None) => x,
+        let projection_predicate = checkpoint_action_projection_predicate(&checkpoint_read_schema);
+        let checkpoint_predicate = match (projection_predicate, meta_predicate) {
+            (None, predicate) | (predicate, None) => predicate,
             (Some(a), Some(b)) => Some(Arc::new(Predicate::and((*a).clone(), (*b).clone()))),
         };
 
@@ -730,7 +717,7 @@ impl LogSegment {
         let checkpoint_result = self.create_checkpoint_stream(
             engine,
             checkpoint_read_schema,
-            effective_predicate,
+            checkpoint_predicate,
             stats_schema,
             partition_schema,
         )?;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,8 +10,9 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    schema_contains_file_actions, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA,
-    MAX_VALUES, METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    schema_contains_file_actions, Sidecar, ADD_NAME, CDC_NAME, CHECKPOINT_METADATA_NAME,
+    DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, PROTOCOL_NAME,
+    REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
 use crate::expressions::{column_name, ColumnName};
@@ -120,37 +121,34 @@ pub(crate) struct LogSegment {
     pub(crate) last_checkpoint_metadata: Option<LastCheckpointHint>,
 }
 
-/// Returns the identifying leaf column path for a known action type, used to build IS NOT NULL
-/// predicates that enable row group skipping in checkpoint parquet files.
+/// Returns a required leaf whose non-nullness identifies a row containing `action_name`.
 ///
-/// For `txn`, this is effective because all app ids end up in a single checkpoint part when
-/// partitioned by `add.path` as the Delta spec requires. Filtering by a specific app id is not
-/// worthwhile since all app ids share one part with a large min/max range (typically UUIDs).
-///
-/// For `add`, an `add.path IS NOT NULL` predicate drops a checkpoint's Remove tombstones, which
-/// project to a null `add` under an add-only read schema. This is safe because scan log replay
-/// discards checkpoint removes without deduplicating on them, so skipping all-remove row groups
-/// changes no survivor. A schema that also names `remove` (checkpoint write, log compaction) has
-/// no identifying column for it and short-circuits to `None` below, preserving tombstones.
-fn action_identifying_column(action_name: &str) -> Option<ColumnName> {
+/// Actions without a required leaf cannot provide a reliable presence witness. For example, every
+/// `commitInfo` leaf is optional, so a valid action could have no non-null leaf.
+fn action_presence_witness(action_name: &str) -> Option<ColumnName> {
     match action_name {
         ADD_NAME => Some(column_name!(ADD_NAME, "path")),
+        REMOVE_NAME => Some(column_name!(REMOVE_NAME, "path")),
         METADATA_NAME => Some(column_name!(METADATA_NAME, "id")),
         PROTOCOL_NAME => Some(column_name!(PROTOCOL_NAME, "minReaderVersion")),
         SET_TRANSACTION_NAME => Some(column_name!(SET_TRANSACTION_NAME, "appId")),
+        CDC_NAME => Some(column_name!(CDC_NAME, "path")),
         DOMAIN_METADATA_NAME => Some(column_name!(DOMAIN_METADATA_NAME, "domain")),
+        CHECKPOINT_METADATA_NAME => Some(column_name!(CHECKPOINT_METADATA_NAME, "version")),
+        SIDECAR_NAME => Some(column_name!(SIDECAR_NAME, "path")),
         _ => None,
     }
 }
 
-/// Builds an IS NOT NULL predicate for row group skipping based on the action types in `schema`.
-/// Returns `None` if any top-level field in the schema is not a recognized action type, since
-/// an unknown type could have non-null rows in the same row group, making skipping unsafe.
-fn schema_to_is_not_null_predicate(schema: &StructType) -> Option<PredicateRef> {
-    // Collect identifying columns for every field; short-circuit to None on any unknown field.
+/// Builds a checkpoint row-group predicate that retains every action requested by `schema`.
+///
+/// Each requested action contributes an `IS NOT NULL` presence witness, and the witnesses are
+/// joined with `OR`. Returns `None` if any field lacks a reliable witness because such an action
+/// could occupy a row group that the resulting predicate would otherwise skip.
+fn checkpoint_action_projection_predicate(schema: &StructType) -> Option<PredicateRef> {
     let columns: Vec<ColumnName> = schema
         .fields()
-        .map(|f| action_identifying_column(f.name()))
+        .map(|field| action_presence_witness(field.name()))
         .collect::<Option<_>>()?;
     let mut predicates = columns
         .into_iter()
@@ -719,7 +717,7 @@ impl LogSegment {
         // Combine schema-derived IS NOT NULL predicate with any caller-supplied predicate so
         // checkpoint parquet row groups without any relevant action type can be skipped.
         // TODO: The semantics of `meta_predicate` will change in a follow-up PR.
-        let is_not_null_pred = schema_to_is_not_null_predicate(&checkpoint_read_schema);
+        let is_not_null_pred = checkpoint_action_projection_predicate(&checkpoint_read_schema);
         let effective_predicate = match (is_not_null_pred, meta_predicate) {
             (None, x) | (x, None) => x,
             (Some(a), Some(b)) => Some(Arc::new(Predicate::and((*a).clone(), (*b).clone()))),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,8 +10,8 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    schema_contains_file_actions, Sidecar, DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA, MAX_VALUES,
-    METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    schema_contains_file_actions, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME, LOG_ADD_SCHEMA,
+    MAX_VALUES, METADATA_NAME, MIN_VALUES, PROTOCOL_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::committer::CatalogCommit;
 use crate::expressions::{column_name, ColumnName};
@@ -126,8 +126,19 @@ pub(crate) struct LogSegment {
 /// For `txn`, this is effective because all app ids end up in a single checkpoint part when
 /// partitioned by `add.path` as the Delta spec requires. Filtering by a specific app id is not
 /// worthwhile since all app ids share one part with a large min/max range (typically UUIDs).
+///
+/// For `add`, an `add.path IS NOT NULL` predicate drops a checkpoint's Remove tombstones, which
+/// project to a null `add` under an add-only read schema. Scan log replay already discards
+/// checkpoint removes without deduplicating on them (`skip_removes = !is_log_batch`), so filtering
+/// them out at the parquet layer changes no survivor and lets the reader skip all-remove row
+/// groups. This makes the predicate safe only for a reader that ignores checkpoint removes: it is
+/// emitted for an add-only checkpoint read schema, while a multi-action schema that also names
+/// `remove` (checkpoint write, log compaction) has no identifying column for `remove` and
+/// short-circuits to `None` below, preserving tombstones. Commit reads use a separate schema, so
+/// removes in commits are unaffected.
 fn action_identifying_column(action_name: &str) -> Option<ColumnName> {
     match action_name {
+        ADD_NAME => Some(column_name!(ADD_NAME, "path")),
         METADATA_NAME => Some(column_name!(METADATA_NAME, "id")),
         PROTOCOL_NAME => Some(column_name!(PROTOCOL_NAME, "minReaderVersion")),
         SET_TRANSACTION_NAME => Some(column_name!(SET_TRANSACTION_NAME, "appId")),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -29,7 +29,7 @@ use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::ArrowWriter;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::scan::test_utils::{
-    add_batch_simple, add_batch_with_remove, sidecar_batch_with_given_paths,
+    add_batch_simple, add_batch_with_remove, remove_only_batch, sidecar_batch_with_given_paths,
     sidecar_batch_with_given_paths_and_sizes,
 };
 use crate::scan::{CHECKPOINT_READ_SCHEMA, COMMIT_READ_SCHEMA};
@@ -1362,6 +1362,144 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     assert!(!is_log_batch);
     assert_batch_matches(first_batch, add_batch_simple(v2_checkpoint_read_schema));
     assert!(iter.next().is_none());
+
+    Ok(())
+}
+
+/// A checkpoint part whose only row is a Remove action projects to a null `add` under the add-only
+/// scan checkpoint schema. `read_actions_with_projected_checkpoint_actions` derives an
+/// `add.path IS NOT NULL` predicate from that schema, which skips the part's row group so the scan
+/// never materializes the tombstone.
+///
+/// The contrast is what proves the predicate does the skipping: reading the same part with no
+/// predicate yields the null-`add` row, but reading through the derived predicate yields nothing.
+#[tokio::test]
+async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    // Real checkpoints store removes with the full file-action schema; the add column is null.
+    add_checkpoint_to_store(
+        &store,
+        remove_only_batch(get_commit_schema().clone()),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_file = log_root
+        .join("00000000000000000001.checkpoint.parquet")?
+        .to_string();
+    let checkpoint_size =
+        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )?;
+
+    // Baseline: with no predicate the part's single (null-`add`) row group is read.
+    let unfiltered = log_segment.create_checkpoint_stream(
+        &engine,
+        CHECKPOINT_READ_SCHEMA.clone(),
+        None, // meta_predicate
+        None, // stats_schema
+        None, // partition_schema
+    )?;
+    let unfiltered_rows: usize = unfiltered
+        .actions
+        .map_ok(|batch| batch.actions.len())
+        .fold_ok(0, std::ops::Add::add)?;
+    assert_eq!(
+        unfiltered_rows, 1,
+        "without a predicate the all-remove part yields its null-add row"
+    );
+
+    // The scan's add-only checkpoint read derives `add.path IS NOT NULL`, skipping the row group.
+    // There are no commit files, so the resulting stream is empty.
+    let mut filtered = log_segment
+        .read_actions_with_projected_checkpoint_actions(
+            &engine,
+            COMMIT_READ_SCHEMA.clone(),
+            CHECKPOINT_READ_SCHEMA.clone(),
+            None, // meta_predicate
+            None, // stats_schema
+            None, // partition_schema
+        )?
+        .actions;
+    assert!(
+        filtered.next().is_none(),
+        "all-remove checkpoint part must be skipped by the add.path IS NOT NULL predicate"
+    );
+
+    Ok(())
+}
+
+/// A checkpoint row group that mixes Adds and a Remove has non-null `add.path` values, so the
+/// derived `add.path IS NOT NULL` predicate must NOT skip it. This guards against an
+/// over-aggressive predicate silently dropping live Adds (or resurrecting a removed file by
+/// dropping the group that also proves the file gone).
+#[tokio::test]
+async fn test_scan_checkpoint_read_keeps_mixed_add_remove_part() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    // One row group holding [remove c001, add c001, add c000, metaData].
+    add_checkpoint_to_store(
+        &store,
+        add_batch_with_remove(get_commit_schema().clone()),
+        "00000000000000000001.checkpoint.parquet",
+    )
+    .await?;
+
+    let checkpoint_file = log_root
+        .join("00000000000000000001.checkpoint.parquet")?
+        .to_string();
+    let checkpoint_size =
+        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )?;
+
+    let iter = log_segment
+        .read_actions_with_projected_checkpoint_actions(
+            &engine,
+            COMMIT_READ_SCHEMA.clone(),
+            CHECKPOINT_READ_SCHEMA.clone(),
+            None, // meta_predicate
+            None, // stats_schema
+            None, // partition_schema
+        )?
+        .actions;
+
+    let mut add_paths: Vec<String> = Vec::new();
+    for batch in iter {
+        let mut visitor = AddVisitor::default();
+        visitor.visit_rows_of(&*batch?.actions)?;
+        add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
+    }
+    add_paths.sort();
+    assert_eq!(
+        add_paths,
+        vec![
+            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet".to_string(),
+            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet".to_string(),
+        ],
+        "the mixed row group must be kept, surfacing both Adds"
+    );
 
     Ok(())
 }
@@ -4267,8 +4405,14 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         Expression::column(ColumnName::new([DOMAIN_METADATA_NAME, "domain"])).is_not_null(),
     )),
 )]
+#[case::add_field(
+    schema! { nullable (ADD_NAME): {} },
+    Some(Arc::new(
+        Expression::column(ColumnName::new([ADD_NAME, "path"])).is_not_null(),
+    )),
+)]
 #[case::unknown_field_returns_none(
-    StructType::new_unchecked([StructField::nullable(ADD_NAME, StructType::new_unchecked([]))]),
+    StructType::new_unchecked([StructField::nullable(REMOVE_NAME, StructType::new_unchecked([]))]),
     None,
 )]
 #[case::multiple_known_fields(
@@ -4284,7 +4428,7 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
 #[case::known_and_unknown_field_returns_none(
     StructType::new_unchecked([
         StructField::nullable(METADATA_NAME, StructType::new_unchecked([])),
-        StructField::nullable(ADD_NAME, StructType::new_unchecked([])),
+        StructField::nullable(REMOVE_NAME, StructType::new_unchecked([])),
     ]),
     None,
 )]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1369,10 +1369,8 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
 /// A checkpoint part whose only row is a Remove action projects to a null `add` under the add-only
 /// scan checkpoint schema. `read_actions_with_projected_checkpoint_actions` derives an
 /// `add.path IS NOT NULL` predicate from that schema, which skips the part's row group so the scan
-/// never materializes the tombstone.
-///
-/// The contrast is what proves the predicate does the skipping: reading the same part with no
-/// predicate yields the null-`add` row, but reading through the derived predicate yields nothing.
+/// never materializes the tombstone. Reading the same part with no predicate (as a baseline) still
+/// yields the null-`add` row, confirming the predicate is what does the skipping.
 #[tokio::test]
 async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
@@ -1442,8 +1440,7 @@ async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
 
 /// A checkpoint row group that mixes Adds and a Remove has non-null `add.path` values, so the
 /// derived `add.path IS NOT NULL` predicate must NOT skip it. This guards against an
-/// over-aggressive predicate silently dropping live Adds (or resurrecting a removed file by
-/// dropping the group that also proves the file gone).
+/// over-aggressive predicate silently dropping live Adds.
 #[tokio::test]
 async fn test_scan_checkpoint_read_keeps_mixed_add_remove_part() -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -10,9 +10,10 @@ use url::Url;
 use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
-    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, DOMAIN_METADATA_NAME,
-    LOG_METADATA_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME,
-    REMOVE_NAME, SET_TRANSACTION_NAME, SIDECAR_NAME,
+    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, CDC_NAME,
+    CHECKPOINT_METADATA_NAME, COMMIT_INFO_NAME, DOMAIN_METADATA_NAME, LOG_METADATA_SCHEMA,
+    MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME, REMOVE_NAME,
+    SET_TRANSACTION_NAME, SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -1398,10 +1399,10 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
 }
 
 /// The scan's add-only checkpoint read schema derives an `add.path IS NOT NULL` meta-predicate
-/// (via `schema_to_is_not_null_predicate`), letting the parquet reader skip any checkpoint row
-/// group whose `add.path` column is entirely null -- a group holding only Remove tombstones (or
-/// other non-Add actions). A group with even one live Add has a non-null `add.path` and is kept in
-/// full, so no live Add is ever dropped.
+/// (via `checkpoint_action_projection_predicate`), letting the parquet reader skip any checkpoint
+/// row group whose `add.path` column is entirely null -- a group holding only Remove tombstones
+/// (or other non-Add actions). A group with even one live Add has a non-null `add.path` and is kept
+/// in full, so no live Add is ever dropped.
 ///
 /// Each case writes one checkpoint parquet file with one row group per supplied batch. A baseline
 /// read with no predicate materializes every row, confirming the rows physically exist -- so the
@@ -4514,32 +4515,56 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         Expression::column(ColumnName::new([ADD_NAME, "path"])).is_not_null(),
     )),
 )]
-#[case::unknown_field_returns_none(
+#[case::remove_field(
     StructType::new_unchecked([StructField::nullable(REMOVE_NAME, StructType::new_unchecked([]))]),
+    Some(Arc::new(
+        Expression::column(ColumnName::new([REMOVE_NAME, "path"])).is_not_null(),
+    )),
+)]
+#[case::cdc_field(
+    schema! { nullable (CDC_NAME): {} },
+    Some(Arc::new(
+        Expression::column(ColumnName::new([CDC_NAME, "path"])).is_not_null(),
+    )),
+)]
+#[case::checkpoint_metadata_field(
+    schema! { nullable (CHECKPOINT_METADATA_NAME): {} },
+    Some(Arc::new(
+        Expression::column(ColumnName::new([CHECKPOINT_METADATA_NAME, "version"])).is_not_null(),
+    )),
+)]
+#[case::sidecar_field(
+    schema! { nullable (SIDECAR_NAME): {} },
+    Some(Arc::new(
+        Expression::column(ColumnName::new([SIDECAR_NAME, "path"])).is_not_null(),
+    )),
+)]
+#[case::action_without_required_leaf_returns_none(
+    schema! { nullable (COMMIT_INFO_NAME): {} },
     None,
 )]
-#[case::multiple_known_fields(
+#[case::add_and_remove_fields(
     StructType::new_unchecked([
-        StructField::nullable(METADATA_NAME, StructType::new_unchecked([])),
-        StructField::nullable(PROTOCOL_NAME, StructType::new_unchecked([])),
+        StructField::nullable(ADD_NAME, StructType::new_unchecked([])),
+        StructField::nullable(REMOVE_NAME, StructType::new_unchecked([])),
     ]),
     Some(Arc::new(Predicate::or(
-        Expression::column(ColumnName::new([METADATA_NAME, "id"])).is_not_null(),
-        Expression::column(ColumnName::new([PROTOCOL_NAME, "minReaderVersion"])).is_not_null(),
+        Expression::column(ColumnName::new([ADD_NAME, "path"])).is_not_null(),
+        Expression::column(ColumnName::new([REMOVE_NAME, "path"])).is_not_null(),
     ))),
 )]
 #[case::known_and_unknown_field_returns_none(
     StructType::new_unchecked([
         StructField::nullable(METADATA_NAME, StructType::new_unchecked([])),
-        StructField::nullable(REMOVE_NAME, StructType::new_unchecked([])),
+        StructField::nullable(COMMIT_INFO_NAME, StructType::new_unchecked([])),
     ]),
     None,
 )]
-fn test_schema_to_is_not_null_predicate(
+fn test_checkpoint_action_projection_predicate(
     #[case] schema: StructType,
     #[case] expected: Option<PredicateRef>,
 ) {
-    assert_eq!(schema_to_is_not_null_predicate(&schema), expected);
+    assert_eq!(checkpoint_action_projection_predicate(&schema), expected);
 }
 
 /// Verify that `read_actions` correctly handles null values in map fields across all

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -29,8 +29,8 @@ use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::ArrowWriter;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::scan::test_utils::{
-    add_batch_simple, add_batch_with_remove, remove_only_batch, sidecar_batch_with_given_paths,
-    sidecar_batch_with_given_paths_and_sizes,
+    add_batch_simple, add_batch_with_remove, adds_only_batch, remove_only_batch,
+    sidecar_batch_with_given_paths, sidecar_batch_with_given_paths_and_sizes,
 };
 use crate::scan::{CHECKPOINT_READ_SCHEMA, COMMIT_READ_SCHEMA};
 use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
@@ -161,6 +161,38 @@ pub(crate) async fn add_checkpoint_to_store(
 ) -> DeltaResult<()> {
     let path = format!("_delta_log/{filename}");
     write_parquet_to_store(store, path, data).await
+}
+
+/// Writes a _delta_log parquet checkpoint where each batch becomes its own row group. Flushing
+/// after every batch forces a row-group boundary, so a test can place e.g. an all-remove group
+/// next to an all-add group in a single file. All batches must share the same Arrow schema.
+async fn add_multi_row_group_checkpoint_to_store(
+    store: &Arc<InMemory>,
+    row_groups: Vec<Box<dyn EngineData>>,
+    filename: &str,
+) -> DeltaResult<()> {
+    let batches = row_groups
+        .into_iter()
+        .map(ArrowEngineData::try_from_engine_data)
+        .collect::<DeltaResult<Vec<_>>>()?;
+    let schema = batches
+        .first()
+        .expect("at least one row group")
+        .record_batch()
+        .schema();
+
+    let mut buffer = vec![];
+    let mut writer = ArrowWriter::try_new(&mut buffer, schema, None)?;
+    for batch in &batches {
+        writer.write(batch.record_batch())?;
+        writer.flush()?;
+    }
+    writer.close()?;
+
+    store
+        .put(&Path::from(format!("_delta_log/{filename}")), buffer.into())
+        .await?;
+    Ok(())
 }
 
 /// Writes all actions to a _delta_log/_sidecars file in the store and return the [`FileMeta`].
@@ -1366,29 +1398,54 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     Ok(())
 }
 
-/// A checkpoint part whose only row is a Remove action projects to a null `add` under the add-only
-/// scan checkpoint schema. `read_actions_with_projected_checkpoint_actions` derives an
-/// `add.path IS NOT NULL` predicate from that schema, which skips the part's row group so the scan
-/// never materializes the tombstone. Reading the same part with no predicate (as a baseline) still
-/// yields the null-`add` row, confirming the predicate is what does the skipping.
+/// The scan's add-only checkpoint read schema derives an `add.path IS NOT NULL` meta-predicate
+/// (via `schema_to_is_not_null_predicate`), letting the parquet reader skip any checkpoint row
+/// group whose `add.path` column is entirely null -- a group holding only Remove tombstones (or
+/// other non-Add actions). A group with even one live Add has a non-null `add.path` and is kept in
+/// full, so no live Add is ever dropped.
+///
+/// Each case writes one checkpoint parquet file with one row group per supplied batch. A baseline
+/// read with no predicate materializes every row, confirming the rows physically exist -- so the
+/// smaller filtered row count is attributable to row-group skipping, not a missing fixture. The
+/// multi-row-group case places an all-remove group next to an all-add group to guard against a
+/// per-row-group regression that would wrongly drop the adjacent live Adds.
+#[rstest]
+#[case::all_remove_part_skipped(vec![remove_only_batch(get_commit_schema().clone()) as _], 0, &[])]
+#[case::mixed_add_remove_part_kept(
+    vec![add_batch_with_remove(get_commit_schema().clone()) as _],
+    4,
+    &[
+        "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet",
+        "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet",
+    ],
+)]
+#[case::all_remove_group_skipped_adjacent_add_group_kept(
+    vec![
+        remove_only_batch(get_commit_schema().clone()) as _,
+        adds_only_batch(get_commit_schema().clone()) as _,
+    ],
+    2,
+    &[
+        "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet",
+        "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c002.snappy.parquet",
+    ],
+)]
 #[tokio::test]
-async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
+async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
+    #[case] row_groups: Vec<Box<dyn EngineData>>,
+    #[case] expected_filtered_rows: usize,
+    #[case] expected_survivor_adds: &[&str],
+) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let engine = SyncEngine::new_with_store(store.clone());
 
+    let checkpoint_name = "00000000000000000001.checkpoint.parquet";
     // Real checkpoints store removes with the full file-action schema; the add column is null.
-    add_checkpoint_to_store(
-        &store,
-        remove_only_batch(get_commit_schema().clone()),
-        "00000000000000000001.checkpoint.parquet",
-    )
-    .await?;
+    let total_rows: usize = row_groups.iter().map(|batch| batch.len()).sum();
+    add_multi_row_group_checkpoint_to_store(&store, row_groups, checkpoint_name).await?;
 
-    let checkpoint_file = log_root
-        .join("00000000000000000001.checkpoint.parquet")?
-        .to_string();
-    let checkpoint_size =
-        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
+    let checkpoint_file = log_root.join(checkpoint_name)?.to_string();
+    let checkpoint_size = get_file_size(&store, &format!("_delta_log/{checkpoint_name}")).await;
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {
@@ -1401,7 +1458,7 @@ async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
         None,
     )?;
 
-    // Baseline: with no predicate the part's single (null-`add`) row group is read.
+    // Baseline: with no predicate every row group is read, so all rows are materialized.
     let unfiltered = log_segment.create_checkpoint_stream(
         &engine,
         CHECKPOINT_READ_SCHEMA.clone(),
@@ -1414,64 +1471,14 @@ async fn test_scan_checkpoint_read_skips_all_remove_part() -> DeltaResult<()> {
         .map_ok(|batch| batch.actions.len())
         .fold_ok(0, std::ops::Add::add)?;
     assert_eq!(
-        unfiltered_rows, 1,
-        "without a predicate the all-remove part yields its null-add row"
+        unfiltered_rows, total_rows,
+        "without a predicate every checkpoint row is materialized"
     );
 
-    // The scan's add-only checkpoint read derives `add.path IS NOT NULL`, skipping the row group.
-    // There are no commit files, so the resulting stream is empty.
-    let mut filtered = log_segment
-        .read_actions_with_projected_checkpoint_actions(
-            &engine,
-            COMMIT_READ_SCHEMA.clone(),
-            CHECKPOINT_READ_SCHEMA.clone(),
-            None, // meta_predicate
-            None, // stats_schema
-            None, // partition_schema
-        )?
-        .actions;
-    assert!(
-        filtered.next().is_none(),
-        "all-remove checkpoint part must be skipped by the add.path IS NOT NULL predicate"
-    );
-
-    Ok(())
-}
-
-/// A checkpoint row group that mixes Adds and a Remove has non-null `add.path` values, so the
-/// derived `add.path IS NOT NULL` predicate must NOT skip it. This guards against an
-/// over-aggressive predicate silently dropping live Adds.
-#[tokio::test]
-async fn test_scan_checkpoint_read_keeps_mixed_add_remove_part() -> DeltaResult<()> {
-    let (store, log_root) = new_in_memory_store();
-    let engine = SyncEngine::new_with_store(store.clone());
-
-    // One row group holding [remove c001, add c001, add c000, metaData].
-    add_checkpoint_to_store(
-        &store,
-        add_batch_with_remove(get_commit_schema().clone()),
-        "00000000000000000001.checkpoint.parquet",
-    )
-    .await?;
-
-    let checkpoint_file = log_root
-        .join("00000000000000000001.checkpoint.parquet")?
-        .to_string();
-    let checkpoint_size =
-        get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
-
-    let log_segment = LogSegment::try_new(
-        LogSegmentFiles {
-            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
-            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
-            ..Default::default()
-        },
-        log_root,
-        None,
-        None,
-    )?;
-
-    let iter = log_segment
+    // The scan's add-only checkpoint read derives `add.path IS NOT NULL`. All-remove row groups are
+    // skipped while groups holding a live Add are kept. There are no commit files, so only
+    // surviving checkpoint rows appear.
+    let filtered = log_segment
         .read_actions_with_projected_checkpoint_actions(
             &engine,
             COMMIT_READ_SCHEMA.clone(),
@@ -1482,20 +1489,29 @@ async fn test_scan_checkpoint_read_keeps_mixed_add_remove_part() -> DeltaResult<
         )?
         .actions;
 
+    let mut filtered_rows = 0;
     let mut add_paths: Vec<String> = Vec::new();
-    for batch in iter {
+    for batch in filtered {
+        let batch = batch?.actions;
+        filtered_rows += batch.len();
         let mut visitor = AddVisitor::default();
-        visitor.visit_rows_of(&*batch?.actions)?;
+        visitor.visit_rows_of(&*batch)?;
         add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
     }
-    add_paths.sort();
     assert_eq!(
-        add_paths,
-        vec![
-            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet".to_string(),
-            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet".to_string(),
-        ],
-        "the mixed row group must be kept, surfacing both Adds"
+        filtered_rows, expected_filtered_rows,
+        "all-remove row groups must be skipped, so only kept groups' rows are materialized"
+    );
+
+    add_paths.sort();
+    let mut expected: Vec<String> = expected_survivor_adds
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    expected.sort();
+    assert_eq!(
+        add_paths, expected,
+        "kept row groups must surface every live Add and no others"
     );
 
     Ok(())

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -163,13 +163,14 @@ pub(crate) async fn add_checkpoint_to_store(
     write_parquet_to_store(store, path, data).await
 }
 
-/// Writes a _delta_log parquet checkpoint where each batch becomes its own row group. Flushing
-/// after every batch forces a row-group boundary, so a test can place e.g. an all-remove group
-/// next to an all-add group in a single file. All batches must share the same Arrow schema.
-async fn add_multi_row_group_checkpoint_to_store(
+/// Writes a parquet file where each batch becomes its own row group. Flushing after every batch
+/// forces a row-group boundary. All batches must share the same Arrow schema. `path` is relative
+/// to the store root (e.g. `_delta_log/..` for a checkpoint, `_delta_log/_sidecars/..` for a
+/// sidecar).
+async fn write_multi_row_group_parquet_to_store(
     store: &Arc<InMemory>,
     row_groups: Vec<Box<dyn EngineData>>,
-    filename: &str,
+    path: &str,
 ) -> DeltaResult<()> {
     let batches = row_groups
         .into_iter()
@@ -189,9 +190,7 @@ async fn add_multi_row_group_checkpoint_to_store(
     }
     writer.close()?;
 
-    store
-        .put(&Path::from(format!("_delta_log/{filename}")), buffer.into())
-        .await?;
+    store.put(&Path::from(path), buffer.into()).await?;
     Ok(())
 }
 
@@ -1406,7 +1405,7 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
 ///
 /// Each case writes one checkpoint parquet file with one row group per supplied batch. A baseline
 /// read with no predicate materializes every row, confirming the rows physically exist -- so the
-/// smaller filtered row count is attributable to row-group skipping, not a missing fixture. The
+/// smaller post-pruning row count is attributable to row-group skipping, not a missing fixture. The
 /// multi-row-group case places an all-remove group next to an all-add group to guard against a
 /// per-row-group regression that would wrongly drop the adjacent live Adds.
 #[rstest]
@@ -1433,7 +1432,7 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
 #[tokio::test]
 async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
     #[case] row_groups: Vec<Box<dyn EngineData>>,
-    #[case] expected_filtered_rows: usize,
+    #[case] expected_rows_after_pruning: usize,
     #[case] expected_survivor_adds: &[&str],
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
@@ -1442,7 +1441,12 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
     let checkpoint_name = "00000000000000000001.checkpoint.parquet";
     // Real checkpoints store removes with the full file-action schema; the add column is null.
     let total_rows: usize = row_groups.iter().map(|batch| batch.len()).sum();
-    add_multi_row_group_checkpoint_to_store(&store, row_groups, checkpoint_name).await?;
+    write_multi_row_group_parquet_to_store(
+        &store,
+        row_groups,
+        &format!("_delta_log/{checkpoint_name}"),
+    )
+    .await?;
 
     let checkpoint_file = log_root.join(checkpoint_name)?.to_string();
     let checkpoint_size = get_file_size(&store, &format!("_delta_log/{checkpoint_name}")).await;
@@ -1489,17 +1493,17 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
         )?
         .actions;
 
-    let mut filtered_rows = 0;
+    let mut rows_after_pruning = 0;
     let mut add_paths: Vec<String> = Vec::new();
     for batch in filtered {
         let batch = batch?.actions;
-        filtered_rows += batch.len();
+        rows_after_pruning += batch.len();
         let mut visitor = AddVisitor::default();
         visitor.visit_rows_of(&*batch)?;
         add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
     }
     assert_eq!(
-        filtered_rows, expected_filtered_rows,
+        rows_after_pruning, expected_rows_after_pruning,
         "all-remove row groups must be skipped, so only kept groups' rows are materialized"
     );
 
@@ -1512,6 +1516,92 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
     assert_eq!(
         add_paths, expected,
         "kept row groups must surface every live Add and no others"
+    );
+
+    Ok(())
+}
+
+/// The derived `add.path IS NOT NULL` predicate reaches a V2 checkpoint's sidecar reads, which
+/// share the add-only checkpoint schema. A sidecar row group holding only Remove tombstones has an
+/// all-null `add.path` and is skipped, while the adjacent all-add group is kept, so its live Adds
+/// still surface.
+#[tokio::test]
+async fn test_scan_checkpoint_read_skips_all_remove_sidecar_row_groups() -> DeltaResult<()> {
+    let (store, log_root) = new_in_memory_store();
+    let engine = SyncEngine::new_with_store(store.clone());
+
+    // Sidecar with an all-remove row group next to an all-add group (c000, c002).
+    let sidecar_name = "sidecarfile.parquet";
+    write_multi_row_group_parquet_to_store(
+        &store,
+        vec![
+            remove_only_batch(get_commit_schema().clone()) as _,
+            adds_only_batch(get_commit_schema().clone()) as _,
+        ],
+        &format!("_delta_log/_sidecars/{sidecar_name}"),
+    )
+    .await?;
+    let sidecar_size = get_file_size(&store, &format!("_delta_log/_sidecars/{sidecar_name}")).await;
+
+    let checkpoint_name = "00000000000000000001.checkpoint.parquet";
+    add_checkpoint_to_store(
+        &store,
+        sidecar_batch_with_given_paths_and_sizes(
+            vec![(sidecar_name, sidecar_size)],
+            get_all_actions_schema().clone(),
+        ),
+        checkpoint_name,
+    )
+    .await?;
+    let checkpoint_file = log_root.join(checkpoint_name)?.to_string();
+    let checkpoint_size = get_file_size(&store, &format!("_delta_log/{checkpoint_name}")).await;
+
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, checkpoint_size)],
+            latest_commit_file: Some(create_log_path("file:///00000000000000000001.json")),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )?;
+
+    // The main checkpoint file carries only sidecar references (null `add.path`) and is skipped;
+    // sidecar discovery reads it separately with no predicate, so the refs are still found.
+    let filtered = log_segment
+        .read_actions_with_projected_checkpoint_actions(
+            &engine,
+            COMMIT_READ_SCHEMA.clone(),
+            CHECKPOINT_READ_SCHEMA.clone(),
+            None, // meta_predicate
+            None, // stats_schema
+            None, // partition_schema
+        )?
+        .actions;
+
+    let mut rows_after_pruning = 0;
+    let mut add_paths: Vec<String> = Vec::new();
+    for batch in filtered {
+        let batch = batch?.actions;
+        rows_after_pruning += batch.len();
+        let mut visitor = AddVisitor::default();
+        visitor.visit_rows_of(&*batch)?;
+        add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
+    }
+    assert_eq!(
+        rows_after_pruning, 2,
+        "the all-remove sidecar row group must be skipped, leaving only the all-add group"
+    );
+
+    add_paths.sort();
+    assert_eq!(
+        add_paths,
+        vec![
+            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet".to_string(),
+            "part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c002.snappy.parquet".to_string(),
+        ],
+        "the kept sidecar row group must surface every live Add and no others"
     );
 
     Ok(())

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -10,10 +10,9 @@ use url::Url;
 use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
-    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, CDC_NAME,
-    CHECKPOINT_METADATA_NAME, COMMIT_INFO_NAME, DOMAIN_METADATA_NAME, LOG_METADATA_SCHEMA,
-    MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, PROTOCOL_NAME, REMOVE_NAME,
-    SET_TRANSACTION_NAME, SIDECAR_NAME,
+    get_all_actions_schema, get_commit_schema, Add, Sidecar, ADD_NAME, COMMIT_INFO_NAME,
+    LOG_METADATA_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, REMOVE_NAME,
+    SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -34,13 +33,14 @@ use crate::scan::test_utils::{
     sidecar_batch_with_given_paths, sidecar_batch_with_given_paths_and_sizes,
 };
 use crate::scan::{CHECKPOINT_READ_SCHEMA, COMMIT_READ_SCHEMA};
-use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
+use crate::schema::{schema, schema_ref, DataType, SchemaRef, StructField, StructType};
 use crate::utils::test_utils::{
     assert_batch_matches, assert_result_error_with_message, create_log_path,
     create_log_path_with_size, string_array_to_engine_data, Action,
 };
 use crate::{
-    DeltaResult, EngineData, Expression, FileMeta, JsonHandler, ParquetHandler, Predicate,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, EvaluationHandler, Expression,
+    FileDataReadResultIterator, FileMeta, JsonHandler, ParquetFooter, ParquetHandler, Predicate,
     PredicateRef, RowVisitor, StorageHandler,
 };
 
@@ -140,17 +140,7 @@ async fn write_parquet_to_store(
     path: String,
     data: Box<dyn EngineData>,
 ) -> DeltaResult<()> {
-    let batch = ArrowEngineData::try_from_engine_data(data)?;
-    let record_batch = batch.record_batch();
-
-    let mut buffer = vec![];
-    let mut writer = ArrowWriter::try_new(&mut buffer, record_batch.schema(), None)?;
-    writer.write(record_batch)?;
-    writer.close()?;
-
-    store.put(&Path::from(path), buffer.into()).await?;
-
-    Ok(())
+    write_multi_row_group_parquet_to_store(store, vec![data], &path).await
 }
 
 /// Writes all actions to a _delta_log parquet checkpoint file in the store.
@@ -164,10 +154,8 @@ pub(crate) async fn add_checkpoint_to_store(
     write_parquet_to_store(store, path, data).await
 }
 
-/// Writes a parquet file where each batch becomes its own row group. Flushing after every batch
-/// forces a row-group boundary. All batches must share the same Arrow schema. `path` is relative
-/// to the store root (e.g. `_delta_log/..` for a checkpoint, `_delta_log/_sidecars/..` for a
-/// sidecar).
+/// Writes a Parquet file with one row group per batch. All batches must share the same Arrow
+/// schema.
 async fn write_multi_row_group_parquet_to_store(
     store: &Arc<InMemory>,
     row_groups: Vec<Box<dyn EngineData>>,
@@ -179,7 +167,7 @@ async fn write_multi_row_group_parquet_to_store(
         .collect::<DeltaResult<Vec<_>>>()?;
     let schema = batches
         .first()
-        .expect("at least one row group")
+        .ok_or_else(|| Error::internal_error("at least one row group is required"))?
         .record_batch()
         .schema();
 
@@ -193,6 +181,82 @@ async fn write_multi_row_group_parquet_to_store(
 
     store.put(&Path::from(path), buffer.into()).await?;
     Ok(())
+}
+
+/// Drains a projected checkpoint action stream, returning the total materialized row count and the
+/// sorted `add.path` of every surviving Add.
+fn collect_filtered_adds(
+    filtered: impl Iterator<Item = DeltaResult<ActionsBatch>>,
+) -> DeltaResult<(usize, Vec<String>)> {
+    let mut rows = 0;
+    let mut add_paths: Vec<String> = Vec::new();
+    for batch in filtered {
+        let batch = batch?.actions;
+        rows += batch.len();
+        let mut visitor = AddVisitor::default();
+        visitor.visit_rows_of(&*batch)?;
+        add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
+    }
+    add_paths.sort();
+    Ok((rows, add_paths))
+}
+
+struct IgnorePredicateParquetHandler(Arc<dyn ParquetHandler>);
+
+impl ParquetHandler for IgnorePredicateParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        _predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.0.read_parquet_files(files, physical_schema, None)
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: Url,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
+    ) -> DeltaResult<()> {
+        self.0.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        self.0.read_parquet_footer(file)
+    }
+}
+
+struct IgnorePredicateEngine {
+    inner: Arc<SyncEngine>,
+    parquet_handler: Arc<IgnorePredicateParquetHandler>,
+}
+
+impl IgnorePredicateEngine {
+    fn new(inner: Arc<SyncEngine>) -> Self {
+        let parquet_handler = Arc::new(IgnorePredicateParquetHandler(inner.parquet_handler()));
+        Self {
+            inner,
+            parquet_handler,
+        }
+    }
+}
+
+impl Engine for IgnorePredicateEngine {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.inner.storage_handler()
+    }
+
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet_handler.clone()
+    }
+
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.inner.json_handler()
+    }
 }
 
 /// Writes all actions to a _delta_log/_sidecars file in the store and return the [`FileMeta`].
@@ -1398,19 +1462,10 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     Ok(())
 }
 
-/// The scan's add-only checkpoint read schema derives an `add.path IS NOT NULL` meta-predicate
-/// (via `checkpoint_action_projection_predicate`), letting the parquet reader skip any checkpoint
-/// row group whose `add.path` column is entirely null -- a group holding only Remove tombstones
-/// (or other non-Add actions). A group with even one live Add has a non-null `add.path` and is kept
-/// in full, so no live Add is ever dropped.
-///
-/// Each case writes one checkpoint parquet file with one row group per supplied batch. A baseline
-/// read with no predicate materializes every row, confirming the rows physically exist -- so the
-/// smaller post-pruning row count is attributable to row-group skipping, not a missing fixture. The
-/// multi-row-group case places an all-remove group next to an all-add group to guard against a
-/// per-row-group regression that would wrongly drop the adjacent live Adds.
 #[rstest]
 #[case::all_remove_part_skipped(vec![remove_only_batch(get_commit_schema().clone()) as _], 0, &[])]
+// The single row group holds a live Add, so the whole batch is kept: all 4 rows
+// (`add_batch_with_remove` = 1 remove + 2 adds + 1 metadata) survive.
 #[case::mixed_add_remove_part_kept(
     vec![add_batch_with_remove(get_commit_schema().clone()) as _],
     4,
@@ -1431,13 +1486,20 @@ async fn test_create_checkpoint_stream_reads_parquet_checkpoint_batch_without_si
     ],
 )]
 #[tokio::test]
-async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
+async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
     #[case] row_groups: Vec<Box<dyn EngineData>>,
     #[case] expected_rows_after_pruning: usize,
     #[case] expected_survivor_adds: &[&str],
+    #[values(false, true)] ignore_predicate: bool,
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
-    let engine = SyncEngine::new_with_store(store.clone());
+    let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
+    let ignore_predicate_engine = IgnorePredicateEngine::new(sync_engine.clone());
+    let engine: &dyn Engine = if ignore_predicate {
+        &ignore_predicate_engine
+    } else {
+        sync_engine.as_ref()
+    };
 
     let checkpoint_name = "00000000000000000001.checkpoint.parquet";
     // Real checkpoints store removes with the full file-action schema; the add column is null.
@@ -1465,7 +1527,7 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
 
     // Baseline: with no predicate every row group is read, so all rows are materialized.
     let unfiltered = log_segment.create_checkpoint_stream(
-        &engine,
+        engine,
         CHECKPOINT_READ_SCHEMA.clone(),
         None, // meta_predicate
         None, // stats_schema
@@ -1480,12 +1542,12 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
         "without a predicate every checkpoint row is materialized"
     );
 
-    // The scan's add-only checkpoint read derives `add.path IS NOT NULL`. All-remove row groups are
-    // skipped while groups holding a live Add are kept. There are no commit files, so only
-    // surviving checkpoint rows appear.
+    // The projected checkpoint read derives `add.path IS NOT NULL`. Engines may use it to skip
+    // all-remove row groups or ignore it and return extra rows; both paths must surface the same
+    // Adds.
     let filtered = log_segment
         .read_actions_with_projected_checkpoint_actions(
-            &engine,
+            engine,
             COMMIT_READ_SCHEMA.clone(),
             CHECKPOINT_READ_SCHEMA.clone(),
             None, // meta_predicate
@@ -1494,21 +1556,14 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
         )?
         .actions;
 
-    let mut rows_after_pruning = 0;
-    let mut add_paths: Vec<String> = Vec::new();
-    for batch in filtered {
-        let batch = batch?.actions;
-        rows_after_pruning += batch.len();
-        let mut visitor = AddVisitor::default();
-        visitor.visit_rows_of(&*batch)?;
-        add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
-    }
-    assert_eq!(
-        rows_after_pruning, expected_rows_after_pruning,
-        "all-remove row groups must be skipped, so only kept groups' rows are materialized"
-    );
+    let (rows_after_pruning, add_paths) = collect_filtered_adds(filtered)?;
+    let expected_materialized_rows = if ignore_predicate {
+        total_rows
+    } else {
+        expected_rows_after_pruning
+    };
+    assert_eq!(rows_after_pruning, expected_materialized_rows);
 
-    add_paths.sort();
     let mut expected: Vec<String> = expected_survivor_adds
         .iter()
         .map(|s| s.to_string())
@@ -1516,22 +1571,29 @@ async fn test_scan_checkpoint_read_skips_all_remove_row_groups(
     expected.sort();
     assert_eq!(
         add_paths, expected,
-        "kept row groups must surface every live Add and no others"
+        "predicate handling must surface every live Add and no others"
     );
 
     Ok(())
 }
 
-/// The derived `add.path IS NOT NULL` predicate reaches a V2 checkpoint's sidecar reads, which
-/// share the add-only checkpoint schema. A sidecar row group holding only Remove tombstones has an
-/// all-null `add.path` and is skipped, while the adjacent all-add group is kept, so its live Adds
-/// still surface.
+#[rstest]
+#[case::row_group_skipping(false, 2)]
+#[case::predicate_ignored(true, 5)]
 #[tokio::test]
-async fn test_scan_checkpoint_read_skips_all_remove_sidecar_row_groups() -> DeltaResult<()> {
+async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
+    #[case] ignore_predicate: bool,
+    #[case] expected_materialized_rows: usize,
+) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
-    let engine = SyncEngine::new_with_store(store.clone());
+    let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
+    let ignore_predicate_engine = IgnorePredicateEngine::new(sync_engine.clone());
+    let engine: &dyn Engine = if ignore_predicate {
+        &ignore_predicate_engine
+    } else {
+        sync_engine.as_ref()
+    };
 
-    // Sidecar with an all-remove row group next to an all-add group (c000, c002).
     let sidecar_name = "sidecarfile.parquet";
     write_multi_row_group_parquet_to_store(
         &store,
@@ -1568,11 +1630,11 @@ async fn test_scan_checkpoint_read_skips_all_remove_sidecar_row_groups() -> Delt
         None,
     )?;
 
-    // The main checkpoint file carries only sidecar references (null `add.path`) and is skipped;
-    // sidecar discovery reads it separately with no predicate, so the refs are still found.
+    // Sidecar discovery reads the manifest without a predicate, so pruning its null-`add.path`
+    // rows from the projected action stream cannot hide sidecar references.
     let filtered = log_segment
         .read_actions_with_projected_checkpoint_actions(
-            &engine,
+            engine,
             COMMIT_READ_SCHEMA.clone(),
             CHECKPOINT_READ_SCHEMA.clone(),
             None, // meta_predicate
@@ -1581,21 +1643,12 @@ async fn test_scan_checkpoint_read_skips_all_remove_sidecar_row_groups() -> Delt
         )?
         .actions;
 
-    let mut rows_after_pruning = 0;
-    let mut add_paths: Vec<String> = Vec::new();
-    for batch in filtered {
-        let batch = batch?.actions;
-        rows_after_pruning += batch.len();
-        let mut visitor = AddVisitor::default();
-        visitor.visit_rows_of(&*batch)?;
-        add_paths.extend(visitor.adds.into_iter().map(|add| add.path));
-    }
+    let (rows_after_pruning, add_paths) = collect_filtered_adds(filtered)?;
     assert_eq!(
-        rows_after_pruning, 2,
-        "the all-remove sidecar row group must be skipped, leaving only the all-add group"
+        rows_after_pruning, expected_materialized_rows,
+        "materialized rows must reflect whether the engine applies the predicate"
     );
 
-    add_paths.sort();
     assert_eq!(
         add_paths,
         vec![
@@ -4485,30 +4538,6 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
 
 #[rstest::rstest]
 #[case::empty_schema(StructType::new_unchecked([]), None)]
-#[case::metadata_field(
-    schema! { nullable (METADATA_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([METADATA_NAME, "id"])).is_not_null(),
-    )),
-)]
-#[case::protocol_field(
-    schema! { nullable (PROTOCOL_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([PROTOCOL_NAME, "minReaderVersion"])).is_not_null(),
-    )),
-)]
-#[case::txn_field(
-    schema! { nullable (SET_TRANSACTION_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([SET_TRANSACTION_NAME, "appId"])).is_not_null(),
-    )),
-)]
-#[case::domain_metadata_field(
-    schema! { nullable (DOMAIN_METADATA_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([DOMAIN_METADATA_NAME, "domain"])).is_not_null(),
-    )),
-)]
 #[case::add_field(
     schema! { nullable (ADD_NAME): {} },
     Some(Arc::new(
@@ -4516,27 +4545,9 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
     )),
 )]
 #[case::remove_field(
-    StructType::new_unchecked([StructField::nullable(REMOVE_NAME, StructType::new_unchecked([]))]),
+    schema! { nullable (REMOVE_NAME): {} },
     Some(Arc::new(
         Expression::column(ColumnName::new([REMOVE_NAME, "path"])).is_not_null(),
-    )),
-)]
-#[case::cdc_field(
-    schema! { nullable (CDC_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([CDC_NAME, "path"])).is_not_null(),
-    )),
-)]
-#[case::checkpoint_metadata_field(
-    schema! { nullable (CHECKPOINT_METADATA_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([CHECKPOINT_METADATA_NAME, "version"])).is_not_null(),
-    )),
-)]
-#[case::sidecar_field(
-    schema! { nullable (SIDECAR_NAME): {} },
-    Some(Arc::new(
-        Expression::column(ColumnName::new([SIDECAR_NAME, "path"])).is_not_null(),
     )),
 )]
 #[case::action_without_required_leaf_returns_none(
@@ -4553,10 +4564,17 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
         Expression::column(ColumnName::new([REMOVE_NAME, "path"])).is_not_null(),
     ))),
 )]
-#[case::known_and_unknown_field_returns_none(
+#[case::witness_and_witnessless_field_returns_none(
     StructType::new_unchecked([
         StructField::nullable(METADATA_NAME, StructType::new_unchecked([])),
         StructField::nullable(COMMIT_INFO_NAME, StructType::new_unchecked([])),
+    ]),
+    None,
+)]
+#[case::known_and_unknown_field_returns_none(
+    StructType::new_unchecked([
+        StructField::nullable(ADD_NAME, StructType::new_unchecked([])),
+        StructField::nullable("futureAction", StructType::new_unchecked([])),
     ]),
     None,
 )]

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -973,6 +973,9 @@ impl Scan {
                 self.build_actions_meta_predicate(),
             )
         };
+        // Scans request only Add actions from checkpoints, so the projected schema derives
+        // `add.path IS NOT NULL`. Remove tombstones in checkpoint state are irrelevant to active
+        // file replay, allowing readers to skip all-remove row groups.
         self.snapshot
             .log_segment()
             .read_actions_with_projected_checkpoint_actions(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -973,9 +973,8 @@ impl Scan {
                 self.build_actions_meta_predicate(),
             )
         };
-        // Scans request only Add actions from checkpoints, so the projected schema derives
-        // `add.path IS NOT NULL`. Remove tombstones in checkpoint state are irrelevant to active
-        // file replay, allowing readers to skip all-remove row groups.
+        // Checkpoints already represent reconciled state, so scans project only Add actions. This
+        // derives `add.path IS NOT NULL` and allows readers to skip non-Add row groups.
         self.snapshot
             .log_segment()
             .read_actions_with_projected_checkpoint_actions(

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -20,8 +20,8 @@ use crate::table_features::ColumnMappingMode;
 use crate::utils::test_utils::string_array_to_engine_data;
 use crate::JsonHandler;
 
-// Parses JSON action strings into a batch with the given schema. The schema is provided as null
-// columns affect equality checks.
+// Parses JSON action strings into a batch using the given schema (null columns affect equality
+// checks).
 fn parse_batch(json: &[&str], output_schema: SchemaRef) -> Box<ArrowEngineData> {
     let handler = SyncJsonHandler::new(None);
     let json_strings: StringArray = json.to_vec().into();
@@ -111,9 +111,7 @@ pub(crate) fn remove_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData
     )
 }
 
-// A batch of two Add actions (no other action types), parsed with the schema provided. Every row
-// has a non-null `add.path`, so this builds an all-add row group that survives an
-// `add.path IS NOT NULL` filter.
+// A batch of two Add actions (no other action types), parsed with the schema provided.
 pub(crate) fn adds_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
     parse_batch(
         &[

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -20,6 +20,17 @@ use crate::table_features::ColumnMappingMode;
 use crate::utils::test_utils::string_array_to_engine_data;
 use crate::JsonHandler;
 
+// Parses JSON action strings into a batch with the given schema. The schema is provided as null
+// columns affect equality checks.
+fn parse_batch(json: &[&str], output_schema: SchemaRef) -> Box<ArrowEngineData> {
+    let handler = SyncJsonHandler::new(None);
+    let json_strings: StringArray = json.to_vec().into();
+    let parsed = handler
+        .parse_json(string_array_to_engine_data(json_strings), output_schema)
+        .unwrap();
+    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+}
+
 // Generates a batch of sidecar actions with the given paths.
 // The schema is provided as null columns affect equality checks.
 pub(crate) fn sidecar_batch_with_given_paths(
@@ -37,8 +48,6 @@ pub(crate) fn sidecar_batch_with_given_paths_and_sizes(
     paths_and_sizes: Vec<(&str, u64)>,
     output_schema: SchemaRef,
 ) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-
     let mut json_strings: Vec<String> = paths_and_sizes
         .iter()
         .map(|(path, size)| {
@@ -49,92 +58,70 @@ pub(crate) fn sidecar_batch_with_given_paths_and_sizes(
         .collect();
     json_strings.push(r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#.to_string());
 
-    let json_strings_array: StringArray =
-        json_strings.iter().map(|s| s.as_str()).collect_vec().into();
-
-    let parsed = handler
-        .parse_json(
-            string_array_to_engine_data(json_strings_array),
-            output_schema,
-        )
-        .unwrap();
-
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &json_strings.iter().map(String::as_str).collect_vec(),
+        output_schema,
+    )
 }
 
 // Generates a batch with an add action.
 // The schema is provided as null columns affect equality checks.
 pub(crate) fn add_batch_simple(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-        r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // Generates a batch with an add action.
 // The schema is provided as null columns affect equality checks.
 pub(crate) fn add_batch_for_row_id(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId": 42, "tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-        r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col"},"createdTime":1677811175819}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId": 42, "tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col"},"createdTime":1677811175819}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // An add batch with a removed file parsed with the schema provided
 pub(crate) fn add_batch_with_remove(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":635,"tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":false}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-        r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":635,"tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":false}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // A batch containing only a Remove action, parsed with the schema provided.
 pub(crate) fn remove_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":635}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":635}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // A batch of two Add actions (no other action types), parsed with the schema provided. Every row
 // has a non-null `add.path`, so this builds an all-add row group that survives an
 // `add.path IS NOT NULL` filter.
 pub(crate) fn adds_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c002.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c002.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // A batch with a Remove action and a partition column (`date`). The Remove has
@@ -143,35 +130,28 @@ pub(crate) fn adds_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> 
 pub(crate) fn add_batch_with_remove_and_partition(
     output_schema: SchemaRef,
 ) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{"date":"2017-12-10"},"size":635}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues":{"date":"2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0}}"}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{"date":"2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0}}"}}"#,
-        r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["date"],"configuration":{"delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
-    ]
-        .into();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{"date":"2017-12-10"},"size":635}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues":{"date":"2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0}}"}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{"date":"2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0}}"}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["date"],"configuration":{"delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+        ],
+        output_schema,
+    )
 }
 
 // add batch with a `date` partition col
 pub(crate) fn add_batch_with_partition_col() -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
-    let json_strings: StringArray = vec![
-        r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["date"],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues": {"date": "2017-12-11"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":false}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
-        r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
-        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-    ]
-        .into();
-    let output_schema = get_commit_schema().clone();
-    let parsed = handler
-        .parse_json(string_array_to_engine_data(json_strings), output_schema)
-        .unwrap();
-    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+    parse_batch(
+        &[
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"date\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["date"],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none"},"createdTime":1677811175819}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","partitionValues": {"date": "2017-12-11"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":false}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"}}}"#,
+            r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+        ],
+        get_commit_schema().clone(),
+    )
 }
 
 /// Create a scan action iter and validate what's called back. If you pass `None` as

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -108,6 +108,21 @@ pub(crate) fn add_batch_with_remove(output_schema: SchemaRef) -> Box<ArrowEngine
     ArrowEngineData::try_from_engine_data(parsed).unwrap()
 }
 
+// A batch containing only a Remove action, parsed with the schema provided. Under an add-only
+// read schema this projects to a null `add`, so its parquet row group carries an all-null
+// `add.path` and is skippable by an `add.path IS NOT NULL` predicate.
+pub(crate) fn remove_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
+    let handler = SyncJsonHandler::new(None);
+    let json_strings: StringArray = vec![
+        r#"{"remove":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c001.snappy.parquet","deletionTimestamp":1677811194426,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":635}}"#,
+    ]
+        .into();
+    let parsed = handler
+        .parse_json(string_array_to_engine_data(json_strings), output_schema)
+        .unwrap();
+    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+}
+
 // A batch with a Remove action and a partition column (`date`). The Remove has
 // `partitionValues: {"date": "2017-12-10"}` but the transform reads from `add.*` columns,
 // so the Remove's partition values are not visible to the data skipping filter.

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -121,6 +121,22 @@ pub(crate) fn remove_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData
     ArrowEngineData::try_from_engine_data(parsed).unwrap()
 }
 
+// A batch of two Add actions (no other action types), parsed with the schema provided. Every row
+// has a non-null `add.path`, so this builds an all-add row group that survives an
+// `add.path IS NOT NULL` filter.
+pub(crate) fn adds_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
+    let handler = SyncJsonHandler::new(None);
+    let json_strings: StringArray = vec![
+        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
+        r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c002.snappy.parquet","partitionValues":{},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
+    ]
+        .into();
+    let parsed = handler
+        .parse_json(string_array_to_engine_data(json_strings), output_schema)
+        .unwrap();
+    ArrowEngineData::try_from_engine_data(parsed).unwrap()
+}
+
 // A batch with a Remove action and a partition column (`date`). The Remove has
 // `partitionValues: {"date": "2017-12-10"}` but the transform reads from `add.*` columns,
 // so the Remove's partition values are not visible to the data skipping filter.

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -108,9 +108,7 @@ pub(crate) fn add_batch_with_remove(output_schema: SchemaRef) -> Box<ArrowEngine
     ArrowEngineData::try_from_engine_data(parsed).unwrap()
 }
 
-// A batch containing only a Remove action, parsed with the schema provided. Under an add-only
-// read schema this projects to a null `add`, so its parquet row group carries an all-null
-// `add.path` and is skippable by an `add.path IS NOT NULL` predicate.
+// A batch containing only a Remove action, parsed with the schema provided.
 pub(crate) fn remove_only_batch(output_schema: SchemaRef) -> Box<ArrowEngineData> {
     let handler = SyncJsonHandler::new(None);
     let json_strings: StringArray = vec![

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -784,11 +784,14 @@ fn test_replay_for_scan_metadata() {
     let scan = snapshot.scan_builder().build().unwrap();
     let result = scan.replay_for_scan_metadata(&engine).unwrap();
     let data: Vec<_> = result.actions.try_collect().unwrap();
-    // No predicate pushdown attempted, because at most one part of a multi-part checkpoint
-    // could be skipped when looking for adds/removes.
+    // The add-only checkpoint read schema derives an `add.path IS NOT NULL` skipping predicate,
+    // so checkpoint parts whose only row is a non-Add action (a null `add.path`) are skipped.
+    // The 5 single-row parts are: txn, metaData, protocol, add, txn. The metaData and protocol
+    // parts carry an all-null `add.path` column and are skipped; the two txn parts physically omit
+    // the `add.path` column (no stats to skip on) and are conservatively kept, as is the add part.
     //
     // NOTE: Each checkpoint part is a single-row file -- guaranteed to produce one row group.
-    assert_eq!(data.len(), 5);
+    assert_eq!(data.len(), 3);
 }
 
 #[test]

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -784,13 +784,8 @@ fn test_replay_for_scan_metadata() {
     let scan = snapshot.scan_builder().build().unwrap();
     let result = scan.replay_for_scan_metadata(&engine).unwrap();
     let data: Vec<_> = result.actions.try_collect().unwrap();
-    // The add-only checkpoint read schema derives an `add.path IS NOT NULL` skipping predicate,
-    // so checkpoint parts whose only row is a non-Add action (a null `add.path`) are skipped.
-    // The 5 single-row parts are: txn, metaData, protocol, add, txn. The metaData and protocol
-    // parts carry an all-null `add.path` column and are skipped; the two txn parts physically omit
-    // the `add.path` column (no stats to skip on) and are conservatively kept, as is the add part.
-    //
-    // NOTE: Each checkpoint part is a single-row file -- guaranteed to produce one row group.
+    // Metadata and protocol parts have all-null `add.path` statistics and are skipped. Transaction
+    // parts omit that column and are retained conservatively.
     assert_eq!(data.len(), 3);
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

A checkpoint's `remove` actions are just VACUUM tombstones. A scan reconciles adds only and already drops checkpoint removes during log replay (`skip_removes = !is_log_batch`), but the add-only checkpoint read still materialized every one as a null-`add` row before throwing it away.

This pushes an `add.path IS NOT NULL` predicate into that read so the parquet reader can skip them up front. `action_presence_leaf` maps each action to its required identifying leaf (`add` -> `add.path`), `checkpoint_action_projection_predicate` ORs an `IS NOT NULL` witness per requested action, and the result is ANDed into the predicate passed to `create_checkpoint_stream`. Row groups made entirely of removes have an all-null `add.path` and can be skipped; any group holding a live Add is kept. The predicate is only a skipping hint, so an engine may ignore it and return extra rows; log replay already tolerates them.


### Why it's safe

- Commit removes are read through a separate schema (`COMMIT_READ_SCHEMA`) and still suppress older adds.
- The predicate is derived from whatever actions a caller projects. Schemas that include `remove` (checkpoint write, log compaction) get a `remove.path IS NOT NULL` arm ORed in, so their remove row groups are always kept. The CRC-from-checkpoint read and the manifest/sidecar-discovery read call `create_checkpoint_stream` directly with no predicate, so they are unaffected. CDF passes no meta-predicate.

## How was this change tested?

Added tests covering an all-remove part being skipped, a mixed add/remove group being kept (both adds surfaced), the same behavior through a V2 sidecar, and the derived-predicate mapping. A predicate-ignoring engine variant asserts that returning extra rows still yields the correct Adds. `test_replay_for_scan_metadata` updated for the skipped parts. Full workspace tests, fmt, and clippy pass.
