### PR TITLE
fix!: reclassify MalformedJson error during schema parsing to Schema error

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -366,7 +366,8 @@ impl Metadata {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth, or
+    /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth,
+    /// [`Error::Unsupported`] when a column declares a type the kernel doesn't support, or
     /// [`Error::MalformedJson`] for other JSON decoding failures.
     #[internal_api]
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
@@ -374,16 +375,19 @@ impl Metadata {
         serde_json::from_str(&self.schema_string).map_err(|error| {
             // serde_json keeps ErrorCode::RecursionLimitExceeded private, so we use string
             // matching.
-            if error.is_syntax()
-                && error
-                    .to_string()
-                    .starts_with(SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX)
-            {
+            let msg = error.to_string();
+            if error.is_syntax() && msg.starts_with(SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX) {
                 Error::schema(format!(
                     "Table schema is too deeply nested: decoding metaData.schemaString exceeded \
                      serde_json's recursion limit: {error}"
                 ))
                 .with_backtrace()
+            } else if error.is_data()
+                && msg.contains(crate::schema::UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX)
+            {
+                // Serde only allows custom errors with a message string, so use prefix matching
+                // to reclassify the error as [`crate::Error::Unsupported`].
+                Error::Unsupported(msg)
             } else {
                 error.into()
             }
@@ -1285,6 +1289,32 @@ mod tests {
             error => error,
         };
         assert!(matches!(malformed_error, Error::MalformedJson(_)));
+    }
+
+    #[rstest]
+    #[case::time("time(6)")]
+    #[case::interval("interval week")]
+    fn parse_schema_unsupported_type_returns_unsupported(#[case] unsupported_type: &str) {
+        let unsupported_metadata = Metadata {
+            schema_string: format!(
+                r#"{{
+                "type": "struct",
+                "fields": [
+                    {{"name": "t", "type": "{unsupported_type}", "nullable": true, "metadata": {{}}}}
+                ]
+            }}"#
+            ),
+            ..Default::default()
+        };
+        let error = unsupported_metadata.parse_schema().unwrap_err();
+        let error = match error {
+            Error::Backtraced { source, .. } => *source,
+            error => error,
+        };
+        assert!(
+            matches!(error, Error::Unsupported(_)),
+            "expected Error::Unsupported, got: {error:?}"
+        );
     }
 
     fn nested_schema(depth: usize) -> StructType {

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -12,8 +12,8 @@ use visitors::{MetadataVisitor, ProtocolVisitor};
 use self::deletion_vector::DeletionVectorDescriptor;
 use crate::expressions::{MapData, Scalar, StructData};
 use crate::schema::{
-    lazy_schema_ref, schema_ref, DataType, MapType, SchemaRef, StructField, StructType,
-    ToSchema as _,
+    is_unsupported_delta_type_error, lazy_schema_ref, schema_ref, DataType, MapType, SchemaRef,
+    StructField, StructType, ToSchema as _,
 };
 use crate::table_features::{
     FeatureType, TableFeature, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
@@ -367,27 +367,26 @@ impl Metadata {
     /// # Errors
     ///
     /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth,
-    /// [`Error::Unsupported`] when a column declares a type the kernel doesn't support, or
-    /// [`Error::MalformedJson`] for other JSON decoding failures.
+    /// [`Error::Unsupported`] when the schema declares a type the kernel doesn't support,
+    /// or [`Error::MalformedJson`] for other JSON decoding failures.
     #[internal_api]
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
         // TODO(#1896): Increase the supported nesting depth or use non-recursive schema decoding.
         serde_json::from_str(&self.schema_string).map_err(|error| {
             // serde_json keeps ErrorCode::RecursionLimitExceeded private, so we use string
             // matching.
-            let msg = error.to_string();
-            if error.is_syntax() && msg.starts_with(SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX) {
+            if error.is_syntax()
+                && error
+                    .to_string()
+                    .starts_with(SERDE_JSON_RECURSION_LIMIT_ERROR_PREFIX)
+            {
                 Error::schema(format!(
                     "Table schema is too deeply nested: decoding metaData.schemaString exceeded \
                      serde_json's recursion limit: {error}"
                 ))
                 .with_backtrace()
-            } else if error.is_data()
-                && msg.contains(crate::schema::UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX)
-            {
-                // Serde only allows custom errors with a message string, so use prefix matching
-                // to reclassify the error as [`crate::Error::Unsupported`].
-                Error::Unsupported(msg)
+            } else if is_unsupported_delta_type_error(&error) {
+                Error::Unsupported(error.to_string()).with_backtrace()
             } else {
                 error.into()
             }
@@ -1275,46 +1274,65 @@ mod tests {
         }
     }
 
-    #[test]
-    fn parse_schema_malformed_json_returns_malformed_json() {
-        let malformed_metadata = Metadata {
-            schema_string: "{".to_string(),
+    #[rstest]
+    // Syntax error -> MalformedJson.
+    #[case::malformed_syntax("{", "MalformedJson")]
+    // Data error lacking the unsupported-type prefix (invalid decimal) -> MalformedJson, NOT
+    // Unsupported: the reclassification must not fire for every is_data error.
+    #[case::malformed_bad_decimal(
+        r#"{"type":"struct","fields":[{"name":"t","type":"decimal(nope)","nullable":true,"metadata":{}}]}"#,
+        "MalformedJson"
+    )]
+    // Regression guard: a well-formed schema whose wrong-typed field value echoes the prefix must
+    // stay MalformedJson. `nullable` is a bool, so a string value is an is_data error whose message
+    // *contains* the prefix; matching by `starts_with` keeps it out of the Unsupported arm.
+    #[case::malformed_value_echoes_prefix(
+        r#"{"type":"struct","fields":[{"name":"t","type":"string","nullable":"Unsupported Delta table type","metadata":{}}]}"#,
+        "MalformedJson"
+    )]
+    // Unsupported primitive types -> Unsupported.
+    #[case::unsupported_time(
+        r#"{"type":"struct","fields":[{"name":"t","type":"time(6)","nullable":true,"metadata":{}}]}"#,
+        "Unsupported"
+    )]
+    #[case::unsupported_interval(
+        r#"{"type":"struct","fields":[{"name":"t","type":"interval week","nullable":true,"metadata":{}}]}"#,
+        "Unsupported"
+    )]
+    // Unsupported primitive nested inside a struct field -> Unsupported (reclassification is
+    // position-agnostic, not limited to top-level columns).
+    #[case::unsupported_nested(
+        r#"{"type":"struct","fields":[{"name":"t","type":{"type":"struct","fields":[{"name":"inner","type":"time(6)","nullable":true,"metadata":{}}]},"nullable":true,"metadata":{}}]}"#,
+        "Unsupported"
+    )]
+    // Unknown complex type -> Unsupported.
+    #[case::unsupported_complex(
+        r#"{"type":"struct","fields":[{"name":"t","type":{"type":"matrix"},"nullable":true,"metadata":{}}]}"#,
+        "Unsupported"
+    )]
+    fn parse_schema_error_classification(
+        #[case] schema_string: &str,
+        #[case] expected_error: &str,
+    ) {
+        let metadata = Metadata {
+            schema_string: schema_string.to_string(),
             ..Default::default()
         };
-        let malformed_error = malformed_metadata.parse_schema().unwrap_err();
         // Error conversion captures a backtrace only when enabled, so normalize both forms before
         // checking the underlying error.
-        let malformed_error = match malformed_error {
+        let error = match metadata.parse_schema().unwrap_err() {
             Error::Backtraced { source, .. } => *source,
             error => error,
         };
-        assert!(matches!(malformed_error, Error::MalformedJson(_)));
-    }
-
-    #[rstest]
-    #[case::time("time(6)")]
-    #[case::interval("interval week")]
-    fn parse_schema_unsupported_type_returns_unsupported(#[case] unsupported_type: &str) {
-        let unsupported_metadata = Metadata {
-            schema_string: format!(
-                r#"{{
-                "type": "struct",
-                "fields": [
-                    {{"name": "t", "type": "{unsupported_type}", "nullable": true, "metadata": {{}}}}
-                ]
-            }}"#
-            ),
-            ..Default::default()
-        };
-        let error = unsupported_metadata.parse_schema().unwrap_err();
-        let error = match error {
-            Error::Backtraced { source, .. } => *source,
-            error => error,
-        };
-        assert!(
-            matches!(error, Error::Unsupported(_)),
-            "expected Error::Unsupported, got: {error:?}"
-        );
+        match expected_error {
+            "MalformedJson" => {
+                assert!(matches!(error, Error::MalformedJson(_)), "got: {error:?}")
+            }
+            "Unsupported" => {
+                assert!(matches!(error, Error::Unsupported(_)), "got: {error:?}")
+            }
+            other => panic!("unknown expected_error discriminant: {other}"),
+        }
     }
 
     fn nested_schema(depth: usize) -> StructType {

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -366,9 +366,9 @@ impl Metadata {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth,
-    /// [`Error::Unsupported`] when the schema declares a type the kernel doesn't support,
-    /// or [`Error::MalformedJson`] for other JSON decoding failures.
+    /// Returns [`Error::Schema`] when the schema exceeds the supported decoding depth or
+    /// declares a type the kernel doesn't support, or [`Error::MalformedJson`] for other
+    /// JSON decoding failures.
     #[internal_api]
     pub(crate) fn parse_schema(&self) -> DeltaResult<StructType> {
         // TODO(#1896): Increase the supported nesting depth or use non-recursive schema decoding.
@@ -386,7 +386,7 @@ impl Metadata {
                 ))
                 .with_backtrace()
             } else if is_unsupported_delta_type_error(&error) {
-                Error::Unsupported(error.to_string()).with_backtrace()
+                Error::schema(error.to_string()).with_backtrace()
             } else {
                 error.into()
             }
@@ -1278,37 +1278,37 @@ mod tests {
     // Syntax error -> MalformedJson.
     #[case::malformed_syntax("{", "MalformedJson")]
     // Data error lacking the unsupported-type prefix (invalid decimal) -> MalformedJson, NOT
-    // Unsupported: the reclassification must not fire for every is_data error.
+    // Schema: the reclassification must not fire for every is_data error.
     #[case::malformed_bad_decimal(
         r#"{"type":"struct","fields":[{"name":"t","type":"decimal(nope)","nullable":true,"metadata":{}}]}"#,
         "MalformedJson"
     )]
     // Regression guard: a well-formed schema whose wrong-typed field value echoes the prefix must
     // stay MalformedJson. `nullable` is a bool, so a string value is an is_data error whose message
