### PR TITLE
feat: initial predicate conversion

### DIFF
--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-08-10"
+}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,3 +1,0 @@
-{
-  "sync_reminder_last_shown": "2026-08-10"
-}

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -11,7 +11,7 @@ use delta_kernel::expressions::{
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
-use crate::predicate::to_df_predicate;
+use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
 
 /// Converts a kernel [`Expression`](KernelExpression) into the equivalent DataFusion
@@ -26,9 +26,7 @@ pub fn to_df_expr(expr: &KernelExpression, input_schema: &StructType) -> DeltaRe
         KernelExpression::Column(name) => column_to_df_expr(name, input_schema),
         KernelExpression::Binary(binary) => binary_expr_to_df_expr(binary, input_schema),
         KernelExpression::Variadic(variadic) => variadic_to_df_expr(variadic, input_schema),
-
-        // A boolean-valued predicate used as a value: lowers to a boolean DataFusion `Expr`.
-        KernelExpression::Predicate(pred) => to_df_predicate(pred, input_schema),
+        KernelExpression::Predicate(pred) => to_df_predicate_expr(pred, input_schema),
 
         // TODO: wire up once this function takes an output schema (`Struct` needs it for field
         // names; `MapToStruct`/`StructPatch` for field types). Each arm's lowering follows later.

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -11,6 +11,7 @@ use delta_kernel::expressions::{
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
+use crate::predicate::to_df_predicate;
 use crate::scalar::to_df_scalar;
 
 /// Converts a kernel [`Expression`](KernelExpression) into the equivalent DataFusion
@@ -26,10 +27,8 @@ pub fn to_df_expr(expr: &KernelExpression, input_schema: &StructType) -> DeltaRe
         KernelExpression::Binary(binary) => binary_expr_to_df_expr(binary, input_schema),
         KernelExpression::Variadic(variadic) => variadic_to_df_expr(variadic, input_schema),
 
-        // TODO: wire up in the predicate-conversion PR (needs the `Predicate -> Expr` converter).
-        KernelExpression::Predicate(_) => Err(Error::unsupported(
-            "converting an embedded Predicate expression is not yet supported",
-        )),
+        // A boolean-valued predicate used as a value: lowers to a boolean DataFusion `Expr`.
+        KernelExpression::Predicate(pred) => to_df_predicate(pred, input_schema),
 
         // TODO: wire up once this function takes an output schema (`Struct` needs it for field
         // names; `MapToStruct`/`StructPatch` for field types). Each arm's lowering follows later.
@@ -221,6 +220,12 @@ mod tests {
     )]
     fn variadic_lowers_to_call(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
+    }
+
+    #[test]
+    fn embedded_predicate_delegates_to_predicate_converter() {
+        let kernel = Expr_::Predicate(Box::new(column_expr!("b").is_null()));
+        assert_eq!(lower(kernel), "b IS NULL");
     }
 
     /// A column reference that does not resolve against the input schema fails at conversion time,

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn embedded_predicate_delegates_to_predicate_converter() {
-        let kernel = Expr_::Predicate(Box::new(column_expr!("b").is_null()));
+        let kernel = KernelExpr::Predicate(Box::new(column_expr!("b").is_null()));
         assert_eq!(lower(kernel), "b IS NULL");
     }
 

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -14,9 +14,11 @@ use datafusion::execution::context::SessionContext;
 use delta_kernel::StorageHandler;
 
 mod expression;
+mod predicate;
 mod scalar;
 
 pub use expression::to_df_expr;
+pub use predicate::to_df_predicate;
 pub use scalar::to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -18,7 +18,7 @@ mod predicate;
 mod scalar;
 
 pub use expression::to_df_expr;
-pub use predicate::to_df_predicate;
+pub use predicate::to_df_predicate_expr;
 pub use scalar::to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -2,7 +2,7 @@
 //!
 //! One match arm per [`Predicate`] variant. Every arm bottoms out in expression conversion:
 //! comparisons and `IS NULL` wrap converted operands, junctions fold converted child predicates,
-//! and a bare boolean expression delegates straight to [`to_datafusion_expr`]. Kernel models the
+//! and a bare boolean expression delegates straight to [`kernel_to_df_expr`]. Kernel models the
 //! derived comparators (`<=`, `>=`, `!=`) as `Not` of a primitive op rather than as distinct
 //! operators, so correctness of those cases rides on the [`Predicate::Not`] arm, not on any
 //! `LtEq`/`GtEq`/`NotEq` mapping here.
@@ -16,28 +16,34 @@ use delta_kernel::expressions::{
     BinaryPredicate, BinaryPredicateOp, Expression, JunctionPredicate, JunctionPredicateOp,
     Predicate, Scalar, UnaryPredicate, UnaryPredicateOp,
 };
+use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
-use crate::expression::to_datafusion_expr;
-use crate::scalar::to_datafusion_scalar;
+use crate::expression::kernel_to_df_expr;
+use crate::scalar::kernel_to_df_scalar;
 
-/// Converts a kernel [`Predicate`] into a boolean-valued DataFusion [`Expr`].
+/// Converts a kernel [`Predicate`] into a boolean-valued DataFusion [`Expr`], validating column
+/// references against `input_schema` (threaded to the expression converter).
 ///
 /// # Errors
 ///
 /// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
 /// predicates -- neither can round-trip through a DataFusion logical plan, and lowering an
 /// `Unknown` to a NULL/false literal would silently drop rows from a filter. Also propagates any
-/// error from converting a child expression (e.g. an interval literal, which has no Arrow
-/// representation) and rejects an `IN` predicate whose right side is not a literal array.
-pub fn to_datafusion_predicate(pred: &Predicate) -> DeltaResult<Expr> {
+/// error from converting a child expression (an unresolved column reference, or an interval
+/// literal, which has no Arrow representation) and rejects an `IN` predicate whose right side is
+/// not a literal array.
+pub fn to_datafusion_predicate(pred: &Predicate, input_schema: &StructType) -> DeltaResult<Expr> {
     match pred {
         // A boolean-valued expression standing in as a predicate: convert it as-is.
-        Predicate::BooleanExpression(expr) => to_datafusion_expr(expr),
-        Predicate::Not(inner) => Ok(Expr::Not(Box::new(to_datafusion_predicate(inner)?))),
-        Predicate::Unary(unary) => unary_to_expr(unary),
-        Predicate::Binary(binary) => binary_to_expr(binary),
-        Predicate::Junction(junction) => junction_to_expr(junction),
+        Predicate::BooleanExpression(expr) => kernel_to_df_expr(expr, input_schema),
+        Predicate::Not(inner) => Ok(Expr::Not(Box::new(to_datafusion_predicate(
+            inner,
+            input_schema,
+        )?))),
+        Predicate::Unary(unary) => unary_to_expr(unary, input_schema),
+        Predicate::Binary(binary) => binary_to_expr(binary, input_schema),
+        Predicate::Junction(junction) => junction_to_expr(junction, input_schema),
         // Engine-defined and opaque-to-both predicates cannot round-trip through a DataFusion
         // logical plan: kernel only understands them through their trait methods, and lowering an
         // Unknown to a literal would change filter semantics (dropping rows).
@@ -52,8 +58,8 @@ pub fn to_datafusion_predicate(pred: &Predicate) -> DeltaResult<Expr> {
 
 /// Lowers a unary predicate. `IsNull` is the only variant; `IS NOT NULL` reaches the converter as
 /// `Not(Unary(IsNull))` and is handled by the [`Predicate::Not`] arm.
-fn unary_to_expr(unary: &UnaryPredicate) -> DeltaResult<Expr> {
-    let expr = to_datafusion_expr(&unary.expr)?;
+fn unary_to_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+    let expr = kernel_to_df_expr(&unary.expr, input_schema)?;
     Ok(match unary.op {
         UnaryPredicateOp::IsNull => Expr::IsNull(Box::new(expr)),
     })
@@ -62,16 +68,16 @@ fn unary_to_expr(unary: &UnaryPredicate) -> DeltaResult<Expr> {
 /// Lowers a binary predicate. `Distinct` maps to the null-safe [`Operator::IsDistinctFrom`]; `In`
 /// is special-cased to an `Expr::InList`. Kernel has no `<=`/`>=`/`!=` operators -- those arrive
 /// wrapped in `Not`, so only the three primitive comparisons need mapping here.
-fn binary_to_expr(binary: &BinaryPredicate) -> DeltaResult<Expr> {
+fn binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let op = match binary.op {
-        BinaryPredicateOp::In => return in_to_expr(&binary.left, &binary.right),
+        BinaryPredicateOp::In => return in_to_expr(&binary.left, &binary.right, input_schema),
         BinaryPredicateOp::Equal => Operator::Eq,
         BinaryPredicateOp::LessThan => Operator::Lt,
         BinaryPredicateOp::GreaterThan => Operator::Gt,
         BinaryPredicateOp::Distinct => Operator::IsDistinctFrom,
     };
-    let left = to_datafusion_expr(&binary.left)?;
-    let right = to_datafusion_expr(&binary.right)?;
+    let left = kernel_to_df_expr(&binary.left, input_schema)?;
+    let right = kernel_to_df_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
@@ -83,7 +89,11 @@ fn binary_to_expr(binary: &BinaryPredicate) -> DeltaResult<Expr> {
 /// # Errors
 ///
 /// Returns [`Error::unsupported`] if the right operand is not a literal array.
-fn in_to_expr(value: &Expression, list: &Expression) -> DeltaResult<Expr> {
+fn in_to_expr(
+    value: &Expression,
+    list: &Expression,
+    input_schema: &StructType,
+) -> DeltaResult<Expr> {
     let Expression::Literal(Scalar::Array(array)) = list else {
         return Err(Error::unsupported(
             "converting an IN predicate requires a literal array on the right-hand side",
@@ -92,9 +102,9 @@ fn in_to_expr(value: &Expression, list: &Expression) -> DeltaResult<Expr> {
     let elements = array
         .array_elements()
         .iter()
-        .map(|scalar| Ok(lit(to_datafusion_scalar(scalar)?)))
+        .map(|scalar| Ok(lit(kernel_to_df_scalar(scalar)?)))
         .collect::<DeltaResult<Vec<_>>>()?;
-    let value = to_datafusion_expr(value)?;
+    let value = kernel_to_df_expr(value, input_schema)?;
     Ok(Expr::InList(InList::new(Box::new(value), elements, false)))
 }
 
@@ -102,7 +112,7 @@ fn in_to_expr(value: &Expression, list: &Expression) -> DeltaResult<Expr> {
 /// chain of `Expr::BinaryExpr`. An empty junction lowers to the operator's identity literal
 /// (`AND` of nothing is `true`, `OR` of nothing is `false`), matching how kernel normalizes empty
 /// junctions at construction.
-fn junction_to_expr(junction: &JunctionPredicate) -> DeltaResult<Expr> {
+fn junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let (op, identity) = match junction.op {
         JunctionPredicateOp::And => (Operator::And, true),
         JunctionPredicateOp::Or => (Operator::Or, false),
@@ -111,8 +121,8 @@ fn junction_to_expr(junction: &JunctionPredicate) -> DeltaResult<Expr> {
     let Some(first) = preds.next() else {
         return Ok(lit(identity));
     };
-    preds.try_fold(to_datafusion_predicate(first)?, |acc, next| {
-        Ok(binary_expr(acc, op, to_datafusion_predicate(next)?))
+    preds.try_fold(to_datafusion_predicate(first, input_schema)?, |acc, next| {
+        Ok(binary_expr(acc, op, to_datafusion_predicate(next, input_schema)?))
     })
 }
 
@@ -121,14 +131,26 @@ mod tests {
     use delta_kernel::expressions::{
         column_expr, ArrayData, Expression as Expr_, Predicate as Pred,
     };
-    use delta_kernel::schema::{ArrayType, DataType};
+    use delta_kernel::schema::{ArrayType, DataType, StructField};
     use rstest::rstest;
 
     use super::*;
 
-    /// Lowers a predicate and renders it as a DataFusion `Display` string for comparison.
+    /// Name-resolution scope for these tests: top-level `a`, `b`, `c`, all `long`.
+    fn test_schema() -> StructType {
+        StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::LONG),
+            StructField::nullable("c", DataType::LONG),
+        ])
+        .unwrap()
+    }
+
+    /// Lowers a predicate against [`test_schema`] and renders it as a DataFusion `Display` string.
     fn lower(pred: Pred) -> String {
-        to_datafusion_predicate(&pred).unwrap().to_string()
+        to_datafusion_predicate(&pred, &test_schema())
+            .unwrap()
+            .to_string()
     }
 
     #[rstest]
@@ -226,6 +248,6 @@ mod tests {
 
     #[test]
     fn unknown_predicate_is_unsupported() {
-        to_datafusion_predicate(&Pred::Unknown("mystery".into())).unwrap_err();
+        to_datafusion_predicate(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,14 +1,4 @@
 //! Conversion from a kernel [`Predicate`] to a boolean-valued DataFusion [`Expr`].
-//!
-//! One match arm per [`Predicate`] variant. Every arm bottoms out in expression conversion:
-//! comparisons and `IS NULL` wrap converted operands, junctions fold converted child predicates,
-//! and a bare boolean expression delegates straight to [`kernel_to_df_expr`]. Kernel models the
-//! derived comparators (`<=`, `>=`, `!=`) as `Not` of a primitive op rather than as distinct
-//! operators, so correctness of those cases rides on the [`Predicate::Not`] arm, not on any
-//! `LtEq`/`GtEq`/`NotEq` mapping here.
-//!
-//! An `impl TryFrom<&Predicate> for Expr` is impossible here: both types are foreign to this
-//! crate, so the orphan rule forbids it. Hence a free function.
 
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
@@ -26,27 +16,20 @@ use crate::scalar::kernel_to_df_scalar;
 /// references against `input_schema` (threaded to the expression converter).
 ///
 /// # Errors
-///
 /// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
-/// predicates -- neither can round-trip through a DataFusion logical plan, and lowering an
-/// `Unknown` to a NULL/false literal would silently drop rows from a filter. Also propagates any
-/// error from converting a child expression (an unresolved column reference, or an interval
-/// literal, which has no Arrow representation) and rejects an `IN` predicate whose right side is
-/// not a literal array.
-pub fn to_datafusion_predicate(pred: &Predicate, input_schema: &StructType) -> DeltaResult<Expr> {
+/// predicates Also propagates any error from converting a child expression (an unresolved column
+/// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
+/// predicate whose right side is not a literal array.
+pub fn kernel_predicate_to_df_expr(pred: &Predicate, input_schema: &StructType) -> DeltaResult<Expr> {
     match pred {
-        // A boolean-valued expression standing in as a predicate: convert it as-is.
         Predicate::BooleanExpression(expr) => kernel_to_df_expr(expr, input_schema),
-        Predicate::Not(inner) => Ok(Expr::Not(Box::new(to_datafusion_predicate(
+        Predicate::Not(inner) => Ok(Expr::Not(Box::new(kernel_predicate_to_df_expr(
             inner,
             input_schema,
         )?))),
-        Predicate::Unary(unary) => unary_to_expr(unary, input_schema),
-        Predicate::Binary(binary) => binary_to_expr(binary, input_schema),
-        Predicate::Junction(junction) => junction_to_expr(junction, input_schema),
-        // Engine-defined and opaque-to-both predicates cannot round-trip through a DataFusion
-        // logical plan: kernel only understands them through their trait methods, and lowering an
-        // Unknown to a literal would change filter semantics (dropping rows).
+        Predicate::Unary(unary) => kernel_unary_to_expr(unary, input_schema),
+        Predicate::Binary(binary) => kernel_binary_to_expr(binary, input_schema),
+        Predicate::Junction(junction) => kernel_junction_to_expr(junction, input_schema),
         Predicate::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque predicate",
         )),
@@ -56,21 +39,18 @@ pub fn to_datafusion_predicate(pred: &Predicate, input_schema: &StructType) -> D
     }
 }
 
-/// Lowers a unary predicate. `IsNull` is the only variant; `IS NOT NULL` reaches the converter as
-/// `Not(Unary(IsNull))` and is handled by the [`Predicate::Not`] arm.
-fn unary_to_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+/// Lowers a unary predicate.
+fn kernel_unary_to_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let expr = kernel_to_df_expr(&unary.expr, input_schema)?;
     Ok(match unary.op {
         UnaryPredicateOp::IsNull => Expr::IsNull(Box::new(expr)),
     })
 }
 
-/// Lowers a binary predicate. `Distinct` maps to the null-safe [`Operator::IsDistinctFrom`]; `In`
-/// is special-cased to an `Expr::InList`. Kernel has no `<=`/`>=`/`!=` operators -- those arrive
-/// wrapped in `Not`, so only the three primitive comparisons need mapping here.
-fn binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+/// Lowers a binary predicate.
+fn kernel_binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let op = match binary.op {
-        BinaryPredicateOp::In => return in_to_expr(&binary.left, &binary.right, input_schema),
+        BinaryPredicateOp::In => return kernel_in_to_expr(&binary.left, &binary.right, input_schema),
         BinaryPredicateOp::Equal => Operator::Eq,
         BinaryPredicateOp::LessThan => Operator::Lt,
         BinaryPredicateOp::GreaterThan => Operator::Gt,
@@ -87,9 +67,8 @@ fn binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaR
 /// `false` here.
 ///
 /// # Errors
-///
 /// Returns [`Error::unsupported`] if the right operand is not a literal array.
-fn in_to_expr(
+fn kernel_in_to_expr(
     value: &Expression,
     list: &Expression,
     input_schema: &StructType,
@@ -108,11 +87,8 @@ fn in_to_expr(
     Ok(Expr::InList(InList::new(Box::new(value), elements, false)))
 }
 
-/// Lowers a junction (`And`/`Or`) by left-associatively folding its converted children into a
-/// chain of `Expr::BinaryExpr`. An empty junction lowers to the operator's identity literal
-/// (`AND` of nothing is `true`, `OR` of nothing is `false`), matching how kernel normalizes empty
-/// junctions at construction.
-fn junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+/// Lowers a junction (`And`/`Or`).
+fn kernel_junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let (op, identity) = match junction.op {
         JunctionPredicateOp::And => (Operator::And, true),
         JunctionPredicateOp::Or => (Operator::Or, false),
@@ -121,8 +97,8 @@ fn junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> 
     let Some(first) = preds.next() else {
         return Ok(lit(identity));
     };
-    preds.try_fold(to_datafusion_predicate(first, input_schema)?, |acc, next| {
-        Ok(binary_expr(acc, op, to_datafusion_predicate(next, input_schema)?))
+    preds.try_fold(kernel_predicate_to_df_expr(first, input_schema)?, |acc, next| {
+        Ok(binary_expr(acc, op, kernel_predicate_to_df_expr(next, input_schema)?))
     })
 }
 
@@ -148,7 +124,7 @@ mod tests {
 
     /// Lowers a predicate against [`test_schema`] and renders it as a DataFusion `Display` string.
     fn lower(pred: Pred) -> String {
-        to_datafusion_predicate(&pred, &test_schema())
+        kernel_predicate_to_df_expr(&pred, &test_schema())
             .unwrap()
             .to_string()
     }
@@ -248,6 +224,6 @@ mod tests {
 
     #[test]
     fn unknown_predicate_is_unsupported() {
-        to_datafusion_predicate(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
+        kernel_predicate_to_df_expr(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,6 +1,7 @@
 //! Conversion from a kernel [`Predicate`] to a boolean-valued DataFusion [`Expr`].
 
 use datafusion::logical_expr::expr::InList;
+use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
 use delta_kernel::expressions::{
     BinaryPredicate, BinaryPredicateOp, Expression, JunctionPredicate, JunctionPredicateOp,
@@ -87,18 +88,19 @@ fn kernel_in_to_expr(
     Ok(Expr::InList(InList::new(Box::new(value), elements, false)))
 }
 
-/// Lowers a junction (`And`/`Or`).
+/// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
+/// left-associative [`conjunction`]/[`disjunction`] helpers. An empty junction lowers to the
+/// operator's identity literal (`AND` of nothing is `true`, `OR` of nothing is `false`), matching
+/// how kernel normalizes empty junctions at construction.
 fn kernel_junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
-    let (op, identity) = match junction.op {
-        JunctionPredicateOp::And => (Operator::And, true),
-        JunctionPredicateOp::Or => (Operator::Or, false),
-    };
-    let mut preds = junction.preds.iter();
-    let Some(first) = preds.next() else {
-        return Ok(lit(identity));
-    };
-    preds.try_fold(kernel_predicate_to_df_expr(first, input_schema)?, |acc, next| {
-        Ok(binary_expr(acc, op, kernel_predicate_to_df_expr(next, input_schema)?))
+    let preds = junction
+        .preds
+        .iter()
+        .map(|pred| kernel_predicate_to_df_expr(pred, input_schema))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    Ok(match junction.op {
+        JunctionPredicateOp::And => conjunction(preds).unwrap_or_else(|| lit(true)),
+        JunctionPredicateOp::Or => disjunction(preds).unwrap_or_else(|| lit(false)),
     })
 }
 

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,0 +1,231 @@
+//! Conversion from a kernel [`Predicate`] to a boolean-valued DataFusion [`Expr`].
+//!
+//! One match arm per [`Predicate`] variant. Every arm bottoms out in expression conversion:
+//! comparisons and `IS NULL` wrap converted operands, junctions fold converted child predicates,
+//! and a bare boolean expression delegates straight to [`to_datafusion_expr`]. Kernel models the
+//! derived comparators (`<=`, `>=`, `!=`) as `Not` of a primitive op rather than as distinct
+//! operators, so correctness of those cases rides on the [`Predicate::Not`] arm, not on any
+//! `LtEq`/`GtEq`/`NotEq` mapping here.
+//!
+//! An `impl TryFrom<&Predicate> for Expr` is impossible here: both types are foreign to this
+//! crate, so the orphan rule forbids it. Hence a free function.
+
+use datafusion::logical_expr::expr::InList;
+use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
+use delta_kernel::expressions::{
+    BinaryPredicate, BinaryPredicateOp, Expression, JunctionPredicate, JunctionPredicateOp,
+    Predicate, Scalar, UnaryPredicate, UnaryPredicateOp,
+};
+use delta_kernel::{DeltaResult, Error};
+
+use crate::expression::to_datafusion_expr;
+use crate::scalar::to_datafusion_scalar;
+
+/// Converts a kernel [`Predicate`] into a boolean-valued DataFusion [`Expr`].
+///
+/// # Errors
+///
+/// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
+/// predicates -- neither can round-trip through a DataFusion logical plan, and lowering an
+/// `Unknown` to a NULL/false literal would silently drop rows from a filter. Also propagates any
+/// error from converting a child expression (e.g. an interval literal, which has no Arrow
+/// representation) and rejects an `IN` predicate whose right side is not a literal array.
+pub fn to_datafusion_predicate(pred: &Predicate) -> DeltaResult<Expr> {
+    match pred {
+        // A boolean-valued expression standing in as a predicate: convert it as-is.
+        Predicate::BooleanExpression(expr) => to_datafusion_expr(expr),
+        Predicate::Not(inner) => Ok(Expr::Not(Box::new(to_datafusion_predicate(inner)?))),
+        Predicate::Unary(unary) => unary_to_expr(unary),
+        Predicate::Binary(binary) => binary_to_expr(binary),
+        Predicate::Junction(junction) => junction_to_expr(junction),
+        // Engine-defined and opaque-to-both predicates cannot round-trip through a DataFusion
+        // logical plan: kernel only understands them through their trait methods, and lowering an
+        // Unknown to a literal would change filter semantics (dropping rows).
+        Predicate::Opaque(_) => Err(Error::unsupported(
+            "cannot convert an engine-defined Opaque predicate",
+        )),
+        Predicate::Unknown(name) => Err(Error::unsupported(format!(
+            "cannot convert Unknown predicate {name:?}"
+        ))),
+    }
+}
+
+/// Lowers a unary predicate. `IsNull` is the only variant; `IS NOT NULL` reaches the converter as
+/// `Not(Unary(IsNull))` and is handled by the [`Predicate::Not`] arm.
+fn unary_to_expr(unary: &UnaryPredicate) -> DeltaResult<Expr> {
+    let expr = to_datafusion_expr(&unary.expr)?;
+    Ok(match unary.op {
+        UnaryPredicateOp::IsNull => Expr::IsNull(Box::new(expr)),
+    })
+}
+
+/// Lowers a binary predicate. `Distinct` maps to the null-safe [`Operator::IsDistinctFrom`]; `In`
+/// is special-cased to an `Expr::InList`. Kernel has no `<=`/`>=`/`!=` operators -- those arrive
+/// wrapped in `Not`, so only the three primitive comparisons need mapping here.
+fn binary_to_expr(binary: &BinaryPredicate) -> DeltaResult<Expr> {
+    let op = match binary.op {
+        BinaryPredicateOp::In => return in_to_expr(&binary.left, &binary.right),
+        BinaryPredicateOp::Equal => Operator::Eq,
+        BinaryPredicateOp::LessThan => Operator::Lt,
+        BinaryPredicateOp::GreaterThan => Operator::Gt,
+        BinaryPredicateOp::Distinct => Operator::IsDistinctFrom,
+    };
+    let left = to_datafusion_expr(&binary.left)?;
+    let right = to_datafusion_expr(&binary.right)?;
+    Ok(binary_expr(left, op, right))
+}
+
+/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, literal_array)` with
+/// the right side a constant `Scalar::Array`; DataFusion carries the list as a `Vec<Expr>` inside
+/// `Expr::InList`. `NOT IN` reaches the converter as `Not(Binary(In, ..))`, so `negated` is always
+/// `false` here.
+///
+/// # Errors
+///
+/// Returns [`Error::unsupported`] if the right operand is not a literal array.
+fn in_to_expr(value: &Expression, list: &Expression) -> DeltaResult<Expr> {
+    let Expression::Literal(Scalar::Array(array)) = list else {
+        return Err(Error::unsupported(
+            "converting an IN predicate requires a literal array on the right-hand side",
+        ));
+    };
+    let elements = array
+        .array_elements()
+        .iter()
+        .map(|scalar| Ok(lit(to_datafusion_scalar(scalar)?)))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    let value = to_datafusion_expr(value)?;
+    Ok(Expr::InList(InList::new(Box::new(value), elements, false)))
+}
+
+/// Lowers a junction (`And`/`Or`) by left-associatively folding its converted children into a
+/// chain of `Expr::BinaryExpr`. An empty junction lowers to the operator's identity literal
+/// (`AND` of nothing is `true`, `OR` of nothing is `false`), matching how kernel normalizes empty
+/// junctions at construction.
+fn junction_to_expr(junction: &JunctionPredicate) -> DeltaResult<Expr> {
+    let (op, identity) = match junction.op {
+        JunctionPredicateOp::And => (Operator::And, true),
+        JunctionPredicateOp::Or => (Operator::Or, false),
+    };
+    let mut preds = junction.preds.iter();
+    let Some(first) = preds.next() else {
+        return Ok(lit(identity));
+    };
+    preds.try_fold(to_datafusion_predicate(first)?, |acc, next| {
+        Ok(binary_expr(acc, op, to_datafusion_predicate(next)?))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use delta_kernel::expressions::{
+        column_expr, ArrayData, Expression as Expr_, Predicate as Pred,
+    };
+    use delta_kernel::schema::{ArrayType, DataType};
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Lowers a predicate and renders it as a DataFusion `Display` string for comparison.
+    fn lower(pred: Pred) -> String {
+        to_datafusion_predicate(&pred).unwrap().to_string()
+    }
+
+    #[rstest]
+    #[case::eq(column_expr!("a").eq(Expr_::literal(1i64)), "a = Int64(1)")]
+    #[case::lt(column_expr!("a").lt(Expr_::literal(1i64)), "a < Int64(1)")]
+    #[case::gt(column_expr!("a").gt(Expr_::literal(1i64)), "a > Int64(1)")]
+    #[case::distinct(
+        column_expr!("a").distinct(Expr_::literal(1i64)),
+        "a IS DISTINCT FROM Int64(1)"
+    )]
+    fn comparison_lowers_to_binary_expr(#[case] kernel: Pred, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    // Kernel has no <=/>=/!= operators: they are Not of a primitive comparison, so they render as
+    // a negated form rather than a native LtEq/GtEq/NotEq.
+    #[rstest]
+    #[case::ne(column_expr!("a").ne(Expr_::literal(1i64)), "NOT a = Int64(1)")]
+    #[case::le(column_expr!("a").le(Expr_::literal(1i64)), "NOT a > Int64(1)")]
+    #[case::ge(column_expr!("a").ge(Expr_::literal(1i64)), "NOT a < Int64(1)")]
+    fn derived_comparison_lowers_to_negated_primitive(
+        #[case] kernel: Pred,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    #[test]
+    fn is_null_lowers_to_is_null() {
+        assert_eq!(lower(column_expr!("a").is_null()), "a IS NULL");
+    }
+
+    #[test]
+    fn is_not_null_lowers_to_negated_is_null() {
+        assert_eq!(lower(column_expr!("a").is_not_null()), "NOT a IS NULL");
+    }
+
+    #[test]
+    fn in_lowers_to_in_list() {
+        let array = ArrayData::try_new(
+            ArrayType::new(DataType::LONG, false),
+            vec![Scalar::Long(1), Scalar::Long(2), Scalar::Long(3)],
+        )
+        .unwrap();
+        let kernel = Pred::binary(
+            BinaryPredicateOp::In,
+            column_expr!("a"),
+            Expr_::literal(Scalar::Array(array)),
+        );
+        assert_eq!(lower(kernel), "a IN ([Int64(1), Int64(2), Int64(3)])");
+    }
+
+    #[test]
+    fn not_in_lowers_to_negated_in_list() {
+        let array = ArrayData::try_new(
+            ArrayType::new(DataType::LONG, false),
+            vec![Scalar::Long(1), Scalar::Long(2)],
+        )
+        .unwrap();
+        let inner = Pred::binary(
+            BinaryPredicateOp::In,
+            column_expr!("a"),
+            Expr_::literal(Scalar::Array(array)),
+        );
+        assert_eq!(lower(Pred::not(inner)), "NOT a IN ([Int64(1), Int64(2)])");
+    }
+
+    #[rstest]
+    #[case::and(
+        Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
+        "a IS NULL AND b IS NULL"
+    )]
+    #[case::or(
+        Pred::or(column_expr!("a").is_null(), column_expr!("b").is_null()),
+        "a IS NULL OR b IS NULL"
+    )]
+    fn junction_lowers_to_folded_binary_expr(#[case] kernel: Pred, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
+    }
+
+    #[test]
+    fn multi_element_and_folds_left_associatively() {
+        let kernel = Pred::and_from([
+            column_expr!("a").is_null(),
+            column_expr!("b").is_null(),
+            column_expr!("c").is_null(),
+        ]);
+        assert_eq!(lower(kernel), "a IS NULL AND b IS NULL AND c IS NULL");
+    }
+
+    #[test]
+    fn boolean_expression_delegates_to_expression_converter() {
+        assert_eq!(lower(Pred::from_expr(column_expr!("a"))), "a");
+    }
+
+    #[test]
+    fn unknown_predicate_is_unsupported() {
+        to_datafusion_predicate(&Pred::Unknown("mystery".into())).unwrap_err();
+    }
+}

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -26,16 +26,21 @@ use crate::scalar::to_df_scalar;
 /// predicates. Also propagates any error from converting a child expression (an unresolved column
 /// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
 /// predicate whose right side is not a literal array.
-pub fn to_df_predicate(pred: &KernelPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
+pub fn to_df_predicate_expr(
+    pred: &KernelPredicate,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
     match pred {
         KernelPredicate::BooleanExpression(expr) => to_df_expr(expr, input_schema),
         KernelPredicate::Not(inner) => {
-            let df_inner = to_df_predicate(inner, input_schema)?;
+            let df_inner = to_df_predicate_expr(inner, input_schema)?;
             Ok(DFExpr::Not(Box::new(df_inner)))
         }
-        KernelPredicate::Unary(unary) => unary_to_df_expr(unary, input_schema),
-        KernelPredicate::Binary(binary) => binary_to_df_expr(binary, input_schema),
-        KernelPredicate::Junction(junction) => junction_to_df_expr(junction, input_schema),
+        KernelPredicate::Unary(unary) => unary_to_df_predicate_expr(unary, input_schema),
+        KernelPredicate::Binary(binary) => binary_to_df_predicate_expr(binary, input_schema),
+        KernelPredicate::Junction(junction) => {
+            junction_to_df_predicate_expr(junction, input_schema)
+        }
         KernelPredicate::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque predicate",
         )),
@@ -46,7 +51,7 @@ pub fn to_df_predicate(pred: &KernelPredicate, input_schema: &StructType) -> Del
 }
 
 /// Lowers a unary predicate.
-fn unary_to_df_expr(
+fn unary_to_df_predicate_expr(
     unary: &KernelUnaryPredicate,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
@@ -57,13 +62,13 @@ fn unary_to_df_expr(
 }
 
 /// Lowers a binary predicate.
-fn binary_to_df_expr(
+fn binary_to_df_predicate_expr(
     binary: &KernelBinaryPredicate,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
     let op = match binary.op {
         KernelBinaryPredicateOp::In => {
-            return in_to_df_expr(&binary.left, &binary.right, input_schema)
+            return in_to_df_predicate_expr(&binary.left, &binary.right, input_schema)
         }
         KernelBinaryPredicateOp::Equal => Operator::Eq,
         KernelBinaryPredicateOp::LessThan => Operator::Lt,
@@ -82,7 +87,7 @@ fn binary_to_df_expr(
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] if the right operand is not a literal array.
-fn in_to_df_expr(
+fn in_to_df_predicate_expr(
     value: &KernelExpression,
     list: &KernelExpression,
     input_schema: &StructType,
@@ -107,14 +112,14 @@ fn in_to_df_expr(
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
 /// left-associative [`conjunction`]/[`disjunction`] helpers.
-fn junction_to_df_expr(
+fn junction_to_df_predicate_expr(
     junction: &KernelJunctionPredicate,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
     let preds: DeltaResult<Vec<DFExpr>> = junction
         .preds
         .iter()
-        .map(|pred| to_df_predicate(pred, input_schema))
+        .map(|pred| to_df_predicate_expr(pred, input_schema))
         .collect();
     let preds = preds?;
     Ok(match junction.op {
@@ -146,7 +151,9 @@ mod tests {
 
     /// Lowers a predicate against [`test_schema`] and renders it as a DataFusion `Display` string.
     fn lower(pred: Pred) -> String {
-        to_df_predicate(&pred, &test_schema()).unwrap().to_string()
+        to_df_predicate_expr(&pred, &test_schema())
+            .unwrap()
+            .to_string()
     }
 
     /// A literal `Scalar::Array` of longs, for `IN`-list cases.
@@ -232,6 +239,6 @@ mod tests {
         Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("b"))
     )]
     fn unsupported_predicate_is_an_error(#[case] pred: Pred) {
-        to_df_predicate(&pred, &test_schema()).unwrap_err();
+        to_df_predicate_expr(&pred, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -21,7 +21,10 @@ use crate::scalar::kernel_to_df_scalar;
 /// predicates Also propagates any error from converting a child expression (an unresolved column
 /// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
 /// predicate whose right side is not a literal array.
-pub fn kernel_predicate_to_df_expr(pred: &Predicate, input_schema: &StructType) -> DeltaResult<Expr> {
+pub fn kernel_predicate_to_df_expr(
+    pred: &Predicate,
+    input_schema: &StructType,
+) -> DeltaResult<Expr> {
     match pred {
         Predicate::BooleanExpression(expr) => kernel_to_df_expr(expr, input_schema),
         Predicate::Not(inner) => Ok(Expr::Not(Box::new(kernel_predicate_to_df_expr(
@@ -51,7 +54,9 @@ fn kernel_unary_to_expr(unary: &UnaryPredicate, input_schema: &StructType) -> De
 /// Lowers a binary predicate.
 fn kernel_binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
     let op = match binary.op {
-        BinaryPredicateOp::In => return kernel_in_to_expr(&binary.left, &binary.right, input_schema),
+        BinaryPredicateOp::In => {
+            return kernel_in_to_expr(&binary.left, &binary.right, input_schema)
+        }
         BinaryPredicateOp::Equal => Operator::Eq,
         BinaryPredicateOp::LessThan => Operator::Lt,
         BinaryPredicateOp::GreaterThan => Operator::Gt,
@@ -89,16 +94,18 @@ fn kernel_in_to_expr(
 }
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
-/// left-associative [`conjunction`]/[`disjunction`] helpers. An empty junction lowers to the
-/// operator's identity literal (`AND` of nothing is `true`, `OR` of nothing is `false`), matching
-/// how kernel normalizes empty junctions at construction.
-fn kernel_junction_to_expr(junction: &JunctionPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+/// left-associative [`conjunction`]/[`disjunction`] helpers.
+fn kernel_junction_to_expr(
+    junction: &JunctionPredicate,
+    input_schema: &StructType,
+) -> DeltaResult<Expr> {
     let preds = junction
         .preds
         .iter()
         .map(|pred| kernel_predicate_to_df_expr(pred, input_schema))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(match junction.op {
+        // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics
         JunctionPredicateOp::And => conjunction(preds).unwrap_or_else(|| lit(true)),
         JunctionPredicateOp::Or => disjunction(preds).unwrap_or_else(|| lit(false)),
     })

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -121,11 +121,10 @@ fn junction_to_df_predicate_expr(
         .iter()
         .map(|pred| to_df_predicate_expr(pred, input_schema))
         .collect();
-    let preds = preds?;
     Ok(match junction.op {
         // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics
-        KernelJunctionPredicateOp::And => conjunction(preds).unwrap_or_else(|| lit(true)),
-        KernelJunctionPredicateOp::Or => disjunction(preds).unwrap_or_else(|| lit(false)),
+        KernelJunctionPredicateOp::And => conjunction(preds?).unwrap_or_else(|| lit(true)),
+        KernelJunctionPredicateOp::Or => disjunction(preds?).unwrap_or_else(|| lit(false)),
     })
 }
 

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -18,14 +18,12 @@ use crate::expression::to_df_expr;
 use crate::scalar::to_df_scalar;
 
 /// Converts a kernel [`Predicate`](KernelPredicate) into a boolean-valued DataFusion
-/// [`Expr`](DFExpr), validating column references against `input_schema` (threaded to the
-/// expression converter).
+/// [`Expr`](DFExpr), checking column references against `input_schema`.
 ///
 /// # Errors
-/// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
-/// predicates. Also propagates any error from converting a child expression (an unresolved column
-/// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
-/// predicate whose right side is not a literal array.
+/// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or `Unknown` predicates, and for an
+/// `IN` whose right side is not a literal array. Also propagates errors from child expressions,
+/// such as an unresolved column or an interval literal (which has no Arrow equivalent).
 pub fn to_df_predicate_expr(
     pred: &KernelPredicate,
     input_schema: &StructType,
@@ -80,10 +78,34 @@ fn binary_to_df_predicate_expr(
     Ok(binary_expr(left, op, right))
 }
 
-/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, literal_array)` with
-/// the right side a constant `Scalar::Array`; DataFusion carries the list as a `Vec<Expr>` inside
-/// `Expr::InList`. `NOT IN` reaches the converter as `Not(Binary(In, ..))`, so `negated` is always
-/// `false` here.
+/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, literal_array)`;
+/// DataFusion uses [`InList`], whose trailing flag negates the test. Kernel has no negated `IN`
+/// (`NOT IN` arrives as `Not(Binary(In, ..))`, handled by the caller's `Not` arm), so the flag is
+/// always `false` here.
+///
+/// The two differ on nulls. DataFusion uses SQL three-valued logic, so a null on either side makes
+/// the result null: `NULL IN (1, 2)` and `2 IN (1, NULL)` are both null. Kernel compares scalars
+/// structurally and always answers true or false, so a null value matches a null element:
+/// `NULL IN (1, NULL)` is true and `NULL IN (1, 2)` is false.
+///
+/// To match kernel, this lowering:
+/// - Drops null elements from the list, adding `IS NULL` on the value if there was one.
+/// - Wraps the membership test in `IS TRUE`, turning DataFusion's null into false.
+///
+/// Both go inside the predicate, not around it, because the caller's `Not` arm may negate the
+/// result and a leftover null would change which rows a filter keeps. Kernel reads
+/// `NOT NULL IN (1, 2)` as `NOT false` = true, but an unguarded DataFusion `NOT NULL` stays null
+/// and drops the row.
+///
+/// KNOWN DIVERGENCES from kernel's Arrow evaluator, which only handles a literal value against a
+/// literal array or against a list column:
+/// - A column value against a literal array (plain `x IN (1, 2)`) errors in kernel. This lowering
+///   answers it, using the same structural rule.
+/// - A list column never reaches here, since a non-literal right side is rejected below. Kernel
+///   evaluates that shape with arrow's `in_list` (via `prim_array_cmp!` in `engine::arrow_utils`),
+///   which drops the null buffer and skips null elements, so a null value answers false instead of
+///   matching a null element. It also panics when the value's type differs from the element type,
+///   since the macro picks the type from the value alone.
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] if the right operand is not a literal array.
@@ -97,17 +119,21 @@ fn in_to_df_predicate_expr(
             "converting an IN predicate requires a literal array on the right-hand side",
         ));
     };
-    let elements: DeltaResult<Vec<DFExpr>> = array
-        .array_elements()
+    let (null_elements, elements): (Vec<_>, Vec<_>) =
+        array.array_elements().iter().partition(|s| s.is_null());
+    let elements: DeltaResult<Vec<DFExpr>> = elements
         .iter()
         .map(|scalar| Ok(lit(to_df_scalar(scalar)?)))
         .collect();
+
     let value = to_df_expr(value, input_schema)?;
-    Ok(DFExpr::InList(InList::new(
-        Box::new(value),
-        elements?,
-        false,
-    )))
+    let in_list = InList::new(Box::new(value.clone()), elements?, false);
+    let is_member = DFExpr::InList(in_list).is_true();
+
+    match null_elements.is_empty() {
+        true => Ok(is_member),
+        false => Ok(is_member.or(value.is_null())),
+    }
 }
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
@@ -130,15 +156,25 @@ fn junction_to_df_predicate_expr(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{new_null_array, Array, AsArray, RecordBatch};
+    use datafusion::arrow::datatypes::Schema as ArrowSchema;
+    use datafusion::common::DFSchema;
+    use datafusion::prelude::SessionContext;
+    use delta_kernel::engine::arrow_conversion::TryIntoArrow;
     use delta_kernel::expressions::{
-        column_expr, ArrayData, Expression as Expr_, Predicate as Pred,
+        column_expr, ArrayData as KernelArrayData, Expression as KernelExpr,
+        Predicate as KernelPred,
     };
     use delta_kernel::schema::{ArrayType, DataType, StructField};
     use rstest::rstest;
 
     use super::*;
 
-    /// Name-resolution scope for these tests: top-level `a`, `b`, `c`, all `long`.
+    // === Shared helpers ===
+
+    /// Columns these tests resolve against: top-level `a`, `b`, `c`, all `long`.
     fn test_schema() -> StructType {
         StructType::try_new([
             StructField::nullable("a", DataType::LONG),
@@ -148,96 +184,190 @@ mod tests {
         .unwrap()
     }
 
-    /// Lowers a predicate against [`test_schema`] and renders it as a DataFusion `Display` string.
-    fn lower(pred: Pred) -> String {
+    /// Lowers a predicate and returns its DataFusion `Display` string.
+    fn lower(pred: KernelPred) -> String {
         to_df_predicate_expr(&pred, &test_schema())
             .unwrap()
             .to_string()
     }
 
-    /// A literal `Scalar::Array` of longs, for `IN`-list cases.
-    fn long_array(values: impl IntoIterator<Item = i64>) -> Expr_ {
-        let elements: Vec<KernelScalar> = values.into_iter().map(KernelScalar::Long).collect();
-        let array = ArrayData::try_new(ArrayType::new(DataType::LONG, false), elements).unwrap();
-        Expr_::literal(KernelScalar::Array(array))
+    /// Lowers a predicate, runs it over one all-null row, and asserts the result is not null.
+    fn evaluate(pred: KernelPred) -> bool {
+        let df_expr = to_df_predicate_expr(&pred, &test_schema()).unwrap();
+        let arrow_schema: ArrowSchema = (&test_schema()).try_into_arrow().unwrap();
+        let arrow_schema = Arc::new(arrow_schema);
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            arrow_schema
+                .fields()
+                .iter()
+                .map(|field| new_null_array(field.data_type(), 1))
+                .collect(),
+        )
+        .unwrap();
+
+        let df_schema = DFSchema::try_from(arrow_schema).unwrap();
+        let physical = SessionContext::new()
+            .create_physical_expr(df_expr, &df_schema)
+            .unwrap();
+        let result = physical
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let result = result.as_boolean();
+
+        assert_eq!(result.null_count(), 0, "predicate evaluated to null");
+        result.value(0)
     }
+
+    /// A literal `Scalar::Array` of longs.
+    fn long_array(values: impl IntoIterator<Item = i64>) -> KernelExpr {
+        let elements: Vec<KernelScalar> = values.into_iter().map(KernelScalar::Long).collect();
+        let array =
+            KernelArrayData::try_new(ArrayType::new(DataType::LONG, false), elements).unwrap();
+        KernelExpr::literal(KernelScalar::Array(array))
+    }
+
+    /// A literal `Scalar::Array` of longs where `None` becomes a null element.
+    fn nullable_long_array(values: impl IntoIterator<Item = Option<i64>>) -> KernelExpr {
+        let elements: Vec<KernelScalar> = values
+            .into_iter()
+            .map(|v| match v {
+                Some(n) => KernelScalar::Long(n),
+                None => KernelScalar::Null(DataType::LONG),
+            })
+            .collect();
+        let array =
+            KernelArrayData::try_new(ArrayType::new(DataType::LONG, true), elements).unwrap();
+        KernelExpr::literal(KernelScalar::Array(array))
+    }
+
+    // === Tests ===
 
     #[rstest]
     // Primitive comparisons lower to a native binary op.
-    #[case::eq(column_expr!("a").eq(Expr_::literal(1i64)), "a = Int64(1)")]
-    #[case::lt(column_expr!("a").lt(Expr_::literal(1i64)), "a < Int64(1)")]
-    #[case::gt(column_expr!("a").gt(Expr_::literal(1i64)), "a > Int64(1)")]
+    #[case::eq(column_expr!("a").eq(KernelExpr::literal(1i64)), "a = Int64(1)")]
+    #[case::lt(column_expr!("a").lt(KernelExpr::literal(1i64)), "a < Int64(1)")]
+    #[case::gt(column_expr!("a").gt(KernelExpr::literal(1i64)), "a > Int64(1)")]
     #[case::distinct(
-        column_expr!("a").distinct(Expr_::literal(1i64)),
+        column_expr!("a").distinct(KernelExpr::literal(1i64)),
         "a IS DISTINCT FROM Int64(1)"
     )]
-    // Kernel has no <=/>=/!= ops: each is `Not` of a primitive comparison, so it renders negated.
-    #[case::ne(column_expr!("a").ne(Expr_::literal(1i64)), "NOT a = Int64(1)")]
-    #[case::le(column_expr!("a").le(Expr_::literal(1i64)), "NOT a > Int64(1)")]
-    #[case::ge(column_expr!("a").ge(Expr_::literal(1i64)), "NOT a < Int64(1)")]
+    // Kernel has no <=/>=/!= ops: each is `Not` of a comparison, so it renders negated.
+    #[case::ne(column_expr!("a").ne(KernelExpr::literal(1i64)), "NOT a = Int64(1)")]
+    #[case::le(column_expr!("a").le(KernelExpr::literal(1i64)), "NOT a > Int64(1)")]
+    #[case::ge(column_expr!("a").ge(KernelExpr::literal(1i64)), "NOT a < Int64(1)")]
     // Unary.
     #[case::is_null(column_expr!("a").is_null(), "a IS NULL")]
     #[case::is_not_null(column_expr!("a").is_not_null(), "NOT a IS NULL")]
-    // IN / NOT IN.
+    // IN / NOT IN. `IS TRUE` turns DataFusion's null into kernel's false, and sits inside the `Not`
+    // so a null value gives `NOT false` instead of `NOT NULL`.
     #[case::in_list(
-        Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2, 3])),
-        "a IN ([Int64(1), Int64(2), Int64(3)])"
+        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2, 3])),
+        "a IN ([Int64(1), Int64(2), Int64(3)]) IS TRUE"
     )]
     #[case::not_in(
-        Pred::not(Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2]))),
-        "NOT a IN ([Int64(1), Int64(2)])"
+        KernelPred::not(KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2]))),
+        "NOT a IN ([Int64(1), Int64(2)]) IS TRUE"
+    )]
+    #[case::null_needle_in_list(
+        KernelPred::binary(
+            KernelBinaryPredicateOp::In,
+            KernelExpr::null_literal(DataType::LONG),
+            long_array([1, 2]),
+        ),
+        "Int64(NULL) IN ([Int64(1), Int64(2)]) IS TRUE"
+    )]
+    // A null element leaves the list and becomes an `IS NULL` check, so a null value still matches
+    // it the way kernel does.
+    #[case::null_element_in_list(
+        KernelPred::binary(
+            KernelBinaryPredicateOp::In,
+            column_expr!("a"),
+            nullable_long_array([Some(1), None]),
+        ),
+        "a IN ([Int64(1)]) IS TRUE OR a IS NULL"
     )]
     // Junctions fold left-associatively.
     #[case::and(
-        Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
+        KernelPred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
         "a IS NULL AND b IS NULL"
     )]
     #[case::or(
-        Pred::or(column_expr!("a").is_null(), column_expr!("b").is_null()),
+        KernelPred::or(column_expr!("a").is_null(), column_expr!("b").is_null()),
         "a IS NULL OR b IS NULL"
     )]
     #[case::multi_and(
-        Pred::and_from([
+        KernelPred::and_from([
             column_expr!("a").is_null(),
             column_expr!("b").is_null(),
             column_expr!("c").is_null(),
         ]),
         "a IS NULL AND b IS NULL AND c IS NULL"
     )]
-    // A bare boolean expression delegates straight to the expression converter.
-    #[case::boolean_expression(Pred::from_expr(column_expr!("a")), "a")]
-    // Nesting: predicates compose recursively. DataFusion's Display does not parenthesize the
-    // junction under a `Not`, though the underlying `Expr` tree is still `Not(And(..))`.
+    // A bare boolean expression goes straight to the expression converter.
+    #[case::boolean_expression(KernelPred::from_expr(column_expr!("a")), "a")]
+    // Nested predicates. DataFusion's Display omits parens around the junction under a `Not`, but
+    // the `Expr` tree is still `Not(And(..))`.
     #[case::not_of_junction(
-        Pred::not(Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null())),
+        KernelPred::not(KernelPred::and(column_expr!("a").is_null(), column_expr!("b").is_null())),
         "NOT a IS NULL AND b IS NULL"
     )]
     #[case::junction_of_junction(
-        Pred::or(
-            Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
+        KernelPred::or(
+            KernelPred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
             column_expr!("c").is_null(),
         ),
         "a IS NULL AND b IS NULL OR c IS NULL"
     )]
     #[case::and_of_comparisons(
-        Pred::and(
-            column_expr!("a").eq(Expr_::literal(1i64)),
-            column_expr!("b").gt(Expr_::literal(2i64)),
+        KernelPred::and(
+            column_expr!("a").eq(KernelExpr::literal(1i64)),
+            column_expr!("b").gt(KernelExpr::literal(2i64)),
         ),
         "a = Int64(1) AND b > Int64(2)"
     )]
-    fn predicate_lowers_to_expected(#[case] kernel: Pred, #[case] expected: &str) {
+    fn predicate_lowers_to_expected(#[case] kernel: KernelPred, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
 
     #[rstest]
-    // Engine-defined and opaque-to-both predicates have no DataFusion equivalent.
-    #[case::unknown(Pred::Unknown("mystery".into()))]
+    // Engine-defined and unknown predicates have no DataFusion equivalent.
+    #[case::unknown(KernelPred::Unknown("mystery".into()))]
     // An `IN` whose right side is not a literal array cannot be lowered.
     #[case::in_without_literal_array(
-        Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("b"))
+        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("b"))
     )]
-    fn unsupported_predicate_is_an_error(#[case] pred: Pred) {
+    fn unsupported_predicate_is_an_error(#[case] pred: KernelPred) {
         to_df_predicate_expr(&pred, &test_schema()).unwrap_err();
+    }
+
+    /// `IN` answers true or false but never null, so it still works under a `NOT`. A null value
+    /// matches a null element, following kernel's structural comparison.
+    #[rstest]
+    #[case::present(Some(2), &[Some(1), Some(2)], true)]
+    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
+    #[case::null_needle_without_null_element(None, &[Some(1), Some(2)], false)]
+    #[case::null_needle_matches_null_element(None, &[Some(1), None], true)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
+    #[case::only_null_element(None, &[None], true)]
+    fn in_predicate_matches_membership_and_never_nulls(
+        #[case] needle: Option<i64>,
+        #[case] elements: &[Option<i64>],
+        #[case] expected: bool,
+    ) {
+        let in_pred = KernelPred::binary(
+            KernelBinaryPredicateOp::In,
+            match needle {
+                Some(n) => KernelExpr::literal(n),
+                None => KernelExpr::null_literal(DataType::LONG),
+            },
+            nullable_long_array(elements.to_vec()),
+        );
+
+        assert_eq!(evaluate(in_pred.clone()), expected);
+        assert_eq!(evaluate(KernelPred::not(in_pred)), !expected);
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -5,9 +5,11 @@ use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
 use delta_kernel::expressions::{
-    BinaryPredicate, BinaryPredicateOp, Expression as KernelExpression, JunctionPredicate,
-    JunctionPredicateOp, Predicate as KernelPredicate, Scalar as KernelScalar, UnaryPredicate,
-    UnaryPredicateOp,
+    BinaryPredicate as KernelBinaryPredicate, BinaryPredicateOp as KernelBinaryPredicateOp,
+    Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
+    JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,
+    Scalar as KernelScalar, UnaryPredicate as KernelUnaryPredicate,
+    UnaryPredicateOp as KernelUnaryPredicateOp,
 };
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
@@ -21,14 +23,15 @@ use crate::scalar::to_df_scalar;
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
-/// predicates Also propagates any error from converting a child expression (an unresolved column
+/// predicates. Also propagates any error from converting a child expression (an unresolved column
 /// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
 /// predicate whose right side is not a literal array.
 pub fn to_df_predicate(pred: &KernelPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
     match pred {
         KernelPredicate::BooleanExpression(expr) => to_df_expr(expr, input_schema),
         KernelPredicate::Not(inner) => {
-            Ok(DFExpr::Not(Box::new(to_df_predicate(inner, input_schema)?)))
+            let df_inner = to_df_predicate(inner, input_schema)?;
+            Ok(DFExpr::Not(Box::new(df_inner)))
         }
         KernelPredicate::Unary(unary) => unary_to_df_expr(unary, input_schema),
         KernelPredicate::Binary(binary) => binary_to_df_expr(binary, input_schema),
@@ -43,21 +46,29 @@ pub fn to_df_predicate(pred: &KernelPredicate, input_schema: &StructType) -> Del
 }
 
 /// Lowers a unary predicate.
-fn unary_to_df_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
+fn unary_to_df_expr(
+    unary: &KernelUnaryPredicate,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
     let expr = to_df_expr(&unary.expr, input_schema)?;
     Ok(match unary.op {
-        UnaryPredicateOp::IsNull => DFExpr::IsNull(Box::new(expr)),
+        KernelUnaryPredicateOp::IsNull => DFExpr::IsNull(Box::new(expr)),
     })
 }
 
 /// Lowers a binary predicate.
-fn binary_to_df_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
+fn binary_to_df_expr(
+    binary: &KernelBinaryPredicate,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
     let op = match binary.op {
-        BinaryPredicateOp::In => return in_to_df_expr(&binary.left, &binary.right, input_schema),
-        BinaryPredicateOp::Equal => Operator::Eq,
-        BinaryPredicateOp::LessThan => Operator::Lt,
-        BinaryPredicateOp::GreaterThan => Operator::Gt,
-        BinaryPredicateOp::Distinct => Operator::IsDistinctFrom,
+        KernelBinaryPredicateOp::In => {
+            return in_to_df_expr(&binary.left, &binary.right, input_schema)
+        }
+        KernelBinaryPredicateOp::Equal => Operator::Eq,
+        KernelBinaryPredicateOp::LessThan => Operator::Lt,
+        KernelBinaryPredicateOp::GreaterThan => Operator::Gt,
+        KernelBinaryPredicateOp::Distinct => Operator::IsDistinctFrom,
     };
     let left = to_df_expr(&binary.left, input_schema)?;
     let right = to_df_expr(&binary.right, input_schema)?;
@@ -81,15 +92,15 @@ fn in_to_df_expr(
             "converting an IN predicate requires a literal array on the right-hand side",
         ));
     };
-    let elements = array
+    let elements: DeltaResult<Vec<DFExpr>> = array
         .array_elements()
         .iter()
         .map(|scalar| Ok(lit(to_df_scalar(scalar)?)))
-        .collect::<DeltaResult<Vec<_>>>()?;
+        .collect();
     let value = to_df_expr(value, input_schema)?;
     Ok(DFExpr::InList(InList::new(
         Box::new(value),
-        elements,
+        elements?,
         false,
     )))
 }
@@ -97,18 +108,19 @@ fn in_to_df_expr(
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
 /// left-associative [`conjunction`]/[`disjunction`] helpers.
 fn junction_to_df_expr(
-    junction: &JunctionPredicate,
+    junction: &KernelJunctionPredicate,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
-    let preds = junction
+    let preds: DeltaResult<Vec<DFExpr>> = junction
         .preds
         .iter()
         .map(|pred| to_df_predicate(pred, input_schema))
-        .collect::<DeltaResult<Vec<_>>>()?;
+        .collect();
+    let preds = preds?;
     Ok(match junction.op {
         // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics
-        JunctionPredicateOp::And => conjunction(preds).unwrap_or_else(|| lit(true)),
-        JunctionPredicateOp::Or => disjunction(preds).unwrap_or_else(|| lit(false)),
+        KernelJunctionPredicateOp::And => conjunction(preds).unwrap_or_else(|| lit(true)),
+        KernelJunctionPredicateOp::Or => disjunction(preds).unwrap_or_else(|| lit(false)),
     })
 }
 
@@ -137,7 +149,15 @@ mod tests {
         to_df_predicate(&pred, &test_schema()).unwrap().to_string()
     }
 
+    /// A literal `Scalar::Array` of longs, for `IN`-list cases.
+    fn long_array(values: impl IntoIterator<Item = i64>) -> Expr_ {
+        let elements: Vec<KernelScalar> = values.into_iter().map(KernelScalar::Long).collect();
+        let array = ArrayData::try_new(ArrayType::new(DataType::LONG, false), elements).unwrap();
+        Expr_::literal(KernelScalar::Array(array))
+    }
+
     #[rstest]
+    // Primitive comparisons lower to a native binary op.
     #[case::eq(column_expr!("a").eq(Expr_::literal(1i64)), "a = Int64(1)")]
     #[case::lt(column_expr!("a").lt(Expr_::literal(1i64)), "a < Int64(1)")]
     #[case::gt(column_expr!("a").gt(Expr_::literal(1i64)), "a > Int64(1)")]
@@ -145,68 +165,23 @@ mod tests {
         column_expr!("a").distinct(Expr_::literal(1i64)),
         "a IS DISTINCT FROM Int64(1)"
     )]
-    fn comparison_lowers_to_binary_expr(#[case] kernel: Pred, #[case] expected: &str) {
-        assert_eq!(lower(kernel), expected);
-    }
-
-    // Kernel has no <=/>=/!= operators: they are Not of a primitive comparison, so they render as
-    // a negated form rather than a native LtEq/GtEq/NotEq.
-    #[rstest]
+    // Kernel has no <=/>=/!= ops: each is `Not` of a primitive comparison, so it renders negated.
     #[case::ne(column_expr!("a").ne(Expr_::literal(1i64)), "NOT a = Int64(1)")]
     #[case::le(column_expr!("a").le(Expr_::literal(1i64)), "NOT a > Int64(1)")]
     #[case::ge(column_expr!("a").ge(Expr_::literal(1i64)), "NOT a < Int64(1)")]
-    fn derived_comparison_lowers_to_negated_primitive(
-        #[case] kernel: Pred,
-        #[case] expected: &str,
-    ) {
-        assert_eq!(lower(kernel), expected);
-    }
-
-    #[test]
-    fn is_null_lowers_to_is_null() {
-        assert_eq!(lower(column_expr!("a").is_null()), "a IS NULL");
-    }
-
-    #[test]
-    fn is_not_null_lowers_to_negated_is_null() {
-        assert_eq!(lower(column_expr!("a").is_not_null()), "NOT a IS NULL");
-    }
-
-    #[test]
-    fn in_lowers_to_in_list() {
-        let array = ArrayData::try_new(
-            ArrayType::new(DataType::LONG, false),
-            vec![
-                KernelScalar::Long(1),
-                KernelScalar::Long(2),
-                KernelScalar::Long(3),
-            ],
-        )
-        .unwrap();
-        let kernel = Pred::binary(
-            BinaryPredicateOp::In,
-            column_expr!("a"),
-            Expr_::literal(KernelScalar::Array(array)),
-        );
-        assert_eq!(lower(kernel), "a IN ([Int64(1), Int64(2), Int64(3)])");
-    }
-
-    #[test]
-    fn not_in_lowers_to_negated_in_list() {
-        let array = ArrayData::try_new(
-            ArrayType::new(DataType::LONG, false),
-            vec![KernelScalar::Long(1), KernelScalar::Long(2)],
-        )
-        .unwrap();
-        let inner = Pred::binary(
-            BinaryPredicateOp::In,
-            column_expr!("a"),
-            Expr_::literal(KernelScalar::Array(array)),
-        );
-        assert_eq!(lower(Pred::not(inner)), "NOT a IN ([Int64(1), Int64(2)])");
-    }
-
-    #[rstest]
+    // Unary.
+    #[case::is_null(column_expr!("a").is_null(), "a IS NULL")]
+    #[case::is_not_null(column_expr!("a").is_not_null(), "NOT a IS NULL")]
+    // IN / NOT IN.
+    #[case::in_list(
+        Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2, 3])),
+        "a IN ([Int64(1), Int64(2), Int64(3)])"
+    )]
+    #[case::not_in(
+        Pred::not(Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2]))),
+        "NOT a IN ([Int64(1), Int64(2)])"
+    )]
+    // Junctions fold left-associatively.
     #[case::and(
         Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
         "a IS NULL AND b IS NULL"
@@ -215,27 +190,48 @@ mod tests {
         Pred::or(column_expr!("a").is_null(), column_expr!("b").is_null()),
         "a IS NULL OR b IS NULL"
     )]
-    fn junction_lowers_to_folded_binary_expr(#[case] kernel: Pred, #[case] expected: &str) {
-        assert_eq!(lower(kernel), expected);
-    }
-
-    #[test]
-    fn multi_element_and_folds_left_associatively() {
-        let kernel = Pred::and_from([
+    #[case::multi_and(
+        Pred::and_from([
             column_expr!("a").is_null(),
             column_expr!("b").is_null(),
             column_expr!("c").is_null(),
-        ]);
-        assert_eq!(lower(kernel), "a IS NULL AND b IS NULL AND c IS NULL");
+        ]),
+        "a IS NULL AND b IS NULL AND c IS NULL"
+    )]
+    // A bare boolean expression delegates straight to the expression converter.
+    #[case::boolean_expression(Pred::from_expr(column_expr!("a")), "a")]
+    // Nesting: predicates compose recursively. DataFusion's Display does not parenthesize the
+    // junction under a `Not`, though the underlying `Expr` tree is still `Not(And(..))`.
+    #[case::not_of_junction(
+        Pred::not(Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null())),
+        "NOT a IS NULL AND b IS NULL"
+    )]
+    #[case::junction_of_junction(
+        Pred::or(
+            Pred::and(column_expr!("a").is_null(), column_expr!("b").is_null()),
+            column_expr!("c").is_null(),
+        ),
+        "a IS NULL AND b IS NULL OR c IS NULL"
+    )]
+    #[case::and_of_comparisons(
+        Pred::and(
+            column_expr!("a").eq(Expr_::literal(1i64)),
+            column_expr!("b").gt(Expr_::literal(2i64)),
+        ),
+        "a = Int64(1) AND b > Int64(2)"
+    )]
+    fn predicate_lowers_to_expected(#[case] kernel: Pred, #[case] expected: &str) {
+        assert_eq!(lower(kernel), expected);
     }
 
-    #[test]
-    fn boolean_expression_delegates_to_expression_converter() {
-        assert_eq!(lower(Pred::from_expr(column_expr!("a"))), "a");
-    }
-
-    #[test]
-    fn unknown_predicate_is_unsupported() {
-        to_df_predicate(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
+    #[rstest]
+    // Engine-defined and opaque-to-both predicates have no DataFusion equivalent.
+    #[case::unknown(Pred::Unknown("mystery".into()))]
+    // An `IN` whose right side is not a literal array cannot be lowered.
+    #[case::in_without_literal_array(
+        Pred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("b"))
+    )]
+    fn unsupported_predicate_is_an_error(#[case] pred: Pred) {
+        to_df_predicate(&pred, &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,17 +1,19 @@
 //! Conversion from a kernel [`Predicate`](KernelPredicate) to a boolean-valued DataFusion
 //! [`Expr`](DFExpr).
 
+use datafusion::functions_nested::expr_fn::array_has;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
 use delta_kernel::expressions::{
-    BinaryPredicate as KernelBinaryPredicate, BinaryPredicateOp as KernelBinaryPredicateOp,
+    ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
+    BinaryPredicateOp as KernelBinaryPredicateOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
     JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,
     Scalar as KernelScalar, UnaryPredicate as KernelUnaryPredicate,
     UnaryPredicateOp as KernelUnaryPredicateOp,
 };
-use delta_kernel::schema::StructType;
+use delta_kernel::schema::{DataType, StructType};
 use delta_kernel::{DeltaResult, Error};
 
 use crate::expression::to_df_expr;
@@ -22,8 +24,9 @@ use crate::scalar::to_df_scalar;
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or `Unknown` predicates, and for an
-/// `IN` whose right side is not a literal array. Also propagates errors from child expressions,
-/// such as an unresolved column or an interval literal (which has no Arrow equivalent).
+/// `IN` whose right side is neither a literal array nor an array-typed column. Also propagates
+/// errors from child expressions, such as an unresolved column or an interval literal (which has
+/// no Arrow equivalent).
 pub fn to_df_predicate_expr(
     pred: &KernelPredicate,
     input_schema: &StructType,
@@ -78,62 +81,87 @@ fn binary_to_df_predicate_expr(
     Ok(binary_expr(left, op, right))
 }
 
-/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, literal_array)`;
-/// DataFusion uses [`InList`], whose trailing flag negates the test. Kernel has no negated `IN`
-/// (`NOT IN` arrives as `Not(Binary(In, ..))`, handled by the caller's `Not` arm), so the flag is
-/// always `false` here.
+/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, elements)`, where
+/// `value` is a literal and `elements` is either a literal array (`1 IN (1, 2)`) or an array-typed
+/// column (`1 IN col`). A literal array lowers to DataFusion's [`InList`], whose trailing flag
+/// negates the test; a column lowers to `array_has(col, value)`. Kernel has no negated `IN`
+/// (`NOT IN` arrives as `Not(Binary(In, ..))`, handled by the caller's `Not` arm), so the `InList`
+/// flag is always `false` here.
 ///
-/// The two differ on nulls. DataFusion uses SQL three-valued logic, so a null on either side makes
-/// the result null: `NULL IN (1, 2)` and `2 IN (1, NULL)` are both null. Kernel compares scalars
-/// structurally and always answers true or false, so a null value matches a null element:
-/// `NULL IN (1, NULL)` is true and `NULL IN (1, 2)` is false.
+/// This accepts exactly the shapes kernel's Arrow evaluator accepts: both of its arms require a
+/// literal left operand, so a column left operand is rejected here as it is there.
 ///
-/// To match kernel, this lowering:
-/// - Drops null elements from the list, adding `IS NULL` on the value if there was one.
-/// - Wraps the membership test in `IS TRUE`, turning DataFusion's null into false.
+/// Kernel and DataFusion agree once the result is forced non-null. Kernel compares elements with
+/// logical (SQL) equality and reports membership as a plain boolean: a null matches nothing (not
+/// even another null), so `NULL IN (1, 2)` and `NULL IN (1, NULL)` are both false, and the result
+/// is never null. DataFusion's [`InList`] and `array_has` both keep SQL three-valued logic, so a
+/// null on either side yields null. This lowering wraps the test in `IS TRUE`, collapsing that
+/// null to false to match kernel.
 ///
-/// Both go inside the predicate, not around it, because the caller's `Not` arm may negate the
-/// result and a leftover null would change which rows a filter keeps. Kernel reads
+/// `IS TRUE` sits inside the predicate, not around it, because the caller's `Not` arm may negate
+/// the result and a leftover null would change which rows a filter keeps. Kernel reads
 /// `NOT NULL IN (1, 2)` as `NOT false` = true, but an unguarded DataFusion `NOT NULL` stays null
 /// and drops the row.
 ///
-/// KNOWN DIVERGENCES from kernel's Arrow evaluator, which only handles a literal value against a
-/// literal array or against a list column:
-/// - A column value against a literal array (plain `x IN (1, 2)`) errors in kernel. This lowering
-///   answers it, using the same structural rule.
-/// - A list column never reaches here, since a non-literal right side is rejected below. Kernel
-///   evaluates that shape with arrow's `in_list` (via `prim_array_cmp!` in `engine::arrow_utils`),
-///   which drops the null buffer and skips null elements, so a null value answers false instead of
-///   matching a null element. It also panics when the value's type differs from the element type,
-///   since the macro picks the type from the value alone.
-///
 /// # Errors
-/// Returns [`Error::unsupported`] if the right operand is not a literal array.
+/// Returns [`Error::unsupported`] if the left operand is not a literal, or the right operand is
+/// neither a literal array nor an array-typed column.
 fn in_to_df_predicate_expr(
     value: &KernelExpression,
     list: &KernelExpression,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
-    let KernelExpression::Literal(KernelScalar::Array(array)) = list else {
+    // Kernel's Arrow evaluator accepts `IN` only with a literal left operand (a column left
+    // operand errors), so reject anything else to match it exactly.
+    let KernelExpression::Literal(_) = value else {
         return Err(Error::unsupported(
-            "converting an IN predicate requires a literal array on the right-hand side",
+            "converting an IN predicate requires a literal left-hand side",
         ));
     };
-    let (null_elements, elements): (Vec<_>, Vec<_>) =
-        array.array_elements().iter().partition(|s| s.is_null());
-    let elements: DeltaResult<Vec<DFExpr>> = elements
+    let value = to_df_expr(value, input_schema)?;
+    let membership =
+        match list {
+            KernelExpression::Literal(KernelScalar::Array(array)) => in_list_expr(value, array)?,
+            KernelExpression::Column(name) => array_has_expr(value, list, name, input_schema)?,
+            _ => return Err(Error::unsupported(
+                "converting an IN predicate requires a literal array or an array-typed column on \
+                 the right-hand side",
+            )),
+        };
+    Ok(membership.is_true())
+}
+
+/// Builds `value IN (<elements>)` from a literal array. Null elements stay in the list: they can
+/// never match under logical equality, and the caller's `IS TRUE` collapses the null they would
+/// otherwise contribute down to false.
+fn in_list_expr(value: DFExpr, array: &KernelArrayData) -> DeltaResult<DFExpr> {
+    let elements: Vec<DFExpr> = array
+        .array_elements()
         .iter()
         .map(|scalar| Ok(lit(to_df_scalar(scalar)?)))
-        .collect();
+        .collect::<DeltaResult<_>>()?;
+    let in_expr = DFExpr::InList(InList::new(Box::new(value), elements, false));
+    Ok(in_expr)
+}
 
-    let value = to_df_expr(value, input_schema)?;
-    let in_list = InList::new(Box::new(value.clone()), elements?, false);
-    let is_member = DFExpr::InList(in_list).is_true();
-
-    match null_elements.is_empty() {
-        true => Ok(is_member),
-        false => Ok(is_member.or(value.is_null())),
-    }
+/// Builds `array_has(<column>, value)` for `value IN <list column>`, which kernel evaluates
+/// element-wise. `column` is the kernel column expression and `name` its resolved name. Note the
+/// flipped argument order: haystack first, needle second.
+///
+/// # Errors
+/// Returns [`Error::unsupported`] if `name` does not resolve to an array-typed column.
+fn array_has_expr(
+    value: DFExpr,
+    column: &KernelExpression,
+    name: &KernelColumnName,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    let DataType::Array(_) = input_schema.field_at(name)?.data_type else {
+        return Err(Error::unsupported(
+            "converting an IN predicate against a column requires an array-typed column",
+        ));
+    };
+    Ok(array_has(to_df_expr(column, input_schema)?, value))
 }
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
@@ -158,8 +186,11 @@ fn junction_to_df_predicate_expr(
 mod tests {
     use std::sync::Arc;
 
-    use datafusion::arrow::array::{new_null_array, Array, AsArray, RecordBatch};
-    use datafusion::arrow::datatypes::Schema as ArrowSchema;
+    use datafusion::arrow::array::{
+        new_null_array, Array, AsArray, Int64Array, ListArray, RecordBatch,
+    };
+    use datafusion::arrow::buffer::{OffsetBuffer, ScalarBuffer};
+    use datafusion::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
     use datafusion::common::DFSchema;
     use datafusion::prelude::SessionContext;
     use delta_kernel::engine::arrow_conversion::TryIntoArrow;
@@ -174,12 +205,14 @@ mod tests {
 
     // === Shared helpers ===
 
-    /// Columns these tests resolve against: top-level `a`, `b`, `c`, all `long`.
+    /// Columns these tests resolve against: top-level `a`, `b`, `c` (all `long`) and `list`
+    /// (an array of nullable `long`, the right-hand side of a list-column `IN`).
     fn test_schema() -> StructType {
         StructType::try_new([
             StructField::nullable("a", DataType::LONG),
             StructField::nullable("b", DataType::LONG),
             StructField::nullable("c", DataType::LONG),
+            StructField::nullable("list", ArrayType::new(DataType::LONG, true)),
         ])
         .unwrap()
     }
@@ -261,15 +294,16 @@ mod tests {
     // Unary.
     #[case::is_null(column_expr!("a").is_null(), "a IS NULL")]
     #[case::is_not_null(column_expr!("a").is_not_null(), "NOT a IS NULL")]
-    // IN / NOT IN. `IS TRUE` turns DataFusion's null into kernel's false, and sits inside the `Not`
-    // so a null value gives `NOT false` instead of `NOT NULL`.
+    // IN / NOT IN. Kernel requires a literal needle. `IS TRUE` turns DataFusion's null into
+    // kernel's false, and sits inside the `Not` so a null value gives `NOT false` instead of
+    // `NOT NULL`.
     #[case::in_list(
-        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2, 3])),
-        "a IN ([Int64(1), Int64(2), Int64(3)]) IS TRUE"
+        KernelPred::binary(KernelBinaryPredicateOp::In, KernelExpr::literal(1i64), long_array([1, 2, 3])),
+        "Int64(1) IN ([Int64(1), Int64(2), Int64(3)]) IS TRUE"
     )]
     #[case::not_in(
-        KernelPred::not(KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2]))),
-        "NOT a IN ([Int64(1), Int64(2)]) IS TRUE"
+        KernelPred::not(KernelPred::binary(KernelBinaryPredicateOp::In, KernelExpr::literal(1i64), long_array([1, 2]))),
+        "NOT Int64(1) IN ([Int64(1), Int64(2)]) IS TRUE"
     )]
     #[case::null_needle_in_list(
         KernelPred::binary(
@@ -279,15 +313,20 @@ mod tests {
         ),
         "Int64(NULL) IN ([Int64(1), Int64(2)]) IS TRUE"
     )]
-    // A null element leaves the list and becomes an `IS NULL` check, so a null value still matches
-    // it the way kernel does.
+    // A null element stays in the list; it can never match under logical equality, and `IS TRUE`
+    // collapses the null it contributes to false.
     #[case::null_element_in_list(
         KernelPred::binary(
             KernelBinaryPredicateOp::In,
-            column_expr!("a"),
+            KernelExpr::literal(1i64),
             nullable_long_array([Some(1), None]),
         ),
-        "a IN ([Int64(1)]) IS TRUE OR a IS NULL"
+        "Int64(1) IN ([Int64(1), Int64(NULL)]) IS TRUE"
+    )]
+    // A literal against a list column lowers to `array_has(list, value)` (haystack first).
+    #[case::in_list_column(
+        KernelPred::binary(KernelBinaryPredicateOp::In, KernelExpr::literal(1i64), column_expr!("list")),
+        "array_has(list, Int64(1)) IS TRUE"
     )]
     // Junctions fold left-associatively.
     #[case::and(
@@ -335,24 +374,33 @@ mod tests {
     #[rstest]
     // Engine-defined and unknown predicates have no DataFusion equivalent.
     #[case::unknown(KernelPred::Unknown("mystery".into()))]
-    // An `IN` whose right side is not a literal array cannot be lowered.
-    #[case::in_without_literal_array(
-        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("b"))
+    // Kernel's evaluator rejects a column needle, so we do too, whether the elements are a literal
+    // array or a list column.
+    #[case::column_needle_in_literal_array(
+        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), long_array([1, 2]))
+    )]
+    #[case::column_needle_in_list_column(
+        KernelPred::binary(KernelBinaryPredicateOp::In, column_expr!("a"), column_expr!("list"))
+    )]
+    // A literal needle against a non-array column (`b` is `long`) cannot be lowered.
+    #[case::in_non_array_column(
+        KernelPred::binary(KernelBinaryPredicateOp::In, KernelExpr::literal(1i64), column_expr!("b"))
     )]
     fn unsupported_predicate_is_an_error(#[case] pred: KernelPred) {
         to_df_predicate_expr(&pred, &test_schema()).unwrap_err();
     }
 
-    /// `IN` answers true or false but never null, so it still works under a `NOT`. A null value
-    /// matches a null element, following kernel's structural comparison.
+    /// `IN` answers true or false but never null, so it still works under a `NOT`. Membership uses
+    /// logical (SQL) equality, so a null matches nothing -- not even another null -- matching
+    /// kernel's evaluator.
     #[rstest]
     #[case::present(Some(2), &[Some(1), Some(2)], true)]
     #[case::absent(Some(9), &[Some(1), Some(2)], false)]
     #[case::null_needle_without_null_element(None, &[Some(1), Some(2)], false)]
-    #[case::null_needle_matches_null_element(None, &[Some(1), None], true)]
+    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
     #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
     #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
-    #[case::only_null_element(None, &[None], true)]
+    #[case::only_null_element(None, &[None], false)]
     fn in_predicate_matches_membership_and_never_nulls(
         #[case] needle: Option<i64>,
         #[case] elements: &[Option<i64>],
@@ -369,5 +417,77 @@ mod tests {
 
         assert_eq!(evaluate(in_pred.clone()), expected);
         assert_eq!(evaluate(KernelPred::not(in_pred)), !expected);
+    }
+
+    /// A literal `IN <list column>` lowers to `array_has` and follows the same never-null,
+    /// logical-equality rule as the literal-array form: a null needle or a null element matches
+    /// nothing, and the result is always a plain boolean, so `NOT IN` is its exact complement.
+    #[rstest]
+    #[case::present(Some(2), &[Some(1), Some(2)], true)]
+    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
+    #[case::null_needle_without_null_element(None, &[Some(1), Some(2)], false)]
+    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
+    #[case::only_null_element(None, &[None], false)]
+    fn in_list_column_matches_membership_and_never_nulls(
+        #[case] needle: Option<i64>,
+        #[case] elements: &[Option<i64>],
+        #[case] expected: bool,
+    ) {
+        let in_pred = KernelPred::binary(
+            KernelBinaryPredicateOp::In,
+            match needle {
+                Some(n) => KernelExpr::literal(n),
+                None => KernelExpr::null_literal(DataType::LONG),
+            },
+            column_expr!("list"),
+        );
+        // Column `list` carries the elements; `a`/`b`/`c` are unused.
+        let batch = list_column_batch(elements);
+
+        assert_eq!(evaluate_over(in_pred.clone(), &batch), expected);
+        assert_eq!(evaluate_over(KernelPred::not(in_pred), &batch), !expected);
+    }
+
+    /// Lowers `pred` against [`test_schema`], evaluates it over the single-row `batch`, and asserts
+    /// the one result is not null.
+    fn evaluate_over(pred: KernelPred, batch: &RecordBatch) -> bool {
+        let df_expr = to_df_predicate_expr(&pred, &test_schema()).unwrap();
+        let df_schema = DFSchema::try_from(batch.schema()).unwrap();
+        let result = SessionContext::new()
+            .create_physical_expr(df_expr, &df_schema)
+            .unwrap()
+            .evaluate(batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let result = result.as_boolean();
+
+        assert_eq!(result.len(), 1, "expected a single-row result");
+        assert_eq!(result.null_count(), 0, "predicate evaluated to null");
+        result.value(0)
+    }
+
+    /// A one-row batch whose single `list` column holds `elements`.
+    fn list_column_batch(elements: &[Option<i64>]) -> RecordBatch {
+        // Reuse the schema's own `list` field so the built array matches the name and metadata
+        // kernel synthesizes (an `element` child field, possibly with field-id metadata).
+        let arrow_schema: ArrowSchema = (&test_schema()).try_into_arrow().unwrap();
+        let list_field = arrow_schema.field_with_name("list").unwrap().clone();
+        let ArrowDataType::List(element_field) = list_field.data_type().clone() else {
+            unreachable!("`list` is declared as an array type");
+        };
+        let list = ListArray::new(
+            element_field,
+            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, elements.len() as i32])),
+            Arc::new(Int64Array::from(elements.to_vec())),
+            None,
+        );
+        RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![list_field])),
+            vec![Arc::new(list)],
+        )
+        .unwrap()
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,69 +1,66 @@
-//! Conversion from a kernel [`Predicate`] to a boolean-valued DataFusion [`Expr`].
+//! Conversion from a kernel [`Predicate`](KernelPredicate) to a boolean-valued DataFusion
+//! [`Expr`](DFExpr).
 
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
-use datafusion::logical_expr::{binary_expr, lit, Expr, Operator};
+use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
 use delta_kernel::expressions::{
-    BinaryPredicate, BinaryPredicateOp, Expression, JunctionPredicate, JunctionPredicateOp,
-    Predicate, Scalar, UnaryPredicate, UnaryPredicateOp,
+    BinaryPredicate, BinaryPredicateOp, Expression as KernelExpression, JunctionPredicate,
+    JunctionPredicateOp, Predicate as KernelPredicate, Scalar as KernelScalar, UnaryPredicate,
+    UnaryPredicateOp,
 };
 use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
-use crate::expression::kernel_to_df_expr;
-use crate::scalar::kernel_to_df_scalar;
+use crate::expression::to_df_expr;
+use crate::scalar::to_df_scalar;
 
-/// Converts a kernel [`Predicate`] into a boolean-valued DataFusion [`Expr`], validating column
-/// references against `input_schema` (threaded to the expression converter).
+/// Converts a kernel [`Predicate`](KernelPredicate) into a boolean-valued DataFusion
+/// [`Expr`](DFExpr), validating column references against `input_schema` (threaded to the
+/// expression converter).
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or opaque-to-both (`Unknown`)
 /// predicates Also propagates any error from converting a child expression (an unresolved column
 /// reference, or an interval literal, which has no Arrow representation) and rejects an `IN`
 /// predicate whose right side is not a literal array.
-pub fn kernel_predicate_to_df_expr(
-    pred: &Predicate,
-    input_schema: &StructType,
-) -> DeltaResult<Expr> {
+pub fn to_df_predicate(pred: &KernelPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
     match pred {
-        Predicate::BooleanExpression(expr) => kernel_to_df_expr(expr, input_schema),
-        Predicate::Not(inner) => Ok(Expr::Not(Box::new(kernel_predicate_to_df_expr(
-            inner,
-            input_schema,
-        )?))),
-        Predicate::Unary(unary) => kernel_unary_to_expr(unary, input_schema),
-        Predicate::Binary(binary) => kernel_binary_to_expr(binary, input_schema),
-        Predicate::Junction(junction) => kernel_junction_to_expr(junction, input_schema),
-        Predicate::Opaque(_) => Err(Error::unsupported(
+        KernelPredicate::BooleanExpression(expr) => to_df_expr(expr, input_schema),
+        KernelPredicate::Not(inner) => {
+            Ok(DFExpr::Not(Box::new(to_df_predicate(inner, input_schema)?)))
+        }
+        KernelPredicate::Unary(unary) => unary_to_df_expr(unary, input_schema),
+        KernelPredicate::Binary(binary) => binary_to_df_expr(binary, input_schema),
+        KernelPredicate::Junction(junction) => junction_to_df_expr(junction, input_schema),
+        KernelPredicate::Opaque(_) => Err(Error::unsupported(
             "cannot convert an engine-defined Opaque predicate",
         )),
-        Predicate::Unknown(name) => Err(Error::unsupported(format!(
+        KernelPredicate::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown predicate {name:?}"
         ))),
     }
 }
 
 /// Lowers a unary predicate.
-fn kernel_unary_to_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
-    let expr = kernel_to_df_expr(&unary.expr, input_schema)?;
+fn unary_to_df_expr(unary: &UnaryPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
+    let expr = to_df_expr(&unary.expr, input_schema)?;
     Ok(match unary.op {
-        UnaryPredicateOp::IsNull => Expr::IsNull(Box::new(expr)),
+        UnaryPredicateOp::IsNull => DFExpr::IsNull(Box::new(expr)),
     })
 }
 
 /// Lowers a binary predicate.
-fn kernel_binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<Expr> {
+fn binary_to_df_expr(binary: &BinaryPredicate, input_schema: &StructType) -> DeltaResult<DFExpr> {
     let op = match binary.op {
-        BinaryPredicateOp::In => {
-            return kernel_in_to_expr(&binary.left, &binary.right, input_schema)
-        }
+        BinaryPredicateOp::In => return in_to_df_expr(&binary.left, &binary.right, input_schema),
         BinaryPredicateOp::Equal => Operator::Eq,
         BinaryPredicateOp::LessThan => Operator::Lt,
         BinaryPredicateOp::GreaterThan => Operator::Gt,
         BinaryPredicateOp::Distinct => Operator::IsDistinctFrom,
     };
-    let left = kernel_to_df_expr(&binary.left, input_schema)?;
-    let right = kernel_to_df_expr(&binary.right, input_schema)?;
+    let left = to_df_expr(&binary.left, input_schema)?;
+    let right = to_df_expr(&binary.right, input_schema)?;
     Ok(binary_expr(left, op, right))
 }
 
@@ -74,12 +71,12 @@ fn kernel_binary_to_expr(binary: &BinaryPredicate, input_schema: &StructType) ->
 ///
 /// # Errors
 /// Returns [`Error::unsupported`] if the right operand is not a literal array.
-fn kernel_in_to_expr(
-    value: &Expression,
-    list: &Expression,
+fn in_to_df_expr(
+    value: &KernelExpression,
+    list: &KernelExpression,
     input_schema: &StructType,
-) -> DeltaResult<Expr> {
-    let Expression::Literal(Scalar::Array(array)) = list else {
+) -> DeltaResult<DFExpr> {
+    let KernelExpression::Literal(KernelScalar::Array(array)) = list else {
         return Err(Error::unsupported(
             "converting an IN predicate requires a literal array on the right-hand side",
         ));
@@ -87,22 +84,26 @@ fn kernel_in_to_expr(
     let elements = array
         .array_elements()
         .iter()
-        .map(|scalar| Ok(lit(kernel_to_df_scalar(scalar)?)))
+        .map(|scalar| Ok(lit(to_df_scalar(scalar)?)))
         .collect::<DeltaResult<Vec<_>>>()?;
-    let value = kernel_to_df_expr(value, input_schema)?;
-    Ok(Expr::InList(InList::new(Box::new(value), elements, false)))
+    let value = to_df_expr(value, input_schema)?;
+    Ok(DFExpr::InList(InList::new(
+        Box::new(value),
+        elements,
+        false,
+    )))
 }
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
 /// left-associative [`conjunction`]/[`disjunction`] helpers.
-fn kernel_junction_to_expr(
+fn junction_to_df_expr(
     junction: &JunctionPredicate,
     input_schema: &StructType,
-) -> DeltaResult<Expr> {
+) -> DeltaResult<DFExpr> {
     let preds = junction
         .preds
         .iter()
-        .map(|pred| kernel_predicate_to_df_expr(pred, input_schema))
+        .map(|pred| to_df_predicate(pred, input_schema))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(match junction.op {
         // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics
@@ -133,9 +134,7 @@ mod tests {
 
     /// Lowers a predicate against [`test_schema`] and renders it as a DataFusion `Display` string.
     fn lower(pred: Pred) -> String {
-        kernel_predicate_to_df_expr(&pred, &test_schema())
-            .unwrap()
-            .to_string()
+        to_df_predicate(&pred, &test_schema()).unwrap().to_string()
     }
 
     #[rstest]
@@ -177,13 +176,17 @@ mod tests {
     fn in_lowers_to_in_list() {
         let array = ArrayData::try_new(
             ArrayType::new(DataType::LONG, false),
-            vec![Scalar::Long(1), Scalar::Long(2), Scalar::Long(3)],
+            vec![
+                KernelScalar::Long(1),
+                KernelScalar::Long(2),
+                KernelScalar::Long(3),
+            ],
         )
         .unwrap();
         let kernel = Pred::binary(
             BinaryPredicateOp::In,
             column_expr!("a"),
-            Expr_::literal(Scalar::Array(array)),
+            Expr_::literal(KernelScalar::Array(array)),
         );
         assert_eq!(lower(kernel), "a IN ([Int64(1), Int64(2), Int64(3)])");
     }
@@ -192,13 +195,13 @@ mod tests {
     fn not_in_lowers_to_negated_in_list() {
         let array = ArrayData::try_new(
             ArrayType::new(DataType::LONG, false),
-            vec![Scalar::Long(1), Scalar::Long(2)],
+            vec![KernelScalar::Long(1), KernelScalar::Long(2)],
         )
         .unwrap();
         let inner = Pred::binary(
             BinaryPredicateOp::In,
             column_expr!("a"),
-            Expr_::literal(Scalar::Array(array)),
+            Expr_::literal(KernelScalar::Array(array)),
         );
         assert_eq!(lower(Pred::not(inner)), "NOT a IN ([Int64(1), Int64(2)])");
     }
@@ -233,6 +236,6 @@ mod tests {
 
     #[test]
     fn unknown_predicate_is_unsupported() {
-        kernel_predicate_to_df_expr(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
+        to_df_predicate(&Pred::Unknown("mystery".into()), &test_schema()).unwrap_err();
     }
 }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -56,9 +56,9 @@ fn unary_to_df_predicate_expr(
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
     let expr = to_df_expr(&unary.expr, input_schema)?;
-    Ok(match unary.op {
-        KernelUnaryPredicateOp::IsNull => DFExpr::IsNull(Box::new(expr)),
-    })
+    match unary.op {
+        KernelUnaryPredicateOp::IsNull => Ok(DFExpr::IsNull(Box::new(expr))),
+    }
 }
 
 /// Lowers a binary predicate.
@@ -121,11 +121,11 @@ fn junction_to_df_predicate_expr(
         .iter()
         .map(|pred| to_df_predicate_expr(pred, input_schema))
         .collect();
-    Ok(match junction.op {
-        // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics
-        KernelJunctionPredicateOp::And => conjunction(preds?).unwrap_or_else(|| lit(true)),
-        KernelJunctionPredicateOp::Or => disjunction(preds?).unwrap_or_else(|| lit(false)),
-    })
+    // An empty junction lowers `AND` to `true` and `OR` to `false`, keeping kernel semantics.
+    match junction.op {
+        KernelJunctionPredicateOp::And => Ok(conjunction(preds?).unwrap_or_else(|| lit(true))),
+        KernelJunctionPredicateOp::Or => Ok(disjunction(preds?).unwrap_or_else(|| lit(false))),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/2971/files) to review incremental changes.
- [**stack/aaron/kernel-df-predicate-conversion**](https://github.com/delta-io/delta-kernel-rs/pull/2971) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2971/files)] ← _this PR_
  - [stack/aaron/kernel-df-struct-conversion](https://github.com/delta-io/delta-kernel-rs/pull/2972) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2972/files/5129b82828fe22713d17926d7c1911001f5fdcb1..c2f5a68d0cc46d3602e3e4d7978d0c207a974510)]
    - [stack/aaron/kernel-df-map-to-struct-conversion](https://github.com/delta-io/delta-kernel-rs/pull/2996) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/2996/files/c2f5a68d0cc46d3602e3e4d7978d0c207a974510..1d5b617b80b6d587b38811b813855717f33fabb3)]
      - [stack/aaron/kernel-df-parse-json-conversion](https://github.com/delta-io/delta-kernel-rs/pull/3056) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3056/files/1d5b617b80b6d587b38811b813855717f33fabb3..0df8318ceaf2b0b4537d7a0d9483cf442d499722)]
        - [stack/aaron/kernel-defined-operator-conversion](https://github.com/delta-io/delta-kernel-rs/pull/3079) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3079/files/0df8318ceaf2b0b4537d7a0d9483cf442d499722..1aea4cb776537bf66a13225ad79081551c06027d)]
          - [stack/aaron/lower-filter-and-project](https://github.com/delta-io/delta-kernel-rs/pull/3094) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3094/files/1aea4cb776537bf66a13225ad79081551c06027d..003e1be44286f4160a4b3ac1e2326c38ba593861)]
            - [stack/aaron/lower-aggregate](https://github.com/delta-io/delta-kernel-rs/pull/3102) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3102/files/003e1be44286f4160a4b3ac1e2326c38ba593861..14c83f7eeaf283f4d5dd4cfed717e579743e462c)]
              - stack/aaron/lower-semijoin-unionall

---------
## What changes are proposed in this pull request?
This change allows for a `Kernel::Predicate` to be converted to a `DataFusion::Expr`. The reason behind this is that `DataFusion::Expr` includes predicate expressions, so any Kernel's predicate expression can be represented as a `DataFusion::Expr` as well.

There was a divergence with current kernel implementation, so I made the change to the kernel here: #3085.

## How was this change tested?
Tests added in new `predicate.rs`.