### PR TITLE
feat: add Cast expression node for partition predicate pushdown

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -663,6 +663,14 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
+        // The engine-visitor FFI has no cast callback yet. Surface it as an unknown expression so
+        // the boundary neither drops nor misinterprets it; an engine treats it as uninterpretable
+        // rather than fabricating one.
+        Expression::Cast(cast) => visit_unknown(
+            visitor,
+            sibling_list_id,
+            &format!("cast_to_{}", cast.target),
+        ),
         Expression::Unknown(name) => visit_unknown(visitor, sibling_list_id, name),
     }
 }

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -663,9 +663,8 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
-        // The engine-visitor FFI has no cast callback yet. Surface it as an unknown expression so
-        // the boundary neither drops nor misinterprets it; an engine treats it as uninterpretable
-        // rather than fabricating one.
+        // The engine-visitor FFI has no cast callback yet; surface it as an unknown expression,
+        // which an engine treats as uninterpretable.
         Expression::Cast(cast) => visit_unknown(
             visitor,
             sibling_list_id,

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -18,7 +18,9 @@ use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
-use crate::arrow::compute::{and_kleene, cast, is_not_null, is_null, not, or_kleene};
+use crate::arrow::compute::{
+    and_kleene, can_cast_types, cast, is_not_null, is_null, not, or_kleene,
+};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, IntervalUnit,
     Schema as ArrowSchema, TimeUnit,
@@ -381,6 +383,20 @@ pub fn evaluate_expression(
         (MapToStruct(_), dt) => Err(Error::Generic(format!(
             "MapToStruct expression requires a DataType::Struct result type, but got {dt:?}"
         ))),
+        (Cast(c), result_type) => {
+            let input = evaluate_expression(&c.expr, batch, None)?;
+            let target = ArrowDataType::try_from_kernel(&c.target)?;
+            // Safe cast semantics: an unrepresentable value becomes NULL rather than erroring,
+            // matching SQL `CAST` / lenient partition-value parsing. Arrow's `cast` default nulls
+            // per-value failures, but errors outright on a type pair it has no cast for; degrade
+            // that to an all-NULL column so an unsupported cast keeps (rather than fails) the scan.
+            let casted = if can_cast_types(input.data_type(), &target) {
+                cast(&input, &target)?
+            } else {
+                new_null_array(&target, input.len())
+            };
+            validate_array_type(casted, result_type)
+        }
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
     }
 }
@@ -3157,5 +3173,49 @@ mod tests {
             .column(0)
             .as_primitive::<Int32Type>();
         assert_eq!(row2_inner.value(0), 30);
+    }
+
+    #[test]
+    fn test_cast_string_to_date() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("part", ArrowDataType::Utf8, true)]);
+        // Row 1 is unparseable and row 2 is null; both must become NULL under safe-cast semantics.
+        let parts = StringArray::from(vec![Some("2025-04-11"), Some("not-a-date"), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(parts)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("part"), DataType::DATE);
+        let result = evaluate_expression(&expr, &batch, None).unwrap();
+
+        let dates = result.as_primitive::<Date32Type>();
+        assert_eq!(dates.value(0), 20189); // 2025-04-11 is 20189 days after the unix epoch
+        assert!(dates.is_null(1));
+        assert!(dates.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_result_type_validated() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("part", ArrowDataType::Utf8, true)]);
+        let parts = StringArray::from(vec![Some("2025-04-11")]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(parts)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("part"), DataType::DATE);
+        // The declared result type must match the cast target.
+        assert!(evaluate_expression(&expr, &batch, Some(&DataType::LONG)).is_err());
+        assert!(evaluate_expression(&expr, &batch, Some(&DataType::DATE)).is_ok());
+    }
+
+    #[test]
+    fn test_cast_unsupported_type_pair_yields_null() {
+        // Arrow has no cast from Boolean to Date. Rather than erroring (which would abort the
+        // scan), the cast degrades to an all-NULL column so the file is kept.
+        let schema = ArrowSchema::new(vec![ArrowField::new("flag", ArrowDataType::Boolean, true)]);
+        let flags = BooleanArray::from(vec![Some(true), Some(false)]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(flags)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("flag"), DataType::DATE);
+        let result = evaluate_expression(&expr, &batch, None).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.null_count(), 2);
+        assert_eq!(result.data_type(), &ArrowDataType::Date32);
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -288,9 +288,9 @@ pub struct ParseJsonExpression {
 /// An expression that casts a child expression to a target type, following SQL `CAST` semantics.
 ///
 /// A value that cannot be represented in the target type evaluates to NULL rather than erroring,
-/// matching how partition values are parsed to their declared type. Only primitive target types
-/// are supported; a non-primitive target disqualifies the expression from evaluation and data
-/// skipping.
+/// matching how partition values are parsed to their declared type. The general (arrow) evaluation
+/// path casts to any arrow-representable target, yielding an all-NULL column for a type pair arrow
+/// cannot cast; data-skipping pushdown is restricted to a narrower set of targets.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CastExpression {
     /// The expression whose value is cast.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -285,6 +285,20 @@ pub struct ParseJsonExpression {
     pub output_schema: SchemaRef,
 }
 
+/// An expression that casts a child expression to a target type, following SQL `CAST` semantics.
+///
+/// A value that cannot be represented in the target type evaluates to NULL rather than erroring,
+/// matching how partition values are parsed to their declared type. Only primitive target types
+/// are supported; a non-primitive target disqualifies the expression from evaluation and data
+/// skipping.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CastExpression {
+    /// The expression whose value is cast.
+    pub expr: Box<Expression>,
+    /// The type the value is cast to.
+    pub target: DataType,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct JunctionPredicate {
     /// The operator.
@@ -418,6 +432,8 @@ pub enum Expression {
     /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
     /// [`MapToStructExpression`] for how values are parsed.
     MapToStruct(MapToStructExpression),
+    /// Cast a child expression to a target type. See [`CastExpression`].
+    Cast(CastExpression),
 }
 
 /// A SQL predicate.
@@ -562,6 +578,15 @@ impl MapToStructExpression {
     pub(crate) fn new(map_expr: impl Into<Expression>) -> Self {
         Self {
             map_expr: Box::new(map_expr.into()),
+        }
+    }
+}
+
+impl CastExpression {
+    pub(crate) fn new(expr: impl Into<Expression>, target: DataType) -> Self {
+        Self {
+            expr: Box::new(expr.into()),
+            target,
         }
     }
 }
@@ -749,6 +774,12 @@ impl Expression {
     /// and to null for every other type. See [`MapToStructExpression`] for the full contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
+    }
+
+    /// Creates a new cast of `expr` to `target`, following SQL `CAST` semantics (unrepresentable
+    /// values become NULL). See [`CastExpression`].
+    pub fn cast(expr: impl Into<Expression>, target: DataType) -> Self {
+        Self::Cast(CastExpression::new(expr, target))
     }
 }
 
@@ -1029,6 +1060,7 @@ impl Display for Expression {
                 )
             }
             MapToStruct(m) => write!(f, "MAP_TO_STRUCT({})", m.map_expr),
+            Cast(c) => write!(f, "CAST({} AS {})", c.expr, c.target),
         }
     }
 }
