### PR TITLE
fix: bump parquet to 58.1 and preserve exact zero null counts

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -74,7 +74,7 @@ features = ["chrono-tz", "ffi", "json"]
 optional = true
 [dependencies.parquet_58]
 package = "parquet"
-version = "58"
+version = "58.1"
 features = ["async", "object_store"]
 optional = true
 

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -254,17 +254,15 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
     Some(value)
 }
 
-/// Extracts the null count from parquet footer statistics for a column.
+/// Extracts the null count from parquet footer statistics for a column. Returns `None` when the
+/// footer carries no null count for the column (parquet 58.1+ preserves a missing count as `None`
+/// rather than forcing it to zero; see https://github.com/apache/arrow-rs/issues/9451), and
+/// `Some(0)` when the footer genuinely reports zero nulls.
 fn extract_nullcount(stats: Option<&Statistics>) -> Option<i64> {
-    // WARNING: The parquet footer decoding forces missing stats to Some(0), which would cause
-    // an IS NULL predicate to wrongly skip the file if it contains any NULL values. To be safe,
-    // we must never return Some(0). See https://github.com/apache/arrow-rs/issues/9451.
-    let nullcount = stats?.null_count_opt().filter(|n| *n > 0);
-
     // Parquet nullcount stats are always u64, so we can directly return the value instead of
     // wrapping it in a Scalar. We can safely cast it from u64 to i64 because the nullcount can
     // never be larger than the rowcount and the parquet rowcount stat is i64.
-    Some(nullcount? as i64)
+    Some(stats?.null_count_opt()? as i64)
 }
 
 fn decimal_from_bytes(bytes: Option<&[u8]>, dtype: DecimalType) -> Option<Scalar> {

--- a/kernel/src/engine/parquet_row_group_skipping.rs
+++ b/kernel/src/engine/parquet_row_group_skipping.rs
@@ -254,14 +254,10 @@ fn extract_max_scalar(data_type: &DataType, stats: &Statistics) -> Option<Scalar
     Some(value)
 }
 
-/// Extracts the null count from parquet footer statistics for a column. Returns `None` when the
-/// footer carries no null count for the column (parquet 58.1+ preserves a missing count as `None`
-/// rather than forcing it to zero; see https://github.com/apache/arrow-rs/issues/9451), and
-/// `Some(0)` when the footer genuinely reports zero nulls.
+/// Extracts the null count from parquet footer statistics for a column. Returns `None` for a
+/// missing count (parquet 58.1+ no longer forces it to zero, see arrow-rs#9451).
 fn extract_nullcount(stats: Option<&Statistics>) -> Option<i64> {
-    // Parquet nullcount stats are always u64, so we can directly return the value instead of
-    // wrapping it in a Scalar. We can safely cast it from u64 to i64 because the nullcount can
-    // never be larger than the rowcount and the parquet rowcount stat is i64.
+    // Cast u64 to i64 is safe: nullcount can never exceed the i64 rowcount.
     Some(stats?.null_count_opt()? as i64)
 }
 

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -87,8 +87,7 @@ fn test_get_stat_values() {
         Some(3i64.into())
     );
 
-    // The utf8 column has no nulls, and parquet 58.1+ reports its footer null count as an exact
-    // zero (see https://github.com/apache/arrow-rs/issues/9451).
+    // No nulls -> exact zero count (parquet 58.1+, arrow-rs#9451).
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("varlen.utf8")),
         Some(0i64.into())
@@ -459,64 +458,29 @@ fn test_get_stat_values() {
     );
 }
 
-// A missing footer null count must decode to `None` (keep the row group), while an exact zero
-// count must be preserved as `Some(0)`. Parquet 58.1+ distinguishes the two; earlier versions
-// forced a missing count to zero (arrow-rs#9451), which this extractor previously worked around
-// by suppressing every zero -- losing the legitimate `Some(0)` needed to prune on IS NULL.
+// A missing footer null count decodes to `None`; an exact zero is preserved as `Some(0)`. Parquet
+// 58.1+ distinguishes the two (arrow-rs#9451).
 #[test]
 fn test_extract_nullcount_distinguishes_missing_from_zero() {
-    // No statistics at all -> None (can't decide, keep).
+    let stats = |null_count| Statistics::int64(Some(1), Some(2), None, null_count, false);
     assert_eq!(extract_nullcount(None), None);
-    // Statistics present but null count absent -> None (can't decide, keep).
-    assert_eq!(
-        extract_nullcount(Some(&Statistics::int64(
-            Some(1),
-            Some(2),
-            None,
-            None,
-            false
-        ))),
-        None
-    );
-    // Exact zero null count -> Some(0) (no nulls; IS NULL can prune).
-    assert_eq!(
-        extract_nullcount(Some(&Statistics::int64(
-            Some(1),
-            Some(2),
-            None,
-            Some(0),
-            false
-        ))),
-        Some(0)
-    );
-    // Positive null count -> preserved.
-    assert_eq!(
-        extract_nullcount(Some(&Statistics::int64(
-            Some(1),
-            Some(2),
-            None,
-            Some(3),
-            false
-        ))),
-        Some(3)
-    );
+    assert_eq!(extract_nullcount(Some(&stats(None))), None);
+    assert_eq!(extract_nullcount(Some(&stats(Some(0)))), Some(0));
+    assert_eq!(extract_nullcount(Some(&stats(Some(3)))), Some(3));
 }
 
