### PR TITLE
fix: use normal data-skipping predicate for checkpoints

### DIFF
--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -158,6 +158,12 @@ must return a column of all nulls.
 **Ordering**: Like `JsonHandler`, data must be returned in file order, and rows within a
 file must be in source order.
 
+**Predicate pushdown**: The predicate is an optional SQL expression. Your handler can ignore it and
+return every requested row, evaluate the complete expression as an exact SQL filter, or use a
+conservative footer compiler that skips a file or row group only when it proves the predicate false
+for every row. Unsupported expressions must not fail the read. Kernel encodes missing-stat safety
+inside checkpoint predicates, so handlers don't need checkpoint-specific NULL semantics.
+
 **Metadata columns**: The handler must support two virtual metadata columns that are not
 stored in the Parquet file but generated at read time:
 
@@ -315,4 +321,3 @@ pub trait PredicateEvaluator {
 ### Default implementation
 
 The `DefaultEngine` uses Arrow compute kernels for expression evaluation.
-

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -897,12 +897,11 @@ pub trait ParquetHandler: AsAny {
     ///
     /// - `files` - File metadata for files to be read.
     /// - `physical_schema` - Select list and order of columns to read from the Parquet file.
-    /// - `predicate` - Optional conservative push-down predicate. Implementations may ignore it. A
-    ///   file, row group, or row may be omitted only when the predicate cannot evaluate to true for
-    ///   any row in that unit. Unsupported subexpressions and references with no matching physical
-    ///   or generated value must remain unknown and must not fail the read. A missing reference
-    ///   remains unknown for pruning even if schema reconciliation synthesizes a NULL output
-    ///   column. Returned data is not guaranteed to satisfy the predicate.
+    /// - `predicate` - Optional SQL push-down predicate. Implementations may ignore it, evaluate
+    ///   the complete expression as an exact SQL filter, or use a conservative footer compiler that
+    ///   omits a unit only when the predicate is proven false for every row. Unsupported
+    ///   subexpressions and references with no matching physical or generated value must not fail
+    ///   the read. Returned data is not guaranteed to satisfy the predicate.
     ///
     /// # Returns
     /// A [`DeltaResult`] containing a [`FileDataReadResultIterator`].

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -16,7 +16,7 @@ use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
 };
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
-use crate::scan::log_replay::PARTITION_VALUES_PARSED_NAME;
+use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
 use crate::scan::metrics::ScanMetrics;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
@@ -411,12 +411,10 @@ impl DataSkippingFilter {
     }
 }
 
-/// Rewrites `pred` for scan checkpoint and sidecar Add row-group skipping. Data references become
-/// IS NULL guarded `stats_parsed.{minValues,maxValues,nullCount}.<col>` comparisons; eligible
-/// partition references become exact, unguarded `partitionValues_parsed.<col>` values. Checkpoint
-/// Removes are irrelevant to scan replay, so partition predicates may prune their null add-side
-/// values. A bare unsupported predicate returns `None`; unsupported junction arms become NULL
-/// literals to preserve three-valued logic.
+/// Rewrites `pred` for scan checkpoint and sidecar Add row-group skipping. The normal SQL-WHERE
+/// data-skipping predicate is combined with a verifier that makes missing structured statistics
+/// evaluate to TRUE under an ordinary exact filter. Partition references use exact typed
+/// `partitionValues_parsed` values and do not require verification.
 ///
 /// `physical_partition_columns` may be narrowed to the predicate's references; pass an empty set
 /// for unpartitioned tables. `physical_floating_partition_columns` identifies FLOAT and DOUBLE
