### PR TITLE
perf!: make log listing single-directory

### DIFF
--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use delta_kernel::object_store::list::{PaginatedListOptions, PaginatedListStore};
 use delta_kernel::object_store::path::Path;
-use delta_kernel::object_store::{self, DynObjectStore, ObjectStoreExt as _, PutMode};
+use delta_kernel::object_store::{self, DynObjectStore, ObjectMeta, ObjectStoreExt as _, PutMode};
 use delta_kernel::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
 use futures::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use itertools::Itertools;
@@ -11,17 +12,33 @@ use url::Url;
 use crate::executor::TaskExecutor;
 use crate::UrlExt;
 
-#[derive(Debug)]
 pub struct ObjectStoreStorageHandler<E: TaskExecutor> {
     inner: Arc<DynObjectStore>,
+    /// `Some` for S3/GCS/Azure (delimiter pushdown), `None` elsewhere (client-side filter).
+    paginated: Option<Arc<dyn PaginatedListStore>>,
     task_executor: Arc<E>,
     readahead: usize,
 }
 
+impl<E: TaskExecutor> std::fmt::Debug for ObjectStoreStorageHandler<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectStoreStorageHandler")
+            .field("inner", &self.inner)
+            .field("paginated", &self.paginated.is_some())
+            .field("readahead", &self.readahead)
+            .finish_non_exhaustive()
+    }
+}
+
 impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
-    pub(crate) fn new(store: Arc<DynObjectStore>, task_executor: Arc<E>) -> Self {
+    pub(crate) fn new(
+        store: Arc<DynObjectStore>,
+        paginated: Option<Arc<dyn PaginatedListStore>>,
+        task_executor: Arc<E>,
+    ) -> Self {
         Self {
             inner: store,
+            paginated,
             task_executor,
             readahead: 10,
         }
@@ -34,21 +51,9 @@ impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
     }
 }
 
-/// Native async implementation for list_from.
-///
-/// Storage metrics are emitted by the outer [`MeteredStorageHandler`] wrapping this
-/// handler (e.g. inside `DefaultEngine`'s `storage_handler()`), so this function just
-/// returns the raw stream.
-///
-/// [`MeteredStorageHandler`]: delta_kernel::metrics::MeteredStorageHandler
-async fn list_from_impl(
-    store: Arc<DynObjectStore>,
-    path: Url,
-) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
-    // The offset is used for list-after; the prefix is used to restrict the listing to a specific
-    // directory. Unfortunately, `Path` provides no easy way to check whether a name is
-    // directory-like, because it strips trailing /, so we're reduced to manually checking the
-    // original URL.
+/// Returns the `(prefix, offset)` to list: a trailing-`/` `path` lists itself, otherwise its
+/// parent is listed after `path`.
+fn list_scope(path: &Url) -> DeltaResult<(Path, Path)> {
     let offset = Path::from_url_path(path.path())?;
     let prefix = if path.path().ends_with('/') {
         offset.clone()
@@ -61,31 +66,130 @@ async fn list_from_impl(
         }
         Path::from_iter(parts)
     };
+    Ok((prefix, offset))
+}
 
-    let has_ordered_listing = supports_ordered_listing(&path);
+/// Builds a [`FileMeta`], taking the scheme and authority from `base`.
+fn file_meta(base: &Url, meta: ObjectMeta) -> FileMeta {
+    let mut location = base.clone();
+    location.set_path(&format!("/{}", meta.location.as_ref()));
+    FileMeta {
+        location,
+        last_modified: meta.last_modified.timestamp_millis(),
+        size: meta.size,
+    }
+}
 
-    let stream = store
-        .list_with_offset(Some(&prefix), &offset)
-        .map(move |meta| {
-            let meta = meta?;
-            let mut location = path.clone();
-            location.set_path(&format!("/{}", meta.location.as_ref()));
-            Ok(FileMeta {
-                location,
-                last_modified: meta.last_modified.timestamp_millis(),
-                size: meta.size,
+/// Options for a follow-up page: continuation token only, no offset (offset is first-page only).
+fn next_page_opts(token: String) -> PaginatedListOptions {
+    PaginatedListOptions {
+        delimiter: Some("/".into()),
+        page_token: Some(token),
+        ..Default::default()
+    }
+}
+
+/// Sorts and drops entries at or before `offset`, for out-of-order or offset-ignoring backends.
+/// Compares in the store's decoded key space, not the encoded URL path.
+fn sort_and_bound(
+    mut items: Vec<ObjectMeta>,
+    base: &Url,
+    offset: &Path,
+) -> BoxStream<'static, DeltaResult<FileMeta>> {
+    if !offset.as_ref().is_empty() {
+        items.retain(|m| m.location.as_ref() > offset.as_ref());
+    }
+    items.sort_unstable_by(|a, b| a.location.cmp(&b.location));
+    let base = base.clone();
+    Box::pin(stream::iter(
+        items.into_iter().map(move |m| Ok(file_meta(&base, m))),
+    ))
+}
+
+/// Single-directory `list_from`, dispatching by whether the store supports delimiter pushdown.
+async fn list_from_impl(
+    store: Arc<DynObjectStore>,
+    paginated: Option<Arc<dyn PaginatedListStore>>,
+    path: Url,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    let (prefix, offset) = list_scope(&path)?;
+    let ordered = supports_ordered_listing(&path);
+    match paginated {
+        Some(p) => list_one_level_paginated(p, path, prefix, offset, ordered).await,
+        None => list_one_level_delimited(store, path, prefix, offset).await,
+    }
+}
+
+/// Fallback for stores without a [`PaginatedListStore`] handle. `list_with_delimiter` is one level
+/// but takes no offset, so bound and sort client-side.
+async fn list_one_level_delimited(
+    store: Arc<DynObjectStore>,
+    base_url: Url,
+    prefix: Path,
+    offset: Path,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    let result = store.list_with_delimiter(Some(&prefix)).await?;
+    Ok(sort_and_bound(result.objects, &base_url, &offset))
+}
+
+/// List one directory level via [`PaginatedListStore`]'s `/` delimiter. Ordered backends stream
+/// pages lazily so a caller can stop early. S3 Express is unordered and rejects `start-after`, so
+/// it gets no offset and is bounded client-side.
+async fn list_one_level_paginated(
+    paginated: Arc<dyn PaginatedListStore>,
+    base_url: Url,
+    prefix: Path,
+    offset: Path,
+    ordered: bool,
+) -> DeltaResult<BoxStream<'static, DeltaResult<FileMeta>>> {
+    // `list_paginated` needs the trailing slash. An empty prefix lists the root.
+    let req_prefix = (!prefix.as_ref().is_empty()).then(|| format!("{}/", prefix.as_ref()));
+    // A directory-like path has offset == prefix, which is not a lower bound worth sending.
+    let req_offset = (ordered && offset != prefix).then(|| offset.to_string());
+
+    let first_opts = PaginatedListOptions {
+        offset: req_offset,
+        delimiter: Some("/".into()),
+        ..Default::default()
+    };
+
+    let pages = stream::try_unfold(Some(first_opts), move |opts| {
+        let (paginated, req_prefix) = (paginated.clone(), req_prefix.clone());
+        async move {
+            let Some(opts) = opts else {
+                return Ok::<_, object_store::Error>(None);
+            };
+            let result = paginated
+                .list_paginated(req_prefix.as_deref(), opts)
+                .await?;
+            Ok(Some((
+                result.result.objects,
+                result.page_token.map(next_page_opts),
+            )))
+        }
+    });
+
+    if ordered {
+        Ok(pages
+            .map_ok(move |objects| {
+                let base_url = base_url.clone();
+                stream::iter(
+                    objects
+                        .into_iter()
+                        .map(move |m| Ok::<_, object_store::Error>(file_meta(&base_url, m))),
+                )
             })
-        });
-
-    if !has_ordered_listing {
-        // Local filesystem doesn't return sorted list - need to collect and sort
-        let mut items: Vec<_> = stream.try_collect().await?;
-        items.sort_unstable();
-        Ok(Box::pin(stream::iter(
-            items.into_iter().map(Ok::<FileMeta, delta_kernel::Error>),
-        )))
+            .try_flatten()
+            .err_into()
+            .boxed())
     } else {
-        Ok(Box::pin(stream))
+        let objects: Vec<ObjectMeta> = pages
+            .try_collect::<Vec<_>>()
+            .await?
+            .into_iter()
+            .flatten()
+            .collect();
+        Ok(sort_and_bound(objects, &base_url, &offset))
     }
 }
 
@@ -192,7 +296,7 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
         &self,
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
-        let future = list_from_impl(self.inner.clone(), path.clone());
+        let future = list_from_impl(self.inner.clone(), self.paginated.clone(), path.clone());
         let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
         Ok(iter) // type coercion drops the unneeded Send bound
     }