-    // *contains* the prefix; matching by `starts_with` keeps it out of the Unsupported arm.
+    // *contains* the prefix; matching by `starts_with` keeps it out of the Schema arm.
     #[case::malformed_value_echoes_prefix(
         r#"{"type":"struct","fields":[{"name":"t","type":"string","nullable":"Unsupported Delta table type","metadata":{}}]}"#,
         "MalformedJson"
     )]
-    // Unsupported primitive types -> Unsupported.
+    // Unsupported primitive types -> Schema.
     #[case::unsupported_time(
         r#"{"type":"struct","fields":[{"name":"t","type":"time(6)","nullable":true,"metadata":{}}]}"#,
-        "Unsupported"
+        "Schema"
     )]
     #[case::unsupported_interval(
         r#"{"type":"struct","fields":[{"name":"t","type":"interval week","nullable":true,"metadata":{}}]}"#,
-        "Unsupported"
+        "Schema"
     )]
-    // Unsupported primitive nested inside a struct field -> Unsupported (reclassification is
+    // Unsupported primitive nested inside a struct field -> Schema (reclassification is
     // position-agnostic, not limited to top-level columns).
     #[case::unsupported_nested(
         r#"{"type":"struct","fields":[{"name":"t","type":{"type":"struct","fields":[{"name":"inner","type":"time(6)","nullable":true,"metadata":{}}]},"nullable":true,"metadata":{}}]}"#,
