### PR TITLE
feat: add UC Delta-Tables reportMetrics wire types and client method

### DIFF
--- a/docs/user-guide/src/unity_catalog/writing.md
+++ b/docs/user-guide/src/unity_catalog/writing.md
@@ -188,6 +188,51 @@ Publishing copies each staged commit from `_staged_commits/<version>.<uuid>.json
 to `_delta_log/<version>.json`. If a published file already exists (from a
 previous publish attempt), the copy is silently skipped.
 
+## Report commit metrics
+
+After a successful commit, report commit metrics to the catalog. For a
+catalog-managed table, the catalog owns table maintenance, not your connector.
+Unity Catalog uses the per-commit metrics you report to decide when to schedule
+OPTIMIZE and VACUUM.
+
+> [!NOTE]
+> Support for the metrics endpoint depends on the catalog. Some catalogs accept
+> reported metrics; others, including the open-source Unity Catalog server, do
+> not implement it yet and return a 404. Treat the report as best-effort: a
+> failure never affects commit correctness.
+
+You supply the counts the write engine observed. The row counts and the
+file-size histogram are only known to your engine. File and byte counts are
+derivable from the commit's add and remove actions.
+
+The catalog requires the commit version on every report, and reads it from
+`file_size_histogram.commit_version`. Set it to the version your commit
+produced. When you have no size distribution to report, send a histogram with
+empty bins that carries only the version.
+
+```rust,ignore
+use unity_catalog_delta_client_api::{CommitReport, FileSizeHistogram};
+
+let report = CommitReport {
+    num_files_added: 3,
+    num_bytes_added: 4096,
+    num_rows_inserted: Some(1000),
+    file_size_histogram: FileSizeHistogram {
+        commit_version,
+        ..Default::default()
+    },
+    ..Default::default()
+};
+
+// table_id comes from the load_table response (metadata.table_uuid).
+if let Err(e) = uc_client
+    .report_metrics("my_catalog", "my_schema", "my_table", &table_id, report)
+    .await
+{
+    eprintln!("metrics report failed (non-fatal): {e}");
+}
+```
+
 ## Post-publish maintenance
 
 Once commits are published, you can checkpoint the table:

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -33,7 +33,8 @@ pub use clients::{InMemoryUpdateTableClient, TableData};
 pub use credentials::{CredentialsResponse, Operation, StorageCredential};
 pub use error::{Error, Result};
 pub use models::{
-    CatalogConfig, Commit, CreateStagingTableRequest, CreateStagingTableResponse,
-    CreateTableRequest, DeltaTableRequirement, DeltaTableUpdate, LoadTableResponse, Protocol,
-    TableIdentifier, TableMetadata, UpdateTableRequest,
+    CatalogConfig, Commit, CommitReport, CreateStagingTableRequest, CreateStagingTableResponse,
+    CreateTableRequest, DeltaTableRequirement, DeltaTableUpdate, FileSizeHistogram,
+    LoadTableResponse, MetricsReport, Protocol, ReportMetricsRequest, TableIdentifier,
+    TableMetadata, UpdateTableRequest,
 };

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -344,6 +344,69 @@ pub struct CreateTableRequest {
     pub last_commit_timestamp_ms: i64,
 }
 
+// ============================================================================
+// reportMetrics: post-commit telemetry
+// ============================================================================
+
+/// Body of a `POST /delta/v1/catalogs/{c}/schemas/{s}/tables/{t}/metrics` request.
+///
+/// Commit telemetry reported to the catalog after a commit succeeds. This is best-effort
+/// telemetry, not part of the commit's correctness path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReportMetricsRequest {
+    /// Table UUID; must match the table identified by the URL path.
+    pub table_id: String,
+    /// The metrics being reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub report: Option<MetricsReport>,
+}
+
+/// Wrapper matching the server's `report` envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct MetricsReport {
+    /// Per-commit statistics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit_report: Option<CommitReport>,
+}
+
+/// Statistics describing a single commit.
+///
+/// File and byte counts are derivable from the commit's add/remove actions. Row counts are only
+/// known to the connector's write engine, so they are optional. The catalog requires a commit
+/// version on every report and reads it from `file_size_histogram.commit_version`, so the histogram
+/// is required.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct CommitReport {
+    pub num_files_added: i64,
+    pub num_bytes_added: i64,
+    pub num_files_removed: i64,
+    pub num_bytes_removed: i64,
+    /// `None` when the write engine did not observe a row count (distinct from `0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_rows_inserted: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_rows_removed: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_rows_updated: Option<i64>,
+    pub file_size_histogram: FileSizeHistogram,
+}
+
+/// File-size histogram as index-aligned arrays mirroring the server's `file-size-histogram`
+/// wire schema: `file_counts[i]` and `total_bytes[i]` describe the bin bounded by
+/// `sorted_bin_boundaries[i]`. The three arrays have equal length.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct FileSizeHistogram {
+    pub sorted_bin_boundaries: Vec<i64>,
+    pub file_counts: Vec<i64>,
+    pub total_bytes: Vec<i64>,
+    /// The commit version this histogram is for.
+    pub commit_version: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -699,5 +762,54 @@ mod tests {
             v["domain-metadata"]["delta.clustering"]["clusteringColumns"][0],
             serde_json::json!(["c1"])
         );