-// An exact zero footer null count lets IS NULL prune a row group whose column has no nulls, while
-// a positive count keeps it. Exercises the production `RowGroupFilter::apply` path against the
-// shared fixture (`varlen.utf8` has 0 nulls, `bool` has 3).
+// A zero null count lets IS NULL prune a column with no nulls; a positive count keeps it. The
+// fixture's `varlen.utf8` has 0 nulls, `bool` has 3.
 #[test]
 fn test_row_group_filter_is_null_prunes_when_nullcount_is_zero() {
     let file = File::open("./tests/data/parquet_row_group_skipping/part-00000-b92e017a-50ba-4676-8322-48fc371c2b59-c000.snappy.parquet").unwrap();
     let metadata = ArrowReaderMetadata::load(&file, Default::default()).unwrap();
     let row_group = metadata.metadata().row_group(0);
 
-    // `varlen.utf8` has an exact zero null count, so IS NULL matches nothing and prunes.
     assert!(!RowGroupFilter::apply(
         row_group,
         &Predicate::is_null(column_name!("varlen.utf8"))
     ));
-    // `bool` has 3 nulls, so IS NULL keeps the row group.
     assert!(RowGroupFilter::apply(
         row_group,
         &Predicate::is_null(column_name!("bool"))
@@ -1099,10 +1063,8 @@ fn checkpoint_filter_opaque_predicate_with_missing_stats() {
 
 #[test]
 fn checkpoint_filter_partition_is_null_prunes_when_all_values_present() {
-    // All partition values are non-null, so the footer null count for
-    // partitionValues_parsed.part_col is an exact 0 (parquet 58.1+ no longer conflates a missing
-    // count with zero, see https://github.com/apache/arrow-rs/issues/9451). `part_col IS NULL`
-    // therefore matches no add file and the row group can be pruned.
+    // All partition values non-null -> exact zero null count, so IS NULL matches nothing and
+    // prunes.
     let tmp = write_checkpoint_parquet(
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
@@ -1117,12 +1079,10 @@ fn checkpoint_filter_partition_is_null_prunes_when_all_values_present() {
     let predicate = Predicate::is_null(column_name!("part_col"));
     let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &partition_columns);
 
-    // The footer reports an exact zero null count for the partition value column.
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("part_col")),
         Some(0i64.into())
     );
-    // IS NULL evaluates to Some(false) -> the row group is pruned.
     assert_eq!(filter.eval_sql_where(&predicate), Some(false));
 }
 

--- a/kernel/src/engine/parquet_row_group_skipping/tests.rs
+++ b/kernel/src/engine/parquet_row_group_skipping/tests.rs
@@ -87,10 +87,11 @@ fn test_get_stat_values() {
         Some(3i64.into())
     );
 
-    // Should be Some(0), but https://github.com/apache/arrow-rs/issues/9451
+    // The utf8 column has no nulls, and parquet 58.1+ reports its footer null count as an exact
+    // zero (see https://github.com/apache/arrow-rs/issues/9451).
     assert_eq!(
         filter.get_nullcount_stat(&column_name!("varlen.utf8")),
-        None // Some(0i64.into())
+        Some(0i64.into())
     );
 
     assert_eq!(
@@ -456,6 +457,70 @@ fn test_get_stat_values() {
                 .unwrap()
         )
     );
+}
+
+// A missing footer null count must decode to `None` (keep the row group), while an exact zero
+// count must be preserved as `Some(0)`. Parquet 58.1+ distinguishes the two; earlier versions
+// forced a missing count to zero (arrow-rs#9451), which this extractor previously worked around
+// by suppressing every zero -- losing the legitimate `Some(0)` needed to prune on IS NULL.
+#[test]
+fn test_extract_nullcount_distinguishes_missing_from_zero() {
+    // No statistics at all -> None (can't decide, keep).
+    assert_eq!(extract_nullcount(None), None);
+    // Statistics present but null count absent -> None (can't decide, keep).
+    assert_eq!(
+        extract_nullcount(Some(&Statistics::int64(
+            Some(1),
+            Some(2),
+            None,
+            None,
+            false
+        ))),
+        None
+    );
+    // Exact zero null count -> Some(0) (no nulls; IS NULL can prune).
+    assert_eq!(
+        extract_nullcount(Some(&Statistics::int64(
+            Some(1),
+            Some(2),
+            None,
+            Some(0),
+            false
+        ))),
+        Some(0)
+    );
+    // Positive null count -> preserved.
+    assert_eq!(
+        extract_nullcount(Some(&Statistics::int64(
+            Some(1),
+            Some(2),
+            None,
+            Some(3),
+            false
+        ))),
+        Some(3)
+    );
+}
+
+// An exact zero footer null count lets IS NULL prune a row group whose column has no nulls, while
+// a positive count keeps it. Exercises the production `RowGroupFilter::apply` path against the
+// shared fixture (`varlen.utf8` has 0 nulls, `bool` has 3).
+#[test]
+fn test_row_group_filter_is_null_prunes_when_nullcount_is_zero() {
+    let file = File::open("./tests/data/parquet_row_group_skipping/part-00000-b92e017a-50ba-4676-8322-48fc371c2b59-c000.snappy.parquet").unwrap();
+    let metadata = ArrowReaderMetadata::load(&file, Default::default()).unwrap();
+    let row_group = metadata.metadata().row_group(0);
+
+    // `varlen.utf8` has an exact zero null count, so IS NULL matches nothing and prunes.
+    assert!(!RowGroupFilter::apply(
+        row_group,
+        &Predicate::is_null(column_name!("varlen.utf8"))
+    ));
+    // `bool` has 3 nulls, so IS NULL keeps the row group.
+    assert!(RowGroupFilter::apply(
+        row_group,
+        &Predicate::is_null(column_name!("bool"))
+    ));
 }
 
 // Intervals are unsupported for skipping under any footer encoding, so extraction returns None.
@@ -1033,10 +1098,11 @@ fn checkpoint_filter_opaque_predicate_with_missing_stats() {
 }
 
 #[test]
-fn checkpoint_filter_partition_nullcount_is_null() {
-    // All partition values are non-null, so footer nullcount for partitionValues_parsed.part_col
-    // is 0. extract_nullcount suppresses Some(0) due to the arrow-rs#9451 workaround, so
-    // get_nullcount_stat returns None. IS NULL on the partition column can't prune.
+fn checkpoint_filter_partition_is_null_prunes_when_all_values_present() {
+    // All partition values are non-null, so the footer null count for
+    // partitionValues_parsed.part_col is an exact 0 (parquet 58.1+ no longer conflates a missing
+    // count with zero, see https://github.com/apache/arrow-rs/issues/9451). `part_col IS NULL`
+    // therefore matches no add file and the row group can be pruned.
     let tmp = write_checkpoint_parquet(
         &[Some(10), Some(20)],
         &[Some(100), Some(200)],
@@ -1051,10 +1117,13 @@ fn checkpoint_filter_partition_nullcount_is_null() {
     let predicate = Predicate::is_null(column_name!("part_col"));
     let filter = CheckpointRowGroupFilter::new(row_group, &predicate, &partition_columns);
 
-    // extract_nullcount never returns Some(0), so nullcount stat is None (can't decide).
-    assert_eq!(filter.get_nullcount_stat(&column_name!("part_col")), None);
-    // IS NULL evaluates to None (can't decide) -> row group is kept.
-    assert_eq!(filter.eval_sql_where(&predicate), None);
+    // The footer reports an exact zero null count for the partition value column.
+    assert_eq!(
+        filter.get_nullcount_stat(&column_name!("part_col")),
+        Some(0i64.into())
+    );
+    // IS NULL evaluates to Some(false) -> the row group is pruned.
+    assert_eq!(filter.eval_sql_where(&predicate), Some(false));
 }
 
 #[test]

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1331,14 +1331,12 @@ fn apply_row_group_filter(parquet_bytes: Bytes, meta_predicate: &Pred) -> usize 
 #[rstest]
 #[case::comparison(
     Pred::gt(column_expr!("id"), Expr::literal(200i64)),
-    // Should skip RG2 and RG3, but https://github.com/apache/arrow-rs/issues/9451
-    Some(6), // Some(3),
+    Some(3),
     "keep RG 0 (null stats) + RG 1 (max>200), skip RG 2 + RG 3 (max<200)"
 )]
 #[case::is_null(
     Pred::is_null(column_expr!("id")),
-    // Should skip RG 1 (nullCount=0), but https://github.com/apache/arrow-rs/issues/9451
-    Some(6), // Some(5),
+    Some(5),
     "keep RG 0 (nullCount>0) + RG 2 (nullCount>0) + RG 3 (null nullCount), skip RG 1 (nullCount=0)"
 )]
 #[case::is_not_null(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bumps `parquet_58` from `58` to `58.1` so we can drop the `extract_nullcount` workaround for [arrow-rs#9451](https://github.com/apache/arrow-rs/issues/9451).

Older parquet forced a missing footer null count to `Some(0)`, so we had to suppress every zero to avoid a missing count masquerading as "no nulls" and wrongly pruning on `IS NULL`. The downside was that a genuine zero null count got thrown away too, so `IS NULL` could never prune a row group whose column really has no nulls. 58.1 tells the two apart (`None` for missing, `Some(0)` for an exact zero), so `extract_nullcount` just forwards the value and the pruning works as intended.

## How was this change tested?

Added unit and end-to-end tests for the missing-vs-zero null count, and un-gated the existing tests that were waiting on this bump.
