### PR TITLE
feat!: add Cast expression node

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -663,8 +663,7 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
-        // The engine-visitor FFI has no cast callback yet; surface it as an unknown expression,
-        // which an engine treats as uninterpretable.
+        // No cast callback yet; surface it as an unknown expression.
         Expression::Cast(cast) => visit_unknown(
             visitor,
             sibling_list_id,

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -663,7 +663,7 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
-        // No cast callback yet; surface it as an unknown expression.
+        // TODO(#2975): Add a dedicated visitor callback for cast expressions.
         Expression::Cast(cast) => visit_unknown(
             visitor,
             sibling_list_id,

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -663,6 +663,13 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
+        // The engine-visitor FFI has no cast callback yet; surface it as an unknown expression,
+        // which an engine treats as uninterpretable.
+        Expression::Cast(cast) => visit_unknown(
+            visitor,
+            sibling_list_id,
+            &format!("cast_to_{}", cast.target),
+        ),
         Expression::Unknown(name) => visit_unknown(visitor, sibling_list_id, name),
     }
 }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -386,16 +386,14 @@ pub fn evaluate_expression(
         (Cast(c), result_type) => {
             let input = evaluate_expression(&c.expr, batch, None)?;
             let target = ArrowDataType::try_from_kernel(&c.target)?;
-            // Safe cast semantics: an unrepresentable value becomes NULL rather than erroring,
-            // matching SQL `CAST` / lenient partition-value parsing. Arrow's `cast` default nulls
-            // per-value failures, but errors outright on a type pair it has no cast for; degrade
-            // that to an all-NULL column so an unsupported cast keeps (rather than fails) the scan.
-            let casted = if can_cast_types(input.data_type(), &target) {
+            // Arrow errors (rather than nulls per-value) on a type pair it cannot cast; degrade
+            // that to an all-NULL column so an unsupported cast keeps the file.
+            let output = if can_cast_types(input.data_type(), &target) {
                 cast(&input, &target)?
             } else {
                 new_null_array(&target, input.len())
             };
-            validate_array_type(casted, result_type)
+            validate_array_type(output, result_type)
         }
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
     }
@@ -3205,8 +3203,7 @@ mod tests {
 
     #[test]
     fn test_cast_unsupported_type_pair_yields_null() {
-        // Arrow has no cast from Boolean to Date. Rather than erroring (which would abort the
-        // scan), the cast degrades to an all-NULL column so the file is kept.
+        // Arrow has no cast from Boolean to Date; the cast degrades to an all-NULL column.
         let schema = ArrowSchema::new(vec![ArrowField::new("flag", ArrowDataType::Boolean, true)]);
         let flags = BooleanArray::from(vec![Some(true), Some(false)]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(flags)]).unwrap();

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -18,7 +18,9 @@ use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
-use crate::arrow::compute::{and_kleene, cast, is_not_null, is_null, not, or_kleene};
+use crate::arrow::compute::{
+    and_kleene, can_cast_types, cast, is_not_null, is_null, not, or_kleene,
+};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, IntervalUnit,
     Schema as ArrowSchema, TimeUnit,
@@ -381,6 +383,20 @@ pub fn evaluate_expression(
         (MapToStruct(_), dt) => Err(Error::Generic(format!(
             "MapToStruct expression requires a DataType::Struct result type, but got {dt:?}"
         ))),
+        (Cast(c), result_type) => {
+            let input = evaluate_expression(&c.expr, batch, None)?;
+            let target = ArrowDataType::try_from_kernel(&c.target)?;
+            // Safe cast semantics: an unrepresentable value becomes NULL rather than erroring,
+            // matching SQL `CAST` / lenient partition-value parsing. Arrow's `cast` default nulls
+            // per-value failures, but errors outright on a type pair it has no cast for; degrade
+            // that to an all-NULL column so an unsupported cast keeps (rather than fails) the scan.
+            let casted = if can_cast_types(input.data_type(), &target) {
+                cast(&input, &target)?
+            } else {
+                new_null_array(&target, input.len())
+            };
+            validate_array_type(casted, result_type)
+        }
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
     }
 }
@@ -3157,5 +3173,49 @@ mod tests {
             .column(0)
             .as_primitive::<Int32Type>();
         assert_eq!(row2_inner.value(0), 30);
+    }
+
+    #[test]
+    fn test_cast_string_to_date() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("part", ArrowDataType::Utf8, true)]);
+        // Row 1 is unparseable and row 2 is null; both must become NULL under safe-cast semantics.
+        let parts = StringArray::from(vec![Some("2025-04-11"), Some("not-a-date"), None]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(parts)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("part"), DataType::DATE);
+        let result = evaluate_expression(&expr, &batch, None).unwrap();
+
+        let dates = result.as_primitive::<Date32Type>();
+        assert_eq!(dates.value(0), 20189); // 2025-04-11 is 20189 days after the unix epoch
+        assert!(dates.is_null(1));
+        assert!(dates.is_null(2));
+    }
+
+    #[test]
+    fn test_cast_result_type_validated() {
+        let schema = ArrowSchema::new(vec![ArrowField::new("part", ArrowDataType::Utf8, true)]);
+        let parts = StringArray::from(vec![Some("2025-04-11")]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(parts)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("part"), DataType::DATE);
+        // The declared result type must match the cast target.
+        assert!(evaluate_expression(&expr, &batch, Some(&DataType::LONG)).is_err());
+        assert!(evaluate_expression(&expr, &batch, Some(&DataType::DATE)).is_ok());
+    }
+
+    #[test]
+    fn test_cast_unsupported_type_pair_yields_null() {
+        // Arrow has no cast from Boolean to Date. Rather than erroring (which would abort the
+        // scan), the cast degrades to an all-NULL column so the file is kept.
+        let schema = ArrowSchema::new(vec![ArrowField::new("flag", ArrowDataType::Boolean, true)]);
+        let flags = BooleanArray::from(vec![Some(true), Some(false)]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(flags)]).unwrap();
+
+        let expr = Expr::cast(column_expr!("flag"), DataType::DATE);
+        let result = evaluate_expression(&expr, &batch, None).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.null_count(), 2);
+        assert_eq!(result.data_type(), &ArrowDataType::Date32);
     }
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1395,21 +1395,15 @@ mod tests {
             assert_roundtrip(&expr);
         }
 
