### PR TITLE
feat: benchmark snapshot construction from an existing snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "flate2",
  "object_store 0.12.5",
  "rayon",
+ "rstest",
  "serde",
  "serde_json",
  "sha2",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -37,6 +37,7 @@ url = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.5"
+rstest = "0.23"
 tempfile = "3"
 
 [[bench]]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,22 +23,23 @@ samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench "som
 
 #### By benchmark name
 
-Benchmark names use the human-readable table name and spec file name. Read benchmarks also
-include the harness config name:
+Benchmark names use the human-readable table name and spec file name. Read benchmarks and
+registered snapshot-construction benchmarks also include the harness config name. Unregistered
+snapshot-construction benchmarks retain the unsuffixed name:
 
 ```
-{table_name}/{spec_file_name}               # snapshot construction
-{table_name}/{spec_file_name}/{config_name} # read
+{table_name}/{spec_file_name}               # unregistered snapshot construction
+{table_name}/{spec_file_name}/{config_name} # read or registered snapshot construction
 ```
 
 - `{table_name}` — the human-readable `name` from the table's `tableInfo.json`
 - `{spec_file_name}` — the spec filename without its `.json` extension (the `case_name`)
-- `{config_name}` — the read harness config from
-  [`bench-registry.json`](#registry-bench-registryjson), such as `serial` or `parallel2`
+- `{config_name}` — the harness config from
+  [`bench-registry.json`](#registry-bench-registryjson), such as `serial`, `fresh`, or `from199`
 
 Examples:
 ```
-crcVeryStale/snapshotLatest
+crcVeryStale/snapshotLatest/fresh
 v1Checkpoint/readMetadataLatest/serial
 v2Checkpoint/readMetadataLatest/parallel2
 ```
@@ -59,7 +60,8 @@ cargo bench -p delta_kernel_benchmarks --bench workload_bench "snapshotLatest"
 cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale.*snapshotLatest"
 
 # profile a specific benchmark with samply
-samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale/snapshotLatest"
+samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench \
+  "crcVeryStale/snapshotLatest/fresh"
 ```
 
 #### By tag (`BENCH_TAGS`)
@@ -139,11 +141,11 @@ CI timings are noisy and tend to run higher than on dedicated hardware, but prop
 
 ## Registry (`bench-registry.json`)
 
-[`bench-registry.json`](bench-registry.json) maps read benchmarks to the harness configs they run.
-Each registered read workload expands into one Criterion benchmark per config, and the config
-`name` becomes the trailing path segment of the benchmark name (see
-[By benchmark name](#by-benchmark-name)). Snapshot-construction workloads construct a new snapshot
-each iteration and are not configured through the registry.
+[`bench-registry.json`](bench-registry.json) maps read and snapshot-construction benchmarks to the
+harness configs they run. Each registered workload expands into one Criterion benchmark per
+config, and the config `name` becomes the trailing path segment of the benchmark name (see
+[By benchmark name](#by-benchmark-name)). Unregistered snapshot-construction workloads retain
+their existing unsuffixed name and fresh snapshot behavior.
 
 The registry is a checked-in file under the crate root, separate from the spec files: the
 workload archive (`benchmarks/workloads/`) is downloaded at build time and gitignored, so configs
@@ -151,6 +153,18 @@ that belong with the source live here and reference benchmarks by name.
 
 ```json
 {
+  "crc1Col200Commits1ChkptCrc195": {
+    "snapshotLatest": [
+      {
+        "name": "fresh",
+        "snapshotBuilder": "for"
+      },
+      {
+        "name": "from199",
+        "snapshotBuilder": { "from": { "version": 199 } }
+      }
+    ]
+  },
   "10kAdds0CommitsSinceChkpt1V2Chkpt": {
     "readMetadataLatest": [
       { "name": "serial",    "parallelScan": "disabled" },
@@ -160,19 +174,24 @@ that belong with the source live here and reference benchmarks by name.
 }
 ```
 
-- The file nests read config lists by table directory name then case name
+- The file nests config lists by table directory name then case name
   (`{ table: { case: [configs] } }`).
 - A read benchmark whose `(table, case)` key is absent from the registry falls back to the built-in
-  serial config. An explicit but empty config list is rejected at load rather than silently
-  dropping the benchmark.
+  serial config. An unlisted snapshot-construction benchmark uses fresh construction without
+  changing its benchmark name. An explicit but empty config list is rejected at load rather than
+  silently dropping the benchmark.
 - Config `name`s within a list must be unique and non-empty (they form the benchmark name's last
-  segment).
+  segment). A list cannot mix read and snapshot-construction configs.
 
 Config-field value forms:
 
 - `parallelScan` (read configs): `"disabled"` or `{ "enabled": { "numThreads": <n> } }` — serde
   externally-tagged, so the fieldless variant is a bare string and the parameterized variant a
   single-key object.
+- `snapshotBuilder` (snapshot-construction configs): `"for"` builds from the table root, while
+  `{ "from": { "version": <n> } }` prebuilds snapshot version `n` outside the timed loop and uses
+  `Snapshot::builder_from` during each iteration.
+- Catalog-managed snapshot benchmarks currently support only `"snapshotBuilder": "for"`.
 
 ## Workload data layout
 
@@ -340,28 +359,34 @@ Or with a specific version:
 
 The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table, whose directory determines `TableInfo::registry_table_key()`) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
 
-### `ReadConfig`
+### Harness configs
 
-Specifies runtime parameters for `Read` workloads that are not part of the spec JSON — currently whether to scan serially or in parallel, and how many threads to use. Multiple configs can be applied to the same workload to compare modes. Which configs run for a given benchmark is determined by the [registry](#registry-bench-registryjson).
+`ReadConfig` specifies whether metadata scanning runs serially or in parallel and how many threads
+to use. `SnapshotConstructionConfig` selects fresh or previous-snapshot construction. Multiple
+configs can be applied to the same workload to compare modes. Which configs run for a given
+benchmark is determined by the
+[registry](#registry-bench-registryjson).
 
 ### `WorkloadRunner`
 
-Owns all pre-built state for a workload (e.g. a pre-constructed `Snapshot`) so that `execute()` measures only the target operation. Read runners also carry the `ReadConfig` selected by the registry. Snapshot-construction runners always construct a new snapshot each iteration.
+Owns all pre-built state for a workload so that `execute()` measures only the target operation.
+Read runners carry the selected `ReadConfig`. Snapshot-construction runners either construct from
+the table root or reuse a configured base snapshot prepared outside the timed loop.
 
 
 ## Source Layout
 
 The workload spec data types (`TableInfo`, `Spec`, `Workload`, …) live in the shared
 [`delta_kernel_workloads`](../workloads/) crate, since the spec types are also used by the
-`acceptance` crate. The read harness config types (`ReadConfig`, `ParallelScan`) and the registry
-that maps read benchmarks to them are benchmark-specific and live in this crate.
+`acceptance` crate. The harness config types and registry that map benchmarks to them are
+benchmark-specific and live in this crate.
 
 | File | Purpose |
 |------|---------|
 | `../workloads/src/models.rs` | Workload spec types: `TableInfo`, `Spec`, `Workload`, `ReadOperation` |
 | `../workloads/src/predicate_parser.rs` | SQL WHERE clause to kernel `Predicate` parser |
-| `src/registry.rs` | Read harness config types and registry loader: `ReadConfig`, `ParallelScan`, `BenchRegistry` |
-| `bench-registry.json` | Checked-in registry mapping read benchmarks to their harness configs |
+| `src/registry.rs` | Read and snapshot-construction harness config types plus `BenchRegistry` |
+| `bench-registry.json` | Checked-in registry mapping benchmarks to their harness configs |
 | `src/runners.rs` | `WorkloadRunner` trait and implementations: `ReadMetadataRunner`, `SnapshotConstructionRunner` |
 | `src/utils.rs` | Workload loading: deserializes workloads from the extracted data directory |
 | `benches/workload_bench.rs` | Criterion entry point — loads workloads + registry, builds runners, drives benchmarks |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -188,10 +188,13 @@ Config-field value forms:
 - `parallelScan` (read configs): `"disabled"` or `{ "enabled": { "numThreads": <n> } }` — serde
   externally-tagged, so the fieldless variant is a bare string and the parameterized variant a
   single-key object.
-- `snapshotBuilder` (snapshot-construction configs): `"for"` builds from the table root, while
+- `snapshotBuilder` (snapshot-construction configs): `"for"` performs fresh construction using
+  the table's normal loading strategy, while
   `{ "from": { "version": <n> } }` prebuilds snapshot version `n` outside the timed loop and uses
-  `Snapshot::builder_from` during each iteration.
-- Catalog-managed snapshot benchmarks currently support only `"snapshotBuilder": "for"`.
+  `Snapshot::builder_from` during each iteration. The base version must be strictly lower than an
+  explicit target version. For a latest-target workload, setup resolves the actual latest snapshot
+  version before accepting the base.
+- Catalog-managed snapshot benchmarks support only `"snapshotBuilder": "for"`.
 
 ## Workload data layout
 
@@ -312,7 +315,9 @@ Deserialized from `tableInfo.json`. Captures a human label (`name`) and `descrip
 Deserialized from a JSON file in a table's `specs/` directory. Describes a single operation to benchmark (what to do, e.g. read at version 3). Two variants are supported:
 
 - **`Read`** — scan a table at an optional version (defaults to latest). A single `Read` spec expands into one benchmark per `ReadOperation` × `ReadConfig` combination — every relevant operation and parallelism mode is benchmarked. Currently only `ReadMetadata` is implemented; `ReadData` is not yet supported.
-- **`SnapshotConstruction`** — measure the cost of building a `Snapshot` from scratch at an optional version (defaults to latest)
+- **`SnapshotConstruction`** — measure the cost of constructing a `Snapshot` at an optional target
+  version (defaults to latest). The harness config selects fresh construction or construction from
+  a prebuilt earlier snapshot.
 
 Read specs:
 ```json
@@ -359,19 +364,9 @@ Or with a specific version:
 
 The concrete unit of work that gets benchmarked. Assembled when loading workloads by pairing a `Spec` (the operation) with a `TableInfo` (the table, whose directory determines `TableInfo::registry_table_key()`) and a `case_name`. A `Spec` file on its own solely describes an operation without context of the table it is performed on; when combined with a table, it becomes a `Workload`. A single table therefore produces multiple workloads, one for each spec file in its `specs/` directory.
 
-### Harness configs
-
-`ReadConfig` specifies whether metadata scanning runs serially or in parallel and how many threads
-to use. `SnapshotConstructionConfig` selects fresh or previous-snapshot construction. Multiple
-configs can be applied to the same workload to compare modes. Which configs run for a given
-benchmark is determined by the
-[registry](#registry-bench-registryjson).
-
 ### `WorkloadRunner`
 
-Owns all pre-built state for a workload so that `execute()` measures only the target operation.
-Read runners carry the selected `ReadConfig`. Snapshot-construction runners either construct from
-the table root or reuse a configured base snapshot prepared outside the timed loop.
+Setup prepares supporting state outside the timed loop; `execute()` runs the measured operation.
 
 
 ## Source Layout

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,11 +35,11 @@ snapshot-construction benchmarks retain the unsuffixed name:
 - `{table_name}` — the human-readable `name` from the table's `tableInfo.json`
 - `{spec_file_name}` — the spec filename without its `.json` extension (the `case_name`)
 - `{config_name}` — the harness config from
-  [`bench-registry.json`](#registry-bench-registryjson), such as `serial`, `fresh`, or `from199`
+  [`bench-registry.json`](#registry-bench-registryjson), such as `serial`, `fromTable`, or `from199`
 
 Examples:
 ```
-crcVeryStale/snapshotLatest/fresh
+crcVeryStale/snapshotLatest/fromTable
 v1Checkpoint/readMetadataLatest/serial
 v2Checkpoint/readMetadataLatest/parallel2
 ```
@@ -61,7 +61,7 @@ cargo bench -p delta_kernel_benchmarks --bench workload_bench "crcVeryStale.*sna
 
 # profile a specific benchmark with samply
 samply record cargo bench -p delta_kernel_benchmarks --bench workload_bench \
-  "crcVeryStale/snapshotLatest/fresh"
+  "crcVeryStale/snapshotLatest/fromTable"
 ```
 
 #### By tag (`BENCH_TAGS`)
@@ -145,7 +145,7 @@ CI timings are noisy and tend to run higher than on dedicated hardware, but prop
 harness configs they run. Each registered workload expands into one Criterion benchmark per
 config, and the config `name` becomes the trailing path segment of the benchmark name (see
 [By benchmark name](#by-benchmark-name)). Unregistered snapshot-construction workloads retain
-their existing unsuffixed name and fresh snapshot behavior.
+their existing unsuffixed name and from-table snapshot behavior.
 
 The registry is a checked-in file under the crate root, separate from the spec files: the
 workload archive (`benchmarks/workloads/`) is downloaded at build time and gitignored, so configs
@@ -156,12 +156,12 @@ that belong with the source live here and reference benchmarks by name.
   "crc1Col200Commits1ChkptCrc195": {
     "snapshotLatest": [
       {
-        "name": "fresh",
-        "snapshotBuilder": "for"
+        "name": "fromTable",
+        "snapshotBuilder": "fromTable"
       },
       {
         "name": "from199",
-        "snapshotBuilder": { "from": { "version": 199 } }
+        "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
       }
     ]
   },
@@ -177,7 +177,7 @@ that belong with the source live here and reference benchmarks by name.
 - The file nests config lists by table directory name then case name
   (`{ table: { case: [configs] } }`).
 - A read benchmark whose `(table, case)` key is absent from the registry falls back to the built-in
-  serial config. An unlisted snapshot-construction benchmark uses fresh construction without
+  serial config. An unlisted snapshot-construction benchmark builds from the table without
   changing its benchmark name. An explicit but empty config list is rejected at load rather than
   silently dropping the benchmark.
 - Config `name`s within a list must be unique and non-empty (they form the benchmark name's last
@@ -188,13 +188,12 @@ Config-field value forms:
 - `parallelScan` (read configs): `"disabled"` or `{ "enabled": { "numThreads": <n> } }` — serde
   externally-tagged, so the fieldless variant is a bare string and the parameterized variant a
   single-key object.
-- `snapshotBuilder` (snapshot-construction configs): `"for"` performs fresh construction using
-  the table's normal loading strategy, while
-  `{ "from": { "version": <n> } }` prebuilds snapshot version `n` outside the timed loop and uses
-  `Snapshot::builder_from` during each iteration. The base version must be strictly lower than an
-  explicit target version. For a latest-target workload, setup resolves the actual latest snapshot
-  version before accepting the base.
-- Catalog-managed snapshot benchmarks support only `"snapshotBuilder": "for"`.
+- `snapshotBuilder` (snapshot-construction configs): `"fromTable"` constructs from the table using
+  its normal loading strategy, while `{ "fromSnapshot": { "version": <n> } }` prebuilds snapshot
+  version `n` outside the timed loop and uses `Snapshot::builder_from` during each iteration. The
+  base version must be strictly lower than an explicit target version. For a latest-target
+  workload, setup resolves the actual latest snapshot version before accepting the base.
+- Catalog-managed snapshot benchmarks support only `"snapshotBuilder": "fromTable"`.
 
 ## Workload data layout
 
@@ -316,8 +315,8 @@ Deserialized from a JSON file in a table's `specs/` directory. Describes a singl
 
 - **`Read`** — scan a table at an optional version (defaults to latest). A single `Read` spec expands into one benchmark per `ReadOperation` × `ReadConfig` combination — every relevant operation and parallelism mode is benchmarked. Currently only `ReadMetadata` is implemented; `ReadData` is not yet supported.
 - **`SnapshotConstruction`** — measure the cost of constructing a `Snapshot` at an optional target
-  version (defaults to latest). The harness config selects fresh construction or construction from
-  a prebuilt earlier snapshot.
+  version (defaults to latest). The harness config selects construction from the table or from a
+  prebuilt earlier snapshot.
 
 Read specs:
 ```json

--- a/benchmarks/bench-registry.json
+++ b/benchmarks/bench-registry.json
@@ -4,5 +4,53 @@
       { "name": "serial",    "parallelScan": "disabled" },
       { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
     ]
+  },
+  "crc1Col200Commits1ChkptCrc150": {
+    "snapshotLatest": [
+      {
+        "name": "fresh",
+        "snapshotBuilder": "for"
+      },
+      {
+        "name": "from199",
+        "snapshotBuilder": { "from": { "version": 199 } }
+      }
+    ]
+  },
+  "crc1Col200Commits1ChkptCrc195": {
+    "snapshotLatest": [
+      {
+        "name": "fresh",
+        "snapshotBuilder": "for"
+      },
+      {
+        "name": "from199",
+        "snapshotBuilder": { "from": { "version": 199 } }
+      }
+    ]
+  },
+  "crc1Col200Commits1ChkptCrcLatest": {
+    "snapshotLatest": [
+      {
+        "name": "fresh",
+        "snapshotBuilder": "for"
+      },
+      {
+        "name": "from199",
+        "snapshotBuilder": { "from": { "version": 199 } }
+      }
+    ]
+  },
+  "crc1Col200Commits1ChkptNoCrc": {
+    "snapshotLatest": [
+      {
+        "name": "fresh",
+        "snapshotBuilder": "for"
+      },
+      {
+        "name": "from199",
+        "snapshotBuilder": { "from": { "version": 199 } }
+      }
+    ]
   }
 }

--- a/benchmarks/bench-registry.json
+++ b/benchmarks/bench-registry.json
@@ -8,48 +8,48 @@
   "crc1Col200Commits1ChkptCrc150": {
     "snapshotLatest": [
       {
-        "name": "fresh",
-        "snapshotBuilder": "for"
+        "name": "fromTable",
+        "snapshotBuilder": "fromTable"
       },
       {
         "name": "from199",
-        "snapshotBuilder": { "from": { "version": 199 } }
+        "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
       }
     ]
   },
   "crc1Col200Commits1ChkptCrc195": {
     "snapshotLatest": [
       {
-        "name": "fresh",
-        "snapshotBuilder": "for"
+        "name": "fromTable",
+        "snapshotBuilder": "fromTable"
       },
       {
         "name": "from199",
-        "snapshotBuilder": { "from": { "version": 199 } }
+        "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
       }
     ]
   },
   "crc1Col200Commits1ChkptCrcLatest": {
     "snapshotLatest": [
       {
-        "name": "fresh",
-        "snapshotBuilder": "for"
+        "name": "fromTable",
+        "snapshotBuilder": "fromTable"
       },
       {
         "name": "from199",
-        "snapshotBuilder": { "from": { "version": 199 } }
+        "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
       }
     ]
   },
   "crc1Col200Commits1ChkptNoCrc": {
     "snapshotLatest": [
       {
-        "name": "fresh",
-        "snapshotBuilder": "for"
+        "name": "fromTable",
+        "snapshotBuilder": "fromTable"
       },
       {
         "name": "from199",
-        "snapshotBuilder": { "from": { "version": 199 } }
+        "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
       }
     ]
   }

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use delta_kernel_benchmarks::registry::BenchRegistry;
+use delta_kernel_benchmarks::registry::{default_snapshot_construction_config, BenchRegistry};
 use delta_kernel_benchmarks::runners::{
     benchmark_name, configured_benchmark_name, create_read_runner, SnapshotConstructionRunner,
     WorkloadRunner,
@@ -65,15 +65,38 @@ fn workload_benchmarks(c: &mut Criterion) {
                 }
             }
             Spec::SnapshotConstruction(snapshot_construction_spec) => {
-                let name = benchmark_name(&workload.table_info, case_name);
-                let runner = SnapshotConstructionRunner::setup(
-                    name,
-                    snapshot_construction_spec,
-                    &workload.table_info,
-                    runtime.clone(),
-                )
-                .expect("Failed to create snapshot construction runner");
-                run_benchmark(c, &runner, &reporter);
+                let configs = registry
+                    .snapshot_configs(workload)
+                    .expect("Registry entry must contain snapshot-construction configs");
+                if let Some(configs) = configs {
+                    for config in configs {
+                        let name = configured_benchmark_name(
+                            &workload.table_info,
+                            case_name,
+                            &config.name,
+                        );
+                        let runner = SnapshotConstructionRunner::setup(
+                            name,
+                            snapshot_construction_spec,
+                            config,
+                            &workload.table_info,
+                            runtime.clone(),
+                        )
+                        .expect("Failed to create snapshot construction runner");
+                        run_benchmark(c, &runner, &reporter);
+                    }
+                } else {
+                    let name = benchmark_name(&workload.table_info, case_name);
+                    let runner = SnapshotConstructionRunner::setup(
+                        name,
+                        snapshot_construction_spec,
+                        default_snapshot_construction_config(),
+                        &workload.table_info,
+                        runtime.clone(),
+                    )
+                    .expect("Failed to create snapshot construction runner");
+                    run_benchmark(c, &runner, &reporter);
+                }
             }
         }
     }

--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use criterion::{criterion_group, criterion_main, Criterion};
 use delta_kernel_benchmarks::registry::{default_snapshot_construction_config, BenchRegistry};
 use delta_kernel_benchmarks::runners::{
-    benchmark_name, configured_benchmark_name, create_read_runner, SnapshotConstructionRunner,
-    WorkloadRunner,
+    configured_benchmark_name, create_read_runner, snapshot_benchmark_name,
+    SnapshotConstructionRunner, WorkloadRunner,
 };
 use delta_kernel_benchmarks::utils::load_all_workloads;
 use delta_kernel_workloads::models::{ReadOperation, Spec};
@@ -65,32 +65,20 @@ fn workload_benchmarks(c: &mut Criterion) {
                 }
             }
             Spec::SnapshotConstruction(snapshot_construction_spec) => {
-                let configs = registry
+                let registered_configs = registry
                     .snapshot_configs(workload)
                     .expect("Registry entry must contain snapshot-construction configs");
-                if let Some(configs) = configs {
-                    for config in configs {
-                        let name = configured_benchmark_name(
-                            &workload.table_info,
-                            case_name,
-                            &config.name,
-                        );
-                        let runner = SnapshotConstructionRunner::setup(
-                            name,
-                            snapshot_construction_spec,
-                            config,
-                            &workload.table_info,
-                            runtime.clone(),
-                        )
-                        .expect("Failed to create snapshot construction runner");
-                        run_benchmark(c, &runner, &reporter);
-                    }
-                } else {
-                    let name = benchmark_name(&workload.table_info, case_name);
+                let registered = registered_configs.is_some();
+                let configs = registered_configs
+                    .unwrap_or_else(|| vec![default_snapshot_construction_config()]);
+                for config in configs {
+                    let config_name = registered.then_some(config.name.as_str());
+                    let name =
+                        snapshot_benchmark_name(&workload.table_info, case_name, config_name);
                     let runner = SnapshotConstructionRunner::setup(
                         name,
                         snapshot_construction_spec,
-                        default_snapshot_construction_config(),
+                        config.snapshot_builder,
                         &workload.table_info,
                         runtime.clone(),
                     )

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -11,12 +11,13 @@ use serde::Deserialize;
 
 // === Harness configs ===
 
-/// A read-operation config: benchmark parameters not carried in the spec JSON. Deserialized
-/// directly from a `bench-registry.json` entry.
+/// A read-operation config: benchmark parameters not carried in the spec JSON.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ReadConfig {
+    /// Name appended to the configured benchmark identifier.
     pub name: String,
+    /// Whether metadata scanning runs serially or in parallel.
     pub parallel_scan: ParallelScan,
 }
 
@@ -35,8 +36,67 @@ pub fn default_read_configs() -> Vec<ReadConfig> {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum ParallelScan {
+    /// Run the metadata scan serially.
     Disabled,
-    Enabled { num_threads: usize },
+    /// Run the metadata scan with the configured number of worker threads.
+    Enabled {
+        /// Number of worker threads.
+        num_threads: usize,
+    },
+}
+
+/// A snapshot-construction config: snapshot builder and CRC replay parameters.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SnapshotConstructionConfig {
+    /// Name appended to the configured benchmark identifier.
+    pub name: String,
+    /// Whether to build from the table root or from a prebuilt snapshot.
+    pub snapshot_builder: SnapshotBuilderConfig,
+}
+
+/// The built-in fresh snapshot-construction config.
+pub fn default_snapshot_construction_config() -> SnapshotConstructionConfig {
+    SnapshotConstructionConfig {
+        name: "fresh".into(),
+        snapshot_builder: SnapshotBuilderConfig::For,
+    }
+}
+
+/// Selects the starting point for snapshot construction.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum SnapshotBuilderConfig {
+    /// Build a fresh snapshot from the table root.
+    For,
+    /// Build from a snapshot preconstructed at `version` outside the timed loop.
+    From {
+        /// Version of the preconstructed base snapshot.
+        version: u64,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum HarnessConfig {
+    Read(ReadConfig),
+    SnapshotConstruction(SnapshotConstructionConfig),
+}
+
+impl HarnessConfig {
+    fn name(&self) -> &str {
+        match self {
+            Self::Read(config) => &config.name,
+            Self::SnapshotConstruction(config) => &config.name,
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Read(_) => "read",
+            Self::SnapshotConstruction(_) => "snapshot-construction",
+        }
+    }
 }
 
 // === Registry ===
@@ -44,7 +104,7 @@ pub enum ParallelScan {
 /// Error type for registry loading and lookup.
 pub type RegistryResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-/// Read harness configs keyed by table directory name and workload spec filename.
+/// Benchmark harness configs keyed by table directory name and workload spec filename.
 ///
 /// For example, this entry runs `readMetadataLatest` against the table in the
 /// `10kAdds0CommitsSinceChkpt1V2Chkpt` directory once serially and once with two scan threads:
@@ -61,11 +121,12 @@ pub type RegistryResult<T> = Result<T, Box<dyn std::error::Error>>;
 /// ```
 ///
 /// Each configuration creates a separate Criterion benchmark whose final name segment is the
-/// configuration `name`. Read workloads absent from the registry use the built-in serial config.
+/// configuration `name`. Unregistered read workloads use the built-in serial config, while
+/// unregistered snapshot-construction workloads retain their default fresh-snapshot behavior.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(transparent)]
 pub struct BenchRegistry {
-    tables: HashMap<String, HashMap<String, Vec<ReadConfig>>>,
+    tables: HashMap<String, HashMap<String, Vec<HarnessConfig>>>,
 }
 
 impl BenchRegistry {
@@ -85,23 +146,52 @@ impl BenchRegistry {
     ///
     /// Returns an error when the workload's table directory has no valid registry key.
     pub fn read_configs(&self, workload: &Workload) -> RegistryResult<Vec<ReadConfig>> {
-        let table = workload.table_info.registry_table_key().ok_or_else(|| {
-            format!(
-                "could not derive a registry table key for workload '{}'",
-                workload.case_name
-            )
-        })?;
-        Ok(self
-            .lookup(table, &workload.case_name)
-            .map_or_else(default_read_configs, ToOwned::to_owned))
+        let (table, case) = workload_registry_key(workload)?;
+        let Some(configs) = self.lookup(table, case) else {
+            return Ok(default_read_configs());
+        };
+        configs
+            .iter()
+            .map(|config| match config {
+                HarnessConfig::Read(config) => Ok(config.clone()),
+                other => Err(config_kind_error(table, case, "read", other.kind())),
+            })
+            .collect()
+    }
+
+    /// Returns configs for a snapshot-construction workload, or `None` when it is unlisted.
+    ///
+    /// Returns an error when the workload's table directory has no valid registry key or the
+    /// registered configs are for a different operation type.
+    pub fn snapshot_configs(
+        &self,
+        workload: &Workload,
+    ) -> RegistryResult<Option<Vec<SnapshotConstructionConfig>>> {
+        let (table, case) = workload_registry_key(workload)?;
+        let Some(configs) = self.lookup(table, case) else {
+            return Ok(None);
+        };
+        configs
+            .iter()
+            .map(|config| match config {
+                HarnessConfig::SnapshotConstruction(config) => Ok(config.clone()),
+                other => Err(config_kind_error(
+                    table,
+                    case,
+                    "snapshot-construction",
+                    other.kind(),
+                )),
+            })
+            .collect::<RegistryResult<Vec<_>>>()
+            .map(Some)
     }
 
     /// Validates the registry structure and its relationship to `workloads`.
     ///
     /// Only registry entries matching a workload in `workloads` receive workload-type validation,
     /// allowing callers to validate a tag-filtered workload set. Returns an error for empty config
-    /// lists, duplicate config names, invalid workload registry keys, or read configs targeting a
-    /// non-read workload.
+    /// lists or names, duplicate names, mixed config types, invalid workload registry keys, or
+    /// configs targeting the wrong workload type.
     pub fn validate(&self, workloads: &[Workload]) -> RegistryResult<()> {
         for (table, cases) in &self.tables {
             for (case, configs) in cases {
@@ -109,37 +199,46 @@ impl BenchRegistry {
                 if configs.is_empty() {
                     return Err(format!("registry entry '{key}' has an empty config list").into());
                 }
-                let names: HashSet<_> = configs.iter().map(|config| config.name.as_str()).collect();
+                if configs.iter().any(|config| config.name().is_empty()) {
+                    return Err(format!("empty config name in '{key}'").into());
+                }
+                let names: HashSet<_> = configs.iter().map(HarnessConfig::name).collect();
                 if names.len() != configs.len() {
                     return Err(format!("registry entry '{key}' has duplicate config names").into());
                 }
-            }
-        }
-
-        for workload in workloads {
-            let table = workload.table_info.registry_table_key().ok_or_else(|| {
-                format!(
-                    "could not derive a registry table key for workload '{}'",
-                    workload.case_name
-                )
-            })?;
-            if self.lookup(table, &workload.case_name).is_some() {
-                if let Spec::SnapshotConstruction(_) = &workload.spec {
+                let expected_kind = configs[0].kind();
+                if let Some(other) = configs.iter().find(|config| config.kind() != expected_kind) {
                     return Err(format!(
-                        "registry entry '{table}/{}' provides read configs for a {} workload",
-                        workload.case_name,
-                        workload.spec.as_str()
+                        "registry entry '{key}' mixes {expected_kind} and {} configs",
+                        other.kind()
                     )
                     .into());
                 }
             }
         }
+
+        for workload in workloads {
+            let (table, case) = workload_registry_key(workload)?;
+            let Some(configs) = self.lookup(table, case) else {
+                continue;
+            };
+            let expected_kind = match &workload.spec {
+                Spec::Read(_) => "read",
+                Spec::SnapshotConstruction(_) => "snapshot-construction",
+            };
+            let actual_kind = configs[0].kind();
+            if actual_kind != expected_kind {
+                return Err(format!(
+                    "registry entry '{table}/{case}' provides {actual_kind} configs for a \
+                     {expected_kind} workload"
+                )
+                .into());
+            }
+        }
         Ok(())
     }
 
-    /// All `(table, case)` keys in the registry. Lets the harness cross-check every entry against
-    /// the loaded workloads so a stale/typo'd key (which would otherwise silently fall back to
-    /// defaults) is caught.
+    /// All `(table, case)` keys in the registry.
     pub fn keys(&self) -> impl Iterator<Item = (&str, &str)> {
         self.tables.iter().flat_map(|(table, cases)| {
             cases
@@ -148,13 +247,31 @@ impl BenchRegistry {
         })
     }
 
-    /// Looks up the config list for `"{table}/{case}"`, if the registry lists it.
-    fn lookup(&self, table: &str, case: &str) -> Option<&[ReadConfig]> {
+    fn lookup(&self, table: &str, case: &str) -> Option<&[HarnessConfig]> {
         self.tables
             .get(table)
             .and_then(|cases| cases.get(case))
             .map(Vec::as_slice)
     }
+}
+
+fn workload_registry_key(workload: &Workload) -> RegistryResult<(&str, &str)> {
+    let table = workload.table_info.registry_table_key().ok_or_else(|| {
+        format!(
+            "could not derive a registry table key for workload '{}'",
+            workload.case_name
+        )
+    })?;
+    Ok((table, &workload.case_name))
+}
+
+fn config_kind_error(
+    table: &str,
+    case: &str,
+    expected: &str,
+    actual: &str,
+) -> Box<dyn std::error::Error> {
+    format!("registry entry '{table}/{case}' contains {actual} configs, expected {expected}").into()
 }
 
 #[cfg(test)]
@@ -196,6 +313,16 @@ mod tests {
             "readMetadataLatest": [
                 { "name": "serial",    "parallelScan": "disabled" },
                 { "name": "parallel2", "parallelScan": { "enabled": { "numThreads": 2 } } }
+            ],
+            "snapshotLatest": [
+                {
+                    "name": "fresh",
+                    "snapshotBuilder": "for"
+                },
+                {
+                    "name": "from199",
+                    "snapshotBuilder": { "from": { "version": 199 } }
+                }
             ]
         }
     }"#;
@@ -205,6 +332,7 @@ mod tests {
         let registry = registry_from_str(FULL_REGISTRY);
         assert_eq!(registry.tables.len(), 1);
         assert_eq!(registry.tables["v2"]["readMetadataLatest"].len(), 2);
+        assert_eq!(registry.tables["v2"]["snapshotLatest"].len(), 2);
     }
 
     #[test]
@@ -223,15 +351,31 @@ mod tests {
     }
 
     #[test]
-    fn unlisted_read_benchmark_falls_back_to_serial() {
-        // An unlisted read benchmark in a populated registry and any lookup against an empty
-        // registry both fall back to the built-in serial config.
+    fn snapshot_configs_use_explicit_entry() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let configs = registry
+            .snapshot_configs(&read_workload("v2", "snapshotLatest"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(configs[0].snapshot_builder, SnapshotBuilderConfig::For);
+        assert_eq!(
+            configs[1].snapshot_builder,
+            SnapshotBuilderConfig::From { version: 199 }
+        );
+    }
+
+    #[test]
+    fn unlisted_benchmarks_use_operation_defaults() {
         for registry in [registry_from_str(FULL_REGISTRY), registry_from_str("{}")] {
             let read = registry
                 .read_configs(&read_workload("other", "readMetadataLatest"))
                 .unwrap();
             assert_eq!(read.len(), 1);
             assert_eq!(read[0].name, "serial");
+            assert!(registry
+                .snapshot_configs(&read_workload("other", "snapshotLatest"))
+                .unwrap()
+                .is_none());
         }
     }
 
@@ -261,8 +405,26 @@ mod tests {
 
         let error = registry.validate(&[workload]).unwrap_err().to_string();
         assert!(
-            error.contains("provides read configs for a snapshotConstruction workload"),
+            error.contains("provides read configs for a snapshot-construction workload"),
             "got: {error}"
+        );
+    }
+
+    #[test]
+    fn wrong_config_type_errors_at_lookup() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let read_err = registry
+            .read_configs(&read_workload("v2", "snapshotLatest"))
+            .unwrap_err()
+            .to_string();
+        assert!(read_err.contains("expected read"), "got: {read_err}");
+        let snapshot_err = registry
+            .snapshot_configs(&read_workload("v2", "readMetadataLatest"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            snapshot_err.contains("expected snapshot-construction"),
+            "got: {snapshot_err}"
         );
     }
 
@@ -280,10 +442,26 @@ mod tests {
     }
 
     #[test]
+    fn mixed_config_types_error_at_validation() {
+        let json = r#"{
+            "t": { "c": [
+                { "name": "read", "parallelScan": "disabled" },
+                {
+                    "name": "snapshot",
+                    "snapshotBuilder": "for"
+                }
+            ] }
+        }"#;
+        let registry: BenchRegistry = serde_json::from_str(json).unwrap();
+        let err = registry.validate(&[]).unwrap_err().to_string();
+        assert!(
+            err.contains("mixes read and snapshot-construction"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn empty_config_list_errors_at_validation() {
-        // An explicit `[]` would expand to zero benchmarks, silently dropping the benchmark, so it
-        // is rejected at load rather than accepted like a missing key (which falls back to
-        // default).
         let json = r#"{ "t": { "readMetadataLatest": [] } }"#;
         let registry: BenchRegistry = serde_json::from_str(json).unwrap();
         let err = registry.validate(&[]).unwrap_err().to_string();
@@ -291,8 +469,17 @@ mod tests {
     }
 
     #[test]
+    fn empty_config_name_errors_at_validation() {
+        let json = r#"{
+            "t": { "c": [ { "name": "", "parallelScan": "disabled" } ] }
+        }"#;
+        let registry: BenchRegistry = serde_json::from_str(json).unwrap();
+        let err = registry.validate(&[]).unwrap_err().to_string();
+        assert!(err.contains("empty config name"), "got: {err}");
+    }
+
+    #[test]
     fn malformed_entry_errors_at_load() {
-        // `parallelScn` is a typo, so the entry is not a valid read config.
         let json = r#"{
             "t": { "c": [ { "name": "x", "parallelScn": "disabled" } ] }
         }"#;
@@ -301,7 +488,6 @@ mod tests {
 
     #[test]
     fn non_object_table_entry_errors() {
-        // Each table key must map to an object of case -> config list, not a scalar.
         let result: Result<BenchRegistry, _> = serde_json::from_str(r#"{ "t": 1 }"#);
         assert!(result.is_err());
     }

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -45,13 +45,13 @@ pub enum ParallelScan {
     },
 }
 
-/// A snapshot-construction config: snapshot builder and CRC replay parameters.
+/// Configuration for a snapshot-construction benchmark.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SnapshotConstructionConfig {
     /// Name appended to the configured benchmark identifier.
     pub name: String,
-    /// Whether to build from the table root or from a prebuilt snapshot.
+    /// Snapshot construction source.
     pub snapshot_builder: SnapshotBuilderConfig,
 }
 
@@ -67,7 +67,7 @@ pub fn default_snapshot_construction_config() -> SnapshotConstructionConfig {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum SnapshotBuilderConfig {
-    /// Build a fresh snapshot from the table root.
+    /// Build a fresh snapshot using the table's resolved loading strategy.
     For,
     /// Build from a snapshot preconstructed at `version` outside the timed loop.
     From {
@@ -77,6 +77,7 @@ pub enum SnapshotBuilderConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+// The variants must remain structurally disjoint because serde selects them by required fields.
 #[serde(untagged)]
 enum HarnessConfig {
     Read(ReadConfig),
@@ -406,6 +407,18 @@ mod tests {
         let error = registry.validate(&[workload]).unwrap_err().to_string();
         assert!(
             error.contains("provides read configs for a snapshot-construction workload"),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn workload_validation_rejects_snapshot_configs_for_read_workload() {
+        let registry = registry_from_str(FULL_REGISTRY);
+        let workload = read_workload("v2", "snapshotLatest");
+
+        let error = registry.validate(&[workload]).unwrap_err().to_string();
+        assert!(
+            error.contains("provides snapshot-construction configs for a read workload"),
             "got: {error}"
         );
     }

--- a/benchmarks/src/registry.rs
+++ b/benchmarks/src/registry.rs
@@ -55,11 +55,11 @@ pub struct SnapshotConstructionConfig {
     pub snapshot_builder: SnapshotBuilderConfig,
 }
 
-/// The built-in fresh snapshot-construction config.
+/// The built-in from-table snapshot-construction config.
 pub fn default_snapshot_construction_config() -> SnapshotConstructionConfig {
     SnapshotConstructionConfig {
-        name: "fresh".into(),
-        snapshot_builder: SnapshotBuilderConfig::For,
+        name: "fromTable".into(),
+        snapshot_builder: SnapshotBuilderConfig::FromTable,
     }
 }
 
@@ -67,10 +67,10 @@ pub fn default_snapshot_construction_config() -> SnapshotConstructionConfig {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum SnapshotBuilderConfig {
-    /// Build a fresh snapshot using the table's resolved loading strategy.
-    For,
+    /// Build a snapshot from the table using its resolved loading strategy.
+    FromTable,
     /// Build from a snapshot preconstructed at `version` outside the timed loop.
-    From {
+    FromSnapshot {
         /// Version of the preconstructed base snapshot.
         version: u64,
     },
@@ -123,7 +123,7 @@ pub type RegistryResult<T> = Result<T, Box<dyn std::error::Error>>;
 ///
 /// Each configuration creates a separate Criterion benchmark whose final name segment is the
 /// configuration `name`. Unregistered read workloads use the built-in serial config, while
-/// unregistered snapshot-construction workloads retain their default fresh-snapshot behavior.
+/// unregistered snapshot-construction workloads retain their default from-table behavior.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(transparent)]
 pub struct BenchRegistry {
@@ -317,12 +317,12 @@ mod tests {
             ],
             "snapshotLatest": [
                 {
-                    "name": "fresh",
-                    "snapshotBuilder": "for"
+                    "name": "fromTable",
+                    "snapshotBuilder": "fromTable"
                 },
                 {
                     "name": "from199",
-                    "snapshotBuilder": { "from": { "version": 199 } }
+                    "snapshotBuilder": { "fromSnapshot": { "version": 199 } }
                 }
             ]
         }
@@ -358,10 +358,13 @@ mod tests {
             .snapshot_configs(&read_workload("v2", "snapshotLatest"))
             .unwrap()
             .unwrap();
-        assert_eq!(configs[0].snapshot_builder, SnapshotBuilderConfig::For);
+        assert_eq!(
+            configs[0].snapshot_builder,
+            SnapshotBuilderConfig::FromTable
+        );
         assert_eq!(
             configs[1].snapshot_builder,
-            SnapshotBuilderConfig::From { version: 199 }
+            SnapshotBuilderConfig::FromSnapshot { version: 199 }
         );
     }
 
@@ -461,7 +464,7 @@ mod tests {
                 { "name": "read", "parallelScan": "disabled" },
                 {
                     "name": "snapshot",
-                    "snapshotBuilder": "for"
+                    "snapshotBuilder": "fromTable"
                 }
             ] }
         }"#;

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -134,7 +134,7 @@ fn validate_snapshot_versions(
     snapshot_spec: &SnapshotConstructionSpec,
     snapshot_builder: &SnapshotBuilderConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let SnapshotBuilderConfig::From { version } = snapshot_builder else {
+    let SnapshotBuilderConfig::FromSnapshot { version } = snapshot_builder else {
         return Ok(());
     };
     if let Some(time_travel) = snapshot_spec.time_travel.as_ref() {
@@ -147,7 +147,8 @@ fn validate_snapshot_strategy(
     snapshot_builder: &SnapshotBuilderConfig,
     is_catalog_managed: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if is_catalog_managed && matches!(snapshot_builder, SnapshotBuilderConfig::From { .. }) {
+    if is_catalog_managed && matches!(snapshot_builder, SnapshotBuilderConfig::FromSnapshot { .. })
+    {
         return Err("Snapshot::builder_from is unsupported for catalog-managed benchmarks".into());
     }
     Ok(())
@@ -417,8 +418,8 @@ pub fn create_read_runner(
 }
 
 enum SnapshotConstructionSource {
-    Fresh(SnapshotStrategy),
-    Existing(Arc<Snapshot>),
+    FromTable(SnapshotStrategy),
+    FromSnapshot(Arc<Snapshot>),
 }
 
 pub struct SnapshotConstructionRunner {
@@ -433,9 +434,9 @@ impl SnapshotConstructionRunner {
     /// Prepares a snapshot-construction benchmark and state excluded from timing.
     ///
     /// `name` is the Criterion benchmark identifier, `snapshot_spec` selects the target version,
-    /// `snapshot_builder` selects fresh or incremental construction, `table_info` identifies the
-    /// table, and `runtime` executes asynchronous setup work. Incremental benchmarks load their
-    /// base snapshot during setup.
+    /// `snapshot_builder` selects from-table or incremental construction, `table_info` identifies
+    /// the table, and `runtime` executes asynchronous setup work. Incremental benchmarks load
+    /// their base snapshot during setup.
     ///
     /// Returns a runner whose [`WorkloadRunner::execute`] method performs only the measured
     /// snapshot construction.
@@ -456,8 +457,10 @@ impl SnapshotConstructionRunner {
         validate_snapshot_strategy(&snapshot_builder, is_catalog_managed)?;
 
         let source = match snapshot_builder {
-            SnapshotBuilderConfig::For => SnapshotConstructionSource::Fresh(snapshot_strategy),
-            SnapshotBuilderConfig::From { version } => {
+            SnapshotBuilderConfig::FromTable => {
+                SnapshotConstructionSource::FromTable(snapshot_strategy)
+            }
+            SnapshotBuilderConfig::FromSnapshot { version } => {
                 let base_time_travel = TimeTravel::Version {
                     version: version.try_into()?,
                 };
@@ -472,7 +475,7 @@ impl SnapshotConstructionRunner {
                         .version();
                     validate_base_precedes_target(version, target_version)?;
                 }
-                SnapshotConstructionSource::Existing(existing_snapshot)
+                SnapshotConstructionSource::FromSnapshot(existing_snapshot)
             }
         };
 
@@ -489,13 +492,13 @@ impl SnapshotConstructionRunner {
 impl WorkloadRunner for SnapshotConstructionRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
         let snapshot = match &self.source {
-            SnapshotConstructionSource::Fresh(snapshot_strategy) => snapshot_strategy
+            SnapshotConstructionSource::FromTable(snapshot_strategy) => snapshot_strategy
                 .load_snapshot(
                     self.engine.as_ref(),
                     &self.runtime,
                     self.time_travel.as_ref(),
                 )?,
-            SnapshotConstructionSource::Existing(existing_snapshot) => {
+            SnapshotConstructionSource::FromSnapshot(existing_snapshot) => {
                 let mut builder = Snapshot::builder_from(existing_snapshot.clone());
                 if let Some(time_travel) = self.time_travel.as_ref() {
                     builder = builder.at_version(time_travel.as_version()?);
@@ -611,8 +614,8 @@ mod tests {
             "basic_partitioned/snapshotLatest"
         );
         assert_eq!(
-            snapshot_benchmark_name(&table_info, "snapshotLatest", Some("fresh")),
-            "basic_partitioned/snapshotLatest/fresh"
+            snapshot_benchmark_name(&table_info, "snapshotLatest", Some("fromTable")),
+            "basic_partitioned/snapshotLatest/fromTable"
         );
     }
 
@@ -662,15 +665,15 @@ mod tests {
     }
 
     fn from_snapshot_config(version: u64) -> SnapshotBuilderConfig {
-        SnapshotBuilderConfig::From { version }
+        SnapshotBuilderConfig::FromSnapshot { version }
     }
 
     #[test]
-    fn test_fresh_snapshot_construction_runner() {
+    fn test_from_table_snapshot_construction_runner() {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
-            SnapshotBuilderConfig::For,
+            SnapshotBuilderConfig::FromTable,
             &test_table_info(),
             test_runtime(),
         )
@@ -817,10 +820,13 @@ mod tests {
                     .unwrap_or_else(|| panic!("missing config '{name}' for '{table}'"))
             };
 
-            assert_eq!(config("fresh").snapshot_builder, SnapshotBuilderConfig::For);
+            assert_eq!(
+                config("fromTable").snapshot_builder,
+                SnapshotBuilderConfig::FromTable
+            );
             assert_eq!(
                 config("from199").snapshot_builder,
-                SnapshotBuilderConfig::From { version: 199 }
+                SnapshotBuilderConfig::FromSnapshot { version: 199 }
             );
             assert_eq!(snapshots.len(), 2, "unexpected configs for '{table}'");
         }
@@ -869,7 +875,8 @@ mod tests {
                             .as_version()
                             .expect("snapshot workload target must be a version");
                         for config in &configs {
-                            if let SnapshotBuilderConfig::From { version } = config.snapshot_builder
+                            if let SnapshotBuilderConfig::FromSnapshot { version } =
+                                config.snapshot_builder
                             {
                                 assert!(
                                     version < target_version,
@@ -958,7 +965,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &spec,
-            SnapshotBuilderConfig::For,
+            SnapshotBuilderConfig::FromTable,
             &test_table_info(),
             test_runtime(),
         )

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -26,7 +26,9 @@ use unity_catalog_delta_client_api::Operation;
 use unity_catalog_delta_client_default::{ClientConfig, UCClient};
 use url::Url;
 
-use crate::registry::{ParallelScan, ReadConfig};
+use crate::registry::{
+    ParallelScan, ReadConfig, SnapshotBuilderConfig, SnapshotConstructionConfig,
+};
 
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
@@ -114,7 +116,37 @@ fn parse_three_part_name(name: &str) -> Result<(&str, &str, &str), Box<dyn std::
     }
 }
 
-/// Resolves the engine and snapshot strategy from a [`TableInfo`].
+fn validate_snapshot_construction_config(
+    snapshot_spec: &SnapshotConstructionSpec,
+    config: &SnapshotConstructionConfig,
+    table_info: &TableInfo,
+    is_catalog_managed: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let SnapshotBuilderConfig::From { version } = config.snapshot_builder else {
+        return Ok(());
+    };
+    if is_catalog_managed {
+        return Err("Snapshot::builder_from is unsupported for catalog-managed benchmarks".into());
+    }
+
+    let target_version = match snapshot_spec.time_travel.as_ref() {
+        Some(time_travel) => time_travel.as_version()?,
+        None => table_info
+            .log_info
+            .num_commits
+            .checked_sub(1)
+            .ok_or("Snapshot construction requires at least one table commit")?,
+    };
+    if version >= target_version {
+        return Err(format!(
+            "Base snapshot version {version} must be below target version {target_version}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Resolves engine credentials and snapshot strategy from a [`TableInfo`].
 ///
 /// For catalog-managed tables (`catalog_info` is present), credentials are vended via `UCClient`
 /// and the snapshot is loaded through the UC Delta-Tables API (`load_table`). For non-UC tables,
@@ -364,10 +396,15 @@ pub fn create_read_runner(
     }
 }
 
+enum SnapshotConstructionSource {
+    Fresh(SnapshotStrategy),
+    Existing(Arc<Snapshot>),
+}
+
 pub struct SnapshotConstructionRunner {
     engine: Arc<dyn Engine>,
     runtime: Arc<tokio::runtime::Runtime>,
-    snapshot_strategy: SnapshotStrategy,
+    source: SnapshotConstructionSource,
     time_travel: Option<TimeTravel>,
     name: String,
 }
@@ -376,15 +413,39 @@ impl SnapshotConstructionRunner {
     pub fn setup(
         name: String,
         snapshot_spec: &SnapshotConstructionSpec,
+        config: SnapshotConstructionConfig,
         table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
+        let is_catalog_managed =
+            matches!(&snapshot_strategy, SnapshotStrategy::CatalogManaged { .. });
+        validate_snapshot_construction_config(
+            snapshot_spec,
+            &config,
+            table_info,
+            is_catalog_managed,
+        )?;
+
+        let source = match config.snapshot_builder {
+            SnapshotBuilderConfig::For => SnapshotConstructionSource::Fresh(snapshot_strategy),
+            SnapshotBuilderConfig::From { version } => {
+                let base_time_travel = TimeTravel::Version {
+                    version: version.try_into()?,
+                };
+                let existing_snapshot = snapshot_strategy.load_snapshot(
+                    engine.as_ref(),
+                    &runtime,
+                    Some(&base_time_travel),
+                )?;
+                SnapshotConstructionSource::Existing(existing_snapshot)
+            }
+        };
 
         Ok(Self {
             engine,
             runtime,
-            snapshot_strategy,
+            source,
             time_travel: snapshot_spec.time_travel.clone(),
             name,
         })
@@ -393,11 +454,21 @@ impl SnapshotConstructionRunner {
 
 impl WorkloadRunner for SnapshotConstructionRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let snapshot = self.snapshot_strategy.load_snapshot(
-            self.engine.as_ref(),
-            &self.runtime,
-            self.time_travel.as_ref(),
-        )?;
+        let snapshot = match &self.source {
+            SnapshotConstructionSource::Fresh(snapshot_strategy) => snapshot_strategy
+                .load_snapshot(
+                    self.engine.as_ref(),
+                    &self.runtime,
+                    self.time_travel.as_ref(),
+                )?,
+            SnapshotConstructionSource::Existing(existing_snapshot) => {
+                let mut builder = Snapshot::builder_from(existing_snapshot.clone());
+                if let Some(time_travel) = self.time_travel.as_ref() {
+                    builder = builder.at_version(time_travel.as_version()?);
+                }
+                builder.build(self.engine.as_ref())?
+            }
+        };
         black_box(snapshot);
         Ok(())
     }
@@ -417,7 +488,7 @@ mod tests {
     use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
 
     use super::*;
-    use crate::registry::BenchRegistry;
+    use crate::registry::{default_snapshot_construction_config, BenchRegistry};
     use crate::utils::load_all_workloads;
 
     fn test_runtime() -> Arc<tokio::runtime::Runtime> {
@@ -531,11 +602,29 @@ mod tests {
         }
     }
 
+    fn registry_workload(table: &str, case: &str, spec: Spec) -> Workload {
+        let mut table_info = test_table_info();
+        table_info.table_info_dir = PathBuf::from(table);
+        Workload {
+            table_info,
+            case_name: case.to_string(),
+            spec,
+        }
+    }
+
+    fn from_snapshot_config(version: u64) -> SnapshotConstructionConfig {
+        SnapshotConstructionConfig {
+            name: format!("from{version}"),
+            snapshot_builder: SnapshotBuilderConfig::From { version },
+        }
+    }
+
     #[test]
     fn test_snapshot_construction_runner_setup() {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         );
@@ -547,6 +636,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )
@@ -559,11 +649,61 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
         assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn test_snapshot_construction_runner_from_existing_snapshot() {
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            &test_snapshot_spec(),
+            from_snapshot_config(0),
+            &test_table_info(),
+            test_runtime(),
+        )
+        .expect("setup should succeed");
+        assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn test_snapshot_construction_rejects_base_at_explicit_target() {
+        let spec = SnapshotConstructionSpec {
+            time_travel: Some(TimeTravel::Version { version: 0 }),
+            expected: None,
+        };
+        let err = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            &spec,
+            from_snapshot_config(0),
+            &test_table_info(),
+            test_runtime(),
+        )
+        .err()
+        .expect("setup should reject a base at the target version")
+        .to_string();
+        assert!(err.contains("must be below target version"), "got: {err}");
+    }
+
+    #[test]
+    fn test_snapshot_construction_rejects_base_at_latest_target() {
+        let table_info = test_table_info();
+        let latest_version = table_info.log_info.num_commits - 1;
+        let err = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "testCase", "fromLatest"),
+            &test_snapshot_spec(),
+            from_snapshot_config(latest_version),
+            &table_info,
+            test_runtime(),
+        )
+        .err()
+        .expect("setup should reject a base at the latest version")
+        .to_string();
+        assert!(err.contains("must be below target version"), "got: {err}");
     }
 
     /// Guards the checked-in `bench-registry.json` so a malformed edit or a duplicate config name
@@ -573,13 +713,11 @@ mod tests {
         let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
         let registry = BenchRegistry::load_from_path(Path::new(&path))
             .expect("checked-in bench-registry.json must load");
-        let mut table_info = test_table_info();
-        table_info.table_info_dir = PathBuf::from("10kAdds0CommitsSinceChkpt1V2Chkpt");
-        let workload = Workload {
-            table_info,
-            case_name: "readMetadataLatest".to_string(),
-            spec: Spec::Read(test_read_spec()),
-        };
+        let workload = registry_workload(
+            "10kAdds0CommitsSinceChkpt1V2Chkpt",
+            "readMetadataLatest",
+            Spec::Read(test_read_spec()),
+        );
         registry
             .validate(slice::from_ref(&workload))
             .expect("checked-in bench-registry.json must validate");
@@ -588,11 +726,37 @@ mod tests {
             read.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["serial", "parallel2"]
         );
+        for table in [
+            "crc1Col200Commits1ChkptCrc150",
+            "crc1Col200Commits1ChkptCrc195",
+            "crc1Col200Commits1ChkptCrcLatest",
+            "crc1Col200Commits1ChkptNoCrc",
+        ] {
+            let workload = registry_workload(
+                table,
+                "snapshotLatest",
+                Spec::SnapshotConstruction(Box::new(test_snapshot_spec())),
+            );
+            let snapshots = registry
+                .snapshot_configs(&workload)
+                .expect("snapshot registry entry should have snapshot configs")
+                .expect("snapshot registry entry should be present");
+            let config = |name| {
+                snapshots
+                    .iter()
+                    .find(|config| config.name == name)
+                    .unwrap_or_else(|| panic!("missing config '{name}' for '{table}'"))
+            };
+
+            assert_eq!(config("fresh").snapshot_builder, SnapshotBuilderConfig::For);
+            assert_eq!(
+                config("from199").snapshot_builder,
+                SnapshotBuilderConfig::From { version: 199 }
+            );
+            assert_eq!(snapshots.len(), 2, "unexpected configs for '{table}'");
+        }
     }
 
-    /// Every registry key must name a real read workload. A key miss silently falls back to the
-    /// serial default, so a stale/typo'd key would otherwise be invisible until the harness runs.
-    /// Skips when the downloaded workload archive is absent (e.g. offline unit runs).
     #[test]
     fn checked_in_registry_keys_match_real_workloads() {
         let Ok(workloads) = load_all_workloads() else {
@@ -621,9 +785,40 @@ mod tests {
             .expect("registry configs must match workload types");
 
         for (table, case) in registry.keys() {
-            workload_by_key.get(&(table, case)).unwrap_or_else(|| {
+            let workload = workload_by_key.get(&(table, case)).unwrap_or_else(|| {
                 panic!("registry key '{table}/{case}' matches no workload (stale or typo'd?)")
             });
+            let resolved = match &workload.spec {
+                Spec::Read(_) => registry.read_configs(workload).unwrap().len(),
+                Spec::SnapshotConstruction(spec) => {
+                    let configs = registry
+                        .snapshot_configs(workload)
+                        .expect("snapshot workload must have snapshot configs")
+                        .expect("registered snapshot workload must resolve configs");
+                    let target_version = match spec.time_travel.as_ref() {
+                        Some(time_travel) => time_travel
+                            .as_version()
+                            .expect("snapshot workload target must be a version"),
+                        None => workload
+                            .table_info
+                            .log_info
+                            .num_commits
+                            .checked_sub(1)
+                            .expect("snapshot workload must contain at least one commit"),
+                    };
+                    for config in &configs {
+                        if let SnapshotBuilderConfig::From { version } = config.snapshot_builder {
+                            assert!(
+                                version < target_version,
+                                "registry base version {version} must be below target version \
+                                 {target_version} for '{table}/{case}'"
+                            );
+                        }
+                    }
+                    configs.len()
+                }
+            };
+            assert_ne!(resolved, 0);
         }
     }
 
@@ -699,6 +894,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &spec,
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -26,7 +26,9 @@ use unity_catalog_delta_client_api::Operation;
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
 use url::Url;
 
-use crate::registry::{ParallelScan, ReadConfig};
+use crate::registry::{
+    ParallelScan, ReadConfig, SnapshotBuilderConfig, SnapshotConstructionConfig,
+};
 
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
@@ -114,7 +116,37 @@ fn parse_three_part_name(name: &str) -> Result<(&str, &str, &str), Box<dyn std::
     }
 }
 
-/// Resolves the engine and snapshot strategy from a [`TableInfo`].
+fn validate_snapshot_construction_config(
+    snapshot_spec: &SnapshotConstructionSpec,
+    config: &SnapshotConstructionConfig,
+    table_info: &TableInfo,
+    is_catalog_managed: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let SnapshotBuilderConfig::From { version } = config.snapshot_builder else {
+        return Ok(());
+    };
+    if is_catalog_managed {
+        return Err("Snapshot::builder_from is unsupported for catalog-managed benchmarks".into());
+    }
+
+    let target_version = match snapshot_spec.time_travel.as_ref() {
+        Some(time_travel) => time_travel.as_version()?,
+        None => table_info
+            .log_info
+            .num_commits
+            .checked_sub(1)
+            .ok_or("Snapshot construction requires at least one table commit")?,
+    };
+    if version >= target_version {
+        return Err(format!(
+            "Base snapshot version {version} must be below target version {target_version}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Resolves engine credentials and snapshot strategy from a [`TableInfo`].
 ///
 /// For catalog-managed tables (`catalog_info` is present), credentials are vended via `UCClient`
 /// and the snapshot is loaded through the UC Delta-Tables API (`load_table`). For non-UC tables,
@@ -364,10 +396,15 @@ pub fn create_read_runner(
     }
 }
 
+enum SnapshotConstructionSource {
+    Fresh(SnapshotStrategy),
+    Existing(Arc<Snapshot>),
+}
+
 pub struct SnapshotConstructionRunner {
     engine: Arc<dyn Engine>,
     runtime: Arc<tokio::runtime::Runtime>,
-    snapshot_strategy: SnapshotStrategy,
+    source: SnapshotConstructionSource,
     time_travel: Option<TimeTravel>,
     name: String,
 }
@@ -376,15 +413,39 @@ impl SnapshotConstructionRunner {
     pub fn setup(
         name: String,
         snapshot_spec: &SnapshotConstructionSpec,
+        config: SnapshotConstructionConfig,
         table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
+        let is_catalog_managed =
+            matches!(&snapshot_strategy, SnapshotStrategy::CatalogManaged { .. });
+        validate_snapshot_construction_config(
+            snapshot_spec,
+            &config,
+            table_info,
+            is_catalog_managed,
+        )?;
+
+        let source = match config.snapshot_builder {
+            SnapshotBuilderConfig::For => SnapshotConstructionSource::Fresh(snapshot_strategy),
+            SnapshotBuilderConfig::From { version } => {
+                let base_time_travel = TimeTravel::Version {
+                    version: version.try_into()?,
+                };
+                let existing_snapshot = snapshot_strategy.load_snapshot(
+                    engine.as_ref(),
+                    &runtime,
+                    Some(&base_time_travel),
+                )?;
+                SnapshotConstructionSource::Existing(existing_snapshot)
+            }
+        };
 
         Ok(Self {
             engine,
             runtime,
-            snapshot_strategy,
+            source,
             time_travel: snapshot_spec.time_travel.clone(),
             name,
         })
@@ -393,11 +454,21 @@ impl SnapshotConstructionRunner {
 
 impl WorkloadRunner for SnapshotConstructionRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let snapshot = self.snapshot_strategy.load_snapshot(
-            self.engine.as_ref(),
-            &self.runtime,
-            self.time_travel.as_ref(),
-        )?;
+        let snapshot = match &self.source {
+            SnapshotConstructionSource::Fresh(snapshot_strategy) => snapshot_strategy
+                .load_snapshot(
+                    self.engine.as_ref(),
+                    &self.runtime,
+                    self.time_travel.as_ref(),
+                )?,
+            SnapshotConstructionSource::Existing(existing_snapshot) => {
+                let mut builder = Snapshot::builder_from(existing_snapshot.clone());
+                if let Some(time_travel) = self.time_travel.as_ref() {
+                    builder = builder.at_version(time_travel.as_version()?);
+                }
+                builder.build(self.engine.as_ref())?
+            }
+        };
         black_box(snapshot);
         Ok(())
     }
@@ -417,7 +488,7 @@ mod tests {
     use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
 
     use super::*;
-    use crate::registry::BenchRegistry;
+    use crate::registry::{default_snapshot_construction_config, BenchRegistry};
     use crate::utils::load_all_workloads;
 
     fn test_runtime() -> Arc<tokio::runtime::Runtime> {
@@ -531,11 +602,29 @@ mod tests {
         }
     }
 
+    fn registry_workload(table: &str, case: &str, spec: Spec) -> Workload {
+        let mut table_info = test_table_info();
+        table_info.table_info_dir = PathBuf::from(table);
+        Workload {
+            table_info,
+            case_name: case.to_string(),
+            spec,
+        }
+    }
+
+    fn from_snapshot_config(version: u64) -> SnapshotConstructionConfig {
+        SnapshotConstructionConfig {
+            name: format!("from{version}"),
+            snapshot_builder: SnapshotBuilderConfig::From { version },
+        }
+    }
+
     #[test]
     fn test_snapshot_construction_runner_setup() {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         );
@@ -547,6 +636,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )
@@ -559,11 +649,61 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
         assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn test_snapshot_construction_runner_from_existing_snapshot() {
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            &test_snapshot_spec(),
+            from_snapshot_config(0),
+            &test_table_info(),
+            test_runtime(),
+        )
+        .expect("setup should succeed");
+        assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn test_snapshot_construction_rejects_base_at_explicit_target() {
+        let spec = SnapshotConstructionSpec {
+            time_travel: Some(TimeTravel::Version { version: 0 }),
+            expected: None,
+        };
+        let err = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            &spec,
+            from_snapshot_config(0),
+            &test_table_info(),
+            test_runtime(),
+        )
+        .err()
+        .expect("setup should reject a base at the target version")
+        .to_string();
+        assert!(err.contains("must be below target version"), "got: {err}");
+    }
+
+    #[test]
+    fn test_snapshot_construction_rejects_base_at_latest_target() {
+        let table_info = test_table_info();
+        let latest_version = table_info.log_info.num_commits - 1;
+        let err = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "testCase", "fromLatest"),
+            &test_snapshot_spec(),
+            from_snapshot_config(latest_version),
+            &table_info,
+            test_runtime(),
+        )
+        .err()
+        .expect("setup should reject a base at the latest version")
+        .to_string();
+        assert!(err.contains("must be below target version"), "got: {err}");
     }
 
     /// Guards the checked-in `bench-registry.json` so a malformed edit or a duplicate config name
@@ -573,13 +713,11 @@ mod tests {
         let path = format!("{}/bench-registry.json", env!("CARGO_MANIFEST_DIR"));
         let registry = BenchRegistry::load_from_path(Path::new(&path))
             .expect("checked-in bench-registry.json must load");
-        let mut table_info = test_table_info();
-        table_info.table_info_dir = PathBuf::from("10kAdds0CommitsSinceChkpt1V2Chkpt");
-        let workload = Workload {
-            table_info,
-            case_name: "readMetadataLatest".to_string(),
-            spec: Spec::Read(test_read_spec()),
-        };
+        let workload = registry_workload(
+            "10kAdds0CommitsSinceChkpt1V2Chkpt",
+            "readMetadataLatest",
+            Spec::Read(test_read_spec()),
+        );
         registry
             .validate(slice::from_ref(&workload))
             .expect("checked-in bench-registry.json must validate");
@@ -588,11 +726,37 @@ mod tests {
             read.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["serial", "parallel2"]
         );
+        for table in [
+            "crc1Col200Commits1ChkptCrc150",
+            "crc1Col200Commits1ChkptCrc195",
+            "crc1Col200Commits1ChkptCrcLatest",
+            "crc1Col200Commits1ChkptNoCrc",
+        ] {
+            let workload = registry_workload(
+                table,
+                "snapshotLatest",
+                Spec::SnapshotConstruction(Box::new(test_snapshot_spec())),
+            );
+            let snapshots = registry
+                .snapshot_configs(&workload)
+                .expect("snapshot registry entry should have snapshot configs")
+                .expect("snapshot registry entry should be present");
+            let config = |name| {
+                snapshots
+                    .iter()
+                    .find(|config| config.name == name)
+                    .unwrap_or_else(|| panic!("missing config '{name}' for '{table}'"))
+            };
+
+            assert_eq!(config("fresh").snapshot_builder, SnapshotBuilderConfig::For);
+            assert_eq!(
+                config("from199").snapshot_builder,
+                SnapshotBuilderConfig::From { version: 199 }
+            );
+            assert_eq!(snapshots.len(), 2, "unexpected configs for '{table}'");
+        }
     }
 
-    /// Every registry key must name a real read workload. A key miss silently falls back to the
-    /// serial default, so a stale/typo'd key would otherwise be invisible until the harness runs.
-    /// Skips when the downloaded workload archive is absent (e.g. offline unit runs).
     #[test]
     fn checked_in_registry_keys_match_real_workloads() {
         let Ok(workloads) = load_all_workloads() else {
@@ -621,9 +785,40 @@ mod tests {
             .expect("registry configs must match workload types");
 
         for (table, case) in registry.keys() {
-            workload_by_key.get(&(table, case)).unwrap_or_else(|| {
+            let workload = workload_by_key.get(&(table, case)).unwrap_or_else(|| {
                 panic!("registry key '{table}/{case}' matches no workload (stale or typo'd?)")
             });
+            let resolved = match &workload.spec {
+                Spec::Read(_) => registry.read_configs(workload).unwrap().len(),
+                Spec::SnapshotConstruction(spec) => {
+                    let configs = registry
+                        .snapshot_configs(workload)
+                        .expect("snapshot workload must have snapshot configs")
+                        .expect("registered snapshot workload must resolve configs");
+                    let target_version = match spec.time_travel.as_ref() {
+                        Some(time_travel) => time_travel
+                            .as_version()
+                            .expect("snapshot workload target must be a version"),
+                        None => workload
+                            .table_info
+                            .log_info
+                            .num_commits
+                            .checked_sub(1)
+                            .expect("snapshot workload must contain at least one commit"),
+                    };
+                    for config in &configs {
+                        if let SnapshotBuilderConfig::From { version } = config.snapshot_builder {
+                            assert!(
+                                version < target_version,
+                                "registry base version {version} must be below target version \
+                                 {target_version} for '{table}/{case}'"
+                            );
+                        }
+                    }
+                    configs.len()
+                }
+            };
+            assert_ne!(resolved, 0);
         }
     }
 
@@ -699,6 +894,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &spec,
+            default_snapshot_construction_config(),
             &test_table_info(),
             test_runtime(),
         )

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -26,9 +26,7 @@ use unity_catalog_delta_client_api::Operation;
 use unity_catalog_delta_client_default::{ClientConfig, UCClient};
 use url::Url;
 
-use crate::registry::{
-    ParallelScan, ReadConfig, SnapshotBuilderConfig, SnapshotConstructionConfig,
-};
+use crate::registry::{ParallelScan, ReadConfig, SnapshotBuilderConfig};
 
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
@@ -47,6 +45,22 @@ pub fn configured_benchmark_name(
     config_name: &str,
 ) -> String {
     format!("{}/{case_name}/{config_name}", table_info.name)
+}
+
+/// Builds a snapshot-construction benchmark name.
+///
+/// `table_info` supplies the human-readable table name, `case_name` identifies the workload spec,
+/// and `config_name` supplies the optional registered-config suffix. The returned name remains
+/// unsuffixed when `config_name` is `None`, preserving legacy names for unregistered workloads.
+pub fn snapshot_benchmark_name(
+    table_info: &TableInfo,
+    case_name: &str,
+    config_name: Option<&str>,
+) -> String {
+    match config_name {
+        Some(config_name) => configured_benchmark_name(table_info, case_name, config_name),
+        None => benchmark_name(table_info, case_name),
+    }
 }
 
 fn build_engine(
@@ -116,30 +130,36 @@ fn parse_three_part_name(name: &str) -> Result<(&str, &str, &str), Box<dyn std::
     }
 }
 
-fn validate_snapshot_construction_config(
+fn validate_snapshot_versions(
     snapshot_spec: &SnapshotConstructionSpec,
-    config: &SnapshotConstructionConfig,
-    table_info: &TableInfo,
-    is_catalog_managed: bool,
+    snapshot_builder: &SnapshotBuilderConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let SnapshotBuilderConfig::From { version } = config.snapshot_builder else {
+    let SnapshotBuilderConfig::From { version } = snapshot_builder else {
         return Ok(());
     };
-    if is_catalog_managed {
+    if let Some(time_travel) = snapshot_spec.time_travel.as_ref() {
+        validate_base_precedes_target(*version, time_travel.as_version()?)?;
+    }
+    Ok(())
+}
+
+fn validate_snapshot_strategy(
+    snapshot_builder: &SnapshotBuilderConfig,
+    is_catalog_managed: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if is_catalog_managed && matches!(snapshot_builder, SnapshotBuilderConfig::From { .. }) {
         return Err("Snapshot::builder_from is unsupported for catalog-managed benchmarks".into());
     }
+    Ok(())
+}
 
-    let target_version = match snapshot_spec.time_travel.as_ref() {
-        Some(time_travel) => time_travel.as_version()?,
-        None => table_info
-            .log_info
-            .num_commits
-            .checked_sub(1)
-            .ok_or("Snapshot construction requires at least one table commit")?,
-    };
-    if version >= target_version {
+fn validate_base_precedes_target(
+    base_version: u64,
+    target_version: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if base_version >= target_version {
         return Err(format!(
-            "Base snapshot version {version} must be below target version {target_version}"
+            "Base snapshot version {base_version} must be below target version {target_version}"
         )
         .into());
     }
@@ -410,24 +430,32 @@ pub struct SnapshotConstructionRunner {
 }
 
 impl SnapshotConstructionRunner {
+    /// Prepares a snapshot-construction benchmark and state excluded from timing.
+    ///
+    /// `name` is the Criterion benchmark identifier, `snapshot_spec` selects the target version,
+    /// `snapshot_builder` selects fresh or incremental construction, `table_info` identifies the
+    /// table, and `runtime` executes asynchronous setup work. Incremental benchmarks load their
+    /// base snapshot during setup.
+    ///
+    /// Returns a runner whose [`WorkloadRunner::execute`] method performs only the measured
+    /// snapshot construction.
+    ///
+    /// Returns an error when the table cannot be resolved, incremental construction is
+    /// unsupported, or the configured base version does not precede the target version.
     pub fn setup(
         name: String,
         snapshot_spec: &SnapshotConstructionSpec,
-        config: SnapshotConstructionConfig,
+        snapshot_builder: SnapshotBuilderConfig,
         table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        validate_snapshot_versions(snapshot_spec, &snapshot_builder)?;
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
         let is_catalog_managed =
             matches!(&snapshot_strategy, SnapshotStrategy::CatalogManaged { .. });
-        validate_snapshot_construction_config(
-            snapshot_spec,
-            &config,
-            table_info,
-            is_catalog_managed,
-        )?;
+        validate_snapshot_strategy(&snapshot_builder, is_catalog_managed)?;
 
-        let source = match config.snapshot_builder {
+        let source = match snapshot_builder {
             SnapshotBuilderConfig::For => SnapshotConstructionSource::Fresh(snapshot_strategy),
             SnapshotBuilderConfig::From { version } => {
                 let base_time_travel = TimeTravel::Version {
@@ -438,6 +466,12 @@ impl SnapshotConstructionRunner {
                     &runtime,
                     Some(&base_time_travel),
                 )?;
+                if snapshot_spec.time_travel.is_none() {
+                    let target_version = Snapshot::builder_from(existing_snapshot.clone())
+                        .build(engine.as_ref())?
+                        .version();
+                    validate_base_precedes_target(version, target_version)?;
+                }
                 SnapshotConstructionSource::Existing(existing_snapshot)
             }
         };
@@ -486,9 +520,11 @@ mod tests {
     use std::sync::LazyLock;
 
     use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
+    use rstest::rstest;
+    use test_utils::copy_directory;
 
     use super::*;
-    use crate::registry::{default_snapshot_construction_config, BenchRegistry};
+    use crate::registry::BenchRegistry;
     use crate::utils::load_all_workloads;
 
     fn test_runtime() -> Arc<tokio::runtime::Runtime> {
@@ -568,6 +604,19 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_benchmark_names_preserve_legacy_and_suffix_registered_configs() {
+        let table_info = test_table_info();
+        assert_eq!(
+            snapshot_benchmark_name(&table_info, "snapshotLatest", None),
+            "basic_partitioned/snapshotLatest"
+        );
+        assert_eq!(
+            snapshot_benchmark_name(&table_info, "snapshotLatest", Some("fresh")),
+            "basic_partitioned/snapshotLatest/fresh"
+        );
+    }
+
+    #[test]
     fn test_read_metadata_runner_serial() {
         let runner = ReadMetadataRunner::setup(
             configured_benchmark_name(&test_table_info(), "testCase", "serial"),
@@ -612,48 +661,21 @@ mod tests {
         }
     }
 
-    fn from_snapshot_config(version: u64) -> SnapshotConstructionConfig {
-        SnapshotConstructionConfig {
-            name: format!("from{version}"),
-            snapshot_builder: SnapshotBuilderConfig::From { version },
-        }
+    fn from_snapshot_config(version: u64) -> SnapshotBuilderConfig {
+        SnapshotBuilderConfig::From { version }
     }
 
     #[test]
-    fn test_snapshot_construction_runner_setup() {
+    fn test_fresh_snapshot_construction_runner() {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
-            default_snapshot_construction_config(),
-            &test_table_info(),
-            test_runtime(),
-        );
-        assert!(runner.is_ok());
-    }
-
-    #[test]
-    fn test_snapshot_construction_runner_name() {
-        let runner = SnapshotConstructionRunner::setup(
-            benchmark_name(&test_table_info(), "testCase"),
-            &test_snapshot_spec(),
-            default_snapshot_construction_config(),
+            SnapshotBuilderConfig::For,
             &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
         assert_eq!(runner.name(), "basic_partitioned/testCase");
-    }
-
-    #[test]
-    fn test_snapshot_construction_runner_execute() {
-        let runner = SnapshotConstructionRunner::setup(
-            benchmark_name(&test_table_info(), "testCase"),
-            &test_snapshot_spec(),
-            default_snapshot_construction_config(),
-            &test_table_info(),
-            test_runtime(),
-        )
-        .expect("setup should succeed");
         assert!(runner.execute().is_ok());
     }
 
@@ -670,16 +692,25 @@ mod tests {
         assert!(runner.execute().is_ok());
     }
 
-    #[test]
-    fn test_snapshot_construction_rejects_base_at_explicit_target() {
+    #[rstest]
+    #[case(Some(0), 0)]
+    #[case(None, 1)]
+    fn test_snapshot_construction_rejects_base_at_target(
+        #[case] target_version: Option<i64>,
+        #[case] base_version: u64,
+    ) {
         let spec = SnapshotConstructionSpec {
-            time_travel: Some(TimeTravel::Version { version: 0 }),
+            time_travel: target_version.map(|version| TimeTravel::Version { version }),
             expected: None,
         };
         let err = SnapshotConstructionRunner::setup(
-            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            configured_benchmark_name(
+                &test_table_info(),
+                "testCase",
+                &format!("from{base_version}"),
+            ),
             &spec,
-            from_snapshot_config(0),
+            from_snapshot_config(base_version),
             &test_table_info(),
             test_runtime(),
         )
@@ -690,20 +721,58 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_construction_rejects_base_at_latest_target() {
-        let table_info = test_table_info();
-        let latest_version = table_info.log_info.num_commits - 1;
-        let err = SnapshotConstructionRunner::setup(
-            configured_benchmark_name(&table_info, "testCase", "fromLatest"),
+    fn snapshot_from_latest_uses_actual_version_instead_of_commit_count() {
+        let mut table_info = test_table_info();
+        table_info.log_info.num_commits = 1;
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "testCase", "from0"),
             &test_snapshot_spec(),
-            from_snapshot_config(latest_version),
+            from_snapshot_config(0),
             &table_info,
             test_runtime(),
         )
-        .err()
-        .expect("setup should reject a base at the latest version")
-        .to_string();
-        assert!(err.contains("must be below target version"), "got: {err}");
+        .expect("setup should use the actual latest snapshot version");
+        assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn snapshot_from_rejects_catalog_managed_config() {
+        let error = validate_snapshot_strategy(&from_snapshot_config(0), true)
+            .expect_err("catalog-managed builder_from must be rejected");
+        assert!(error.to_string().contains("catalog-managed"));
+    }
+
+    #[test]
+    fn snapshot_from_honors_explicit_target_before_latest() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../kernel/tests/data/basic_partitioned"
+        ));
+        copy_directory(source, temp.path()).unwrap();
+        std::fs::write(
+            temp.path().join("_delta_log/00000000000000000002.json"),
+            "not valid json\n",
+        )
+        .unwrap();
+
+        let mut table_info = test_table_info();
+        table_info.table_path = Some(Url::from_directory_path(temp.path()).unwrap());
+        table_info.log_info.num_commits = 3;
+        let spec = SnapshotConstructionSpec {
+            time_travel: Some(TimeTravel::Version { version: 1 }),
+            expected: None,
+        };
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "snapshotVersion1", "from0"),
+            &spec,
+            from_snapshot_config(0),
+            &table_info,
+            test_runtime(),
+        )
+        .expect("setup should succeed");
+
+        runner.execute().expect("version 2 must not be read");
     }
 
     /// Guards the checked-in `bench-registry.json` so a malformed edit or a duplicate config name
@@ -795,24 +864,19 @@ mod tests {
                         .snapshot_configs(workload)
                         .expect("snapshot workload must have snapshot configs")
                         .expect("registered snapshot workload must resolve configs");
-                    let target_version = match spec.time_travel.as_ref() {
-                        Some(time_travel) => time_travel
+                    if let Some(time_travel) = spec.time_travel.as_ref() {
+                        let target_version = time_travel
                             .as_version()
-                            .expect("snapshot workload target must be a version"),
-                        None => workload
-                            .table_info
-                            .log_info
-                            .num_commits
-                            .checked_sub(1)
-                            .expect("snapshot workload must contain at least one commit"),
-                    };
-                    for config in &configs {
-                        if let SnapshotBuilderConfig::From { version } = config.snapshot_builder {
-                            assert!(
-                                version < target_version,
-                                "registry base version {version} must be below target version \
-                                 {target_version} for '{table}/{case}'"
-                            );
+                            .expect("snapshot workload target must be a version");
+                        for config in &configs {
+                            if let SnapshotBuilderConfig::From { version } = config.snapshot_builder
+                            {
+                                assert!(
+                                    version < target_version,
+                                    "registry base version {version} must be below target version \
+                                     {target_version} for '{table}/{case}'"
+                                );
+                            }
                         }
                     }
                     configs.len()
@@ -894,7 +958,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &spec,
-            default_snapshot_construction_config(),
+            SnapshotBuilderConfig::For,
             &test_table_info(),
             test_runtime(),
         )

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -26,9 +26,7 @@ use unity_catalog_delta_client_api::Operation;
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
 use url::Url;
 
-use crate::registry::{
-    ParallelScan, ReadConfig, SnapshotBuilderConfig, SnapshotConstructionConfig,
-};
+use crate::registry::{ParallelScan, ReadConfig, SnapshotBuilderConfig};
 
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
@@ -47,6 +45,22 @@ pub fn configured_benchmark_name(
     config_name: &str,
 ) -> String {
     format!("{}/{case_name}/{config_name}", table_info.name)
+}
+
+/// Builds a snapshot-construction benchmark name.
+///
+/// `table_info` supplies the human-readable table name, `case_name` identifies the workload spec,
+/// and `config_name` supplies the optional registered-config suffix. The returned name remains
+/// unsuffixed when `config_name` is `None`, preserving legacy names for unregistered workloads.
+pub fn snapshot_benchmark_name(
+    table_info: &TableInfo,
+    case_name: &str,
+    config_name: Option<&str>,
+) -> String {
+    match config_name {
+        Some(config_name) => configured_benchmark_name(table_info, case_name, config_name),
+        None => benchmark_name(table_info, case_name),
+    }
 }
 
 fn build_engine(
@@ -116,30 +130,36 @@ fn parse_three_part_name(name: &str) -> Result<(&str, &str, &str), Box<dyn std::
     }
 }
 
-fn validate_snapshot_construction_config(
+fn validate_snapshot_versions(
     snapshot_spec: &SnapshotConstructionSpec,
-    config: &SnapshotConstructionConfig,
-    table_info: &TableInfo,
-    is_catalog_managed: bool,
+    snapshot_builder: &SnapshotBuilderConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let SnapshotBuilderConfig::From { version } = config.snapshot_builder else {
+    let SnapshotBuilderConfig::From { version } = snapshot_builder else {
         return Ok(());
     };
-    if is_catalog_managed {
+    if let Some(time_travel) = snapshot_spec.time_travel.as_ref() {
+        validate_base_precedes_target(*version, time_travel.as_version()?)?;
+    }
+    Ok(())
+}
+
+fn validate_snapshot_strategy(
+    snapshot_builder: &SnapshotBuilderConfig,
+    is_catalog_managed: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if is_catalog_managed && matches!(snapshot_builder, SnapshotBuilderConfig::From { .. }) {
         return Err("Snapshot::builder_from is unsupported for catalog-managed benchmarks".into());
     }
+    Ok(())
+}
 
-    let target_version = match snapshot_spec.time_travel.as_ref() {
-        Some(time_travel) => time_travel.as_version()?,
-        None => table_info
-            .log_info
-            .num_commits
-            .checked_sub(1)
-            .ok_or("Snapshot construction requires at least one table commit")?,
-    };
-    if version >= target_version {
+fn validate_base_precedes_target(
+    base_version: u64,
+    target_version: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if base_version >= target_version {
         return Err(format!(
-            "Base snapshot version {version} must be below target version {target_version}"
+            "Base snapshot version {base_version} must be below target version {target_version}"
         )
         .into());
     }
@@ -410,24 +430,32 @@ pub struct SnapshotConstructionRunner {
 }
 
 impl SnapshotConstructionRunner {
+    /// Prepares a snapshot-construction benchmark and state excluded from timing.
+    ///
+    /// `name` is the Criterion benchmark identifier, `snapshot_spec` selects the target version,
+    /// `snapshot_builder` selects fresh or incremental construction, `table_info` identifies the
+    /// table, and `runtime` executes asynchronous setup work. Incremental benchmarks load their
+    /// base snapshot during setup.
+    ///
+    /// Returns a runner whose [`WorkloadRunner::execute`] method performs only the measured
+    /// snapshot construction.
+    ///
+    /// Returns an error when the table cannot be resolved, incremental construction is
+    /// unsupported, or the configured base version does not precede the target version.
     pub fn setup(
         name: String,
         snapshot_spec: &SnapshotConstructionSpec,
-        config: SnapshotConstructionConfig,
+        snapshot_builder: SnapshotBuilderConfig,
         table_info: &TableInfo,
         runtime: Arc<tokio::runtime::Runtime>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        validate_snapshot_versions(snapshot_spec, &snapshot_builder)?;
         let (engine, snapshot_strategy) = resolve_snapshot_strategy(table_info, runtime.clone())?;
         let is_catalog_managed =
             matches!(&snapshot_strategy, SnapshotStrategy::CatalogManaged { .. });
-        validate_snapshot_construction_config(
-            snapshot_spec,
-            &config,
-            table_info,
-            is_catalog_managed,
-        )?;
+        validate_snapshot_strategy(&snapshot_builder, is_catalog_managed)?;
 
-        let source = match config.snapshot_builder {
+        let source = match snapshot_builder {
             SnapshotBuilderConfig::For => SnapshotConstructionSource::Fresh(snapshot_strategy),
             SnapshotBuilderConfig::From { version } => {
                 let base_time_travel = TimeTravel::Version {
@@ -438,6 +466,12 @@ impl SnapshotConstructionRunner {
                     &runtime,
                     Some(&base_time_travel),
                 )?;
+                if snapshot_spec.time_travel.is_none() {
+                    let target_version = Snapshot::builder_from(existing_snapshot.clone())
+                        .build(engine.as_ref())?
+                        .version();
+                    validate_base_precedes_target(version, target_version)?;
+                }
                 SnapshotConstructionSource::Existing(existing_snapshot)
             }
         };
@@ -486,9 +520,11 @@ mod tests {
     use std::sync::LazyLock;
 
     use delta_kernel_workloads::models::{ReadSpec, Spec, TableInfo, TimeTravel, Workload};
+    use rstest::rstest;
+    use test_utils::copy_directory;
 
     use super::*;
-    use crate::registry::{default_snapshot_construction_config, BenchRegistry};
+    use crate::registry::BenchRegistry;
     use crate::utils::load_all_workloads;
 
     fn test_runtime() -> Arc<tokio::runtime::Runtime> {
@@ -568,6 +604,19 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_benchmark_names_preserve_legacy_and_suffix_registered_configs() {
+        let table_info = test_table_info();
+        assert_eq!(
+            snapshot_benchmark_name(&table_info, "snapshotLatest", None),
+            "basic_partitioned/snapshotLatest"
+        );
+        assert_eq!(
+            snapshot_benchmark_name(&table_info, "snapshotLatest", Some("fresh")),
+            "basic_partitioned/snapshotLatest/fresh"
+        );
+    }
+
+    #[test]
     fn test_read_metadata_runner_serial() {
         let runner = ReadMetadataRunner::setup(
             configured_benchmark_name(&test_table_info(), "testCase", "serial"),
@@ -612,48 +661,21 @@ mod tests {
         }
     }
 
-    fn from_snapshot_config(version: u64) -> SnapshotConstructionConfig {
-        SnapshotConstructionConfig {
-            name: format!("from{version}"),
-            snapshot_builder: SnapshotBuilderConfig::From { version },
-        }
+    fn from_snapshot_config(version: u64) -> SnapshotBuilderConfig {
+        SnapshotBuilderConfig::From { version }
     }
 
     #[test]
-    fn test_snapshot_construction_runner_setup() {
+    fn test_fresh_snapshot_construction_runner() {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &test_snapshot_spec(),
-            default_snapshot_construction_config(),
-            &test_table_info(),
-            test_runtime(),
-        );
-        assert!(runner.is_ok());
-    }
-
-    #[test]
-    fn test_snapshot_construction_runner_name() {
-        let runner = SnapshotConstructionRunner::setup(
-            benchmark_name(&test_table_info(), "testCase"),
-            &test_snapshot_spec(),
-            default_snapshot_construction_config(),
+            SnapshotBuilderConfig::For,
             &test_table_info(),
             test_runtime(),
         )
         .expect("setup should succeed");
         assert_eq!(runner.name(), "basic_partitioned/testCase");
-    }
-
-    #[test]
-    fn test_snapshot_construction_runner_execute() {
-        let runner = SnapshotConstructionRunner::setup(
-            benchmark_name(&test_table_info(), "testCase"),
-            &test_snapshot_spec(),
-            default_snapshot_construction_config(),
-            &test_table_info(),
-            test_runtime(),
-        )
-        .expect("setup should succeed");
         assert!(runner.execute().is_ok());
     }
 
@@ -670,16 +692,25 @@ mod tests {
         assert!(runner.execute().is_ok());
     }
 
-    #[test]
-    fn test_snapshot_construction_rejects_base_at_explicit_target() {
+    #[rstest]
+    #[case(Some(0), 0)]
+    #[case(None, 1)]
+    fn test_snapshot_construction_rejects_base_at_target(
+        #[case] target_version: Option<i64>,
+        #[case] base_version: u64,
+    ) {
         let spec = SnapshotConstructionSpec {
-            time_travel: Some(TimeTravel::Version { version: 0 }),
+            time_travel: target_version.map(|version| TimeTravel::Version { version }),
             expected: None,
         };
         let err = SnapshotConstructionRunner::setup(
-            configured_benchmark_name(&test_table_info(), "testCase", "from0"),
+            configured_benchmark_name(
+                &test_table_info(),
+                "testCase",
+                &format!("from{base_version}"),
+            ),
             &spec,
-            from_snapshot_config(0),
+            from_snapshot_config(base_version),
             &test_table_info(),
             test_runtime(),
         )
@@ -690,20 +721,58 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_construction_rejects_base_at_latest_target() {
-        let table_info = test_table_info();
-        let latest_version = table_info.log_info.num_commits - 1;
-        let err = SnapshotConstructionRunner::setup(
-            configured_benchmark_name(&table_info, "testCase", "fromLatest"),
+    fn snapshot_from_latest_uses_actual_version_instead_of_commit_count() {
+        let mut table_info = test_table_info();
+        table_info.log_info.num_commits = 1;
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "testCase", "from0"),
             &test_snapshot_spec(),
-            from_snapshot_config(latest_version),
+            from_snapshot_config(0),
             &table_info,
             test_runtime(),
         )
-        .err()
-        .expect("setup should reject a base at the latest version")
-        .to_string();
-        assert!(err.contains("must be below target version"), "got: {err}");
+        .expect("setup should use the actual latest snapshot version");
+        assert!(runner.execute().is_ok());
+    }
+
+    #[test]
+    fn snapshot_from_rejects_catalog_managed_config() {
+        let error = validate_snapshot_strategy(&from_snapshot_config(0), true)
+            .expect_err("catalog-managed builder_from must be rejected");
+        assert!(error.to_string().contains("catalog-managed"));
+    }
+
+    #[test]
+    fn snapshot_from_honors_explicit_target_before_latest() {
+        let temp = tempfile::tempdir().unwrap();
+        let source = Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../kernel/tests/data/basic_partitioned"
+        ));
+        copy_directory(source, temp.path()).unwrap();
+        std::fs::write(
+            temp.path().join("_delta_log/00000000000000000002.json"),
+            "not valid json\n",
+        )
+        .unwrap();
+
+        let mut table_info = test_table_info();
+        table_info.table_path = Some(Url::from_directory_path(temp.path()).unwrap());
+        table_info.log_info.num_commits = 3;
+        let spec = SnapshotConstructionSpec {
+            time_travel: Some(TimeTravel::Version { version: 1 }),
+            expected: None,
+        };
+        let runner = SnapshotConstructionRunner::setup(
+            configured_benchmark_name(&table_info, "snapshotVersion1", "from0"),
+            &spec,
+            from_snapshot_config(0),
+            &table_info,
+            test_runtime(),
+        )
+        .expect("setup should succeed");
+
+        runner.execute().expect("version 2 must not be read");
     }
 
     /// Guards the checked-in `bench-registry.json` so a malformed edit or a duplicate config name
@@ -795,24 +864,19 @@ mod tests {
                         .snapshot_configs(workload)
                         .expect("snapshot workload must have snapshot configs")
                         .expect("registered snapshot workload must resolve configs");
-                    let target_version = match spec.time_travel.as_ref() {
-                        Some(time_travel) => time_travel
+                    if let Some(time_travel) = spec.time_travel.as_ref() {
+                        let target_version = time_travel
                             .as_version()
-                            .expect("snapshot workload target must be a version"),
-                        None => workload
-                            .table_info
-                            .log_info
-                            .num_commits
-                            .checked_sub(1)
-                            .expect("snapshot workload must contain at least one commit"),
-                    };
-                    for config in &configs {
-                        if let SnapshotBuilderConfig::From { version } = config.snapshot_builder {
-                            assert!(
-                                version < target_version,
-                                "registry base version {version} must be below target version \
-                                 {target_version} for '{table}/{case}'"
-                            );
+                            .expect("snapshot workload target must be a version");
+                        for config in &configs {
+                            if let SnapshotBuilderConfig::From { version } = config.snapshot_builder
+                            {
+                                assert!(
+                                    version < target_version,
+                                    "registry base version {version} must be below target version \
+                                     {target_version} for '{table}/{case}'"
+                                );
+                            }
                         }
                     }
                     configs.len()
@@ -894,7 +958,7 @@ mod tests {
         let runner = SnapshotConstructionRunner::setup(
             benchmark_name(&test_table_info(), "testCase"),
             &spec,
-            default_snapshot_construction_config(),
+            SnapshotBuilderConfig::For,
             &test_table_info(),
             test_runtime(),
         )


### PR DESCRIPTION
## Stacked PR

Merge order:

1. **`stack/benchmarking-incremental-snapshot`** (this PR)
2. [`stack/benchmarking-incremental-crc` (#2965)](https://github.com/delta-io/delta-kernel-rs/pull/2965)

## What changes are proposed in this pull request?

Snapshot-construction benchmarks currently rebuild from the table root, which makes it difficult
to isolate the cost of advancing an existing snapshot. This extends the benchmark registry so a
workload can compare from-table construction with `Snapshot::builder_from` using a base snapshot
that is prepared outside the timed loop.

- Add named snapshot-construction configurations while preserving the existing behavior and name
  for unregistered workloads.
- Support from-table construction and construction from a configured earlier snapshot.
- Validate that the base version precedes the target and reject unsupported catalog-managed
  `builder_from` configurations.
- Register from-table and from-snapshot comparisons for the CRC workload fixtures.

This only changes the benchmark harness; it does not add or change public kernel APIs.

## How was this change tested?

- `cargo test -p delta_kernel_benchmarks --all-features --lib` (37 tests passed)
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- Workspace Arrow/no-default-features clippy check
