### PR TITLE
fix: normalize decimal scalar parsing failures to ParseError

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -931,24 +931,6 @@ mod tests {
     }
 
     #[test]
-    fn test_decimal_parse_errors_normalized() {
-        // Failures caused by the raw decimal string must surface as ParseError, not the
-        // lower-level ParseIntError / InvalidDecimal variants they originate from.
-        let dtype = DecimalType::try_new(5, 2).unwrap();
-        let cases = [
-            "1.2e",    // non-numeric exponent -> ParseIntError from exp parse
-            "1x.23",   // non-numeric integer part -> ParseIntError from int parse
-            "1.2x",    // non-numeric fractional part -> ParseIntError from combined parse
-            "1234.56", // exceeds target precision -> InvalidDecimal from DecimalData::try_new
-        ];
-        for raw in cases {
-            match PrimitiveType::parse_decimal(raw, dtype) {
-                Err(Error::ParseError(..)) => {}
-                other => panic!("expected ParseError for {raw:?}, got {other:?}"),
-            }
-        }
-    }
-    #[test]
     fn test_decimal_display() {
         let s = Scalar::decimal(123456789, 9, 2).unwrap();
         assert_eq!(s.to_string(), "1234567.89");
@@ -1061,8 +1043,10 @@ mod tests {
 
     fn expect_fail_parse(raw: &str, prec: u8, scale: u8) {
         let s = PrimitiveType::decimal(prec, scale).unwrap();
-        let res = s.parse_scalar(raw);
-        assert!(res.is_err(), "Fail on {raw}");
+        match s.parse_scalar(raw) {
+            Err(Error::ParseError(..)) => {}
+            other => panic!("expected ParseError for {raw:?}, got {other:?}"),
+        }
     }
 
     #[test]

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -837,16 +837,15 @@ impl PrimitiveType {
     }
 
     fn parse_decimal(raw: &str, dtype: DecimalType) -> Result<Scalar, Error> {
-        // TODO(#2950): Normalize all decimal parsing failures to Error::ParseError.
+        let parse_error = || PrimitiveType::from(dtype).parse_error(raw);
         let (base, exp): (&str, i128) = match raw.find(['e', 'E']) {
             None => (raw, 0), // no 'e' or 'E', so there's no exponent
             Some(pos) => {
                 let (base, exp) = raw.split_at(pos);
                 // exp now has '[e/E][exponent]', strip the 'e/E' and parse it
-                (base, exp[1..].parse()?)
+                (base, exp[1..].parse().map_err(|_| parse_error())?)
             }
         };
-        let parse_error = || PrimitiveType::from(dtype).parse_error(raw);
         require!(!base.is_empty(), parse_error());
 
         // now split on any '.' and parse
@@ -871,10 +870,14 @@ impl PrimitiveType {
         let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
         require!(scale == dtype.scale(), parse_error());
         let int: i128 = match frac_part {
-            None => int_part.parse()?,
-            Some(frac_part) => format!("{int_part}{frac_part}").parse()?,
+            None => int_part.parse().map_err(|_| parse_error())?,
+            Some(frac_part) => format!("{int_part}{frac_part}")
+                .parse()
+                .map_err(|_| parse_error())?,
         };
-        Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
+        DecimalData::try_new(int, dtype)
+            .map(Scalar::Decimal)
+            .map_err(|_| parse_error())
     }
 }
 
@@ -925,6 +928,25 @@ mod tests {
         DecimalData::try_new(123456789, dtype).expect_err("should have failed");
         PrimitiveType::parse_decimal("0.12345", dtype).expect_err("should have failed");
         PrimitiveType::parse_decimal("12345", dtype).expect_err("should have failed");
+    }
+
+    #[test]
+    fn test_decimal_parse_errors_normalized() {
+        // Failures caused by the raw decimal string must surface as ParseError, not the
+        // lower-level ParseIntError / InvalidDecimal variants they originate from.
+        let dtype = DecimalType::try_new(5, 2).unwrap();
+        let cases = [
+            "1.2e",    // non-numeric exponent -> ParseIntError from exp parse
+            "1x.23",   // non-numeric integer part -> ParseIntError from int parse
+            "1.2x",    // non-numeric fractional part -> ParseIntError from combined parse
+            "1234.56", // exceeds target precision -> InvalidDecimal from DecimalData::try_new
+        ];
+        for raw in cases {
+            match PrimitiveType::parse_decimal(raw, dtype) {
+                Err(Error::ParseError(..)) => {}
+                other => panic!("expected ParseError for {raw:?}, got {other:?}"),
+            }
+        }
     }
     #[test]
     fn test_decimal_display() {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #2950.

`PrimitiveType::parse_scalar` documents invalid encodings as `Error::ParseError`, but `parse_decimal` leaks lower-level variants for failures caused by the raw string:

- a non-numeric exponent or integer/fraction returns `Error::ParseIntError` through `?`
- a value exceeding the target precision returns `Error::InvalidDecimal` from `DecimalData::try_new`

This maps those raw-string failures to the existing `parse_error()` closure (`ParseError(raw, target_type)`), matching the rest of `parse_scalar`. `DecimalData::try_new` still surfaces `InvalidDecimal` when called directly to construct a decimal, so that variant keeps its meaning for direct type/value construction.

## How was this change tested?

`cargo test -p delta_kernel --lib expressions::scalars` (all green). Added `test_decimal_parse_errors_normalized`, which asserts each of the four leak paths (bad exponent, bad integer part, bad fraction, over-precision) now returns `ParseError`; it fails on `main` with `ParseIntError`/`InvalidDecimal`.
