### PR TITLE
fix: fold checkpoint skipping predicate unsupported arms to true

### DIFF
--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -363,9 +363,9 @@ pub trait KernelPredicateEvaluator {
 
     /// Evaluates a (possibly inverted) predicate with SQL WHERE semantics.
     ///
-    /// NOTE: A NULL literal in a boolean position is treated as unknown (not false), because
-    /// callers like `build_actions_meta_predicate` use NULL as a sentinel for unsupported arms.
-    /// Treating it as false would let `AND(supported, NULL)` incorrectly prune files.
+    /// NOTE: A NULL literal in a boolean position is treated as unknown, not false. Predicate
+    /// rewriters may use NULL as a sentinel for unsupported arms, so treating it as false could
+    /// make `AND(supported, NULL)` incorrectly prune files.
     ///
     /// By default, [`Self::eval_pred`] behaves badly for comparisons involving NULL columns
     /// (e.g. `a < 10` when `a` is NULL), because the comparison correctly evaluates to NULL, but

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -415,13 +415,13 @@ impl DataSkippingFilter {
 /// IS NULL guarded `stats_parsed.{minValues,maxValues,nullCount}.<col>` comparisons; eligible
 /// partition references become exact, unguarded `partitionValues_parsed.<col>` values. Checkpoint
 /// Removes are irrelevant to scan replay, so partition predicates may prune their null add-side
-/// values. A bare unsupported predicate returns `None`; unsupported junction arms become NULL
-/// literals to preserve three-valued logic.
+/// values. A structurally unsupported leaf returns `None`. When a junction child produces no
+/// usable checkpoint condition, the creator substitutes TRUE so the child cannot exclude an Add.
 ///
 /// `physical_partition_columns` may be narrowed to the predicate's references; pass an empty set
 /// for unpartitioned tables. `physical_floating_partition_columns` identifies FLOAT and DOUBLE
 /// partitions whose parquet min/max may omit NaNs. `physical_stats_columns` is the table-level
-/// stats membership set; references outside it fold to NULL (keeping the file).
+/// stats membership set; references outside it cannot produce data-stat conditions.
 pub(crate) fn as_checkpoint_skipping_predicate(
     pred: &Pred,
     physical_partition_columns: &HashSet<ColumnName>,
@@ -871,19 +871,23 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         None
     }
 
-    /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` becomes
-    /// ```text
-    /// AND(
-    ///   OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
-    ///   OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
-    /// )
-    /// ```
+    /// Replaces each child that produced no usable checkpoint condition with TRUE, the conservative
+    /// may-match value required by the Parquet pushdown contract. This preserves supported pruning
+    /// under AND and disables pruning under OR, where the missing child may match. Kernel's
+    /// `eval_pred_sql_where` keeps NULL as unknown, but consumers that apply ordinary SQL filtering
+    /// discard NULL, so a NULL literal is not a portable fallback.
     fn finish_eval_pred_junction(
         &self,
-        op: JunctionPredicateOp,
+        mut op: JunctionPredicateOp,
         preds: &mut dyn Iterator<Item = Option<Pred>>,
         inverted: bool,
     ) -> Option<Pred> {
-        Some(collect_junction_preds(op, preds, inverted))
+        if inverted {
+            op = op.invert();
+        }
+        Some(Pred::junction(
+            op,
+            preds.map(|pred| pred.unwrap_or_else(|| Pred::literal(true))),
+        ))
     }
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -565,26 +565,35 @@ fn test_checkpoint_skipping_partition_range_ops(
 #[case::float(Scalar::Float(1.0))]
 #[case::double(Scalar::Double(1.0))]
 #[case::integer_literal(Scalar::from(1))]
-fn test_checkpoint_skipping_floating_partition_comparison_is_disabled(#[case] value: Scalar) {
+fn test_checkpoint_skipping_floating_partition_comparisons_keep_all(#[case] value: Scalar) {
     let partition_columns = HashSet::from([column_name!("part_col")]);
-    let pred = Pred::ne(column_expr!("part_col"), value.clone());
-    let skipping_pred = as_checkpoint_skipping_predicate(
-        &pred,
-        &partition_columns,
-        &partition_columns,
-        &HashSet::new(),
-    )
-    .unwrap();
-    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
-        column_name!("partitionValues_parsed.part_col"),
-        value,
-    )]));
+    let col = column_expr!("part_col");
+    let predicates = [
+        Pred::eq(col.clone(), value.clone()),
+        Pred::ne(col.clone(), value.clone()),
+        Pred::distinct(col.clone(), value.clone()),
+        Pred::not(Pred::distinct(col, value.clone())),
+    ];
 
-    expect_eq!(
-        resolver.eval(&skipping_pred),
-        NULL,
-        "parquet footer min/max exclude NaN partition values"
-    );
+    for pred in predicates {
+        let skipping_pred = as_checkpoint_skipping_predicate(
+            &pred,
+            &partition_columns,
+            &partition_columns,
+            &HashSet::new(),
+        )
+        .unwrap();
+        let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
+            column_name!("partitionValues_parsed.part_col"),
+            value.clone(),
+        )]));
+
+        expect_eq!(
+            resolver.eval(&skipping_pred),
+            TRUE,
+            "parquet footer min/max exclude NaN partition values for {pred}"
+        );
+    }
 }
 
 #[rstest]