+    }
+
+    #[test]
+    fn report_metrics_request_wire_shape() {
+        let req = ReportMetricsRequest {
+            table_id: "abc".to_string(),
+            report: Some(MetricsReport {
+                commit_report: Some(CommitReport {
+                    num_files_added: 3,
+                    num_bytes_added: 300,
+                    num_files_removed: 1,
+                    num_bytes_removed: 100,
+                    num_rows_inserted: Some(42),
+                    num_rows_removed: None,
+                    num_rows_updated: None,
+                    file_size_histogram: FileSizeHistogram {
+                        sorted_bin_boundaries: vec![0, 1000],
+                        file_counts: vec![2, 1],
+                        total_bytes: vec![150, 150],
+                        commit_version: 7,
+                    },
+                }),
+            }),
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["table-id"], "abc");
+        let cr = &v["report"]["commit-report"];
+        assert_eq!(cr["num-files-added"], 3);
+        assert_eq!(cr["num-bytes-removed"], 100);
+        assert_eq!(cr["num-rows-inserted"], 42);
+        // Absent optional row counts are omitted from the wire body.
+        assert!(cr.get("num-rows-removed").is_none());
+        assert!(cr.get("num-rows-updated").is_none());
+        assert_eq!(cr["file-size-histogram"]["commit-version"], 7);
+        assert_eq!(
+            cr["file-size-histogram"]["sorted-bin-boundaries"],
+            serde_json::json!([0, 1000])
+        );
+    }
+
+    #[test]
+    fn report_metrics_request_omits_absent_report() {
+        let req = ReportMetricsRequest {
+            table_id: "abc".to_string(),
+            report: None,
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["table-id"], "abc");
+        assert!(v.get("report").is_none());
     }
 }

--- a/unity-catalog-delta-client-default/src/clients/uc_client.rs
+++ b/unity-catalog-delta-client-default/src/clients/uc_client.rs
@@ -1,13 +1,14 @@
 use reqwest::StatusCode;
 use tracing::instrument;
 use unity_catalog_delta_client_api::{
-    CatalogConfig, CredentialsResponse, LoadTableResponse, Operation,
+    CatalogConfig, CommitReport, CredentialsResponse, LoadTableResponse, MetricsReport, Operation,
+    ReportMetricsRequest,
 };
 use url::Url;
 
 use crate::config::ClientConfig;
 use crate::error::Result;
-use crate::http::{build_http_client, execute_with_retry, handle_response};
+use crate::http::{build_http_client, execute_with_retry, handle_empty_response, handle_response};
 
 /// Builds the Delta-Tables per-table resource path
 /// (`delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`) that the `load_table` and
@@ -103,5 +104,34 @@ impl UCClient {
         let response =
             execute_with_retry(&self.config, || self.http_client.get(url.clone()).send()).await?;
         handle_response(response).await
+    }
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}/metrics`: report
+    /// best-effort commit telemetry to the catalog after a commit succeeds.
+    ///
+    /// Supply the row counts and histogram that only the write engine knows.
+    #[instrument(skip(self, report))]
+    pub async fn report_metrics(
+        &self,
+        catalog: &str,
+        schema: &str,
+        table: &str,
+        table_id: &str,
+        report: CommitReport,
+    ) -> Result<()> {
+        let path = format!("{}/metrics", table_path(catalog, schema, table));
+        let url = self.base_url.join(&path)?;
+        let body = ReportMetricsRequest {
+            table_id: table_id.to_string(),
+            report: Some(MetricsReport {
+                commit_report: Some(report),
+            }),
+        };
+
+        let response = execute_with_retry(&self.config, || {
+            self.http_client.post(url.clone()).json(&body).send()
+        })
+        .await?;
+        handle_empty_response(response).await
     }
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2956/files) to review incremental changes.
- [**stack/uc-metrics**](https://github.com/delta-io/delta-kernel-rs/pull/2956) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2956/files)] ← _this PR_
  - [stack/uc-client-user-agent](https://github.com/delta-io/delta-kernel-rs/pull/3033) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3033/files/5c5345c7e646d75911944a53f941c7b2edcabf0f..12a4b42d85a30ac49f592a3bee383d96a66fdecc)]
    - [stack/uc-create-table](https://github.com/delta-io/delta-kernel-rs/pull/3034) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3034/files/12a4b42d85a30ac49f592a3bee383d96a66fdecc..5d961e7e0b589c3dc8e18c8016b6a7d8e349d4d7)]

---------
## What changes are proposed in this pull request?

The UC Delta-Tables API exposes a `reportMetrics` endpoint for  post-commit telemetry. This change adds the wire types and a `UCClient::report_metrics` method so connectors can report commit stats to UC after a successful commit.

## How was this change tested?

New UTs, new test against the OSS UC server, and existing tests pass.