-        #[test]
-        fn test_cast_expression_roundtrip() {
-            let cases: Vec<Expression> = vec![
-                Expression::cast(column_expr!("part"), DataType::DATE),
-                Expression::cast(Expression::literal("2025-01-01"), DataType::DATE),
-                // Nested cast: the child is itself a cast.
-                Expression::cast(
-                    Expression::cast(column_expr!("part"), DataType::STRING),
-                    DataType::INTEGER,
-                ),
-            ];
-
-            for expr in &cases {
-                assert_roundtrip(expr);
-            }
+        #[rstest::rstest]
+        #[case::column(Expression::cast(column_expr!("part"), DataType::DATE))]
+        #[case::literal(Expression::cast(Expression::literal("2025-01-01"), DataType::DATE))]
+        #[case::nested(Expression::cast(
+            Expression::cast(column_expr!("part"), DataType::STRING),
+            DataType::INTEGER,
+        ))]
+        fn test_cast_expression_roundtrip(#[case] expr: Expression) {
+            assert_roundtrip(&expr);
         }
 
         #[rstest::rstest]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -280,6 +280,20 @@ pub struct ParseJsonExpression {
     pub output_schema: SchemaRef,
 }
 
+/// An expression that casts a child expression to a target type, following SQL `CAST` semantics.
+///
+/// A value that cannot be represented in the target type evaluates to NULL rather than erroring,
+/// matching how partition values are parsed to their declared type. The arrow evaluation path
+/// casts to any arrow-representable target, yielding an all-NULL column for a type pair arrow
+/// cannot cast.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CastExpression {
+    /// The expression whose value is cast.
+    pub expr: Box<Expression>,
+    /// The type the value is cast to.
+    pub target: DataType,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct JunctionPredicate {
     /// The operator.
@@ -413,6 +427,8 @@ pub enum Expression {
     /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
     /// [`MapToStructExpression`] for how values are parsed.
     MapToStruct(MapToStructExpression),
+    /// Cast a child expression to a target type. See [`CastExpression`].
+    Cast(CastExpression),
 }
 
 /// A SQL predicate.
@@ -557,6 +573,15 @@ impl MapToStructExpression {
     pub(crate) fn new(map_expr: impl Into<Expression>) -> Self {
         Self {
             map_expr: Box::new(map_expr.into()),
+        }
+    }
+}
+
+impl CastExpression {
+    pub(crate) fn new(expr: impl Into<Expression>, target: DataType) -> Self {
+        Self {
+            expr: Box::new(expr.into()),
+            target,
         }
     }
 }
@@ -744,6 +769,12 @@ impl Expression {
     /// and to null for every other type. See [`MapToStructExpression`] for the full contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr))
+    }
+
+    /// Creates a new cast of `expr` to `target`, following SQL `CAST` semantics (unrepresentable
+    /// values become NULL). See [`CastExpression`].
+    pub fn cast(expr: impl Into<Expression>, target: DataType) -> Self {
+        Self::Cast(CastExpression::new(expr, target))
     }
 }
 
