### PR TITLE
refactor: extract StatColumns and emit prefixes from the checkpoint creator

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -416,14 +416,15 @@ impl DataSkippingFilter {
 ///
 /// Adds IS NULL guards on each stat column reference so the parquet RowGroupFilter
 /// conservatively keeps row groups containing files with missing stats (null stat values
-/// are invisible to footer min/max). For example, `col_a > 100` becomes:
+/// are invisible to footer min/max). The rewrite is `stats_parsed.*`-rooted, so `col_a > 100`
+/// becomes:
 /// ```text
-/// OR(maxValues.col_a IS NULL, maxValues.col_a > 100)
+/// OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100)
 /// ```
 ///
 /// Partition columns are excluded since their values live in `add.partitionValues_parsed`,
 /// not `add.stats_parsed`. `physical_partition_columns` is the table's full partition list;
-/// pass an empty slice for unpartitioned tables.
+/// pass an empty set for unpartitioned tables.
 ///
 /// `physical_stats_columns` restricts rewrites to columns which are expected to have stats
 /// collected; other references fold to NULL (keeps the file). Must match the column set
@@ -434,13 +435,12 @@ pub(crate) fn as_checkpoint_skipping_predicate(
     physical_partition_columns: &[String],
     physical_stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
-    let partition_columns: HashSet<&str> = physical_partition_columns
-        .iter()
-        .map(String::as_str)
-        .collect();
+    let partition_columns: HashSet<String> = physical_partition_columns.iter().cloned().collect();
     CheckpointDataSkippingPredicateCreator {
-        partition_columns,
-        stats_columns: physical_stats_columns,
+        stats: StatColumns {
+            partition_columns: &partition_columns,
+            stats_columns: physical_stats_columns,
+        },
     }
     .eval(pred)
 }
@@ -512,6 +512,58 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
     matches!(data_type, DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype))
 }
 
+/// Shared data-column stat-path mechanism for the two predicate creators. Maps a data column to its
+/// `stats_parsed.{minValues,maxValues,nullCount}.<col>` reference, gated on the column having
+/// collected stats. Partition-column handling differs between the creators and stays with each.
+struct StatColumns<'a> {
+    /// Physical names of partition columns. Stats for these come from
+    /// `partitionValues_parsed.<col>` (exact values) instead of min/max ranges; each creator
+    /// applies its own partition policy.
+    partition_columns: &'a HashSet<String>,
+    /// Physical leaf paths whose stats are present in `stats_parsed` (honors
+    /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
+    /// columns). References to data columns not in this set return `None`, which
+    /// junction-folds to NULL. Must match the column set used to build
+    /// `physical_stats_schema`; otherwise the rewritten predicate references columns absent
+    /// from the unified schema.
+    stats_columns: &'a HashSet<ColumnName>,
+}
+
+impl StatColumns<'_> {
+    fn is_partition_column(&self, col: &ColumnName) -> bool {
+        let path = col.path();
+        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+    }
+
+    fn is_stats_column(&self, col: &ColumnName) -> bool {
+        self.stats_columns.contains(col)
+    }
+
+    /// Data column -> `stats_parsed.minValues.<col>`, or `None` when unindexed or not
+    /// min/max-eligible.
+    fn data_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        (self.is_stats_column(col) && has_min_max_stats(data_type))
+            .then(|| Expr::from(column_name!("stats_parsed", MIN_VALUES).join(col)))
+    }
+
+    /// Data column -> `stats_parsed.maxValues.<col>`, or `None` when unindexed or not
+    /// min/max-eligible.
+    fn data_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
+        (self.is_stats_column(col) && has_min_max_stats(data_type))
+            .then(|| Expr::from(column_name!("stats_parsed", MAX_VALUES).join(col)))
+    }
+
+    /// Data column -> `stats_parsed.nullCount.<col>`, or `None` when unindexed.
+    fn data_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
+        self.is_stats_column(col)
+            .then(|| Expr::from(column_name!("stats_parsed", NULL_COUNT).join(col)))
+    }
+
+    fn rowcount_stat(&self) -> Expr {
+        column_expr!("stats_parsed", NUM_RECORDS)
+    }
+}
+
 /// Rewrites user predicates into stats-based predicates for data skipping.
 ///
 /// For data columns, rewrites to `stats_parsed.minValues.*`/`stats_parsed.maxValues.*`/