@@ -1138,7 +1170,7 @@ mod tests {
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
-    use super::{column_expr, column_pred, Expression as Expr, Predicate as Pred};
+    use super::{column_expr, column_pred, DataType, Expression as Expr, Predicate as Pred};
 
     /// Helper function to verify roundtrip serialization/deserialization
     fn assert_roundtrip<T: Serialize + DeserializeOwned + PartialEq + Debug>(value: &T) {
@@ -1162,6 +1194,10 @@ mod tests {
             (
                 Expr::array([column_expr!("x"), column_expr!("y"), Expr::literal(0)]),
                 "ARRAY(Column(x), Column(y), 0)",
+            ),
+            (
+                Expr::cast(column_expr!("x"), DataType::DATE),
+                "CAST(Column(x) AS date)",
             ),
         ];
 
@@ -1460,6 +1496,23 @@ mod tests {
             let cases: Vec<Expression> = vec![
                 Expression::map_to_struct(column_expr!("pv")),
                 Expression::map_to_struct(Expression::literal("ignored")),
+            ];
+
+            for expr in &cases {
+                assert_roundtrip(expr);
+            }
+        }
+
+        #[test]
+        fn test_cast_expression_roundtrip() {
+            let cases: Vec<Expression> = vec![
+                Expression::cast(column_expr!("part"), DataType::DATE),
+                Expression::cast(Expression::literal("2025-01-01"), DataType::DATE),
+                // Nested cast: the child is itself a cast.
+                Expression::cast(
+                    Expression::cast(column_expr!("part"), DataType::STRING),
+                    DataType::INTEGER,
+                ),
             ];
 
             for expr in &cases {

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -126,6 +126,22 @@ pub trait KernelPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
+    /// A (possibly inverted) comparison between `CAST(<col> AS target)` and a scalar, e.g.
+    /// `CAST(<col> AS DATE) < <value>`. The scalar is always on the right (the caller commutes the
+    /// operator for `<value> op CAST(<col>)`). Unsupported by default so evaluators that cannot
+    /// reason about a cast conservatively keep the file; implementations that can (e.g. exact
+    /// partition-value pruning) override it.
+    fn eval_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<Self::Output> {
+        None
+    }
+
     /// Dispatches an opaque predicate.
     fn eval_pred_opaque(
         &self,
@@ -186,6 +202,7 @@ pub trait KernelPredicateEvaluator {
             | Expr::Variadic(_)
             | Expr::ParseJson(_)
             | Expr::MapToStruct(_)
+            | Expr::Cast(_)
             | Expr::Unknown(_) => None,
         }
     }
@@ -216,6 +233,7 @@ pub trait KernelPredicateEvaluator {
                 | Expr::Opaque(_)
                 | Expr::ParseJson { .. }
                 | Expr::MapToStruct(_)
+                | Expr::Cast(_)
                 | Expr::Unknown(_) => {
                     debug!("Unsupported operand: IS [NOT] NULL: {expr:?}");
                     None
@@ -271,7 +289,7 @@ pub trait KernelPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output> {
         use BinaryPredicateOp::*;
-        use Expr::{Column, Literal};
+        use Expr::{Cast, Column, Literal};
 
         match (left, right) {
             (Column(a), Column(b)) => self.eval_pred_binary_columns(op, a, b, inverted),
@@ -290,6 +308,22 @@ pub trait KernelPredicateEvaluator {
                 Equal => self.eval_pred_eq(col, val, inverted),
                 Distinct => self.eval_pred_distinct(col, val, inverted),
                 In => None, // arg order is semantically important
+            },
+            // `CAST(<col> AS target) op <value>` for a bare column child, e.g.
+            // `CAST(<col> AS DATE) < <value>`.
+            (Cast(c), Literal(val)) => match c.expr.as_ref() {
+                Column(col) => self.eval_pred_cast(op, col, &c.target, val, inverted),
+                _ => None,
+            },
+            (Literal(val), Cast(c)) => match c.expr.as_ref() {
+                // Commute so the cast column is on the left, mirroring the `Literal op Column` arm.
+                Column(col) => match op {
+                    LessThan => self.eval_pred_cast(GreaterThan, col, &c.target, val, inverted),
+                    GreaterThan => self.eval_pred_cast(LessThan, col, &c.target, val, inverted),
+                    Equal => self.eval_pred_cast(Equal, col, &c.target, val, inverted),
+                    Distinct | In => None,
+                },
+                _ => None,
             },
             _ => {
                 debug!("Unsupported binary operand(s): {left:?} {op:?} {right:?}");
@@ -648,10 +682,37 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
                     warn!("Failed to evaluate {:?}: {err:?}", op.as_ref());
                 })
                 .ok(),
+            Expr::Cast(c) => cast_scalar(self.eval_expr(&c.expr)?, &c.target),
             // ParseJson and MapToStruct produce structured output, not scalar values
             Expr::ParseJson(_) | Expr::MapToStruct(_) => None,
             Expr::Unknown(_) => None,
         }
+    }
+}
+
+/// Casts a scalar following SQL `CAST` semantics, for the cases exact partition-value pruning
+/// needs: a string source is parsed into a primitive target (the way partition values are parsed
+/// to their declared type), and a source already of the target type passes through. An unparseable
+/// string yields `Scalar::Null` (never TRUE against a comparison), matching the safe-cast semantics
+/// of the arrow evaluation path.
+///
+/// This is deliberately narrower than a full cast: any other source/target combination yields
+/// `None` so the caller conservatively keeps the file. In particular it does not attempt
+/// numeric/temporal casts (e.g. `Long -> Int`) that the arrow path can perform; those only reach
+/// this scalar path through a resolver that supplies partition values as scalars, which no
+/// production caller does today (the sole production evaluator uses an empty column resolver).
+fn cast_scalar(value: Scalar, target: &DataType) -> Option<Scalar> {
+    if value.data_type() == *target {
+        return Some(value);
+    }
+    match (value, target) {
+        (Scalar::String(raw), DataType::Primitive(ptype)) => Some(
+            ptype
+                .parse_scalar(&raw)
+                .unwrap_or_else(|_| Scalar::Null(target.clone())),
+        ),
+        (Scalar::Null(_), _) => Some(Scalar::Null(target.clone())),
+        _ => None,
     }
 }
 
@@ -693,6 +754,18 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
     fn eval_pred_eq(&self, col: &ColumnName, val: &Scalar, inverted: bool) -> Option<bool> {
         let col = self.resolve_column(col)?;
         self.eval_pred_binary_scalars(BinaryPredicateOp::Equal, &col, val, inverted)
+    }
+
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<bool> {
+        let col = cast_scalar(self.resolve_column(col)?, target)?;
+        self.eval_pred_binary_scalars(op, &col, val, inverted)
     }
 
     fn eval_pred_binary_scalars(
@@ -927,6 +1000,19 @@ pub trait DataSkippingPredicateEvaluator {
         };
         self.finish_eval_pred_junction(op, &mut preds.into_iter(), false)
     }
+
+    /// See [`KernelPredicateEvaluator::eval_pred_cast`]. Unsupported by default, so evaluators that
+    /// cannot reason about a cast conservatively keep the file.
+    fn eval_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<Self::Output> {
+        None
+    }
 }
 
 impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T {
@@ -976,6 +1062,17 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
         _inverted: bool,
     ) -> Option<Self::Output> {
         None
+    }
+
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Self::Output> {
+        self.eval_pred_cast(op, col, target, val, inverted)
     }
 
     fn eval_pred_opaque(

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -691,16 +691,18 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
 }
 
 /// Casts a scalar following SQL `CAST` semantics, for the cases exact partition-value pruning
-/// needs: a string source is parsed into a primitive target (the way partition values are parsed
-/// to their declared type), and a source already of the target type passes through. An unparseable
-/// string yields `Scalar::Null` (never TRUE against a comparison), matching the safe-cast semantics
-/// of the arrow evaluation path.
+/// needs: a string source is parsed into a primitive target via
+/// [`PrimitiveType::parse_scalar`](crate::schema::PrimitiveType::parse_scalar),
+/// and a source already of the target type passes through. An unparseable string yields
+/// `Scalar::Null` (never TRUE against a comparison).
 ///
-/// This is deliberately narrower than a full cast: any other source/target combination yields
-/// `None` so the caller conservatively keeps the file. In particular it does not attempt
-/// numeric/temporal casts (e.g. `Long -> Int`) that the arrow path can perform; those only reach
-/// this scalar path through a resolver that supplies partition values as scalars, which no
-/// production caller does today (the sole production evaluator uses an empty column resolver).
+/// `parse_scalar` accepts a strict subset of the formats the arrow evaluation path accepts (e.g.
+/// arrow parses the hyphen-less `20240115` as a date but `parse_scalar` does not), so this path is
+/// only ever more conservative than arrow: a form it rejects becomes NULL (keep), never a differing
+/// non-null value. This is also deliberately narrower than a full cast -- any source/target
+/// combination other than string-to-primitive or an identity pass-through yields `None` so the
+/// caller conservatively keeps the file, and it does not attempt numeric/temporal casts (e.g.
+/// `Long -> Int`) that the arrow path can perform.
 fn cast_scalar(value: Scalar, target: &DataType) -> Option<Scalar> {
     if value.data_type() == *target {
         return Some(value);

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -319,9 +319,8 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
-            // The declarative-plans proto has no cast node yet. Serialize as an opaque unknown so
-            // the boundary neither drops nor misinterprets it; a receiver treats it as an
-            // uninterpretable expression rather than fabricating one.
+            // The declarative-plans proto has no cast node yet; serialize as an opaque unknown,
+            // which a receiver treats as uninterpretable.
             Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
         };
         proto_expr::Expression { kind: Some(kind) }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -319,6 +319,10 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
+            // The declarative-plans proto has no cast node yet. Serialize as an opaque unknown so
+            // the boundary neither drops nor misinterprets it; a receiver treats it as an
+            // uninterpretable expression rather than fabricating one.
+            Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
         };
         proto_expr::Expression { kind: Some(kind) }
     }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -18,7 +18,7 @@ use crate::kernel_predicates::{
 };
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
 use crate::scan::metrics::ScanMetrics;
-use crate::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
+use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
@@ -51,18 +51,6 @@ pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
     DataSkippingPredicateCreator::new(&Default::default(), &stats_columns).eval(pred)
 }
 
-/// Test helper: builds a partition name->type map defaulting every column to `STRING`, the type
-/// that enables cast pushdown. Tests that need a non-string partition type build the map directly.
-#[cfg(test)]
-pub(crate) fn string_partition_columns(
-    partition_columns: &HashSet<String>,
-) -> HashMap<String, DataType> {
-    partition_columns
-        .iter()
-        .map(|name| (name.clone(), DataType::STRING))
-        .collect()
-}
-
 /// Permissive stats-columns set for tests that exercise rewrite mechanics, not the gate.
 #[cfg(test)]
 pub(crate) fn all_referenced_columns(pred: &Pred) -> HashSet<ColumnName> {
@@ -75,8 +63,7 @@ pub(crate) fn as_data_skipping_predicate_with_partitions(
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
-    let partition_columns = string_partition_columns(partition_columns);
-    DataSkippingPredicateCreator::new(&partition_columns, &stats_columns).eval(pred)
+    DataSkippingPredicateCreator::new(partition_columns, &stats_columns).eval(pred)
 }
 
 /// Like [`as_data_skipping_predicate_with_partitions`] but invokes
@@ -87,8 +74,7 @@ fn as_sql_data_skipping_predicate(
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
-    let partition_columns = string_partition_columns(partition_columns);
-    as_sql_data_skipping_predicate_with_stats_columns(pred, &partition_columns, &stats_columns)
+    as_sql_data_skipping_predicate_with_stats_columns(pred, partition_columns, &stats_columns)
 }
 
 /// Like [`as_sql_data_skipping_predicate`] but only rewrites references to columns in
@@ -96,7 +82,7 @@ fn as_sql_data_skipping_predicate(
 /// junction-fold into NULL literals.
 pub(crate) fn as_sql_data_skipping_predicate_with_stats_columns(
     pred: &Pred,
-    partition_columns: &HashMap<String, DataType>,
+    partition_columns: &HashSet<String>,
     stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
     DataSkippingPredicateCreator::new(partition_columns, stats_columns).eval_sql_where(pred)
@@ -322,13 +308,9 @@ impl DataSkippingFilter {
         physical_partition_schema: Option<&SchemaRef>,
         partition_expr: ExpressionRef,
         is_add_expr: ExpressionRef,
-    ) -> Option<(SchemaRef, ExpressionRef, HashMap<String, DataType>)> {
-        let partition_columns: HashMap<String, DataType> = physical_partition_schema
-            .map(|s| {
-                s.fields()
-                    .map(|f| (f.name().to_string(), f.data_type().clone()))
-                    .collect()
-            })
+    ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
+        let partition_columns: HashSet<String> = physical_partition_schema
+            .map(|s| s.fields().map(|f| f.name().to_string()).collect())
             .unwrap_or_default();
 
         let stats_field =
@@ -456,7 +438,7 @@ pub(crate) fn as_checkpoint_skipping_predicate(
         .iter()
         .map(String::as_str)
         .collect();
-    NullGuardedDataSkippingPredicateCreator {
+    CheckpointDataSkippingPredicateCreator {
         partition_columns,
         stats_columns: physical_stats_columns,
     }
@@ -492,27 +474,6 @@ fn binary_comparison_predicate(
         BinaryPredicateOp::Distinct | BinaryPredicateOp::In => return None,
     };
     Some(comparison_predicate(ord, expr, val, inverted))
-}
-
-/// Whether a cast to `target` is eligible for partition-cast pruning. Restricted to string
-/// parsing into an integer type: a base-10 integer parse is unambiguous, so wherever the arrow
-/// cast the rewrite evaluates yields a non-null value it equals what any other engine's cast
-/// yields, and any disagreement leaves one side NULL (keep), never two differing non-null values.
-/// Rounding-sensitive (`decimal`, `float`) and timezone-sensitive (`timestamp`, and `date` --
-/// arrow parses an offset-bearing string like `2024-01-15T20:00:00-08:00` as a UTC instant and
-/// takes its date, which can land on a different day than an engine that casts date-only) targets
-/// can produce differing non-null values across engines and could skip a matching file, so they
-/// are excluded.
-fn is_cast_prunable_target(target: &DataType) -> bool {
-    matches!(
-        target,
-        DataType::Primitive(
-            PrimitiveType::Byte
-                | PrimitiveType::Short
-                | PrimitiveType::Integer
-                | PrimitiveType::Long
-        )
-    )
 }
 
 /// Collects sub-predicates into a junction (AND/OR), replacing unsupported sub-predicates (None)
@@ -576,10 +537,9 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
 /// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
 /// the exact value for every row in the file (serving as both min and max).
 struct DataSkippingPredicateCreator<'a> {
-    /// Physical names of partition columns mapped to their declared types. For these columns,
-    /// stats come from `partitionValues_parsed.<col>` (exact values) instead of min/max ranges.
-    /// The declared type gates cast pushdown (see [`Self::eval_pred_cast`]).
-    partition_columns: &'a HashMap<String, DataType>,
+    /// Physical names of partition columns. For these columns, stats come from
+    /// `partitionValues_parsed.<col>` (exact values) instead of min/max ranges.
+    partition_columns: &'a HashSet<String>,
     /// Physical leaf paths whose stats are present in `stats_parsed` (honors
     /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
     /// columns). References to data columns not in this set return `None` from the
@@ -591,10 +551,7 @@ struct DataSkippingPredicateCreator<'a> {
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
-    fn new(
-        partition_columns: &'a HashMap<String, DataType>,
-        stats_columns: &'a HashSet<ColumnName>,
-    ) -> Self {
+    fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
         Self {
             partition_columns,
             stats_columns,
@@ -603,15 +560,7 @@ impl<'a> DataSkippingPredicateCreator<'a> {
 
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
-        path.len() == 1 && self.partition_columns.contains_key(path[0].as_str())
-    }
-
-    /// Returns the declared type of `col` if it is a single-path partition column.
-    fn partition_column_type(&self, col: &ColumnName) -> Option<&DataType> {
-        match col.path() {
-            [name] => self.partition_columns.get(name.as_str()),
-            _ => None,
-        }
+        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
     }
 
     /// Returns `true` when `col` is in `stats_columns`.
@@ -719,50 +668,6 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         })
     }
 
-    /// Prunes `CAST(<partition_col> AS target) <op> <val>` by casting the exact partition value.
-    ///
-    /// Pruning is restricted to casting a **string** partition column to an integer target (see
-    /// [`is_cast_prunable_target`]). Three conditions converge on soundness:
-    ///
-    /// - Only partition columns have an exact value per file (min == max), so casting that single
-    ///   value and comparing is precise. A data column would have to cast its min/max stats, which
-    ///   is unsound because a cast is not order-preserving in general (e.g. lexicographic string
-    ///   order is not numeric order), so casted min/max need not bound the casted values.
-    /// - The rewrite is evaluated by the engine, so pruning is only sound when the engine and the
-    ///   arrow evaluator agree on the cast. A base-10 integer parse is unambiguous across engines;
-    ///   timezone- and rounding-sensitive targets (`timestamp`, `date`, `decimal`, `float`) can
-    ///   differ and would risk skipping a matching file.
-    /// - Arrow's comparison kernels error on a mismatched type pair rather than yielding NULL, and
-    ///   an error on the skipping path aborts the scan. Pushing down only when the literal already
-    ///   matches the cast target keeps the comparison well-typed.
-    ///
-    /// Any other source, target, or literal type returns `None` (keep the file). The rewrite
-    /// compares `CAST(partitionValues_parsed.<col> AS target)`, which the arrow evaluator applies
-    /// per row with safe (NULL-on-failure) semantics, wrapped in `OR(NOT is_add, ...)` so Remove
-    /// rows are never filtered.
-    fn eval_pred_cast(
-        &self,
-        op: BinaryPredicateOp,
-        col: &ColumnName,
-        target: &DataType,
-        val: &Scalar,
-        inverted: bool,
-    ) -> Option<Pred> {
-        let source = self.partition_column_type(col)?;
-        if *source != DataType::STRING
-            || !is_cast_prunable_target(target)
-            || val.data_type() != *target
-        {
-            return None;
-        }
-        let cast_expr = Expr::cast(
-            joined_column_expr!("partitionValues_parsed", col),
-            target.clone(),
-        );
-        let cmp = binary_comparison_predicate(op, cast_expr, val, inverted)?;
-        Some(self.guard_for_removes(cmp))
-    }
-
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Pred> {
         KernelPredicateEvaluatorDefaults::eval_pred_scalar(val, inverted).map(Pred::literal)
     }
@@ -828,10 +733,10 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     }
 }
 
-/// Like [`DataSkippingPredicateCreator`] but adds IS NULL guards on stat column references
-/// for safe parquet row group filtering. Partition columns are excluded since their values
-/// live in `add.partitionValues_parsed`, not `add.stats_parsed`.
-struct NullGuardedDataSkippingPredicateCreator<'a> {
+/// Like [`DataSkippingPredicateCreator`] but adds IS NULL guards on stat column references for safe
+/// parquet row group filtering. A partition column has no `stats_parsed` stats, so only its exact
+/// value under `partitionValues_parsed` can be compared (see [`Self::eval_pred_cast`]).
+struct CheckpointDataSkippingPredicateCreator<'a> {
     partition_columns: HashSet<&'a str>,
     /// Physical leaf paths whose stats are present in `stats_parsed`. Same contract as
     /// `DataSkippingPredicateCreator::stats_columns`. Must match the column set used to
@@ -839,7 +744,7 @@ struct NullGuardedDataSkippingPredicateCreator<'a> {
     stats_columns: &'a HashSet<ColumnName>,
 }
 
-impl NullGuardedDataSkippingPredicateCreator<'_> {
+impl CheckpointDataSkippingPredicateCreator<'_> {
     /// Returns true if the column is a partition column (no stats in `stats_parsed`).
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
@@ -852,13 +757,13 @@ impl NullGuardedDataSkippingPredicateCreator<'_> {
     }
 }
 
-impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<'_> {
+impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'_> {
     type Output = Pred;
     type ColumnStat = Expr;
 
-    // These stat methods produce unprefixed column references (e.g. `minValues.col`) because
-    // the checkpoint skipping path applies its own `add.stats_parsed` prefix afterward.
-    // Partition columns return None since their values live in `add.partitionValues_parsed`.
+    // These stat methods produce unprefixed data-column references (e.g. `minValues.col`); the
+    // checkpoint skipping path prefixes them with `add.stats_parsed` afterward. Partition columns
+    // return None since they carry no `stats_parsed` stats; `eval_pred_cast` handles them.
 
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col)
@@ -938,6 +843,36 @@ impl DataSkippingPredicateEvaluator for NullGuardedDataSkippingPredicateCreator<
     /// No guard needed — no stat column reference. `NULL IS NULL` → `Some(true)`.
     fn eval_pred_scalar_is_null(&self, val: &Scalar, inverted: bool) -> Option<Pred> {
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
+    }
+
+    /// Rewrites `CAST(<partition_col> AS target) <op> <val>` to a comparison on the exact partition
+    /// value, `partitionValues_parsed.<col>` (the caller prefixes it with `add`). Only partition
+    /// columns qualify: their value is exact per file, so casting it is precise, whereas casting a
+    /// data column's min/max stats is unsound (a cast need not preserve order) and returns `None`.
+    ///
+    /// Every target is sound here because the same engine prunes and matches, so the two cannot
+    /// disagree on the cast -- unlike the in-memory path, which does not prune casts at all.
+    ///
+    /// The `OR(CAST(...) IS NULL, ...)` guard keeps a row whose cast is null (a non-Add row's null
+    /// partition value, or an unparseable value under the safe cast), so a row is skipped only when
+    /// it has a real value outside the range.
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Pred> {
+        if !self.is_partition_column(col) {
+            return None;
+        }
+        let cast_expr = Expr::cast(
+            joined_column_expr!("partitionValues_parsed", col),
+            target.clone(),
+        );
+        let comparison = binary_comparison_predicate(op, cast_expr.clone(), val, inverted)?;
+        Some(Pred::or(Pred::is_null(cast_expr), comparison))
     }
 
     /// IS NULL guard on nullCount stat.

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -18,7 +18,7 @@ use crate::kernel_predicates::{
 };
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
 use crate::scan::metrics::ScanMetrics;
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
@@ -485,16 +485,34 @@ fn binary_comparison_predicate(
     val: &Scalar,
     inverted: bool,
 ) -> Option<Pred> {
-    let pred_fn = match (op, inverted) {
-        (BinaryPredicateOp::LessThan, false) => Pred::lt,
-        (BinaryPredicateOp::LessThan, true) => Pred::ge,
-        (BinaryPredicateOp::GreaterThan, false) => Pred::gt,
-        (BinaryPredicateOp::GreaterThan, true) => Pred::le,
-        (BinaryPredicateOp::Equal, false) => Pred::eq,
-        (BinaryPredicateOp::Equal, true) => Pred::ne,
-        (BinaryPredicateOp::Distinct | BinaryPredicateOp::In, _) => return None,
+    let ord = match op {
+        BinaryPredicateOp::LessThan => Ordering::Less,
+        BinaryPredicateOp::GreaterThan => Ordering::Greater,
+        BinaryPredicateOp::Equal => Ordering::Equal,
+        BinaryPredicateOp::Distinct | BinaryPredicateOp::In => return None,
     };
-    Some(pred_fn(expr, val.clone()))
+    Some(comparison_predicate(ord, expr, val, inverted))
+}
+
+/// Whether a cast to `target` is eligible for partition-cast pruning. Restricted to string
+/// parsing into an integer type: a base-10 integer parse is unambiguous, so wherever the arrow
+/// cast the rewrite evaluates yields a non-null value it equals what any other engine's cast
+/// yields, and any disagreement leaves one side NULL (keep), never two differing non-null values.
+/// Rounding-sensitive (`decimal`, `float`) and timezone-sensitive (`timestamp`, and `date` --
+/// arrow parses an offset-bearing string like `2024-01-15T20:00:00-08:00` as a UTC instant and
+/// takes its date, which can land on a different day than an engine that casts date-only) targets
+/// can produce differing non-null values across engines and could skip a matching file, so they
+/// are excluded.
+fn is_cast_prunable_target(target: &DataType) -> bool {
+    matches!(
+        target,
+        DataType::Primitive(
+            PrimitiveType::Byte
+                | PrimitiveType::Short
+                | PrimitiveType::Integer
+                | PrimitiveType::Long
+        )
+    )
 }
 
 /// Collects sub-predicates into a junction (AND/OR), replacing unsupported sub-predicates (None)
@@ -559,8 +577,8 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
 /// the exact value for every row in the file (serving as both min and max).
 struct DataSkippingPredicateCreator<'a> {
     /// Physical names of partition columns mapped to their declared types. For these columns,
-    /// stats come from `partitionValues.<col>` (exact values) instead of min/max ranges. The
-    /// declared type gates cast pushdown (see [`Self::eval_pred_cast`]).
+    /// stats come from `partitionValues_parsed.<col>` (exact values) instead of min/max ranges.
+    /// The declared type gates cast pushdown (see [`Self::eval_pred_cast`]).
     partition_columns: &'a HashMap<String, DataType>,
     /// Physical leaf paths whose stats are present in `stats_parsed` (honors
     /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
@@ -703,20 +721,22 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 
     /// Prunes `CAST(<partition_col> AS target) <op> <val>` by casting the exact partition value.
     ///
-    /// Pruning is restricted to casting a **string** partition column to a **primitive** target.
-    /// Two independent reasons converge on this:
+    /// Pruning is restricted to casting a **string** partition column to an integer target (see
+    /// [`is_cast_prunable_target`]). Three conditions converge on soundness:
     ///
     /// - Only partition columns have an exact value per file (min == max), so casting that single
     ///   value and comparing is precise. A data column would have to cast its min/max stats, which
     ///   is unsound because a cast is not order-preserving in general (e.g. lexicographic string
     ///   order is not numeric order), so casted min/max need not bound the casted values.
     /// - The rewrite is evaluated by the engine, so pruning is only sound when the engine and the
-    ///   arrow evaluator agree on the cast. Parsing a string into a primitive is the protocol's own
-    ///   partition-value parsing and is deterministic across engines; other directions (e.g. `date
-    ///   -> string` rendering, `float -> int` rounding, timezone interpretation) can differ and
-    ///   would risk skipping a matching file.
+    ///   arrow evaluator agree on the cast. A base-10 integer parse is unambiguous across engines;
+    ///   timezone- and rounding-sensitive targets (`timestamp`, `date`, `decimal`, `float`) can
+    ///   differ and would risk skipping a matching file.
+    /// - Arrow's comparison kernels error on a mismatched type pair rather than yielding NULL, and
+    ///   an error on the skipping path aborts the scan. Pushing down only when the literal already
+    ///   matches the cast target keeps the comparison well-typed.
     ///
-    /// Any other source or a non-primitive target returns `None` (keep the file). The rewrite
+    /// Any other source, target, or literal type returns `None` (keep the file). The rewrite
     /// compares `CAST(partitionValues_parsed.<col> AS target)`, which the arrow evaluator applies
     /// per row with safe (NULL-on-failure) semantics, wrapped in `OR(NOT is_add, ...)` so Remove
     /// rows are never filtered.
@@ -729,7 +749,10 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         inverted: bool,
     ) -> Option<Pred> {
         let source = self.partition_column_type(col)?;
-        if *source != DataType::STRING || !matches!(target, DataType::Primitive(_)) {
+        if *source != DataType::STRING
+            || !is_cast_prunable_target(target)
+            || val.data_type() != *target
+        {
             return None;
         }
         let cast_expr = Expr::cast(

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -51,6 +51,18 @@ pub(crate) fn as_data_skipping_predicate(pred: &Pred) -> Option<Pred> {
     DataSkippingPredicateCreator::new(&Default::default(), &stats_columns).eval(pred)
 }
 
+/// Test helper: builds a partition name->type map defaulting every column to `STRING`, the type
+/// that enables cast pushdown. Tests that need a non-string partition type build the map directly.
+#[cfg(test)]
+pub(crate) fn string_partition_columns(
+    partition_columns: &HashSet<String>,
+) -> HashMap<String, DataType> {
+    partition_columns
+        .iter()
+        .map(|name| (name.clone(), DataType::STRING))
+        .collect()
+}
+
 /// Permissive stats-columns set for tests that exercise rewrite mechanics, not the gate.
 #[cfg(test)]
 pub(crate) fn all_referenced_columns(pred: &Pred) -> HashSet<ColumnName> {
@@ -63,7 +75,8 @@ pub(crate) fn as_data_skipping_predicate_with_partitions(
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
-    DataSkippingPredicateCreator::new(partition_columns, &stats_columns).eval(pred)
+    let partition_columns = string_partition_columns(partition_columns);
+    DataSkippingPredicateCreator::new(&partition_columns, &stats_columns).eval(pred)
 }
 
 /// Like [`as_data_skipping_predicate_with_partitions`] but invokes
@@ -74,7 +87,8 @@ fn as_sql_data_skipping_predicate(
     partition_columns: &HashSet<String>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
-    as_sql_data_skipping_predicate_with_stats_columns(pred, partition_columns, &stats_columns)
+    let partition_columns = string_partition_columns(partition_columns);
+    as_sql_data_skipping_predicate_with_stats_columns(pred, &partition_columns, &stats_columns)
 }
 
 /// Like [`as_sql_data_skipping_predicate`] but only rewrites references to columns in
@@ -82,7 +96,7 @@ fn as_sql_data_skipping_predicate(
 /// junction-fold into NULL literals.
 pub(crate) fn as_sql_data_skipping_predicate_with_stats_columns(
     pred: &Pred,
-    partition_columns: &HashSet<String>,
+    partition_columns: &HashMap<String, DataType>,
     stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
     DataSkippingPredicateCreator::new(partition_columns, stats_columns).eval_sql_where(pred)
@@ -308,9 +322,13 @@ impl DataSkippingFilter {
         physical_partition_schema: Option<&SchemaRef>,
         partition_expr: ExpressionRef,
         is_add_expr: ExpressionRef,
-    ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
-        let partition_columns: HashSet<String> = physical_partition_schema
-            .map(|s| s.fields().map(|f| f.name().to_string()).collect())
+    ) -> Option<(SchemaRef, ExpressionRef, HashMap<String, DataType>)> {
+        let partition_columns: HashMap<String, DataType> = physical_partition_schema
+            .map(|s| {
+                s.fields()
+                    .map(|f| (f.name().to_string(), f.data_type().clone()))
+                    .collect()
+            })
             .unwrap_or_default();
 
         let stats_field =
@@ -458,6 +476,27 @@ fn comparison_predicate(ord: Ordering, col: Expr, val: &Scalar, inverted: bool) 
     pred_fn(col, val.clone())
 }
 
+/// Builds an exact `<expr> <op> <val>` comparison predicate (honoring inversion), for a value
+/// that is exact rather than a min/max range. Returns `None` for operators that are not
+/// order/equality comparisons (`Distinct`, `In`).
+fn binary_comparison_predicate(
+    op: BinaryPredicateOp,
+    expr: Expr,
+    val: &Scalar,
+    inverted: bool,
+) -> Option<Pred> {
+    let pred_fn = match (op, inverted) {
+        (BinaryPredicateOp::LessThan, false) => Pred::lt,
+        (BinaryPredicateOp::LessThan, true) => Pred::ge,
+        (BinaryPredicateOp::GreaterThan, false) => Pred::gt,
+        (BinaryPredicateOp::GreaterThan, true) => Pred::le,
+        (BinaryPredicateOp::Equal, false) => Pred::eq,
+        (BinaryPredicateOp::Equal, true) => Pred::ne,
+        (BinaryPredicateOp::Distinct | BinaryPredicateOp::In, _) => return None,
+    };
+    Some(pred_fn(expr, val.clone()))
+}
+
 /// Collects sub-predicates into a junction (AND/OR), replacing unsupported sub-predicates (None)
 /// with a single NULL literal to preserve correct three-valued logic. One NULL is enough to
 /// produce the correct behavior during predicate evaluation; additional NULLs are redundant.
@@ -519,9 +558,10 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
 /// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
 /// the exact value for every row in the file (serving as both min and max).
 struct DataSkippingPredicateCreator<'a> {
-    /// Physical names of partition columns. For these columns, stats come from
-    /// `partitionValues.<col>` (exact values) instead of min/max ranges.
-    partition_columns: &'a HashSet<String>,
+    /// Physical names of partition columns mapped to their declared types. For these columns,
+    /// stats come from `partitionValues.<col>` (exact values) instead of min/max ranges. The
+    /// declared type gates cast pushdown (see [`Self::eval_pred_cast`]).
+    partition_columns: &'a HashMap<String, DataType>,
     /// Physical leaf paths whose stats are present in `stats_parsed` (honors
     /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
     /// columns). References to data columns not in this set return `None` from the
@@ -533,7 +573,10 @@ struct DataSkippingPredicateCreator<'a> {
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
-    fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
+    fn new(
+        partition_columns: &'a HashMap<String, DataType>,
+        stats_columns: &'a HashSet<ColumnName>,
+    ) -> Self {
         Self {
             partition_columns,
             stats_columns,
@@ -542,7 +585,15 @@ impl<'a> DataSkippingPredicateCreator<'a> {
 
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
-        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+        path.len() == 1 && self.partition_columns.contains_key(path[0].as_str())
+    }
+
+    /// Returns the declared type of `col` if it is a single-path partition column.
+    fn partition_column_type(&self, col: &ColumnName) -> Option<&DataType> {
+        match col.path() {
+            [name] => self.partition_columns.get(name.as_str()),
+            _ => None,
+        }
     }
 
     /// Returns `true` when `col` is in `stats_columns`.
@@ -648,6 +699,45 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         } else {
             cmp
         })
+    }
+
+    /// Prunes `CAST(<partition_col> AS target) <op> <val>` by casting the exact partition value.
+    ///
+    /// Pruning is restricted to casting a **string** partition column to a **primitive** target.
+    /// Two independent reasons converge on this:
+    ///
+    /// - Only partition columns have an exact value per file (min == max), so casting that single
+    ///   value and comparing is precise. A data column would have to cast its min/max stats, which
+    ///   is unsound because a cast is not order-preserving in general (e.g. lexicographic string
+    ///   order is not numeric order), so casted min/max need not bound the casted values.
+    /// - The rewrite is evaluated by the engine, so pruning is only sound when the engine and the
+    ///   arrow evaluator agree on the cast. Parsing a string into a primitive is the protocol's own
+    ///   partition-value parsing and is deterministic across engines; other directions (e.g. `date
+    ///   -> string` rendering, `float -> int` rounding, timezone interpretation) can differ and
+    ///   would risk skipping a matching file.
+    ///
+    /// Any other source or a non-primitive target returns `None` (keep the file). The rewrite
+    /// compares `CAST(partitionValues_parsed.<col> AS target)`, which the arrow evaluator applies
+    /// per row with safe (NULL-on-failure) semantics, wrapped in `OR(NOT is_add, ...)` so Remove
+    /// rows are never filtered.
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Pred> {
+        let source = self.partition_column_type(col)?;
+        if *source != DataType::STRING || !matches!(target, DataType::Primitive(_)) {
+            return None;
+        }
+        let cast_expr = Expr::cast(
+            joined_column_expr!("partitionValues_parsed", col),
+            target.clone(),
+        );
+        let cmp = binary_comparison_predicate(op, cast_expr, val, inverted)?;
+        Some(self.guard_for_removes(cmp))
     }
 
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Pred> {

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -417,7 +417,7 @@ fn test_all_null_pruning_all_comparison_ops(#[case] pred: Pred) {
 
 #[test]
 fn test_timestamp_stats_enabled() {
-    let empty = HashSet::new();
+    let empty = HashMap::new();
     let stats_columns: HashSet<ColumnName> = [column_name!("timestamp_col")].into_iter().collect();
     let creator = DataSkippingPredicateCreator {
         partition_columns: &empty,
@@ -737,6 +737,72 @@ fn test_partition_column_rewrite() {
             .is_some_and(|s| s.contains("stats_parsed.maxValues.data_col")),
         "Expected stats_parsed.maxValues.data_col for data column, got {pred_str:?}"
     );
+}
+
+/// A `CAST(<partition_col> AS DATE) <op> <literal>` predicate rewrites to a comparison on
+/// `CAST(partitionValues_parsed.<col> AS DATE)`, guarded so Remove rows are never filtered. The
+/// same cast over a data column is not supported (data stats aren't exact), so it folds out.
+#[test]
+fn test_cast_partition_column_rewrite() {
+    let partition_columns = test_partition_columns();
+
+    let cast_part = Expr::cast(column_expr!("part_col"), DataType::DATE);
+    let pred = Pred::eq(cast_part, Scalar::Date(20185));
+    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
+    assert_eq!(
+        skipping_pred.as_ref().map(|p| p.to_string()),
+        Some(
+            "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS date) = 20185)"
+                .to_string()
+        ),
+        "cast over a partition column should compare the cast partition value, got {skipping_pred:?}"
+    );
+
+    // The same cast over a data column has no exact value to cast, so it is unsupported (keep).
+    let cast_data = Expr::cast(column_expr!("data_col"), DataType::DATE);
+    let pred = Pred::eq(cast_data, Scalar::Date(20185));
+    assert_eq!(
+        as_data_skipping_predicate_with_partitions(&pred, &partition_columns),
+        None,
+        "cast over a data column should not produce a skipping predicate"
+    );
+}
+
+/// Only a string partition column is cast-pruned. Casting a non-string partition column (here a
+/// DATE column to LONG) is not the protocol's string-parse direction and could disagree with the
+/// engine's cast, so it folds out (keep) rather than risk skipping a matching file.
+#[test]
+fn test_cast_non_string_partition_column_not_pruned() {
+    let partition_columns = HashMap::from_iter([("part_col".to_string(), DataType::DATE)]);
+    let cast_part = Expr::cast(column_expr!("part_col"), DataType::LONG);
+    let pred = Pred::eq(cast_part, Scalar::from(20185i64));
+    let stats_columns = all_referenced_columns(&pred);
+    let creator = DataSkippingPredicateCreator::new(&partition_columns, &stats_columns);
+    assert_eq!(
+        creator.eval(&pred),
+        None,
+        "casting a non-string partition column must not produce a skipping predicate"
+    );
+}
+
+/// The direct (scalar) evaluator casts the exact string partition value and compares it, so it can
+/// keep or prune a file by evaluating `CAST(part AS DATE) = <date>` against the partition value.
+#[test]
+fn test_cast_partition_direct_eval() {
+    // 2025-04-11 is 20189 days after the unix epoch.
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("part_col"),
+        Scalar::from("2025-04-11"),
+    )]));
+    let cast_part = Expr::cast(column_expr!("part_col"), DataType::DATE);
+
+    // Matching date: keep (TRUE).
+    let pred = Pred::eq(cast_part.clone(), Scalar::Date(20189));
+    assert_eq!(resolver.eval_pred(&pred, false), TRUE);
+
+    // Non-matching date: prune (FALSE).
+    let pred = Pred::eq(cast_part, Scalar::Date(20190));
+    assert_eq!(resolver.eval_pred(&pred, false), FALSE);
 }
 
 #[rstest]
@@ -1506,6 +1572,7 @@ fn stats_columns_gate_rewrite(
     #[case] stats: HashSet<ColumnName>,
     #[case] expected: &str,
 ) {
+    let partition_columns = string_partition_columns(&partition_columns);
     let result =
         as_sql_data_skipping_predicate_with_stats_columns(&pred, &partition_columns, &stats)
             .expect("SQL-WHERE rewrite always returns Some for these cases");

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -417,7 +417,7 @@ fn test_all_null_pruning_all_comparison_ops(#[case] pred: Pred) {
 
 #[test]
 fn test_timestamp_stats_enabled() {
-    let empty = HashMap::new();
+    let empty = HashSet::new();
     let stats_columns: HashSet<ColumnName> = [column_name!("timestamp_col")].into_iter().collect();
     let creator = DataSkippingPredicateCreator {
         partition_columns: &empty,
@@ -688,10 +688,10 @@ fn test_partition_columns() -> HashSet<String> {
     ["part_col".to_string()].into()
 }
 
-/// `CAST(part_col AS INTEGER)`, the cast expression the partition-cast pushdown tests compare
-/// against (an integer target is the only cast-prunable target -- see `is_cast_prunable_target`).
-fn cast_part_int() -> Expr {
-    Expr::cast(column_expr!("part_col"), DataType::INTEGER)
+/// `CAST(part_col AS DATE)`, the cast expression the checkpoint partition-cast tests compare
+/// against.
+fn cast_part_date() -> Expr {
+    Expr::cast(column_expr!("part_col"), DataType::DATE)
 }
 
 /// Helper to build a resolver for mixed partition + data stats evaluation.
@@ -745,168 +745,119 @@ fn test_partition_column_rewrite() {
     );
 }
 
-/// A `CAST(<partition_col> AS INTEGER) <op> <literal>` predicate rewrites to a comparison on
-/// `CAST(partitionValues_parsed.<col> AS INTEGER)`, guarded so Remove rows are never filtered. The
-/// same cast over a data column is not supported (data stats aren't exact), so it folds out.
-#[test]
-fn test_cast_partition_column_rewrite() {
+/// The in-memory path must never prune on a cast: arrow evaluates the predicate but a different
+/// engine may match the rows, and their cast semantics can disagree. Every cast folds to keep, for
+/// both partition and data columns and any target. (Casts prune on the checkpoint path instead,
+/// where pruner == matcher -- see `test_checkpoint_cast_*`.)
+#[rstest]
+#[case::partition_date(Expr::cast(column_expr!("part_col"), DataType::DATE), Scalar::Date(20185))]
+#[case::partition_int(Expr::cast(column_expr!("part_col"), DataType::INTEGER), Scalar::from(20185i32))]
+#[case::data_date(Expr::cast(column_expr!("data_col"), DataType::DATE), Scalar::Date(20185))]
+#[case::data_int(Expr::cast(column_expr!("data_col"), DataType::INTEGER), Scalar::from(20185i32))]
+fn test_in_memory_cast_never_prunes(#[case] cast_expr: Expr, #[case] val: Scalar) {
     let partition_columns = test_partition_columns();
-
-    let pred = Pred::eq(cast_part_int(), Scalar::from(20185i32));
-    let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
-    assert_eq!(
-        skipping_pred.as_ref().map(|p| p.to_string()),
-        Some(
-            "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) = 20185)"
-                .to_string()
-        ),
-        "cast over a partition column should compare the cast partition value, got {skipping_pred:?}"
-    );
-
-    // The same cast over a data column has no exact value to cast, so it is unsupported (keep).
-    let cast_data = Expr::cast(column_expr!("data_col"), DataType::INTEGER);
-    let pred = Pred::eq(cast_data, Scalar::from(20185i32));
+    let pred = Pred::eq(cast_expr, val);
     assert_eq!(
         as_data_skipping_predicate_with_partitions(&pred, &partition_columns),
         None,
-        "cast over a data column should not produce a skipping predicate"
+        "in-memory path must never prune on a cast, got a skipping predicate for {pred}"
     );
 }
 
-/// Only a string partition column is cast-pruned. Casting a non-string partition column (here a
-/// DATE column to LONG) is not the protocol's string-parse direction and could disagree with the
-/// engine's cast, so it folds out (keep) rather than risk skipping a matching file.
+/// A `CAST(<partition_col> AS target)` rewrites to a guarded comparison on
+/// `CAST(partitionValues_parsed.<col> AS target)`; a cast over a data column folds out.
 #[test]
-fn test_cast_non_string_partition_column_not_pruned() {
-    let partition_columns = HashMap::from_iter([("part_col".to_string(), DataType::DATE)]);
-    let cast_part = Expr::cast(column_expr!("part_col"), DataType::LONG);
-    let pred = Pred::eq(cast_part, Scalar::from(20185i64));
-    let stats_columns = all_referenced_columns(&pred);
-    let creator = DataSkippingPredicateCreator::new(&partition_columns, &stats_columns);
+fn test_checkpoint_cast_partition_column_rewrite() {
+    let partition_columns = vec!["part_col".to_string()];
+    let pred = Pred::eq(cast_part_date(), Scalar::Date(20185));
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats);
     assert_eq!(
-        creator.eval(&pred),
+        skipping_pred.as_ref().map(|p| p.to_string()),
+        Some(
+            "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+             CAST(Column(partitionValues_parsed.part_col) AS date) = 20185)"
+                .to_string()
+        ),
+        "checkpoint cast over a partition column should compare the guarded cast value, got {skipping_pred:?}"
+    );
+
+    // The same cast over a data column has no exact value to cast, so it folds out (keep).
+    let cast_data = Expr::cast(column_expr!("data_col"), DataType::DATE);
+    let pred = Pred::eq(cast_data, Scalar::Date(20185));
+    let stats = all_referenced_columns(&pred);
+    assert_eq!(
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats),
         None,
-        "casting a non-string partition column must not produce a skipping predicate"
+        "checkpoint cast over a data column should not produce a skipping predicate"
     );
 }
 
-/// The direct (scalar) evaluator casts the exact string partition value and compares it, so it can
-/// keep or prune a file by evaluating `CAST(part AS INTEGER) = <int>` against the partition value.
-#[test]
-fn test_cast_partition_direct_eval() {
-    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
-        column_name!("part_col"),
-        Scalar::from("42"),
-    )]));
-
-    // Matching value: keep (TRUE).
-    let pred = Pred::eq(cast_part_int(), Scalar::from(42i32));
-    assert_eq!(resolver.eval_pred(&pred, false), TRUE);
-
-    // Non-matching value: prune (FALSE).
-    let pred = Pred::eq(cast_part_int(), Scalar::from(43i32));
-    assert_eq!(resolver.eval_pred(&pred, false), FALSE);
-}
-
-/// The rewrite fires for every order/equality operator, including the commuted `<literal> op
-/// CAST(<col>)` form (operator swapped so the cast column stays on the left).
+/// Every order/equality operator produces the guarded `OR(CAST(...) IS NULL, cmp)` form, including
+/// the commuted `<literal> op CAST(<col>)` leg (operator swapped so the cast column stays left).
 #[rstest]
 #[case::eq(
-    Pred::eq(cast_part_int(), Scalar::from(20185i32)),
-    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) = 20185)"
+    Pred::eq(cast_part_date(), Scalar::Date(20185)),
+    "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+     CAST(Column(partitionValues_parsed.part_col) AS date) = 20185)"
 )]
 #[case::lt(
