### PR TITLE
test: rerun benchmarking CI if under threshold

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,10 +19,11 @@
 # in base-branch context (which has the write scope this workflow lacks under
 # pull_request from a fork).
 #
-# The run-benchmark job fails if any benchmark regresses past the fail
-# threshold in benchmarks/ci/parse_critcmp.py, unless the PR carries the
-# ignore-benchmark-failure label. The comment artifact is uploaded before that
-# gate runs, so the result table still gets posted on a gate failure.
+# The run-benchmark job reruns one fresh comparison when a non-overridden
+# regression is below RERUN_THRESHOLD, then fails if the final comparison still
+# crosses the fail threshold in benchmarks/ci/parse_critcmp.py. The comment artifact
+# is uploaded before the gate runs, so the result table still gets posted on a gate
+# failure. The ignore-benchmark-failure label bypasses both retry and failure.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@
 # pull_request from a fork).
 #
 # The run-benchmark job reruns one fresh comparison when a non-overridden
-# regression is below RERUN_THRESHOLD, then fails if the final comparison still
+# regression is below RETRY_THRESHOLD, then fails if the final comparison still
 # crosses the fail threshold in benchmarks/ci/parse_critcmp.py. The comment artifact
 # is uploaded before the gate runs, so the result table still gets posted on a gate
 # failure. The ignore-benchmark-failure label bypasses both retry and failure.

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -17,6 +17,10 @@ a marker emoji (see the threshold constants). When any benchmark lands in the
 slowest tier, the run records a regression in the file named by
 BENCH_REGRESSION_FILE (if set) so the workflow can fail the job.
 
