### PR TITLE
feat: use stale CRC in DomainMetadata queries

### DIFF
--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -485,9 +485,8 @@ impl DomainMetadataVisitor {
         domain_metadatas
     }
 
-    /// The newest-wins map with tombstones (`removed == true`) retained. Callers that reconcile
-    /// against a base map need the tombstones so a removal in a newer commit can suppress a domain
-    /// the base holds. [`Self::into_domain_metadatas`] strips them for the common case.
+    /// The newest-wins domain-metadata map, retaining tombstones (`removed == true`).
+    /// [`Self::into_domain_metadatas`] returns the same map with tombstones stripped.
     pub(crate) fn into_domain_metadatas_including_tombstones(self) -> DomainMetadataMap {
         self.domain_metadatas
     }

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -479,10 +479,16 @@ impl DomainMetadataVisitor {
             .is_some_and(|filter| self.domain_metadatas.len() == filter.len())
     }
 
-    pub(crate) fn into_domain_metadatas(mut self) -> DomainMetadataMap {
-        // note that the resulting visitor.domain_metadatas includes removed domains, so we need to
-        // filter
-        self.domain_metadatas.retain(|_, dm| !dm.removed);
+    pub(crate) fn into_domain_metadatas(self) -> DomainMetadataMap {
+        let mut domain_metadatas = self.into_domain_metadatas_including_tombstones();
+        domain_metadatas.retain(|_, dm| !dm.removed);
+        domain_metadatas
+    }
+
+    /// The newest-wins map with tombstones (`removed == true`) retained. Callers that reconcile
+    /// against a base map need the tombstones so a removal in a newer commit can suppress a domain
+    /// the base holds. [`Self::into_domain_metadatas`] strips them for the common case.
+    pub(crate) fn into_domain_metadatas_including_tombstones(self) -> DomainMetadataMap {
         self.domain_metadatas
     }
 }

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -480,7 +480,7 @@ impl DomainMetadataVisitor {
     }
 
     pub(crate) fn into_domain_metadatas(self) -> DomainMetadataMap {
-        let mut domain_metadatas = self.into_domain_metadatas_including_tombstones();
+        let mut domain_metadatas = self.domain_metadatas;
         domain_metadatas.retain(|_, dm| !dm.removed);
         domain_metadatas
     }

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -117,7 +117,8 @@ impl Crc {
             self.metadata = m;
         }
 
-        // Apply the delta onto the CRC's existing map. The variant (Complete or Partial) stays the
+        // Apply the delta onto the CRC's existing map: upsert each non-removed entry
+        // (newest wins), drop each tombstone. The variant (Complete or Partial) stays the
         // same since a delta never changes whether the base was authoritative.
         let map = match &mut self.domain_metadata_state {
             DomainMetadataState::Complete(m) | DomainMetadataState::Partial(m) => m,

--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -117,19 +117,12 @@ impl Crc {
             self.metadata = m;
         }
 
-        // Apply the delta onto the CRC's existing map: upsert each non-removed entry
-        // (newest wins), drop each tombstone. The variant (Complete or Partial) stays the
+        // Apply the delta onto the CRC's existing map. The variant (Complete or Partial) stays the
         // same since a delta never changes whether the base was authoritative.
         let map = match &mut self.domain_metadata_state {
             DomainMetadataState::Complete(m) | DomainMetadataState::Partial(m) => m,
         };
-        for (domain, dm) in delta.domain_metadata {
-            if dm.is_removed() {
-                map.remove(&domain);
-            } else {
-                map.insert(domain, dm);
-            }
-        }
+        merge_domain_metadata(map, delta.domain_metadata);
 
         // Apply the delta onto the CRC's existing map: upsert each entry (newest wins).
         // The variant (Complete or Partial) stays the same since a delta never changes whether
@@ -151,6 +144,21 @@ impl Crc {
 
         self.version = new_version;
         self
+    }
+}
+
+/// Fold newest-wins domain-metadata entries (tombstones retained) onto `base`: a tombstone
+/// (`is_removed()`) drops the domain, any other entry upserts it.
+pub(crate) fn merge_domain_metadata(
+    base: &mut HashMap<String, DomainMetadata>,
+    entries: impl IntoIterator<Item = (String, DomainMetadata)>,
+) {
+    for (domain, dm) in entries {
+        if dm.is_removed() {
+            base.remove(&domain);
+        } else {
+            base.insert(domain, dm);
+        }
     }
 }
 

--- a/kernel/src/crc/mod.rs
+++ b/kernel/src/crc/mod.rs
@@ -26,7 +26,7 @@ mod writer;
 use std::collections::HashMap;
 
 #[allow(unused)]
-pub(crate) use delta::CrcDelta;
+pub(crate) use delta::{merge_domain_metadata, CrcDelta};
 pub use file_size_histogram::FileSizeHistogram;
 pub use file_stats::FileStats;
 #[allow(unused)]

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -80,10 +80,13 @@ pub enum DomainMetadataState {
     /// map does not exist.
     Complete(HashMap<String, DomainMetadata>),
 
-    /// The CRC file did not have the `domainMetadata` field. The map starts empty and gets
-    /// populated by incremental CRC replay over the JSON commits after the latest stale CRC.
-    /// Hits are authoritative (definitely present at this version); misses are NOT
-    /// (the domain may exist in older commits), so callers must do a further log scan.
+    /// The CRC file did not have the `domainMetadata` field, so the full active-domain set is
+    /// unknown. Hits in the map are authoritative (definitely present at this version); misses
+    /// are NOT (the domain may exist in a commit the CRC did not account for), so a miss requires
+    /// a further log scan. The map is empty when a stale CRC that lacked the field was not
+    /// incrementally replayed, or populated when incremental CRC replay folded in the commits
+    /// after it. An empty map is not a distinct state: it simply has no authoritative hits, so
+    /// every query falls through to a log scan.
     Partial(HashMap<String, DomainMetadata>),
 }
 