@@ -1351,12 +1360,10 @@ fn multiple_partition_columns_rewrite_and_evaluation() {
     );
 }
 
-// Without normalization, `AND([unknown])` would become `AND([NULL])` via
-// `collect_junction_preds`, which evaluates to `Some(false)` under `eval_sql_where` and
-// incorrectly prunes all row groups. The junction constructor normalizes `AND([unknown])`
-// to just `unknown`, which correctly returns `None` (no pushdown).
+// The junction constructor normalizes `AND([unknown])` to `unknown` before rewriting. With no
+// parent junction to insert a conservative TRUE fallback, the unsupported leaf remains `None`.
 #[test]
-fn single_unsupported_pred_in_junction_disables_checkpoint_pushdown() {
+fn normalized_single_unsupported_pred_disables_checkpoint_pushdown() {
     let pred = Pred::and_from([Pred::unknown("unsupported")]);
     let stats = all_referenced_columns(&pred);
     let skipping_pred =
@@ -1364,6 +1371,18 @@ fn single_unsupported_pred_in_junction_disables_checkpoint_pushdown() {
     assert!(
         skipping_pred.is_none(),
         "Single unsupported predicate in a junction should disable pushdown, got: {skipping_pred:?}"
+    );
+}
+
+#[test]
+fn negated_unsupported_pred_disables_checkpoint_pushdown() {
+    let pred = Pred::not(Pred::unknown("unsupported"));
+    let stats = all_referenced_columns(&pred);
+    let skipping_pred =
+        as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats);
+    assert!(
+        skipping_pred.is_none(),
+        "Negated unsupported predicate should disable pushdown, got: {skipping_pred:?}"
     );
 }
 
@@ -1751,11 +1770,8 @@ fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
     );
 }
 
-/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint
-/// creator, which adds an `IS NULL` guard on each stat ref for safe parquet
-/// row-group filtering. The non-stat arm still folds to NULL.
 #[test]
-fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
+fn checkpoint_pushdown_non_stat_arm_folds_to_true_literal() {
     let pred = Pred::and(
         Pred::gt(column_expr!("stat"), Scalar::from(100)),
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
@@ -1766,6 +1782,99 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
     assert_eq!(
         result.to_string(),
         "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, \
-         Column(stats_parsed.maxValues.stat) > 100), null)"
+         Column(stats_parsed.maxValues.stat) > 100), true)"
+    );
+}
+
+#[rstest]
+#[case::and_supported_true(
+    Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    ),
+    column_name!("stats_parsed.maxValues.stat"),
+    Scalar::from(150i32),
+    TRUE,
+)]
+#[case::or_supported_false(
+    Pred::or(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    ),
+    column_name!("stats_parsed.maxValues.stat"),
+    Scalar::from(50i32),
+    TRUE,
+)]
+#[case::not_and_supported_false(
+    Pred::not(Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    )),
+    column_name!("stats_parsed.minValues.stat"),
+    Scalar::from(150i32),
+    TRUE,
+)]
+#[case::not_or_supported_false(
+    Pred::not(Pred::or(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    )),
+    column_name!("stats_parsed.minValues.stat"),
+    Scalar::from(150i32),
+    FALSE,
+)]
+#[case::and_logical_null(
+    Pred::and(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::null_literal(),
+    ),
+    column_name!("stats_parsed.maxValues.stat"),
+    Scalar::from(50i32),
+    FALSE,
+)]
+#[case::or_logical_null(
+    Pred::or(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::null_literal(),
+    ),
+    column_name!("stats_parsed.maxValues.stat"),
+    Scalar::from(50i32),
+    TRUE,
+)]
+fn checkpoint_pushdown_true_fallback_semantics(
+    #[case] pred: Pred,
+    #[case] stat_column: ColumnName,
+    #[case] stat_value: Scalar,
+    #[case] expected: Option<bool>,
+) {
+    let stats = stats_cols(&["stat"]);
+    let result =
+        as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
+    let resolver = HashMap::from_iter([(stat_column, stat_value)]);
+    let filter = DefaultKernelPredicateEvaluator::from(resolver);
+    expect_eq!(
+        filter.eval(&result),
+        expected,
+        "TRUE fallback semantics for {pred}"
+    );
+}
+
+#[rstest]
+fn checkpoint_true_fold_preserves_row_group_skip_decision(
+    #[values(JunctionPredicateOp::And, JunctionPredicateOp::Or)] op: JunctionPredicateOp,
+    #[values(TRUE, FALSE, NULL)] supported: Option<bool>,
+) {
+    let supported = supported.map_or_else(Pred::null_literal, Pred::literal);
+    let null_fold = Pred::junction(op, [supported.clone(), Pred::null_literal()]);
+    let true_fold = Pred::junction(op, [supported, Pred::literal(true)]);
+    let filter = DefaultKernelPredicateEvaluator::from(UnimplementedColumnResolver);
+
+    let null_fold_result = filter.eval_sql_where(&null_fold);
+    let true_fold_result = filter.eval_sql_where(&true_fold);
+    assert_eq!(
+        null_fold_result == FALSE,
+        true_fold_result == FALSE,
+        "{op:?} changed its row-group skip decision: NULL fold {null_fold_result:?}, \
+         TRUE fold {true_fold_result:?}"
     );
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1042,10 +1042,10 @@ impl Scan {
     /// guards.
     ///
     /// Returns `None` if the scan has no predicate, if neither a data-column stats schema nor a
-    /// partition schema is available, or if the predicate is a bare unsupported expression (e.g.
-    /// column-column comparison). Junctions represent unsupported arms with a NULL literal,
-    /// preserving three-valued logic while allowing independently decisive supported arms to
-    /// prune.
+    /// partition schema is available, or if the predicate is a structurally unsupported leaf (e.g.
+    /// a column-column comparison). Within a junction, children that produce no usable checkpoint
+    /// condition become TRUE, preserving supported pruning through AND without allowing an
+    /// unavailable child to exclude an Add.
     fn build_actions_meta_predicate(&self) -> Option<PredicateRef> {
         let PhysicalPredicate::Some(ref predicate, _) = self.state_info.physical_predicate else {
             return None;

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -354,8 +354,8 @@ impl StateInfo {
         // Stats-eligible column set. Partition columns are excluded; they flow through
         // `partitionValues_parsed` instead.
         let physical_stats_columns = table_configuration.physical_stats_columns_set(None);
-        // Observability: predicate refs outside `physical_stats_columns` get folded to NULL
-        // by the gate. Surface the dropped set so an engine operator can see what got folded.
+        // Observability: predicate refs outside `physical_stats_columns` cannot produce checkpoint
+        // conditions. Surface the dropped set so an engine operator can see what is unavailable.
         // The filter walk is bounded by predicate width but still does a physical-name
         // resolution per ref, so gate it on the log level to skip the work when DEBUG is off.
         if enabled!(Level::DEBUG) && matches!(physical_predicate, PhysicalPredicate::Some(_, _)) {
@@ -369,7 +369,7 @@ impl StateInfo {
                 .collect();
             if !dropped.is_empty() {
                 debug!(
-                    "Checkpoint pushdown: predicate refs to non-stats columns folded to NULL: {:?}",
+                    "Checkpoint pushdown: predicate refs unavailable from checkpoint stats: {:?}",
                     dropped
                 );
             }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR changes how the checkpoint predicate rewriter handles a junction child for which it produces no usable condition. It now inserts `TRUE` instead of a Boolean `NULL` literal. The regular in-memory data-skipping rewriter still uses its existing `NULL` fallback.

### Why this predicate must be conservative

Kernel gives `ParquetHandler` an optional predicate for pruning checkpoint files, row groups, or rows. A handler may keep extra data, but it must not remove an `Add` that may point to a file matching the original query.

Kernel's row-group evaluator calls `eval_pred_sql_where`, which preserves a `NULL` sentinel as `None`; the row-group filter skips only when the result is `Some(false)`. An engine applying ordinary SQL `WHERE` semantics keeps only `TRUE` and discards both `FALSE` and `NULL`. Because the predicate AST does not mark a `NULL` literal as a sentinel, `TRUE` is the portable representation of "this condition cannot rule the Add out."

| Consumer | Keep rule | Result for a `NULL` literal |
|---|---|---|
| Kernel row-group evaluator | keep unless `FALSE` | keep |
| Ordinary SQL filter | keep only `TRUE` | discard |

### What `None` means during the rewrite

The evaluator framework uses Rust `None` both for logical SQL unknown and when an evaluator cannot produce a condition. A non-partition data column outside `physical_stats_columns` produces `None` for a direct range comparison because Kernel cannot build a predicate over a stats field that is not present. `None` does not mean that the source predicate is false or absent.

The creator constructs a predicate at rewrite time; it does not evaluate a checkpoint row. Before this PR, a junction materialized a `None` child as Boolean `NULL`. This PR materializes it as `TRUE`. The same conservative fallback applies to any junction child returning `None`, including a logical `NULL` child.

### Pushdown behavior

Let `R(S)` be the conservative checkpoint rewrite of a supported source arm `S`, and let `U` be a child for which the rewriter returns `None`.

| Source shape | Emitted checkpoint predicate | Behavior |
|---|---|---|
| `S AND U` | `R(S) AND TRUE` | `R(S)` can still prune |
| `S OR U` | `R(S) OR TRUE` | keep because `U` may match |
| `NOT(S OR U)` | `R(NOT S) AND TRUE` | `R(NOT S)` can still prune |
| `NOT(S AND U)` | `R(NOT S) OR TRUE` | keep because `NOT(U)` may match |
| structurally unsupported top-level `U` or `NOT(U)` | no pushed predicate | keep all `Add` rows |
| synthesized `=`, `!=`, or `DISTINCT` junction | replace each unavailable internal condition with `TRUE` | preserve a conservative may-match result |

Using the OR identity `FALSE` for `U` is unsafe. If `R(S)` is false but the source arm `U` is true, `R(S) OR FALSE` drops a matching file.

Negation does not wrap a generated `TRUE`. The evaluator carries an `inverted` flag through `NOT`, applies De Morgan's law to junctions, and asks supported leaves for their inverted comparisons before inserting the fallback. Therefore no generated fallback has a materialized `NOT` ancestor.

After that normalization, the emitted tree contains only monotone `AND` and `OR` junctions around fallback values. Replacing a missing condition with `TRUE`, the may-match top value, cannot introduce a false result. The same argument applies recursively and to the junctions synthesized for `=`, `!=`, and `DISTINCT`.

The change also preserves Kernel's row-group skip decisions. Under three-valued logic, an AND containing the old `NULL` fallback is false exactly when another child is false; replacing that `NULL` with `TRUE` does not change this. An OR containing `NULL` is never false, and an OR containing `TRUE` is also never false.

### Complete negated OR example

Assume `indexed_score` and `indexed_region` have checkpoint stats, while `unindexed_count` and `unindexed_cost` do not. Start with a negated OR whose two operands are themselves conjunctions:

```text
NOT(
  (indexed_score > 100 AND indexed_region = "us")
  OR
  (unindexed_count > 0 AND unindexed_cost < 50)
)
```

The evaluator pushes the negation through the OR and both inner ANDs before rewriting any leaf:

```text
(indexed_score <= 100 OR indexed_region != "us")
AND
(unindexed_count <= 0 OR unindexed_cost >= 50)
```

The supported leaves produce guarded checkpoint conditions. The two unindexed leaves produce `None`:

```text
R(indexed_score <= 100) =
  OR(minValues.indexed_score IS NULL,
     minValues.indexed_score <= 100)

R(indexed_region != "us") =
  OR(
    OR(minValues.indexed_region IS NULL,
       minValues.indexed_region != "us"),
    OR(maxValues.indexed_region IS NULL,
       maxValues.indexed_region != "us")
  )

unindexed_count <= 0 => None
unindexed_cost >= 50 => None
```

The final emitted predicate is therefore:

```text
AND(
  OR(R(indexed_score <= 100), R(indexed_region != "us")),
  OR(TRUE, TRUE)
)
```

Consider an `Add` with `minValues.indexed_score = 50` and a data row `(indexed_score = 50, indexed_region = "us", unindexed_count = 0, unindexed_cost = 100)`. Both original inner conjunctions are false, so the complete source predicate is `NOT(FALSE OR FALSE) = TRUE`. The supported checkpoint arm is true because `minValues.indexed_score <= 100`.

Before this PR, the checkpoint result was `TRUE AND NULL = NULL`; Kernel's row-group evaluator kept it, but an ordinary SQL filter discarded it. This PR emits `TRUE AND TRUE = TRUE`, so both consumers keep the matching `Add`. The complex supported side still prunes whenever its rewritten OR is false.

### Complete negated AND example

Use the same stats availability with a negated AND whose operands are themselves disjunctions:

```text
NOT(
  (indexed_score > 100 OR indexed_region = "us")
  AND
  (unindexed_count > 0 OR unindexed_cost < 50)
)
```

De Morgan normalization produces:

```text
(indexed_score <= 100 AND indexed_region != "us")
OR
(unindexed_count <= 0 AND unindexed_cost >= 50)
```

The indexed leaves use the same guarded rewrites shown above, while both unindexed leaves again return `None`. The emitted checkpoint predicate is:

```text
OR(
  AND(R(indexed_score <= 100), R(indexed_region != "us")),
  AND(TRUE, TRUE)
)
```

Now consider an `Add` with `minValues.indexed_score = 150`, `minValues.indexed_region = "us"`, and `maxValues.indexed_region = "us"`, plus a data row `(indexed_score = 150, indexed_region = "us", unindexed_count = 0, unindexed_cost = 100)`. The first original disjunction is true and the second is false, so the complete source predicate is `NOT(TRUE AND FALSE) = TRUE`. Both indexed negations are false, so the supported checkpoint arm is false.

Before this PR, the checkpoint result was `FALSE OR NULL = NULL`, which an ordinary SQL filter discarded even though the file matches through the unindexed negated arm. This PR emits `FALSE OR TRUE = TRUE`, so the `Add` survives. This is why an unavailable OR arm cannot use the identity value `FALSE`.

In both examples, `TRUE` means only that checkpoint metadata cannot rule the arm out. The normal data scan still applies the original predicate to the file's rows.

## How was this change tested?

- Covered supported and unavailable arms under `AND`, `OR`, `NOT(AND)`, and `NOT(OR)`.
- Covered logical `NULL` children and the synthesized junctions used by `=`, `!=`, `DISTINCT`, and inverted `DISTINCT`.
- Compared old NULL-fold and new TRUE-fold row-group skip decisions for `AND` and `OR` across supported results of `TRUE`, `FALSE`, and `NULL`.
- Verified that structurally unsupported top-level and negated predicates produce no checkpoint predicate.
- Ran the complete `delta_kernel` library suite with all features.

```shell
cargo nextest run -p delta_kernel --lib --all-features
```