@@ -519,35 +571,21 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
 /// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
 /// the exact value for every row in the file (serving as both min and max).
 struct DataSkippingPredicateCreator<'a> {
-    /// Physical names of partition columns. For these columns, stats come from
-    /// `partitionValues.<col>` (exact values) instead of min/max ranges.
-    partition_columns: &'a HashSet<String>,
-    /// Physical leaf paths whose stats are present in `stats_parsed` (honors
-    /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
-    /// columns). References to data columns not in this set return `None` from the
-    /// `get_*_stat` methods, which junction-folds to NULL.
-    ///
-    /// Must match the column set used to build `physical_stats_schema`; otherwise the
-    /// rewritten predicate references columns absent from the unified schema.
-    stats_columns: &'a HashSet<ColumnName>,
+    stats: StatColumns<'a>,
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
     fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
         Self {
-            partition_columns,
-            stats_columns,
+            stats: StatColumns {
+                partition_columns,
+                stats_columns,
+            },
         }
     }
 
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        let path = col.path();
-        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
-    }
-
-    /// Returns `true` when `col` is in `stats_columns`.
-    fn is_stats_column(&self, col: &ColumnName) -> bool {
-        self.stats_columns.contains(col)
+        self.stats.is_partition_column(col)
     }
 
     /// Wraps a predicate with `OR(NOT is_add, pred)` to protect Remove rows from being
@@ -570,12 +608,8 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
-        } else if !self.is_stats_column(col) || !has_min_max_stats(data_type) {
-            None
         } else {
-            Some(Expr::from(
-                column_name!("stats_parsed", MIN_VALUES).join(col),
-            ))
+            self.stats.data_min_stat(col, data_type)
         }
     }
 
@@ -585,12 +619,8 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
-        } else if !self.is_stats_column(col) || !has_min_max_stats(data_type) {
-            None
         } else {
-            Some(Expr::from(
-                column_name!("stats_parsed", MAX_VALUES).join(col),
-            ))
+            self.stats.data_max_stat(col, data_type)
         }
     }
 
@@ -616,18 +646,16 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     /// Retrieves the null count of a column. Partition columns don't have nullCount stats,
     /// nor do data columns outside the stat-columns set.
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) || !self.is_stats_column(col) {
+        if self.is_partition_column(col) {
             None
         } else {
-            Some(Expr::from(
-                ColumnName::new(["stats_parsed", NULL_COUNT]).join(col),
-            ))
+            self.stats.data_nullcount_stat(col)
         }
     }
 
     /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(column_expr!("stats_parsed", NUM_RECORDS))
+        Some(self.stats.rowcount_stat())
     }
 
     /// For partition columns, wraps the comparison with `OR(NOT is_add, comparison)` so that
@@ -719,23 +747,13 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 /// parquet row group filtering in checkpoint/sidecar files. Partition columns are excluded since
 /// their values live in `add.partitionValues_parsed`, not `add.stats_parsed`.
 struct CheckpointDataSkippingPredicateCreator<'a> {
-    partition_columns: HashSet<&'a str>,
-    /// Physical leaf paths whose stats are present in `stats_parsed`. Same contract as
-    /// `DataSkippingPredicateCreator::stats_columns`. Must match the column set used to
-    /// build `physical_stats_schema`, or the row-group filter sees a missing field.
-    stats_columns: &'a HashSet<ColumnName>,
+    stats: StatColumns<'a>,
 }
 
 impl CheckpointDataSkippingPredicateCreator<'_> {
     /// Returns true if the column is a partition column (no stats in `stats_parsed`).
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        let path = col.path();
-        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
-    }
-
-    /// Returns `true` when `col` is in `stats_columns`.
-    fn is_stats_column(&self, col: &ColumnName) -> bool {
-        self.stats_columns.contains(col)
+        self.stats.is_partition_column(col)
     }
 }
 
@@ -743,39 +761,33 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
     type Output = Pred;
     type ColumnStat = Expr;
 