--- a/kernel/src/crc/state.rs
+++ b/kernel/src/crc/state.rs
@@ -83,10 +83,8 @@ pub enum DomainMetadataState {
     /// The CRC file did not have the `domainMetadata` field, so the full active-domain set is
     /// unknown. Hits in the map are authoritative (definitely present at this version); misses
     /// are NOT (the domain may exist in a commit the CRC did not account for), so a miss requires
-    /// a further log scan. The map is empty when a stale CRC that lacked the field was not
-    /// incrementally replayed, or populated when incremental CRC replay folded in the commits
-    /// after it. An empty map is not a distinct state: it simply has no authoritative hits, so
-    /// every query falls through to a log scan.
+    /// a further log scan. The map is empty for a stale CRC that was not incrementally replayed,
+    /// and populated when incremental CRC replay folds in the commits after it.
     Partial(HashMap<String, DomainMetadata>),
 }
 

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -36,13 +36,14 @@ impl LogSegment {
     }
 
     /// Answer a domain-metadata query rooted in an authoritative (`Complete`) but stale CRC's
-    /// `base_active` map at `base_version`, scanning ONLY the commits in `(base_version, end]`.
+    /// `base_active` map at `base_version`, scanning ONLY the commits in
+    /// `(base_version, self.end_version]`.
     ///
     /// The checkpoint and every commit at/below `base_version` are skipped via
     /// [`Self::segment_after_version`]. For each domain the newest action in the tail wins; a tail
-    /// tombstone means the domain is absent at `end` even when `base_active` holds it. A domain the
-    /// tail never mentions falls back to `base_active`. `domains == None` answers all active
-    /// domains; `Some(filter)` answers only the requested ones. Returned maps never contain
+    /// tombstone means the domain is absent at `self.end_version` even when `base_active` holds it.
+    /// A domain the tail never mentions falls back to `base_active`. `domains == None` answers all
+    /// active domains; `Some(filter)` answers only the requested ones. Returned maps never contain
     /// tombstones.
     pub(crate) fn scan_domain_metadatas_rooted_in_crc(
         &self,

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -11,7 +11,7 @@ use super::LogSegment;
 use crate::actions::visitors::DomainMetadataVisitor;
 use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA};
 use crate::log_replay::ActionsBatch;
-use crate::{DeltaResult, Engine, RowVisitor as _};
+use crate::{DeltaResult, Engine, RowVisitor as _, Version};
 
 pub(crate) type DomainMetadataMap = HashMap<String, DomainMetadata>;
 
@@ -28,25 +28,94 @@ impl LogSegment {
         domains: Option<&HashSet<&str>>,
         engine: &dyn Engine,
     ) -> DeltaResult<DomainMetadataMap> {
+        Ok(self
+            .visit_domain_metadatas(domains, engine)?
+            .into_domain_metadatas())
+    }
+
+    /// Answer a domain-metadata query rooted in an authoritative (`Complete`) but stale CRC's
+    /// `base_active` map at `base_version`, scanning ONLY the commits in `(base_version, end]`.
+    ///
+    /// The checkpoint and every commit at/below `base_version` are skipped via
+    /// [`Self::segment_after_version`]. For each domain the newest action in the tail wins; a tail
+    /// tombstone means the domain is absent at `end` even when `base_active` holds it. A domain the
+    /// tail never mentions falls back to `base_active`. `domains == None` answers all active
+    /// domains; `Some(filter)` answers only the requested ones. Returned maps never contain
+    /// tombstones.
+    pub(crate) fn scan_domain_metadatas_rooted_in_crc(
+        &self,
+        base_version: Version,
+        base_active: &HashMap<String, DomainMetadata>,
+        domains: Option<&HashSet<&str>>,
+        engine: &dyn Engine,
+    ) -> DeltaResult<DomainMetadataMap> {
+        let tail = self
+            .segment_after_version(base_version)
+            .scan_tail_including_tombstones(domains, engine)?;
+        let reconciled = match domains {
+            // Filtered: the newest tail action per requested domain wins; a tombstone settles the
+            // answer as absent. Fall back to `base_active` only when the tail never mentions it.
+            Some(filter) => filter
+                .iter()
+                .filter_map(|&k| match tail.get(k) {
+                    Some(dm) if dm.is_removed() => None,
+                    Some(dm) => Some((k.to_string(), dm.clone())),
+                    None => base_active.get(k).map(|dm| (k.to_string(), dm.clone())),
+                })
+                .collect(),
+            // Unfiltered: merge the whole tail onto the base, dropping tombstoned domains.
+            None => {
+                let mut active = base_active.clone();
+                for (domain, dm) in tail {
+                    if dm.is_removed() {
+                        active.remove(&domain);
+                    } else {
+                        active.insert(domain, dm);
+                    }
+                }
+                active
+            }
+        };
+        Ok(reconciled)
+    }
+
+    /// Reverse-replay this segment for domain metadata, keeping tombstones. Terminates early once
+    /// every requested domain is decided (a tombstone counts as decided). The CRC-rooted path keeps
+    /// tombstones so a removal in a newer commit can suppress a domain the base holds.
+    fn scan_tail_including_tombstones(
+        &self,
+        domains: Option<&HashSet<&str>>,
+        engine: &dyn Engine,
+    ) -> DeltaResult<DomainMetadataMap> {
+        Ok(self
+            .visit_domain_metadatas(domains, engine)?
+            .into_domain_metadatas_including_tombstones())
+    }
+
+    /// Reverse-replay this segment, folding domain metadata actions into a
+    /// [`DomainMetadataVisitor`] (newest-first, first-seen-wins). A domain filter terminates
+    /// the scan early once every requested domain is found; without one the whole segment is
+    /// replayed. The caller chooses whether to keep or strip tombstones from the returned
+    /// visitor.
+    fn visit_domain_metadatas(
+        &self,
+        domains: Option<&HashSet<&str>>,
+        engine: &dyn Engine,
+    ) -> DeltaResult<DomainMetadataVisitor> {
         let domain_filter = domains.map(|set| {
             set.iter()
                 .map(|s| s.to_string())
                 .collect::<HashSet<String>>()
         });
         let mut visitor = DomainMetadataVisitor::new(domain_filter);
-        // If a specific set of domains is requested then we can terminate log replay early as
-        // soon as all requested domains have been found. If all domains are requested then we
-        // are forced to replay the entire log.
         for actions in self.read_domain_metadata_batches(engine)? {
             let domain_metadatas = actions?.actions;
             visitor.visit_rows_of(domain_metadatas.as_ref())?;
-            // if all requested domains have been found, terminate early
             if visitor.filter_found() {
                 break;
             }
         }
-
-        Ok(visitor.into_domain_metadatas())
+        Ok(visitor)
     }
 
     /// Read action batches from the log, projecting rows to only contain domain metadata columns.