@@ -428,14 +426,68 @@ pub(crate) fn as_checkpoint_skipping_predicate(
     physical_floating_partition_columns: &HashSet<ColumnName>,
     physical_stats_columns: &HashSet<ColumnName>,
 ) -> Option<Pred> {
-    CheckpointDataSkippingPredicateCreator {
+    let creator = CheckpointDataSkippingPredicateCreator {
         data_skipping_columns: DataSkippingColumns {
             physical_partition_columns,
             physical_stats_columns,
         },
         physical_floating_partition_columns,
+    };
+
+    // Preserve the eligibility gate separately from the SQL-WHERE rewrite so a bare unsupported
+    // input does not produce a useless checkpoint predicate.
+    creator.eval(pred)?;
+    with_stats_verification(creator.eval_sql_where(pred)?)
+}
+
+/// Makes a checkpoint data-skipping predicate safe for ordinary exact SQL filtering. Missing
+/// structured statistics make the verifier false and therefore keep the checkpoint row.
+fn with_stats_verification(predicate: Pred) -> Option<Pred> {
+    let mut references: Vec<_> = predicate.references().into_iter().cloned().collect();
+    references.sort();
+
+    let mut verifiers = Vec::new();
+    for reference in references {
+        match reference.path().first().map(String::as_str) {
+            Some(root) if root == PARTITION_VALUES_PARSED_NAME => continue,
+            Some(root) if root == STATS_PARSED_NAME => {
+                verifiers.push(verify_stats_reference(&reference)?)
+            }
+            _ => return None,
+        }
     }
-    .eval(pred)
+    if verifiers.is_empty() {
+        return Some(predicate);
+    }
+
+    Some(Pred::or(predicate, Pred::not(Pred::and_from(verifiers))))
+}
+
+/// Builds a total presence check for one structured-stat reference.
+fn verify_stats_reference(reference: &ColumnName) -> Option<Pred> {
+    let path = reference.path();
+    if path.len() == 2 && path[0] == STATS_PARSED_NAME && path[1] == NUM_RECORDS {
+        return Some(Pred::is_not_null(reference.clone()));
+    }
+    if path.len() < 3 || path[0] != STATS_PARSED_NAME {
+        return None;
+    }
+
+    match path[1].as_str() {
+        NULL_COUNT => Some(Pred::is_not_null(reference.clone())),
+        MIN_VALUES | MAX_VALUES => {
+            let physical_column = ColumnName::new(&path[2..]);
+            let null_count = column_name!(STATS_PARSED_NAME, NULL_COUNT).join(&physical_column);
+            let num_records = column_name!(STATS_PARSED_NAME, NUM_RECORDS);
+            let all_null = Pred::and_from([
+                Pred::is_not_null(null_count.clone()),
+                Pred::is_not_null(num_records.clone()),
+                Pred::eq(null_count, num_records),
+            ]);
+            Some(Pred::or(Pred::is_not_null(reference.clone()), all_null))
+        }
+        _ => None,
+    }
 }
 
 /// Maps an ordering and inversion flag to the corresponding comparison predicate.
@@ -473,6 +525,28 @@ fn collect_junction_preds(
         })
         .collect();
     Pred::junction(op, preds)
+}
+
+/// Collects checkpoint predicates without introducing NULL sentinels. Unsupported AND children
+/// are omitted, while an unsupported OR child makes the complete OR unavailable.
+fn collect_checkpoint_junction_preds(
+    mut op: JunctionPredicateOp,
+    preds: &mut dyn Iterator<Item = Option<Pred>>,
+    inverted: bool,
+) -> Option<Pred> {
+    if inverted {
+        op = op.invert();
+    }
+    match op {
+        JunctionPredicateOp::And => {
+            let preds: Vec<_> = preds.flatten().collect();
+            (!preds.is_empty()).then(|| Pred::junction(op, preds))
+        }
+        JunctionPredicateOp::Or => {
+            let preds: Vec<_> = preds.collect::<Option<_>>()?;
+            (!preds.is_empty()).then(|| Pred::junction(op, preds))
+        }
+    }
 }
 
 /// Adjusts a comparison value before comparing against a max stat, to account for the Delta
@@ -756,8 +830,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
     type ColumnStat = Expr;
 
     // Stat selection and max-stat truncation are shared through `DataSkippingColumns`. This
-    // creator also limits footer-ineligible columns and predicate shapes while applying
-    // checkpoint-specific null guards.
+    // creator also limits footer-ineligible columns and predicate shapes.
 
     fn get_min_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
         // Parquet footer min/max exclude NaNs, so they cannot bound every floating partition value.
@@ -796,12 +869,6 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         self.eval_partial_cmp(ord, max, &adjusted, inverted)
     }
 
-    /// Wraps a data-stat comparison with an IS NULL guard, so a missing stat keeps the row group.
-    /// `col > 100` becomes
-    /// `OR(stats_parsed.maxValues.col IS NULL, stats_parsed.maxValues.col > 100)`.
-    /// Partition comparisons reference the typed per-Add value without a null guard. The parquet
-    /// filter evaluates that column through row-group footer bounds; null-only groups remain
-    /// unknown while mixed groups may be pruned from their non-null bounds.
     fn eval_partial_cmp(
         &self,
         ord: Ordering,
@@ -809,12 +876,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         val: &Scalar,
         inverted: bool,
     ) -> Option<Pred> {
-        let comparison = comparison_predicate(ord, col.clone(), val, inverted);
-        Some(if is_partition_value_reference(&col) {
-            comparison
-        } else {
-            Pred::or(Pred::is_null(col), comparison)
-        })
+        Some(comparison_predicate(ord, col, val, inverted))
     }
 
     fn eval_pred_scalar(&self, val: &Scalar, inverted: bool) -> Option<Pred> {
@@ -825,12 +887,8 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         KernelPredicateEvaluatorDefaults::eval_pred_scalar_is_null(val, inverted).map(Pred::literal)
     }
 