-    // These stat methods produce unprefixed column references (e.g. `minValues.col`) because
-    // the checkpoint skipping path applies its own `add.stats_parsed` prefix afterward.
-    // Partition columns return None since their values live in `add.partitionValues_parsed`.
+    // The stat methods produce `stats_parsed.*`-rooted references; the checkpoint skipping path
+    // then scopes them under `add`. Partition columns return None since their values live in
+    // `add.partitionValues_parsed`.
 
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col)
-            || !self.is_stats_column(col)
-            || !has_min_max_stats(data_type)
-        {
+        if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(column_name!(MIN_VALUES).join(col)))
+        self.stats.data_min_stat(col, data_type)
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        if self.is_partition_column(col)
-            || !self.is_stats_column(col)
-            || !has_min_max_stats(data_type)
-        {
+        if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(ColumnName::new([MAX_VALUES]).join(col)))
+        self.stats.data_max_stat(col, data_type)
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
-        if self.is_partition_column(col) || !self.is_stats_column(col) {
+        if self.is_partition_column(col) {
             return None;
         }
-        Some(Expr::from(ColumnName::new([NULL_COUNT]).join(col)))
+        self.stats.data_nullcount_stat(col)
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(column_expr!(NUM_RECORDS))
+        Some(self.stats.rowcount_stat())
     }
 
     /// Compares a column's max stat against a literal value, adjusting for timestamp
@@ -797,13 +809,13 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
 
     /// Wraps a stat column comparison with an IS NULL guard.
     ///
-    /// `col > 100` → `OR(maxValues.col IS NULL, maxValues.col > 100)`
+    /// `col > 100` → `OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col > 100)`
     ///
     /// `col = 100` (calls this twice, once per stat):
     /// ```text
     /// AND(
-    ///   OR(minValues.col IS NULL, minValues.col <= 100),
-    ///   OR(maxValues.col IS NULL, maxValues.col >= 100)
+    ///   OR(stats_parsed.minValues.col IS NULL, stats_parsed.minValues.col <= 100),
+    ///   OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col >= 100)
     /// )
     /// ```
     fn eval_partial_cmp(
@@ -874,8 +886,8 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
     /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` →
     /// ```text
     /// AND(
-    ///   OR(maxValues.col_a IS NULL, maxValues.col_a > 100),
-    ///   OR(minValues.col_b IS NULL, minValues.col_b < 50)
+    ///   OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
+    ///   OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
     /// )
     /// ```
     fn finish_eval_pred_junction(

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -437,8 +437,8 @@ pub(crate) fn as_checkpoint_skipping_predicate(
 ) -> Option<Pred> {
     let partition_columns: HashSet<String> = physical_partition_columns.iter().cloned().collect();
     CheckpointDataSkippingPredicateCreator {
-        stats: StatColumns {
-            partition_columns: &partition_columns,
+        data_skipping_columns: DataSkippingColumns {
+            physical_partition_columns: &partition_columns,
             stats_columns: physical_stats_columns,
         },
     }
@@ -512,27 +512,23 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
     matches!(data_type, DataType::Primitive(ptype) if is_skipping_eligible_datatype(ptype))
 }
 
-/// Shared data-column stat-path mechanism for the two predicate creators. Maps a data column to its
-/// `stats_parsed.{minValues,maxValues,nullCount}.<col>` reference, gated on the column having
-/// collected stats. Partition-column handling differs between the creators and stays with each.
-struct StatColumns<'a> {
+/// Column metadata shared by the data-skipping predicate creators.
+struct DataSkippingColumns<'a> {
     /// Physical names of partition columns. Stats for these come from
     /// `partitionValues_parsed.<col>` (exact values) instead of min/max ranges; each creator
     /// applies its own partition policy.
-    partition_columns: &'a HashSet<String>,
+    physical_partition_columns: &'a HashSet<String>,
     /// Physical leaf paths whose stats are present in `stats_parsed` (honors
     /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
-    /// columns). References to data columns not in this set return `None`, which
-    /// junction-folds to NULL. Must match the column set used to build
-    /// `physical_stats_schema`; otherwise the rewritten predicate references columns absent
-    /// from the unified schema.
+    /// columns). Must match the column set used to build `physical_stats_schema`; otherwise the
+    /// rewritten predicate references columns absent from the unified schema.
     stats_columns: &'a HashSet<ColumnName>,
 }
 
-impl StatColumns<'_> {
+impl DataSkippingColumns<'_> {
     fn is_partition_column(&self, col: &ColumnName) -> bool {
         let path = col.path();
-        path.len() == 1 && self.partition_columns.contains(path[0].as_str())
+        path.len() == 1 && self.physical_partition_columns.contains(path[0].as_str())
     }
 
     fn is_stats_column(&self, col: &ColumnName) -> bool {
@@ -571,21 +567,21 @@ impl StatColumns<'_> {
 /// For partition columns, rewrites to `partitionValues_parsed.*` since the partition value is
 /// the exact value for every row in the file (serving as both min and max).
 struct DataSkippingPredicateCreator<'a> {
-    stats: StatColumns<'a>,
+    data_skipping_columns: DataSkippingColumns<'a>,
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
     fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
         Self {
-            stats: StatColumns {
-                partition_columns,
+            data_skipping_columns: DataSkippingColumns {
+                physical_partition_columns: partition_columns,
                 stats_columns,
             },
         }
     }
 
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        self.stats.is_partition_column(col)
+        self.data_skipping_columns.is_partition_column(col)
     }
 
     /// Wraps a predicate with `OR(NOT is_add, pred)` to protect Remove rows from being
@@ -609,7 +605,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
-            self.stats.data_min_stat(col, data_type)
+            self.data_skipping_columns.data_min_stat(col, data_type)
         }
     }
 
