### PR TITLE
fix: correctly generate `extendedFileMetadata` for removeFile

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -740,6 +740,8 @@ pub(crate) static FILE_CONSTANT_VALUES_NAME: &str = "fileConstantValues";
 pub(crate) static BASE_ROW_ID_NAME: &str = "baseRowId";
 pub(crate) static DEFAULT_ROW_COMMIT_VERSION_NAME: &str = "defaultRowCommitVersion";
 pub(crate) static CLUSTERING_PROVIDER_NAME: &str = "clusteringProvider";
+pub(crate) static PARTITION_VALUES_NAME: &str = "partitionValues";
+pub(crate) static SIZE_NAME: &str = "size";
 pub(crate) static TAGS_NAME: &str = "tags";
 pub(crate) static STATS_PARSED_NAME: &str = "stats_parsed";
 #[internal_api]
@@ -752,12 +754,12 @@ pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| 
     // Note that fields projected out of a nullable struct must be nullable
     schema_ref! {
         nullable "path": STRING,
-        nullable "size": LONG,
+        nullable SIZE_NAME: LONG,
         nullable "modificationTime": LONG,
         nullable "stats": STRING,
         nullable "deletionVector": (DeletionVectorDescriptor::to_schema()),
         nullable FILE_CONSTANT_VALUES_NAME: {
-            nullable "partitionValues": { STRING => nullable STRING },
+            nullable PARTITION_VALUES_NAME: { STRING => nullable STRING },
             nullable BASE_ROW_ID_NAME: LONG,
             nullable DEFAULT_ROW_COMMIT_VERSION_NAME: LONG,
             nullable "tags": { STRING => nullable STRING },

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2025,6 +2025,31 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_action_projection_sets_extended_metadata() -> DeltaResult<()> {
+        let patch = build_remove_struct_patch(
+            0,     /* commit_timestamp */
+            true,  /* data_change */
+            &[],   /* columns_to_drop */
+            false, /* coalesce_stats_with_parsed */
+        )?;
+        let path_patch = patch
+            .field_patches
+            .get("path")
+            .expect("path should have inserted fields");
+        let extended_file_metadata = path_patch
+            .insertions
+            .get(2)
+            .expect("extendedFileMetadata should follow deletionTimestamp and dataChange");
+        let expected = Expression::from_pred(Predicate::and_from([
+            col!("size").is_not_null(),
+            col!(FILE_CONSTANT_VALUES_NAME, "partitionValues").is_not_null(),
+            col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
+        ]));
+        assert_eq!(extended_file_metadata.as_ref(), &expected);
+        Ok(())
+    }
+
+    #[test]
     fn test_new_deletion_vector_path() -> Result<(), Box<dyn std::error::Error>> {
         let engine = SyncEngine::new();
         let path =

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -34,7 +34,7 @@ use crate::row_tracking::{RowTrackingDomainMetadata, RowTrackingVisitor};
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::{
     BASE_ROW_ID_NAME, DEFAULT_ROW_COMMIT_VERSION_NAME, FILE_CONSTANT_VALUES_NAME,
-    PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME, TAGS_NAME,
+    PARTITION_VALUES_NAME, PARTITION_VALUES_PARSED_NAME, SIZE_NAME, STATS_PARSED_NAME, TAGS_NAME,
 };
 use crate::scan::scan_row_schema;
 use crate::schema::void_utils::{add_void_stripping, validate_schema_for_write};
@@ -1552,8 +1552,8 @@ fn build_remove_struct_patch(
     coalesce_stats_with_parsed: bool,
 ) -> DeltaResult<ExpressionStructPatch> {
     let extended_file_metadata = Predicate::and_from([
-        col!("size").is_not_null(),
-        col!(FILE_CONSTANT_VALUES_NAME, "partitionValues").is_not_null(),
+        col!(SIZE_NAME).is_not_null(),
+        col!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME).is_not_null(),
         col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
     ]);
     let mut patch = ExpressionStructPatchBuilder::new()
@@ -1563,7 +1563,10 @@ fn build_remove_struct_patch(
         .insert_after("path", lit(data_change))
         // extended_file_metadata
         .insert_after("path", Expression::from(extended_file_metadata))
-        .insert_after("path", col!(FILE_CONSTANT_VALUES_NAME, "partitionValues"));
+        .insert_after(
+            "path",
+            col!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME),
+        );
 
     if coalesce_stats_with_parsed {
         // Replace stats with COALESCE(stats, TO_JSON(stats_parsed)) and drop stats_parsed.
@@ -2041,8 +2044,8 @@ mod tests {
             .get(2)
             .expect("extendedFileMetadata should follow deletionTimestamp and dataChange");
         let expected = Expression::from_pred(Predicate::and_from([
-            col!("size").is_not_null(),
-            col!(FILE_CONSTANT_VALUES_NAME, "partitionValues").is_not_null(),
+            col!(SIZE_NAME).is_not_null(),
+            col!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME).is_not_null(),
             col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
         ]));
         assert_eq!(extended_file_metadata.as_ref(), &expected);

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1551,10 +1551,11 @@ fn build_remove_struct_patch(
     columns_to_drop: &[&str],
     coalesce_stats_with_parsed: bool,
 ) -> DeltaResult<ExpressionStructPatch> {
+    // Note: The Delta protocol requires `partitionValues`, `size`, and `tags` when
+    // `extendedFileMetadata` is true. We require only `partitionValues` and `size` to match Spark.
     let extended_file_metadata = Predicate::and_from([
         col!(SIZE_NAME).is_not_null(),
         col!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME).is_not_null(),
-        col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
     ]);
     let mut patch = ExpressionStructPatchBuilder::new()
         // deletionTimestamp
@@ -2046,7 +2047,6 @@ mod tests {
         let expected = Expression::from_pred(Predicate::and_from([
             col!(SIZE_NAME).is_not_null(),
             col!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME).is_not_null(),
-            col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
         ]));
         assert_eq!(extended_file_metadata.as_ref(), &expected);
         Ok(())

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -49,7 +49,7 @@ use crate::table_features::TableFeature;
 use crate::utils::require;
 use crate::{
     version_as_i64, DataType, DeltaResult, Engine, EngineData, Expression, FileMeta,
-    IntoEngineData, RowVisitor, Version,
+    IntoEngineData, Predicate, RowVisitor, Version,
 };
 
 #[cfg(feature = "internal-api")]
@@ -1551,13 +1551,18 @@ fn build_remove_struct_patch(
     columns_to_drop: &[&str],
     coalesce_stats_with_parsed: bool,
 ) -> DeltaResult<ExpressionStructPatch> {
+    let extended_file_metadata = Predicate::and_from([
+        col!("size").is_not_null(),
+        col!(FILE_CONSTANT_VALUES_NAME, "partitionValues").is_not_null(),
+        col!(FILE_CONSTANT_VALUES_NAME, TAGS_NAME).is_not_null(),
+    ]);
     let mut patch = ExpressionStructPatchBuilder::new()
         // deletionTimestamp
         .insert_after("path", lit(commit_timestamp))
         // dataChange
         .insert_after("path", lit(data_change))
         // extended_file_metadata
-        .insert_after("path", lit(true))
+        .insert_after("path", Expression::from(extended_file_metadata))
         .insert_after("path", col!(FILE_CONSTANT_VALUES_NAME, "partitionValues"));
 
     if coalesce_stats_with_parsed {

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -201,13 +201,23 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
 /// Verifies `extendedFileMetadata` is true exactly when `size`, `partitionValues`, and `tags`
 /// are all present.
 #[rstest::rstest]
-#[case::all_present(None)]
-#[case::missing_size(Some(ExtendedMetadataField::Size))]
-#[case::missing_partition_values(Some(ExtendedMetadataField::PartitionValues))]
-#[case::missing_tags(Some(ExtendedMetadataField::Tags))]
+#[case::all_present(&[])]
+#[case::missing_size(&[ExtendedMetadataField::Size])]
+#[case::missing_partition_values(&[ExtendedMetadataField::PartitionValues])]
+#[case::missing_tags(&[ExtendedMetadataField::Tags])]
+#[case::only_size(&[
+    ExtendedMetadataField::PartitionValues,
+    ExtendedMetadataField::Tags,
+])]
+#[case::only_partition_values(&[ExtendedMetadataField::Size, ExtendedMetadataField::Tags])]
+#[case::only_tags(&[
+    ExtendedMetadataField::Size,
+    ExtendedMetadataField::PartitionValues,
+])]
+#[case::none_present(&ExtendedMetadataField::ALL)]
 #[tokio::test]
 async fn test_remove_scanned_file_sets_extended_metadata(
-    #[case] missing_field: Option<ExtendedMetadataField>,
+    #[case] missing_fields: &[ExtendedMetadataField],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let table_url = Url::from_directory_path(&table_path).unwrap();
@@ -228,14 +238,14 @@ async fn test_remove_scanned_file_sets_extended_metadata(
     let scan = snapshot.clone().scan_builder().build()?;
     let mut txn = begin_transaction(snapshot, engine.as_ref())?.with_data_change(true);
     for scan_metadata in scan.scan_metadata(engine.as_ref())? {
-        txn.remove_files(with_missing_extended_metadata_field(
+        txn.remove_files(with_missing_extended_metadata_fields(
             engine.as_ref(),
             scan_metadata?.scan_files,
-            missing_field,
+            missing_fields,
         )?);
     }
     let commit_result = txn.commit(engine.as_ref());
-    if missing_field == Some(ExtendedMetadataField::Size) {
+    if missing_fields.contains(&ExtendedMetadataField::Size) {
         // TODO(#2717): The commit is materialized before post-commit validation returns this error,
         // so the committed Remove action remains available for validation below.
         assert_result_error_with_message(commit_result, "Data missing for field size");
@@ -247,12 +257,12 @@ async fn test_remove_scanned_file_sets_extended_metadata(
     let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;
     assert_eq!(remove_actions.len(), 1);
     let remove = &remove_actions[0];
-    assert_eq!(remove["extendedFileMetadata"], missing_field.is_none());
+    assert_eq!(remove["extendedFileMetadata"], missing_fields.is_empty());
     for field in ExtendedMetadataField::ALL {
         let present = remove
             .get(field.name())
             .is_some_and(|value| !value.is_null());
-        assert_eq!(present, Some(field) != missing_field);
+        assert_eq!(present, !missing_fields.contains(&field));
     }
 
     let scan = snapshot.scan_builder().build()?;
@@ -909,27 +919,27 @@ impl ExtendedMetadataField {
     }
 }
 
-fn with_missing_extended_metadata_field(
+fn with_missing_extended_metadata_fields(
     engine: &dyn Engine,
     scan_files: FilteredEngineData,
-    missing_field: Option<ExtendedMetadataField>,
+    missing_fields: &[ExtendedMetadataField],
 ) -> Result<FilteredEngineData, Box<dyn std::error::Error>> {
     let (data, selection_vector) = scan_files.into_parts();
     let map_type = MapType::new(DataType::STRING, DataType::STRING, true);
-    let tags = if missing_field == Some(ExtendedMetadataField::Tags) {
+    let tags = if missing_fields.contains(&ExtendedMetadataField::Tags) {
         Scalar::Null(DataType::from(map_type.clone()))
     } else {
         Scalar::Map(MapData::try_new(map_type.clone(), [("key", "value")])?)
     };
     let mut patch =
         ExpressionStructPatchBuilder::new().replace_at(["fileConstantValues"], "tags", lit(tags));
-    if let Some(field) = missing_field {
+    for field in missing_fields {
         patch = match field {
             ExtendedMetadataField::Size => patch.replace("size", lit(Scalar::Null(DataType::LONG))),
             ExtendedMetadataField::PartitionValues => patch.replace_at(
                 ["fileConstantValues"],
                 field.name(),
-                lit(Scalar::Null(DataType::from(map_type))),
+                lit(Scalar::Null(DataType::from(map_type.clone()))),
             ),
             ExtendedMetadataField::Tags => patch,
         };

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -198,26 +198,27 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-/// Verifies `extendedFileMetadata` is true exactly when `size`, `partitionValues`, and `tags`
-/// are all present.
+/// Verifies `extendedFileMetadata` is true exactly when `size` and `partitionValues` are present;
+/// `tags` does not affect it.
 #[rstest::rstest]
-#[case::all_present(&[])]
-#[case::missing_size(&[ExtendedMetadataField::Size])]
-#[case::missing_partition_values(&[ExtendedMetadataField::PartitionValues])]
-#[case::missing_tags(&[ExtendedMetadataField::Tags])]
+#[case::all_present(&[], true)]
+#[case::missing_size(&[ExtendedMetadataField::Size], false)]
+#[case::missing_partition_values(&[ExtendedMetadataField::PartitionValues], false)]
+#[case::missing_tags(&[ExtendedMetadataField::Tags], true)]
 #[case::only_size(&[
     ExtendedMetadataField::PartitionValues,
     ExtendedMetadataField::Tags,
-])]
-#[case::only_partition_values(&[ExtendedMetadataField::Size, ExtendedMetadataField::Tags])]
+], false)]
+#[case::only_partition_values(&[ExtendedMetadataField::Size, ExtendedMetadataField::Tags], false)]
 #[case::only_tags(&[
     ExtendedMetadataField::Size,
     ExtendedMetadataField::PartitionValues,
-])]
-#[case::none_present(&ExtendedMetadataField::ALL)]
+], false)]
+#[case::none_present(&ExtendedMetadataField::ALL, false)]
 #[tokio::test]
 async fn test_remove_scanned_file_sets_extended_metadata(
     #[case] missing_fields: &[ExtendedMetadataField],
+    #[case] expected_extended_file_metadata: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let table_url = Url::from_directory_path(&table_path).unwrap();
@@ -257,7 +258,10 @@ async fn test_remove_scanned_file_sets_extended_metadata(
     let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;
     assert_eq!(remove_actions.len(), 1);
     let remove = &remove_actions[0];
-    assert_eq!(remove["extendedFileMetadata"], missing_fields.is_empty());
+    assert_eq!(
+        remove["extendedFileMetadata"],
+        expected_extended_file_metadata
+    );
     for field in ExtendedMetadataField::ALL {
         let present = remove
             .get(field.name())

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -248,12 +248,11 @@ async fn test_remove_scanned_file_sets_extended_metadata(
     assert_eq!(remove_actions.len(), 1);
     let remove = &remove_actions[0];
     assert_eq!(remove["extendedFileMetadata"], missing_field.is_none());
-    if let Some(field) = missing_field {
-        assert!(remove.get(field.name()).is_none());
-    } else {
-        for field in ExtendedMetadataField::ALL {
-            assert!(remove.get(field.name()).is_some());
-        }
+    for field in ExtendedMetadataField::ALL {
+        let present = remove
+            .get(field.name())
+            .is_some_and(|value| !value.is_null());
+        assert_eq!(present, Some(field) != missing_field);
     }
 
     let scan = snapshot.scan_builder().build()?;

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -6,22 +6,25 @@ use std::sync::Arc;
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::actions::{NUM_RECORDS, TIGHT_BOUNDS};
 use delta_kernel::arrow::array::{Int32Array, RecordBatch};
+use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine_data::FilteredEngineData;
-use delta_kernel::expressions::{column_expr, Scalar};
+use delta_kernel::expressions::{column_expr, lit, ExpressionStructPatchBuilder, MapData, Scalar};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::scan::StatsOptions;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::scan::{scan_row_schema, StatsOptions};
+use delta_kernel::schema::{schema_ref, DataType, MapType, StructField, StructType};
+use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
-use delta_kernel::{Expression as Expr, Predicate as Pred, Snapshot};
+use delta_kernel::{Engine, Expression as Expr, Predicate as Pred, Snapshot};
 use itertools::Itertools;
 use serde_json::Deserializer;
 use tempfile::tempdir;
 use test_utils::{
-    begin_transaction, copy_directory, create_default_engine, create_default_engine_mt_executor,
-    load_and_begin_transaction, read_actions_from_commit, setup_test_tables,
+    assert_result_error_with_message, begin_transaction, copy_directory, create_default_engine,
+    create_default_engine_mt_executor, insert_data, load_and_begin_transaction,
+    read_actions_from_commit, setup_test_tables, test_table_setup,
 };
 use url::Url;
 
@@ -191,6 +194,79 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
         }
         _ => panic!("Transaction should be committed"),
     }
+
+    Ok(())
+}
+
+/// Verifies `extendedFileMetadata` is true exactly when `size`, `partitionValues`, and `tags`
+/// are all present.
+#[rstest::rstest]
+#[case::all_present(None)]
+#[case::missing_size(Some(ExtendedMetadataField::Size))]
+#[case::missing_partition_values(Some(ExtendedMetadataField::PartitionValues))]
+#[case::missing_tags(Some(ExtendedMetadataField::Tags))]
+#[tokio::test]
+async fn test_remove_scanned_file_sets_extended_metadata(
+    #[case] missing_field: Option<ExtendedMetadataField>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let table_url = Url::from_directory_path(&table_path).unwrap();
+    let schema = schema_ref! { nullable "number": INTEGER };
+
+    let snapshot = create_table(&table_path, schema, "Test/1.0")
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_post_commit_snapshot();
+    let snapshot = insert_data(
+        snapshot,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?
+    .unwrap_post_commit_snapshot();
+
+    let scan = snapshot.clone().scan_builder().build()?;
+    let mut txn = begin_transaction(snapshot, engine.as_ref())?.with_data_change(true);
+    for scan_metadata in scan.scan_metadata(engine.as_ref())? {
+        txn.remove_files(with_missing_extended_metadata_field(
+            engine.as_ref(),
+            scan_metadata?.scan_files,
+            missing_field,
+        )?);
+    }
+    let commit_result = txn.commit(engine.as_ref());
+    if missing_field == Some(ExtendedMetadataField::Size) {
+        // TODO(#2717): The commit is materialized before post-commit validation returns this error,
+        // so the committed Remove action remains available for validation below.
+        assert_result_error_with_message(commit_result, "Data missing for field size");
+    } else {
+        commit_result?.unwrap_committed();
+    }
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+
+    let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;
+    assert_eq!(remove_actions.len(), 1);
+    let remove = &remove_actions[0];
+    assert_eq!(remove["extendedFileMetadata"], missing_field.is_none());
+    if let Some(field) = missing_field {
+        assert!(remove.get(field.name()).is_none());
+    } else {
+        for field in ExtendedMetadataField::ALL {
+            assert!(remove.get(field.name()).is_some());
+        }
+    }
+
+    let scan = snapshot.scan_builder().build()?;
+    let mut surviving_files = 0;
+    for scan_metadata in scan.scan_metadata(engine.as_ref())? {
+        surviving_files += scan_metadata?
+            .scan_files
+            .selection_vector()
+            .iter()
+            .filter(|selected| **selected)
+            .count();
+    }
+    assert_eq!(surviving_files, 0);
 
     Ok(())
 }
@@ -813,6 +889,60 @@ async fn test_remove_files_verify_files_excluded_from_scan(
         }
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ExtendedMetadataField {
+    Size,
+    PartitionValues,
+    Tags,
+}
+
+impl ExtendedMetadataField {
+    const ALL: [Self; 3] = [Self::Size, Self::PartitionValues, Self::Tags];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Size => "size",
+            Self::PartitionValues => "partitionValues",
+            Self::Tags => "tags",
+        }
+    }
+}
+
+fn with_missing_extended_metadata_field(
+    engine: &dyn Engine,
+    scan_files: FilteredEngineData,
+    missing_field: Option<ExtendedMetadataField>,
+) -> Result<FilteredEngineData, Box<dyn std::error::Error>> {
+    let (data, selection_vector) = scan_files.into_parts();
+    let map_type = MapType::new(DataType::STRING, DataType::STRING, true);
+    let tags = if missing_field == Some(ExtendedMetadataField::Tags) {
+        Scalar::Null(DataType::from(map_type.clone()))
+    } else {
+        Scalar::Map(MapData::try_new(map_type.clone(), [("key", "value")])?)
+    };
+    let mut patch =
+        ExpressionStructPatchBuilder::new().replace_at(["fileConstantValues"], "tags", lit(tags));
+    if let Some(field) = missing_field {
+        patch = match field {
+            ExtendedMetadataField::Size => patch.replace("size", lit(Scalar::Null(DataType::LONG))),
+            ExtendedMetadataField::PartitionValues => patch.replace_at(
+                ["fileConstantValues"],
+                field.name(),
+                lit(Scalar::Null(DataType::from(map_type))),
+            ),
+            ExtendedMetadataField::Tags => patch,
+        };
+    }
+    let schema = scan_row_schema();
+    let evaluator = engine.evaluation_handler().new_expression_evaluator(
+        schema.clone(),
+        Arc::new(Expr::struct_patch(patch)?),
+        schema.into(),
+    )?;
+    let data = evaluator.evaluate(data.as_ref())?;
+    Ok(FilteredEngineData::try_new(data, selection_vector)?)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixed https://github.com/delta-io/delta-kernel-rs/issues/3002. TL;DR: generate `extendedFileMetadata` only when `size`, `partitionValues`, `tags` all exists 
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Integration tests for all cases: the three fields individually missing/all exist