+When a non-overridden regression is below the automatic retry threshold, the
+run records that it is retryable in BENCH_RETRY_FILE (if set). Thresholds use
+the displayed two-decimal multiplier so the retry decision matches the comment.
+
 Usage:
     critcmp base changes | python3 benchmarks/ci/parse_critcmp.py
 """
@@ -29,6 +33,7 @@ import sys
 ROCKET_THRESHOLD = 1.15
 GRAY_THRESHOLD = 1.03
 FAIL_THRESHOLD = 1.15
+RETRY_THRESHOLD = 1.50
 
 # |ratio - 1| within this renders as "1.00x" with no faster/slower suffix
 # (half of the 2-decimal display step).
@@ -213,6 +218,11 @@ def main():
     rows = parse_rows(lines)
     regressed = any(change_emoji(r['ratio']) == RED_X for r in rows)
     ignored = os.environ.get('BENCH_IGNORE_FAILURE') == 'true'
+    max_slowdown = max(
+        (round(r['ratio'], 2) for r in rows if r['ratio'] is not None and r['ratio'] > 1),
+        default=1.0,
+    )
+    retryable = regressed and not ignored and max_slowdown < RETRY_THRESHOLD
 
     print(f'## Benchmark results: {render_verdict(regressed, ignored)}')
     print("")
@@ -228,6 +238,11 @@ def main():
     if flag_path:
         with open(flag_path, 'w') as f:
             f.write('true' if regressed else 'false')
+
+    retry_path = os.environ.get('BENCH_RETRY_FILE')
+    if retry_path:
+        with open(retry_path, 'w') as f:
+            f.write('true' if retryable else 'false')
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/ci/parse_critcmp.py
+++ b/benchmarks/ci/parse_critcmp.py
@@ -213,6 +213,13 @@ def render_table(rows):
     out.append("</details>")
     return "\n".join(out)
 
+def write_flag(env_var, value):
+    """Write 'true'/'false' to the file named by env_var, if that var is set."""
+    path = os.environ.get(env_var)
+    if path:
+        with open(path, 'w') as f:
+            f.write('true' if value else 'false')
+
 def main():
     lines = sys.stdin.read().splitlines()
     rows = parse_rows(lines)
@@ -233,16 +240,10 @@ def main():
     print(render_legend())
 
     # Record whether any benchmark crossed FAIL_THRESHOLD so the workflow can
-    # fail the job (unless overridden by the ignore-benchmark-failure label).
-    flag_path = os.environ.get('BENCH_REGRESSION_FILE')
-    if flag_path:
-        with open(flag_path, 'w') as f:
-            f.write('true' if regressed else 'false')
-
-    retry_path = os.environ.get('BENCH_RETRY_FILE')
-    if retry_path:
-        with open(retry_path, 'w') as f:
-            f.write('true' if retryable else 'false')
+    # fail the job (unless overridden by the ignore-benchmark-failure label), and
+    # whether the regression is noisy enough to warrant one automatic retry.
+    write_flag('BENCH_REGRESSION_FILE', regressed)
+    write_flag('BENCH_RETRY_FILE', retryable)
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -101,6 +101,7 @@ MERGE_SHA=$(git rev-parse HEAD)
 # ---------------------------------------------------------------------------
 git fetch origin -- "$BASE_REF"
 git checkout FETCH_HEAD
+BASE_SHA=$(git rev-parse HEAD)
 (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
 
 # ---------------------------------------------------------------------------
@@ -123,8 +124,31 @@ git checkout "$MERGE_SHA"
 #
 # parse_critcmp.py records whether any benchmark regressed past its fail
 # threshold in this file; benchmark.yml's gate step reads it to fail the job.
+# It also records whether a non-overridden regression is below the automatic
+# retry threshold, allowing one fresh measurement pair to replace a noisy run.
 export BENCH_REGRESSION_FILE=/tmp/bench-regression.txt
-COMPARISON=$((cd benchmarks && critcmp base changes) | python3 benchmarks/ci/parse_critcmp.py)
+export BENCH_RETRY_FILE=/tmp/bench-retry.txt
+ATTEMPT=1
+MAX_ATTEMPTS=2
+
+while true; do
+  COMPARISON=$((cd benchmarks && critcmp base changes) | python3 benchmarks/ci/parse_critcmp.py)
+  RETRY=$(tr -d '[:space:]' < "$BENCH_RETRY_FILE" 2>/dev/null || echo false)
+
+  if [[ "$RETRY" != "true" || "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]]; then
+    break
+  fi
+
+  ATTEMPT=$((ATTEMPT + 1))
+  echo "::notice::Benchmark regression is below 1.50x; starting attempt $ATTEMPT/$MAX_ATTEMPTS."
+  (
+    cd benchmarks
+    cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER"
+  )
+  git checkout "$BASE_SHA"
+  (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
+  git checkout "$MERGE_SHA"
+done
 
 # ---------------------------------------------------------------------------
 # 6. Write results to /tmp/bench-comment.md
@@ -140,6 +164,9 @@ SHORT_SHA="${HEAD_SHA:0:7}"
 SUMMARY="Commit: \`${SHORT_SHA}\` &middot; Trigger: ${TRIGGER:-auto-push}"
 [[ -n "$TAGS" ]]   && SUMMARY+=" &middot; Tags: \`${TAGS}\`"
 [[ -n "$FILTER" ]] && SUMMARY+=" &middot; Filter: \`${FILTER}\`"
+if [[ "$ATTEMPT" -gt 1 ]]; then
+  SUMMARY+=" &middot; Automatic retry: attempt ${ATTEMPT}/${MAX_ATTEMPTS}"
+fi
 SUMMARY+=" &middot; Updated: $(TZ=America/Los_Angeles date '+%Y-%m-%d %H:%M %Z')"
 
 # Leading marker is an HTML comment, invisible to readers; the post-comment

--- a/benchmarks/ci/run-benchmarks.sh
+++ b/benchmarks/ci/run-benchmarks.sh
@@ -87,51 +87,47 @@ echo "mem: $(free -m | awk '/^Mem:/ {print $2 " MB total, " $7 " MB available"}'
 echo "==========================="
 
 # ---------------------------------------------------------------------------
-# 3. Benchmark the integration commit (PR head merged into base)
-# ---------------------------------------------------------------------------
-# HEAD is the merge commit checked out by the workflow; capture it so step 5 can
-# restore this tree after the base checkout below.
-MERGE_SHA=$(git rev-parse HEAD)
-(cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER")
-
-# ---------------------------------------------------------------------------
-# 4. Switch to the base branch and benchmark it
-#    The benchmarks/target/ directory is not tracked by git, so the
-#    "changes" baseline files are preserved across the branch switch.
-# ---------------------------------------------------------------------------
-git fetch origin -- "$BASE_REF"
-git checkout FETCH_HEAD
-BASE_SHA=$(git rev-parse HEAD)
-(cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
-
-# ---------------------------------------------------------------------------
-# 5. Compare baselines with critcmp and format as a markdown comment
-#    (per-tier summary line + collapsed per-benchmark table; see
-#    benchmarks/ci/parse_critcmp.py for the format and tier thresholds).
-#      - Parses actual duration values (not rank factors) to compute a ratio
-# ---------------------------------------------------------------------------
-# Step 4 left the working tree on the base branch, so parse_critcmp.py on disk
-# is the base version. Restore the merge tree so the comment is formatted by the
-# PR's own formatter (a formatter change is then exercised on the PR that
-# introduces it). The raw PR-head SHA is not reachable in the shallow merge-ref
-# checkout, so restore the merge commit captured in step 3. Only tracked sources
-# move; the `base`/`changes` criterion baselines live in gitignored
-# benchmarks/target/ and survive the checkout.
-git checkout "$MERGE_SHA"
-# Use `critcmp` to compare the criterion output for `base` and `changes`. We use `critcmp` instead of manually
-# parsing criterion outputs because criterion may update its output format. By using `critcmp`, we inherit all
-# updated criterion output parsing.
+# 3. Benchmark both sides, compare with critcmp, retry once on a noisy regression
+#    Each attempt benchmarks the merge tree ("changes") and the base tree
+#    ("base"), then compares them. HEAD is the merge commit (PR head merged into
+#    base) checked out by the workflow; capture it so each attempt can restore
+#    this tree. The base SHA is resolved from the fetch without a checkout -- the
+#    loop checks it out itself.
 #
-# parse_critcmp.py records whether any benchmark regressed past its fail
-# threshold in this file; benchmark.yml's gate step reads it to fail the job.
-# It also records whether a non-overridden regression is below the automatic
-# retry threshold, allowing one fresh measurement pair to replace a noisy run.
+#    After measuring, restore the merge tree so the comment is formatted by the
+#    PR's own parse_critcmp.py (a formatter change is then exercised on the PR
+#    that introduces it). The raw PR-head SHA is not reachable in the shallow
+#    merge-ref checkout, so restore the captured merge commit. Only tracked
+#    sources move; the `base`/`changes` criterion baselines live in gitignored
+#    benchmarks/target/ and survive the checkout.
+#
+#    We use `critcmp` to compare the criterion output for `base` and `changes`
+#    instead of parsing criterion output ourselves: criterion may change its
+#    output format, and critcmp tracks it, so we inherit any format updates.
+#
+#    parse_critcmp.py records whether any benchmark regressed past its fail
+#    threshold in BENCH_REGRESSION_FILE (benchmark.yml's gate step reads it to
+#    fail the job). It also records whether a non-overridden regression is below
+#    the automatic retry threshold in BENCH_RETRY_FILE, allowing one fresh
+#    measurement pair to replace a noisy run.
+# ---------------------------------------------------------------------------
+run_bench() { (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline "$1" "$FILTER"); }
+
+MERGE_SHA=$(git rev-parse HEAD)
+git fetch origin -- "$BASE_REF"
+BASE_SHA=$(git rev-parse FETCH_HEAD)
+
 export BENCH_REGRESSION_FILE=/tmp/bench-regression.txt
 export BENCH_RETRY_FILE=/tmp/bench-retry.txt
 ATTEMPT=1
 MAX_ATTEMPTS=2
 
 while true; do
+  run_bench changes
+  git checkout "$BASE_SHA"
+  run_bench base
+  git checkout "$MERGE_SHA"
+
   COMPARISON=$((cd benchmarks && critcmp base changes) | python3 benchmarks/ci/parse_critcmp.py)
   RETRY=$(tr -d '[:space:]' < "$BENCH_RETRY_FILE" 2>/dev/null || echo false)
 
@@ -140,18 +136,11 @@ while true; do
   fi
 
   ATTEMPT=$((ATTEMPT + 1))
-  echo "::notice::Benchmark regression is below 1.50x; starting attempt $ATTEMPT/$MAX_ATTEMPTS."
-  (
-    cd benchmarks
-    cargo bench --locked --bench workload_bench -- --save-baseline changes "$FILTER"
-  )
-  git checkout "$BASE_SHA"
-  (cd benchmarks && cargo bench --locked --bench workload_bench -- --save-baseline base "$FILTER")
-  git checkout "$MERGE_SHA"
+  echo "::notice::Benchmark regression within retry band; starting attempt $ATTEMPT/$MAX_ATTEMPTS."
 done
 
 # ---------------------------------------------------------------------------
-# 6. Write results to /tmp/bench-comment.md
+# 4. Write results to /tmp/bench-comment.md
 #    benchmark.yml uploads this as an artifact; benchmark-post-comment.yml
 #    downloads it and posts the PR comment in base-branch context.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

Added a step to re-run benchmarking if there's a regression (between 1.15x and 1.50x) that is potentially due to noise. Only re-runs once.

## How was this change tested?

Benchmarking runs in this PR.
