### PR TITLE
feat: SetTxn queries: fix retention bug, root in CRC

### DIFF
--- a/kernel/src/action_reconciliation/log_replay.rs
+++ b/kernel/src/action_reconciliation/log_replay.rs
@@ -525,23 +525,27 @@ impl ActionReconciliationVisitor<'_> {
             return Ok(None); // Not a txn action, continue checking other types
         };
 
-        // Check retention if last_updated is present
+        // Replay is newest-to-oldest, so the first txn seen for an app_id is the winner. Record it
+        // before checking retention: an expired winner must still suppress older txns for the same
+        // app_id rather than let one of them survive.
+        if !self.seen_txns.insert(app_id.to_string()) {
+            return Ok(Some(false)); // superseded by a newer txn for this app_id
+        }
+
+        // Exclude the winner when retention has expired it. A txn without last_updated never
+        // expires (kept for backward compatibility).
         if let Some(retention_ts) = self.txn_expiration_timestamp {
             if let Some(last_updated) =
                 getters[Self::TXN_LAST_UPDATED.index].get_opt(i, Self::TXN_LAST_UPDATED.name)?
             {
                 let last_updated: i64 = last_updated;
                 if last_updated <= retention_ts {
-                    // Transaction is old, exclude it
                     return Ok(Some(false));
                 }
             }
-            // Note: transactions without last_updated are kept for backward compatibility
         }
 
-        // If the app ID already exists in the set, the insertion will return false,
-        // indicating that this is a duplicate.
-        Ok(Some(self.seen_txns.insert(app_id.to_string())))
+        Ok(Some(true))
     }
 
     /// Processes a potential domainMetadata action to determine if it should be included.
@@ -1106,14 +1110,51 @@ mod tests {
 
         visitor.visit_rows_of(batch.as_ref())?;
 
-        // app1 and app4 should be filtered out (too old)
-        // app2 and app3 should be kept
+        // app1 and app4 are excluded (expired); app2 and app3 are emitted. All four app_ids are
+        // recorded as seen, since recording precedes the retention check.
         let expected = vec![false, true, true, false];
         assert_eq!(visitor.selection_vector, expected);
         assert_eq!(visitor.actions_count, 2);
-        assert_eq!(visitor.seen_txns.len(), 2);
-        assert!(visitor.seen_txns.contains("app2"));
-        assert!(visitor.seen_txns.contains("app3"));
+        assert_eq!(visitor.seen_txns.len(), 4);
+
+        Ok(())
+    }
+
+    // Replay is newest-to-oldest. When an app_id's newest txn is expired but an older one is not,
+    // the app_id must be dropped entirely: the expired newest suppresses the older duplicate, and
+    // neither reaches the checkpoint. Guards against resurrecting the older txn (a stale winner).
+    #[test]
+    fn test_action_reconciliation_expired_newest_txn_suppresses_older_txn_for_same_app(
+    ) -> DeltaResult<()> {
+        let json_strings: StringArray = vec![
+            // Newest for "app" (visited first), expired.
+            r#"{"txn":{"appId":"app","version":2,"lastUpdated":500}}"#,
+            // Older for "app", not expired. Must NOT survive.
+            r#"{"txn":{"appId":"app","version":1,"lastUpdated":2000}}"#,
+        ]
+        .into();
+        let batch = parse_json_batch(json_strings);
+
+        let mut seen_file_keys = HashSet::new();
+        let mut seen_txns = HashSet::new();
+        let mut seen_domains = HashSet::new();
+        let mut visitor = ActionReconciliationVisitor::new(
+            &mut seen_file_keys,
+            true,
+            vec![true; 2],
+            0,
+            false,
+            false,
+            &mut seen_txns,
+            &mut seen_domains,
+            Some(1000),
+        );
+
+        visitor.visit_rows_of(batch.as_ref())?;
+
+        assert_eq!(visitor.selection_vector, vec![false, false]);
+        assert_eq!(visitor.actions_count, 0);
+        assert_eq!(visitor.seen_txns.len(), 1);
 
         Ok(())
     }

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -977,6 +977,21 @@ impl SetTransaction {
             last_updated,
         }
     }
