### PR TITLE
feat: expose partition path encoding helpers

### DIFF
--- a/kernel/src/partition/hive.rs
+++ b/kernel/src/partition/hive.rs
@@ -26,6 +26,7 @@
 
 use std::borrow::Cow;
 
+use delta_kernel_derive::internal_api;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 
 const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
@@ -65,6 +66,7 @@ const HADOOP_URI_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
 /// [`build_partition_path`], as used by kernel-java and Delta-Spark. Returns
 /// [`Cow::Borrowed`] when no encoding is needed (zero allocation fast path).
 /// See the module-level documentation in [`super`] for the full pipeline.
+#[internal_api]
 pub(crate) fn uri_encode_path(hive_escaped: &str) -> Cow<'_, str> {
     utf8_percent_encode(hive_escaped, HADOOP_URI_PATH_ENCODE_SET).into()
 }
@@ -132,6 +134,7 @@ pub(crate) fn escape_partition_value(s: &str) -> Cow<'_, str> {
 /// assert_eq!(null_path, empty_path);
 /// assert_eq!(null_path, "col=__HIVE_DEFAULT_PARTITION__/");
 /// ```
+#[internal_api]
 pub(crate) fn build_partition_path(columns: &[(&str, Option<&str>)]) -> String {
     // Lower-bound capacity: exact when no escaping needed (the common case for
     // partition names and most values like dates, integers, short strings).

--- a/kernel/src/partition/mod.rs
+++ b/kernel/src/partition/mod.rs
@@ -162,6 +162,9 @@
 //! becomes unparseable. In kernel, `escape_partition_value` takes `&str`, so Rust's type
 //! system prevents non-UTF-8 bytes from reaching the encoding layer.
 
+#[cfg(feature = "internal-api")]
+pub mod hive;
+#[cfg(not(feature = "internal-api"))]
 pub(crate) mod hive;
 pub mod serialization;
 pub(crate) mod validation;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose Hive partition path construction and Delta add-path URI encoding through the `internal-api` feature. This lets custom clients reuse Kernel's escaping behavior when they cannot use `WriteContext::write_dir()`, avoiding copied implementations that could drift from Kernel.

### This PR affects the following public APIs

The `partition::hive` module, `build_partition_path`, and `uri_encode_path` are public when the unstable `internal-api` feature is enabled.

## How was this change tested?

- `cargo +nightly fmt --check`
- Existing Hive path tests cover multiple columns, escaping, null values, and URI encoding.
- The focused test command could not download dependencies because `index.crates.io` DNS resolution was unavailable in the development environment.