-    Pred::lt(cast_part_int(), Scalar::from(20185i32)),
-    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) < 20185)"
+    Pred::lt(cast_part_date(), Scalar::Date(20185)),
+    "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+     CAST(Column(partitionValues_parsed.part_col) AS date) < 20185)"
 )]
 #[case::gt(
-    Pred::gt(cast_part_int(), Scalar::from(20185i32)),
-    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) > 20185)"
+    Pred::gt(cast_part_date(), Scalar::Date(20185)),
+    "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+     CAST(Column(partitionValues_parsed.part_col) AS date) > 20185)"
 )]
 #[case::lt_commuted(
-    Pred::lt(Scalar::from(20185i32), cast_part_int()),
-    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) > 20185)"
+    Pred::lt(Scalar::Date(20185), cast_part_date()),
+    "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+     CAST(Column(partitionValues_parsed.part_col) AS date) > 20185)"
 )]
 #[case::gt_commuted(
-    Pred::gt(Scalar::from(20185i32), cast_part_int()),
-    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) < 20185)"
+    Pred::gt(Scalar::Date(20185), cast_part_date()),
+    "OR(CAST(Column(partitionValues_parsed.part_col) AS date) IS NULL, \
+     CAST(Column(partitionValues_parsed.part_col) AS date) < 20185)"
 )]