@@ -240,5 +309,40 @@ mod tests {
         let result = visitor.into_domain_metadatas();
         assert_eq!(result["domainA"].configuration(), "cfgA");
         assert_eq!(result["domainC"].configuration(), "cfgC");
+    }
+
+    /// Adds a third commit to [`build_two_commit_log`] that tombstones "domainA".
+    fn build_log_with_tombstone() -> (impl crate::Engine, std::sync::Arc<Snapshot>) {
+        let (engine, snapshot) = build_two_commit_log();
+        let table_root = snapshot.table_root().clone();
+        let _ = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), &engine)
+            .unwrap()
+            .with_domain_metadata_removed("domainA".to_string())
+            .commit(&engine)
+            .unwrap();
+        let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
+        (engine, snapshot)
+    }
+
+    #[tokio::test]
+    async fn test_scan_tail_keeps_tombstone_that_scan_domain_metadatas_drops() {
+        let (engine, snapshot) = build_log_with_tombstone();
+        let log_segment = snapshot.log_segment();
+
+        // scan_domain_metadatas strips the tombstone: "domainA" is gone.
+        let active = log_segment.scan_domain_metadatas(None, &engine).unwrap();
+        assert!(!active.contains_key("domainA"));
+        assert!(active.contains_key("domainB"));
+        assert!(active.contains_key("domainC"));
+
+        // scan_tail_including_tombstones retains it as a tombstone so it can suppress a base
+        // domain.
+        let with_tombstones = log_segment
+            .scan_tail_including_tombstones(None, &engine)
+            .unwrap();
+        assert!(with_tombstones["domainA"].is_removed());
+        assert!(!with_tombstones["domainB"].is_removed());
+        assert!(!with_tombstones["domainC"].is_removed());
     }
 }

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -1,7 +1,8 @@
 //! Domain metadata replay logic for [`LogSegment`].
 //!
-//! This module contains the method that performs a log replay to extract the latest domain
-//! metadata actions from a [`LogSegment`].
+//! Two entry points: [`LogSegment::scan_domain_metadatas`] replays the whole log for the latest
+//! domain metadata, and [`LogSegment::scan_domain_metadatas_rooted_in_crc`] scans only the commits
+//! after an authoritative stale CRC and reconciles them against its active-domain map.
 
 use std::collections::{HashMap, HashSet};
 
@@ -10,6 +11,7 @@ use tracing::instrument;
 use super::LogSegment;
 use crate::actions::visitors::DomainMetadataVisitor;
 use crate::actions::{DomainMetadata, LOG_DOMAIN_METADATA_SCHEMA};
+use crate::crc::merge_domain_metadata;
 use crate::log_replay::ActionsBatch;
 use crate::{DeltaResult, Engine, RowVisitor as _, Version};
 
@@ -66,13 +68,7 @@ impl LogSegment {
             // Unfiltered: merge the whole tail onto the base, dropping tombstoned domains.
             None => {
                 let mut active = base_active.clone();
-                for (domain, dm) in tail {
-                    if dm.is_removed() {
-                        active.remove(&domain);
-                    } else {
-                        active.insert(domain, dm);
-                    }
-                }
+                merge_domain_metadata(&mut active, tail);
                 active
             }
         };
@@ -108,9 +104,13 @@ impl LogSegment {
                 .collect::<HashSet<String>>()
         });
         let mut visitor = DomainMetadataVisitor::new(domain_filter);
+        // If a specific set of domains is requested then we can terminate log replay early as
+        // soon as all requested domains have been found. If all domains are requested then we
+        // are forced to replay the entire log.
         for actions in self.read_domain_metadata_batches(engine)? {
             let domain_metadatas = actions?.actions;
             visitor.visit_rows_of(domain_metadatas.as_ref())?;
+            // if all requested domains have been found, terminate early
             if visitor.filter_found() {
                 break;
             }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -585,7 +585,8 @@ impl Snapshot {
     }
 
     /// Load domain metadata: if Complete in the CRC, answer from the cache; else if every
-    /// requested domain is in a Partial cache, also answer from the cache; else full log
+    /// requested domain is in a Partial cache, also answer from the cache; else if a stale Complete
+    /// CRC is held, scan only the commits after it and reconcile against its map; else full log
     /// replay. `domains == None` means load all.
     ///
     /// Reports metrics: `DomainMetadataLoadSuccess` or `DomainMetadataLoadFailure`.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -645,6 +645,22 @@ impl Snapshot {
                 }
             }
         }