+
+    /// Whether this transaction is expired: `last_updated <= expiration_timestamp` with both
+    /// present. A `None` `last_updated` (no timestamp recorded) or a `None` `expiration_timestamp`
+    /// (no retention duration configured) never expires.
+    pub(crate) fn is_expired(&self, expiration_timestamp: Option<i64>) -> bool {
+        matches!(
+            (expiration_timestamp, self.last_updated),
+            (Some(exp_ts), Some(lu)) if lu <= exp_ts
+        )
+    }
+
+    /// This transaction's `version`, unless it is expired under `expiration_timestamp`.
+    pub(crate) fn non_expired_version(&self, expiration_timestamp: Option<i64>) -> Option<i64> {
+        (!self.is_expired(expiration_timestamp)).then_some(self.version)
+    }
 }
 
 /// The sidecar action references a sidecar file which provides some of the checkpoint's
@@ -1112,7 +1127,6 @@ mod tests {
     use rstest::rstest;
     use serde_json::json;
 
-    use super::set_transaction::is_set_txn_expired;
     use super::*;
     use crate::arrow::array::{
         Array, BooleanArray, Int32Array, Int64Array, ListArray, ListBuilder, MapBuilder,
@@ -1197,14 +1211,16 @@ mod tests {
     #[case::last_updated_before_expiration(Some(2000), Some(1000), true)]
     #[case::last_updated_at_expiration(Some(1000), Some(1000), true)]
     #[case::last_updated_after_expiration(Some(2000), Some(3000), false)]
-    fn test_is_set_txn_expired(
+    fn test_set_transaction_expiration(
         #[case] expiration_timestamp: Option<i64>,
         #[case] last_updated: Option<i64>,
-        #[case] expected: bool,
+        #[case] expired: bool,
     ) {
+        let txn = SetTransaction::new("app".to_string(), 7, last_updated);
+        assert_eq!(txn.is_expired(expiration_timestamp), expired);
         assert_eq!(
-            is_set_txn_expired(expiration_timestamp, last_updated),
-            expected
+            txn.non_expired_version(expiration_timestamp),
+            (!expired).then_some(7)
         );
     }
 

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -3,7 +3,7 @@ use crate::actions::visitors::SetTransactionVisitor;
 use crate::actions::{SetTransaction, LOG_TXN_SCHEMA};
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
-use crate::{DeltaResult, Engine, RowVisitor as _};
+use crate::{DeltaResult, Engine, RowVisitor as _, Version};
 
 /// Returns `true` if a set transaction is expired according to the given expiration and
 /// last-updated timestamps. A transaction is expired when both values are present and
@@ -20,6 +20,12 @@ pub(crate) fn is_set_txn_expired(
     )
 }
 
+/// Resolves the latest `txn` action per application id via log replay, where the newest action in
+/// log order wins.
+///
+/// Every method returns the resolved `txn` as-is. Applying retention is the caller's
+/// responsibility: filter the resolved result with [`is_set_txn_expired`]. Filtering during replay
+/// instead would drop an expired newest `txn` and resolve to an older one.
 pub(crate) struct SetTransactionScanner {}
 
 impl SetTransactionScanner {
@@ -31,28 +37,42 @@ impl SetTransactionScanner {
         log_segment: &LogSegment,
         application_id: &str,
         engine: &dyn Engine,
-        expiration_timestamp: Option<i64>,
     ) -> DeltaResult<Option<SetTransaction>> {
-        let mut transactions = scan_application_transactions(
-            log_segment,
-            Some(application_id),
-            engine,
-            expiration_timestamp,
-        )?;
+        let mut transactions =
+            scan_application_transactions(log_segment, Some(application_id), engine)?;
         Ok(transactions.remove(application_id))
     }
 
-    /// Scan the Delta Log to obtain the all of the latest `txn` actions.
-    ///
-    /// This performs log replay and populates the `SetTransactionMap` with the latest `txn` action
-    /// found for each app_id.
+    /// Scan the Delta Log for the latest `txn` action of every application id.
     #[allow(unused)]
     pub(crate) fn get_all(
         log_segment: &LogSegment,
         engine: &dyn Engine,
-        expiration_timestamp: Option<i64>,
     ) -> DeltaResult<SetTransactionMap> {
-        scan_application_transactions(log_segment, None, engine, expiration_timestamp)
+        scan_application_transactions(log_segment, None, engine)
+    }
+
+    /// Fetch the latest `txn` action for `application_id`, rooted in an authoritative (`Complete`)
+    /// but stale CRC's `base_active` map at `base_version`, scanning ONLY the commits in
+    /// `(base_version, log_segment.end_version]`.
+    ///
+    /// The checkpoint and every commit at/below `base_version` are skipped via
+    /// [`LogSegment::segment_after_version`]. When the tail holds a `txn` for `application_id`, its
+    /// newest wins; otherwise the result is that id's entry in `base_active`, the value the CRC
+    /// recorded at `base_version`.
+    pub(crate) fn get_one_rooted_in_crc(
+        log_segment: &LogSegment,
+        application_id: &str,
+        base_active: &SetTransactionMap,
+        base_version: Version,
+        engine: &dyn Engine,
+    ) -> DeltaResult<Option<SetTransaction>> {
+        let tail = Self::get_one(
+            &log_segment.segment_after_version(base_version),
+            application_id,
+            engine,
+        )?;
+        Ok(tail.or_else(|| base_active.get(application_id).cloned()))
     }
 }
 
@@ -63,10 +83,8 @@ fn scan_application_transactions(
     log_segment: &LogSegment,
     application_id: Option<&str>,
     engine: &dyn Engine,
-    expiration_timestamp: Option<i64>,
 ) -> DeltaResult<SetTransactionMap> {
-    let mut visitor =
-        SetTransactionVisitor::new(application_id.map(|s| s.to_owned()), expiration_timestamp);
+    let mut visitor = SetTransactionVisitor::new(application_id.map(|s| s.to_owned()));
     // If a specific id is requested then we can terminate log replay early as soon as it was
     // found. If all ids are requested then we are forced to replay the entire log.
     for maybe_data in replay_for_app_ids(log_segment, engine)? {
@@ -113,8 +131,8 @@ mod tests {
         let log_segment = snapshot.log_segment();
 
         (
-            SetTransactionScanner::get_all(log_segment, &engine, None).unwrap(),
-            SetTransactionScanner::get_one(log_segment, app_id, &engine, None).unwrap(),
+            SetTransactionScanner::get_all(log_segment, &engine).unwrap(),
+            SetTransactionScanner::get_one(log_segment, app_id, &engine).unwrap(),
         )
     }
 
@@ -171,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn test_txn_retention_filtering() {
+    fn test_get_all_returns_every_txn_unfiltered() {
         let path = std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-with-last-updated/"));
         let url = url::Url::from_directory_path(path.unwrap()).unwrap();
         let engine = SyncEngine::new();
@@ -179,34 +197,25 @@ mod tests {
         let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let log_segment = snapshot.log_segment();
 
-        // Test with no retention (should get all transactions)
-        let all_txns = SetTransactionScanner::get_all(log_segment, &engine, None).unwrap();
+        // The scanner returns every app_id regardless of `lastUpdated`; callers apply retention.
+        let all_txns = SetTransactionScanner::get_all(log_segment, &engine).unwrap();
         assert_eq!(all_txns.len(), 4);
-
-        // Test with retention that filters out old transactions
-        let expiration_timestamp = Some(100); // Very old timestamp
-        let filtered_txns =
-            SetTransactionScanner::get_all(log_segment, &engine, expiration_timestamp).unwrap();
-
-        // Exact count depends on test data
-        assert!(filtered_txns.len() <= all_txns.len());
     }
 
     #[test]
-    fn test_visitor_retention_with_null_last_updated() {
+    fn test_visitor_keeps_newest_by_log_order_regardless_of_last_updated() {
+        // Batches are visited in reverse log order, so the first row wins per app_id.
         let json_strings: StringArray = vec![
-            r#"{"txn":{"appId":"app_with_time","version":1,"lastUpdated":100}}"#,
-            r#"{"txn":{"appId":"app_without_time","version":2}}"#,
+            r#"{"txn":{"appId":"app","version":2,"lastUpdated":100}}"#,
+            r#"{"txn":{"appId":"app","version":1,"lastUpdated":999}}"#,
         ]
         .into();
         let batch = parse_json_batch(json_strings);
 
-        let mut visitor = SetTransactionVisitor::new(None, Some(1000));
+        let mut visitor = SetTransactionVisitor::new(None);
         visitor.visit_rows_of(batch.as_ref()).unwrap();
 
-        // app_with_last_updated should be filtered out (100 < 1000)
-        // app_without_last_updated should be kept
         assert_eq!(visitor.set_transactions.len(), 1);
-        assert!(visitor.set_transactions.contains_key("app_without_time"));
+        assert_eq!(visitor.set_transactions.get("app").unwrap().version, 2);
     }
 }

--- a/kernel/src/actions/set_transaction.rs
+++ b/kernel/src/actions/set_transaction.rs
@@ -5,27 +5,12 @@ use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
 use crate::{DeltaResult, Engine, RowVisitor as _, Version};
 
-/// Returns `true` if a set transaction is expired according to the given expiration and
-/// last-updated timestamps. A transaction is expired when both values are present and
-/// `last_updated <= expiration_timestamp`. Transactions without `last_updated` never
-/// expire. A `None` expiration timestamp (no retention duration configured) means
-/// nothing expires.
-pub(crate) fn is_set_txn_expired(
-    expiration_timestamp: Option<i64>,
-    last_updated: Option<i64>,
-) -> bool {
-    matches!(
-        (expiration_timestamp, last_updated),
-        (Some(exp_ts), Some(lu)) if lu <= exp_ts
-    )
-}
-
 /// Resolves the latest `txn` action per application id via log replay, where the newest action in
 /// log order wins.
 ///
 /// Every method returns the resolved `txn` as-is. Applying retention is the caller's
-/// responsibility: filter the resolved result with [`is_set_txn_expired`]. Filtering during replay
-/// instead would drop an expired newest `txn` and resolve to an older one.
+/// responsibility: use [`SetTransaction::non_expired_version`] on the resolved result. Filtering
+/// during replay instead would drop an expired newest `txn` and resolve to an older one.
 pub(crate) struct SetTransactionScanner {}
 
 impl SetTransactionScanner {

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 
 use super::deletion_vector::DeletionVectorDescriptor;
-use super::set_transaction::is_set_txn_expired;
 use super::*;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::log_segment::DomainMetadataMap;
@@ -308,18 +307,14 @@ pub(crate) type SetTransactionMap = HashMap<String, SetTransaction>;
 pub(crate) struct SetTransactionVisitor {
     pub(crate) set_transactions: SetTransactionMap,
     pub(crate) application_id: Option<String>,
-    /// Minimum timestamp for transaction retention. Transactions with last_updated
-    /// older than or equal to this timestamp will be filtered out. None means no filtering.
-    expiration_timestamp: Option<i64>,
 }
 
 impl SetTransactionVisitor {
     /// Create a new visitor. When application_id is set then bookkeeping is only for that id only
-    pub(crate) fn new(application_id: Option<String>, expiration_timestamp: Option<i64>) -> Self {
+    pub(crate) fn new(application_id: Option<String>) -> Self {
         SetTransactionVisitor {
             set_transactions: HashMap::default(),
             application_id,
-            expiration_timestamp,
         }
     }
 
@@ -364,9 +359,6 @@ impl RowVisitor for SetTransactionVisitor {
                     .is_none_or(|requested| requested.eq(&app_id))
                 {
                     let txn = SetTransactionVisitor::visit_txn(i, app_id, getters)?;
-                    if is_set_txn_expired(self.expiration_timestamp, txn.last_updated) {
-                        continue;
-                    }
                     if !self.set_transactions.contains_key(&txn.app_id) {
                         self.set_transactions.insert(txn.app_id.clone(), txn);
                     }

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -436,7 +436,9 @@ impl Snapshot {
     /// Fetch the latest version of the provided `application_id` for this snapshot. Filters the
     /// txn based on the delta.setTransactionRetentionDuration property and lastUpdated.
     ///
-    /// Uses the CRC fast path when available, otherwise falls back to log replay.
+    /// Serves from an at-version CRC when it has the app_id (or authoritatively lacks it); else
+    /// roots a tail-only scan in a stale but `Complete` CRC, skipping the checkpoint; else full log
+    /// replay.
     ///
     /// Reports metrics: `SetTransactionLoadSuccess` or `SetTransactionLoadFailure`.
     // TODO: add a get_app_id_versions to fetch all at once using SetTransactionScanner::get_all
@@ -485,15 +487,39 @@ impl Snapshot {
             }
         }
 
-        // Fallback: full log replay.
-        let txn = SetTransactionScanner::get_one(
-            self.log_segment(),
-            application_id,
-            engine,
-            expiration_timestamp,
-        )?;
-        record_metric(false, txn.is_some());
-        Ok(txn.map(|t| t.version))
+        // A stale but authoritative (`Complete`) CRC roots a tail-only scan over the commits after
+        // it, skipping the checkpoint. A stale `Partial` CRC (one whose file lacked the
+        // `setTransactions` field) has no authoritative transaction set, so it cannot root the
+        // scan and falls through to the full replay below.
+        if let Some(base) = self.base_crc() {
+            if let SetTransactionState::Complete(base_active) = &base.set_transaction_state {
+                let txn = SetTransactionScanner::get_one_rooted_in_crc(
+                    self.log_segment(),
+                    application_id,
+                    base_active,
+                    base.version,
+                    engine,
+                )?;
+                let version = txn
+                    .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
+                    .map(|txn| txn.version);
+                // TODO: report a distinct metric source here. A rooted tail scan is neither a
+                //       cache hit nor a full replay, yet `from_cache = false` buckets it with
+                //       full replay, hiding the checkpoint-skipping win. A 3-variant source enum
+                //       (cache / crc-rooted / full-replay) would let metrics measure it.
+                record_metric(false, version.is_some());
+                return Ok(version);
+            }
+        }
+
+        // Fallback: full log replay. Scan for the newest txn and apply expiration to it, like the
+        // CRC paths above.
+        let txn = SetTransactionScanner::get_one(self.log_segment(), application_id, engine)?;
+        let version = txn
+            .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
+            .map(|txn| txn.version);
+        record_metric(false, version.is_some());
+        Ok(version)
     }
 
     /// Fetch the domainMetadata for a specific domain in this snapshot. This returns the latest

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -9,7 +9,7 @@ use tracing::{debug, info, instrument, warn};
 use url::Url;
 
 use crate::action_reconciliation::calculate_transaction_expiration_timestamp;
-use crate::actions::set_transaction::{is_set_txn_expired, SetTransactionScanner};
+use crate::actions::set_transaction::SetTransactionScanner;
 use crate::actions::{DomainMetadata, INTERNAL_DOMAIN_PREFIX};
 use crate::checkpoint::{
     CheckpointSpec, CheckpointWriter, V2CheckpointConfig, DEFAULT_FILE_ACTIONS_PER_SIDECAR_HINT,
@@ -470,16 +470,14 @@ impl Snapshot {
                     // Complete is authoritative: a miss means the app_id has no transaction.
                     let version = map
                         .get(application_id)
-                        .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
-                        .map(|txn| txn.version);
+                        .and_then(|txn| txn.non_expired_version(expiration_timestamp));
                     record_metric(true, version.is_some());
                     return Ok(version);
                 }
                 SetTransactionState::Partial(map) => {
                     // Hit is authoritative; miss falls through to log replay below.
                     if let Some(txn) = map.get(application_id) {
-                        let version = (!is_set_txn_expired(expiration_timestamp, txn.last_updated))
-                            .then_some(txn.version);
+                        let version = txn.non_expired_version(expiration_timestamp);
                         record_metric(true, version.is_some());
                         return Ok(version);
                     }
@@ -500,9 +498,7 @@ impl Snapshot {
                     base.version,
                     engine,
                 )?;
-                let version = txn
-                    .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
-                    .map(|txn| txn.version);
+                let version = txn.and_then(|txn| txn.non_expired_version(expiration_timestamp));
                 // TODO: report a distinct metric source here. A rooted tail scan is neither a
                 //       cache hit nor a full replay, yet `from_cache = false` buckets it with
                 //       full replay, hiding the checkpoint-skipping win. A 3-variant source enum
@@ -515,9 +511,7 @@ impl Snapshot {
         // Fallback: full log replay. Scan for the newest txn and apply expiration to it, like the
         // CRC paths above.
         let txn = SetTransactionScanner::get_one(self.log_segment(), application_id, engine)?;
-        let version = txn
-            .filter(|txn| !is_set_txn_expired(expiration_timestamp, txn.last_updated))
-            .map(|txn| txn.version);
+        let version = txn.and_then(|txn| txn.non_expired_version(expiration_timestamp));
         record_metric(false, version.is_some());
         Ok(version)
     }

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -1687,6 +1687,46 @@ async fn test_set_txn_null_last_updated_never_expires_via_log_replay() -> DeltaR
     Ok(())
 }
 
+// The newest txn by log order for an app_id wins, then expiration is applied to it: an expired
+// newest yields None, it does NOT fall back to an older non-expired txn. Uses non-monotonic
+// lastUpdated (v1 far-future, v2 tiny) so the newest-by-log-order txn (v2) is the expired one.
+#[tokio::test]
+async fn test_set_txn_expired_newest_returns_none_not_older_via_log_replay() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let schema = schema_ref! { nullable "id": INTEGER };
+    create_table(&table_path, schema, "test_engine")
+        .with_table_properties([("delta.setTransactionRetentionDuration", "interval 365 days")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let store = Arc::new(LocalFileSystem::new());
+    add_commit(
+        &table_path,
+        store.as_ref(),
+        1,
+        r#"{"txn":{"appId":"app","version":1,"lastUpdated":99999999999999}}"#.to_string(),
+    )
+    .await
+    .unwrap();
+    add_commit(
+        &table_path,
+        store.as_ref(),
+        2,
+        r#"{"txn":{"appId":"app","version":2,"lastUpdated":1000}}"#.to_string(),
+    )
+    .await
+    .unwrap();
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 2);
+    assert!(fresh.crc_at_version().is_none());
+    assert_eq!(fresh.get_app_id_version("app", engine.as_ref())?, None);
+
+    Ok(())
+}
+
 // ============================================================================
 // File Histogram Tracking Across Commits
 // ============================================================================
@@ -2520,6 +2560,111 @@ async fn test_dm_query_stale_partial_crc_falls_through_to_full_scan() -> DeltaRe
     };
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         fresh.get_domain_metadata("dom_before", &no_parquet).ok()
+    }))
+    .is_err());
+
+    Ok(())
+}
+
+// ============================================================================
+// Set transactions rooted in a stale (but authoritative) CRC
+// ============================================================================
+
+/// Builds checkpoint@10, commits to v20, and a CRC at v15. Loaded with the default `Disabled`
+/// replay so the v15 CRC is retained as a stale base (`crc_at_version()` is `None`). Seeds three
+/// app_ids covering every reconcile arm:
+/// - `app_before` set at v5 and never touched again (base stands),
+/// - `app_updated` set at v6 then re-set to a higher version at v16 (tail supersedes the base),
+/// - `app_after` set at v18 (new in the tail).
+async fn setup_stale_crc_txn_table<E: TaskExecutor>(
+    engine: &Arc<DefaultEngine<E>>,
+    table_path: &str,
+) -> DeltaResult<()> {
+    let schema = schema_ref! { nullable "id": INTEGER };
+    let mut snap = create_table(table_path, schema, "test_engine")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+
+    for v in 1..=20i64 {
+        snap = commit_data(snap, engine, v, |txn| match v {
+            5 => txn.with_transaction_id("app_before".to_string(), 5),
+            6 => txn.with_transaction_id("app_updated".to_string(), 6),
+            16 => txn.with_transaction_id("app_updated".to_string(), 16),
+            18 => txn.with_transaction_id("app_after".to_string(), 18),
+            _ => txn,
+        })
+        .await?;
+
+        if v == 10 {
+            snap = snap.checkpoint(engine.as_ref(), None)?.1;
+        }
+        if v == 15 {
+            snap.write_checksum(engine.as_ref())?;
+        }
+    }
+    Ok(())
+}
+
+// Every app_id resolves against a stale Complete CRC by scanning only the commit tail. The
+// NoParquetReadsEngine panics if the v10 checkpoint is read, proving the checkpoint is skipped.
+#[rstest]
+#[case::base_stands("app_before", Some(5))]
+#[case::tail_supersedes_base("app_updated", Some(16))]
+#[case::tail_added("app_after", Some(18))]
+#[case::never_existed("app_missing", None)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txn_query_rooted_in_stale_complete_crc(
+    #[case] app_id: &str,
+    #[case] expected: Option<i64>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_txn_table(&engine, &table_path).await?;
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 20);
+    assert!(
+        fresh.crc_at_version().is_none(),
+        "the stale CRC must not sit at the snapshot version"
+    );
+
+    let engine = NoParquetReadsEngine {
+        inner: engine.clone(),
+    };
+    assert_eq!(fresh.get_app_id_version(app_id, &engine)?, expected);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_txn_query_stale_partial_crc_falls_through_to_full_scan() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    setup_stale_crc_txn_table(&engine, &table_path).await?;
+
+    // Strip setTransactions from the v15 CRC so it reloads as Partial: not authoritative, so the
+    // query must not take the rooted path.
+    strip_field_from_crc(&table_path, 15, "setTransactions");
+
+    let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(fresh.version(), 20);
+    assert!(fresh.crc_at_version().is_none());
+
+    // Results are still correct via the full scan (with the real engine).
+    assert_eq!(
+        fresh.get_app_id_version("app_before", engine.as_ref())?,
+        Some(5)
+    );
+    assert_eq!(
+        fresh.get_app_id_version("app_updated", engine.as_ref())?,
+        Some(16)
+    );
+
+    // A full scan reads the v10 checkpoint, so NoParquetReadsEngine panics: the Partial base did
+    // NOT take the rooted (checkpoint-skipping) path.
+    let no_parquet = NoParquetReadsEngine {
+        inner: engine.clone(),
+    };
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fresh.get_app_id_version("app_before", &no_parquet).ok()
     }))
     .is_err());
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR does three things:

1. For Snapshots loaded with incremental-crc-replay disabled, this PR allows them to root SetTxn queries in CRCs. That is: given 10.checkpoint, 11.json to 20.json, and 15.crc: to search for a SetTxn, scan 20.json to 16.json backwards, then read 15.crc, skipping the checkpoint.

Only applies to Complete SetTxn state. If 15.crc is missing the setTransactions field (Partial), it is not authoritative, so the query performs normal (full) log replay.

2. This PR also fixes the retention filtering order in queries. All three query paths (at-version CRC, rooted CRC, full replay) now resolve the newest SetTxn first, then apply retention. The full-replay path previously filtered during log replay, which could drop an expired newest SetTxn and resolve to an older one. `SetTransactionScanner` no longer takes an expiration timestamp; callers filter the resolved result.

3. Fixes the same retention-order bug in the checkpoint/log-compaction write path. `check_txn_action` filtered by retention before recording the app_id, so an expired newest SetTxn let an older one survive into the checkpoint. It now records the app_id first, then applies retention, matching delta-spark.

## How was this change tested?

New UT and integration tests.