-fn test_cast_partition_rewrite_ops(#[case] pred: Pred, #[case] expected: &str) {
-    let partition_columns = test_partition_columns();
+fn test_checkpoint_cast_partition_rewrite_ops(#[case] pred: Pred, #[case] expected: &str) {
+    let partition_columns = vec!["part_col".to_string()];
+    let stats = all_referenced_columns(&pred);
     assert_eq!(
-        as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
-            .map(|p| p.to_string()),
+        as_checkpoint_skipping_predicate(&pred, &partition_columns, &stats).map(|p| p.to_string()),
         Some(expected.to_string()),
         "rewrite mismatch for {pred}"
     );
 }
 
-/// The direct evaluator exercises the commuted (`<literal> op CAST`) and inverted
-/// (`NOT(CAST op <literal>)`) operator legs, confirming the operator swap and inversion keep vs
-/// prune correctly. `part_col` resolves to the string `"42"` (integer 42).
+/// Evaluates the comparison the rewrite embeds against the exact partition value: a match keeps, a
+/// non-match prunes, and a null or unparseable value casts to NULL (never a skip). The outer
+/// `CAST(...) IS NULL` guard (see the rewrite-shape tests) keeps those NULL rows under an engine's
+/// SQL-WHERE semantics, where a bare NULL would otherwise drop the row.
 #[rstest]
-// Commuted: 41 < 42 -> keep; 43 < 42 is false -> prune.
-#[case::lt_commuted_keep(Pred::lt(Scalar::from(41i32), cast_part_int()), TRUE)]
-#[case::lt_commuted_prune(Pred::lt(Scalar::from(43i32), cast_part_int()), FALSE)]
-// Commuted: 41 > 42 is false -> prune.
-#[case::gt_commuted_prune(Pred::gt(Scalar::from(41i32), cast_part_int()), FALSE)]
-// Inverted: NOT(42 < 43) -> prune; NOT(42 < 41) -> keep.
-#[case::not_lt_prune(Pred::not(Pred::lt(cast_part_int(), Scalar::from(43i32))), FALSE)]
-#[case::not_lt_keep(Pred::not(Pred::lt(cast_part_int(), Scalar::from(41i32))), TRUE)]
-// Inverted equality: NOT(42 = 42) -> prune; NOT(42 = 43) -> keep.
-#[case::not_eq_prune(Pred::not(Pred::eq(cast_part_int(), Scalar::from(42i32))), FALSE)]
-#[case::not_eq_keep(Pred::not(Pred::eq(cast_part_int(), Scalar::from(43i32))), TRUE)]
-fn test_cast_partition_direct_eval_ops(#[case] pred: Pred, #[case] expected: Option<bool>) {
-    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
-        column_name!("part_col"),
-        Scalar::from("42"),
-    )]));
-    assert_eq!(
-        resolver.eval_pred(&pred, false),
-        expected,
-        "eval mismatch for {pred}"
+#[case::match_keep(Scalar::from("2025-04-14"), TRUE)]
+#[case::no_match_prune(Scalar::from("2025-04-15"), FALSE)]
+#[case::null_keep(Scalar::Null(DataType::STRING), NULL)]
+#[case::unparseable_keep(Scalar::from("not-a-date"), NULL)]
+fn test_checkpoint_cast_comparison_eval(#[case] part_val: Scalar, #[case] expected: Option<bool>) {
+    // 2025-04-14 is day 20192 since the epoch.
+    let comparison = Pred::eq(
+        Expr::cast(
+            column_expr!("partitionValues_parsed.part_col"),
+            DataType::DATE,
+        ),
+        Scalar::Date(20192),
     );
-}
-
-/// Pushdown is refused unless the source is a string partition column cast to an integer target
-/// *and* the comparison literal already matches that target. A literal whose type differs from the
-/// cast target (which would make the arrow comparison kernel error and abort the scan), and the
-/// timezone-sensitive `date`/`timestamp` targets (arrow parses an offset-bearing string via UTC,
-/// which can disagree with an engine's cast), all fold to keep.
-#[rstest]
-// Long literal against an INTEGER target: mismatched types -> keep.
-#[case::int_target_long_literal(
-    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::INTEGER), Scalar::from(5i64))
-)]
-// Timezone-sensitive DATE target -> keep.
-#[case::date_target(
-    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::DATE), Scalar::Date(20185))
-)]
-// Timezone-sensitive TIMESTAMP target -> keep.
-#[case::timestamp_target(
-    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::TIMESTAMP), Scalar::Timestamp(0))
-)]
-fn test_cast_partition_not_pruned(#[case] pred: Pred) {
-    let partition_columns = test_partition_columns();
-    assert_eq!(
-        as_data_skipping_predicate_with_partitions(&pred, &partition_columns),
-        None,
-        "unsound cast pushdown must fold to keep, got a skipping predicate for {pred}"
-    );
-}
-
-/// An unparseable or NULL partition value must evaluate the cast comparison to NULL (keep the
-/// file), never FALSE (which would silently drop a matching file).
-#[rstest]
-#[case::unparseable(Scalar::from("not-an-int"))]
-#[case::null_value(Scalar::Null(DataType::STRING))]
-fn test_cast_partition_unparseable_keeps(#[case] part_val: Scalar) {
     let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
-        column_name!("part_col"),
+        column_name!("partitionValues_parsed.part_col"),
         part_val,
     )]));
