### PR TITLE
fix: report accurate filesystem commit file sizes

### DIFF
--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -47,12 +47,11 @@ impl Committer for FileSystemCommitter {
                     committed_version = version,
                     "Committed delta file via filesystem committer"
                 );
-                // For now, we don't need the real size of the written file, so we can use 0.
-                // If we need this in the future, we can get it from StorageHandler::head.
+                let size = engine.storage_handler().head(&published_commit_path)?.size;
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    0,
+                    size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }
@@ -91,13 +90,14 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::{Metadata, Protocol};
+    use crate::actions::{Metadata, Protocol, LOG_METADATA_SCHEMA};
     use crate::committer::{CommitProtocolMetadata, CommitType};
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::path::LogRoot;
+    use crate::IntoEngineData;
 
     #[tokio::test]
     async fn disallow_filesystem_committer_for_catalog_managed_tables() {
@@ -135,13 +135,17 @@ mod tests {
     async fn test_filesystem_committer_returns_valid_commit_response() {
         let storage = Arc::new(InMemory::new());
         let table_root = Url::parse("memory:///").unwrap();
-        let engine = SyncEngine::new_with_store(storage);
+        let engine = SyncEngine::new_with_store(storage.clone());
 
         let committer = FileSystemCommitter::new();
         let log_root = LogRoot::new(table_root).unwrap();
         let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
         let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
+        let action = metadata
+            .clone()
+            .into_engine_data(LOG_METADATA_SCHEMA.clone(), &engine)
+            .unwrap();
         let commit_metadata = CommitMetadata::new(
             log_root,
             1,
@@ -151,14 +155,22 @@ mod tests {
             CommitProtocolMetadata::try_new(Some(protocol), Some(metadata), None, None).unwrap(),
             vec![],
         );
-        let actions = Box::new(std::iter::empty());
+        let actions = Box::new(std::iter::once(Ok(
+            FilteredEngineData::with_all_rows_selected(action),
+        )));
 
         let result = committer.commit(&engine, actions, commit_metadata).unwrap();
+        let stored_size = storage
+            .head(&Path::from("_delta_log/00000000000000000001.json"))
+            .await
+            .unwrap()
+            .size;
 
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
-                assert_eq!(file_meta.size, 0);
+                assert!(file_meta.size > 0);
+                assert_eq!(file_meta.size, stored_size);
                 assert!(file_meta
                     .location
                     .as_str()


### PR DESCRIPTION
## What changes are proposed in this pull request?

After the atomic JSON write succeeds, `FileSystemCommitter` calls `StorageHandler::head` and uses the stored object size in the returned `FileMeta` instead of the placeholder `0`.

This keeps the existing `JsonHandler` API unchanged. The trade-off is one additional storage metadata request after each successful filesystem commit. If that request fails, the commit file may already be durable even though the commit call returns an error.

### This PR affects the following public APIs

None.

## How was this change tested?

Ran the focused filesystem committer test, including verification that the returned nonzero size exactly matches the stored object size.