@@ -620,7 +616,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             Some(joined_column_expr!("partitionValues_parsed", col))
         } else {
-            self.stats.data_max_stat(col, data_type)
+            self.data_skipping_columns.data_max_stat(col, data_type)
         }
     }
 
@@ -649,13 +645,13 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         if self.is_partition_column(col) {
             None
         } else {
-            self.stats.data_nullcount_stat(col)
+            self.data_skipping_columns.data_nullcount_stat(col)
         }
     }
 
     /// Retrieves the row count statistic.
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(self.stats.rowcount_stat())
+        Some(self.data_skipping_columns.rowcount_stat())
     }
 
     /// For partition columns, wraps the comparison with `OR(NOT is_add, comparison)` so that
@@ -747,13 +743,13 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
 /// parquet row group filtering in checkpoint/sidecar files. Partition columns are excluded since
 /// their values live in `add.partitionValues_parsed`, not `add.stats_parsed`.
 struct CheckpointDataSkippingPredicateCreator<'a> {
-    stats: StatColumns<'a>,
+    data_skipping_columns: DataSkippingColumns<'a>,
 }
 
 impl CheckpointDataSkippingPredicateCreator<'_> {
     /// Returns true if the column is a partition column (no stats in `stats_parsed`).
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        self.stats.is_partition_column(col)
+        self.data_skipping_columns.is_partition_column(col)
     }
 }
 
@@ -769,25 +765,25 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         if self.is_partition_column(col) {
             return None;
         }