@@ -1024,6 +1055,7 @@ impl Display for Expression {
                 )
             }
             MapToStruct(m) => write!(f, "MAP_TO_STRUCT({})", m.map_expr),
+            Cast(c) => write!(f, "CAST({} AS {})", c.expr, c.target),
         }
     }
 }
@@ -1133,7 +1165,7 @@ mod tests {
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
-    use super::{column_expr, column_pred, Expression as Expr, Predicate as Pred};
+    use super::{column_expr, column_pred, DataType, Expression as Expr, Predicate as Pred};
 
     /// Helper function to verify roundtrip serialization/deserialization
     fn assert_roundtrip<T: Serialize + DeserializeOwned + PartialEq + Debug>(value: &T) {
@@ -1157,6 +1189,10 @@ mod tests {
             (
                 Expr::array([column_expr!("x"), column_expr!("y"), Expr::literal(0)]),
                 "ARRAY(Column(x), Column(y), 0)",
+            ),
+            (
+                Expr::cast(column_expr!("x"), DataType::DATE),
+                "CAST(Column(x) AS date)",
             ),
         ];
 
@@ -1361,6 +1397,23 @@ mod tests {
                 Expression::literal("default"),
             ]);
             assert_roundtrip(&expr);
+        }
+
+        #[test]
+        fn test_cast_expression_roundtrip() {
+            let cases: Vec<Expression> = vec![
+                Expression::cast(column_expr!("part"), DataType::DATE),
+                Expression::cast(Expression::literal("2025-01-01"), DataType::DATE),
+                // Nested cast: the child is itself a cast.
+                Expression::cast(
+                    Expression::cast(column_expr!("part"), DataType::STRING),
+                    DataType::INTEGER,
+                ),
+            ];
+
+            for expr in &cases {
+                assert_roundtrip(expr);
+            }
         }
 
         #[rstest::rstest]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -280,12 +280,8 @@ pub struct ParseJsonExpression {
     pub output_schema: SchemaRef,
 }
 
-/// An expression that casts a child expression to a target type, following SQL `CAST` semantics.
-///
-/// A value that cannot be represented in the target type evaluates to NULL rather than erroring,
-/// matching how partition values are parsed to their declared type. The arrow evaluation path
-/// casts to any arrow-representable target, yielding an all-NULL column for a type pair arrow
-/// cannot cast.
+/// An expression that casts a child expression to a target type, following SQL `CAST` semantics: a
+/// value that cannot be represented in the target type evaluates to NULL rather than erroring.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CastExpression {
     /// The expression whose value is cast.

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -693,7 +693,7 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
 /// via [`PrimitiveType::parse_scalar`](crate::schema::PrimitiveType::parse_scalar), and a source
 /// already of the target type passes through. An unparseable string yields `Scalar::Null`.
 ///
