### PR TITLE
fix: normalize decimal scalar parse errors

### DIFF
--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -832,15 +832,15 @@ impl PrimitiveType {
     }
 
     fn parse_decimal(raw: &str, dtype: DecimalType) -> Result<Scalar, Error> {
+        let parse_error = || PrimitiveType::from(dtype).parse_error(raw);
         let (base, exp): (&str, i128) = match raw.find(['e', 'E']) {
             None => (raw, 0), // no 'e' or 'E', so there's no exponent
             Some(pos) => {
                 let (base, exp) = raw.split_at(pos);
                 // exp now has '[e/E][exponent]', strip the 'e/E' and parse it
-                (base, exp[1..].parse()?)
+                (base, exp[1..].parse().map_err(|_| parse_error())?)
             }
         };
-        let parse_error = || PrimitiveType::from(dtype).parse_error(raw);
         require!(!base.is_empty(), parse_error());
 
         // now split on any '.' and parse
@@ -865,10 +865,14 @@ impl PrimitiveType {
         let scale: u8 = scale.try_into().map_err(|_| parse_error())?;
         require!(scale == dtype.scale(), parse_error());
         let int: i128 = match frac_part {
-            None => int_part.parse()?,
-            Some(frac_part) => format!("{int_part}{frac_part}").parse()?,
+            None => int_part.parse().map_err(|_| parse_error())?,
+            Some(frac_part) => format!("{int_part}{frac_part}")
+                .parse()
+                .map_err(|_| parse_error())?,
         };
-        Ok(Scalar::Decimal(DecimalData::try_new(int, dtype)?))
+        Ok(Scalar::Decimal(
+            DecimalData::try_new(int, dtype).map_err(|_| parse_error())?,
+        ))
     }
 }
 
@@ -1013,8 +1017,14 @@ mod tests {
 
     fn expect_fail_parse(raw: &str, prec: u8, scale: u8) {
         let s = PrimitiveType::decimal(prec, scale).unwrap();
-        let res = s.parse_scalar(raw);
-        assert!(res.is_err(), "Fail on {raw}");
+        let expected_type = s.data_type();
+        match s.parse_scalar(raw) {
+            Err(Error::ParseError(value, data_type)) => {
+                assert_eq!(value, raw);
+                assert_eq!(data_type, expected_type);
+            }
+            result => panic!("expected ParseError for {raw}, got {result:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Normalize failures caused by serialized decimal strings to `Error::ParseError`, matching the documented `PrimitiveType::parse_scalar` contract. Direct `DecimalData::try_new` callers continue to receive `InvalidDecimal`.

Closes #2950

## How was this change tested?

- `cargo +nightly fmt -- --check`
- `cargo test -p delta_kernel --lib` (3,412 passed; 42 ignored)
- `cargo clippy -p delta_kernel --tests --benches -- -D warnings`
- `cargo doc -p delta_kernel --no-deps` (completed with pre-existing rustdoc warnings)