-        self.stats.data_min_stat(col, data_type)
+        self.data_skipping_columns.data_min_stat(col, data_type)
     }
 
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        self.stats.data_max_stat(col, data_type)
+        self.data_skipping_columns.data_max_stat(col, data_type)
     }
 
     fn get_nullcount_stat(&self, col: &ColumnName) -> Option<Expr> {
         if self.is_partition_column(col) {
             return None;
         }
-        self.stats.data_nullcount_stat(col)
+        self.data_skipping_columns.data_nullcount_stat(col)
     }
 
     fn get_rowcount_stat(&self) -> Option<Expr> {
-        Some(self.stats.rowcount_stat())
+        Some(self.data_skipping_columns.rowcount_stat())
     }
 
     /// Compares a column's max stat against a literal value, adjusting for timestamp

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -419,10 +419,7 @@ fn test_all_null_pruning_all_comparison_ops(#[case] pred: Pred) {
 fn test_timestamp_stats_enabled() {
     let empty = HashSet::new();
     let stats_columns: HashSet<ColumnName> = [column_name!("timestamp_col")].into_iter().collect();
-    let creator = DataSkippingPredicateCreator {
-        partition_columns: &empty,
-        stats_columns: &stats_columns,
-    };
+    let creator = DataSkippingPredicateCreator::new(&empty, &stats_columns);
     let col = &column_name!("timestamp_col");
 
     assert!(
@@ -496,7 +493,7 @@ fn test_checkpoint_skipping_semantic(
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
     let stats = all_referenced_columns(&pred);
     let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
-    let resolver = HashMap::from_iter([(column_name!("maxValues.x"), max_val)]);
+    let resolver = HashMap::from_iter([(column_name!("stats_parsed.maxValues.x"), max_val)]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
 }
@@ -506,8 +503,10 @@ fn test_checkpoint_skipping_semantic(
 #[test]
 fn test_checkpoint_skipping_null_guard_vs_regular() {
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
-    let resolver =
-        HashMap::from_iter([(column_name!("maxValues.x"), Scalar::Null(DataType::INTEGER))]);
+    let resolver = HashMap::from_iter([(
+        column_name!("stats_parsed.maxValues.x"),
+        Scalar::Null(DataType::INTEGER),
+    )]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
 
     let stats = all_referenced_columns(&pred);
@@ -546,8 +545,14 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
 
     // Both stats present and both allow pruning -> skip
     let resolver = HashMap::from_iter([
-        (column_name!("maxValues.col_a"), Scalar::from(50)),
-        (column_name!("minValues.col_b"), Scalar::from(60)),
+        (
+            column_name!("stats_parsed.maxValues.col_a"),
+            Scalar::from(50),
+        ),
+        (
+            column_name!("stats_parsed.minValues.col_b"),
+            Scalar::from(60),
+        ),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
@@ -559,10 +564,13 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
     // col_a stats null, but col_b stats alone are enough to prune -> still skip
     let resolver = HashMap::from_iter([
         (
-            column_name!("maxValues.col_a"),
+            column_name!("stats_parsed.maxValues.col_a"),
             Scalar::Null(DataType::INTEGER),
         ),
-        (column_name!("minValues.col_b"), Scalar::from(60)),
+        (
+            column_name!("stats_parsed.minValues.col_b"),
+            Scalar::from(60),
+        ),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
@@ -574,10 +582,13 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
     // col_a stats null and col_b doesn't allow pruning -> keep
     let resolver = HashMap::from_iter([
         (
-            column_name!("maxValues.col_a"),
+            column_name!("stats_parsed.maxValues.col_a"),
             Scalar::Null(DataType::INTEGER),
         ),
-        (column_name!("minValues.col_b"), Scalar::from(30)),
+        (
+            column_name!("stats_parsed.minValues.col_b"),
+            Scalar::from(30),
+        ),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
@@ -601,7 +612,7 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
-        "OR(Column(maxValues.ts_col) IS NULL, Column(maxValues.ts_col) > 999001)"
+        "OR(Column(stats_parsed.maxValues.ts_col) IS NULL, Column(stats_parsed.maxValues.ts_col) > 999001)"
     );
 
     // EQ: max stat leg should use adjusted literal
@@ -610,8 +621,8 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
-        "AND(OR(Column(minValues.ts_col) IS NULL, NOT(Column(minValues.ts_col) > 1000000)), \
-         OR(Column(maxValues.ts_col) IS NULL, NOT(Column(maxValues.ts_col) < 999001)))"
+        "AND(OR(Column(stats_parsed.minValues.ts_col) IS NULL, NOT(Column(stats_parsed.minValues.ts_col) > 1000000)), \
+         OR(Column(stats_parsed.maxValues.ts_col) IS NULL, NOT(Column(stats_parsed.maxValues.ts_col) < 999001)))"
     );
 }
 
@@ -1537,8 +1548,8 @@ fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
     );
 }
 
-/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint-pushdown
-/// (NullGuarded) creator, which adds an `IS NULL` guard on each stat ref for safe parquet
+/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint
+/// creator, which adds an `IS NULL` guard on each stat ref for safe parquet
 /// row-group filtering. The non-stat arm still folds to NULL.
 #[test]
 fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
@@ -1550,6 +1561,6 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
     let result = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
     assert_eq!(
         result.to_string(),
-        "AND(OR(Column(maxValues.stat) IS NULL, Column(maxValues.stat) > 100), null)"
+        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, Column(stats_parsed.maxValues.stat) > 100), null)"
     );
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -536,9 +536,9 @@ impl<'a> SchemaTransform<'a> for GetReferencedFields<'a> {
     }
 }
 
-/// Prefixes all column references in a predicate with a fixed path.
-/// Transforms data-skipping predicates (e.g., `minValues.x > 100`) into
-/// checkpoint/sidecar-compatible predicates (e.g., `add.stats_parsed.minValues.x > 100`).
+/// Prefixes all column references in a predicate with a fixed path. The checkpoint path prefixes
+/// stat expressions that already carry their `stats_parsed.*` root (e.g. `stats_parsed.minValues.x
+/// > 100`) with `add`, yielding `add.stats_parsed.minValues.x > 100`.
 struct PrefixColumns {
     prefix: ColumnName,
 }
@@ -994,8 +994,8 @@ impl Scan {
     /// Builds a predicate for row group skipping in checkpoint and sidecar parquet files.
     ///
     /// The scan predicate is first transformed into a data-skipping form with IS NULL guards
-    /// (e.g., `x > 100` becomes `OR(maxValues.x IS NULL, maxValues.x > 100)`), then column
-    /// references are prefixed with `add.stats_parsed` to match the physical column layout
+    /// (e.g., `x > 100` becomes `OR(stats_parsed.maxValues.x IS NULL, stats_parsed.maxValues.x >
+    /// 100)`), then column references are prefixed with `add` to match the physical column layout
     /// of checkpoint/sidecar files. The parquet reader's row group filter can then use
     /// parquet-level statistics on these nested columns to skip entire row groups that cannot
     /// contain matching files.
@@ -1025,7 +1025,7 @@ impl Scan {
         )?;
 
         let mut prefixer = PrefixColumns {
-            prefix: ColumnName::new(["add", "stats_parsed"]),
+            prefix: ColumnName::new(["add"]),
         };
         let prefixed = prefixer.transform_pred(&skipping_pred);
         Some(Arc::new(prefixed.into_owned()))

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1299,7 +1299,7 @@ fn build_prefixed_checkpoint_predicate(pred: &Pred) -> Option<Pred> {
     let stats = all_referenced_columns(pred);
     let skipping_pred = as_checkpoint_skipping_predicate(pred, &[], &stats)?;
     let mut prefixer = PrefixColumns {
-        prefix: ColumnName::new(["add", "stats_parsed"]),
+        prefix: ColumnName::new(["add"]),
     };
     Some(prefixer.transform_pred(&skipping_pred).into_owned())
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2963/files) to review incremental changes.
- [**stack/stats-columns-refactor**](https://github.com/delta-io/delta-kernel-rs/pull/2963) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2963/files)] ← _this PR_
  - [stack/checkpoint-partition-skipping-feature](https://github.com/delta-io/delta-kernel-rs/pull/2917) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2917/files/d794da6a266547a2eea7ace2c4d27ecd6bafdb87..458ba2499c683085c66251a0602417401ebb3bb6)]
    - [stack/checkpoint-partition-skipping-tests](https://github.com/delta-io/delta-kernel-rs/pull/2967) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2967/files/9a561d573dc86753ffc032cd07ad7a41b9b48baf..b014ef4b73a369e291fb7504f5a4c648b90180e0)]

---------
## What changes are proposed in this pull request?

Pure refactor, no behavior change. 

The two `DataSkippingPredicateEvaluator` creators (log-replay and checkpoint) duplicated the data-column stat-path logic, and the checkpoint creator emitted unprefixed `minValues.col` references that `build_actions_meta_predicate` then prefixed with `add.stats_parsed`. This extracts the shared data-column path into a `StatColumns` type and moves the `stats_parsed` root into the checkpoint creator, so both creators emit `stats_parsed.*`-rooted references and the caller prefixes with `add` alone.



## How was this change tested?

Existing tests pass unchanged except the checkpoint-path unit assertions