-/// Only string-to-primitive and identity conversions are handled; any other source/target
+/// String-to-primitive, identity, and null-source conversions are handled; any other source/target
 /// combination yields `None`, including numeric/temporal casts like `Long -> Int` that the arrow
 /// path can perform. The accepted string formats are a strict subset of arrow's (e.g. arrow parses
 /// the hyphen-less `20240115` as a date but `parse_scalar` does not), so this path is only ever

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -128,9 +128,9 @@ pub trait KernelPredicateEvaluator {
 
     /// A (possibly inverted) comparison between `CAST(<col> AS target)` and a scalar, e.g.
     /// `CAST(<col> AS DATE) < <value>`. The scalar is always on the right (the caller commutes the
-    /// operator for `<value> op CAST(<col>)`). Unsupported by default so evaluators that cannot
-    /// reason about a cast conservatively keep the file; a per-row evaluator that resolves the
-    /// column to its exact value can override it.
+    /// operator for `<value> op CAST(<col>)`). Unsupported by default so a cast never drives file
+    /// pruning. A per-row evaluator that resolves the column to its exact value can override it; a
+    /// range-based evaluator can only do so soundly when the cast preserves order over the range.
     fn eval_pred_cast(
         &self,
         _op: BinaryPredicateOp,
@@ -309,19 +309,18 @@ pub trait KernelPredicateEvaluator {
                 Distinct => self.eval_pred_distinct(col, val, inverted),
                 In => None, // arg order is semantically important
             },
-            // `CAST(<col> AS target) op <value>` for a bare column child, e.g.
-            // `CAST(<col> AS DATE) < <value>`.
             (Cast(c), Literal(val)) => match c.expr.as_ref() {
                 Column(col) => self.eval_pred_cast(op, col, &c.target, val, inverted),
                 _ => None,
             },
             (Literal(val), Cast(c)) => match c.expr.as_ref() {
-                // Commute so the cast column is on the left, mirroring the `Literal op Column` arm.
+                // Commute so the cast column is on the left.
                 Column(col) => match op {
                     LessThan => self.eval_pred_cast(GreaterThan, col, &c.target, val, inverted),
                     GreaterThan => self.eval_pred_cast(LessThan, col, &c.target, val, inverted),
                     Equal => self.eval_pred_cast(Equal, col, &c.target, val, inverted),
-                    Distinct | In => None,
+                    Distinct => self.eval_pred_cast(Distinct, col, &c.target, val, inverted),
+                    In => None, // arg order is semantically important
                 },
                 _ => None,
             },
@@ -692,15 +691,13 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
 
 /// Casts a scalar following SQL `CAST` semantics: a string source is parsed into a primitive target
 /// via [`PrimitiveType::parse_scalar`](crate::schema::PrimitiveType::parse_scalar), and a source
-/// already of the target type passes through. An unparseable string yields `Scalar::Null` (never
-/// TRUE against a comparison).
+/// already of the target type passes through. An unparseable string yields `Scalar::Null`.
 ///
-/// `parse_scalar` accepts a strict subset of the formats the arrow evaluation path accepts (e.g.
-/// arrow parses the hyphen-less `20240115` as a date but `parse_scalar` does not), so this path is
-/// only ever more conservative than arrow: a form it rejects becomes NULL, never a differing
-/// non-null value. It is deliberately narrower than a full cast -- any source/target combination
-/// other than string-to-primitive or an identity pass-through yields `None`, and it does not
-/// attempt numeric/temporal casts (e.g. `Long -> Int`) that the arrow path can perform.
+/// Only string-to-primitive and identity conversions are handled; any other source/target
+/// combination yields `None`, including numeric/temporal casts like `Long -> Int` that the arrow
+/// path can perform. The accepted string formats are a strict subset of arrow's (e.g. arrow parses
+/// the hyphen-less `20240115` as a date but `parse_scalar` does not), so this path is only ever
+/// more conservative than arrow: a form it rejects becomes NULL, never a differing non-null value.
 fn cast_scalar(value: Scalar, target: &DataType) -> Option<Scalar> {
     if value.data_type() == *target {
         return Some(value);

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -126,6 +126,22 @@ pub trait KernelPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
+    /// A (possibly inverted) comparison between `CAST(<col> AS target)` and a scalar, e.g.
+    /// `CAST(<col> AS DATE) < <value>`. The scalar is always on the right (the caller commutes the
+    /// operator for `<value> op CAST(<col>)`). Unsupported by default so evaluators that cannot
+    /// reason about a cast conservatively keep the file; a per-row evaluator that resolves the
+    /// column to its exact value can override it.
+    fn eval_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<Self::Output> {
+        None
+    }
+
     /// Dispatches an opaque predicate.
     fn eval_pred_opaque(
         &self,
@@ -186,6 +202,7 @@ pub trait KernelPredicateEvaluator {
             | Expr::Variadic(_)
             | Expr::ParseJson(_)
             | Expr::MapToStruct(_)
+            | Expr::Cast(_)
             | Expr::Unknown(_) => None,
         }
     }
@@ -216,6 +233,7 @@ pub trait KernelPredicateEvaluator {
                 | Expr::Opaque(_)
                 | Expr::ParseJson { .. }
                 | Expr::MapToStruct(_)
+                | Expr::Cast(_)
                 | Expr::Unknown(_) => {
                     debug!("Unsupported operand: IS [NOT] NULL: {expr:?}");
                     None
@@ -271,7 +289,7 @@ pub trait KernelPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output> {
         use BinaryPredicateOp::*;
-        use Expr::{Column, Literal};
+        use Expr::{Cast, Column, Literal};
 
         match (left, right) {
             (Column(a), Column(b)) => self.eval_pred_binary_columns(op, a, b, inverted),
@@ -290,6 +308,22 @@ pub trait KernelPredicateEvaluator {
                 Equal => self.eval_pred_eq(col, val, inverted),
                 Distinct => self.eval_pred_distinct(col, val, inverted),
                 In => None, // arg order is semantically important
+            },
+            // `CAST(<col> AS target) op <value>` for a bare column child, e.g.
+            // `CAST(<col> AS DATE) < <value>`.
+            (Cast(c), Literal(val)) => match c.expr.as_ref() {
+                Column(col) => self.eval_pred_cast(op, col, &c.target, val, inverted),
+                _ => None,
+            },
+            (Literal(val), Cast(c)) => match c.expr.as_ref() {
+                // Commute so the cast column is on the left, mirroring the `Literal op Column` arm.
+                Column(col) => match op {
+                    LessThan => self.eval_pred_cast(GreaterThan, col, &c.target, val, inverted),
+                    GreaterThan => self.eval_pred_cast(LessThan, col, &c.target, val, inverted),
+                    Equal => self.eval_pred_cast(Equal, col, &c.target, val, inverted),
+                    Distinct | In => None,
+                },
+                _ => None,
             },
             _ => {
                 debug!("Unsupported binary operand(s): {left:?} {op:?} {right:?}");
@@ -648,10 +682,37 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
                     warn!("Failed to evaluate {:?}: {err:?}", op.as_ref());
                 })
                 .ok(),
+            Expr::Cast(c) => cast_scalar(self.eval_expr(&c.expr)?, &c.target),
             // ParseJson and MapToStruct produce structured output, not scalar values
             Expr::ParseJson(_) | Expr::MapToStruct(_) => None,
             Expr::Unknown(_) => None,
         }
+    }
+}
+
+/// Casts a scalar following SQL `CAST` semantics: a string source is parsed into a primitive target
+/// via [`PrimitiveType::parse_scalar`](crate::schema::PrimitiveType::parse_scalar), and a source
+/// already of the target type passes through. An unparseable string yields `Scalar::Null` (never
+/// TRUE against a comparison).
+///
+/// `parse_scalar` accepts a strict subset of the formats the arrow evaluation path accepts (e.g.
+/// arrow parses the hyphen-less `20240115` as a date but `parse_scalar` does not), so this path is
+/// only ever more conservative than arrow: a form it rejects becomes NULL, never a differing
+/// non-null value. It is deliberately narrower than a full cast -- any source/target combination
+/// other than string-to-primitive or an identity pass-through yields `None`, and it does not
+/// attempt numeric/temporal casts (e.g. `Long -> Int`) that the arrow path can perform.
+fn cast_scalar(value: Scalar, target: &DataType) -> Option<Scalar> {
+    if value.data_type() == *target {
+        return Some(value);
+    }
+    match (value, target) {
+        (Scalar::String(raw), DataType::Primitive(ptype)) => Some(
+            ptype
+                .parse_scalar(&raw)
+                .unwrap_or_else(|_| Scalar::Null(target.clone())),
+        ),
+        (Scalar::Null(_), _) => Some(Scalar::Null(target.clone())),
+        _ => None,
     }
 }
 
@@ -693,6 +754,18 @@ impl<R: ResolveColumnAsScalar> KernelPredicateEvaluator for DefaultKernelPredica
     fn eval_pred_eq(&self, col: &ColumnName, val: &Scalar, inverted: bool) -> Option<bool> {
         let col = self.resolve_column(col)?;
         self.eval_pred_binary_scalars(BinaryPredicateOp::Equal, &col, val, inverted)
+    }
+
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<bool> {
+        let col = cast_scalar(self.resolve_column(col)?, target)?;
+        self.eval_pred_binary_scalars(op, &col, val, inverted)
     }
 
     fn eval_pred_binary_scalars(

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -67,6 +67,32 @@ impl ResolveColumnAsScalar for IsAddResolver {
 }
 
 #[rstest::rstest]
+#[case::string_to_integer_succeeds(
+    Scalar::String("42".to_string()),
+    DataType::INTEGER,
+    Some(Scalar::Integer(42))
+)]
+#[case::string_to_integer_failure_is_null(
+    Scalar::String("not an integer".to_string()),
+    DataType::INTEGER,
+    Some(Scalar::Null(DataType::INTEGER))
+)]
+#[case::identity_passthrough(Scalar::Long(42), DataType::LONG, Some(Scalar::Long(42)))]
+#[case::null_source_uses_target_type(
+    Scalar::Null(DataType::STRING),
+    DataType::INTEGER,
+    Some(Scalar::Null(DataType::INTEGER))
+)]
+#[case::unsupported_pair(Scalar::Long(42), DataType::INTEGER, None)]
+fn test_cast_scalar(
+    #[case] value: Scalar,
+    #[case] target: DataType,
+    #[case] expected: Option<Scalar>,
+) {
+    assert_eq!(cast_scalar(value, &target), expected);
+}
+
+#[rstest::rstest]
 #[case::bool_true_not_inverted(Scalar::Boolean(true), false, Some(true))]
 #[case::bool_true_inverted(Scalar::Boolean(true), true, Some(false))]
 #[case::bool_false_not_inverted(Scalar::Boolean(false), false, Some(false))]
