### PR TITLE
fix: fold checkpoint skipping predicate unsupported arms to true

### DIFF
--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -363,9 +363,11 @@ pub trait KernelPredicateEvaluator {
 
     /// Evaluates a (possibly inverted) predicate with SQL WHERE semantics.
     ///
-    /// NOTE: A NULL literal in a boolean position is treated as unknown (not false), because
-    /// callers like `build_actions_meta_predicate` use NULL as a sentinel for unsupported arms.
-    /// Treating it as false would let `AND(supported, NULL)` incorrectly prune files.
+    /// NOTE: A NULL literal in a boolean position is treated as unknown (not false), because the
+    /// in-memory data-skipping predicate uses NULL as a sentinel for unsupported arms. Treating it
+    /// as false would let `AND(supported, NULL)` incorrectly prune files. (The checkpoint
+    /// pushdown predicate instead folds unsupported arms to TRUE, since it may be evaluated by a
+    /// two-valued row filter that has no unknown; see `as_checkpoint_skipping_predicate`.)
     ///
     /// By default, [`Self::eval_pred`] behaves badly for comparisons involving NULL columns
     /// (e.g. `a < 10` when `a` is NULL), because the comparison correctly evaluates to NULL, but

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -427,9 +427,10 @@ impl DataSkippingFilter {
 /// pass an empty set for unpartitioned tables.
 ///
 /// `physical_stats_columns` restricts rewrites to columns which are expected to have stats
-/// collected; other references fold to NULL (keeps the file). Must match the column set
+/// collected; other references fold to TRUE (keeps the file). Must match the column set
 /// used to build `physical_stats_schema`, otherwise the row-group filter sees a missing
-/// field.
+/// field. TRUE (rather than NULL) keeps the predicate sound whether the reader applies it as a
+/// row-group hint or an exact row filter (see `finish_eval_pred_junction` below).
 pub(crate) fn as_checkpoint_skipping_predicate(
     pred: &Pred,
     physical_partition_columns: &HashSet<ColumnName>,
@@ -886,19 +887,34 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         None
     }
 
-    /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` →
+    /// Combines sub-predicates with AND/OR, replacing unsupported arms with TRUE. `col_a > 100
+    /// AND col_b < 50` →
     /// ```text
     /// AND(
     ///   OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
     ///   OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
     /// )
     /// ```
+    ///
+    /// Unlike the in-memory creator (whose result is evaluated with `eval_sql_where`
+    /// three-valued logic, where an unsupported arm can safely fold to NULL), this predicate is
+    /// pushed to the parquet reader, which may apply it as an exact row filter under ordinary
+    /// two-valued logic. A NULL there reads as false and would drop a row the arm cannot judge,
+    /// so unsupported arms fold to TRUE (keep). TRUE is neutral under both logics
+    /// (`AND(x, TRUE) = x`, `OR(x, TRUE) = TRUE`), so the predicate is sound whether the reader
+    /// skips row groups or filters rows.
     fn finish_eval_pred_junction(
         &self,
-        op: JunctionPredicateOp,
+        mut op: JunctionPredicateOp,
         preds: &mut dyn Iterator<Item = Option<Pred>>,
         inverted: bool,
     ) -> Option<Pred> {
-        Some(collect_junction_preds(op, preds, inverted))
+        if inverted {
+            op = op.invert();
+        }
+        Some(Pred::junction(
+            op,
+            preds.map(|pred| pred.unwrap_or_else(|| Pred::literal(true))),
+        ))
     }
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -1548,11 +1548,12 @@ fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
     );
 }
 
-/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint
-/// creator, which adds an `IS NULL` guard on each stat ref for safe parquet
-/// row-group filtering. The non-stat arm still folds to NULL.
+/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint creator,
+/// which adds an `IS NULL` guard on each stat ref for safe parquet row-group filtering. The
+/// non-stat arm folds to TRUE (not NULL) so the pushed predicate is sound whether the reader
+/// applies it as a row-group hint or a two-valued exact row filter.
 #[test]
-fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
+fn checkpoint_pushdown_non_stat_arm_folds_to_true_literal() {
     let pred = Pred::and(
         Pred::gt(column_expr!("stat"), Scalar::from(100)),
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
@@ -1561,6 +1562,32 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
     let result = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
     assert_eq!(
         result.to_string(),
-        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, Column(stats_parsed.maxValues.stat) > 100), null)"
+        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, Column(stats_parsed.maxValues.stat) > 100), true)"
+    );
+}
+
+/// Guards the reason for the TRUE fold. When the supported arm evaluates TRUE (keep), the
+/// whole predicate must be TRUE. The TRUE-folded unsupported arm gives `AND(TRUE, TRUE) =
+/// TRUE`; a NULL fold would give `AND(TRUE, NULL) = NULL`, which a two-valued row filter reads
+/// as false -> a dropped row -> a lost live Add. Resolving the stat isolates the fold's effect.
+#[test]
+fn checkpoint_pushdown_true_fold_does_not_poison_supported_arm() {
+    let pred = Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    );
+    let stats = stats_cols(&["stat"]);
+    let result = as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &stats).unwrap();
+    // maxValues.stat = 150 makes the supported arm `150 > 100` TRUE (keep). With a TRUE fold the
+    // predicate is TRUE; a NULL fold would collapse it to NULL (unknown), which is the bug.
+    let resolver = HashMap::from_iter([(
+        column_name!("stats_parsed.maxValues.stat"),
+        Scalar::from(150i32),
+    )]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    expect_eq!(
+        filter.eval(&result),
+        TRUE,
+        "TRUE-folded unsupported arm leaves the supported arm's keep verdict intact"
     );
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The checkpoint data-skipping predicate (built by `as_checkpoint_skipping_predicate` and pushed into the checkpoint parquet read as a `meta_predicate`) folded predicate arms it could not rewrite -- e.g. a column with no collected stats -- to a `NULL` literal. `NULL` is a three-valued-logic sentinel: it is only sound when the consumer evaluates the predicate with SQL `WHERE` (three-valued) semantics, where `AND(supported, NULL)` stays unknown and keeps the file.

But this predicate is a push-down hint to the engine's parquet reader, and an engine may apply it as an exact row filter under ordinary two-valued logic. There, `NULL` in a boolean position reads as false, so `AND(supported, NULL)` drops the row -- silently discarding a file the arm could not actually judge.

This changes the checkpoint evaluator to fold unsupported arms to `TRUE` (keep) instead of `NULL`. `TRUE` is neutral under both logics (`AND(x, TRUE) = x`, `OR(x, TRUE) = TRUE`) and never drops a row, so the pushed predicate is sound whether the reader skips row groups or filters rows.

The in-memory data-skipping evaluator is unchanged: its result is evaluated by kernel via `eval_sql_where` (three-valued), where the `NULL` fold is correct. Only the checkpoint pushdown evaluator changes.

## How was this change tested?

Updated the unit test that pinned the old `NULL` fold to assert the `TRUE` fold, and added a test that evaluates the checkpoint predicate under two-valued semantics to confirm an unsupported arm keeps the row rather than dropping it. Full `delta_kernel` lib suite, fmt, and clippy pass.