-    let pred = Pred::eq(cast_part_int(), Scalar::from(42i32));
-    assert_eq!(resolver.eval_pred(&pred, false), NULL);
+    assert_eq!(
+        resolver.eval(&comparison),
+        expected,
+        "eval mismatch for {comparison}"
+    );
 }
 
 #[rstest]
@@ -1676,7 +1627,6 @@ fn stats_columns_gate_rewrite(
     #[case] stats: HashSet<ColumnName>,
     #[case] expected: &str,
 ) {
-    let partition_columns = string_partition_columns(&partition_columns);
     let result =
         as_sql_data_skipping_predicate_with_stats_columns(&pred, &partition_columns, &stats)
             .expect("SQL-WHERE rewrite always returns Some for these cases");

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -688,6 +688,12 @@ fn test_partition_columns() -> HashSet<String> {
     ["part_col".to_string()].into()
 }
 
+/// `CAST(part_col AS INTEGER)`, the cast expression the partition-cast pushdown tests compare
+/// against (an integer target is the only cast-prunable target -- see `is_cast_prunable_target`).
+fn cast_part_int() -> Expr {
+    Expr::cast(column_expr!("part_col"), DataType::INTEGER)
+}
+
 /// Helper to build a resolver for mixed partition + data stats evaluation.
 fn mixed_resolver(
     part_val: &str,
@@ -739,28 +745,27 @@ fn test_partition_column_rewrite() {
     );
 }
 
-/// A `CAST(<partition_col> AS DATE) <op> <literal>` predicate rewrites to a comparison on
-/// `CAST(partitionValues_parsed.<col> AS DATE)`, guarded so Remove rows are never filtered. The
+/// A `CAST(<partition_col> AS INTEGER) <op> <literal>` predicate rewrites to a comparison on
+/// `CAST(partitionValues_parsed.<col> AS INTEGER)`, guarded so Remove rows are never filtered. The
 /// same cast over a data column is not supported (data stats aren't exact), so it folds out.
 #[test]
 fn test_cast_partition_column_rewrite() {
     let partition_columns = test_partition_columns();
 
-    let cast_part = Expr::cast(column_expr!("part_col"), DataType::DATE);
-    let pred = Pred::eq(cast_part, Scalar::Date(20185));
+    let pred = Pred::eq(cast_part_int(), Scalar::from(20185i32));
     let skipping_pred = as_data_skipping_predicate_with_partitions(&pred, &partition_columns);
     assert_eq!(
         skipping_pred.as_ref().map(|p| p.to_string()),
         Some(
-            "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS date) = 20185)"
+            "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) = 20185)"
                 .to_string()
         ),
         "cast over a partition column should compare the cast partition value, got {skipping_pred:?}"
     );
 
     // The same cast over a data column has no exact value to cast, so it is unsupported (keep).
-    let cast_data = Expr::cast(column_expr!("data_col"), DataType::DATE);
-    let pred = Pred::eq(cast_data, Scalar::Date(20185));
+    let cast_data = Expr::cast(column_expr!("data_col"), DataType::INTEGER);
+    let pred = Pred::eq(cast_data, Scalar::from(20185i32));
     assert_eq!(
         as_data_skipping_predicate_with_partitions(&pred, &partition_columns),
         None,
@@ -786,23 +791,122 @@ fn test_cast_non_string_partition_column_not_pruned() {
 }
 
 /// The direct (scalar) evaluator casts the exact string partition value and compares it, so it can
-/// keep or prune a file by evaluating `CAST(part AS DATE) = <date>` against the partition value.
+/// keep or prune a file by evaluating `CAST(part AS INTEGER) = <int>` against the partition value.
 #[test]
 fn test_cast_partition_direct_eval() {
-    // 2025-04-11 is 20189 days after the unix epoch.
     let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
         column_name!("part_col"),
-        Scalar::from("2025-04-11"),
+        Scalar::from("42"),
     )]));