@@ -591,6 +617,26 @@ fn test_eval_distinct() {
     );
 }
 
+#[test]
+fn test_default_evaluator_resolves_column_then_casts_and_compares() {
+    let col = column_name!("x");
+    let filter = DefaultKernelPredicateEvaluator::from(HashMap::from([(
+        col.clone(),
+        Scalar::String("10".to_string()),
+    )]));
+
+    assert_eq!(
+        filter.eval_pred_cast(
+            BinaryPredicateOp::LessThan,
+            &col,
+            &DataType::INTEGER,
+            &Scalar::Integer(20),
+            false,
+        ),
+        Some(true)
+    );
+}
+
 // NOTE: We're testing routing here -- the actual comparisons are already validated by
 // test_eval_binary_scalars.
 #[test]
@@ -644,6 +690,24 @@ fn eval_binary() {
             "DISTINCT(10, x) (inverted: {inverted})"
         );
     }
+}
+
+#[rstest::rstest]
+#[case::less_than(BinaryPredicateOp::LessThan, false)]
+#[case::greater_than(BinaryPredicateOp::GreaterThan, true)]
+fn test_eval_binary_commutes_literal_and_cast_column(
+    #[case] op: BinaryPredicateOp,
+    #[case] expected: bool,
+    #[values(false, true)] inverted: bool,
+) {
+    let val = Expr::literal(10);
+    let cast_col = Expr::cast(column_expr!("x"), DataType::INTEGER);
+    let filter = DefaultKernelPredicateEvaluator::from(Scalar::String("1".to_string()));
+
+    assert_eq!(
+        filter.eval_pred_binary(op, &val, &cast_col, inverted),
+        Some(expected != inverted)
+    );
 }
 
 #[derive(Debug, PartialEq)]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -319,8 +319,7 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