+        // A stale but authoritative (`Complete`) CRC roots a tail-only scan over the commits after
+        // it, skipping the checkpoint. A `Partial` base is not authoritative for misses, so it
+        // falls through to the full scan below.
+        if let Some(base) = self.base_crc() {
+            if let DomainMetadataState::Complete(base_active) = &base.domain_metadata_state {
+                let rooted = self.log_segment().scan_domain_metadatas_rooted_in_crc(
+                    base.version,
+                    base_active,
+                    domains,
+                    engine,
+                )?;
+                record_metric(false, rooted.len());
+                return Ok(rooted);
+            }
+        }
+
         // Fallback: scan the log_segment from scratch.
         // TODO: a Partial cache already covers the commits read during snapshot load. A
         //       miss search could skip that range and only scan the older commits, then

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -658,6 +658,10 @@ impl Snapshot {
                     domains,
                     engine,
                 )?;
+                // TODO: report a distinct metric source here. A rooted tail scan is neither a
+                //       cache hit nor a full replay, yet `from_cache = false` buckets it with
+                //       full replay, hiding the checkpoint-skipping win. A 3-variant source enum
+                //       (cache / crc-rooted / full-replay) would let metrics measure it.
                 record_metric(false, rooted.len());
                 return Ok(rooted);
             }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -646,8 +646,9 @@ impl Snapshot {
             }
         }
         // A stale but authoritative (`Complete`) CRC roots a tail-only scan over the commits after
