### PR TITLE
feat!: push checkpoint partition casts to parquet handlers

### DIFF
--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -110,6 +110,11 @@ pub trait JsonHandler {
   columns should be omitted from the output to save space. The write must be atomic. If
   `overwrite` is false and the file exists, fail with an error.
 
+If a read handler applies the predicate hint, it may discard data only when conservative
+evaluation of the complete predicate proves it cannot match. JSON evaluation uses exact row
+values. Parquet footer evaluation may cast min/max only when the cast preserves those bounds.
+Unsupported expressions and missing references remain unknown and must not fail the read.
+
 ### Default implementation
 
 The `DefaultEngine` uses `arrow_json` for parsing and the `object_store` crate for I/O.

--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -103,17 +103,13 @@ pub trait JsonHandler {
   columns match the `output_schema`. Missing fields should produce nulls for nullable columns.
 
 - **`read_json_files`**: Data must be returned in file order (same order as the `files` slice
-  argument), and rows within a file must be in source order. The predicate is an optional hint.  The
-  engine may ignore it.
+  argument), and rows within a file must be in source order. The predicate is an optional hint that
+  the engine may ignore. If applied, evaluate exact row values conservatively; unsupported
+  expressions and missing references remain unknown.
 
 - **`write_json_file`**: Must write newline-delimited JSON (one JSON object per line). Null
   columns should be omitted from the output to save space. The write must be atomic. If
   `overwrite` is false and the file exists, fail with an error.
-
-If a read handler applies the predicate hint, it may discard data only when conservative
-evaluation of the complete predicate proves it cannot match. JSON evaluation uses exact row
-values. Parquet footer evaluation may cast min/max only when the cast preserves those bounds.
-Unsupported expressions and missing references remain unknown and must not fail the read.
 
 ### Default implementation
 
@@ -162,6 +158,10 @@ must return a column of all nulls.
 
 **Ordering**: Like `JsonHandler`, data must be returned in file order, and rows within a
 file must be in source order.
+
+**Predicate hint**: If applied, the complete predicate may discard data only when conservative
+evaluation proves it cannot match. Footer min/max may be cast only when the cast preserves their
+bounds; unsupported expressions and missing references remain unknown.
 
 **Metadata columns**: The handler must support two virtual metadata columns that are not
 stored in the Parquet file but generated at read time:
@@ -320,4 +320,3 @@ pub trait PredicateEvaluator {
 ### Default implementation
 
 The `DefaultEngine` uses Arrow compute kernels for expression evaluation.
-

--- a/ffi/src/expressions/arrow_eval.rs
+++ b/ffi/src/expressions/arrow_eval.rs
@@ -972,6 +972,16 @@ mod tests {
             ) -> Option<Predicate> {
                 None
             }
+            fn eval_pred_cast(
+                &self,
+                _: BinaryPredicateOp,
+                _: &ColumnName,
+                _: &DataType,
+                _: &Scalar,
+                _: bool,
+            ) -> Option<Predicate> {
+                None
+            }
             fn eval_pred_opaque(
                 &self,
                 _: &OpaquePredicateOpRef,

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -880,11 +880,12 @@ pub trait DataSkippingPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
-    /// Override hook called by the blanket [`KernelPredicateEvaluator`] implementation for CAST.
+    /// See [`KernelPredicateEvaluator::eval_pred_cast`].
     ///
-    /// `inverted` represents the outer `NOT`. Returns `None` unless evaluation uses exact values or
-    /// the cast is proven to preserve the bounds represented by [`Self::ColumnStat`].
-    fn eval_data_skipping_pred_cast(
+    /// Implementations may evaluate exact values or rewrite casts over exact-value references. A
+    /// bound-based consumer of a rewritten predicate must independently prove that the cast
+    /// preserves those bounds.
+    fn eval_pred_cast(
         &self,
         _op: BinaryPredicateOp,
         _col: &ColumnName,
@@ -1071,9 +1072,7 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
         val: &Scalar,
         inverted: bool,
     ) -> Option<Self::Output> {
-        DataSkippingPredicateEvaluator::eval_data_skipping_pred_cast(
-            self, op, col, target, val, inverted,
-        )
+        DataSkippingPredicateEvaluator::eval_pred_cast(self, op, col, target, val, inverted)
     }
 
     fn eval_pred_opaque(

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -880,6 +880,21 @@ pub trait DataSkippingPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output>;
 
+    /// Override hook called by the blanket [`KernelPredicateEvaluator`] implementation for CAST.
+    ///
+    /// `inverted` represents the outer `NOT`. Returns `None` unless evaluation uses exact values or
+    /// the cast is proven to preserve the bounds represented by [`Self::ColumnStat`].
+    fn eval_data_skipping_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<Self::Output> {
+        None
+    }
+
     /// See [`KernelPredicateEvaluator::eval_pred_opaque`].
     fn eval_pred_opaque(
         &self,
@@ -1046,6 +1061,19 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
         _inverted: bool,
     ) -> Option<Self::Output> {
         None
+    }
+
+    fn eval_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Self::Output> {
+        DataSkippingPredicateEvaluator::eval_data_skipping_pred_cast(
+            self, op, col, target, val, inverted,
+        )
     }
 
     fn eval_pred_opaque(

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -887,14 +887,12 @@ pub trait DataSkippingPredicateEvaluator {
     /// preserves those bounds.
     fn eval_pred_cast(
         &self,
-        _op: BinaryPredicateOp,
-        _col: &ColumnName,
-        _target: &DataType,
-        _val: &Scalar,
-        _inverted: bool,
-    ) -> Option<Self::Output> {
-        None
-    }
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Self::Output>;
 
     /// See [`KernelPredicateEvaluator::eval_pred_opaque`].
     fn eval_pred_opaque(

--- a/kernel/src/kernel_predicates/parquet_stats_skipping.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping.rs
@@ -90,6 +90,17 @@ impl<T: ParquetStatsProvider> DataSkippingPredicateEvaluator for T {
         KernelPredicateEvaluatorDefaults::eval_pred_binary_scalars(op, left, right, inverted)
     }
 
+    fn eval_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<bool> {
+        None
+    }
+
     fn eval_pred_opaque(
         &self,
         op: &OpaquePredicateOpRef,

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -40,6 +40,17 @@ impl ParquetStatsProvider for UnimplementedTestFilter {
     }
 }
 
+#[test]
+fn test_cast_stays_unknown_for_parquet_stats() {
+    let filter = UnimplementedTestFilter;
+    let pred = Pred::eq(
+        Expr::cast(column_expr!("x"), DataType::DATE),
+        Scalar::Date(19_723),
+    );
+
+    expect_eq!(filter.eval(&pred), NULL, "{pred:#?}");
+}
+
 /// Tests apply_junction and apply_scalar
 #[test]
 fn test_junctions() {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -902,8 +902,9 @@ pub trait ParquetHandler: AsAny {
     /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. A
     ///   file, row group, or row may be omitted only when the predicate cannot evaluate to true for
     ///   any row in that unit. CAST and NULL semantics must agree with the eventual query filter.
-    ///   Casting footer min/max is valid only when the cast preserves those bounds; otherwise the
-    ///   CAST subexpression must remain unknown and must not fail the read. Other unsupported
+    ///   An evaluator using exact row values may evaluate a compatible CAST directly. Footer
+    ///   min/max may be cast only when the cast preserves those bounds; otherwise footer evaluation
+    ///   of the CAST must remain unknown and must not fail the read. Other unsupported
     ///   subexpressions and references with no matching physical or generated value must also
     ///   remain unknown and must not fail the read. A missing reference remains unknown for pruning
     ///   even if schema reconciliation synthesizes a NULL output column. Returned data is not

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -689,12 +689,10 @@ pub trait JsonHandler: AsAny {
     /// - `physical_schema` - Select list of columns to read from the JSON file.
     /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. If
     ///   applied, a file or row may be omitted only when the predicate cannot evaluate to true for
-    ///   any row in that unit. CAST conversion, failure, and NULL semantics must agree with the
-    ///   eventual query filter. JSON handlers evaluate exact row values, so footer-bound
-    ///   preservation does not apply. Unsupported subexpressions and references with no matching
-    ///   physical or generated value must remain unknown and must not fail the read. A missing
-    ///   reference remains unknown for pruning even if schema reconciliation synthesizes a NULL
-    ///   output column. Returned data is not guaranteed to satisfy the predicate.
+    ///   any row in that unit. CAST conversion, failure, and NULL semantics must match final
+    ///   filtering over exact row values. Unsupported or missing references remain unknown without
+    ///   failing the read, including references synthesized as NULL columns during schema
+    ///   reconciliation. Returned data is not guaranteed to satisfy the predicate.
     fn read_json_files(
         &self,
         files: &[FileMeta],
@@ -902,13 +900,13 @@ pub trait ParquetHandler: AsAny {
     /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. A
     ///   file, row group, or row may be omitted only when the predicate cannot evaluate to true for
     ///   any row in that unit. CAST and NULL semantics must agree with the eventual query filter.
-    ///   An evaluator using exact row values may evaluate a compatible CAST directly. Footer
-    ///   min/max may be cast only when the cast preserves those bounds; otherwise footer evaluation
-    ///   of the CAST must remain unknown and must not fail the read. Other unsupported
-    ///   subexpressions and references with no matching physical or generated value must also
-    ///   remain unknown and must not fail the read. A missing reference remains unknown for pruning
-    ///   even if schema reconciliation synthesizes a NULL output column. Returned data is not
-    ///   guaranteed to satisfy the predicate.
+    ///   An evaluator using exact row values may apply the CAST directly. Footer min/max may be
+    ///   cast only when the cast preserves those bounds; otherwise footer evaluation of the CAST
+    ///   must remain unknown and must not fail the read. Other unsupported subexpressions and
+    ///   references with no matching physical or generated value must also remain unknown without
+    ///   failing the read. A missing reference remains unknown for pruning even if schema
+    ///   reconciliation synthesizes a NULL output column. Returned data is not guaranteed to
+    ///   satisfy the predicate.
     ///
     /// # Returns
     /// A [`DeltaResult`] containing a [`FileDataReadResultIterator`].

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -689,10 +689,12 @@ pub trait JsonHandler: AsAny {
     /// - `physical_schema` - Select list of columns to read from the JSON file.
     /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. If
     ///   applied, a file or row may be omitted only when the predicate cannot evaluate to true for
-    ///   any row in that unit. Unsupported subexpressions and references with no matching physical
-    ///   or generated value must remain unknown and must not fail the read. A missing reference
-    ///   remains unknown for pruning even if schema reconciliation synthesizes a NULL output
-    ///   column. Returned data is not guaranteed to satisfy the predicate.
+    ///   any row in that unit. CAST conversion, failure, and NULL semantics must agree with the
+    ///   eventual query filter. JSON handlers evaluate exact row values, so footer-bound
+    ///   preservation does not apply. Unsupported subexpressions and references with no matching
+    ///   physical or generated value must remain unknown and must not fail the read. A missing
+    ///   reference remains unknown for pruning even if schema reconciliation synthesizes a NULL
+    ///   output column. Returned data is not guaranteed to satisfy the predicate.
     fn read_json_files(
         &self,
         files: &[FileMeta],
@@ -899,10 +901,13 @@ pub trait ParquetHandler: AsAny {
     /// - `physical_schema` - Select list and order of columns to read from the Parquet file.
     /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. A
     ///   file, row group, or row may be omitted only when the predicate cannot evaluate to true for
-    ///   any row in that unit. Unsupported subexpressions and references with no matching physical
-    ///   or generated value must remain unknown and must not fail the read. A missing reference
-    ///   remains unknown for pruning even if schema reconciliation synthesizes a NULL output
-    ///   column. Returned data is not guaranteed to satisfy the predicate.
+    ///   any row in that unit. CAST and NULL semantics must agree with the eventual query filter.
+    ///   Casting footer min/max is valid only when the cast preserves those bounds; otherwise the
+    ///   CAST subexpression must remain unknown and must not fail the read. Other unsupported
+    ///   subexpressions and references with no matching physical or generated value must also
+    ///   remain unknown and must not fail the read. A missing reference remains unknown for pruning
+    ///   even if schema reconciliation synthesizes a NULL output column. Returned data is not
+    ///   guaranteed to satisfy the predicate.
     ///
     /// # Returns
     /// A [`DeltaResult`] containing a [`FileDataReadResultIterator`].

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -825,8 +825,8 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
     }
 
-    /// Rewrites casts only over per-Add partition leaves; data-column casts return `None`.
-    fn eval_data_skipping_pred_cast(
+    /// Rewrites casts over exact per-Add partition values.
+    fn eval_pred_cast(
         &self,
         op: BinaryPredicateOp,
         col: &ColumnName,
@@ -834,7 +834,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         val: &Scalar,
         inverted: bool,
     ) -> Option<Pred> {
-        if !self.is_partition_column(col) || self.partition_min_max_may_omit_values(col) {
+        if !self.is_partition_column(col) {
             return None;
         }
         let ord = match op {

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -825,6 +825,28 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
     }
 
+    /// Rewrites casts only over per-Add partition leaves; data-column casts return `None`.
+    fn eval_data_skipping_pred_cast(
+        &self,
+        op: BinaryPredicateOp,
+        col: &ColumnName,
+        target: &DataType,
+        val: &Scalar,
+        inverted: bool,
+    ) -> Option<Pred> {
+        if !self.is_partition_column(col) || self.partition_min_max_may_omit_values(col) {
+            return None;
+        }
+        let ord = match op {
+            BinaryPredicateOp::LessThan => Ordering::Less,
+            BinaryPredicateOp::Equal => Ordering::Equal,
+            BinaryPredicateOp::GreaterThan => Ordering::Greater,
+            BinaryPredicateOp::Distinct | BinaryPredicateOp::In => return None,
+        };
+        let cast = Expr::cast(partition_value_expr(col), target.clone());
+        Some(comparison_predicate(ord, cast, val, inverted))
+    }
+
     /// Partition NULL checks use the exact parsed value. Data `IS NULL` uses a guarded null count;
     /// data `IS NOT NULL` remains unsupported because row-group filtering cannot compare it with
     /// `numRecords`.

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -715,6 +715,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             .map(Pred::literal)
     }
 
+    // TODO(#3011): Rewrite partition CASTs over exact values through the engine evaluator.
     fn eval_pred_cast(
         &self,
         _op: BinaryPredicateOp,

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -715,6 +715,17 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
             .map(Pred::literal)
     }
 
+    fn eval_pred_cast(
+        &self,
+        _op: BinaryPredicateOp,
+        _col: &ColumnName,
+        _target: &DataType,
+        _val: &Scalar,
+        _inverted: bool,
+    ) -> Option<Pred> {
+        None
+    }
+
     /// Rewrites an opaque predicate via its `as_data_skipping_predicate`, wrapped with
     /// `OR(NOT is_add, ...)`. Opaque rewrites may embed op-computed verdicts (e.g. an engine
     /// callback behind FFI) that bypass kernel's null-stats folding, so kernel itself must

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -834,7 +834,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         val: &Scalar,
         inverted: bool,
     ) -> Option<Pred> {
-        if !self.is_partition_column(col) {
+        if !self.data_skipping_columns.is_partition_column(col) {
             return None;
         }
         let ord = match op {

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -746,7 +746,7 @@ fn test_checkpoint_partition_cast_reference_eval_is_conservative(#[case] partiti
 }
 
 #[test]
-fn partition_cast_does_not_disable_safe_in_memory_conjunct() {
+fn partition_cast_preserves_supported_in_memory_conjunct() {
     let partition_columns = test_partition_columns();
     let pred = Pred::and(
         Pred::ge(

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -587,6 +587,202 @@ fn test_checkpoint_skipping_floating_partition_comparison_is_disabled(#[case] va
     );
 }
 
+#[test]
+fn test_checkpoint_skipping_floating_partition_cast_is_disabled() {
+    let partition_columns = HashSet::from([column_name!("part_col")]);
+    let pred = Pred::eq(
+        Expr::cast(column_expr!("part_col"), DataType::INTEGER),
+        Scalar::from(42),
+    );
+
+    assert!(
+        as_checkpoint_skipping_predicate(
+            &pred,
+            &partition_columns,
+            &partition_columns,
+            &HashSet::new(),
+        )
+        .is_none(),
+        "parquet footer min/max exclude NaN partition values"
+    );
+}
+
+#[rstest]
+#[case::range(
+    {
+        let cast = Expr::cast(column_expr!("part_col"), DataType::DATE);
+        Pred::and(
+            Pred::ge(cast.clone(), Scalar::Date(20_641)),
+            Pred::lt(cast, Scalar::Date(20_644)),
+        )
+    },
+    Some(concat!(
+        "AND(NOT(CAST(Column(partitionValues_parsed.part_col) AS date) < 20641), ",
+        "CAST(Column(partitionValues_parsed.part_col) AS date) < 20644)"
+    )),
+)]
+#[case::equality(
+    Pred::eq(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    Some("CAST(Column(partitionValues_parsed.part_col) AS date) = 20641"),
+)]
+#[case::inverted_less(
+    Pred::ge(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    Some("NOT(CAST(Column(partitionValues_parsed.part_col) AS date) < 20641)"),
+)]
+#[case::inverted_greater(
+    Pred::le(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    Some("NOT(CAST(Column(partitionValues_parsed.part_col) AS date) > 20641)"),
+)]
+#[case::inverted_equality(
+    Pred::ne(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    Some("NOT(CAST(Column(partitionValues_parsed.part_col) AS date) = 20641)"),
+)]
+#[case::literal_on_left(
+    Pred::lt(
+        Scalar::Date(20_641),
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+    ),
+    Some("CAST(Column(partitionValues_parsed.part_col) AS date) > 20641"),
+)]
+#[case::distinct(
+    Pred::binary(
+        BinaryPredicateOp::Distinct,
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    None,
+)]
+#[case::in_list(
+    Pred::binary(
+        BinaryPredicateOp::In,
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    None,
+)]
+fn test_checkpoint_skipping_partition_date_cast_comparisons(
+    #[case] pred: Pred,
+    #[case] expected: Option<&str>,
+) {
+    let partition_columns = test_partition_columns();
+    let actual = as_checkpoint_skipping_predicate(
+        &pred,
+        &partition_columns,
+        &HashSet::new(),
+        &HashSet::new(),
+    )
+    .map(|pred| pred.to_string());
+
+    assert_eq!(actual.as_deref(), expected);
+}
+
+#[test]
+fn test_partition_date_cast_is_checkpoint_only() {
+    let partition_columns = test_partition_columns();
+    let partition_cast = Pred::eq(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    );
+    let data_cast = Pred::eq(
+        Expr::cast(column_expr!("data_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    );
+
+    assert!(
+        as_checkpoint_skipping_predicate(
+            &data_cast,
+            &partition_columns,
+            &HashSet::new(),
+            &HashSet::from([column_name!("data_col")]),
+        )
+        .is_none(),
+        "checkpoint CAST pushdown requires an exact partition value"
+    );
+    assert!(
+        as_data_skipping_predicate_with_partitions(&partition_cast, &partition_columns).is_none(),
+        "in-memory data skipping must not evaluate partition casts"
+    );
+}
+
+#[rstest]
+#[case::null_value(Scalar::Null(DataType::STRING))]
+#[case::invalid_value(Scalar::from("not-a-date"))]
+fn test_checkpoint_partition_cast_reference_eval_is_conservative(#[case] partition_value: Scalar) {
+    let partition_columns = test_partition_columns();
+    let pred = Pred::eq(
+        Expr::cast(column_expr!("part_col"), DataType::DATE),
+        Scalar::Date(20_641),
+    );
+    let skipping_pred = as_checkpoint_skipping_predicate(
+        &pred,
+        &partition_columns,
+        &HashSet::new(),
+        &HashSet::new(),
+    )
+    .unwrap();
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        partition_value,
+    )]));
+
+    expect_eq!(
+        resolver.eval(&skipping_pred),
+        NULL,
+        "null and invalid partition values must evaluate to NULL"
+    );
+}
+
+#[test]
+fn partition_cast_does_not_disable_safe_in_memory_conjunct() {
+    let partition_columns = test_partition_columns();
+    let pred = Pred::and(
+        Pred::ge(
+            Expr::cast(column_expr!("part_col"), DataType::DATE),
+            Scalar::Date(20_641),
+        ),
+        Pred::gt(column_expr!("data_col"), Scalar::from(100)),
+    );
+
+    let skipping_pred =
+        as_data_skipping_predicate_with_partitions(&pred, &partition_columns).unwrap();
+
+    assert_eq!(
+        skipping_pred.to_string(),
+        "AND(null, Column(stats_parsed.maxValues.data_col) > 100)"
+    );
+
+    let checkpoint_pred = as_checkpoint_skipping_predicate(
+        &pred,
+        &partition_columns,
+        &HashSet::new(),
+        &HashSet::from([column_name!("data_col")]),
+    )
+    .unwrap()
+    .to_string();
+    assert!(
+        checkpoint_pred.contains("CAST(Column(partitionValues_parsed.part_col) AS date)"),
+        "{checkpoint_pred}"
+    );
+    assert!(
+        checkpoint_pred.contains("stats_parsed.maxValues.data_col"),
+        "{checkpoint_pred}"
+    );
+}
+
+// Partition null predicates read `partitionValues_parsed.part_col` directly. FALSE is the pruning
+// verdict; TRUE keeps the row group.
 #[rstest]
 #[case::is_null_null(false, Scalar::Null(DataType::STRING), TRUE)]
 #[case::is_null_value(false, Scalar::from("x"), FALSE)]
@@ -627,6 +823,10 @@ fn test_checkpoint_skipping_partition_missing_stats_keeps_all() {
     for pred in [
         Pred::eq(column_expr!("part_col"), Scalar::from("B")),
         Pred::lt(column_expr!("part_col"), Scalar::from("B")),
+        Pred::eq(
+            Expr::cast(column_expr!("part_col"), DataType::DATE),
+            Scalar::Date(20_641),
+        ),
         Pred::is_null(column_expr!("part_col")),
         Pred::is_not_null(column_expr!("part_col")),
     ] {

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -588,22 +588,23 @@ fn test_checkpoint_skipping_floating_partition_comparison_is_disabled(#[case] va
 }
 
 #[test]
-fn test_checkpoint_skipping_floating_partition_cast_is_disabled() {
+fn test_checkpoint_skipping_floating_partition_cast_rewrites_exact_value() {
     let partition_columns = HashSet::from([column_name!("part_col")]);
     let pred = Pred::eq(
         Expr::cast(column_expr!("part_col"), DataType::INTEGER),
         Scalar::from(42),
     );
 
-    assert!(
-        as_checkpoint_skipping_predicate(
-            &pred,
-            &partition_columns,
-            &partition_columns,
-            &HashSet::new(),
-        )
-        .is_none(),
-        "parquet footer min/max exclude NaN partition values"
+    let skipping_pred = as_checkpoint_skipping_predicate(
+        &pred,
+        &partition_columns,
+        &partition_columns,
+        &HashSet::new(),
+    );
+
+    assert_eq!(
+        skipping_pred.map(|pred| pred.to_string()).as_deref(),
+        Some("CAST(Column(partitionValues_parsed.part_col) AS integer) = 42")
     );
 }
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -689,6 +689,85 @@ fn test_checkpoint_skipping_partition_date_cast_comparisons(
     assert_eq!(actual.as_deref(), expected);
 }
 
+fn partition_date_cast() -> Expr {
+    Expr::cast(column_expr!("part_col"), DataType::DATE)
+}
+
+#[rstest]
+#[case::eq_match(
+    Pred::eq(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    TRUE
+)]
+#[case::eq_nomatch(
+    Pred::eq(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-08",
+    FALSE
+)]
+#[case::lt_true(
+    Pred::lt(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-06",
+    TRUE
+)]
+#[case::lt_false(
+    Pred::lt(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    FALSE
+)]
+#[case::gt_true(
+    Pred::gt(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-08",
+    TRUE
+)]
+#[case::gt_false(
+    Pred::gt(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    FALSE
+)]
+#[case::ge_boundary(
+    Pred::ge(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    TRUE
+)]
+#[case::le_boundary(
+    Pred::le(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    TRUE
+)]
+#[case::ne_match(
+    Pred::ne(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-07",
+    FALSE
+)]
+#[case::ne_nomatch(
+    Pred::ne(partition_date_cast(), Scalar::Date(20_641)),
+    "2026-07-08",
+    TRUE
+)]
+fn test_checkpoint_partition_cast_eval_discriminates_per_operator(
+    #[case] pred: Pred,
+    #[case] partition_value: &str,
+    #[case] expected: Option<bool>,
+) {
+    let skipping_pred = as_checkpoint_skipping_predicate(
+        &pred,
+        &test_partition_columns(),
+        &HashSet::new(),
+        &HashSet::new(),
+    )
+    .unwrap();
+    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+        column_name!("partitionValues_parsed.part_col"),
+        Scalar::from(partition_value),
+    )]));
+
+    expect_eq!(
+        resolver.eval(&skipping_pred),
+        expected,
+        "{pred:#?} @ {partition_value}"
+    );
+}
+
 #[test]
 fn test_partition_date_cast_is_checkpoint_only() {
     let partition_columns = test_partition_columns();

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1168,31 +1168,45 @@ fn test_build_actions_meta_predicate_static_skip_all() {
 }
 
 // Partition-only scans have no stats schema, so the partition schema must enable the rewrite.
-#[test]
-fn test_build_actions_meta_predicate_partition_only() {
+#[rstest]
+#[case::equality(Pred::eq(
+    column_expr!("modified"),
+    Expr::literal("2021-02-01"),
+), None)]
+#[case::date_cast_range(Pred::and(
+    Pred::ge(
+        Expr::cast(column_expr!("modified"), DataType::DATE),
+        Scalar::Date(20_641),
+    ),
+    Pred::lt(
+        Expr::cast(column_expr!("modified"), DataType::DATE),
+        Scalar::Date(20_644),
+    ),
+), Some("CAST(Column(add.partitionValues_parsed.modified) AS date)"))]
+fn test_build_actions_meta_predicate_partition_only(
+    #[case] predicate: Pred,
+    #[case] expected_cast: Option<&str>,
+) {
     // `app-txn-checkpoint` is partitioned by `modified` (string), no column mapping.
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
     let engine = SyncEngine::new();
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
-    let predicate = Arc::new(Pred::eq(
-        column_expr!("modified"),
-        Expr::literal("2021-02-01"),
-    ));
     let scan = snapshot
         .scan_builder()
-        .with_predicate(predicate)
+        .with_predicate(Arc::new(predicate))
         .build()
         .unwrap();
 
-    let meta_pred = scan.build_actions_meta_predicate();
-    assert!(
-        meta_pred.is_some(),
-        "partition-only predicate should still produce a checkpoint meta-predicate"
-    );
+    let meta_pred = scan
+        .build_actions_meta_predicate()
+        .expect("partition-only predicate should produce a checkpoint meta-predicate");
+    let rendered = meta_pred.to_string();
+    if let Some(expected_cast) = expected_cast {
+        assert!(rendered.contains(expected_cast), "{rendered}");
+    }
     let refs: Vec<String> = meta_pred
-        .unwrap()
         .references()
         .into_iter()
         .map(|c| c.to_string())
@@ -1218,20 +1232,25 @@ fn test_build_actions_meta_predicate_partition_column_mapping(#[case] mode: &str
     let engine = SyncEngine::new();
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
-    let predicate = Arc::new(Pred::eq(column_expr!("category"), Expr::literal("a")));
+    let predicate = Arc::new(Pred::eq(
+        Expr::cast(column_expr!("category"), DataType::DATE),
+        Scalar::Date(20_641),
+    ));
     let scan = snapshot
         .scan_builder()
         .with_predicate(predicate)
         .build()
         .unwrap();
 
-    let meta_pred = scan.build_actions_meta_predicate();
+    let meta_pred = scan
+        .build_actions_meta_predicate()
+        .expect("partition predicate under column mapping should produce a meta-predicate");
+    let rendered = meta_pred.to_string();
     assert!(
-        meta_pred.is_some(),
-        "partition predicate under column mapping should produce a meta-predicate"
+        rendered.contains("CAST(Column(add.partitionValues_parsed"),
+        "{rendered}"
     );
     let refs: Vec<String> = meta_pred
-        .unwrap()
         .references()
         .into_iter()
         .map(|c| c.to_string())
@@ -1632,6 +1651,13 @@ fn standard_multi_rg() -> Bytes {
 #[case::partition_eq(Pred::eq(column_expr!("part"), Expr::literal("a")), vec![1, 3])]
 #[case::partition_lt(Pred::lt(column_expr!("part"), Expr::literal("b")), vec![1, 3])]
 #[case::partition_all_pruned(Pred::eq(column_expr!("part"), Expr::literal("z")), vec![])]
+#[case::partition_cast_kept(
+    Pred::eq(
+        Expr::cast(column_expr!("part"), DataType::DATE),
+        Scalar::Date(18_628),
+    ),
+    vec![1, 2, 3, 4]
+)]
 #[case::and_stats_and_partition(
     Pred::and(
         Pred::eq(column_expr!("part"), Expr::literal("a")),

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1658,6 +1658,16 @@ fn standard_multi_rg() -> Bytes {
     ),
     vec![1, 2, 3, 4]
 )]