-    /// Partition NULL checks use the exact parsed value. Data `IS NULL` uses a guarded null count;
-    /// data `IS NOT NULL` remains unsupported because row-group filtering cannot compare it with
-    /// `numRecords`.
-    // TODO(#1873): IS NOT NULL pruning requires cross-column range comparison in RowGroupFilter.
-    // Skippable when the nullCount and numRecords ranges don't overlap (e.g. nullCount in
-    // [0, 0] vs numRecords in [500, 2000] proves all files have non-null values).
+    /// Partition NULL checks use the exact parsed value. Data NULL checks use the same null-count
+    /// predicates as normal data skipping.
     fn eval_pred_is_null(&self, col: &ColumnName, inverted: bool) -> Option<Pred> {
         if self.data_skipping_columns.is_partition_column(col) {
             let partition_value = partition_value_expr(col);
@@ -840,12 +898,11 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
                 Pred::is_null(partition_value)
             });
         }
-        if inverted {
-            return None; // IS NOT NULL: column vs column, can't prune (#1873)
-        }
-        let nullcount = self.get_nullcount_stat(col)?;
-        let comparison = Pred::ne(nullcount.clone(), Expr::literal(0i64));
-        Some(Pred::or(Pred::is_null(nullcount), comparison))
+        let safe_to_skip = match inverted {
+            true => self.get_rowcount_stat()?,
+            false => Expr::literal(0i64),
+        };
+        Some(Pred::ne(self.get_nullcount_stat(col)?, safe_to_skip))
     }
 
     fn eval_pred_binary_scalars(
@@ -859,9 +916,9 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
             .map(Pred::literal)
     }
 
-    /// Unsupported. Opaque predicates can construct data-stat references directly, bypassing IS
-    /// NULL guards and risking false pruning when a live Add has missing stats. Returns `None` to
-    /// conservatively drop these from the skipping predicate.
+    /// Unsupported. Opaque predicates can construct data-stat references whose availability
+    /// contract Kernel cannot verify. Returns `None` to conservatively drop them from the skipping
+    /// predicate.
     fn eval_pred_opaque(
         &self,
         _op: &OpaquePredicateOpRef,
@@ -871,19 +928,12 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
         None
     }
 
-    /// Combines sub-predicates with AND/OR. `col_a > 100 AND col_b < 50` becomes
-    /// ```text
-    /// AND(
-    ///   OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
-    ///   OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
-    /// )
-    /// ```
     fn finish_eval_pred_junction(
         &self,
         op: JunctionPredicateOp,
         preds: &mut dyn Iterator<Item = Option<Pred>>,
         inverted: bool,
     ) -> Option<Pred> {
-        Some(collect_junction_preds(op, preds, inverted))
+        collect_checkpoint_junction_preds(op, preds, inverted)
     }
 }

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -475,37 +475,133 @@ fn test_adjust_scalar_for_max_stat_truncation() {
     );
 }
 