-    let cast_part = Expr::cast(column_expr!("part_col"), DataType::DATE);
 
-    // Matching date: keep (TRUE).
-    let pred = Pred::eq(cast_part.clone(), Scalar::Date(20189));
+    // Matching value: keep (TRUE).
+    let pred = Pred::eq(cast_part_int(), Scalar::from(42i32));
     assert_eq!(resolver.eval_pred(&pred, false), TRUE);
 
-    // Non-matching date: prune (FALSE).
-    let pred = Pred::eq(cast_part, Scalar::Date(20190));
+    // Non-matching value: prune (FALSE).
+    let pred = Pred::eq(cast_part_int(), Scalar::from(43i32));
     assert_eq!(resolver.eval_pred(&pred, false), FALSE);
+}
+
+/// The rewrite fires for every order/equality operator, including the commuted `<literal> op
+/// CAST(<col>)` form (operator swapped so the cast column stays on the left).
+#[rstest]
+#[case::eq(
+    Pred::eq(cast_part_int(), Scalar::from(20185i32)),
+    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) = 20185)"
+)]
+#[case::lt(
+    Pred::lt(cast_part_int(), Scalar::from(20185i32)),
+    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) < 20185)"
+)]
+#[case::gt(
+    Pred::gt(cast_part_int(), Scalar::from(20185i32)),
+    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) > 20185)"
+)]
+#[case::lt_commuted(
+    Pred::lt(Scalar::from(20185i32), cast_part_int()),
+    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) > 20185)"
+)]
+#[case::gt_commuted(
+    Pred::gt(Scalar::from(20185i32), cast_part_int()),
+    "OR(NOT(Column(is_add)), CAST(Column(partitionValues_parsed.part_col) AS integer) < 20185)"
+)]
+fn test_cast_partition_rewrite_ops(#[case] pred: Pred, #[case] expected: &str) {
+    let partition_columns = test_partition_columns();
+    assert_eq!(
+        as_data_skipping_predicate_with_partitions(&pred, &partition_columns)
+            .map(|p| p.to_string()),
+        Some(expected.to_string()),
+        "rewrite mismatch for {pred}"
+    );
+}
+
+/// The direct evaluator exercises the commuted (`<literal> op CAST`) and inverted
+/// (`NOT(CAST op <literal>)`) operator legs, confirming the operator swap and inversion keep vs
+/// prune correctly. `part_col` resolves to the string `"42"` (integer 42).
+#[rstest]
+// Commuted: 41 < 42 -> keep; 43 < 42 is false -> prune.
+#[case::lt_commuted_keep(Pred::lt(Scalar::from(41i32), cast_part_int()), TRUE)]
+#[case::lt_commuted_prune(Pred::lt(Scalar::from(43i32), cast_part_int()), FALSE)]
+// Commuted: 41 > 42 is false -> prune.
+#[case::gt_commuted_prune(Pred::gt(Scalar::from(41i32), cast_part_int()), FALSE)]
+// Inverted: NOT(42 < 43) -> prune; NOT(42 < 41) -> keep.
+#[case::not_lt_prune(Pred::not(Pred::lt(cast_part_int(), Scalar::from(43i32))), FALSE)]
+#[case::not_lt_keep(Pred::not(Pred::lt(cast_part_int(), Scalar::from(41i32))), TRUE)]
+// Inverted equality: NOT(42 = 42) -> prune; NOT(42 = 43) -> keep.
+#[case::not_eq_prune(Pred::not(Pred::eq(cast_part_int(), Scalar::from(42i32))), FALSE)]
+#[case::not_eq_keep(Pred::not(Pred::eq(cast_part_int(), Scalar::from(43i32))), TRUE)]
+fn test_cast_partition_direct_eval_ops(#[case] pred: Pred, #[case] expected: Option<bool>) {
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("part_col"),
+        Scalar::from("42"),
+    )]));
+    assert_eq!(
+        resolver.eval_pred(&pred, false),
+        expected,
+        "eval mismatch for {pred}"
+    );
+}
+
+/// Pushdown is refused unless the source is a string partition column cast to an integer target
+/// *and* the comparison literal already matches that target. A literal whose type differs from the
+/// cast target (which would make the arrow comparison kernel error and abort the scan), and the
+/// timezone-sensitive `date`/`timestamp` targets (arrow parses an offset-bearing string via UTC,
+/// which can disagree with an engine's cast), all fold to keep.
+#[rstest]
+// Long literal against an INTEGER target: mismatched types -> keep.
+#[case::int_target_long_literal(
+    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::INTEGER), Scalar::from(5i64))
+)]
+// Timezone-sensitive DATE target -> keep.
+#[case::date_target(
+    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::DATE), Scalar::Date(20185))
+)]
+// Timezone-sensitive TIMESTAMP target -> keep.
+#[case::timestamp_target(
+    Pred::eq(Expr::cast(column_expr!("part_col"), DataType::TIMESTAMP), Scalar::Timestamp(0))
+)]
+fn test_cast_partition_not_pruned(#[case] pred: Pred) {
+    let partition_columns = test_partition_columns();
+    assert_eq!(
+        as_data_skipping_predicate_with_partitions(&pred, &partition_columns),
+        None,
+        "unsound cast pushdown must fold to keep, got a skipping predicate for {pred}"
+    );
+}
+
+/// An unparseable or NULL partition value must evaluate the cast comparison to NULL (keep the
+/// file), never FALSE (which would silently drop a matching file).
+#[rstest]
+#[case::unparseable(Scalar::from("not-an-int"))]
+#[case::null_value(Scalar::Null(DataType::STRING))]
+fn test_cast_partition_unparseable_keeps(#[case] part_val: Scalar) {
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("part_col"),
+        part_val,
+    )]));
+    let pred = Pred::eq(cast_part_int(), Scalar::from(42i32));
+    assert_eq!(resolver.eval_pred(&pred, false), NULL);
 }
 
 #[rstest]

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1878,6 +1878,7 @@ mod tests {
             }
             Expression::ParseJson(p) => count_to_json(&p.json_expr),
             Expression::MapToStruct(m) => count_to_json(&m.map_expr),
+            Expression::Cast(c) => count_to_json(&c.expr),
             Expression::Predicate(_)
             | Expression::Literal(_)
             | Expression::Column(_)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -536,18 +536,27 @@ impl<'a> SchemaTransform<'a> for GetReferencedFields<'a> {
     }
 }
 
-/// Prefixes all column references in a predicate with a fixed path.
-/// Transforms data-skipping predicates (e.g., `minValues.x > 100`) into
-/// checkpoint/sidecar-compatible predicates (e.g., `add.stats_parsed.minValues.x > 100`).
-struct PrefixColumns {
-    prefix: ColumnName,
-}
+/// Prefixes the column references produced by the checkpoint skipping predicate creator to match
+/// the checkpoint's physical layout. Stats references (`minValues`/`maxValues`/`nullCount`/
+/// `numRecords`) live under `add.stats_parsed`; partition references (`partitionValues_parsed.*`,
+/// emitted for cast-on-partition comparisons) live under `add` directly. Routing by the leading
+/// path segment keeps a single pass over the predicate.
+struct PrefixCheckpointColumns;
 