-        "Unsupported"
+        "Schema"
     )]
-    // Unknown complex type -> Unsupported.
+    // Unknown complex type -> Schema.
     #[case::unsupported_complex(
         r#"{"type":"struct","fields":[{"name":"t","type":{"type":"matrix"},"nullable":true,"metadata":{}}]}"#,
-        "Unsupported"
+        "Schema"
     )]
     fn parse_schema_error_classification(
         #[case] schema_string: &str,
@@ -1328,8 +1328,8 @@ mod tests {
             "MalformedJson" => {
                 assert!(matches!(error, Error::MalformedJson(_)), "got: {error:?}")
             }
-            "Unsupported" => {
-                assert!(matches!(error, Error::Unsupported(_)), "got: {error:?}")
+            "Schema" => {
+                assert!(matches!(error, Error::Schema(_)), "got: {error:?}")
             }
             other => panic!("unknown expected_error discriminant: {other}"),
         }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -42,9 +42,23 @@ pub(crate) mod validation;
 pub(crate) mod variant_utils;
 pub(crate) mod void_utils;
 
-/// Prefix of the error message emitted when deserializing a Delta table type the kernel does
-/// not support.
-pub(crate) const UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX: &str = "Unsupported Delta table type";
+/// Prefix of the error message the schema deserializers emit for an unsupported type.
+const UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX: &str = "Unsupported Delta table type";
+
+/// Builds the serde custom error for a Delta type the kernel does not support. Pairs with
+/// [`is_unsupported_delta_type_error`] for detecting whether a serde error is this kind.
+fn unsupported_delta_type_error<E: serde::de::Error>(name: &str) -> E {
+    E::custom(format!("{UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX}: '{name}'"))
+}
+
+/// Returns `true` if `error` is the "unsupported Delta type" failure produced by
+/// `unsupported_delta_type_error`.
+pub(crate) fn is_unsupported_delta_type_error(error: &serde_json::Error) -> bool {
+    error.is_data()
+        && error
+            .to_string()
+            .starts_with(UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX)
+}
 
 pub type Schema = StructType;
 pub type SchemaRef = Arc<StructType>;
@@ -2155,9 +2169,9 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             "timestamp_ntz" => Ok(PrimitiveType::TimestampNtz),
             "void" => Ok(PrimitiveType::Void),
             // Accept canonical and narrowed interval spellings
-            s if s.starts_with("interval ") => normalize_interval_type(s).ok_or_else(|| {
-                serde::de::Error::custom(format!("{UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX}: '{s}'"))
-            }),
+            s if s.starts_with("interval ") => {
+                normalize_interval_type(s).ok_or_else(|| unsupported_delta_type_error(s))
+            }
             decimal_str if decimal_str.starts_with("decimal(") && decimal_str.ends_with(')') => {
                 // Parse decimal type
                 let mut parts = decimal_str[8..decimal_str.len() - 1].split(',');
@@ -2215,9 +2229,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                     ))),
                 }
             }