-// Verifies the guarded checkpoint skipping predicate:
-// - Prunes when stats are present and below threshold
-// - Keeps when stats are present and above threshold
-// - Conservatively keeps when stats are null (IS NULL guard fires)
+#[test]
+fn test_stats_verifier_shapes() {
+    let num_records = column_name!("stats_parsed.numRecords");
+    let null_count = column_name!("stats_parsed.nullCount.x");
+    let min = column_name!("stats_parsed.minValues.x");
+    let max = column_name!("stats_parsed.maxValues.x");
+    let all_null = Pred::and_from([
+        Pred::is_not_null(null_count.clone()),
+        Pred::is_not_null(num_records.clone()),
+        Pred::eq(null_count.clone(), num_records.clone()),
+    ]);
+
+    assert_eq!(
+        verify_stats_reference(&num_records),
+        Some(Pred::is_not_null(num_records))
+    );
+    assert_eq!(
+        verify_stats_reference(&null_count),
+        Some(Pred::is_not_null(null_count))
+    );
+    assert_eq!(
+        verify_stats_reference(&min),
+        Some(Pred::or(Pred::is_not_null(min), all_null.clone()))
+    );
+    assert_eq!(
+        verify_stats_reference(&max),
+        Some(Pred::or(Pred::is_not_null(max), all_null))
+    );
+}
+
+#[test]
+fn test_stats_verifier_is_deterministic_and_ignores_partitions() {
+    let max_a = column_name!("stats_parsed.maxValues.a");
+    let max_b = column_name!("stats_parsed.maxValues.b");
+    let predicate = Pred::and_from([
+        Pred::gt(max_b.clone(), Scalar::from(20)),
+        Pred::eq(
+            column_expr!("partitionValues_parsed.part"),
+            Scalar::from("x"),
+        ),
+        Pred::gt(max_a.clone(), Scalar::from(10)),
+    ]);
+    let expected = Pred::or(
+        predicate.clone(),
+        Pred::not(Pred::and_from([
+            verify_stats_reference(&max_a).unwrap(),
+            verify_stats_reference(&max_b).unwrap(),
+        ])),
+    );
+
+    assert_eq!(with_stats_verification(predicate), Some(expected));
+
+    let partition_only = Pred::eq(
+        column_expr!("partitionValues_parsed.part"),
+        Scalar::from("x"),
+    );
+    assert_eq!(
+        with_stats_verification(partition_only.clone()),
+        Some(partition_only)
+    );
+}
+
+#[test]
+fn test_stats_verifier_rejects_invalid_stats_layout() {
+    let predicate = Pred::is_not_null(column_expr!("stats_parsed.unknown.x"));
+    assert!(with_stats_verification(predicate).is_none());
+}
+
+// Verifies the complete checkpoint predicate under ordinary SQL evaluation.
 #[rstest]
-#[case::stats_below_threshold(Scalar::from(50), FALSE, "max=50, col>100 should skip")]
-#[case::stats_above_threshold(Scalar::from(150), TRUE, "max=150, col>100 should keep")]
-#[case::stats_null(
+#[case::stats_below_threshold(Scalar::from(50), Scalar::from(0i64), Scalar::from(10i64), FALSE)]
+#[case::stats_above_threshold(Scalar::from(150), Scalar::from(0i64), Scalar::from(10i64), TRUE)]
+#[case::max_missing(
     Scalar::Null(DataType::INTEGER),
-    TRUE,
-    "null max should keep (IS NULL guard)"
+    Scalar::from(0i64),
+    Scalar::from(10i64),
+    TRUE
+)]
+#[case::null_count_missing(
+    Scalar::from(50),
+    Scalar::Null(DataType::LONG),
+    Scalar::from(10i64),
+    TRUE
+)]
+#[case::num_records_missing(
+    Scalar::from(50),
+    Scalar::from(0i64),
+    Scalar::Null(DataType::LONG),
+    TRUE
+)]
+#[case::all_null(
+    Scalar::Null(DataType::INTEGER),
+    Scalar::from(10i64),
+    Scalar::from(10i64),
+    FALSE
+)]
+#[case::non_add(
+    Scalar::Null(DataType::INTEGER),
+    Scalar::Null(DataType::LONG),
+    Scalar::Null(DataType::LONG),
+    TRUE
 )]
 fn test_checkpoint_skipping_semantic(
     #[case] max_val: Scalar,
+    #[case] null_count: Scalar,
+    #[case] num_records: Scalar,
     #[case] expected: Option<bool>,
-    #[case] description: &str,
 ) {
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
     let stats = all_referenced_columns(&pred);
     let skipping_pred =
         as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
-    let resolver = HashMap::from_iter([(column_name!("stats_parsed.maxValues.x"), max_val)]);
+    let resolver = HashMap::from_iter([
+        (column_name!("stats_parsed.maxValues.x"), max_val),
+        (column_name!("stats_parsed.nullCount.x"), null_count),
+        (column_name!("stats_parsed.numRecords"), num_records),
+    ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
-    expect_eq!(filter.eval(&skipping_pred), expected, "{description}");
+    expect_eq!(filter.eval(&skipping_pred), expected, "{pred:?}");
 }
 
-// These values model the partition footer aggregate for `part_col = "B"`. A Remove-only group has
-// no min/max and is kept as unknown. When a non-matching Add with value "A" shares a group with a
-// Remove, parquet ignores the Remove's null and reports "A", allowing the whole group to be pruned.
+// These values model the partition footer aggregate for `part_col = "B"`. Partition references
+// are exact values and have no verifier, so a NULL Remove-side value does not pass SQL-WHERE. When
+// a non-matching Add with value "A" shares a group with a Remove, parquet reports "A" and can also
+// prune the complete group.
 #[rstest]
-#[case::remove_only(Scalar::Null(DataType::STRING), NULL)]
+#[case::remove_only(Scalar::Null(DataType::STRING), FALSE)]
 #[case::remove_with_non_matching_add(Scalar::from("A"), FALSE)]
 fn test_checkpoint_skipping_partition_comparison_with_remove(
     #[case] footer_value: Scalar,
@@ -573,17 +669,11 @@ fn test_checkpoint_skipping_floating_partition_comparison_is_disabled(#[case] va
         &partition_columns,
         &partition_columns,
         &HashSet::new(),
-    )
-    .unwrap();
-    let resolver = DefaultKernelPredicateEvaluator::from(HashMap::from_iter([(
-        column_name!("partitionValues_parsed.part_col"),
-        value,
-    )]));
+    );
 
-    expect_eq!(
-        resolver.eval(&skipping_pred),
-        NULL,
-        "parquet footer min/max exclude NaN partition values"
+    assert!(
+        skipping_pred.is_none(),
+        "parquet footer min/max exclude NaN partition values: {value}"
     );
 }
 
@@ -676,6 +766,11 @@ fn test_checkpoint_skipping_mixed_partition_and_data(
             column_name!("stats_parsed.maxValues.data_col"),
             Scalar::from(data_max),
         ),
+        (
+            column_name!("stats_parsed.nullCount.data_col"),
+            Scalar::from(0i64),
+        ),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(10i64)),
     ]));
     expect_eq!(resolver.eval(&skipping_pred), expected, "{pred:?}");
 }