-impl<'a> ExpressionTransform<'a> for PrefixColumns {
+impl<'a> ExpressionTransform<'a> for PrefixCheckpointColumns {
     transform_output_type!(|'a, T| Cow<'a, T>);
 
     fn transform_expr_column(&mut self, name: &'a ColumnName) -> Cow<'a, ColumnName> {
-        Cow::Owned(self.prefix.join(name))
+        let is_partition = name
+            .path()
+            .first()
+            .is_some_and(|f| f == "partitionValues_parsed");
+        let prefix = if is_partition {
+            ColumnName::new(["add"])
+        } else {
+            ColumnName::new(["add", "stats_parsed"])
+        };
+        Cow::Owned(prefix.join(name))
     }
 }
 
@@ -1013,21 +1022,26 @@ impl Scan {
         };
         self.state_info.physical_stats_schema.as_ref()?;
 
-        let partition_columns = self
-            .snapshot
-            .table_configuration()
-            .metadata()
-            .partition_columns();
+        // The predicate uses physical column names, so partition detection needs physical names
+        // too. `physical_partition_schema` carries them whenever the predicate references a
+        // partition column; the logical fallback is equivalent under identity column mapping.
+        let partition_columns: Vec<String> =
+            match self.state_info.physical_partition_schema.as_ref() {
+                Some(schema) => schema.fields().map(|f| f.name().to_string()).collect(),
+                None => self
+                    .snapshot
+                    .table_configuration()
+                    .metadata()
+                    .partition_columns()
+                    .to_vec(),
+            };
         let skipping_pred = as_checkpoint_skipping_predicate(
             predicate,
-            partition_columns,
+            &partition_columns,
             &self.state_info.physical_stats_columns,
         )?;
 
-        let mut prefixer = PrefixColumns {
-            prefix: ColumnName::new(["add", "stats_parsed"]),
-        };
-        let prefixed = prefixer.transform_pred(&skipping_pred);
+        let prefixed = PrefixCheckpointColumns.transform_pred(&skipping_pred);
         Some(Arc::new(prefixed.into_owned()))
     }
 

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1096,18 +1096,28 @@ fn test_scan_metadata_stats_columns_with_predicate() {
 }
 
 #[test]
-fn test_prefix_columns_simple() {
-    let mut prefixer = PrefixColumns {
-        prefix: ColumnName::new(["add", "stats_parsed"]),
-    };
-    // A simple binary predicate: x > 100
-    let pred = Pred::gt(column_expr!("x"), Expr::literal(100i64));
-    let result = prefixer.transform_pred(&pred).into_owned();
+fn test_prefix_checkpoint_columns_data_column() {
+    // A data-column stat reference routes under add.stats_parsed.
+    let pred = Pred::gt(column_expr!("minValues.x"), Expr::literal(100i64));
+    let result = PrefixCheckpointColumns.transform_pred(&pred).into_owned();
 
-    // The column reference should now be add.stats_parsed.x
     let refs: Vec<_> = result.references().into_iter().collect();
     assert_eq!(refs.len(), 1);
-    assert_eq!(*refs[0], column_name!("add.stats_parsed.x"));
+    assert_eq!(*refs[0], column_name!("add.stats_parsed.minValues.x"));
+}
+
+#[test]
+fn test_prefix_checkpoint_columns_partition_column() {
+    // A partition-value reference routes under add directly, not add.stats_parsed.
+    let pred = Pred::gt(
+        column_expr!("partitionValues_parsed.p"),
+        Expr::literal(100i64),
+    );
+    let result = PrefixCheckpointColumns.transform_pred(&pred).into_owned();
+
+    let refs: Vec<_> = result.references().into_iter().collect();
+    assert_eq!(refs.len(), 1);
+    assert_eq!(*refs[0], column_name!("add.partitionValues_parsed.p"));
 }
 
 #[test]
@@ -1144,6 +1154,44 @@ fn test_build_actions_meta_predicate_with_predicate() {
             "Column reference should have 'stats_parsed' as second element: {col_ref}"
         );
     }
+}
+
+/// A cast over a partition column must resolve to that column's *physical* name under column
+/// mapping, since the meta predicate is in physical names. The `category` partition column has
+/// physical name `col-6dc68f07-...`, so the rewrite references
+/// `add.partitionValues_parsed.col-6dc68f07-...`, not the logical `category`. The predicate also
+/// touches the `value` data column so a stats schema exists (else the meta predicate is skipped).
+#[test]
+fn test_build_actions_meta_predicate_partition_cast_uses_physical_name() {
+    let (_engine, snapshot) = without_transforms_snapshot("./tests/data/partition_cm/name/");
+    let category_physical = "col-6dc68f07-711d-4f00-8bd6-1f5bc698e8ad";
+
+    let predicate = Arc::new(Pred::and(
+        Pred::gt(
+            Expr::cast(column_expr!("category"), DataType::LONG),
+            Expr::literal(100i64),
+        ),
+        Pred::gt(column_expr!("value"), Expr::literal(0i32)),
+    ));
+    let scan = snapshot
+        .scan_builder()
+        .with_predicate(predicate)
+        .build()
+        .unwrap();
+
+    let meta_pred = scan
+        .build_actions_meta_predicate()
+        .expect("cast over a partition column should produce a meta predicate");
+    let refs: Vec<_> = meta_pred.references().into_iter().cloned().collect();
+    assert!(
+        refs.contains(&ColumnName::new([
+            "add",
+            "partitionValues_parsed",
+            category_physical
+        ])),
+        "partition cast must reference the physical partition column under \
+         add.partitionValues_parsed, got {refs:?}"
+    );
 }
 
 #[test]
@@ -1294,14 +1342,15 @@ impl CheckpointParquetBuilder {
     }
 }
 
-/// Builds a checkpoint skipping predicate and prefixes column references with `add.stats_parsed`.
+/// Builds a checkpoint skipping predicate and prefixes column references for the checkpoint layout.
 fn build_prefixed_checkpoint_predicate(pred: &Pred) -> Option<Pred> {
     let stats = all_referenced_columns(pred);
     let skipping_pred = as_checkpoint_skipping_predicate(pred, &[], &stats)?;
-    let mut prefixer = PrefixColumns {
-        prefix: ColumnName::new(["add", "stats_parsed"]),
-    };
-    Some(prefixer.transform_pred(&skipping_pred).into_owned())
+    Some(
+        PrefixCheckpointColumns
+            .transform_pred(&skipping_pred)
+            .into_owned(),
+    )
 }
 
 /// Applies a meta predicate as a row group filter and returns the total rows read.

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -2,7 +2,7 @@ use std::borrow::{Cow, ToOwned};
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef,
+    BinaryExpression, BinaryPredicate, CastExpression, ColumnName, Expression, ExpressionRef,
     ExpressionStructPatch, JunctionPredicate, MapToStructExpression, OpaqueExpression,
     OpaquePredicate, ParseJsonExpression, Predicate, Scalar, UnaryExpression, UnaryPredicate,
     VariadicExpression,
@@ -139,6 +139,12 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_expr_map_to_struct(expr)
     }
 
+    /// Called for each cast expression encountered during the traversal. The provided
+    /// implementation just forwards to [`Self::recurse_into_expr_cast`].
+    fn transform_expr_cast(&mut self, expr: &'a CastExpression) -> Self::Output<CastExpression> {
+        self.recurse_into_expr_cast(expr)
+    }
+
     /// Called for the child of each predicate expression encountered during the
     /// traversal. The provided implementation just forwards to [`Self::recurse_into_expr_pred`].
     fn transform_expr_pred(&mut self, pred: &'a Predicate) -> Self::Output<Predicate> {
@@ -262,6 +268,10 @@ pub trait ExpressionTransform<'a> {
                 let child = self.transform_expr_map_to_struct(m);
                 map_owned_or_else(expr, child, Expression::MapToStruct)
             }
+            Expression::Cast(c) => {
+                let child = self.transform_expr_cast(c);
+                map_owned_or_else(expr, child, Expression::Cast)
+            }
             Expression::Unknown(u) => {
                 let child = self.transform_expr_unknown(u);
                 map_owned_or_else(expr, child, Expression::Unknown)
@@ -335,6 +345,12 @@ pub trait ExpressionTransform<'a> {
     ) -> Self::Output<MapToStructExpression> {
         let nested = self.transform_expr(&expr.map_expr);
         map_owned_or_else(expr, nested, MapToStructExpression::new)
+    }
+
+    /// Recursively transforms the child expression of a cast expression (unary).
+    fn recurse_into_expr_cast(&mut self, expr: &'a CastExpression) -> Self::Output<CastExpression> {
+        let f = |child| CastExpression::new(child, expr.target.clone());
+        map_owned_or_else(expr, self.transform_expr(&expr.expr), f)
     }
 
     /// Recursively transforms the children of an opaque expression (variadic).


### PR DESCRIPTION
## What changes are proposed in this pull request?

This adds a `Cast` node to the expression AST and teaches the scan/data-skipping path to evaluate it, so a typed cast can be pushed down for **partition** pruning.

### Why

Connectors push query filters into the kernel as `Expression` trees for file pruning, but there's no way to represent a typed cast today. A predicate like `CAST(<string partition column> AS DATE) < '2025-01-01'` either gets dropped (no pruning) or degrades to a lexicographic string comparison (wrong for dates/ints). This lets it be represented and evaluated with the right types.

### What it adds

- `Expression::Cast { expr, target }` with SQL `CAST` semantics — an unrepresentable value casts to `NULL` rather than erroring. Constructor, `Display` (`CAST(<expr> AS <type>)`), and serde.
- Arrow evaluation via arrow's safe `cast`, validated against the declared result type. An arrow-unsupported type pair degrades to an all-NULL column instead of erroring, so a cast the engine can't do keeps the scan alive rather than aborting it.
- A new `eval_pred_cast` hook on the predicate evaluators (default: unsupported → keep the file), dispatched from `eval_pred_binary` for `CAST(<col>) <op> <literal>` and its commuted form.
- The data-skipping rewrite turns a partition-column cast into a comparison on `CAST(partitionValues_parsed.<col> AS target)`, guarded by `OR(NOT is_add, ...)` so Remove rows are never filtered.

### Why cast-pruning is limited to `string → primitive` on partition columns

This is the correctness crux — two independent reasons land on the same restriction:

- **Partition-only.** A partition column has one exact value per file (`min == max`), so casting that single value and comparing is precise. A data column would have to cast its min/max stats, which is unsound: a cast isn't order-preserving (`"10" < "9"` as strings but `10 > 9` as ints), so casted stats needn't bound the casted values, and pruning on them could drop a matching file. Data-column casts fold to keep.
- **String-source.** Pruning is only sound when the engine and the kernel compute the *same* cast. Parsing a string into a primitive is the protocol's own partition-value parsing — deterministic across engines. Other directions (`date → string` rendering, `float → int` rounding, timezone interpretation) can differ, and a disagreement in the pruning direction would skip a file the engine would have matched. Non-string sources fold to keep too.

At the plans-proto and engine-visitor FFI boundaries there's no cast node yet, so a `Cast` surfaces as an opaque `Unknown("cast_to_<type>")` — the boundary neither drops it nor fabricates a different node; a receiver treats it as uninterpretable rather than misreading it.

## How was this change tested?

Added tests covering the partition-column rewrite (and the data-column/non-string cases folding to keep), the direct evaluator's cast-and-compare, arrow safe-cast NULL semantics, the unsupported-pair → NULL degradation, result-type validation, and serde round-trip. Full workspace tests, clippy, and fmt pass.