-            // The declarative-plans proto has no cast node yet; serialize as an opaque unknown,
-            // which a receiver treats as uninterpretable.
+            // No proto cast node yet; serialize as an opaque unknown.
             Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
         };
         proto_expr::Expression { kind: Some(kind) }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -319,6 +319,9 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
+            // The declarative-plans proto has no cast node yet; serialize as an opaque unknown,
+            // which a receiver treats as uninterpretable.
+            Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
         };
         proto_expr::Expression { kind: Some(kind) }
     }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -1878,6 +1878,7 @@ mod tests {
             }
             Expression::ParseJson(p) => count_to_json(&p.json_expr),
             Expression::MapToStruct(m) => count_to_json(&m.map_expr),
+            Expression::Cast(c) => count_to_json(&c.expr),
             Expression::Predicate(_)
             | Expression::Literal(_)
             | Expression::Column(_)

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -510,6 +510,10 @@ impl ExpressionDepthChecker {
 impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
     transform_output_type!(|'a, T| DeltaResult<()>);
 
+    fn transform_expr_cast(&mut self, expr: &'a CastExpression) -> DeltaResult<()> {
+        self.depth_limited(Self::recurse_into_expr_cast, expr)
+    }
+
     fn transform_expr_struct(&mut self, fields: &'a [ExpressionRef]) -> DeltaResult<()> {
         self.depth_limited(Self::recurse_into_expr_struct, fields)
     }
@@ -1116,6 +1120,19 @@ mod tests {
         assert_eq!(check_with_call_count(5), (6, 14));
         assert_eq!(check_with_call_count(6), (6, 16));
         assert_eq!(check_with_call_count(7), (6, 16));
+    }
+
+    #[test]
+    fn test_depth_checker_counts_cast_expressions() {
+        let expr = Expr::cast(
+            Expr::cast(column_expr!("x"), DataType::INTEGER),
+            DataType::LONG,
+        );
+
+        assert_eq!(
+            ExpressionDepthChecker::check_expr_with_call_count(&expr, 0),
+            (1, 2)
+        );
     }
 
     #[test]

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -2,7 +2,7 @@ use std::borrow::{Cow, ToOwned};
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, ColumnName, Expression, ExpressionRef,
+    BinaryExpression, BinaryPredicate, CastExpression, ColumnName, Expression, ExpressionRef,
     ExpressionStructPatch, JunctionPredicate, MapToStructExpression, OpaqueExpression,
     OpaquePredicate, ParseJsonExpression, Predicate, Scalar, UnaryExpression, UnaryPredicate,
     VariadicExpression,
@@ -139,6 +139,12 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_expr_map_to_struct(expr)
     }
 
+    /// Called for each cast expression encountered during the traversal. The provided
+    /// implementation just forwards to [`Self::recurse_into_expr_cast`].
+    fn transform_expr_cast(&mut self, expr: &'a CastExpression) -> Self::Output<CastExpression> {
+        self.recurse_into_expr_cast(expr)
+    }
+
     /// Called for the child of each predicate expression encountered during the
     /// traversal. The provided implementation just forwards to [`Self::recurse_into_expr_pred`].
     fn transform_expr_pred(&mut self, pred: &'a Predicate) -> Self::Output<Predicate> {
@@ -262,6 +268,10 @@ pub trait ExpressionTransform<'a> {
                 let child = self.transform_expr_map_to_struct(m);
                 map_owned_or_else(expr, child, Expression::MapToStruct)
             }
+            Expression::Cast(c) => {
+                let child = self.transform_expr_cast(c);
+                map_owned_or_else(expr, child, Expression::Cast)
+            }
             Expression::Unknown(u) => {
                 let child = self.transform_expr_unknown(u);
                 map_owned_or_else(expr, child, Expression::Unknown)
@@ -335,6 +345,12 @@ pub trait ExpressionTransform<'a> {
     ) -> Self::Output<MapToStructExpression> {
         let nested = self.transform_expr(&expr.map_expr);
         map_owned_or_else(expr, nested, MapToStructExpression::new)
+    }
+
+    /// Recursively transforms the child expression of a cast expression (unary).
+    fn recurse_into_expr_cast(&mut self, expr: &'a CastExpression) -> Self::Output<CastExpression> {
+        let f = |child| CastExpression::new(child, expr.target.clone());
+        map_owned_or_else(expr, self.transform_expr(&expr.expr), f)
     }
 
     /// Recursively transforms the children of an opaque expression (variadic).


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add Expression::Cast(CastExpression { expr, target }) with SQL CAST semantics: an unrepresentable value evaluates to NULL rather than erroring. 

Connectors push query filters into the kernel as expression trees; a typed cast lets a predicate like CAST(<string partition column> AS DATE) < '2025-01-01' be represented faithfully instead of dropped or degraded to a lexicographic string comparison.

No data skipping is supported in this pr, will be done in a followup.

## How was this change tested?
New test cases