-            unsupported => Err(serde::de::Error::custom(format!(
-                "{UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX}: '{unsupported}'"
-            ))),
+            unsupported => Err(unsupported_delta_type_error(unsupported)),
         }
     }
 }
@@ -2375,7 +2387,7 @@ impl<'de> serde::Deserialize<'de> for DataType {
                     "map" => MapType::deserialize(value)
                         .map(DataType::from)
                         .map_err(|e| Error::custom(e.to_string())),
-                    _ => Err(Error::custom(format!("Unknown complex type: '{type_str}'"))),
+                    _ => Err(unsupported_delta_type_error(type_str)),
                 };
             }
         }

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -42,6 +42,10 @@ pub(crate) mod validation;
 pub(crate) mod variant_utils;
 pub(crate) mod void_utils;
 
+/// Prefix of the error message emitted when deserializing a Delta table type the kernel does
+/// not support.
+pub(crate) const UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX: &str = "Unsupported Delta table type";
+
 pub type Schema = StructType;
 pub type SchemaRef = Arc<StructType>;
 
@@ -2152,7 +2156,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
             "void" => Ok(PrimitiveType::Void),
             // Accept canonical and narrowed interval spellings
             s if s.starts_with("interval ") => normalize_interval_type(s).ok_or_else(|| {
-                serde::de::Error::custom(format!("Unsupported Delta table type: '{s}'"))
+                serde::de::Error::custom(format!("{UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX}: '{s}'"))
             }),
             decimal_str if decimal_str.starts_with("decimal(") && decimal_str.ends_with(')') => {
                 // Parse decimal type
@@ -2212,7 +2216,7 @@ impl<'de> serde::Deserialize<'de> for PrimitiveType {
                 }
             }
             unsupported => Err(serde::de::Error::custom(format!(
-                "Unsupported Delta table type: '{unsupported}'"
+                "{UNSUPPORTED_DELTA_TYPE_ERROR_PREFIX}: '{unsupported}'"
             ))),
         }
     }


### PR DESCRIPTION

## What changes are proposed in this pull request?
During parsing of Metadata action schema, we currently throw MalformedJsonError whenever we hit an unsupported type. This is because serde only surfaces custom errors with messages, and hence we generically map serde errors to MalformedJson error.

Instead, we should reclassify it to Schema error so that upstream callers can appropriately detect this is an unsupported feature rather than an actual failure. Unfortunately, we have to use string matching to do this - but we already do something similar for the json recursion limit error.

## Breaking Change
This is a breaking change because we are now returning a different error variant for unsupported schema types. Any callers that were previously matching on MalformedJson error needs to match instead on the new error type (`Error::Schema`)

## How was this change tested?
unit tests