### PR TITLE
fix: make generic errors more specific in snapshot creation

### DIFF
--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -357,7 +357,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Time-travel version 5 exceeds max_catalog_version 3"));
+            .contains("Requested version 5 exceeds max catalog version 3"));
     }
 
     #[tokio::test]
@@ -395,7 +395,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("log_tail must be sorted and contiguous"));
+            .contains("Log tail versions 1 and 3 are not contiguous"));
     }
 
     #[rstest]

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -84,6 +84,7 @@ impl From<Error> for KernelError {
             Error::Extract(..) => KernelError::ExtractError,
             Error::Generic(_) => KernelError::GenericError,
             Error::GenericError { .. } => KernelError::GenericError,
+            Error::MaxCatalogVersion(_) => KernelError::GenericError,
             Error::IOError(_) => KernelError::IOErrorError,
             #[cfg(feature = "default-engine-base")]
             Error::Parquet(_) => KernelError::ParquetError,

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -85,6 +85,7 @@ impl From<Error> for KernelError {
             Error::Generic(_) => KernelError::GenericError,
             Error::GenericError { .. } => KernelError::GenericError,
             Error::MaxCatalogVersion(_) => KernelError::GenericError,
+            Error::LogTailVersionsNotContiguous { .. } => KernelError::GenericError,
             Error::IOError(_) => KernelError::IOErrorError,
             #[cfg(feature = "default-engine-base")]
             Error::Parquet(_) => KernelError::ParquetError,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2838,9 +2838,9 @@ mod tests {
             invalid_snapshot,
             KernelError::GenericError,
             Some(concat!(
-                "Generic delta kernel error: Staged commits in log_tail require ",
-                "max_catalog_version to be set. Use with_max_catalog_version() ",
-                "when providing staged commits."
+                "Max catalog version error: Max catalog version is required when providing ",
+                "staged commits in the log tail. ",
+                "Use with_max_catalog_version()."
             )),
         );
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -71,6 +71,15 @@ pub enum Error {
     #[error("Max catalog version error: {0}")]
     MaxCatalogVersion(String),
 
+    /// The supplied log tail contains adjacent versions that are not contiguous.
+    #[error("Log tail versions {first_version} and {second_version} are not contiguous")]
+    LogTailVersionsNotContiguous {
+        /// Earlier version in the invalid adjacent pair.
+        first_version: Version,
+        /// Later version in the invalid adjacent pair.
+        second_version: Version,
+    },
+
     /// Some kind of [`std::io::Error`]
     #[error(transparent)]
     IOError(std::io::Error),

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -67,6 +67,10 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
+    /// An error involving the maximum catalog-ratified version when building a snapshot.
+    #[error("Max catalog version error: {0}")]
+    MaxCatalogVersion(String),
+
     /// Some kind of [`std::io::Error`]
     #[error(transparent)]
     IOError(std::io::Error),

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -329,8 +329,8 @@ impl SnapshotBuilder {
         for pair in log_tail.windows(2) {
             require!(
                 pair[0].version + 1 == pair[1].version,
-                Error::generic(format!(
-                    "log_tail must be sorted and contiguous, but found versions {} and {}",
+                Error::MaxCatalogVersion(format!(
+                    "Log tail versions {} and {} are not contiguous",
                     pair[0].version, pair[1].version
                 ))
             );
@@ -345,9 +345,10 @@ impl SnapshotBuilder {
         // Staged commits require max_catalog_version
         require!(
             !has_catalog_commits || max_catalog_version.is_some(),
-            Error::generic(
-                "Staged commits in log_tail require max_catalog_version to be set. \
-                 Use with_max_catalog_version() when providing staged commits."
+            Error::MaxCatalogVersion(
+                "Max catalog version is required when providing staged commits in the log tail. \
+                 Use with_max_catalog_version()."
+                    .to_string()
             )
         );
 
@@ -355,8 +356,8 @@ impl SnapshotBuilder {
         if let (Some(ver), Some(max_cv)) = (version, max_catalog_version) {
             require!(
                 ver <= max_cv,
-                Error::generic(format!(
-                    "Time-travel version {ver} exceeds max_catalog_version {max_cv}"
+                Error::MaxCatalogVersion(format!(
+                    "Requested version {ver} exceeds max catalog version {max_cv}"
                 ))
             );
         }
@@ -367,8 +368,9 @@ impl SnapshotBuilder {
                 // With time-travel: last log_tail entry must be >= requested version
                 require!(
                     last.version >= ver,
-                    Error::generic(format!(
-                        "Log tail last version {} is less than requested version {ver}",
+                    Error::MaxCatalogVersion(format!(
+                        "Log tail version {} is less than requested version {ver} for max catalog \
+                         version {max_cv}",
                         last.version
                     ))
                 );
@@ -376,8 +378,8 @@ impl SnapshotBuilder {
                 // Without time-travel: last log_tail entry must == max_catalog_version
                 require!(
                     last.version == max_cv,
-                    Error::generic(format!(
-                        "Log tail last version {} does not match max_catalog_version {max_cv}",
+                    Error::MaxCatalogVersion(format!(
+                        "Log tail version {} does not match max catalog version {max_cv}",
                         last.version
                     ))
                 );
@@ -397,15 +399,21 @@ impl SnapshotBuilder {
 
         require!(
             !is_catalog_managed || max_catalog_version.is_some(),
-            Error::generic(
-                "Catalog-managed table requires max_catalog_version to be set. \
-                 Use with_max_catalog_version() when loading a catalog-managed table."
+            Error::MaxCatalogVersion(
+                "Max catalog version is required when loading a catalog-managed table. \
+                 Use with_max_catalog_version()."
+                    .to_string()
             )
         );
-        require!(
-            is_catalog_managed || max_catalog_version.is_none(),
-            Error::generic("max_catalog_version must not be set for non-catalog-managed tables.")
-        );
+        if let Some(max_catalog_version) = max_catalog_version {
+            require!(
+                is_catalog_managed,
+                Error::MaxCatalogVersion(format!(
+                    "Max catalog version {max_catalog_version} must not be set for a \
+                     non-catalog-managed table"
+                ))
+            );
+        }
 
         Ok(())
     }
@@ -862,10 +870,7 @@ mod tests {
                 .with_log_tail(log_tail)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Staged commits in log_tail require max_catalog_version"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -880,10 +885,7 @@ mod tests {
                 .with_max_catalog_version(3)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Time-travel version 5 exceeds max_catalog_version 3"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -908,10 +910,7 @@ mod tests {
                 .with_max_catalog_version(3)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Log tail last version 2 does not match max_catalog_version 3"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -923,10 +922,7 @@ mod tests {
 
             let result = SnapshotBuilder::new_for(table_root).build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Catalog-managed table requires max_catalog_version"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -943,10 +939,7 @@ mod tests {
                 .with_max_catalog_version(0)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("max_catalog_version must not be set for non-catalog-managed tables"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -970,10 +963,7 @@ mod tests {
                 .with_max_catalog_version(3)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Log tail last version 1 is less than requested version 2"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -1027,10 +1017,7 @@ mod tests {
             // Incremental update without mcv should fail
             let result = SnapshotBuilder::new_from(initial).build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("Catalog-managed table requires max_catalog_version"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }
@@ -1063,10 +1050,7 @@ mod tests {
                 .with_max_catalog_version(mcv)
                 .build(engine.as_ref());
 
-            assert!(result
-                .unwrap_err()
-                .to_string()
-                .contains("log_tail must be sorted and contiguous"));
+            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
 
             Ok(())
         }

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -329,10 +329,10 @@ impl SnapshotBuilder {
         for pair in log_tail.windows(2) {
             require!(
                 pair[0].version + 1 == pair[1].version,
-                Error::MaxCatalogVersion(format!(
-                    "Log tail versions {} and {} are not contiguous",
-                    pair[0].version, pair[1].version
-                ))
+                Error::LogTailVersionsNotContiguous {
+                    first_version: pair[0].version,
+                    second_version: pair[1].version,
+                }
             );
         }
 
@@ -1050,7 +1050,10 @@ mod tests {
                 .with_max_catalog_version(mcv)
                 .build(engine.as_ref());
 
-            assert!(matches!(result, Err(Error::MaxCatalogVersion(_))));
+            assert!(matches!(
+                result,
+                Err(Error::LogTailVersionsNotContiguous { .. })
+            ));
 
             Ok(())
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously we just used generic errors for max catalog version and non-continuous log segments in snapshot creation. This PR adds new errors which give more information in these cases.

## How was this change tested?

All tests still passing