+#[case::partition_cast_and_stats(
+    Pred::and(
+        Pred::eq(
+            Expr::cast(column_expr!("part"), DataType::DATE),
+            Scalar::Date(18_628),
+        ),
+        Pred::gt(column_expr!("x"), Expr::literal(150i64)),
+    ),
+    vec![3, 4]
+)]
 #[case::and_stats_and_partition(
     Pred::and(
         Pred::eq(column_expr!("part"), Expr::literal("a")),

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1223,7 +1223,10 @@ fn test_build_actions_meta_predicate_partition_only(
 #[rstest]
 #[case::name_mode("name")]
 #[case::id_mode("id")]
-fn test_build_actions_meta_predicate_partition_column_mapping(#[case] mode: &str) {
+fn test_build_actions_meta_predicate_partition_column_mapping(
+    #[case] mode: &str,
+    #[values(false, true)] casted: bool,
+) {
     // `partition_cm/{name,id}` use column mapping, partitioned by `category`
     // (physical name col-6dc68f07-711d-4f00-8bd6-1f5bc698e8ad in both fixtures).
     let path =
@@ -1232,13 +1235,17 @@ fn test_build_actions_meta_predicate_partition_column_mapping(#[case] mode: &str
     let engine = SyncEngine::new();
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
 
-    let predicate = Arc::new(Pred::eq(
-        Expr::cast(column_expr!("category"), DataType::DATE),
-        Scalar::Date(20_641),
-    ));
+    let predicate = if casted {
+        Pred::eq(
+            Expr::cast(column_expr!("category"), DataType::DATE),
+            Scalar::Date(20_641),
+        )
+    } else {
+        Pred::eq(column_expr!("category"), Expr::literal("a"))
+    };
     let scan = snapshot
         .scan_builder()
-        .with_predicate(predicate)
+        .with_predicate(Arc::new(predicate))
         .build()
         .unwrap();
 
@@ -1246,10 +1253,7 @@ fn test_build_actions_meta_predicate_partition_column_mapping(#[case] mode: &str
         .build_actions_meta_predicate()
         .expect("partition predicate under column mapping should produce a meta-predicate");
     let rendered = meta_pred.to_string();
-    assert!(
-        rendered.contains("CAST(Column(add.partitionValues_parsed"),
-        "{rendered}"
-    );
+    assert_eq!(rendered.contains("CAST("), casted, "{rendered}");
     let refs: Vec<String> = meta_pred
         .references()
         .into_iter()


### PR DESCRIPTION
## Stacked PR

Review the [incremental diff](https://github.com/delta-io/delta-kernel-rs/pull/2983/files) for `stack/checkpoint-cast-pushdown`.

---

## What changes are proposed in this pull request?

This PR preserves comparisons over partition-column casts in the predicate passed to checkpoint Parquet handlers.

For example:

```text
CAST(partition_col AS DATE) >= <date>
```

is rewritten to reference the typed checkpoint value:

```text
CAST(add.partitionValues_parsed.<physical_column> AS DATE) >= <date>
```

The handler can then use the predicate for row-group skipping when its CAST and NULL semantics match final query evaluation.

Safety boundaries:

- Only partition columns are rewritten. Data-column casts remain unknown because applying an arbitrary cast to min/max statistics can produce unsound bounds.
- Parquet handlers must prune conservatively. They may use casted footer bounds only when the cast preserves those bounds.
- Unsupported CAST terms remain unknown, while independent safe conjuncts can still prune.

This PR does not add CAST support to the in-memory `DataSkippingFilter` or the default Parquet footer evaluator. The in-memory follow-up is tracked in [#3011](https://github.com/delta-io/delta-kernel-rs/issues/3011).

## How was this change tested?

- `cargo nextest run -p delta_kernel --lib --all-features` (4,161 passed)
- `cargo nextest run -p delta_kernel --lib --all-features partition_cast`
- `cargo clippy -p delta_kernel --lib --all-features -- -D warnings`
- `cargo doc -p delta_kernel --all-features --no-deps`
