### PR TITLE
fix: apply schema-derived IS NOT NULL skipping in parallel checkpoint reads

### DIFF
--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -135,7 +135,7 @@ fn action_presence_witness(action_name: &str) -> Option<ColumnName> {
 /// Each requested action contributes an `IS NOT NULL` presence witness, and the witnesses are
 /// joined with `OR`. Returns `None` if the schema is empty, or if any field lacks a reliable
 /// witness (an action that could occupy a row group the resulting predicate would otherwise skip).
-fn checkpoint_action_projection_predicate(schema: &StructType) -> Option<PredicateRef> {
+pub(crate) fn checkpoint_action_projection_predicate(schema: &StructType) -> Option<PredicateRef> {
     let columns: Vec<ColumnName> = schema
         .fields()
         .map(|field| action_presence_witness(field.name()))

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -12,6 +12,7 @@ use delta_kernel_derive::internal_api;
 use itertools::Itertools;
 
 use crate::log_replay::{ActionsBatch, ParallelLogReplayProcessor};
+use crate::log_segment::checkpoint_action_projection_predicate;
 use crate::scan::CHECKPOINT_READ_SCHEMA;
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Engine, EngineData, FileMeta};
@@ -53,9 +54,13 @@ impl<P: ParallelLogReplayProcessor> ParallelPhase<P> {
         leaf_files: Vec<FileMeta>,
         read_schema: SchemaRef,
     ) -> DeltaResult<Self> {
+        // Derive an IS NOT NULL predicate from the read schema so checkpoint parquet row groups
+        // with no relevant action type are skipped, matching the sequential path in
+        // `LogSegment::read_actions_with_projected_checkpoint_actions`.
+        let is_not_null_pred = checkpoint_action_projection_predicate(&read_schema);
         let leaf_checkpoint_reader = engine
             .parquet_handler()
-            .read_parquet_files(&leaf_files, read_schema, None)?
+            .read_parquet_files(&leaf_files, read_schema, is_not_null_pred)?
             .map_ok(|batch| ActionsBatch::new(batch, false));
         Ok(Self {
             processor,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #2951. The parallel checkpoint read path did not apply the IS NOT NULL row-group skipping predicate that the sequential path derives from the checkpoint read schema, so it decoded row groups the sequential path skips (e.g. all-remove parts).

`ParallelPhase::try_new` read the leaf/sidecar files with a `None` predicate, while `LogSegment::read_actions_with_projected_checkpoint_actions` derives one via `schema_to_is_not_null_predicate` and passes it to the parquet read. This widens `schema_to_is_not_null_predicate` to `pub(crate)` and derives the same predicate from the read schema in the parallel path. Since the parallel leaf reads use the same add-only checkpoint schema, the derived predicate matches the sequential one. Results are unchanged; the parallel path just stops decoding row groups it would immediately discard.

## How was this change tested?

The existing `test_parallel_workflow_with_metrics` suite asserts the parallel workflow returns the same files as single-node `scan_metadata` across the sidecar and all-remove tables, so it guards against the predicate skipping any row group that still holds a needed action. `cargo test -p delta_kernel --all-features --lib parallel::` passes (64 tests), as do the `schema_to_is_not_null_predicate` unit cases. No dedicated test is added because row-group skipping happens at the parquet layer before the visitor and is not surfaced by the existing metrics, and the correctness invariant (identical output) is already covered by that suite; happy to add a table fixture that exercises the skip if reviewers prefer.