@@ -690,27 +785,32 @@ fn test_checkpoint_skipping_partition_timestamp_no_truncation_adjustment() {
             .unwrap();
     assert_eq!(
         skipping_pred.to_string(),
-        "Column(partitionValues_parsed.part_ts) > 1000000",
+        "AND(NOT(Column(partitionValues_parsed.part_ts) IS NULL), true, \
+         Column(partitionValues_parsed.part_ts) > 1000000)",
         "partition timestamp must not get the 999us data-column truncation adjustment"
     );
 }
 
 #[test]
-fn test_checkpoint_skipping_null_guard_vs_regular() {
+fn test_checkpoint_verifier_keeps_missing_stats() {
     let pred = Pred::gt(column_expr!("x"), Scalar::from(100));
-    let resolver = HashMap::from_iter([(
-        column_name!("stats_parsed.maxValues.x"),
-        Scalar::Null(DataType::INTEGER),
-    )]);
+    let resolver = HashMap::from_iter([
+        (
+            column_name!("stats_parsed.maxValues.x"),
+            Scalar::Null(DataType::INTEGER),
+        ),
+        (column_name!("stats_parsed.nullCount.x"), Scalar::from(0i64)),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(10i64)),
+    ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
 
     let stats = all_referenced_columns(&pred);
-    let guarded =
+    let verified =
         as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
     expect_eq!(
-        filter.eval(&guarded),
+        filter.eval(&verified),
         TRUE,
-        "guarded pred with null stats -> TRUE (keep)"
+        "checkpoint predicate with a missing max stat -> TRUE (keep)"
     );
 
     let regular = as_data_skipping_predicate(&pred).unwrap();
@@ -721,15 +821,8 @@ fn test_checkpoint_skipping_null_guard_vs_regular() {
     );
 }
 
-// Verifies that a conjunction can still prune when one column has null stats but the other
-// column's stats are sufficient. For `col_a > 100 AND col_b < 50`, the guarded predicate is:
-//
-//   AND(
-//     OR(stats_parsed.maxValues.col_a IS NULL, stats_parsed.maxValues.col_a > 100),
-//     OR(stats_parsed.minValues.col_b IS NULL, stats_parsed.minValues.col_b < 50)
-//   )
-//
-// Even if col_a's stats are null, col_b's stats alone can prune the row group.
+// A missing stat makes the global verifier false, so the checkpoint row is kept even when an
+// independent AND arm could have pruned it. This is the selected global-verifier trade-off.
 #[test]
 fn test_checkpoint_skipping_conjunction_partial_null_stats() {
     let pred = Pred::and(
@@ -750,6 +843,15 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
             column_name!("stats_parsed.minValues.col_b"),
             Scalar::from(60),
         ),
+        (
+            column_name!("stats_parsed.nullCount.col_a"),
+            Scalar::from(0i64),
+        ),
+        (
+            column_name!("stats_parsed.nullCount.col_b"),
+            Scalar::from(0i64),
+        ),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(10i64)),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
@@ -768,12 +870,21 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
             column_name!("stats_parsed.minValues.col_b"),
             Scalar::from(60),
         ),
+        (
+            column_name!("stats_parsed.nullCount.col_a"),
+            Scalar::from(0i64),
+        ),
+        (
+            column_name!("stats_parsed.nullCount.col_b"),
+            Scalar::from(0i64),
+        ),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(10i64)),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
         filter.eval(&skipping_pred),