-        // it, skipping the checkpoint. A `Partial` base is not authoritative for misses, so it
-        // falls through to the full scan below.
+        // it, skipping the checkpoint. A stale `Partial` CRC (one whose file lacked the
+        // `domainMetadata` field) has no authoritative active-domain set, so it cannot root the
+        // scan and falls through to the full replay below.
         if let Some(base) = self.base_crc() {
             if let DomainMetadataState::Complete(base_active) = &base.domain_metadata_state {
                 let rooted = self.log_segment().scan_domain_metadatas_rooted_in_crc(

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -2359,8 +2359,9 @@ impl Engine for ParquetForbiddenEngine {
 
 /// Builds checkpoint@10, commits to v20, and a CRC at v15. Loaded with the default
 /// `Disabled` replay so the v15 CRC is retained as a stale base (`crc_at_version()` is `None`).
-/// Seeds three domains covering the reconcile table:
+/// Seeds four domains covering every reconcile arm:
 /// - `dom_before` set at v5 and never touched again (base stands),
+/// - `dom_updated` set at v6 then re-set at v16 (tail config overrides the base),
 /// - `dom_after` set at v18 (new in the tail),
 /// - `dom_removed` set at v8 then tombstoned at v17 (tail removal shadows the base).
 async fn setup_stale_crc_dm_table<E: TaskExecutor>(
@@ -2387,7 +2388,11 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
             .with_data_change(true);
         txn = match v {
             5 => txn.with_domain_metadata("dom_before".to_string(), "cfg_before".to_string()),
+            6 => txn.with_domain_metadata("dom_updated".to_string(), "cfg_updated".to_string()),
             8 => txn.with_domain_metadata("dom_removed".to_string(), "cfg_removed".to_string()),
+            16 => {
+                txn.with_domain_metadata("dom_updated".to_string(), "cfg_updated_v16".to_string())
+            }
             17 => txn.with_domain_metadata_removed("dom_removed".to_string()),
             18 => txn.with_domain_metadata("dom_after".to_string(), "cfg_after".to_string()),
             _ => txn,
@@ -2410,11 +2415,13 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
 }
 
 #[rstest]
-#[case::filtered_present("dom_before", Some("cfg_before"))]
-#[case::filtered_tail_added("dom_after", Some("cfg_after"))]
-#[case::filtered_tail_removed("dom_removed", None)]
+#[case::base_stands("dom_before", Some("cfg_before"))]
+#[case::tail_overrides_base("dom_updated", Some("cfg_updated_v16"))]
+#[case::tail_added("dom_after", Some("cfg_after"))]
+#[case::tail_removed("dom_removed", None)]
+#[case::never_existed("dom_missing", None)]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_dm_query_roots_in_stale_complete_crc_skips_checkpoint(
+async fn test_dm_query_rooted_in_stale_complete_crc_filtered(
     #[case] domain: &str,
     #[case] expected: Option<&str>,
 ) -> DeltaResult<()> {
@@ -2425,21 +2432,80 @@ async fn test_dm_query_roots_in_stale_complete_crc_skips_checkpoint(
     assert_eq!(fresh.version(), 20);
     assert!(fresh.crc_at_version().is_none());
 
-    // The rooted scan reads only the commit tail (16..=20), never the v10 parquet checkpoint.
+    // ParquetForbiddenEngine proves the rooted scan reads only the commit tail (16..=20), never
+    // the v10 parquet checkpoint.
     let forbidden = ParquetForbiddenEngine {
         inner: engine.clone(),
     };
-
     assert_eq!(
         fresh.get_domain_metadata(domain, &forbidden)?,
         expected.map(str::to_string)
     );
 
-    // The unfiltered query resolves the whole active set through the same rooted path.
-    let all = fresh.get_all_domain_metadata(&forbidden)?;
-    let mut domains: Vec<_> = all.iter().map(|dm| dm.domain().to_string()).collect();
-    domains.sort();
-    assert_eq!(domains, ["dom_after", "dom_before"]);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dm_query_rooted_in_stale_complete_crc_unfiltered() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_dm_table(&engine, &table_path).await?;
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 20);
+    assert!(fresh.crc_at_version().is_none());
+
+    let forbidden = ParquetForbiddenEngine {
+        inner: engine.clone(),
+    };
+    let active: HashMap<_, _> = fresh
+        .get_all_domain_metadata(&forbidden)?
+        .into_iter()
+        .map(|dm| (dm.domain().to_string(), dm.configuration().to_string()))
+        .collect();
+    assert_eq!(
+        active,
+        HashMap::from([
+            ("dom_before".to_string(), "cfg_before".to_string()),
+            ("dom_updated".to_string(), "cfg_updated_v16".to_string()),
+            ("dom_after".to_string(), "cfg_after".to_string()),
+        ])
+    );
+
+    Ok(())
+}
+
+// A single multi-domain filter must resolve each domain independently through the reconcile:
+// base fallback, tail override, tail add, tail tombstone, and a never-existed domain in one call.
+// This is the shape the real caller (Transaction::get_domain_metadatas_internal) uses.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dm_query_rooted_in_stale_complete_crc_multi_domain_filter() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_dm_table(&engine, &table_path).await?;
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let forbidden = ParquetForbiddenEngine {
+        inner: engine.clone(),
+    };
+    let filter = HashSet::from([
+        "dom_before",
+        "dom_updated",
+        "dom_after",
+        "dom_removed",
+        "dom_missing",
+    ]);
+    let got: HashMap<_, _> = fresh
+        .get_domain_metadatas_internal(&forbidden, Some(&filter))?
+        .into_iter()
+        .map(|(domain, dm)| (domain, dm.configuration().to_string()))
+        .collect();
+    assert_eq!(
+        got,
+        HashMap::from([
+            ("dom_before".to_string(), "cfg_before".to_string()),
+            ("dom_updated".to_string(), "cfg_updated_v16".to_string()),
+            ("dom_after".to_string(), "cfg_after".to_string()),
+        ])
+    );
 
     Ok(())
 }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -15,6 +15,7 @@ use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::snapshot::{ChecksumWriteResult, IncrementalReplay, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::Transaction;
 use delta_kernel::{DeltaResult, Engine, FileStats, Version};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
@@ -2045,18 +2046,32 @@ async fn commit_with_dm_and_txn<E: TaskExecutor>(
     engine: &Arc<DefaultEngine<E>>,
     v: i64,
 ) -> DeltaResult<SnapshotRef> {
+    commit_data(snapshot, engine, v, |txn| {
+        txn.with_domain_metadata("domain".to_string(), format!("value_{v}"))
+            .with_transaction_id("app".to_string(), v)
+    })
+    .await
+}
+
+/// Commit one data file at version `v`, letting `customize` attach the version-specific actions
+/// (domain metadata, set transactions, removals) to the WRITE transaction.
+async fn commit_data<E: TaskExecutor>(
+    snapshot: SnapshotRef,
+    engine: &Arc<DefaultEngine<E>>,
+    v: i64,
+    customize: impl FnOnce(Transaction) -> Transaction,
+) -> DeltaResult<SnapshotRef> {
     let arrow_schema = TryFromKernel::try_from_kernel(snapshot.schema().as_ref())?;
     let batch = RecordBatch::try_new(
         Arc::new(arrow_schema),
         vec![Arc::new(Int32Array::from(vec![v as i32]))],
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
-    let mut txn = snapshot
+    let txn = snapshot
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_operation("WRITE".to_string())
-        .with_data_change(true)
-        .with_domain_metadata("domain".to_string(), format!("value_{v}"))
-        .with_transaction_id("app".to_string(), v);
+        .with_data_change(true);
+    let mut txn = customize(txn);
     let write_context = txn.unpartitioned_write_context()?;
     let adds = engine
         .write_parquet(&ArrowEngineData::new(batch), &write_context)
@@ -2302,19 +2317,18 @@ async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() 
 // Domain metadata rooted in a stale (but authoritative) CRC
 // ============================================================================
 
-/// Engine that delegates every handler to an inner engine, except `read_parquet_files`, which
-/// panics. A domain-metadata query reads only JSON commits; the sole parquet read on the path is
-/// the V1 checkpoint. So this proves the checkpoint is never read: it passes when the query roots
-/// in a stale CRC and scans only the commit tail, and panics when it falls through to a full scan.
-struct ParquetForbiddenEngine {
+/// Delegates every handler to an inner engine, but panics on `read_parquet_files`. A
+/// domain-metadata query reads only JSON commits, so the only parquet a scan would touch is the
+/// V1 checkpoint.
+struct NoParquetReadsEngine {
     inner: Arc<dyn Engine>,
 }
 
-struct ParquetForbiddenHandler {
+struct NoParquetReadsHandler {
     inner: Arc<dyn delta_kernel::ParquetHandler>,
 }
 
-impl delta_kernel::ParquetHandler for ParquetForbiddenHandler {
+impl delta_kernel::ParquetHandler for NoParquetReadsHandler {
     fn read_parquet_files(
         &self,
         _files: &[delta_kernel::FileMeta],
@@ -2340,7 +2354,7 @@ impl delta_kernel::ParquetHandler for ParquetForbiddenHandler {
     }
 }
 
-impl Engine for ParquetForbiddenEngine {
+impl Engine for NoParquetReadsEngine {
     fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
         self.inner.evaluation_handler()
     }
@@ -2351,7 +2365,7 @@ impl Engine for ParquetForbiddenEngine {
         self.inner.json_handler()
     }
     fn parquet_handler(&self) -> Arc<dyn delta_kernel::ParquetHandler> {
-        Arc::new(ParquetForbiddenHandler {
+        Arc::new(NoParquetReadsHandler {
             inner: self.inner.parquet_handler(),
         })
     }
@@ -2376,17 +2390,7 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
         .unwrap_post_commit_snapshot();
 
     for v in 1..=20i64 {
-        let arrow_schema = TryFromKernel::try_from_kernel(snap.schema().as_ref())?;
-        let batch = RecordBatch::try_new(
-            Arc::new(arrow_schema),
-            vec![Arc::new(Int32Array::from(vec![v as i32]))],
-        )
-        .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
-        let mut txn = snap
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-            .with_operation("WRITE".to_string())
-            .with_data_change(true);
-        txn = match v {
+        snap = commit_data(snap, engine, v, |txn| match v {
             5 => txn.with_domain_metadata("dom_before".to_string(), "cfg_before".to_string()),
             6 => txn.with_domain_metadata("dom_updated".to_string(), "cfg_updated".to_string()),
             8 => txn.with_domain_metadata("dom_removed".to_string(), "cfg_removed".to_string()),
@@ -2396,13 +2400,8 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
             17 => txn.with_domain_metadata_removed("dom_removed".to_string()),
             18 => txn.with_domain_metadata("dom_after".to_string(), "cfg_after".to_string()),
             _ => txn,
-        };
-        let write_context = txn.unpartitioned_write_context()?;
-        let adds = engine
-            .write_parquet(&ArrowEngineData::new(batch), &write_context)
-            .await?;
-        txn.add_files(adds);
-        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        })
+        .await?;
 
         if v == 10 {
             snap = snap.checkpoint(engine.as_ref(), None)?.1;
@@ -2414,99 +2413,78 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
     Ok(())
 }
 
+/// The active-domain set at v20 the rooted scan must resolve, regardless of query shape.
+fn expected_active() -> HashMap<String, String> {
+    [
+        ("dom_before", "cfg_before"),
+        ("dom_updated", "cfg_updated_v16"),
+        ("dom_after", "cfg_after"),
+    ]
+    .iter()
+    .map(|(d, c)| (d.to_string(), c.to_string()))
+    .collect()
+}
+
+/// A domain-metadata query shape and its expected result against [`setup_stale_crc_dm_table`].
+enum Query {
+    /// `get_domain_metadata(domain)` for one domain.
+    One(&'static str, Option<&'static str>),
+    /// `get_domain_metadatas_internal` with a multi-domain filter (the real caller's shape).
+    Filter(&'static [&'static str]),
+    /// `get_all_domain_metadata()`.
+    All,
+}
+
+// Every query shape resolves against a stale Complete CRC by scanning only the commit tail. The
+// NoParquetReadsEngine panics if the v10 checkpoint is read, proving the checkpoint is skipped.
 #[rstest]
-#[case::base_stands("dom_before", Some("cfg_before"))]
-#[case::tail_overrides_base("dom_updated", Some("cfg_updated_v16"))]
-#[case::tail_added("dom_after", Some("cfg_after"))]
-#[case::tail_removed("dom_removed", None)]
-#[case::never_existed("dom_missing", None)]
+#[case::base_stands(Query::One("dom_before", Some("cfg_before")))]
+#[case::tail_overrides_base(Query::One("dom_updated", Some("cfg_updated_v16")))]
+#[case::tail_added(Query::One("dom_after", Some("cfg_after")))]
+#[case::tail_removed(Query::One("dom_removed", None))]
+#[case::never_existed(Query::One("dom_missing", None))]
+#[case::multi_domain_filter(Query::Filter(&[
+    "dom_before", "dom_updated", "dom_after", "dom_removed", "dom_missing",
+]))]
+#[case::unfiltered(Query::All)]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_dm_query_rooted_in_stale_complete_crc_filtered(
-    #[case] domain: &str,
-    #[case] expected: Option<&str>,
-) -> DeltaResult<()> {
+async fn test_dm_query_rooted_in_stale_complete_crc(#[case] query: Query) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     setup_stale_crc_dm_table(&engine, &table_path).await?;
 
     let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(fresh.version(), 20);
-    assert!(fresh.crc_at_version().is_none());
-
-    // ParquetForbiddenEngine proves the rooted scan reads only the commit tail (16..=20), never
-    // the v10 parquet checkpoint.
-    let forbidden = ParquetForbiddenEngine {
-        inner: engine.clone(),
-    };
-    assert_eq!(
-        fresh.get_domain_metadata(domain, &forbidden)?,
-        expected.map(str::to_string)
+    assert!(
+        fresh.crc_at_version().is_none(),
+        "the stale CRC must not sit at the snapshot version"
     );
 
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_dm_query_rooted_in_stale_complete_crc_unfiltered() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    setup_stale_crc_dm_table(&engine, &table_path).await?;
-
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    assert_eq!(fresh.version(), 20);
-    assert!(fresh.crc_at_version().is_none());
-
-    let forbidden = ParquetForbiddenEngine {
+    let engine = NoParquetReadsEngine {
         inner: engine.clone(),
     };
-    let active: HashMap<_, _> = fresh
-        .get_all_domain_metadata(&forbidden)?
-        .into_iter()
-        .map(|dm| (dm.domain().to_string(), dm.configuration().to_string()))
-        .collect();
-    assert_eq!(
-        active,
-        HashMap::from([
-            ("dom_before".to_string(), "cfg_before".to_string()),
-            ("dom_updated".to_string(), "cfg_updated_v16".to_string()),
-            ("dom_after".to_string(), "cfg_after".to_string()),
-        ])
-    );
-
-    Ok(())
-}
-
-// A single multi-domain filter must resolve each domain independently through the reconcile:
-// base fallback, tail override, tail add, tail tombstone, and a never-existed domain in one call.
-// This is the shape the real caller (Transaction::get_domain_metadatas_internal) uses.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_dm_query_rooted_in_stale_complete_crc_multi_domain_filter() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    setup_stale_crc_dm_table(&engine, &table_path).await?;
-
-    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
-    let forbidden = ParquetForbiddenEngine {
-        inner: engine.clone(),
-    };
-    let filter = HashSet::from([
-        "dom_before",
-        "dom_updated",
-        "dom_after",
-        "dom_removed",
-        "dom_missing",
-    ]);
-    let got: HashMap<_, _> = fresh
-        .get_domain_metadatas_internal(&forbidden, Some(&filter))?
-        .into_iter()
-        .map(|(domain, dm)| (domain, dm.configuration().to_string()))
-        .collect();
-    assert_eq!(
-        got,
-        HashMap::from([
-            ("dom_before".to_string(), "cfg_before".to_string()),
-            ("dom_updated".to_string(), "cfg_updated_v16".to_string()),
-            ("dom_after".to_string(), "cfg_after".to_string()),
-        ])
-    );
-
+    match query {
+        Query::One(domain, expected) => assert_eq!(
+            fresh.get_domain_metadata(domain, &engine)?,
+            expected.map(str::to_string)
+        ),
+        Query::Filter(keys) => {
+            let filter = keys.iter().copied().collect();
+            let got: HashMap<String, String> = fresh
+                .get_domain_metadatas_internal(&engine, Some(&filter))?
+                .into_iter()
+                .map(|(domain, dm)| (domain, dm.configuration().to_string()))
+                .collect();
+            assert_eq!(got, expected_active());
+        }
+        Query::All => {
+            let all: HashMap<String, String> = fresh
+                .get_all_domain_metadata(&engine)?
+                .into_iter()
+                .map(|dm| (dm.domain().to_string(), dm.configuration().to_string()))
+                .collect();
+            assert_eq!(all, expected_active());
+        }
+    }
     Ok(())
 }
 
@@ -2533,13 +2511,13 @@ async fn test_dm_query_stale_partial_crc_falls_through_to_full_scan() -> DeltaRe
         None
     );
 
-    // A full scan reads the v10 checkpoint, so the parquet-forbidden engine panics: this proves
-    // the Partial base did NOT take the rooted (checkpoint-skipping) path.
-    let forbidden = ParquetForbiddenEngine {
+    // A full scan reads the v10 checkpoint, so NoParquetReadsEngine panics: the Partial base did
+    // NOT take the rooted (checkpoint-skipping) path.
+    let no_parquet = NoParquetReadsEngine {
         inner: engine.clone(),
     };
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        fresh.get_domain_metadata("dom_before", &forbidden).ok()
+        fresh.get_domain_metadata("dom_before", &no_parquet).ok()
     }))
     .is_err());
 

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -2297,3 +2297,185 @@ async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() 
 
     Ok(())
 }
+
+// ============================================================================
+// Domain metadata rooted in a stale (but authoritative) CRC
+// ============================================================================
+
+/// Engine that delegates every handler to an inner engine, except `read_parquet_files`, which
+/// panics. A domain-metadata query reads only JSON commits; the sole parquet read on the path is
+/// the V1 checkpoint. So this proves the checkpoint is never read: it passes when the query roots
+/// in a stale CRC and scans only the commit tail, and panics when it falls through to a full scan.
+struct ParquetForbiddenEngine {
+    inner: Arc<dyn Engine>,
+}
+
+struct ParquetForbiddenHandler {
+    inner: Arc<dyn delta_kernel::ParquetHandler>,
+}
+
+impl delta_kernel::ParquetHandler for ParquetForbiddenHandler {
+    fn read_parquet_files(
+        &self,
+        _files: &[delta_kernel::FileMeta],
+        _physical_schema: delta_kernel::schema::SchemaRef,
+        _predicate: Option<delta_kernel::PredicateRef>,
+    ) -> DeltaResult<delta_kernel::FileDataReadResultIterator> {
+        panic!("read_parquet_files called: the checkpoint must not be read on the rooted path");
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: Url,
+        data: delta_kernel::DeltaResultIteratorStatic<Box<dyn delta_kernel::EngineData>>,
+    ) -> DeltaResult<()> {
+        self.inner.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(
+        &self,
+        file: &delta_kernel::FileMeta,
+    ) -> DeltaResult<delta_kernel::ParquetFooter> {
+        self.inner.read_parquet_footer(file)
+    }
+}
+
+impl Engine for ParquetForbiddenEngine {
+    fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn delta_kernel::StorageHandler> {
+        self.inner.storage_handler()
+    }
+    fn json_handler(&self) -> Arc<dyn delta_kernel::JsonHandler> {
+        self.inner.json_handler()
+    }
+    fn parquet_handler(&self) -> Arc<dyn delta_kernel::ParquetHandler> {
+        Arc::new(ParquetForbiddenHandler {
+            inner: self.inner.parquet_handler(),
+        })
+    }
+}
+
+/// Builds checkpoint@10, commits to v20, and a CRC at v15. Loaded with the default
+/// `Disabled` replay so the v15 CRC is retained as a stale base (`crc_at_version()` is `None`).
+/// Seeds three domains covering the reconcile table:
+/// - `dom_before` set at v5 and never touched again (base stands),
+/// - `dom_after` set at v18 (new in the tail),
+/// - `dom_removed` set at v8 then tombstoned at v17 (tail removal shadows the base).
+async fn setup_stale_crc_dm_table<E: TaskExecutor>(
+    engine: &Arc<DefaultEngine<E>>,
+    table_path: &str,
+) -> DeltaResult<()> {
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let mut snap = create_table(table_path, schema, "test_engine")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    for v in 1..=20i64 {
+        let arrow_schema = TryFromKernel::try_from_kernel(snap.schema().as_ref())?;
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![Arc::new(Int32Array::from(vec![v as i32]))],
+        )
+        .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
+        let mut txn = snap
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("WRITE".to_string())
+            .with_data_change(true);
+        txn = match v {
+            5 => txn.with_domain_metadata("dom_before".to_string(), "cfg_before".to_string()),
+            8 => txn.with_domain_metadata("dom_removed".to_string(), "cfg_removed".to_string()),
+            17 => txn.with_domain_metadata_removed("dom_removed".to_string()),
+            18 => txn.with_domain_metadata("dom_after".to_string(), "cfg_after".to_string()),
+            _ => txn,
+        };
+        let write_context = txn.unpartitioned_write_context()?;
+        let adds = engine
+            .write_parquet(&ArrowEngineData::new(batch), &write_context)
+            .await?;
+        txn.add_files(adds);
+        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+
+        if v == 10 {
+            snap = snap.checkpoint(engine.as_ref(), None)?.1;
+        }
+        if v == 15 {
+            snap.write_checksum(engine.as_ref())?;
+        }
+    }
+    Ok(())
+}
+
+#[rstest]
+#[case::filtered_present("dom_before", Some("cfg_before"))]
+#[case::filtered_tail_added("dom_after", Some("cfg_after"))]
+#[case::filtered_tail_removed("dom_removed", None)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dm_query_roots_in_stale_complete_crc_skips_checkpoint(
+    #[case] domain: &str,
+    #[case] expected: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_dm_table(&engine, &table_path).await?;
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 20);
+    assert!(fresh.crc_at_version().is_none());
+
+    // The rooted scan reads only the commit tail (16..=20), never the v10 parquet checkpoint.
+    let forbidden = ParquetForbiddenEngine {
+        inner: engine.clone(),
+    };
+
+    assert_eq!(
+        fresh.get_domain_metadata(domain, &forbidden)?,
+        expected.map(str::to_string)
+    );
+
+    // The unfiltered query resolves the whole active set through the same rooted path.
+    let all = fresh.get_all_domain_metadata(&forbidden)?;
+    let mut domains: Vec<_> = all.iter().map(|dm| dm.domain().to_string()).collect();
+    domains.sort();
+    assert_eq!(domains, ["dom_after", "dom_before"]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dm_query_stale_partial_crc_falls_through_to_full_scan() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_dm_table(&engine, &table_path).await?;
+
+    // Strip domainMetadata from the v15 CRC so it reloads as Partial: not authoritative, so the
+    // query must not take the rooted path.
+    strip_field_from_crc(&table_path, 15, "domainMetadata");
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 20);
+    assert!(fresh.crc_at_version().is_none());
+
+    // Results are still correct via the full scan (with the real engine).
+    assert_eq!(
+        fresh.get_domain_metadata("dom_before", engine.as_ref())?,
+        Some("cfg_before".to_string())
+    );
+    assert_eq!(
+        fresh.get_domain_metadata("dom_removed", engine.as_ref())?,
+        None
+    );
+
+    // A full scan reads the v10 checkpoint, so the parquet-forbidden engine panics: this proves
+    // the Partial base did NOT take the rooted (checkpoint-skipping) path.
+    let forbidden = ParquetForbiddenEngine {
+        inner: engine.clone(),
+    };
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fresh.get_domain_metadata("dom_before", &forbidden).ok()
+    }))
+    .is_err());
+
+    Ok(())
+}

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -11,12 +11,16 @@ use delta_kernel::engine::arrow_conversion::TryFromKernel;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::path::ParsedLogPath;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
 use delta_kernel::snapshot::{ChecksumWriteResult, IncrementalReplay, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::transaction::Transaction;
-use delta_kernel::{DeltaResult, Engine, FileStats, Version};
+use delta_kernel::{
+    DeltaResult, DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler,
+    FileDataReadResultIterator, FileMeta, FileStats, JsonHandler, ParquetFooter, ParquetHandler,
+    PredicateRef, StorageHandler, Version,
+};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::executor::TaskExecutor;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
@@ -2317,54 +2321,52 @@ async fn test_stale_crc_fresh_build_fails_load_when_advance_commit_is_corrupt() 
 // Domain metadata rooted in a stale (but authoritative) CRC
 // ============================================================================
 
-/// Delegates every handler to an inner engine, but panics on `read_parquet_files`. A
-/// domain-metadata query reads only JSON commits, so the only parquet a scan would touch is the
-/// V1 checkpoint.
+/// Delegates every handler to `inner`, but panics on `read_parquet_files`. A domain-metadata query
+/// reads only JSON commits, so the only parquet a scan would touch is the V1 checkpoint; the panic
+/// proves the rooted path skips it. That the pruned tail segment itself excludes the checkpoint and
+/// every commit at/below the base CRC is covered by `test_segment_crc_filtering`.
 struct NoParquetReadsEngine {
     inner: Arc<dyn Engine>,
 }
 
 struct NoParquetReadsHandler {
-    inner: Arc<dyn delta_kernel::ParquetHandler>,
+    inner: Arc<dyn ParquetHandler>,
 }
 
-impl delta_kernel::ParquetHandler for NoParquetReadsHandler {
+impl ParquetHandler for NoParquetReadsHandler {
     fn read_parquet_files(
         &self,
-        _files: &[delta_kernel::FileMeta],
-        _physical_schema: delta_kernel::schema::SchemaRef,
-        _predicate: Option<delta_kernel::PredicateRef>,
-    ) -> DeltaResult<delta_kernel::FileDataReadResultIterator> {
+        _files: &[FileMeta],
+        _physical_schema: SchemaRef,
+        _predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
         panic!("read_parquet_files called: the checkpoint must not be read on the rooted path");
     }
 
     fn write_parquet_file(
         &self,
         location: Url,
-        data: delta_kernel::DeltaResultIteratorStatic<Box<dyn delta_kernel::EngineData>>,
+        data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
         self.inner.write_parquet_file(location, data)
     }
 
-    fn read_parquet_footer(
-        &self,
-        file: &delta_kernel::FileMeta,
-    ) -> DeltaResult<delta_kernel::ParquetFooter> {
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
         self.inner.read_parquet_footer(file)
     }
 }
 
 impl Engine for NoParquetReadsEngine {
-    fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
         self.inner.evaluation_handler()
     }
-    fn storage_handler(&self) -> Arc<dyn delta_kernel::StorageHandler> {
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
         self.inner.storage_handler()
     }
-    fn json_handler(&self) -> Arc<dyn delta_kernel::JsonHandler> {
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
         self.inner.json_handler()
     }
-    fn parquet_handler(&self) -> Arc<dyn delta_kernel::ParquetHandler> {
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
         Arc::new(NoParquetReadsHandler {
             inner: self.inner.parquet_handler(),
         })


### PR DESCRIPTION
## What changes are proposed in this pull request?

When connectors do _not_ perform incremental CRC replay, then previously Kernel would only root DM queries in checkpoints. i.e. givem 10.checkpoint, 11.json to 30.json, and 15.crc -- Kernel would ignore the CRC.

This PR enables Kernel to make use of stale CRC during DM queries.

## How was this change tested?

New UTs.