@@ -269,10 +373,15 @@ fn supports_ordered_listing(url: &Url) -> bool {
 #[cfg(test)]
 mod tests {
     use std::ops::Range;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
+    use delta_kernel::object_store::list::{
+        PaginatedListOptions, PaginatedListResult, PaginatedListStore,
+    };
     use delta_kernel::object_store::local::LocalFileSystem;
     use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel::object_store::{ListResult, ObjectMeta, ObjectStore, PutPayload};
     use delta_kernel::Engine as _;
     use delta_kernel_default_engine_test_utils::current_time_duration;
     use itertools::Itertools;
@@ -290,7 +399,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = Arc::new(LocalFileSystem::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
-        let handler = ObjectStoreStorageHandler::new(store.clone(), executor);
+        let handler = ObjectStoreStorageHandler::new(store.clone(), None, executor);
         (tmp, store, handler)
     }
 
@@ -337,7 +446,7 @@ mod tests {
 
         let store = Arc::new(LocalFileSystem::new());
         let executor = Arc::new(TokioBackgroundExecutor::new());
-        let storage = ObjectStoreStorageHandler::new(store, executor);
+        let storage = ObjectStoreStorageHandler::new(store, None, executor);
 
         let mut slices: Vec<FileSlice> = Vec::new();
 
@@ -371,7 +480,7 @@ mod tests {
         let engine = DefaultEngineBuilder::new(store).build();
         let files: Vec<_> = engine
             .storage_handler()
-            .list_from(&table_root.join("_delta_log").unwrap().join("0").unwrap())
+            .list_from(&table_root.join("_delta_log/").unwrap().join("0").unwrap())
             .unwrap()
             .try_collect()
             .unwrap();
@@ -401,7 +510,7 @@ mod tests {
         let engine = DefaultEngineBuilder::new(store).build();
         let files = engine
             .storage_handler()
-            .list_from(&url.join("_delta_log").unwrap().join("0").unwrap())
+            .list_from(&url.join("_delta_log/").unwrap().join("0").unwrap())
             .unwrap();
         let mut len = 0;
         for (file, expected) in files.zip(expected_names.iter()) {
@@ -556,5 +665,356 @@ mod tests {
             Err(Error::FileNotFound(_))
         ));
         handler.delete(&missing_url).unwrap();
+    }
+
+    /// [`PaginatedListStore`] over [`InMemory`] mimicking cloud `list_paginated`: `/` grouping,
+    /// `offset` start-after, one `page_size` chunk per call. `reverse` lists descending (exercises
+    /// the sort path). `honors_offset = false` models S3 Express dropping `start-after`.
+    /// `fail_after = Some(n)` errors on page `n`.
+    struct MockPaginatedStore {
+        inner: Arc<InMemory>,
+        page_size: usize,
+        reverse: bool,
+        honors_offset: bool,
+        fail_after: Option<usize>,
+        pages_fetched: Arc<AtomicUsize>,
+    }
+
+    impl MockPaginatedStore {
+        fn new(inner: Arc<InMemory>, page_size: usize, reverse: bool) -> Self {
+            Self {
+                inner,
+                page_size,
+                reverse,
+                honors_offset: true,
+                fail_after: None,
+                pages_fetched: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn ignoring_offset(mut self) -> Self {
+            self.honors_offset = false;
+            self
+        }
+
+        fn failing_after(mut self, pages: usize) -> Self {
+            self.fail_after = Some(pages);
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl PaginatedListStore for MockPaginatedStore {
+        async fn list_paginated(
+            &self,
+            prefix: Option<&str>,
+            opts: PaginatedListOptions,
+        ) -> delta_kernel::object_store::Result<PaginatedListResult> {
+            assert_eq!(
+                opts.delimiter.as_deref(),
+                Some("/"),
+                "expected `/` delimiter"
+            );
+            let fetched = self.pages_fetched.fetch_add(1, Ordering::Relaxed);
+            if self.fail_after == Some(fetched) {
+                return Err(delta_kernel::object_store::Error::Generic {
+                    store: "MockPaginatedStore",
+                    source: "injected mid-stream failure".into(),
+                });
+            }
+            let prefix = prefix.unwrap_or("");
+
+            // Direct children of the prefix, in key order. Offset-independent so the page cursor
+            // stays valid across pages (the offset only arrives on page one).
+            let mut objects: Vec<ObjectMeta> = self
+                .inner
+                .list(None)
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .map(|m| m.unwrap())
+                .filter(|m| {
+                    m.location
+                        .as_ref()
+                        .strip_prefix(prefix)
+                        .is_some_and(|rest| !rest.contains('/'))
+                })
+                .collect();
+            objects.sort_by(|a, b| a.location.cmp(&b.location));
+            if self.reverse {
+                objects.reverse();
+            }
+
+            // Page one `page_size` chunk per call, keyed by an integer start cursor. A first-page
+            // offset advances the cursor past every key at or before it (start-after is exclusive).
+            let mut start: usize = opts
+                .page_token
+                .as_deref()
+                .map(|t| t.parse().unwrap())
+                .unwrap_or(0);
+            if self.honors_offset {
+                if let Some(offset) = &opts.offset {
+                    start = objects.partition_point(|m| m.location.as_ref() <= offset.as_str());
+                }
+            }
+            let end = (start + self.page_size).min(objects.len());
+            let page: Vec<ObjectMeta> = objects[start..end].to_vec();
+            let page_token = (end < objects.len()).then(|| end.to_string());
+            Ok(PaginatedListResult {
+                result: ListResult {
+                    common_prefixes: Vec::new(),
+                    objects: page,
+                },
+                page_token,
+            })
+        }
+    }
+
+    async fn put_key(store: &InMemory, key: &str) {
+        store
+            .put(&Path::from(key), PutPayload::from_static(b"x"))
+            .await
+            .unwrap();
+    }
+
+    fn collect_names<E: TaskExecutor>(
+        handler: &ObjectStoreStorageHandler<E>,
+        url: &str,
+    ) -> Vec<String> {
+        handler
+            .list_from(&Url::parse(url).unwrap())
+            .unwrap()
+            .map(|m| m.unwrap().location.path().to_string())
+            .collect()
+    }
+
+    /// Commits 0-2, a checkpoint at 2, and `staged` commits under `_staged_commits/`.
+    async fn seed_log(store: &InMemory, staged: usize) {
+        for v in 0..3 {
+            put_key(store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        put_key(store, "_delta_log/00000000000000000002.checkpoint.parquet").await;
+        for v in 0..staged {
+            put_key(
+                store,
+                &format!("_delta_log/_staged_commits/{v:020}.{v}-uuid.json"),
+            )
+            .await;
+        }
+    }
+
+    /// Both paths return only the direct children of `_delta_log/`, not the staged commits.
+    #[rstest::rstest]
+    #[case::path_a_paginated(true)]
+    #[case::path_b_fallback(false)]
+    #[tokio::test]
+    async fn list_from_single_directory_omits_staged_commits(#[case] paginated: bool) {
+        let store = Arc::new(InMemory::new());
+        seed_log(&store, 20).await;
+
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let paginated: Option<Arc<dyn PaginatedListStore>> =
+            paginated.then(|| Arc::new(MockPaginatedStore::new(store.clone(), 100, false)) as _);
+        let handler = ObjectStoreStorageHandler::new(store.clone(), paginated, executor);
+
+        // `s3://` is an ordered backend.
+        let names = collect_names(&handler, "s3://bucket/_delta_log/0");
+
+        assert!(
+            names.iter().all(|n| !n.contains("_staged_commits")),
+            "single-directory listing must exclude staged commits: {names:?}"
+        );
+        assert_eq!(
+            names.len(),
+            4,
+            "expected 3 commits + 1 checkpoint: {names:?}"
+        );
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted, "results must be sorted");
+    }
+
+    /// An unordered backend sorts, so descending input still comes back sorted.
+    #[tokio::test]
+    async fn list_from_paginated_unordered_sorts() {
+        let store = Arc::new(InMemory::new());
+        seed_log(&store, 5).await;
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 2, true));
+
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        // `--x-s3` is an S3 Express (unordered) bucket.
+        let names = collect_names(&handler, "s3://bucket--x-s3/_delta_log/0");
+
+        assert_eq!(names.len(), 4);
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(
+            names, sorted,
+            "unordered results must be sorted by the caller"
+        );
+    }
+
+    /// The lazy paginated path fetches only the pages a caller consumes.
+    #[tokio::test]
+    async fn list_from_paginated_ordered_is_lazy() {
+        let store = Arc::new(InMemory::new());
+        for v in 0..50 {
+            put_key(&store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 5, false));
+        let pages_fetched = mock.pages_fetched.clone();
+
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        let start = Url::parse("s3://bucket/_delta_log/0").unwrap();
+        let first_three: Vec<_> = handler.list_from(&start).unwrap().take(3).collect();
+
+        assert_eq!(first_three.len(), 3);
+        // Taking 3 from 5-per-page fetches only the first page.
+        assert_eq!(pages_fetched.load(Ordering::Relaxed), 1);
+    }
+
+    /// The ordered path threads the page token across many pages, in global order, with no dropped
+    /// or duplicated entries.
+    #[tokio::test]
+    async fn list_from_paginated_ordered_threads_pages_in_order() {
+        let store = Arc::new(InMemory::new());
+        for v in 0..50 {
+            put_key(&store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 5, false)); // 10 pages
+        let pages_fetched = mock.pages_fetched.clone();
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        let names = collect_names(&handler, "s3://bucket/_delta_log/0");
+
+        assert_eq!(
+            names.len(),
+            50,
+            "every direct child returned across all pages"
+        );
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(
+            names, sorted,
+            "ordered path stays sorted across page boundaries"
+        );
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(
+            unique.len(),
+            50,
+            "no dropped or duplicated entries at boundaries"
+        );
+        assert!(
+            pages_fetched.load(Ordering::Relaxed) >= 10,
+            "continuation threaded"
+        );
+    }
+
+    /// A first-page offset that excludes entries must stay bounded across page boundaries.
+    #[tokio::test]
+    async fn list_from_paginated_ordered_bounds_offset_across_pages() {
+        let store = Arc::new(InMemory::new());
+        for v in 0..20 {
+            put_key(&store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 5, false));
+
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        // Listing after version 4 spans multiple pages. Versions 0-4 must never appear.
+        let names = collect_names(&handler, "s3://bucket/_delta_log/00000000000000000004.json");
+
+        assert_eq!(names.len(), 15, "only versions 5-19: {names:?}");
+        assert!(names
+            .iter()
+            .all(|n| n.as_str() > "/_delta_log/00000000000000000004.json"));
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    /// An S3 Express bucket ignores `start-after`, so the offset must be enforced client-side.
+    #[tokio::test]
+    async fn list_from_paginated_s3_express_bounds_offset_client_side() {
+        let store = Arc::new(InMemory::new());
+        for v in 0..6 {
+            put_key(&store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        // Unordered, and ignores the offset the engine sends.
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 2, true).ignoring_offset());
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        // Listing after version 2 must still exclude versions 0-2.
+        let names = collect_names(
+            &handler,
+            "s3://bucket--x-s3/_delta_log/00000000000000000002.json",
+        );
+
+        assert_eq!(
+            names.len(),
+            3,
+            "only versions 3-5 are after the offset: {names:?}"
+        );
+        assert!(names
+            .iter()
+            .all(|n| n.as_str() > "/_delta_log/00000000000000000002.json"));
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    /// A failure on any page surfaces as an error, not a silently truncated listing.
+    #[rstest::rstest]
+    #[case::ordered("s3://bucket/_delta_log/0", false)]
+    #[case::unordered("s3://bucket--x-s3/_delta_log/0", true)]
+    #[tokio::test]
+    async fn list_from_paginated_surfaces_mid_stream_error(
+        #[case] url: &str,
+        #[case] reverse: bool,
+    ) {
+        let store = Arc::new(InMemory::new());
+        for v in 0..20 {
+            put_key(&store, &format!("_delta_log/{v:020}.json")).await;
+        }
+        // page_size 5, fail on the 2nd page (index 1).
+        let mock = Arc::new(MockPaginatedStore::new(store.clone(), 5, reverse).failing_after(1));
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), Some(mock as _), executor);
+
+        let outcome = handler.list_from(&Url::parse(url).unwrap());
+        let saw_err = match outcome {
+            Err(_) => true,
+            Ok(iter) => iter.into_iter().any(|r| r.is_err()),
+        };
+        assert!(
+            saw_err,
+            "a mid-stream page failure must surface, not silently truncate"
+        );
+    }
+
+    /// Listing the root directory (empty prefix) via the delimited fallback returns only top-level
+    /// files, not entries nested under a subdirectory.
+    #[tokio::test]
+    async fn list_from_root_delimited_returns_top_level_only() {
+        let store = Arc::new(InMemory::new());
+        put_key(&store, "00000000000000000000.json").await;
+        put_key(&store, "sub/nested.json").await;
+        let executor = Arc::new(TokioBackgroundExecutor::new());
+        let handler = ObjectStoreStorageHandler::new(store.clone(), None, executor);
+
+        let names = collect_names(&handler, "memory:///");
+
+        assert_eq!(
+            names,
+            vec!["/00000000000000000000.json"],
+            "only top-level files: {names:?}"
+        );
     }
 }

--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -53,6 +53,10 @@ impl<E: TaskExecutor> ObjectStoreStorageHandler<E> {
 
 /// Returns the `(prefix, offset)` to list: a trailing-`/` `path` lists itself, otherwise its
 /// parent is listed after `path`.
+///
+/// - `s3://bucket/_delta_log/` -> (`_delta_log`, `_delta_log`)
+/// - `s3://bucket/_delta_log/00000000000000000005.json` -> (`_delta_log`,
+///   `_delta_log/00000000000000000005.json`)
 fn list_scope(path: &Url) -> DeltaResult<(Path, Path)> {
     let offset = Path::from_url_path(path.path())?;
     let prefix = if path.path().ends_with('/') {
@@ -1016,5 +1020,12 @@ mod tests {
             vec!["/00000000000000000000.json"],
             "only top-level files: {names:?}"
         );
+    }
+
+    #[test]
+    fn list_scope_rejects_authority_only_url() {
+        // No path segments and not directory-like, thus no parent to list after.
+        let url = Url::parse("s3://bucket").unwrap();
+        assert!(matches!(list_scope(&url), Err(Error::Generic(_))));
     }
 }

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -29,7 +29,7 @@ use self::executor::TaskExecutor;
 use self::filesystem::ObjectStoreStorageHandler;
 use self::json::DefaultJsonHandler;
 use self::parquet::DefaultParquetHandler;
-use self::storage::{engine_store_from_url_opts, EngineStore};
+use self::storage::EngineStore;
 
 pub mod executor;
 pub mod file_stream;
@@ -223,7 +223,7 @@ pub struct DefaultEngineBuilder<E> {
 impl<E> std::fmt::Debug for DefaultEngineBuilder<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DefaultEngineBuilder")
-            .field("listing_capable", &self.store.paginated().is_some())
+            .field("listing_capable", &self.store.paginated.is_some())
             .field("io_config", &self.io_config)
             .finish_non_exhaustive()
     }
@@ -252,7 +252,7 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
     /// expose delimiter pushdown and falls back to a single `list_with_delimiter` request.
     pub fn new(object_store: Arc<DynObjectStore>) -> Self {
         Self {
-            store: EngineStore::Plain(object_store),
+            store: EngineStore::plain(object_store),
             task_executor: DefaultTaskExecutor,
             io_config: ReadIoConfig::default(),
         }
@@ -277,7 +277,7 @@ impl DefaultEngineBuilder<DefaultTaskExecutor> {
         V: Into<String>,
     {
         Ok(Self {
-            store: engine_store_from_url_opts(url, options)?,
+            store: EngineStore::from_url_opts(url, options)?,
             task_executor: DefaultTaskExecutor,
             io_config: ReadIoConfig::default(),
         })
@@ -347,10 +347,13 @@ impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
 
 impl<E: TaskExecutor> DefaultEngine<E> {
     fn new_with_opts(store: EngineStore, task_executor: Arc<E>, io_config: ReadIoConfig) -> Self {
-        let object_store = store.object_store();
+        let EngineStore {
+            object_store,
+            paginated,
+        } = store;
         let raw_storage: Arc<dyn StorageHandler> = Arc::new(ObjectStoreStorageHandler::new(
             object_store.clone(),
-            store.paginated(),
+            paginated,
             task_executor.clone(),
         ));
 

--- a/default-engine/src/lib.rs
+++ b/default-engine/src/lib.rs
@@ -29,6 +29,7 @@ use self::executor::TaskExecutor;
 use self::filesystem::ObjectStoreStorageHandler;
 use self::json::DefaultJsonHandler;
 use self::parquet::DefaultParquetHandler;
+use self::storage::{engine_store_from_url_opts, EngineStore};
 
 pub mod executor;
 pub mod file_stream;
@@ -210,14 +211,22 @@ pub struct DefaultEngine<E: TaskExecutor> {
 ///     .with_task_executor(Arc::new(TokioBackgroundExecutor::new()))
 ///     .build();
 /// ```
-#[derive(Debug)]
 pub struct DefaultEngineBuilder<E> {
-    object_store: Arc<DynObjectStore>,
+    store: EngineStore,
     /// The state is either [`DefaultTaskExecutor`] or `Arc<E>` with a custom task executor.
     task_executor: E,
     /// Read-path I/O concurrency config applied to the JSON and Parquet handlers. `None` fields
     /// fall back to the handlers' defaults.
     io_config: ReadIoConfig,
+}
+
+impl<E> std::fmt::Debug for DefaultEngineBuilder<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DefaultEngineBuilder")
+            .field("listing_capable", &self.store.paginated().is_some())
+            .field("io_config", &self.io_config)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Read-path I/O tuning for [`DefaultEngine`]'s JSON and Parquet handlers.
@@ -237,19 +246,47 @@ struct ReadIoConfig {
 pub struct DefaultTaskExecutor;
 
 impl DefaultEngineBuilder<DefaultTaskExecutor> {
-    /// Create a new [`DefaultEngineBuilder`] instance with the default executor.
+    /// Create a new [`DefaultEngineBuilder`] with the default executor.
+    ///
+    /// For cloud stores, prefer [`from_url_opts`](Self::from_url_opts): a `dyn ObjectStore` cannot
+    /// expose delimiter pushdown and falls back to a single `list_with_delimiter` request.
     pub fn new(object_store: Arc<DynObjectStore>) -> Self {
         Self {
-            object_store,
+            store: EngineStore::Plain(object_store),
             task_executor: DefaultTaskExecutor,
             io_config: ReadIoConfig::default(),
         }
     }
 
+    /// Create a [`DefaultEngineBuilder`] from an [`EngineStore`] built separately (e.g. FFI, or a
+    /// custom backend).
+    pub fn from_engine_store(store: EngineStore) -> Self {
+        Self {
+            store,
+            task_executor: DefaultTaskExecutor,
+            io_config: ReadIoConfig::default(),
+        }
+    }
+
+    /// Create a [`DefaultEngineBuilder`] from a URL and object-store options, enabling delimiter
+    /// pushdown for S3/GCS/Azure. Prefer this over [`new`](Self::new) for cloud.
+    pub fn from_url_opts<I, K, V>(url: &Url, options: I) -> DeltaResult<Self>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<String>,
+    {
+        Ok(Self {
+            store: engine_store_from_url_opts(url, options)?,
+            task_executor: DefaultTaskExecutor,
+            io_config: ReadIoConfig::default(),
+        })
+    }
+
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
         let task_executor = Arc::new(executor::tokio::TokioBackgroundExecutor::new());
-        DefaultEngine::new_with_opts(self.object_store, task_executor, self.io_config)
+        DefaultEngine::new_with_opts(self.store, task_executor, self.io_config)
     }
 }
 
@@ -262,7 +299,7 @@ impl<E> DefaultEngineBuilder<E> {
         task_executor: Arc<F>,
     ) -> DefaultEngineBuilder<Arc<F>> {
         DefaultEngineBuilder {
-            object_store: self.object_store,
+            store: self.store,
             task_executor,
             io_config: self.io_config,
         }
@@ -293,7 +330,7 @@ impl<E> DefaultEngineBuilder<E> {
 impl<E: TaskExecutor> DefaultEngineBuilder<Arc<E>> {
     /// Build the [`DefaultEngine`] instance.
     pub fn build(self) -> DefaultEngine<E> {
-        DefaultEngine::new_with_opts(self.object_store, self.task_executor, self.io_config)
+        DefaultEngine::new_with_opts(self.store, self.task_executor, self.io_config)
     }
 }
 
@@ -309,13 +346,11 @@ impl DefaultEngine<executor::tokio::TokioBackgroundExecutor> {
 }
 
 impl<E: TaskExecutor> DefaultEngine<E> {
-    fn new_with_opts(
-        object_store: Arc<DynObjectStore>,
-        task_executor: Arc<E>,
-        io_config: ReadIoConfig,
-    ) -> Self {
+    fn new_with_opts(store: EngineStore, task_executor: Arc<E>, io_config: ReadIoConfig) -> Self {
+        let object_store = store.object_store();
         let raw_storage: Arc<dyn StorageHandler> = Arc::new(ObjectStoreStorageHandler::new(
             object_store.clone(),
+            store.paginated(),
             task_executor.clone(),
         ));
 

--- a/default-engine/src/storage.rs
+++ b/default-engine/src/storage.rs
@@ -12,34 +12,63 @@ use delta_kernel::object_store::{self, DynObjectStore, Error, ObjectStore, Objec
 use delta_kernel::{DeltaResult, Error as DeltaError};
 use url::Url;
 
-/// A store that also supports delimiter-pushdown listing. Blanket-implemented for every store that
-/// is both an [`ObjectStore`] and a [`PaginatedListStore`] (S3/GCS/Azure).
-pub trait ListingStore: ObjectStore + PaginatedListStore {}
-impl<T: ObjectStore + PaginatedListStore> ListingStore for T {}
-
-/// The backing store for a [`DefaultEngine`](crate::DefaultEngine). `Listing` enables delimiter
-/// pushdown and keeps that capability inseparable from the store it lists. `Plain` uses the
-/// client-side fallback.
-pub enum EngineStore {
-    Plain(Arc<DynObjectStore>),
-    Listing(Arc<dyn ListingStore>),
+/// The backing store for a [`DefaultEngine`](crate::DefaultEngine). The optional
+/// [`PaginatedListStore`] enables delimiter pushdown: the LIST request groups keys by `/` (e.g. S3
+/// `delimiter=/`) so the backend returns only direct children. Without it, listing falls back to
+/// `list_with_delimiter` and bounds the result client-side.
+pub struct EngineStore {
+    pub(crate) object_store: Arc<DynObjectStore>,
+    pub(crate) paginated: Option<Arc<dyn PaginatedListStore>>,
 }
 
 impl EngineStore {
-    /// The store as an [`ObjectStore`] for reads and writes.
-    pub(crate) fn object_store(&self) -> Arc<DynObjectStore> {
-        match self {
-            EngineStore::Plain(s) => s.clone(),
-            EngineStore::Listing(s) => s.clone(), // upcasts to dyn ObjectStore
+    pub fn plain(object_store: Arc<DynObjectStore>) -> Self {
+        Self {
+            object_store,
+            paginated: None,
         }
     }
 
-    /// The delimiter-pushdown handle, `Some` only for a `Listing` store.
-    pub(crate) fn paginated(&self) -> Option<Arc<dyn PaginatedListStore>> {
-        match self {
-            EngineStore::Plain(_) => None,
-            EngineStore::Listing(s) => Some(s.clone()), // upcasts to dyn PaginatedListStore
+    /// The one `Arc` backs both reads and listing, so they cannot diverge.
+    pub fn with_paginated<S: ObjectStore + PaginatedListStore + 'static>(store: Arc<S>) -> Self {
+        Self {
+            object_store: store.clone(),
+            paginated: Some(store),
         }
+    }
+
+    /// Delimiter-pushdown capable for S3, GCS, and Azure, plain otherwise.
+    pub fn from_url_opts<I, K, V>(url: &Url, options: I) -> DeltaResult<Self>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: Into<String>,
+    {
+        // A registered custom handler takes precedence and is not listing-capable. Drop the read
+        // guard before delegating, since store_from_url_opts locks URL_REGISTRY again.
+        let is_custom = URL_REGISTRY
+            .read()
+            .map(|handlers| handlers.contains_key(url.scheme()))
+            .unwrap_or(false);
+        if is_custom {
+            return Ok(Self::plain(store_from_url_opts(url, options)?));
+        }
+
+        let (scheme, _path) = ObjectStoreScheme::parse(url).map_err(object_store::Error::from)?;
+        let opts = options
+            .into_iter()
+            .map(|(k, v)| (k.as_ref().to_string(), v.into()));
+        macro_rules! listing {
+            ($builder:expr) => {
+                Self::with_paginated(Arc::new(build_cloud_store($builder, url, opts)?))
+            };
+        }
+        Ok(match scheme {
+            ObjectStoreScheme::AmazonS3 => listing!(AmazonS3Builder::new()),
+            ObjectStoreScheme::GoogleCloudStorage => listing!(GoogleCloudStorageBuilder::new()),
+            ObjectStoreScheme::MicrosoftAzure => listing!(MicrosoftAzureBuilder::new()),
+            _ => Self::plain(store_from_url_opts(url, opts)?),
+        })
     }
 }
 
@@ -145,42 +174,6 @@ where
     Ok(Arc::new(store))
 }
 
-/// Like [`store_from_url_opts`], but returns an [`EngineStore`]: `Listing` for S3, GCS, and Azure,
-/// `Plain` otherwise.
-pub fn engine_store_from_url_opts<I, K, V>(url: &Url, options: I) -> DeltaResult<EngineStore>
-where
-    I: IntoIterator<Item = (K, V)>,
-    K: AsRef<str>,
-    V: Into<String>,
-{
-    // A registered custom handler takes precedence and is not listing-capable. Drop the read guard
-    // before delegating, since store_from_url_opts locks URL_REGISTRY again.
-    let is_custom = URL_REGISTRY
-        .read()
-        .map(|handlers| handlers.contains_key(url.scheme()))
-        .unwrap_or(false);
-    if is_custom {
-        return Ok(EngineStore::Plain(store_from_url_opts(url, options)?));
-    }
-
-    let (scheme, _path) = ObjectStoreScheme::parse(url).map_err(object_store::Error::from)?;
-    let opts = options
-        .into_iter()
-        .map(|(k, v)| (k.as_ref().to_string(), v.into()));
-    // `opts` is consumed once, so only the matching arm runs.
-    macro_rules! listing {
-        ($builder:expr) => {
-            EngineStore::Listing(Arc::new(build_cloud_store($builder, url, opts)?))
-        };
-    }
-    Ok(match scheme {
-        ObjectStoreScheme::AmazonS3 => listing!(AmazonS3Builder::new()),
-        ObjectStoreScheme::GoogleCloudStorage => listing!(GoogleCloudStorageBuilder::new()),
-        ObjectStoreScheme::MicrosoftAzure => listing!(MicrosoftAzureBuilder::new()),
-        _ => EngineStore::Plain(store_from_url_opts(url, opts)?),
-    })
-}
-
 /// Builds a concrete cloud store from `url` and `options`, mirroring
 /// `object_store::parse_url_opts`, which returns `Box<dyn ObjectStore>` and erases the
 /// `PaginatedListStore` capability.
@@ -202,7 +195,7 @@ fn build_cloud_store<B: CloudBuilder>(
 /// Builder surface [`build_cloud_store`] needs.
 trait CloudBuilder: Sized {
     type ConfigKey: std::str::FromStr;
-    type Store: ListingStore;
+    type Store: ObjectStore + PaginatedListStore;
     fn with_url(self, url: String) -> Self;
     fn with_config(self, key: Self::ConfigKey, value: String) -> Self;
     fn build(self) -> object_store::Result<Self::Store>;
@@ -247,8 +240,8 @@ mod tests {
     use hdfs_native_object_store::HdfsObjectStoreBuilder;
 
     use super::{
-        build_cloud_store, engine_store_from_url_opts, insert_url_handler, store_from_url_opts,
-        ClosureReturn, EngineStore, URL_REGISTRY,
+        build_cloud_store, insert_url_handler, store_from_url_opts, ClosureReturn, EngineStore,
+        URL_REGISTRY,
     };
     use crate::*;
 
@@ -310,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn engine_store_is_listing_for_cloud_schemes() {
+    fn engine_store_is_paginated_for_cloud_schemes() {
         for url in [
             "s3://bucket/table",
             "gs://bucket/table",
@@ -318,10 +311,10 @@ mod tests {
         ] {
             let url = Url::parse(url).unwrap();
             let opts: HashMap<String, String> = HashMap::default();
-            let store = engine_store_from_url_opts(&url, opts).unwrap();
+            let store = EngineStore::from_url_opts(&url, opts).unwrap();
             assert!(
-                store.paginated().is_some(),
-                "expected a listing store for {url}"
+                store.paginated.is_some(),
+                "expected a paginated store for {url}"
             );
         }
     }
@@ -331,16 +324,15 @@ mod tests {
         for url in ["memory:///table", "file:///tmp/table"] {
             let url = Url::parse(url).unwrap();
             let opts: HashMap<String, String> = HashMap::default();
-            let store = engine_store_from_url_opts(&url, opts).unwrap();
+            let store = EngineStore::from_url_opts(&url, opts).unwrap();
             assert!(
-                store.paginated().is_none(),
+                store.paginated.is_none(),
                 "expected a plain store for {url}"
             );
-            assert!(matches!(store, EngineStore::Plain(_)));
         }
     }
 
-    /// A registered custom handler yields a `Plain` store even for a cloud scheme.
+    /// A registered custom handler yields a plain store even for a cloud scheme.
     #[test]
     fn engine_store_is_plain_for_registered_custom_handler() {
         fn memory_handler<I, K, V>(url: &Url, _opts: I) -> ClosureReturn
@@ -355,9 +347,15 @@ mod tests {
         insert_url_handler(scheme, Arc::new(memory_handler)).unwrap();
 
         let url = Url::parse(&format!("{scheme}://bucket/table")).unwrap();
-        let store = engine_store_from_url_opts(&url, HashMap::<String, String>::default()).unwrap();
-        assert!(store.paginated().is_none());
-        assert!(matches!(store, EngineStore::Plain(_)));
+        let store = EngineStore::from_url_opts(&url, HashMap::<String, String>::default()).unwrap();
+        assert!(store.paginated.is_none());
+    }
+
+    #[test]
+    fn engine_store_from_url_opts_rejects_unknown_scheme() {
+        let url = Url::parse("ftp://host/table").unwrap();
+        let result = EngineStore::from_url_opts(&url, HashMap::<String, String>::default());
+        assert!(result.is_err(), "unknown scheme must not build a store");
     }
 
     // Guards against drift: build_cloud_store and parse_url_opts must handle the same keys, both

--- a/default-engine/src/storage.rs
+++ b/default-engine/src/storage.rs
@@ -1,10 +1,47 @@
 use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, RwLock};
 
+use delta_kernel::object_store::aws::{AmazonS3, AmazonS3Builder, AmazonS3ConfigKey};
+use delta_kernel::object_store::azure::{AzureConfigKey, MicrosoftAzure, MicrosoftAzureBuilder};
+use delta_kernel::object_store::gcp::{
+    GoogleCloudStorage, GoogleCloudStorageBuilder, GoogleConfigKey,
+};
+use delta_kernel::object_store::list::PaginatedListStore;
 use delta_kernel::object_store::path::Path;
-use delta_kernel::object_store::{self, Error, ObjectStore};
-use delta_kernel::Error as DeltaError;
+use delta_kernel::object_store::{self, DynObjectStore, Error, ObjectStore, ObjectStoreScheme};
+use delta_kernel::{DeltaResult, Error as DeltaError};
 use url::Url;
+
+/// A store that also supports delimiter-pushdown listing. Blanket-implemented for every store that
+/// is both an [`ObjectStore`] and a [`PaginatedListStore`] (S3/GCS/Azure).
+pub trait ListingStore: ObjectStore + PaginatedListStore {}
+impl<T: ObjectStore + PaginatedListStore> ListingStore for T {}
+
+/// The backing store for a [`DefaultEngine`](crate::DefaultEngine). `Listing` enables delimiter
+/// pushdown and keeps that capability inseparable from the store it lists. `Plain` uses the
+/// client-side fallback.
+pub enum EngineStore {
+    Plain(Arc<DynObjectStore>),
+    Listing(Arc<dyn ListingStore>),
+}
+
+impl EngineStore {
+    /// The store as an [`ObjectStore`] for reads and writes.
+    pub(crate) fn object_store(&self) -> Arc<DynObjectStore> {
+        match self {
+            EngineStore::Plain(s) => s.clone(),
+            EngineStore::Listing(s) => s.clone(), // upcasts to dyn ObjectStore
+        }
+    }
+
+    /// The delimiter-pushdown handle, `Some` only for a `Listing` store.
+    pub(crate) fn paginated(&self) -> Option<Arc<dyn PaginatedListStore>> {
+        match self {
+            EngineStore::Plain(_) => None,
+            EngineStore::Listing(s) => Some(s.clone()), // upcasts to dyn PaginatedListStore
+        }
+    }
+}
 
 /// Alias for convenience
 type ClosureReturn = Result<(Box<dyn ObjectStore>, Path), Error>;
@@ -108,15 +145,111 @@ where
     Ok(Arc::new(store))
 }
 
+/// Like [`store_from_url_opts`], but returns an [`EngineStore`]: `Listing` for S3, GCS, and Azure,
+/// `Plain` otherwise.
+pub fn engine_store_from_url_opts<I, K, V>(url: &Url, options: I) -> DeltaResult<EngineStore>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: Into<String>,
+{
+    // A registered custom handler takes precedence and is not listing-capable. Drop the read guard
+    // before delegating, since store_from_url_opts locks URL_REGISTRY again.
+    let is_custom = URL_REGISTRY
+        .read()
+        .map(|handlers| handlers.contains_key(url.scheme()))
+        .unwrap_or(false);
+    if is_custom {
+        return Ok(EngineStore::Plain(store_from_url_opts(url, options)?));
+    }
+
+    let (scheme, _path) = ObjectStoreScheme::parse(url).map_err(object_store::Error::from)?;
+    let opts = options
+        .into_iter()
+        .map(|(k, v)| (k.as_ref().to_string(), v.into()));
+    // `opts` is consumed once, so only the matching arm runs.
+    macro_rules! listing {
+        ($builder:expr) => {
+            EngineStore::Listing(Arc::new(build_cloud_store($builder, url, opts)?))
+        };
+    }
+    Ok(match scheme {
+        ObjectStoreScheme::AmazonS3 => listing!(AmazonS3Builder::new()),
+        ObjectStoreScheme::GoogleCloudStorage => listing!(GoogleCloudStorageBuilder::new()),
+        ObjectStoreScheme::MicrosoftAzure => listing!(MicrosoftAzureBuilder::new()),
+        _ => EngineStore::Plain(store_from_url_opts(url, opts)?),
+    })
+}
+
+/// Builds a concrete cloud store from `url` and `options`, mirroring
+/// `object_store::parse_url_opts`, which returns `Box<dyn ObjectStore>` and erases the
+/// `PaginatedListStore` capability.
+fn build_cloud_store<B: CloudBuilder>(
+    builder: B,
+    url: &Url,
+    options: impl IntoIterator<Item = (String, String)>,
+) -> DeltaResult<B::Store> {
+    let builder = options.into_iter().fold(
+        builder.with_url(url.to_string()),
+        |builder, (key, value)| match key.to_ascii_lowercase().parse() {
+            Ok(config_key) => builder.with_config(config_key, value),
+            Err(_) => builder,
+        },
+    );
+    Ok(builder.build()?)
+}
+
+/// Builder surface [`build_cloud_store`] needs.
+trait CloudBuilder: Sized {
+    type ConfigKey: std::str::FromStr;
+    type Store: ListingStore;
+    fn with_url(self, url: String) -> Self;
+    fn with_config(self, key: Self::ConfigKey, value: String) -> Self;
+    fn build(self) -> object_store::Result<Self::Store>;
+}
+
+macro_rules! impl_cloud_builder {
+    ($builder:ty, $key:ty, $store:ty) => {
+        impl CloudBuilder for $builder {
+            type ConfigKey = $key;
+            type Store = $store;
+            fn with_url(self, url: String) -> Self {
+                self.with_url(url)
+            }
+            fn with_config(self, key: Self::ConfigKey, value: String) -> Self {
+                self.with_config(key, value)
+            }
+            fn build(self) -> object_store::Result<Self::Store> {
+                self.build()
+            }
+        }
+    };
+}
+
+impl_cloud_builder!(AmazonS3Builder, AmazonS3ConfigKey, AmazonS3);
+impl_cloud_builder!(
+    GoogleCloudStorageBuilder,
+    GoogleConfigKey,
+    GoogleCloudStorage
+);
+impl_cloud_builder!(MicrosoftAzureBuilder, AzureConfigKey, MicrosoftAzure);
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
+    use delta_kernel::object_store::aws::AmazonS3Builder;
+    use delta_kernel::object_store::azure::MicrosoftAzureBuilder;
+    use delta_kernel::object_store::gcp::GoogleCloudStorageBuilder;
+    use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::object_store::path::Path;
     use delta_kernel::object_store::{self, ObjectStore};
     use hdfs_native_object_store::HdfsObjectStoreBuilder;
 
-    use super::{insert_url_handler, store_from_url_opts, URL_REGISTRY};
+    use super::{
+        build_cloud_store, engine_store_from_url_opts, insert_url_handler, store_from_url_opts,
+        ClosureReturn, EngineStore, URL_REGISTRY,
+    };
     use crate::*;
 
     /// Example funciton of doing testing of a custom [HdfsObjectStore] construction
@@ -174,5 +307,80 @@ mod tests {
                 panic!("Expected to get an error when constructing an HdfsObjectStore, but something didn't work as expected! Either the parse_url_opts_hdfs_native function didn't get called, or the hdfs-native-object-store no longer errors when it cannot connect to HDFS");
             }
         }
+    }
+
+    #[test]
+    fn engine_store_is_listing_for_cloud_schemes() {
+        for url in [
+            "s3://bucket/table",
+            "gs://bucket/table",
+            "abfss://container@account.dfs.core.windows.net/table",
+        ] {
+            let url = Url::parse(url).unwrap();
+            let opts: HashMap<String, String> = HashMap::default();
+            let store = engine_store_from_url_opts(&url, opts).unwrap();
+            assert!(
+                store.paginated().is_some(),
+                "expected a listing store for {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn engine_store_is_plain_for_local_or_memory() {
+        for url in ["memory:///table", "file:///tmp/table"] {
+            let url = Url::parse(url).unwrap();
+            let opts: HashMap<String, String> = HashMap::default();
+            let store = engine_store_from_url_opts(&url, opts).unwrap();
+            assert!(
+                store.paginated().is_none(),
+                "expected a plain store for {url}"
+            );
+            assert!(matches!(store, EngineStore::Plain(_)));
+        }
+    }
+
+    /// A registered custom handler yields a `Plain` store even for a cloud scheme.
+    #[test]
+    fn engine_store_is_plain_for_registered_custom_handler() {
+        fn memory_handler<I, K, V>(url: &Url, _opts: I) -> ClosureReturn
+        where
+            I: IntoIterator<Item = (K, V)>,
+            K: AsRef<str>,
+            V: Into<String>,
+        {
+            Ok((Box::new(InMemory::new()), Path::parse(url.path()).unwrap()))
+        }
+        let scheme = "custom-listing-test";
+        insert_url_handler(scheme, Arc::new(memory_handler)).unwrap();
+
+        let url = Url::parse(&format!("{scheme}://bucket/table")).unwrap();
+        let store = engine_store_from_url_opts(&url, HashMap::<String, String>::default()).unwrap();
+        assert!(store.paginated().is_none());
+        assert!(matches!(store, EngineStore::Plain(_)));
+    }
+
+    // Guards against drift: build_cloud_store and parse_url_opts must handle the same keys, both
+    // tolerating an unknown one. Covers all three cloud builders.
+    #[test]
+    fn build_cloud_store_matches_parse_url_opts_option_handling() {
+        let s3 = Url::parse("s3://bucket/table").unwrap();
+        let s3_opts = [
+            ("region".to_string(), "us-west-2".to_string()),
+            ("bogus_unknown_key".to_string(), "x".to_string()),
+        ];
+        assert!(object_store::parse_url_opts(&s3, s3_opts.clone()).is_ok());
+        assert!(build_cloud_store(AmazonS3Builder::new(), &s3, s3_opts).is_ok());
+
+        let gcs = Url::parse("gs://bucket/table").unwrap();
+        let gcs_opts = [("bogus_unknown_key".to_string(), "x".to_string())];
+        assert!(build_cloud_store(GoogleCloudStorageBuilder::new(), &gcs, gcs_opts).is_ok());
+
+        let azure = Url::parse("abfss://c@a.dfs.core.windows.net/table").unwrap();
+        let azure_opts = [
+            ("skip_signature".to_string(), "true".to_string()),
+            ("bogus_unknown_key".to_string(), "x".to_string()),
+        ];
+        assert!(build_cloud_store(MicrosoftAzureBuilder::new(), &azure, azure_opts).is_ok());
     }
 }

--- a/docs/user-guide/src/concepts/engine_trait.md
+++ b/docs/user-guide/src/concepts/engine_trait.md
@@ -38,7 +38,7 @@ write commit and checkpoint files.
 
 | Method | Purpose |
 |--------|---------|
-| `list_from(path)` | List files lexicographically after `path` in the same directory |
+| `list_from(path)` | List files lexicographically after `path` in the same directory, non-recursively |
 | `read_files(files)` | Read byte ranges from one or more files |
 | `copy_atomic(src, dst)` | Atomically copy a file (used for publishing commits) |
 | `put(path, data, overwrite)` | Write raw bytes to a path (fails if `overwrite` is false and file exists) |

--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -48,9 +48,10 @@ pub trait StorageHandler {
 
 ### Key contracts
 
-- **`list_from`**: Results must be sorted lexicographically by path. If the path ends with
-  `/`, list all files in that directory. Otherwise, list files lexicographically greater than
-  the given path in the same directory.
+- **`list_from`**: Results must be sorted lexicographically by path. Lists a single directory
+  level: nested files and subdirectory entries are excluded. If the path ends with `/`, list the
+  files directly within that directory. Otherwise, list files directly within the same directory
+  that sort lexicographically after the given path.
 
 - **`copy_atomic`**: Must fail with `Error::FileAlreadyExists` if the destination exists.
   This is used for commit publishing in catalog-managed tables.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -18,8 +18,6 @@ use delta_kernel::history_manager::{
     get_earliest_commit as kernel_get_earliest_commit,
     latest_version_as_of as kernel_latest_version_as_of, CommitAt, HistoryCommitType,
 };
-#[cfg(feature = "default-engine-base")]
-use delta_kernel::object_store::ObjectStore;
 use delta_kernel::schema::Schema;
 use delta_kernel::snapshot::{CheckpointWriteResult, Snapshot, SnapshotRef};
 use delta_kernel::{DeltaResult, Engine, EngineData, FileStats, LogPath, Version};
@@ -935,31 +933,32 @@ fn get_default_engine_impl(
     io_config: IoConcurrencyConfig,
     allocate_error: AllocateErrorFn,
 ) -> DeltaResult<Handle<SharedExternEngine>> {
-    use delta_kernel_default_engine::storage::store_from_url_opts;
+    use delta_kernel_default_engine::storage::{engine_store_from_url_opts, EngineStore};
 
-    let store = match object_store_backend {
-        ObjectStoreBackend::UrlScheme => store_from_url_opts(&url, options)?,
-        ObjectStoreBackend::Rest(rest) => {
-            rest_engine::build_rest_object_store(&url, &options, rest.as_ref())?
-        }
-    };
+    let store =
+        match object_store_backend {
+            ObjectStoreBackend::UrlScheme => engine_store_from_url_opts(&url, options)?,
+            ObjectStoreBackend::Rest(rest) => EngineStore::Plain(
+                rest_engine::build_rest_object_store(&url, &options, rest.as_ref())?,
+            ),
+        };
     build_engine_from_store(store, executor_config, io_config, allocate_error)
 }
 
-/// Assemble a default engine from a pre-built [`ObjectStore`], applying executor and read-path I/O
-/// tuning. Shared by the URL-scheme and REST engine builder paths.
+/// Assemble a default engine from an [`EngineStore`], applying executor and read-path I/O tuning.
+/// Shared by the URL-scheme and REST engine builder paths.
 #[cfg(feature = "default-engine-base")]
 pub(crate) fn build_engine_from_store(
-    store: Arc<dyn ObjectStore>,
+    store: delta_kernel_default_engine::storage::EngineStore,
     executor_config: Option<MultithreadedExecutorConfig>,
     io_config: IoConcurrencyConfig,
     allocate_error: AllocateErrorFn,
 ) -> DeltaResult<Handle<SharedExternEngine>> {
     use delta_kernel_default_engine::DefaultEngineBuilder;
 
-    // The builder is generic over the executor type, so apply the shared I/O config via a generic
+    // The builder is generic over the executor type, so apply the shared config via a generic
     // helper to both branches without naming the concrete builder type.
-    fn apply_io_config<E>(
+    fn apply_config<E>(
         builder: DefaultEngineBuilder<E>,
         io_config: &IoConcurrencyConfig,
     ) -> DefaultEngineBuilder<E> {
@@ -978,10 +977,11 @@ pub(crate) fn build_engine_from_store(
             config.worker_threads,
             config.max_blocking_threads,
         )?;
-        let builder = DefaultEngineBuilder::new(store).with_task_executor(Arc::new(executor));
-        Arc::new(apply_io_config(builder, &io_config).build())
+        let builder =
+            DefaultEngineBuilder::from_engine_store(store).with_task_executor(Arc::new(executor));
+        Arc::new(apply_config(builder, &io_config).build())
     } else {
-        let builder = apply_io_config(DefaultEngineBuilder::new(store), &io_config);
+        let builder = apply_config(DefaultEngineBuilder::from_engine_store(store), &io_config);
         Arc::new(builder.build())
     };
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -933,12 +933,12 @@ fn get_default_engine_impl(
     io_config: IoConcurrencyConfig,
     allocate_error: AllocateErrorFn,
 ) -> DeltaResult<Handle<SharedExternEngine>> {
-    use delta_kernel_default_engine::storage::{engine_store_from_url_opts, EngineStore};
+    use delta_kernel_default_engine::storage::EngineStore;
 
     let store =
         match object_store_backend {
-            ObjectStoreBackend::UrlScheme => engine_store_from_url_opts(&url, options)?,
-            ObjectStoreBackend::Rest(rest) => EngineStore::Plain(
+            ObjectStoreBackend::UrlScheme => EngineStore::from_url_opts(&url, options)?,
+            ObjectStoreBackend::Rest(rest) => EngineStore::plain(
                 rest_engine::build_rest_object_store(&url, &options, rest.as_ref())?,
             ),
         };

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -13,7 +13,7 @@ use delta_kernel::scan::Scan;
 use delta_kernel::schema::MetadataColumnSpec;
 use delta_kernel::{DeltaResult, SnapshotRef};
 use delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel_default_engine::storage::{EngineStore, ListingStore};
+use delta_kernel_default_engine::storage::EngineStore;
 use delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use url::Url;
 
@@ -134,17 +134,18 @@ pub fn get_engine(
         })?;
         use ObjectStoreScheme::*;
         let url_str = url.to_string();
-        // Each concrete cloud store is a `ListingStore`, so wrap it in `EngineStore::Listing` to
-        // enable delimiter-pushdown listing.
-        macro_rules! listing_store {
+        // Each concrete cloud store supports delimiter-pushdown listing.
+        macro_rules! engine_store {
             ($builder:ty) => {
-                Arc::new(<$builder>::from_env().with_url(url_str).build()?) as Arc<dyn ListingStore>
+                EngineStore::with_paginated(Arc::new(
+                    <$builder>::from_env().with_url(url_str).build()?,
+                ))
             };
         }
-        let store: Arc<dyn ListingStore> = match scheme {
-            AmazonS3 => listing_store!(AmazonS3Builder),
-            GoogleCloudStorage => listing_store!(GoogleCloudStorageBuilder),
-            MicrosoftAzure => listing_store!(MicrosoftAzureBuilder),
+        let store = match scheme {
+            AmazonS3 => engine_store!(AmazonS3Builder),
+            GoogleCloudStorage => engine_store!(GoogleCloudStorageBuilder),
+            MicrosoftAzure => engine_store!(MicrosoftAzureBuilder),
             Local | Memory | Http => {
                 return Err(delta_kernel::Error::Generic(format!(
                     "Scheme {scheme:?} doesn't support getting credentials from environment"
@@ -157,7 +158,7 @@ pub fn get_engine(
                 )));
             }
         };
-        Ok(DefaultEngineBuilder::from_engine_store(EngineStore::Listing(store)).build())
+        Ok(DefaultEngineBuilder::from_engine_store(store).build())
     } else if !args.option.is_empty() {
         let opts = args.option.iter().map(|option| {
             let parts: Vec<&str> = option.split("=").collect();

--- a/kernel/examples/common/src/lib.rs
+++ b/kernel/examples/common/src/lib.rs
@@ -8,12 +8,12 @@ use delta_kernel::arrow::array::RecordBatch;
 use delta_kernel::object_store::aws::AmazonS3Builder;
 use delta_kernel::object_store::azure::MicrosoftAzureBuilder;
 use delta_kernel::object_store::gcp::GoogleCloudStorageBuilder;
-use delta_kernel::object_store::{DynObjectStore, ObjectStoreScheme};
+use delta_kernel::object_store::ObjectStoreScheme;
 use delta_kernel::scan::Scan;
 use delta_kernel::schema::MetadataColumnSpec;
 use delta_kernel::{DeltaResult, SnapshotRef};
 use delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
-use delta_kernel_default_engine::storage::store_from_url_opts;
+use delta_kernel_default_engine::storage::{EngineStore, ListingStore};
 use delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use url::Url;
 
@@ -134,18 +134,17 @@ pub fn get_engine(
         })?;
         use ObjectStoreScheme::*;
         let url_str = url.to_string();
-        let store: Arc<DynObjectStore> = match scheme {
-            AmazonS3 => Arc::new(AmazonS3Builder::from_env().with_url(url_str).build()?),
-            GoogleCloudStorage => Arc::new(
-                GoogleCloudStorageBuilder::from_env()
-                    .with_url(url_str)
-                    .build()?,
-            ),
-            MicrosoftAzure => Arc::new(
-                MicrosoftAzureBuilder::from_env()
-                    .with_url(url_str)
-                    .build()?,
-            ),
+        // Each concrete cloud store is a `ListingStore`, so wrap it in `EngineStore::Listing` to
+        // enable delimiter-pushdown listing.
+        macro_rules! listing_store {
+            ($builder:ty) => {
+                Arc::new(<$builder>::from_env().with_url(url_str).build()?) as Arc<dyn ListingStore>
+            };
+        }
+        let store: Arc<dyn ListingStore> = match scheme {
+            AmazonS3 => listing_store!(AmazonS3Builder),
+            GoogleCloudStorage => listing_store!(GoogleCloudStorageBuilder),
+            MicrosoftAzure => listing_store!(MicrosoftAzureBuilder),
             Local | Memory | Http => {
                 return Err(delta_kernel::Error::Generic(format!(
                     "Scheme {scheme:?} doesn't support getting credentials from environment"
@@ -158,13 +157,13 @@ pub fn get_engine(
                 )));
             }
         };
-        Ok(DefaultEngineBuilder::new(Arc::new(store)).build())
+        Ok(DefaultEngineBuilder::from_engine_store(EngineStore::Listing(store)).build())
     } else if !args.option.is_empty() {
         let opts = args.option.iter().map(|option| {
             let parts: Vec<&str> = option.split("=").collect();
             (parts[0].to_ascii_lowercase(), parts[1])
         });
-        Ok(DefaultEngineBuilder::new(store_from_url_opts(url, opts)?).build())
+        Ok(DefaultEngineBuilder::from_url_opts(url, opts)?.build())
     } else {
         let mut options = if let Some(ref region) = args.region {
             HashMap::from([("region", region.clone())])
@@ -174,7 +173,7 @@ pub fn get_engine(
         if args.public {
             options.insert("skip_signature", "true".to_string());
         }
-        Ok(DefaultEngineBuilder::new(store_from_url_opts(url, options)?).build())
+        Ok(DefaultEngineBuilder::from_url_opts(url, options)?.build())
     }
 }
 

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -34,26 +34,36 @@ impl StorageHandler for SyncStorageHandler {
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
         let (store, base_url, offset) = resolve_scope(self.store.as_ref(), url_path)?;
 
-        // For directory URLs, prefix == offset and the offset acts as a lower bound that still
-        // includes everything underneath (since `dir/a` > `dir` lexicographically). For file
-        // URLs, the prefix is the parent directory and the offset filters out files at-or-below.
+        // Directory URLs list the directory itself (prefix == offset). File URLs list the parent
+        // directory after the file. The retain below narrows the raw listing to direct children.
         let prefix = if url_path.path().ends_with('/') {
             offset.clone()
         } else {
             let mut parts: Vec<_> = offset.parts().collect();
-            parts.pop();
+            if parts.pop().is_none() {
+                return Err(Error::generic(format!(
+                    "Offset path must not be a root directory. Got: '{url_path}'"
+                )));
+            }
             Path::from_iter(parts)
         };
 
-        // LocalFileSystem and InMemory do not return sorted listings, so we collect and sort
-        // to give callers a deterministic order.
+        // `list_with_offset` recurses, so filter to direct children (one path part left after the
+        // prefix).
         let mut metas: Vec<_> = futures::executor::block_on(
             store
                 .list_with_offset(Some(&prefix), &offset)
                 .collect::<Vec<_>>(),
         )
         .into_iter()
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
+        metas.retain(|meta| {
+            meta.location
+                .prefix_match(&prefix)
+                .is_some_and(|parts| parts.count() == 1)
+        });
+        // LocalFileSystem and InMemory do not return sorted listings, so sort for a deterministic
+        // order.
         metas.sort_unstable_by(|a, b| a.location.cmp(&b.location));
 
         let iter = metas.into_iter().map(move |meta| {
@@ -221,10 +231,9 @@ mod tests {
         Ok(())
     }
 
-    /// `list_from` against an [`ObjectStore`] must walk subdirectories, matching the local FS
-    /// implementation that uses `read_dir` recursively.
+    /// `list_from` is single-directory: files nested in subdirectories are excluded.
     #[tokio::test]
-    async fn list_from_store_is_recursive() {
+    async fn list_from_store_is_single_directory() {
         let store = std::sync::Arc::new(InMemory::new());
         store
             .put(
@@ -253,7 +262,15 @@ mod tests {
             .iter()
             .map(|f| f.location.path().to_string())
             .collect();
-        assert_eq!(names, vec!["/a/file1.json", "/a/sub/file2.json"]);
+        assert_eq!(names, vec!["/a/file1.json"]);
+    }
+
+    #[test]
+    fn list_from_root_offset_errors() {
+        let storage = SyncStorageHandler::new(Some(std::sync::Arc::new(InMemory::new())));
+        // Authority-only URL: empty path, not directory-like, so the offset has no parent.
+        let url = Url::parse("memory://bucket").unwrap();
+        assert!(matches!(storage.list_from(&url), Err(Error::Generic(_))));
     }
 
     #[test]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -608,20 +608,20 @@ pub(crate) trait IntoEngineData {
 /// file system where the Delta table is present. Connector implementation of
 /// this trait can hide filesystem specific details from Delta Kernel.
 pub trait StorageHandler: AsAny {
-    /// Recursively list files whose full path is lexicographically greater than (UTF-8 sorting)
-    /// the given `path`, restricted to descendants of `path`'s parent directory. The result must
-    /// be sorted by the full path (UTF-8 byte order).
+    /// List files directly within `path`'s parent directory whose full path is lexicographically
+    /// greater than (UTF-8 sorting) the given `path`. The result must be sorted by the full path
+    /// (UTF-8 byte order).
     ///
-    /// The listing is **recursive**: files in nested subdirectories are included, not just files
-    /// directly under the parent. For example, listing from `dir/0001.json` may return
-    /// `dir/0002.json`, `dir/sub/0003.json`, and `dir/sub/nested/0004.json`, all interleaved
-    /// in lexicographic order.
+    /// The listing is a **single directory level**: files in nested subdirectories are not
+    /// included, and subdirectories are not returned as entries. For example, listing from
+    /// `dir/0001.json` returns direct children like `dir/0002.checkpoint.parquet` and
+    /// `dir/0002.json` (in lexicographic order), but nothing under `dir/sub/`.
     ///
     /// The parent directory is derived from `path`:
     /// - If `path` is directory-like (ends with `/`), the parent is `path` itself and the result
-    ///   contains all files at or below that directory.
-    /// - Otherwise, the parent is the directory containing `path`, and only files (at any depth
-    ///   under that parent) whose full path sorts strictly greater than `path` are returned.
+    ///   contains the files directly within it.
+    /// - Otherwise, the parent is the directory containing `path`, and only files directly within
+    ///   that parent whose full path sorts strictly greater than `path` are returned.
     fn list_from(&self, path: &Url)
         -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>>;
 

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -20,7 +20,7 @@ use url::Url;
 
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
-use crate::path::{may_begin_listable_log_path, LogPathFileType, ParsedLogPath};
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::{DeltaResult, Error, StorageHandler, Version};
 
 #[cfg(test)]
@@ -54,9 +54,10 @@ pub(crate) struct LogSegmentFiles {
 
 /// Returns a lazy iterator of [`ParsedLogPath`]s from the filesystem over versions
 /// `[start_version, end_version]`. The iterator handles parsing, filtering out non-listable
-/// files (e.g. dot-prefixed files), and stopping at `end_version`. It stops consuming the
-/// underlying listing at the first path past the version-named region, so directories like
-/// `_staged_commits/` and `_sidecars/` are never paged through.
+/// files (e.g. dot-prefixed files), and stopping at `end_version`.
+///
+/// [`StorageHandler::list_from`] is single-directory, so subdirectories like `_staged_commits/`
+/// and `_sidecars/` are never listed.
 ///
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
@@ -69,22 +70,8 @@ pub(crate) fn list_delta_log_from_storage(
     end_version: Version,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_from = log_root.join(&format!("{start_version:020}"))?;
-    let log_root_str = log_root.to_string();
     let files = storage
         .list_from(&start_from)?
-        // The listing is sorted by full path, so nothing relevant follows the first relative path
-        // past the version-named region (see `may_begin_listable_log_path`). Stopping there avoids
-        // paging through `_staged_commits/` and `_sidecars/`, which can hold thousands of files.
-        // A path that doesn't strip the log_root prefix is kept; parsing discards it.
-        // TODO(#2740): push the bound into the listing request itself.
-        .take_while(move |meta_res| match meta_res {
-            Ok(meta) => meta
-                .location
-                .as_str()
-                .strip_prefix(&log_root_str)
-                .is_none_or(may_begin_listable_log_path),
-            Err(_) => true,
-        })
         .map(|meta| ParsedLogPath::try_from(meta?))
         // NOTE: this filters out .crc files etc which start with "." - some engines
         // produce `.something.parquet.crc` corresponding to `something.parquet`. Kernel

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -21,7 +21,7 @@ use url::Url;
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
 use crate::path::{LogPathFileType, ParsedLogPath};
-use crate::{DeltaResult, Error, StorageHandler, Version};
+use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
 
 #[cfg(test)]
 mod tests;
@@ -70,8 +70,7 @@ pub(crate) fn list_delta_log_from_storage(
     end_version: Version,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_from = log_root.join(&format!("{start_version:020}"))?;
-    let files = storage
-        .list_from(&start_from)?
+    let files = debug_assert_direct_children(log_root, storage.list_from(&start_from)?)
         .map(|meta| ParsedLogPath::try_from(meta?))
         // NOTE: this filters out .crc files etc which start with "." - some engines
         // produce `.something.parquet.crc` corresponding to `something.parquet`. Kernel
@@ -86,6 +85,30 @@ pub(crate) fn list_delta_log_from_storage(
             Err(_) => true,
         });
     Ok(files)
+}
+
+/// True if `child` is a direct child of the directory `dir`.
+fn is_single_directory_child(dir: &Url, child: &Url) -> bool {
+    dir.make_relative(child)
+        .is_none_or(|rel| !rel.contains('/'))
+}
+
+/// Debug-only guard catching a [`StorageHandler::list_from`] that recurses into subdirectories.
+fn debug_assert_direct_children(
+    dir: &Url,
+    iter: impl Iterator<Item = DeltaResult<FileMeta>>,
+) -> impl Iterator<Item = DeltaResult<FileMeta>> {
+    let dir = dir.clone();
+    iter.inspect(move |res| {
+        if let Ok(meta) = res {
+            debug_assert!(
+                is_single_directory_child(&dir, &meta.location),
+                "list_from returned '{}', not a direct child of '{}'",
+                meta.location,
+                dir,
+            );
+        }
+    })
 }
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1331,3 +1331,52 @@ fn find_complete_checkpoint_version_cases(
 ) {
     assert_eq!(find_complete_checkpoint_version(&files), expected);
 }
+
+/// Recursing `list_from` will trip this guard.
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "not a direct child")]
+fn list_delta_log_from_storage_rejects_recursive_listing() {
+    use crate::{FileSlice, StorageHandler};
+
+    struct RecursingStorage;
+    impl StorageHandler for RecursingStorage {
+        fn list_from(
+            &self,
+            _path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            let nested = FileMeta {
+                location: Url::parse(
+                    "memory:///_delta_log/_staged_commits/00000000000000000001.abc.json",
+                )
+                .unwrap(),
+                last_modified: 0,
+                size: 1,
+            };
+            Ok(Box::new(std::iter::once(Ok(nested))))
+        }
+        fn read_files(
+            &self,
+            _files: Vec<FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+            Ok(Box::new(std::iter::empty()))
+        }
+        fn copy_atomic(&self, _src: &Url, _dst: &Url) -> DeltaResult<()> {
+            Ok(())
+        }
+        fn put(&self, _path: &Url, _data: bytes::Bytes, _overwrite: bool) -> DeltaResult<()> {
+            Ok(())
+        }
+        fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+            unreachable!()
+        }
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            Ok(())
+        }
+    }
+
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let iter = list_delta_log_from_storage(&RecursingStorage, &log_root, 0, Version::MAX).unwrap();
+    // The assert fires lazily as the item is pulled.
+    let _ = iter.collect::<Vec<_>>();
+}

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -135,7 +135,7 @@ fn assert_source(commit: &ParsedLogPath, expected_source: CommitSource) {
 /// A [`StorageHandler`] wrapper that counts the number of `list_from` calls and the number of
 /// items consumed from the returned iterators. Used to verify that
 /// `list_with_backward_checkpoint_scan` issues the expected number of storage listing requests,
-/// and that listing terminates without consuming files past the version-named region.
+/// and that single-directory listing never yields files from subdirectories.
 struct CountingStorageHandler {
     inner: Arc<dyn StorageHandler>,
     list_from_count: AtomicU32,
@@ -473,14 +473,13 @@ async fn test_listing_omits_staged_commits() {
 }
 
 #[tokio::test]
-async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() {
+async fn test_listing_never_yields_staged_commits_in_subdirectory() {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
         (2, LogPathFileType::Commit, CommitSource::Filesystem),
     ];
-    // Staged commits sort after every version-named file ('_' > '9'), so a sorted listing
-    // reaches them only after all relevant files. None should be consumed beyond the first.
+    // Staged commits live under `_staged_commits/`, never yielded by single-directory listing.
     log_files
         .extend((0..100).map(|v| (v, LogPathFileType::StagedCommit, CommitSource::Filesystem)));
 
@@ -493,19 +492,17 @@ async fn test_listing_stops_at_first_staged_commit_without_consuming_the_rest() 
     assert_eq!(commits.len(), 3);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 3 commits plus the single staged commit that stops the listing
-    assert_eq!(storage.items_listed(), 4);
+    // Only the 3 direct-child commits are listed.
+    assert_eq!(storage.items_listed(), 3);
 }
 
-// Any path past the version-named region stops the listing, not just `_staged_commits/`:
-// checkpoint sidecars under `_sidecars/` and non-underscore names whose first byte sorts
-// past '9' (e.g. 'Z'). Both sentinels sort before `_staged_commits/`, so no staged commit
-// is ever consumed.
+// Direct-child files that are not log files (a stray `_last_checkpoint` or a name sorting past
+// '9' such as 'Z') are listed but excluded from the log segment by parsing.
 #[rstest]
-#[case::sidecar("_delta_log/_sidecars/016ae953-37a9-438e-8683-9a9a4a79a395.parquet")]
+#[case::last_checkpoint("_delta_log/_last_checkpoint")]
 #[case::non_underscore_sentinel("_delta_log/Zsentinel")]
 #[tokio::test]
-async fn test_listing_stops_at_first_non_version_named_path(#[case] sentinel_path: &str) {
+async fn test_listing_ignores_direct_child_non_log_files(#[case] sentinel_path: &str) {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -522,14 +519,12 @@ async fn test_listing_stops_at_first_non_version_named_path(#[case] sentinel_pat
     assert_eq!(commits.len(), 3);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 3 commits plus the sentinel that stops the listing
+    // 3 commits plus the direct-child sentinel.
     assert_eq!(storage.items_listed(), 4);
 }
 
 #[tokio::test]
-async fn test_listing_stops_at_last_checkpoint_marker() {
-    // In a real table `_last_checkpoint` sorts before `_staged_commits/` ('_la' < '_st'), so
-    // it is the path that stops the listing.
+async fn test_listing_with_checkpoint_and_crc_omits_staged_commits() {
     let mut log_files = vec![
         (0, LogPathFileType::Commit, CommitSource::Filesystem),
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -557,8 +552,7 @@ async fn test_listing_stops_at_last_checkpoint_marker() {
     assert_eq!(latest_crc.unwrap().version, 2);
     assert_eq!(latest_commit.unwrap().version, 2);
     assert_eq!(max_pub, Some(2));
-    // 5 version-named files plus the `_last_checkpoint` that stops the listing; no staged
-    // commit is ever consumed
+    // 5 version-named direct children plus `_last_checkpoint`. Staged commits are never listed.
     assert_eq!(storage.items_listed(), 6);
 }
 

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -108,23 +108,6 @@ fn path_contains_delta_log_dir(mut path_segments: std::str::Split<'_, char>) -> 
     path_segments.any(|p| p == DELTA_LOG_DIR)
 }
 
-/// Returns whether `rel_path`, a path relative to the `_delta_log/` directory, could still be
-/// within the version-named region of a lexicographically sorted log listing.
-///
-/// Every listable log file begins with a 20-digit version, so its first byte is an ASCII digit.
-/// Paths like `_staged_commits/`, `_sidecars/`, and `_last_checkpoint` sort after every
-/// version-named file because `'_'` (0x5F) > `'9'` (0x39), so a sorted listing can stop at the
-/// first relative path whose first byte sorts past `'9'`.
-///
-/// This is a scan bound, not a log-file filter, so it must not require a digit first byte: a
-/// path sorting before `'0'` (e.g. a dot-prefixed `.{version}.json.crc` written by some engines)
-/// can still be followed by version-named files, and stopping there would silently drop them.
-/// Such paths are kept here and discarded by [`ParsedLogPath`] parsing instead. An empty
-/// `rel_path` is conservatively kept.
-pub(crate) fn may_begin_listable_log_path(rel_path: &str) -> bool {
-    rel_path.as_bytes().first().is_none_or(|b| *b <= b'9')
-}
-
 impl<Location: AsUrl> ParsedLogPath<Location> {
     /// Estimated heap size in bytes, best-effort estimate.
     ///
@@ -590,23 +573,6 @@ pub(crate) mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         assert!(url.path().ends_with('/'));
         url
-    }
-
-    #[test]
-    fn test_may_begin_listable_log_path() {
-        // version-named files, and anything sorting before them, keep the scan going
-        assert!(may_begin_listable_log_path("00000000000000000010.json"));
-        assert!(may_begin_listable_log_path(
-            ".00000000000000000010.json.crc"
-        ));
-        assert!(may_begin_listable_log_path(""));
-        // paths sorting past '9' end the version-named region
-        assert!(!may_begin_listable_log_path("_last_checkpoint"));
-        assert!(!may_begin_listable_log_path("_sidecars/3a0d65cd.parquet"));
-        assert!(!may_begin_listable_log_path(
-            "_staged_commits/00000000000000000010.3a0d65cd.json"
-        ));
-        assert!(!may_begin_listable_log_path("Zsentinel"));
     }
 
     #[test]

--- a/kernel/src/plans/ir/operation.rs
+++ b/kernel/src/plans/ir/operation.rs
@@ -37,7 +37,7 @@ impl Operation {
 /// is documented on the variant in terms of [`PlanResult`](crate::plans::PlanResult).
 #[derive(Debug)]
 pub enum IoOperation {
-    /// Recursively list files at the given URL.
+    /// List files directly within the directory of the given URL (single level).
     ///
     /// Should return a [`PlanResult::FileMeta`](crate::plans::PlanResult::FileMeta) with one entry
     /// per file. See [`StorageHandler::list_from`] for more details on the ordering contract.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes `StorageHandler::list_from` from recursive listing to a single directory level. Kernel only needs files directly under `_delta_log/`, so this avoids walking `_sidecars/` and `_staged_commits/` during log discovery.

For the default engine, built-in S3, GCS, and Azure stores send both the starting offset and `delimiter=/`, and fetch continuation pages lazily. Stores without that paginated capability still use `list_with_offset` so capable backends can push down the offset, then filter nested descendants client-side.

Fixes #2740.

### This PR affects the following public APIs

- **Breaking:** `StorageHandler::list_from` now returns only direct child files; nested files and directory entries are excluded.
- Adds `EngineStore::{plain, with_paginated, from_url_opts}` to preserve provider-specific pagination where it is available.
- `DefaultEngineBuilder::new` accepts `impl Into<EngineStore>`, so existing `Arc<ObjectStore>` callers remain source-compatible.
- Kernel log discovery defensively tolerates recursive results for a two-release migration window; engines should adopt the single-directory contract now.

## How was this change tested?

- `cargo nextest run -p delta_kernel_default_engine --all-features`: 179 passed.
- `cargo nextest run -p delta_kernel --all-features`: 9,133 passed, 54 skipped.
- Request-level Azure coverage verifies `prefix`, `delimiter`, `startFrom`, continuation markers, offset filtering, and lazy page fetches.
- Fallback coverage verifies `list_with_offset` receives the requested offset and nested files are excluded.
- Cloud factory coverage verifies S3, GCS, and Azure retain their paginated-listing handle.
- Workspace docs and all split no-default-feature checks pass. Clippy passes for the affected kernel and default-engine crates.

The local FFI run passes 443/444 tests; the remaining trybuild failure is pre-existing diagnostic-text drift in `handle::tests::invalid_handle_code`. Workspace clippy is likewise blocked by the existing redundant closure in `ffi/src/ffi_tracing.rs`; neither file is changed here.