### PR TITLE
feat: expression conversion

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,0 +1,199 @@
+//! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
+//!
+//! One match arm per [`Expression`] variant, each recursing on its children. Leaf arms
+//! (`Literal`, `Column`) bottom out directly; compound arms (`Binary`, `Variadic`, `Struct`)
+//! rebuild the equivalent DataFusion node from converted children.
+//!
+//! This conversion is **untyped**: it maps an expression to its natural DataFusion shape with no
+//! target output field. Arms that can only be lowered against a target schema -- casts, JSON
+//! parsing, map-to-struct reshaping, sparse struct patches -- return [`Error::unsupported`] until
+//! the typed `Project`-node compiler that supplies that context is wired up.
+//!
+//! An `impl TryFrom<&Expression> for Expr` is impossible here: both types are foreign to this
+//! crate, so the orphan rule forbids it. Hence a free function.
+
+use datafusion::common::Column;
+use datafusion::functions::core::expr_fn::{coalesce, get_field};
+use datafusion::functions_nested::expr_fn::make_array;
+use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
+use delta_kernel::expressions::{
+    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, VariadicExpression,
+    VariadicExpressionOp,
+};
+use delta_kernel::{DeltaResult, Error};
+
+use crate::scalar::kernel_to_df_scalar;
+
+/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`].
+///
+/// # Errors
+///
+/// Returns [`Error::unsupported`] for expressions that have no untyped DataFusion equivalent:
+/// engine-defined (`Opaque`) or opaque-to-both (`Unknown`) expressions, the `ToJson` unary op,
+/// the embedded-predicate arm (until the predicate converter lands), and the schema-dependent
+/// arms (`Struct`, `ParseJson`, `MapToStruct`, `StructPatch`). Also propagates any error from
+/// converting a child scalar (e.g. an interval literal, which has no Arrow representation) or an
+/// empty column reference.
+pub fn to_datafusion_expr(expr: &Expression) -> DeltaResult<Expr> {
+    match expr {
+        Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
+        Expression::Column(name) => column_to_expr(name),
+        Expression::Binary(binary) => binary_to_expr(binary),
+        Expression::Variadic(variadic) => variadic_to_expr(variadic),
+        // A boolean-valued predicate used where a value is expected. Wired up by the
+        // predicate-conversion branch, which supplies the `Predicate -> Expr` converter.
+        Expression::Predicate(_) => Err(Error::unsupported(
+            "converting an embedded Predicate expression is not yet supported",
+        )),
+        Expression::Unary(_) => Err(Error::unsupported(
+            "converting the ToJson expression is not yet supported",
+        )),
+        // Engine-defined and opaque-to-both expressions cannot round-trip through a DataFusion
+        // logical plan: kernel only understands them through their trait methods.
+        Expression::Opaque(_) => Err(Error::unsupported(
+            "cannot convert an engine-defined Opaque expression",
+        )),
+        Expression::Unknown(name) => Err(Error::unsupported(format!(
+            "cannot convert Unknown expression {name:?}"
+        ))),
+        // These lower correctly only against a target output schema, which the untyped conversion
+        // does not carry, so they are deferred to the typed `Project`-node compiler. `Struct` is
+        // deferred too: its field values are self-contained, but its field *names* live in the
+        // target schema, and a struct built here would only ever be re-labelled by that compiler
+        // -- so lowering it in isolation produces a value nothing executes as-is.
+        Expression::Struct(_, _)
+        | Expression::ParseJson(_)
+        | Expression::MapToStruct(_)
+        | Expression::StructPatch(_) => Err(Error::unsupported(
+            "converting schema-dependent expressions (Struct, ParseJson, MapToStruct, \
+             StructPatch) requires a typed projection context",
+        )),
+    }
+}
+
+/// Lowers a column reference to a `get_field` chain rooted at the first path segment, e.g. `a.b.c`
+/// becomes `get_field(get_field(col("a"), "b"), "c")`. A single-segment path is just the root
+/// column.
+///
+/// # Errors
+///
+/// Returns [`Error::unsupported`] for an empty column path, which has no column to root on.
+fn column_to_expr(name: &ColumnName) -> DeltaResult<Expr> {
+    let mut path = name.iter();
+    let root = path
+        .next()
+        .ok_or_else(|| Error::unsupported("cannot convert an empty column reference"))?;
+    let root = Expr::Column(Column::new_unqualified(root));
+    Ok(path.fold(root, get_field))
+}
+
+/// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
+/// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
+/// so they never reach this arm.
+fn binary_to_expr(binary: &BinaryExpression) -> DeltaResult<Expr> {
+    let op = match binary.op {
+        BinaryExpressionOp::Plus => Operator::Plus,
+        BinaryExpressionOp::Minus => Operator::Minus,
+        BinaryExpressionOp::Multiply => Operator::Multiply,
+        BinaryExpressionOp::Divide => Operator::Divide,
+    };
+    let left = to_datafusion_expr(&binary.left)?;
+    let right = to_datafusion_expr(&binary.right)?;
+    Ok(binary_expr(left, op, right))
+}
+
+/// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`,
+/// each over the converted arguments.
+fn variadic_to_expr(variadic: &VariadicExpression) -> DeltaResult<Expr> {
+    let args = variadic
+        .exprs
+        .iter()
+        .map(to_datafusion_expr)
+        .collect::<DeltaResult<Vec<_>>>()?;
+    Ok(match variadic.op {
+        VariadicExpressionOp::Coalesce => coalesce(args),
+        VariadicExpressionOp::Array => make_array(args),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use delta_kernel::expressions::{column_expr, Expression as Expr_};
+    use delta_kernel::schema::DataType;
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Lowers an expression and renders it as a DataFusion `Display` string for comparison.
+    fn lower(expr: Expr_) -> String {
+        to_datafusion_expr(&expr).unwrap().to_string()
+    }
+
+    #[rstest]
+    #[case::i32(Expr_::literal(7i32), "Int32(7)")]
+    #[case::i64(Expr_::literal(42i64), "Int64(42)")]
+    #[case::string(Expr_::literal("abc"), "Utf8(\"abc\")")]
+    #[case::boolean(Expr_::literal(true), "Boolean(true)")]
+    #[case::null(Expr_::null_literal(DataType::LONG), "Int64(NULL)")]
+    fn literal_lowers_to_scalar(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    #[rstest]
+    #[case::single(Expr_::column(["a"]), "a")]
+    #[case::depth_2(Expr_::column(["a", "b"]), "get_field(a, Utf8(\"b\"))")]
+    #[case::depth_3(
+        Expr_::column(["a", "b", "c"]),
+        "get_field(get_field(a, Utf8(\"b\")), Utf8(\"c\"))"
+    )]
+    fn column_lowers_to_get_field_chain(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    #[rstest]
+    #[case::plus(column_expr!("a") + Expr_::literal(1i64), "a + Int64(1)")]
+    #[case::minus(column_expr!("a") - Expr_::literal(1i64), "a - Int64(1)")]
+    #[case::multiply(column_expr!("a") * Expr_::literal(2i64), "a * Int64(2)")]
+    #[case::divide(column_expr!("a") / Expr_::literal(2i64), "a / Int64(2)")]
+    fn arithmetic_binary_lowers_to_binary_expr(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    #[test]
+    fn nested_arithmetic_preserves_grouping() {
+        let kernel = (column_expr!("x") + Expr_::literal(4i64)) * Expr_::literal(10i64);
+        assert_eq!(lower(kernel), "(x + Int64(4)) * Int64(10)");
+    }
+
+    #[test]
+    fn coalesce_lowers_to_coalesce_call() {
+        let kernel = Expr_::coalesce([column_expr!("a"), column_expr!("b"), Expr_::literal(0i64)]);
+        assert_eq!(lower(kernel), "coalesce(a, b, Int64(0))");
+    }
+
+    #[test]
+    fn array_lowers_to_make_array_call() {
+        let kernel = Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]);
+        assert_eq!(lower(kernel), "make_array(Int64(1), Int64(2))");
+    }
+
+    #[test]
+    fn struct_is_deferred_to_typed_projection() {
+        // A struct's field values are convertible, but its field names come from the target
+        // schema this untyped conversion does not carry, so `Struct` is deferred to the typed
+        // `Project` compiler rather than lowered to an anonymously-named `struct(..)`.
+        let kernel = Expr_::struct_from([column_expr!("a"), Expr_::literal(1i64)]);
+        to_datafusion_expr(&kernel).unwrap_err();
+    }
+
+    #[test]
+    fn embedded_predicate_is_unsupported() {
+        let kernel = Expr_::Predicate(Box::new(column_expr!("a").is_null()));
+        to_datafusion_expr(&kernel).unwrap_err();
+    }
+
+    #[test]
+    fn unknown_expression_is_unsupported() {
+        to_datafusion_expr(&Expr_::Unknown("mystery".into())).unwrap_err();
+    }
+}

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -18,7 +18,7 @@ use crate::scalar::kernel_to_df_scalar;
 /// # Errors
 /// Returns an error for a column that does not resolve against `input_schema`, and
 /// [`Error::unsupported`] for arms with no untyped DataFusion equivalent (see the `TODO`s below).
-pub fn kernel_to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
+pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
     match expr {
         Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
         Expression::Column(name) => kernel_column_to_df_expr(name, input_schema),
@@ -88,8 +88,8 @@ fn kernel_binary_expr_to_df_expr(binary: &BinaryExpression, input_schema: &Struc
         BinaryExpressionOp::Multiply => Operator::Multiply,
         BinaryExpressionOp::Divide => Operator::Divide,
     };
-    let left = kernel_to_datafusion_expr(&binary.left, input_schema)?;
-    let right = kernel_to_datafusion_expr(&binary.right, input_schema)?;
+    let left = kernel_to_df_expr(&binary.left, input_schema)?;
+    let right = kernel_to_df_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
@@ -99,7 +99,7 @@ fn kernel_variadic_to_df_expr(variadic: &VariadicExpression, input_schema: &Stru
     let args = variadic
         .exprs
         .iter()
-        .map(|e| kernel_to_datafusion_expr(e, input_schema))
+        .map(|e| kernel_to_df_expr(e, input_schema))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(match variadic.op {
         VariadicExpressionOp::Coalesce => coalesce(args),
@@ -135,7 +135,7 @@ mod tests {
     /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
     /// string.
     fn lower(expr: Expr_) -> String {
-        kernel_to_datafusion_expr(&expr, &test_schema())
+        kernel_to_df_expr(&expr, &test_schema())
             .unwrap()
             .to_string()
     }
@@ -196,6 +196,6 @@ mod tests {
     #[case::unknown_nested(Expr_::column(["a", "b", "missing"]))]
     #[case::descend_into_non_struct(Expr_::column(["x", "y"]))]
     fn unresolved_column_is_an_error(#[case] kernel: Expr_) {
-        kernel_to_datafusion_expr(&kernel, &test_schema()).unwrap_err();
+        kernel_to_df_expr(&kernel, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,13 +1,30 @@
 //! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
 //!
 //! One match arm per [`Expression`] variant, each recursing on its children. Leaf arms
-//! (`Literal`, `Column`) bottom out directly; compound arms (`Binary`, `Variadic`, `Struct`)
-//! rebuild the equivalent DataFusion node from converted children.
+//! (`Literal`, `Column`) bottom out directly; compound arms (`Binary`, `Variadic`) rebuild the
+//! equivalent DataFusion node from converted children.
 //!
 //! This conversion is **untyped**: it maps an expression to its natural DataFusion shape with no
-//! target output field. Arms that can only be lowered against a target schema -- casts, JSON
-//! parsing, map-to-struct reshaping, sparse struct patches -- return [`Error::unsupported`] until
-//! the typed `Project`-node compiler that supplies that context is wired up.
+//! target output field. It still takes the input schema, but only to fail fast: a column reference
+//! is validated against it (the path must resolve through nested structs) and then lowered to a
+//! `col(..)`/`get_field(..)` chain. DataFusion would resolve that chain against the upstream schema
+//! during plan analysis regardless; validating here turns a dangling reference into a clear error
+//! at conversion time instead of a late, less-legible analysis failure.
+//!
+//! The variants group by why they are or are not lowerable in this untyped conversion:
+//!
+//! 1. **Natural type** (`Literal`, `Column`, `Binary`, `Variadic`): self-describing; lowered here.
+//! 2. **Predicate** (`Predicate`): a boolean-valued predicate used as a value. Deferred to the
+//!    predicate-conversion branch, which supplies the `Predicate -> Expr` converter.
+//! 3. **Typed** (`Struct`, `MapToStruct`, `StructPatch`): lowerable only against a target output
+//!    schema -- for field *names* (`Struct`) and/or field *types* (`MapToStruct`, `StructPatch`) --
+//!    which this untyped conversion does not carry. Deferred to the typed `Project`-node compiler.
+//! 4. **ParseJson**: carries its own `output_schema`, so it is not blocked on a target schema. It
+//!    is unsupported because DataFusion core has no stock JSON-string -> struct parser; lowering it
+//!    needs a custom UDF that mirrors kernel's `parse_json` decoder, which is not yet wired up.
+//! 5. **Terminal** (`Unary(ToJson)`, `Opaque`, `Unknown`): no faithful untyped lowering. `ToJson`
+//!    needs a UDF kernel has not wired; `Opaque` is engine-defined and understood only through its
+//!    trait methods; `Unknown` has no semantics to lower (kernel forbids interpreting it).
 //!
 //! An `impl TryFrom<&Expression> for Expr` is impossible here: both types are foreign to this
 //! crate, so the orphan rule forbids it. Hence a free function.
@@ -17,57 +34,77 @@ use datafusion::functions::core::expr_fn::{coalesce, get_field};
 use datafusion::functions_nested::expr_fn::make_array;
 use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, VariadicExpression,
-    VariadicExpressionOp,
+    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, UnaryExpressionOp,
+    VariadicExpression, VariadicExpressionOp,
 };
+use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
 use crate::scalar::kernel_to_df_scalar;
 
-/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`].
+/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`], validating column
+/// references against `input_schema` (the name-resolution scope: a column path must resolve
+/// through the nested structs of this schema).
 ///
 /// # Errors
 ///
-/// Returns [`Error::unsupported`] for expressions that have no untyped DataFusion equivalent:
+/// Returns an error for a column reference that does not resolve against `input_schema`, and
+/// [`Error::unsupported`] for expressions that have no untyped DataFusion equivalent:
 /// engine-defined (`Opaque`) or opaque-to-both (`Unknown`) expressions, the `ToJson` unary op,
-/// the embedded-predicate arm (until the predicate converter lands), and the schema-dependent
-/// arms (`Struct`, `ParseJson`, `MapToStruct`, `StructPatch`). Also propagates any error from
-/// converting a child scalar (e.g. an interval literal, which has no Arrow representation) or an
-/// empty column reference.
-pub fn to_datafusion_expr(expr: &Expression) -> DeltaResult<Expr> {
+/// the embedded-predicate arm (until the predicate converter lands), the schema-dependent arms
+/// (`Struct`, `MapToStruct`, `StructPatch`), and `ParseJson` (which lacks a stock DataFusion
+/// lowering, not a schema). Also propagates any error from converting a child scalar (e.g. an
+/// interval literal, which has no Arrow representation).
+pub fn to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
     match expr {
+        // === 1. Natural type: self-describing, lowered here ===
         Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
-        Expression::Column(name) => column_to_expr(name),
-        Expression::Binary(binary) => binary_to_expr(binary),
-        Expression::Variadic(variadic) => variadic_to_expr(variadic),
-        // A boolean-valued predicate used where a value is expected. Wired up by the
-        // predicate-conversion branch, which supplies the `Predicate -> Expr` converter.
+        Expression::Column(name) => column_to_expr(name, input_schema),
+        Expression::Binary(binary) => binary_to_expr(binary, input_schema),
+        Expression::Variadic(variadic) => variadic_to_expr(variadic, input_schema),
+
+        // === 2. Predicate: a boolean-valued predicate used where a value is expected ===
+        // Wired up by the predicate-conversion branch, which supplies the `Predicate -> Expr`
+        // converter.
         Expression::Predicate(_) => Err(Error::unsupported(
             "converting an embedded Predicate expression is not yet supported",
         )),
-        Expression::Unary(_) => Err(Error::unsupported(
-            "converting the ToJson expression is not yet supported",
+
+        // === 3. Typed: lowerable only against a target output schema ===
+        // `Struct` needs the schema for its field *names*; `MapToStruct` and `StructPatch` need it
+        // for the field *types* that drive their reshape. This untyped conversion carries none, so
+        // all three defer to the typed `Project`-node compiler.
+        Expression::Struct(_, _)
+        | Expression::MapToStruct(_)
+        | Expression::StructPatch(_) => Err(Error::unsupported(
+            "converting schema-dependent expressions (Struct, MapToStruct, StructPatch) requires \
+             a typed projection context",
         )),
-        // Engine-defined and opaque-to-both expressions cannot round-trip through a DataFusion
-        // logical plan: kernel only understands them through their trait methods.
+
+        // === 4. ParseJson: self-typed, but no stock DataFusion lowering ===
+        // Unlike the typed arms above, `ParseJson` carries its own output schema, so it needs no
+        // external context. It is unsupported only because DataFusion core has no stock expression
+        // for typed JSON parsing -- lowering it requires a custom scalar UDF mirroring kernel's
+        // `parse_json` decoder, which is not yet wired up.
+        Expression::ParseJson(_) => Err(Error::unsupported(
+            "converting a ParseJson expression requires a custom JSON-parsing UDF, not yet wired up",
+        )),
+
+        // === 5. Terminal: no faithful untyped lowering ===
+        Expression::Unary(u) => match u.op {
+            // `ToJson` needs a UDF kernel has not wired up.
+            UnaryExpressionOp::ToJson => Err(Error::unsupported(
+                "converting the ToJson expression is not yet supported",
+            )),
+        },
+        // Engine-defined; kernel understands it only through its trait methods.
         Expression::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque expression",
         )),
+        // No semantics to lower: kernel forbids interpreting an Unknown expression.
         Expression::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown expression {name:?}"
         ))),
-        // These lower correctly only against a target output schema, which the untyped conversion
-        // does not carry, so they are deferred to the typed `Project`-node compiler. `Struct` is
-        // deferred too: its field values are self-contained, but its field *names* live in the
-        // target schema, and a struct built here would only ever be re-labelled by that compiler
-        // -- so lowering it in isolation produces a value nothing executes as-is.
-        Expression::Struct(_, _)
-        | Expression::ParseJson(_)
-        | Expression::MapToStruct(_)
-        | Expression::StructPatch(_) => Err(Error::unsupported(
-            "converting schema-dependent expressions (Struct, ParseJson, MapToStruct, \
-             StructPatch) requires a typed projection context",
-        )),
     }
 }
 
@@ -75,14 +112,21 @@ pub fn to_datafusion_expr(expr: &Expression) -> DeltaResult<Expr> {
 /// becomes `get_field(get_field(col("a"), "b"), "c")`. A single-segment path is just the root
 /// column.
 ///
+/// The path is first resolved against `input_schema` so a dangling reference fails here rather than
+/// later during DataFusion plan analysis. The resolved field is not otherwise used: the emitted
+/// `col(..)`/`get_field(..)` chain is nameless and DataFusion re-resolves it against the upstream
+/// schema.
+///
 /// # Errors
 ///
-/// Returns [`Error::unsupported`] for an empty column path, which has no column to root on.
-fn column_to_expr(name: &ColumnName) -> DeltaResult<Expr> {
+/// Returns an error for an empty path, a segment that names no field, or an intermediate segment
+/// whose field is not a struct (all surfaced by [`StructType::field_at`]).
+fn column_to_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<Expr> {
+    input_schema.field_at(name)?;
     let mut path = name.iter();
     let root = path
         .next()
-        .ok_or_else(|| Error::unsupported("cannot convert an empty column reference"))?;
+        .ok_or_else(|| Error::generic("cannot convert an empty column reference"))?;
     let root = Expr::Column(Column::new_unqualified(root));
     Ok(path.fold(root, get_field))
 }
@@ -90,25 +134,25 @@ fn column_to_expr(name: &ColumnName) -> DeltaResult<Expr> {
 /// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
 /// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
 /// so they never reach this arm.
-fn binary_to_expr(binary: &BinaryExpression) -> DeltaResult<Expr> {
+fn binary_to_expr(binary: &BinaryExpression, input_schema: &StructType) -> DeltaResult<Expr> {
     let op = match binary.op {
         BinaryExpressionOp::Plus => Operator::Plus,
         BinaryExpressionOp::Minus => Operator::Minus,
         BinaryExpressionOp::Multiply => Operator::Multiply,
         BinaryExpressionOp::Divide => Operator::Divide,
     };
-    let left = to_datafusion_expr(&binary.left)?;
-    let right = to_datafusion_expr(&binary.right)?;
+    let left = to_datafusion_expr(&binary.left, input_schema)?;
+    let right = to_datafusion_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
 /// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`,
 /// each over the converted arguments.
-fn variadic_to_expr(variadic: &VariadicExpression) -> DeltaResult<Expr> {
+fn variadic_to_expr(variadic: &VariadicExpression, input_schema: &StructType) -> DeltaResult<Expr> {
     let args = variadic
         .exprs
         .iter()
-        .map(to_datafusion_expr)
+        .map(|e| to_datafusion_expr(e, input_schema))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(match variadic.op {
         VariadicExpressionOp::Coalesce => coalesce(args),
@@ -119,14 +163,34 @@ fn variadic_to_expr(variadic: &VariadicExpression) -> DeltaResult<Expr> {
 #[cfg(test)]
 mod tests {
     use delta_kernel::expressions::{column_expr, Expression as Expr_};
-    use delta_kernel::schema::DataType;
+    use delta_kernel::schema::{DataType, StructField, StructType};
     use rstest::rstest;
 
     use super::*;
 
-    /// Lowers an expression and renders it as a DataFusion `Display` string for comparison.
+    /// Name-resolution scope for these tests: `a: { b: { c: long } }`, plus top-level `b` and `x`.
+    fn test_schema() -> StructType {
+        StructType::try_new([
+            StructField::nullable(
+                "a",
+                StructType::try_new([StructField::nullable(
+                    "b",
+                    StructType::try_new([StructField::nullable("c", DataType::LONG)]).unwrap(),
+                )])
+                .unwrap(),
+            ),
+            StructField::nullable("b", DataType::LONG),
+            StructField::nullable("x", DataType::LONG),
+        ])
+        .unwrap()
+    }
+
+    /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
+    /// string.
     fn lower(expr: Expr_) -> String {
-        to_datafusion_expr(&expr).unwrap().to_string()
+        to_datafusion_expr(&expr, &test_schema())
+            .unwrap()
+            .to_string()
     }
 
     #[rstest]
@@ -177,23 +241,14 @@ mod tests {
         assert_eq!(lower(kernel), "make_array(Int64(1), Int64(2))");
     }
 
-    #[test]
-    fn struct_is_deferred_to_typed_projection() {
-        // A struct's field values are convertible, but its field names come from the target
-        // schema this untyped conversion does not carry, so `Struct` is deferred to the typed
-        // `Project` compiler rather than lowered to an anonymously-named `struct(..)`.
-        let kernel = Expr_::struct_from([column_expr!("a"), Expr_::literal(1i64)]);
-        to_datafusion_expr(&kernel).unwrap_err();
-    }
-
-    #[test]
-    fn embedded_predicate_is_unsupported() {
-        let kernel = Expr_::Predicate(Box::new(column_expr!("a").is_null()));
-        to_datafusion_expr(&kernel).unwrap_err();
-    }
-
-    #[test]
-    fn unknown_expression_is_unsupported() {
-        to_datafusion_expr(&Expr_::Unknown("mystery".into())).unwrap_err();
+    /// A column reference that does not resolve against the input schema fails at conversion time,
+    /// not later during DataFusion analysis. Covers each `field_at` failure mode.
+    #[rstest]
+    #[case::empty(Expr_::Column(ColumnName::new(Vec::<String>::new())))]
+    #[case::unknown_root(Expr_::column(["nope"]))]
+    #[case::unknown_nested(Expr_::column(["a", "b", "missing"]))]
+    #[case::descend_into_non_struct(Expr_::column(["x", "y"]))]
+    fn unresolved_column_is_an_error(#[case] kernel: Expr_) {
+        to_datafusion_expr(&kernel, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -16,15 +16,14 @@ use crate::scalar::kernel_to_df_scalar;
 /// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`].
 ///
 /// # Errors
-///
 /// Returns an error for a column that does not resolve against `input_schema`, and
 /// [`Error::unsupported`] for arms with no untyped DataFusion equivalent (see the `TODO`s below).
-pub fn to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
+pub fn kernel_to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
     match expr {
         Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
-        Expression::Column(name) => column_to_expr(name, input_schema),
-        Expression::Binary(binary) => binary_to_expr(binary, input_schema),
-        Expression::Variadic(variadic) => variadic_to_expr(variadic, input_schema),
+        Expression::Column(name) => kernel_column_to_df_expr(name, input_schema),
+        Expression::Binary(binary) => kernel_binary_expr_to_df_expr(binary, input_schema),
+        Expression::Variadic(variadic) => kernel_variadic_to_df_expr(variadic, input_schema),
 
         // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
         Expression::Predicate(_) => Err(Error::unsupported(
@@ -63,7 +62,7 @@ pub fn to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> Delta
 /// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
 /// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
 /// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
-fn column_to_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<Expr> {
+fn kernel_column_to_df_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<Expr> {
     input_schema.field_at(name)?;
     let mut path = name.iter();
     let root = path
@@ -82,25 +81,25 @@ fn column_to_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<E
 /// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
 /// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
 /// so they never reach this arm.
-fn binary_to_expr(binary: &BinaryExpression, input_schema: &StructType) -> DeltaResult<Expr> {
+fn kernel_binary_expr_to_df_expr(binary: &BinaryExpression, input_schema: &StructType) -> DeltaResult<Expr> {
     let op = match binary.op {
         BinaryExpressionOp::Plus => Operator::Plus,
         BinaryExpressionOp::Minus => Operator::Minus,
         BinaryExpressionOp::Multiply => Operator::Multiply,
         BinaryExpressionOp::Divide => Operator::Divide,
     };
-    let left = to_datafusion_expr(&binary.left, input_schema)?;
-    let right = to_datafusion_expr(&binary.right, input_schema)?;
+    let left = kernel_to_datafusion_expr(&binary.left, input_schema)?;
+    let right = kernel_to_datafusion_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
 /// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`,
 /// each over the converted arguments.
-fn variadic_to_expr(variadic: &VariadicExpression, input_schema: &StructType) -> DeltaResult<Expr> {
+fn kernel_variadic_to_df_expr(variadic: &VariadicExpression, input_schema: &StructType) -> DeltaResult<Expr> {
     let args = variadic
         .exprs
         .iter()
-        .map(|e| to_datafusion_expr(e, input_schema))
+        .map(|e| kernel_to_datafusion_expr(e, input_schema))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(match variadic.op {
         VariadicExpressionOp::Coalesce => coalesce(args),
@@ -136,7 +135,7 @@ mod tests {
     /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
     /// string.
     fn lower(expr: Expr_) -> String {
-        to_datafusion_expr(&expr, &test_schema())
+        kernel_to_datafusion_expr(&expr, &test_schema())
             .unwrap()
             .to_string()
     }
@@ -197,6 +196,6 @@ mod tests {
     #[case::unknown_nested(Expr_::column(["a", "b", "missing"]))]
     #[case::descend_into_non_struct(Expr_::column(["x", "y"]))]
     fn unresolved_column_is_an_error(#[case] kernel: Expr_) {
-        to_datafusion_expr(&kernel, &test_schema()).unwrap_err();
+        kernel_to_datafusion_expr(&kernel, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,36 +1,7 @@
 //! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
-//!
-//! One match arm per [`Expression`] variant, each recursing on its children. Leaf arms
-//! (`Literal`, `Column`) bottom out directly; compound arms (`Binary`, `Variadic`) rebuild the
-//! equivalent DataFusion node from converted children.
-//!
-//! This conversion is **untyped**: it maps an expression to its natural DataFusion shape with no
-//! target output field. It still takes the input schema, but only to fail fast: a column reference
-//! is validated against it (the path must resolve through nested structs) and then lowered to a
-//! `col(..)`/`get_field(..)` chain. DataFusion would resolve that chain against the upstream schema
-//! during plan analysis regardless; validating here turns a dangling reference into a clear error
-//! at conversion time instead of a late, less-legible analysis failure.
-//!
-//! The variants group by why they are or are not lowerable in this untyped conversion:
-//!
-//! 1. **Natural type** (`Literal`, `Column`, `Binary`, `Variadic`): self-describing; lowered here.
-//! 2. **Predicate** (`Predicate`): a boolean-valued predicate used as a value. Deferred to the
-//!    predicate-conversion branch, which supplies the `Predicate -> Expr` converter.
-//! 3. **Typed** (`Struct`, `MapToStruct`, `StructPatch`): lowerable only against a target output
-//!    schema -- for field *names* (`Struct`) and/or field *types* (`MapToStruct`, `StructPatch`) --
-//!    which this untyped conversion does not carry. Deferred to the typed `Project`-node compiler.
-//! 4. **ParseJson**: carries its own `output_schema`, so it is not blocked on a target schema. It
-//!    is unsupported because DataFusion core has no stock JSON-string -> struct parser; lowering it
-//!    needs a custom UDF that mirrors kernel's `parse_json` decoder, which is not yet wired up.
-//! 5. **Terminal** (`Unary(ToJson)`, `Opaque`, `Unknown`): no faithful untyped lowering. `ToJson`
-//!    needs a UDF kernel has not wired; `Opaque` is engine-defined and understood only through its
-//!    trait methods; `Unknown` has no semantics to lower (kernel forbids interpreting it).
-//!
-//! An `impl TryFrom<&Expression> for Expr` is impossible here: both types are foreign to this
-//! crate, so the orphan rule forbids it. Hence a free function.
 
 use datafusion::common::Column;
-use datafusion::functions::core::expr_fn::{coalesce, get_field};
+use datafusion::functions::core::expr_fn::{coalesce, get_field_path};
 use datafusion::functions_nested::expr_fn::make_array;
 use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
 use delta_kernel::expressions::{
@@ -42,38 +13,26 @@ use delta_kernel::{DeltaResult, Error};
 
 use crate::scalar::kernel_to_df_scalar;
 
-/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`], validating column
-/// references against `input_schema` (the name-resolution scope: a column path must resolve
-/// through the nested structs of this schema).
+/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`].
 ///
 /// # Errors
 ///
-/// Returns an error for a column reference that does not resolve against `input_schema`, and
-/// [`Error::unsupported`] for expressions that have no untyped DataFusion equivalent:
-/// engine-defined (`Opaque`) or opaque-to-both (`Unknown`) expressions, the `ToJson` unary op,
-/// the embedded-predicate arm (until the predicate converter lands), the schema-dependent arms
-/// (`Struct`, `MapToStruct`, `StructPatch`), and `ParseJson` (which lacks a stock DataFusion
-/// lowering, not a schema). Also propagates any error from converting a child scalar (e.g. an
-/// interval literal, which has no Arrow representation).
+/// Returns an error for a column that does not resolve against `input_schema`, and
+/// [`Error::unsupported`] for arms with no untyped DataFusion equivalent (see the `TODO`s below).
 pub fn to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
     match expr {
-        // === 1. Natural type: self-describing, lowered here ===
         Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
         Expression::Column(name) => column_to_expr(name, input_schema),
         Expression::Binary(binary) => binary_to_expr(binary, input_schema),
         Expression::Variadic(variadic) => variadic_to_expr(variadic, input_schema),
 
-        // === 2. Predicate: a boolean-valued predicate used where a value is expected ===
-        // Wired up by the predicate-conversion branch, which supplies the `Predicate -> Expr`
-        // converter.
+        // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
         Expression::Predicate(_) => Err(Error::unsupported(
             "converting an embedded Predicate expression is not yet supported",
         )),
 
-        // === 3. Typed: lowerable only against a target output schema ===
-        // `Struct` needs the schema for its field *names*; `MapToStruct` and `StructPatch` need it
-        // for the field *types* that drive their reshape. This untyped conversion carries none, so
-        // all three defer to the typed `Project`-node compiler.
+        // TODO: wire up once this function takes an output schema (`Struct` needs it for field
+        // names; `MapToStruct`/`StructPatch` for field types). Each arm's lowering follows later.
         Expression::Struct(_, _)
         | Expression::MapToStruct(_)
         | Expression::StructPatch(_) => Err(Error::unsupported(
@@ -81,46 +40,29 @@ pub fn to_datafusion_expr(expr: &Expression, input_schema: &StructType) -> Delta
              a typed projection context",
         )),
 
-        // === 4. ParseJson: self-typed, but no stock DataFusion lowering ===
-        // Unlike the typed arms above, `ParseJson` carries its own output schema, so it needs no
-        // external context. It is unsupported only because DataFusion core has no stock expression
-        // for typed JSON parsing -- lowering it requires a custom scalar UDF mirroring kernel's
-        // `parse_json` decoder, which is not yet wired up.
+        // TODO: wire up via a custom JSON-parsing UDF (DataFusion core has no stock JSON parser).
         Expression::ParseJson(_) => Err(Error::unsupported(
-            "converting a ParseJson expression requires a custom JSON-parsing UDF, not yet wired up",
+            "converting a ParseJson expression requires a custom JSON-parsing UDF",
         )),
 
-        // === 5. Terminal: no faithful untyped lowering ===
         Expression::Unary(u) => match u.op {
-            // `ToJson` needs a UDF kernel has not wired up.
             UnaryExpressionOp::ToJson => Err(Error::unsupported(
                 "converting the ToJson expression is not yet supported",
             )),
         },
-        // Engine-defined; kernel understands it only through its trait methods.
+
         Expression::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque expression",
         )),
-        // No semantics to lower: kernel forbids interpreting an Unknown expression.
         Expression::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown expression {name:?}"
         ))),
     }
 }
 
-/// Lowers a column reference to a `get_field` chain rooted at the first path segment, e.g. `a.b.c`
-/// becomes `get_field(get_field(col("a"), "b"), "c")`. A single-segment path is just the root
-/// column.
-///
-/// The path is first resolved against `input_schema` so a dangling reference fails here rather than
-/// later during DataFusion plan analysis. The resolved field is not otherwise used: the emitted
-/// `col(..)`/`get_field(..)` chain is nameless and DataFusion re-resolves it against the upstream
-/// schema.
-///
-/// # Errors
-///
-/// Returns an error for an empty path, a segment that names no field, or an intermediate segment
-/// whose field is not a struct (all surfaced by [`StructType::field_at`]).
+/// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
+/// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
+/// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
 fn column_to_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<Expr> {
     input_schema.field_at(name)?;
     let mut path = name.iter();
@@ -128,7 +70,13 @@ fn column_to_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<E
         .next()
         .ok_or_else(|| Error::generic("cannot convert an empty column reference"))?;
     let root = Expr::Column(Column::new_unqualified(root));
-    Ok(path.fold(root, get_field))
+    let field_names = path.map(lit).collect::<Vec<_>>();
+    // A bare column stays a bare column; only nested access wraps it in a `get_field` call.
+    Ok(if field_names.is_empty() {
+        root
+    } else {
+        get_field_path(root, field_names)
+    })
 }
 
 /// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
@@ -208,9 +156,9 @@ mod tests {
     #[case::depth_2(Expr_::column(["a", "b"]), "get_field(a, Utf8(\"b\"))")]
     #[case::depth_3(
         Expr_::column(["a", "b", "c"]),
-        "get_field(get_field(a, Utf8(\"b\")), Utf8(\"c\"))"
+        "get_field(a, Utf8(\"b\"), Utf8(\"c\"))"
     )]
-    fn column_lowers_to_get_field_chain(#[case] kernel: Expr_, #[case] expected: &str) {
+    fn column_lowers_to_nested_field_access(#[case] kernel: Expr_, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,7 +1,5 @@
 //! Conversion from a kernel [`Expression`](KernelExpression) to a DataFusion [`Expr`](DFExpr).
 
-// Each foreign type is aliased with its source crate (`Kernel*`/`DF*`) so every use site reads
-// unambiguously across the two crates this converter bridges.
 use datafusion::common::Column as DFColumn;
 use datafusion::functions::core::expr_fn::{coalesce, get_field_path};
 use datafusion::functions_nested::expr_fn::make_array;
@@ -123,7 +121,7 @@ fn variadic_to_df_expr(
 
 #[cfg(test)]
 mod tests {
-    use delta_kernel::expressions::{column_expr, Expression as Expr_};
+    use delta_kernel::expressions::{column_expr, Expression as KernelExpr};
     use delta_kernel::schema::{DataType, StructField, StructType};
     use rstest::rstest;
 
@@ -148,92 +146,88 @@ mod tests {
 
     /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
     /// string.
-    fn lower(expr: Expr_) -> String {
+    fn lower(expr: KernelExpr) -> String {
         to_df_expr(&expr, &test_schema()).unwrap().to_string()
     }
 
     #[rstest]
-    #[case::i32(Expr_::literal(7i32), "Int32(7)")]
-    #[case::i64(Expr_::literal(42i64), "Int64(42)")]
-    #[case::string(Expr_::literal("abc"), "Utf8(\"abc\")")]
-    #[case::boolean(Expr_::literal(true), "Boolean(true)")]
-    #[case::null(Expr_::null_literal(DataType::LONG), "Int64(NULL)")]
-    fn literal_lowers_to_scalar(#[case] kernel: Expr_, #[case] expected: &str) {
+    #[case::i32(KernelExpr::literal(7i32), "Int32(7)")]
+    #[case::i64(KernelExpr::literal(42i64), "Int64(42)")]
+    #[case::string(KernelExpr::literal("abc"), "Utf8(\"abc\")")]
+    #[case::boolean(KernelExpr::literal(true), "Boolean(true)")]
+    #[case::null(KernelExpr::null_literal(DataType::LONG), "Int64(NULL)")]
+    fn literal_lowers_to_scalar(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
     #[rstest]
-    #[case::single(Expr_::column(["a"]), "a")]
-    #[case::depth_2(Expr_::column(["a", "b"]), "get_field(a, Utf8(\"b\"))")]
+    #[case::single(KernelExpr::column(["a"]), "a")]
+    #[case::depth_2(KernelExpr::column(["a", "b"]), "get_field(a, Utf8(\"b\"))")]
     #[case::depth_3(
-        Expr_::column(["a", "b", "c"]),
+        KernelExpr::column(["a", "b", "c"]),
         "get_field(a, Utf8(\"b\"), Utf8(\"c\"))"
     )]
-    fn column_lowers_to_nested_field_access(#[case] kernel: Expr_, #[case] expected: &str) {
+    fn column_lowers_to_nested_field_access(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
     #[rstest]
-    #[case::plus(column_expr!("a") + Expr_::literal(1i64), "a + Int64(1)")]
-    #[case::minus(column_expr!("a") - Expr_::literal(1i64), "a - Int64(1)")]
-    #[case::multiply(column_expr!("a") * Expr_::literal(2i64), "a * Int64(2)")]
-    #[case::divide(column_expr!("a") / Expr_::literal(2i64), "a / Int64(2)")]
-    fn arithmetic_binary_lowers_to_binary_expr(#[case] kernel: Expr_, #[case] expected: &str) {
+    #[case::plus(column_expr!("a") + KernelExpr::literal(1i64), "a + Int64(1)")]
+    #[case::minus(column_expr!("a") - KernelExpr::literal(1i64), "a - Int64(1)")]
+    #[case::multiply(column_expr!("a") * KernelExpr::literal(2i64), "a * Int64(2)")]
+    #[case::divide(column_expr!("a") / KernelExpr::literal(2i64), "a / Int64(2)")]
+    fn arithmetic_binary_lowers_to_binary_expr(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
-    /// Nested arithmetic lowers to the matching operator tree. DataFusion's `Display`
-    /// parenthesizes a child only when its precedence is strictly lower than the parent's, so the
-    /// `precedence_pins_grouping` case is deliberate: lower-precedence `Plus`/`Minus` operands
-    /// under a higher-precedence `Multiply` MUST print parentheses, which makes the assertion
-    /// sensitive to re-association -- a wrongly-flattened tree renders differently.
+    /// Nested arithmetic lowers to the matching operator tree.
     #[rstest]
     #[case::precedence_pins_grouping(
-        (column_expr!("x") + Expr_::literal(1i64)) * (column_expr!("b") - Expr_::literal(2i64)),
+        (column_expr!("x") + KernelExpr::literal(1i64)) * (column_expr!("b") - KernelExpr::literal(2i64)),
         "(x + Int64(1)) * (b - Int64(2))"
     )]
     #[case::nested_field_and_all_ops(
-        (Expr_::column(["a", "b", "c"]) * Expr_::literal(5i64)
+        (KernelExpr::column(["a", "b", "c"]) * KernelExpr::literal(5i64)
             - (column_expr!("b") + column_expr!("x")))
-            / Expr_::literal(20i64),
+            / KernelExpr::literal(20i64),
         "(get_field(a, Utf8(\"b\"), Utf8(\"c\")) * Int64(5) - b + x) / Int64(20)"
     )]
-    fn nested_arithmetic_lowers_to_operator_tree(#[case] kernel: Expr_, #[case] expected: &str) {
+    fn nested_arithmetic_lowers_to_operator_tree(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
     #[rstest]
     #[case::coalesce(
-        Expr_::coalesce([column_expr!("a"), column_expr!("b"), Expr_::literal(0i64)]),
+        KernelExpr::coalesce([column_expr!("a"), column_expr!("b"), KernelExpr::literal(0i64)]),
         "coalesce(a, b, Int64(0))"
     )]
     #[case::array(
-        Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]),
+        KernelExpr::array([KernelExpr::literal(1i64), KernelExpr::literal(2i64)]),
         "make_array(Int64(1), Int64(2))"
     )]
     #[case::nested_coalesce(
-        Expr_::coalesce([Expr_::coalesce([column_expr!("a"), column_expr!("b")]), column_expr!("x")]),
+        KernelExpr::coalesce([KernelExpr::coalesce([column_expr!("a"), column_expr!("b")]), column_expr!("x")]),
         "coalesce(coalesce(a, b), x)"
     )]
     #[case::nested_array(
-        Expr_::array([
-            Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]),
-            Expr_::array([Expr_::literal(3i64), Expr_::literal(4i64)]),
+        KernelExpr::array([
+            KernelExpr::array([KernelExpr::literal(1i64), KernelExpr::literal(2i64)]),
+            KernelExpr::array([KernelExpr::literal(3i64), KernelExpr::literal(4i64)]),
         ]),
         "make_array(make_array(Int64(1), Int64(2)), make_array(Int64(3), Int64(4)))"
     )]
-    fn variadic_lowers_to_call(#[case] kernel: Expr_, #[case] expected: &str) {
+    fn variadic_lowers_to_call(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
     /// A column reference that does not resolve against the input schema fails at conversion time,
     /// not later during DataFusion analysis. Covers each `field_at` failure mode.
     #[rstest]
-    #[case::empty(Expr_::Column(KernelColumnName::default()))]
-    #[case::unknown_root(Expr_::column(["nope"]))]
-    #[case::unknown_nested(Expr_::column(["a", "b", "missing"]))]
-    #[case::descend_into_non_struct(Expr_::column(["x", "y"]))]
-    fn unresolved_column_is_an_error(#[case] kernel: Expr_) {
+    #[case::empty(KernelExpr::Column(KernelColumnName::default()))]
+    #[case::unknown_root(KernelExpr::column(["nope"]))]
+    #[case::unknown_nested(KernelExpr::column(["a", "b", "missing"]))]
+    #[case::descend_into_non_struct(KernelExpr::column(["x", "y"]))]
+    fn unresolved_column_is_an_error(#[case] kernel: KernelExpr) {
         to_df_expr(&kernel, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,12 +1,14 @@
 //! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
 
+use datafusion::arrow::datatypes::DataType as ArrowDataType;
 use datafusion::common::Column;
 use datafusion::functions::core::expr_fn::{coalesce, get_field_path};
 use datafusion::functions_nested::expr_fn::make_array;
-use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
+use datafusion::logical_expr::{binary_expr, lit, try_cast, Expr, Operator};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, UnaryExpressionOp,
-    VariadicExpression, VariadicExpressionOp,
+    BinaryExpression, BinaryExpressionOp, CastExpression, ColumnName, Expression,
+    UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
 };
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
@@ -24,6 +26,7 @@ pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaR
         Expression::Column(name) => kernel_column_to_df_expr(name, input_schema),
         Expression::Binary(binary) => kernel_binary_expr_to_df_expr(binary, input_schema),
         Expression::Variadic(variadic) => kernel_variadic_to_df_expr(variadic, input_schema),
+        Expression::Cast(cast) => kernel_cast_to_df_expr(cast, input_schema),
 
         // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
         Expression::Predicate(_) => Err(Error::unsupported(
@@ -81,7 +84,10 @@ fn kernel_column_to_df_expr(name: &ColumnName, input_schema: &StructType) -> Del
 /// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
 /// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
 /// so they never reach this arm.
-fn kernel_binary_expr_to_df_expr(binary: &BinaryExpression, input_schema: &StructType) -> DeltaResult<Expr> {
+fn kernel_binary_expr_to_df_expr(
+    binary: &BinaryExpression,
+    input_schema: &StructType,
+) -> DeltaResult<Expr> {
     let op = match binary.op {
         BinaryExpressionOp::Plus => Operator::Plus,
         BinaryExpressionOp::Minus => Operator::Minus,
@@ -95,7 +101,10 @@ fn kernel_binary_expr_to_df_expr(binary: &BinaryExpression, input_schema: &Struc
 
 /// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`,
 /// each over the converted arguments.
-fn kernel_variadic_to_df_expr(variadic: &VariadicExpression, input_schema: &StructType) -> DeltaResult<Expr> {
+fn kernel_variadic_to_df_expr(
+    variadic: &VariadicExpression,
+    input_schema: &StructType,
+) -> DeltaResult<Expr> {
     let args = variadic
         .exprs
         .iter()
@@ -107,10 +116,23 @@ fn kernel_variadic_to_df_expr(variadic: &VariadicExpression, input_schema: &Stru
     })
 }
 
+/// Lowers a cast to `Expr::TryCast`, matching kernel's per-value SQL semantics: a value that does
+/// not fit the target becomes NULL rather than erroring (DataFusion `Cast` errors on overflow;
+/// `TryCast` does not).
+///
+/// One divergence from kernel's evaluator: for a type pair Arrow cannot cast at all, kernel
+/// degrades to an all-NULL column, whereas DataFusion `TryCast` planning raises `not_impl_err!`.
+/// That fallback needs the runtime input array type, so it cannot be expressed at lowering time.
+fn kernel_cast_to_df_expr(cast: &CastExpression, input_schema: &StructType) -> DeltaResult<Expr> {
+    let expr = kernel_to_df_expr(&cast.expr, input_schema)?;
+    let target: ArrowDataType = (&cast.target).try_into_arrow()?;
+    Ok(try_cast(expr, target))
+}
+
 #[cfg(test)]
 mod tests {
     use delta_kernel::expressions::{column_expr, Expression as Expr_};
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::schema::{ArrayType, DataType, StructField, StructType};
     use rstest::rstest;
 
     use super::*;
@@ -186,6 +208,24 @@ mod tests {
     fn array_lowers_to_make_array_call() {
         let kernel = Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]);
         assert_eq!(lower(kernel), "make_array(Int64(1), Int64(2))");
+    }
+
+    // Kernel casts follow SQL NULL-on-failure semantics, so they lower to TryCast, not Cast. The
+    // `string -> int` case is the one where that choice is observable: it can fail per value (and
+    // yields NULL under TryCast), unlike `-> string`, which effectively never does.
+    #[rstest]
+    #[case::widen(Expr_::cast(column_expr!("b"), DataType::STRING), "TRY_CAST(b AS Utf8)")]
+    #[case::narrowing(Expr_::cast(column_expr!("b"), DataType::INTEGER), "TRY_CAST(b AS Int32)")]
+    #[case::fallible_parse(
+        Expr_::cast(Expr_::literal("abc"), DataType::INTEGER),
+        "TRY_CAST(Utf8(\"abc\") AS Int32)"
+    )]
+    #[case::nested_target(
+        Expr_::cast(column_expr!("b"), ArrayType::new(DataType::LONG, true).into()),
+        "TRY_CAST(b AS List(Int64, field: 'element'))"
+    )]
+    fn cast_lowers_to_try_cast(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
     }
 
     /// A column reference that does not resolve against the input schema fails at conversion time,

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,14 +1,12 @@
 //! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
 
-use datafusion::arrow::datatypes::DataType as ArrowDataType;
 use datafusion::common::Column;
 use datafusion::functions::core::expr_fn::{coalesce, get_field_path};
 use datafusion::functions_nested::expr_fn::make_array;
-use datafusion::logical_expr::{binary_expr, lit, try_cast, Expr, Operator};
-use delta_kernel::engine::arrow_conversion::TryIntoArrow;
+use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, CastExpression, ColumnName, Expression,
-    UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
+    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, UnaryExpressionOp,
+    VariadicExpression, VariadicExpressionOp,
 };
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
@@ -26,7 +24,15 @@ pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaR
         Expression::Column(name) => kernel_column_to_df_expr(name, input_schema),
         Expression::Binary(binary) => kernel_binary_expr_to_df_expr(binary, input_schema),
         Expression::Variadic(variadic) => kernel_variadic_to_df_expr(variadic, input_schema),
-        Expression::Cast(cast) => kernel_cast_to_df_expr(cast, input_schema),
+
+        // TODO(delta-io/delta-kernel-rs#3007): implement once kernel's Cast semantics are
+        // clarified. Likely lowers to `Expr::TryCast` (matching kernel's per-value
+        // NULL-on-failure), but kernel degrades a whole-pair-incompatible cast (`can_cast_types`
+        // false, e.g. struct -> int) to an all-NULL column whereas DataFusion raises a planning
+        // error, and the intended contract for that case is still open.
+        Expression::Cast(_) => Err(Error::unsupported(
+            "converting a Cast expression is not yet supported",
+        )),
 
         // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
         Expression::Predicate(_) => Err(Error::unsupported(
@@ -116,23 +122,10 @@ fn kernel_variadic_to_df_expr(
     })
 }
 
-/// Lowers a cast to `Expr::TryCast`, matching kernel's per-value SQL semantics: a value that does
-/// not fit the target becomes NULL rather than erroring (DataFusion `Cast` errors on overflow;
-/// `TryCast` does not).
-///
-/// One divergence from kernel's evaluator: for a type pair Arrow cannot cast at all, kernel
-/// degrades to an all-NULL column, whereas DataFusion `TryCast` planning raises `not_impl_err!`.
-/// That fallback needs the runtime input array type, so it cannot be expressed at lowering time.
-fn kernel_cast_to_df_expr(cast: &CastExpression, input_schema: &StructType) -> DeltaResult<Expr> {
-    let expr = kernel_to_df_expr(&cast.expr, input_schema)?;
-    let target: ArrowDataType = (&cast.target).try_into_arrow()?;
-    Ok(try_cast(expr, target))
-}
-
 #[cfg(test)]
 mod tests {
     use delta_kernel::expressions::{column_expr, Expression as Expr_};
-    use delta_kernel::schema::{ArrayType, DataType, StructField, StructType};
+    use delta_kernel::schema::{DataType, StructField, StructType};
     use rstest::rstest;
 
     use super::*;
@@ -208,24 +201,6 @@ mod tests {
     fn array_lowers_to_make_array_call() {
         let kernel = Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]);
         assert_eq!(lower(kernel), "make_array(Int64(1), Int64(2))");
-    }
-
-    // Kernel casts follow SQL NULL-on-failure semantics, so they lower to TryCast, not Cast. The
-    // `string -> int` case is the one where that choice is observable: it can fail per value (and
-    // yields NULL under TryCast), unlike `-> string`, which effectively never does.
-    #[rstest]
-    #[case::widen(Expr_::cast(column_expr!("b"), DataType::STRING), "TRY_CAST(b AS Utf8)")]
-    #[case::narrowing(Expr_::cast(column_expr!("b"), DataType::INTEGER), "TRY_CAST(b AS Int32)")]
-    #[case::fallible_parse(
-        Expr_::cast(Expr_::literal("abc"), DataType::INTEGER),
-        "TRY_CAST(Utf8(\"abc\") AS Int32)"
-    )]
-    #[case::nested_target(
-        Expr_::cast(column_expr!("b"), ArrayType::new(DataType::LONG, true).into()),
-        "TRY_CAST(b AS List(Int64, field: 'element'))"
-    )]
-    fn cast_lowers_to_try_cast(#[case] kernel: Expr_, #[case] expected: &str) {
-        assert_eq!(lower(kernel), expected);
     }
 
     /// A column reference that does not resolve against the input schema fails at conversion time,

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -1,64 +1,67 @@
-//! Conversion from a kernel [`Expression`] to a DataFusion [`Expr`].
+//! Conversion from a kernel [`Expression`](KernelExpression) to a DataFusion [`Expr`](DFExpr).
 
-use datafusion::common::Column;
+// Each foreign type is aliased with its source crate (`Kernel*`/`DF*`) so every use site reads
+// unambiguously across the two crates this converter bridges.
+use datafusion::common::Column as DFColumn;
 use datafusion::functions::core::expr_fn::{coalesce, get_field_path};
 use datafusion::functions_nested::expr_fn::make_array;
-use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
+use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName, Expression, UnaryExpressionOp,
-    VariadicExpression, VariadicExpressionOp,
+    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
+    Expression as KernelExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
 };
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
-use crate::scalar::kernel_to_df_scalar;
+use crate::scalar::to_df_scalar;
 
-/// Converts a kernel [`Expression`] into the equivalent DataFusion [`Expr`].
+/// Converts a kernel [`Expression`](KernelExpression) into the equivalent DataFusion
+/// [`Expr`](DFExpr).
 ///
 /// # Errors
 /// Returns an error for a column that does not resolve against `input_schema`, and
 /// [`Error::unsupported`] for arms with no untyped DataFusion equivalent (see the `TODO`s below).
-pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaResult<Expr> {
+pub fn to_df_expr(expr: &KernelExpression, input_schema: &StructType) -> DeltaResult<DFExpr> {
     match expr {
-        Expression::Literal(scalar) => Ok(lit(kernel_to_df_scalar(scalar)?)),
-        Expression::Column(name) => kernel_column_to_df_expr(name, input_schema),
-        Expression::Binary(binary) => kernel_binary_expr_to_df_expr(binary, input_schema),
-        Expression::Variadic(variadic) => kernel_variadic_to_df_expr(variadic, input_schema),
+        KernelExpression::Literal(scalar) => Ok(lit(to_df_scalar(scalar)?)),
+        KernelExpression::Column(name) => column_to_df_expr(name, input_schema),
+        KernelExpression::Binary(binary) => binary_expr_to_df_expr(binary, input_schema),
+        KernelExpression::Variadic(variadic) => variadic_to_df_expr(variadic, input_schema),
 
         // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
-        Expression::Predicate(_) => Err(Error::unsupported(
+        KernelExpression::Predicate(_) => Err(Error::unsupported(
             "converting an embedded Predicate expression is not yet supported",
         )),
 
         // TODO: wire up once this function takes an output schema (`Struct` needs it for field
         // names; `MapToStruct`/`StructPatch` for field types). Each arm's lowering follows later.
-        Expression::Struct(_, _)
-        | Expression::MapToStruct(_)
-        | Expression::StructPatch(_) => Err(Error::unsupported(
-            "converting schema-dependent expressions (Struct, MapToStruct, StructPatch) requires \
-             a typed projection context",
+        KernelExpression::Struct(_, _)
+        | KernelExpression::MapToStruct(_)
+        | KernelExpression::StructPatch(_) => Err(Error::unsupported(
+            "converting schema-dependent expressions (Struct, MapToStruct, StructPatch) \
+                 requires a typed projection context",
         )),
 
         // TODO: wire up via a custom JSON-parsing UDF (DataFusion core has no stock JSON parser).
-        Expression::ParseJson(_) => Err(Error::unsupported(
+        KernelExpression::ParseJson(_) => Err(Error::unsupported(
             "converting a ParseJson expression requires a custom JSON-parsing UDF",
         )),
 
-        Expression::Unary(u) => match u.op {
+        KernelExpression::Unary(u) => match u.op {
             UnaryExpressionOp::ToJson => Err(Error::unsupported(
                 "converting the ToJson expression is not yet supported",
             )),
         },
 
         // TODO(#3007): implement once kernel's Cast semantics are clarified.
-        Expression::Cast(_) => Err(Error::unsupported(
+        KernelExpression::Cast(_) => Err(Error::unsupported(
             "converting a Cast expression is not yet supported",
         )),
 
-        Expression::Opaque(_) => Err(Error::unsupported(
+        KernelExpression::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque expression",
         )),
-        Expression::Unknown(name) => Err(Error::unsupported(format!(
+        KernelExpression::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown expression {name:?}"
         ))),
     }
@@ -67,54 +70,54 @@ pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaR
 /// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
 /// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
 /// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
-fn kernel_column_to_df_expr(name: &ColumnName, input_schema: &StructType) -> DeltaResult<Expr> {
-    input_schema.field_at(name)?;
+fn column_to_df_expr(name: &KernelColumnName, input_schema: &StructType) -> DeltaResult<DFExpr> {
+    let _ = input_schema.field_at(name)?;
     let mut path = name.iter();
-    let root = path
-        .next()
-        .ok_or_else(|| Error::generic("cannot convert an empty column reference"))?;
-    let root = Expr::Column(Column::new_unqualified(root));
-    let field_names = path.map(lit).collect::<Vec<_>>();
+    let Some(root) = path.next() else {
+        return Err(Error::generic("cannot convert an empty column reference"));
+    };
+    let root = DFExpr::Column(DFColumn::new_unqualified(root));
+    let field_names = Vec::from_iter(path.map(lit));
     // A bare column stays a bare column; only nested access wraps it in a `get_field` call.
-    Ok(if field_names.is_empty() {
-        root
+    if field_names.is_empty() {
+        Ok(root)
     } else {
-        get_field_path(root, field_names)
-    })
+        Ok(get_field_path(root, field_names))
+    }
 }
 
 /// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
 /// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
 /// so they never reach this arm.
-fn kernel_binary_expr_to_df_expr(
+fn binary_expr_to_df_expr(
     binary: &BinaryExpression,
     input_schema: &StructType,
-) -> DeltaResult<Expr> {
+) -> DeltaResult<DFExpr> {
     let op = match binary.op {
         BinaryExpressionOp::Plus => Operator::Plus,
         BinaryExpressionOp::Minus => Operator::Minus,
         BinaryExpressionOp::Multiply => Operator::Multiply,
         BinaryExpressionOp::Divide => Operator::Divide,
     };
-    let left = kernel_to_df_expr(&binary.left, input_schema)?;
-    let right = kernel_to_df_expr(&binary.right, input_schema)?;
+    let left = to_df_expr(&binary.left, input_schema)?;
+    let right = to_df_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
 /// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`,
 /// each over the converted arguments.
-fn kernel_variadic_to_df_expr(
+fn variadic_to_df_expr(
     variadic: &VariadicExpression,
     input_schema: &StructType,
-) -> DeltaResult<Expr> {
-    let args = variadic
+) -> DeltaResult<DFExpr> {
+    let args: DeltaResult<Vec<DFExpr>> = variadic
         .exprs
         .iter()
-        .map(|e| kernel_to_df_expr(e, input_schema))
-        .collect::<DeltaResult<Vec<_>>>()?;
+        .map(|e| to_df_expr(e, input_schema))
+        .collect();
     Ok(match variadic.op {
-        VariadicExpressionOp::Coalesce => coalesce(args),
-        VariadicExpressionOp::Array => make_array(args),
+        VariadicExpressionOp::Coalesce => coalesce(args?),
+        VariadicExpressionOp::Array => make_array(args?),
     })
 }
 
@@ -146,9 +149,7 @@ mod tests {
     /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
     /// string.
     fn lower(expr: Expr_) -> String {
-        kernel_to_df_expr(&expr, &test_schema())
-            .unwrap()
-            .to_string()
+        to_df_expr(&expr, &test_schema()).unwrap().to_string()
     }
 
     #[rstest]
@@ -181,32 +182,58 @@ mod tests {
         assert_eq!(lower(kernel), expected);
     }
 
-    #[test]
-    fn nested_arithmetic_preserves_grouping() {
-        let kernel = (column_expr!("x") + Expr_::literal(4i64)) * Expr_::literal(10i64);
-        assert_eq!(lower(kernel), "(x + Int64(4)) * Int64(10)");
+    /// Nested arithmetic lowers to the matching operator tree. DataFusion's `Display`
+    /// parenthesizes a child only when its precedence is strictly lower than the parent's, so the
+    /// `precedence_pins_grouping` case is deliberate: lower-precedence `Plus`/`Minus` operands
+    /// under a higher-precedence `Multiply` MUST print parentheses, which makes the assertion
+    /// sensitive to re-association -- a wrongly-flattened tree renders differently.
+    #[rstest]
+    #[case::precedence_pins_grouping(
+        (column_expr!("x") + Expr_::literal(1i64)) * (column_expr!("b") - Expr_::literal(2i64)),
+        "(x + Int64(1)) * (b - Int64(2))"
+    )]
+    #[case::nested_field_and_all_ops(
+        (Expr_::column(["a", "b", "c"]) * Expr_::literal(5i64)
+            - (column_expr!("b") + column_expr!("x")))
+            / Expr_::literal(20i64),
+        "(get_field(a, Utf8(\"b\"), Utf8(\"c\")) * Int64(5) - b + x) / Int64(20)"
+    )]
+    fn nested_arithmetic_lowers_to_operator_tree(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
     }
 
-    #[test]
-    fn coalesce_lowers_to_coalesce_call() {
-        let kernel = Expr_::coalesce([column_expr!("a"), column_expr!("b"), Expr_::literal(0i64)]);
-        assert_eq!(lower(kernel), "coalesce(a, b, Int64(0))");
-    }
-
-    #[test]
-    fn array_lowers_to_make_array_call() {
-        let kernel = Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]);
-        assert_eq!(lower(kernel), "make_array(Int64(1), Int64(2))");
+    #[rstest]
+    #[case::coalesce(
+        Expr_::coalesce([column_expr!("a"), column_expr!("b"), Expr_::literal(0i64)]),
+        "coalesce(a, b, Int64(0))"
+    )]
+    #[case::array(
+        Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]),
+        "make_array(Int64(1), Int64(2))"
+    )]
+    #[case::nested_coalesce(
+        Expr_::coalesce([Expr_::coalesce([column_expr!("a"), column_expr!("b")]), column_expr!("x")]),
+        "coalesce(coalesce(a, b), x)"
+    )]
+    #[case::nested_array(
+        Expr_::array([
+            Expr_::array([Expr_::literal(1i64), Expr_::literal(2i64)]),
+            Expr_::array([Expr_::literal(3i64), Expr_::literal(4i64)]),
+        ]),
+        "make_array(make_array(Int64(1), Int64(2)), make_array(Int64(3), Int64(4)))"
+    )]
+    fn variadic_lowers_to_call(#[case] kernel: Expr_, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
     }
 
     /// A column reference that does not resolve against the input schema fails at conversion time,
     /// not later during DataFusion analysis. Covers each `field_at` failure mode.
     #[rstest]
-    #[case::empty(Expr_::Column(ColumnName::new(Vec::<String>::new())))]
+    #[case::empty(Expr_::Column(KernelColumnName::default()))]
     #[case::unknown_root(Expr_::column(["nope"]))]
     #[case::unknown_nested(Expr_::column(["a", "b", "missing"]))]
     #[case::descend_into_non_struct(Expr_::column(["x", "y"]))]
     fn unresolved_column_is_an_error(#[case] kernel: Expr_) {
-        kernel_to_df_expr(&kernel, &test_schema()).unwrap_err();
+        to_df_expr(&kernel, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -25,15 +25,6 @@ pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaR
         Expression::Binary(binary) => kernel_binary_expr_to_df_expr(binary, input_schema),
         Expression::Variadic(variadic) => kernel_variadic_to_df_expr(variadic, input_schema),
 
-        // TODO(delta-io/delta-kernel-rs#3007): implement once kernel's Cast semantics are
-        // clarified. Likely lowers to `Expr::TryCast` (matching kernel's per-value
-        // NULL-on-failure), but kernel degrades a whole-pair-incompatible cast (`can_cast_types`
-        // false, e.g. struct -> int) to an all-NULL column whereas DataFusion raises a planning
-        // error, and the intended contract for that case is still open.
-        Expression::Cast(_) => Err(Error::unsupported(
-            "converting a Cast expression is not yet supported",
-        )),
-
         // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
         Expression::Predicate(_) => Err(Error::unsupported(
             "converting an embedded Predicate expression is not yet supported",
@@ -58,6 +49,11 @@ pub fn kernel_to_df_expr(expr: &Expression, input_schema: &StructType) -> DeltaR
                 "converting the ToJson expression is not yet supported",
             )),
         },
+
+        // TODO(#3007): implement once kernel's Cast semantics are clarified.
+        Expression::Cast(_) => Err(Error::unsupported(
+            "converting a Cast expression is not yet supported",
+        )),
 
         Expression::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque expression",

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -113,10 +113,10 @@ fn variadic_to_df_expr(
         .iter()
         .map(|e| to_df_expr(e, input_schema))
         .collect();
-    Ok(match variadic.op {
-        VariadicExpressionOp::Coalesce => coalesce(args?),
-        VariadicExpressionOp::Array => make_array(args?),
-    })
+    match variadic.op {
+        VariadicExpressionOp::Coalesce => Ok(coalesce(args?)),
+        VariadicExpressionOp::Array => Ok(make_array(args?)),
+    }
 }
 
 #[cfg(test)]

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -192,7 +192,10 @@ mod tests {
             / KernelExpr::literal(20i64),
         "(get_field(a, Utf8(\"b\"), Utf8(\"c\")) * Int64(5) - b + x) / Int64(20)"
     )]
-    fn nested_arithmetic_lowers_to_operator_tree(#[case] kernel: KernelExpr, #[case] expected: &str) {
+    fn nested_arithmetic_lowers_to_operator_tree(
+        #[case] kernel: KernelExpr,
+        #[case] expected: &str,
+    ) {
         assert_eq!(lower(kernel), expected);
     }
 

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -13,9 +13,11 @@ use std::sync::Arc;
 use datafusion::execution::context::SessionContext;
 use delta_kernel::StorageHandler;
 
+mod expression;
 mod scalar;
 
-pub use scalar::to_df_scalar;
+pub use expression::to_datafusion_expr;
+pub use scalar::kernel_to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.
 ///

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -16,7 +16,7 @@ use delta_kernel::StorageHandler;
 mod expression;
 mod scalar;
 
-pub use expression::to_datafusion_expr;
+pub use expression::kernel_to_datafusion_expr;
 pub use scalar::kernel_to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -16,7 +16,7 @@ use delta_kernel::StorageHandler;
 mod expression;
 mod scalar;
 
-pub use expression::kernel_to_datafusion_expr;
+pub use expression::kernel_to_df_expr;
 pub use scalar::kernel_to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -16,8 +16,8 @@ use delta_kernel::StorageHandler;
 mod expression;
 mod scalar;
 
-pub use expression::kernel_to_df_expr;
-pub use scalar::kernel_to_df_scalar;
+pub use expression::to_df_expr;
+pub use scalar::to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.
 ///


### PR DESCRIPTION
## What changes are proposed in this pull request?
This is the first PR towards converting a kernel expression into a df expression. I have chosen to implement conversions for `Literal`, `Column`, `Binary`, and `Variadic` in this PR, since they are the most straightforward and have direct mappings to implementations with df exposed functions. Note that `Column`, `Binary`, and `Variadic` requires `input_schema`. Here, `input_schema` refers to the schema that would be passed in during the planning phase from the child plan.

## How was this change tested?
These expressions are converted to string and then tested to ensure the proper conversion.