### PR TITLE
fix: source checkpoint partition columns from physical schema

### DIFF
--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -9,14 +9,14 @@ use crate::actions::visitors::SelectionVectorVisitor;
 use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
-    column_expr, column_name, joined_column_expr, BinaryPredicateOp, ColumnName,
-    Expression as Expr, ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef,
-    Predicate as Pred, PredicateRef, Scalar,
+    column_expr, column_name, BinaryPredicateOp, ColumnName, Expression as Expr, ExpressionRef,
+    JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef, Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
+use crate::scan::log_replay::PARTITION_VALUES_PARSED_NAME;
 use crate::scan::metrics::ScanMetrics;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
@@ -60,7 +60,7 @@ pub(crate) fn all_referenced_columns(pred: &Pred) -> HashSet<ColumnName> {
 #[cfg(test)]
 pub(crate) fn as_data_skipping_predicate_with_partitions(
     pred: &Pred,
-    partition_columns: &HashSet<String>,
+    partition_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
     DataSkippingPredicateCreator::new(partition_columns, &stats_columns).eval(pred)
@@ -71,7 +71,7 @@ pub(crate) fn as_data_skipping_predicate_with_partitions(
 #[cfg(test)]
 fn as_sql_data_skipping_predicate(
     pred: &Pred,
-    partition_columns: &HashSet<String>,
+    partition_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
     let stats_columns = all_referenced_columns(pred);
     as_sql_data_skipping_predicate_with_stats_columns(pred, partition_columns, &stats_columns)
@@ -82,7 +82,7 @@ fn as_sql_data_skipping_predicate(
 /// junction-fold into NULL literals.
 pub(crate) fn as_sql_data_skipping_predicate_with_stats_columns(
     pred: &Pred,
-    partition_columns: &HashSet<String>,
+    partition_columns: &HashSet<ColumnName>,
     stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
     DataSkippingPredicateCreator::new(partition_columns, stats_columns).eval_sql_where(pred)
@@ -308,9 +308,9 @@ impl DataSkippingFilter {
         physical_partition_schema: Option<&SchemaRef>,
         partition_expr: ExpressionRef,
         is_add_expr: ExpressionRef,
-    ) -> Option<(SchemaRef, ExpressionRef, HashSet<String>)> {
-        let partition_columns: HashSet<String> = physical_partition_schema
-            .map(|s| s.fields().map(|f| f.name().to_string()).collect())
+    ) -> Option<(SchemaRef, ExpressionRef, HashSet<ColumnName>)> {
+        let partition_columns: HashSet<ColumnName> = physical_partition_schema
+            .map(|s| s.fields().map(|f| ColumnName::new([f.name()])).collect())
             .unwrap_or_default();
 
         let stats_field =
@@ -432,14 +432,13 @@ impl DataSkippingFilter {
 /// field.
 pub(crate) fn as_checkpoint_skipping_predicate(
     pred: &Pred,
-    physical_partition_columns: &[String],
+    physical_partition_columns: &HashSet<ColumnName>,
     physical_stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
-    let partition_columns: HashSet<String> = physical_partition_columns.iter().cloned().collect();
     CheckpointDataSkippingPredicateCreator {
         data_skipping_columns: DataSkippingColumns {
-            physical_partition_columns: &partition_columns,
-            stats_columns: physical_stats_columns,
+            physical_partition_columns,
+            physical_stats_columns,
         },
     }
     .eval(pred)
@@ -503,6 +502,12 @@ fn adjust_scalar_for_max_stat_truncation(val: &Scalar) -> Scalar {
     }
 }
 
+/// The `partitionValues_parsed.<col>` reference holding a partition column's exact value, which
+/// serves as both its min and max stat. `col` is a top-level physical partition name.
+fn partition_value_expr(col: &ColumnName) -> Expr {
+    Expr::from(ColumnName::new([PARTITION_VALUES_PARSED_NAME]).join(col))
+}
+
 /// A column carries min/max stats iff it's a primitive whose type supports min/max skipping.
 /// Boolean / Binary, Array, Map, and Variant leaves carry nullCount only. Struct columns
 /// have no per-struct stats; only their primitive leaves do, recursively.
@@ -514,25 +519,24 @@ fn has_min_max_stats(data_type: &DataType) -> bool {
 
 /// Column metadata shared by the data-skipping predicate creators.
 struct DataSkippingColumns<'a> {
-    /// Physical names of partition columns. Stats for these come from
-    /// `partitionValues_parsed.<col>` (exact values) instead of min/max ranges; each creator
-    /// applies its own partition policy.
-    physical_partition_columns: &'a HashSet<String>,
+    /// Physical names of partition columns (always single-segment: Delta partition columns are
+    /// top-level). Stats for these come from `partitionValues_parsed.<col>` (exact values) instead
+    /// of min/max ranges; each creator applies its own partition policy.
+    physical_partition_columns: &'a HashSet<ColumnName>,
     /// Physical leaf paths whose stats are present in `stats_parsed` (honors
     /// `delta.dataSkippingNumIndexedCols`, `delta.dataSkippingStatsColumns`, and required
     /// columns). Must match the column set used to build `physical_stats_schema`; otherwise the
     /// rewritten predicate references columns absent from the unified schema.
-    stats_columns: &'a HashSet<ColumnName>,
+    physical_stats_columns: &'a HashSet<ColumnName>,
 }
 
 impl DataSkippingColumns<'_> {
     fn is_partition_column(&self, col: &ColumnName) -> bool {
-        let path = col.path();
-        path.len() == 1 && self.physical_partition_columns.contains(path[0].as_str())
+        self.physical_partition_columns.contains(col)
     }
 
     fn is_stats_column(&self, col: &ColumnName) -> bool {
-        self.stats_columns.contains(col)
+        self.physical_stats_columns.contains(col)
     }
 
     /// Data column -> `stats_parsed.minValues.<col>`, or `None` when unindexed or not
@@ -571,11 +575,14 @@ struct DataSkippingPredicateCreator<'a> {
 }
 
 impl<'a> DataSkippingPredicateCreator<'a> {
-    fn new(partition_columns: &'a HashSet<String>, stats_columns: &'a HashSet<ColumnName>) -> Self {
+    fn new(
+        physical_partition_columns: &'a HashSet<ColumnName>,
+        physical_stats_columns: &'a HashSet<ColumnName>,
+    ) -> Self {
         Self {
             data_skipping_columns: DataSkippingColumns {
-                physical_partition_columns: partition_columns,
-                stats_columns,
+                physical_partition_columns,
+                physical_stats_columns,
             },
         }
     }
@@ -603,7 +610,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     /// outside the stat-columns set or whose type is not min/max-eligible.
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
-            Some(joined_column_expr!("partitionValues_parsed", col))
+            Some(partition_value_expr(col))
         } else {
             self.data_skipping_columns.data_min_stat(col, data_type)
         }
@@ -614,7 +621,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     /// type is not min/max-eligible.
     fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         if self.is_partition_column(col) {
-            Some(joined_column_expr!("partitionValues_parsed", col))
+            Some(partition_value_expr(col))
         } else {
             self.data_skipping_columns.data_max_stat(col, data_type)
         }
@@ -665,7 +672,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     ) -> Option<Pred> {
         // Detect partition columns by the prefix set in get_min_stat/get_max_stat.
         let is_partition = matches!(&col, Expr::Column(name)
-            if name.path().first().is_some_and(|f| f == "partitionValues_parsed"));
+            if name.path().first().is_some_and(|f| f == PARTITION_VALUES_PARSED_NAME));
         let cmp = comparison_predicate(ord, col, val, inverted);
         Some(if is_partition {
             self.guard_for_removes(cmp)
@@ -687,7 +694,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
     /// For data columns, uses nullCount stats.
     fn eval_pred_is_null(&self, col: &ColumnName, inverted: bool) -> Option<Pred> {
         if self.is_partition_column(col) {
-            let pv_expr = joined_column_expr!("partitionValues_parsed", col);
+            let pv_expr = partition_value_expr(col);
             let pred = if inverted {
                 Pred::is_not_null(pv_expr)
             } else {

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -492,7 +492,7 @@ fn test_checkpoint_skipping_semantic(
 ) {
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
     let stats = all_referenced_columns(&pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     let resolver = HashMap::from_iter([(column_name!("stats_parsed.maxValues.x"), max_val)]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
@@ -510,7 +510,7 @@ fn test_checkpoint_skipping_null_guard_vs_regular() {
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
 
     let stats = all_referenced_columns(&pred);
-    let guarded = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let guarded = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     expect_eq!(
         filter.eval(&guarded),
         TRUE,
@@ -541,7 +541,7 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
         Pred::lt(column_expr!("col_b"), Scalar::from(50)),
     );
     let stats = all_referenced_columns(&pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
 
     // Both stats present and both allow pruning -> skip
     let resolver = HashMap::from_iter([
@@ -609,7 +609,7 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     // GT: should produce OR(maxValues.ts_col IS NULL, maxValues.ts_col > 999001)
     let pred = Pred::gt(col.clone(), timestamp.clone());
     let stats = all_referenced_columns(&pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
         "OR(Column(stats_parsed.maxValues.ts_col) IS NULL, Column(stats_parsed.maxValues.ts_col) > 999001)"
@@ -618,7 +618,7 @@ fn test_checkpoint_skipping_timestamp_adjustment(
     // EQ: max stat leg should use adjusted literal
     let pred = Pred::eq(col.clone(), timestamp.clone());
     let stats = all_referenced_columns(&pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         skipping_pred.to_string(),
         "AND(OR(Column(stats_parsed.minValues.ts_col) IS NULL, NOT(Column(stats_parsed.minValues.ts_col) > 1000000)), \
@@ -682,7 +682,7 @@ fn test_timestamp_predicates_use_adjusted_max_stats(
 // Partition timestamp columns use exact values (not truncated), so no adjustment is applied.
 #[test]
 fn test_partition_timestamp_column_no_adjustment() {
-    let partition_columns: HashSet<String> = ["ts_part".to_string()].into();
+    let partition_columns: HashSet<ColumnName> = [column_name!("ts_part")].into();
     let pred = Pred::gt(column_expr!("ts_part"), Scalar::Timestamp(1_000_000));
     let skipping_pred =
         as_data_skipping_predicate_with_partitions(&pred, &partition_columns).unwrap();
@@ -695,8 +695,8 @@ fn test_partition_timestamp_column_no_adjustment() {
 // Tests for partition-aware data skipping
 
 /// Helper to build a partition columns set with a single "part_col" entry.
-fn test_partition_columns() -> HashSet<String> {
-    ["part_col".to_string()].into()
+fn test_partition_columns() -> HashSet<ColumnName> {
+    [column_name!("part_col")].into()
 }
 
 /// Helper to build a resolver for mixed partition + data stats evaluation.
@@ -1079,8 +1079,8 @@ fn null_partition_value_evaluation(
 // rewrite to partitionValues_parsed and both get is_add guards.
 #[test]
 fn multiple_partition_columns_rewrite_and_evaluation() {
-    let partition_columns: HashSet<String> =
-        ["part_a", "part_b"].iter().map(|s| s.to_string()).collect();
+    let partition_columns: HashSet<ColumnName> =
+        [column_name!("part_a"), column_name!("part_b")].into();
 
     let pred = Pred::and(
         Pred::eq(column_expr!("part_a"), Scalar::from("X")),
@@ -1157,7 +1157,7 @@ fn multiple_partition_columns_rewrite_and_evaluation() {
 fn single_unsupported_pred_in_junction_disables_checkpoint_pushdown() {
     let pred = Pred::and_from([Pred::unknown("unsupported")]);
     let stats = all_referenced_columns(&pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &[], &stats);
+    let skipping_pred = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats);
     assert!(
         skipping_pred.is_none(),
         "Single unsupported predicate in a junction should disable pushdown, got: {skipping_pred:?}"
@@ -1460,7 +1460,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
 #[rstest]
 #[case::non_stat_only_folds_to_trivial_null(
     Pred::gt(column_expr!("non_stat"), Scalar::from(1)),
-    HashSet::<String>::new(),
+    HashSet::<ColumnName>::new(),
     stats_cols(&["stat"]),
     "AND(null, true)",
 )]
@@ -1469,7 +1469,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
         Pred::gt(column_expr!("stat"), Scalar::from(100)),
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
     ),
-    HashSet::<String>::new(),
+    HashSet::<ColumnName>::new(),
     stats_cols(&["stat"]),
     "AND(AND(NOT(Column(stats_parsed.nullCount.stat) = Column(stats_parsed.numRecords)), \
      true, Column(stats_parsed.maxValues.stat) > 100), AND(null, true))",
@@ -1479,7 +1479,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
         Pred::gt(column_expr!("user.email"), Scalar::from(100)),
         Pred::gt(column_expr!("user.password"), Scalar::from(200)),
     ),
-    HashSet::<String>::new(),
+    HashSet::<ColumnName>::new(),
     stats_cols(&["user.email"]),
     "AND(AND(NOT(Column(stats_parsed.nullCount.user.email) = Column(stats_parsed.numRecords)), \
      true, Column(stats_parsed.maxValues.user.email) > 100), AND(null, true))",
@@ -1492,7 +1492,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
             Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
         ),
     ),
-    HashSet::from(["part".to_string()]),
+    HashSet::from([column_name!("part")]),
     stats_cols(&["stat"]),
     "AND(AND(OR(NOT(Column(is_add)), NOT(Column(partitionValues_parsed.part) IS NULL)), \
      true, OR(NOT(Column(is_add)), Column(partitionValues_parsed.part) > 'p')), \
@@ -1504,7 +1504,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
         Pred::gt(column_expr!("stat"), Scalar::from(100)),
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
     ),
-    HashSet::<String>::new(),
+    HashSet::<ColumnName>::new(),
     stats_cols(&["stat", "non_stat"]),
     "AND(AND(NOT(Column(stats_parsed.nullCount.stat) = Column(stats_parsed.numRecords)), \
      true, Column(stats_parsed.maxValues.stat) > 100), \
@@ -1513,7 +1513,7 @@ fn stats_cols(cols: &[&str]) -> HashSet<ColumnName> {
 )]
 fn stats_columns_gate_rewrite(
     #[case] pred: Pred,
-    #[case] partition_columns: HashSet<String>,
+    #[case] partition_columns: HashSet<ColumnName>,
     #[case] stats: HashSet<ColumnName>,
     #[case] expected: &str,
 ) {
@@ -1558,7 +1558,7 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
     );
     let stats = stats_cols(&["stat"]);
-    let result = as_checkpoint_skipping_predicate(&pred, &[], &stats).unwrap();
+    let result = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         result.to_string(),
         "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, Column(stats_parsed.maxValues.stat) > 100), null)"

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1013,14 +1013,18 @@ impl Scan {
         };
         self.state_info.physical_stats_schema.as_ref()?;
 
-        let partition_columns = self
-            .snapshot
-            .table_configuration()
-            .metadata()
-            .partition_columns();
+        // `partitionValues_parsed` is keyed by PHYSICAL partition name, and (under column mapping)
+        // the predicate also references physical columns, so partition detection reads the physical
+        // partition schema rather than the logical names in table metadata.
+        let partition_columns: HashSet<ColumnName> = self
+            .state_info
+            .physical_partition_schema
+            .as_ref()
+            .map(|s| s.fields().map(|f| ColumnName::new([f.name()])).collect())
+            .unwrap_or_default();
         let skipping_pred = as_checkpoint_skipping_predicate(
             predicate,
-            partition_columns,
+            &partition_columns,
             &self.state_info.physical_stats_columns,
         )?;
 

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1297,7 +1297,7 @@ impl CheckpointParquetBuilder {
 /// Builds a checkpoint skipping predicate and prefixes column references with `add.stats_parsed`.
 fn build_prefixed_checkpoint_predicate(pred: &Pred) -> Option<Pred> {
     let stats = all_referenced_columns(pred);
-    let skipping_pred = as_checkpoint_skipping_predicate(pred, &[], &stats)?;
+    let skipping_pred = as_checkpoint_skipping_predicate(pred, &HashSet::new(), &stats)?;
     let mut prefixer = PrefixColumns {
         prefix: ColumnName::new(["add"]),
     };


### PR DESCRIPTION
## What changes are proposed in this pull request?

The checkpoint meta-predicate compared physical predicate columns against **logical** partition names sourced from table metadata (`metadata().partition_columns()`), while the field and parameter were named `physical_partition_columns`. Under column mapping (where physical != logical), partition columns were never recognized in the checkpoint row-group skipping path.

This sources partition columns from the physical partition schema instead, making the name honest, and types partition columns as `ColumnName` across the data-skipping predicate creators (dropping the single-segment string check in `is_partition_column`, since both sets now share the same domain type as the stats columns).

No behavior change in this PR on its own (the checkpoint creator does not yet rewrite partition columns), but it establishes the physical-name guarantee the stacked partition row-group skipping work relies on.

## How was this change tested?

Existing data-skipping unit tests, updated to construct partition sets as `ColumnName`.