-        FALSE,
-        "col_a null but col_b prunable -> still skip"
+        TRUE,
+        "missing col_a max disables pruning for the complete predicate"
     );
 
     // col_a stats null and col_b doesn't allow pruning -> keep
@@ -786,6 +897,15 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
             column_name!("stats_parsed.minValues.col_b"),
             Scalar::from(30),
         ),
+        (
+            column_name!("stats_parsed.nullCount.col_a"),
+            Scalar::from(0i64),
+        ),
+        (
+            column_name!("stats_parsed.nullCount.col_b"),
+            Scalar::from(0i64),
+        ),
+        (column_name!("stats_parsed.numRecords"), Scalar::from(10i64)),
     ]);
     let filter = DefaultKernelPredicateEvaluator::from(resolver);
     expect_eq!(
@@ -795,36 +915,33 @@ fn test_checkpoint_skipping_conjunction_partial_null_stats() {
     );
 }
 
-// Verifies the null-guarded checkpoint skipping path also applies the 999us timestamp
-// truncation adjustment to max stat comparisons.
+// Verifies the checkpoint path applies the 999us timestamp truncation adjustment inside `P`.
 #[rstest]
 fn test_checkpoint_skipping_timestamp_adjustment(
     #[values(Scalar::Timestamp(1_000_000), Scalar::TimestampNtz(1_000_000))] timestamp: Scalar,
 ) {
     let col = &column_expr!("ts_col");
 
-    // GT: should produce OR(maxValues.ts_col IS NULL, maxValues.ts_col > 999001)
     let pred = Pred::gt(col.clone(), timestamp.clone());
     let stats = all_referenced_columns(&pred);
     let skipping_pred =
         as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
-    assert_eq!(
-        skipping_pred.to_string(),
-        "OR(Column(stats_parsed.maxValues.ts_col) IS NULL, \
-         Column(stats_parsed.maxValues.ts_col) > 999001)"
+    let output = skipping_pred.to_string();
+    assert!(
+        output.contains("Column(stats_parsed.maxValues.ts_col) > 999001"),
+        "adjusted max comparison missing from {output}"
     );
 
-    // EQ: max stat leg should use adjusted literal
+    // EQ: the min leg remains unadjusted while the max leg is widened.
     let pred = Pred::eq(col.clone(), timestamp.clone());
     let stats = all_referenced_columns(&pred);
     let skipping_pred =
         as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
-    assert_eq!(
-        skipping_pred.to_string(),
-        "AND(OR(Column(stats_parsed.minValues.ts_col) IS NULL, \
-         NOT(Column(stats_parsed.minValues.ts_col) > 1000000)), \
-         OR(Column(stats_parsed.maxValues.ts_col) IS NULL, \
-         NOT(Column(stats_parsed.maxValues.ts_col) < 999001)))"
+    let output = skipping_pred.to_string();
+    assert!(
+        output.contains("Column(stats_parsed.minValues.ts_col) > 1000000")
+            && output.contains("Column(stats_parsed.maxValues.ts_col) < 999001"),
+        "timestamp bounds were not adjusted as expected: {output}"
     );
 }
 
@@ -1751,11 +1868,9 @@ fn mixed_and_non_stat_arm_still_prunes_via_stat_arm() {
     );
 }
 
-/// Same scenario as `stat_and_non_stat_folds_non_stat` but through the checkpoint
-/// creator, which adds an `IS NULL` guard on each stat ref for safe parquet
-/// row-group filtering. The non-stat arm still folds to NULL.
+/// The checkpoint creator omits an unsupported AND child rather than inserting a NULL sentinel.
 #[test]
-fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
+fn checkpoint_pushdown_omits_unsupported_and_child() {
     let pred = Pred::and(
         Pred::gt(column_expr!("stat"), Scalar::from(100)),
         Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
@@ -1763,9 +1878,43 @@ fn checkpoint_pushdown_non_stat_arm_folds_to_null_literal() {
     let stats = stats_cols(&["stat"]);
     let result =
         as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).unwrap();
-    assert_eq!(
-        result.to_string(),
-        "AND(OR(Column(stats_parsed.maxValues.stat) IS NULL, \
-         Column(stats_parsed.maxValues.stat) > 100), null)"
+    let output = result.to_string();
+    assert!(output.contains("stats_parsed.maxValues.stat"));
+    assert!(!output.contains("non_stat"));
+}
+
+#[test]
+fn checkpoint_pushdown_declines_or_with_unsupported_child() {
+    let pred = Pred::or(
+        Pred::gt(column_expr!("stat"), Scalar::from(100)),
+        Pred::gt(column_expr!("non_stat"), Scalar::from(50)),
+    );
+    let stats = stats_cols(&["stat"]);
+    assert!(
+        as_checkpoint_skipping_predicate(&pred, &HashSet::new(), &HashSet::new(), &stats).is_none()
+    );
+}
+
+#[test]
+fn checkpoint_pushdown_applies_junction_policy_after_not() {
+    let supported = Pred::gt(column_expr!("stat"), Scalar::from(100));
+    let unsupported = Pred::gt(column_expr!("non_stat"), Scalar::from(50));
+    let stats = stats_cols(&["stat"]);
+
+    let not_and = Pred::not(Pred::and(supported.clone(), unsupported.clone()));
+    assert!(
+        as_checkpoint_skipping_predicate(&not_and, &HashSet::new(), &HashSet::new(), &stats)
+            .is_none(),
+        "NOT(AND) becomes OR and must retain every child"
+    );
+
+    let not_or = Pred::not(Pred::or(supported.clone(), unsupported));
+    let actual =
+        as_checkpoint_skipping_predicate(&not_or, &HashSet::new(), &HashSet::new(), &stats)
+            .unwrap();
+    let output = actual.to_string();
+    assert!(
+        output.contains("stats_parsed.minValues.stat") && !output.contains("non_stat"),
+        "NOT(OR) becomes AND and omits the unsupported child: {output}"
     );
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1034,18 +1034,15 @@ impl Scan {
 
     /// Builds a predicate for row group skipping in checkpoint and sidecar parquet files.
     ///
-    /// The scan predicate is rewritten into a data-skipping form scoped under the `add` action:
-    /// data-column references become `add.stats_parsed.{minValues,maxValues,nullCount}.<col>` and
-    /// partition references become `add.partitionValues_parsed.<col>`, so the parquet reader's row
-    /// group filter can use footer statistics to skip row groups that cannot contain matching
-    /// files. See [`as_checkpoint_skipping_predicate`] for the rewrite and its data-stat IS NULL
-    /// guards.
+    /// The scan predicate is rewritten into a normal SQL-WHERE data-skipping predicate `P` scoped
+    /// under the `add` action. Structured-stat references are protected by a total verifier `V`,
+    /// producing `P OR NOT V`, so an ordinary exact SQL filter keeps rows with missing statistics.
+    /// Typed partition values are exact and are not included in `V`.
     ///
     /// Returns `None` if the scan has no predicate, if neither a data-column stats schema nor a
     /// partition schema is available, or if the predicate is a bare unsupported expression (e.g.
-    /// column-column comparison). Junctions represent unsupported arms with a NULL literal,
-    /// preserving three-valued logic while allowing independently decisive supported arms to
-    /// prune.
+    /// column-column comparison). Unsupported AND children are omitted; an unsupported OR child
+    /// disables that complete OR rewrite.
     fn build_actions_meta_predicate(&self) -> Option<PredicateRef> {
         let PhysicalPredicate::Some(ref predicate, _) = self.state_info.physical_predicate else {
             return None;

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1116,6 +1116,10 @@ fn test_build_actions_meta_predicate_with_predicate() {
 
     // Verify all column references are prefixed with add.stats_parsed
     let pred = meta_pred.unwrap();
+    assert!(
+        !pred.to_string().contains("DISTINCT"),
+        "checkpoint predicates use P OR NOT V, not a DISTINCT boundary"
+    );
     for col_ref in pred.references() {
         let path: Vec<_> = col_ref.iter().collect();
         assert_eq!(
@@ -1495,14 +1499,14 @@ fn apply_row_group_filter(parquet_bytes: Bytes, meta_predicate: &Pred) -> usize 
 ///
 /// | Predicate      | RG 0 (2 rows)         | RG 1 (1 row)       | RG 2 (1 row)       | RG 3 (2 rows)        | Total |
 /// |----------------|-----------------------|--------------------|--------------------|-----------------------|-------|
-/// | id > 200       | keep (null max stats) | keep (max=300>200) | skip (max=50<200)  | skip (max=150<200)    | 3     |
+/// | id > 200       | keep (missing stats)  | keep (max=300>200) | skip (max=50<200)  | keep (missing stats)  | 5     |
 /// | id IS NULL     | keep (nullCount>0)    | skip (nullCount=0) | keep (nullCount=10)| keep (null nullCount) | 5     |
-/// | id IS NOT NULL | no predicate (col vs col, #1873)                                                       | 6     |
+/// | id IS NOT NULL | keep                    | keep               | keep               | keep                  | 6     |
 #[rstest]
 #[case::comparison(
     Pred::gt(column_expr!("id"), Expr::literal(200i64)),
-    Some(3),
-    "keep RG 0 (null stats) + RG 1 (max>200), skip RG 2 + RG 3 (max<200)"
+    Some(5),
+    "keep RG 0 + RG 3 (missing stats) and RG 1 (max>200), skip only RG 2"
 )]
 #[case::is_null(
     Pred::is_null(column_expr!("id")),
@@ -1511,8 +1515,8 @@ fn apply_row_group_filter(parquet_bytes: Bytes, meta_predicate: &Pred) -> usize 
 )]
 #[case::is_not_null(
     Pred::not(Pred::is_null(column_expr!("id"))),
-    None,
-    "IS NOT NULL produces no skipping predicate (column vs column, #1873)"
+    Some(6),
+    "IS NOT NULL produces the normal predicate; this footer cannot prove its column-column comparison"
 )]
 fn test_checkpoint_row_group_skipping(
     #[case] pred: Pred,
@@ -1825,18 +1829,26 @@ fn test_checkpoint_predicate_reaches_parquet_handler(
     }
 
     let reads = engine.take_reads();
-    assert!(
-        reads.iter().any(|read| {
+    let matching_predicates: Vec<_> = reads
+        .iter()
+        .filter(|read| {
             read.files
                 .iter()
                 .any(|file| file.contains(expected_file_fragment))
-                && read
-                    .predicate
-                    .as_ref()
-                    .is_some_and(|predicate| predicate.references().contains(&expected_ref))
-        }),
+        })
+        .filter_map(|read| read.predicate.as_ref())
+        .filter(|predicate| predicate.references().contains(&expected_ref))
+        .collect();
+    assert!(
+        !matching_predicates.is_empty(),
         "expected {expected_ref} on a {expected_file_fragment} read, got {reads:#?}"
     );
+    for predicate in matching_predicates {
+        assert!(
+            !predicate.to_string().contains("DISTINCT"),
+            "V1 checkpoints and V2 sidecars must receive P OR NOT V without DISTINCT: {predicate}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR makes checkpoint and sidecar row-group skipping use the normal Kernel SQL-WHERE data-skipping predicate P. Checkpoint handling retains a small policy adapter for footer eligibility and unsupported junctions, but it no longer defines different leaf semantics.

Because this predicate crosses the ParquetHandler boundary, an engine may apply it as an ordinary exact SQL filter, where NULL is rejected. Kernel therefore sends one self-contained expression, Q = P OR NOT verifyStats(P). The verifier is true only when every structured statistic referenced by P is usable. If a required statistic is missing, the verifier is false and Q is true, so the checkpoint Add is retained. A NULL min or max remains usable when present nullCount and numRecords prove that the file is entirely NULL. Exact partition values are not statistics and are excluded from the verifier.

Unsupported AND children are omitted because the remaining supported condition can still prune safely. An unsupported OR child disables that OR rewrite because either child may match; inversion is applied first, so the same rule covers De Morgan forms. The in-memory DataSkippingFilter remains unchanged because Kernel already owns its final keep-TRUE-or-NULL step. Engines receive an ordinary SQL expression with no checkpoint-specific root convention and no DISTINCT boundary.

## How was this change tested?

Added producer and exact-evaluation coverage for complete, missing, and all-NULL statistics; verifier shape and ordering; partition-only and mixed predicates; unsupported AND, OR, and NOT forms; timestamps; floating partition columns; and non-Add rows. Added default footer row-group coverage and V1 checkpoint and V2 sidecar boundary assertions that the predicate reaches ParquetHandler without DISTINCT. The full delta_kernel unit suite and data-skipping integration suite pass, as do formatting, affected-crate Clippy, no-default-features Clippy, and workspace rustdoc. Workspace-wide Clippy is currently blocked by the pre-existing redundant closure warning in ffi/src/ffi_tracing.rs:381.