### PR TITLE
feat!: introduce UpdateTableTransactionBuilder for write transactions

### DIFF
--- a/delta-kernel-unity-catalog/src/lib.rs
+++ b/delta-kernel-unity-catalog/src/lib.rs
@@ -314,7 +314,7 @@ mod tests {
         } else {
             Box::new(FileSystemCommitter::new())
         };
-        let txn = snapshot.clone().transaction(committer, &engine)?;
+        let txn = snapshot.clone().transaction().build(&engine, committer)?;
         let _write_context = txn.unpartitioned_write_context()?;
 
         match txn.commit(&engine)? {

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -259,7 +259,8 @@ mod tests {
             .build(&engine)
             .unwrap();
         let result = v0_snapshot
-            .transaction(Box::new(TestCatalogCommitter), &engine)
+            .transaction()
+            .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
             .commit(&engine)
             .unwrap();

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -104,7 +104,8 @@ fn commit(
     let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
     match snapshot
         .clone()
-        .transaction(committer, engine)?
+        .transaction()
+        .build(engine, committer)?
         .commit(engine)?
     {
         CommitResult::CommittedTransaction(t) => Ok(t
@@ -164,7 +165,8 @@ async fn test_insert_without_publish_hits_limit() -> Result<(), TestError> {
     let committer = Box::new(UCCommitter::new(commits_client.clone(), TABLE_ID));
     let err = snapshot
         .clone()
-        .transaction(committer, &engine)?
+        .transaction()
+        .build(&engine, committer)?
         .commit(&engine)
         .unwrap_err();
     assert!(

--- a/docs/user-guide/src/catalog_managed/overview.md
+++ b/docs/user-guide/src/catalog_managed/overview.md
@@ -126,7 +126,7 @@ IDs, catalog APIs, or catalog servers. Instead:
 |      .with_log_tail(commits)                              |
 |      .with_max_catalog_version(version)                   |
 |      .build(&engine)                                      |
-|    snapshot.transaction(committer, &engine)                |
+|    snapshot.transaction().build(&engine, committer)       |
 +---------------------------+-------------------------------+
                             | calls Kernel APIs
                             v

--- a/docs/user-guide/src/catalog_managed/writing.md
+++ b/docs/user-guide/src/catalog_managed/writing.md
@@ -61,8 +61,9 @@ let committer = Box::new(MyCatalogCommitter::new(
     table_id.clone(),
 ));
 let mut txn = snapshot
-    .transaction(committer, &engine)?
-    .with_operation("INSERT".to_string());
+    .transaction()
+    .with_operation("INSERT".to_string())
+    .build(&engine, committer)?;
 
 // Drive your Parquet writer from the write context, then hand the resulting
 // add-file metadata batch to the transaction. See the

--- a/docs/user-guide/src/concepts/architecture.md
+++ b/docs/user-guide/src/concepts/architecture.md
@@ -155,9 +155,10 @@ A `Transaction` writes data to a table. It is built from a snapshot:
 
 ```rust,ignore
 let mut txn = snapshot                              // Arc<Snapshot>
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
-    .with_data_change(true);
+    .with_data_change(true)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 // Write Parquet files, then register their metadata.
 txn.add_files(file_metadata);

--- a/docs/user-guide/src/connector/overview.md
+++ b/docs/user-guide/src/connector/overview.md
@@ -91,7 +91,7 @@ From a snapshot, you can:
 |-----------|-----------|-------------------------------|
 | Get schema and metadata | `snapshot.schema()`, `snapshot.table_properties()` | Table schema discovery |
 | Read data | `snapshot.scan_builder()` | Scan / PartitionReader |
-| Write data | `snapshot.transaction(committer, &engine)` | Writer / Committer |
+| Write data | `snapshot.transaction().build(&engine, committer)` | Writer / Committer |
 | Checkpoint | `snapshot.create_checkpoint_writer(&engine)` | Maintenance task |
 
 ## What your connector does vs. what Kernel does

--- a/docs/user-guide/src/getting_started/quick_start_write.md
+++ b/docs/user-guide/src/getting_started/quick_start_write.md
@@ -69,10 +69,11 @@ async fn main() -> DeltaResult<()> {
     let snapshot = Snapshot::builder_for(url.clone()).build(&engine)?;
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+        .transaction()
         .with_operation("INSERT".to_string())
         .with_engine_info("quick-start/1.0")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
     // Build an Arrow RecordBatch
     let arrow_schema: delta_kernel::arrow::datatypes::Schema =
@@ -154,9 +155,10 @@ The write flow has four parts:
 **Start a transaction:**
 ```rust,ignore
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
-    .with_data_change(true);
+    .with_data_change(true)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 ```
 
 **Build your data as an Arrow RecordBatch and wrap it:**

--- a/docs/user-guide/src/unity_catalog/writing.md
+++ b/docs/user-guide/src/unity_catalog/writing.md
@@ -68,8 +68,9 @@ including those that haven't been published to `_delta_log/` yet.
 use delta_kernel_unity_catalog::UCCommitter;
 
 let committer = Box::new(UCCommitter::new(commits_client.clone(), table_id.clone()));
-let mut txn = snapshot.clone().transaction(committer, &engine)?
-    .with_operation("INSERT".to_string());
+let mut txn = snapshot.clone().transaction()
+    .with_operation("INSERT".to_string())
+    .build(&engine, committer)?;
 ```
 
 `UCCommitter` requires a multi-threaded tokio runtime. The default Kernel
@@ -215,8 +216,9 @@ let snapshot = catalog.load_snapshot(table_id, table_uri, &engine).await?;
 
 // 5. Create transaction with UCCommitter
 let committer = Box::new(UCCommitter::new(commits_client.clone(), table_id.clone()));
-let mut txn = snapshot.clone().transaction(committer, &engine)?
-    .with_operation("INSERT".to_string());
+let mut txn = snapshot.clone().transaction()
+    .with_operation("INSERT".to_string())
+    .build(&engine, committer)?;
 
 // 6. Write data
 let write_context = txn.unpartitioned_write_context()?;

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -42,10 +42,11 @@ let snapshot = Snapshot::builder_for(url).build(&engine)?;
 
 // 2. Create a transaction
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
     .with_engine_info("my-app/1.0")
-    .with_data_change(true);
+    .with_data_change(true)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 // 3. Get write context
 let write_context = Arc::new(txn.unpartitioned_write_context()?);
@@ -86,10 +87,11 @@ writing against:
 
 ```rust,ignore
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
     .with_engine_info("my-app/1.0")
-    .with_data_change(true);
+    .with_data_change(true)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 ```
 
 The builder methods:
@@ -215,9 +217,10 @@ construction:
 
 ```rust,ignore
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
-    .with_blind_append();
+    .with_blind_append()
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 ```
 
 Kernel records `isBlindAppend: true` in the commit's `commitInfo` action. This flag
@@ -247,9 +250,10 @@ that action, call `with_commit_info()` with your custom data and its schema:
 
 ```rust,ignore
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
-    .with_commit_info(engine_commit_info, commit_info_schema);
+    .with_commit_info(engine_commit_info, commit_info_schema)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 ```
 
 The `engine_commit_info` argument is a `Box<dyn EngineData>` containing the fields you want

--- a/docs/user-guide/src/writing/domain_metadata.md
+++ b/docs/user-guide/src/writing/domain_metadata.md
@@ -33,12 +33,13 @@ transactions.
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_domain_metadata(
         "myConnector.settings".to_string(),
         r#"{"version": 1, "compress": true}"#.to_string(),
     )
-    .with_operation("UPDATE METADATA".to_string());
+    .with_operation("UPDATE METADATA".to_string())
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 txn.commit(&engine)?;
 # Ok(())
@@ -80,9 +81,10 @@ exist yet.
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_domain_metadata_removed("myConnector.settings".to_string())
-    .with_operation("REMOVE METADATA".to_string());
+    .with_operation("REMOVE METADATA".to_string())
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 txn.commit(&engine)?;
 # Ok(())

--- a/docs/user-guide/src/writing/idempotent_writes.md
+++ b/docs/user-guide/src/writing/idempotent_writes.md
@@ -52,9 +52,10 @@ if let Some(committed_version) = snapshot.get_app_id_version(app_id, &engine)? {
 
 // Not yet committed. Proceed with the write.
 let txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_transaction_id(app_id.to_string(), batch_version)
-    .with_operation("STREAMING UPDATE".to_string());
+    .with_operation("STREAMING UPDATE".to_string())
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 // ... write data, add files, commit ...
 # Ok(())

--- a/docs/user-guide/src/writing/partitioned_writes.md
+++ b/docs/user-guide/src/writing/partitioned_writes.md
@@ -44,9 +44,10 @@ The pattern for partitioned writes is: **group your data by partition values, cr
 # let engine = DefaultEngine::builder(store_from_url(&url)?).build();
 let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let mut txn = snapshot
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .transaction()
     .with_operation("INSERT".to_string())
-    .with_data_change(true);
+    .with_data_change(true)
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 // Suppose you have data grouped by partition values already.
 // For each partition, create a WriteContext and write.

--- a/docs/user-guide/src/writing/removing_files.md
+++ b/docs/user-guide/src/writing/removing_files.md
@@ -150,8 +150,9 @@ let snapshot = Snapshot::builder_for(url).build(&engine)?;
 // 2. Create a transaction
 let mut txn = snapshot
     .clone()
-    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
-    .with_operation("DELETE".to_string());
+    .transaction()
+    .with_operation("DELETE".to_string())
+    .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
 // 3. Build a scan and get file metadata
 let scan = snapshot.scan_builder().build()?;

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -90,7 +90,7 @@ fn transaction_impl(
     let engine = extern_engine.engine();
     let snapshot = Snapshot::builder_for(url?).build(engine.as_ref())?;
     let committer = Box::new(FileSystemCommitter::new());
-    let transaction = snapshot.transaction(committer, engine.as_ref());
+    let transaction = snapshot.transaction().build(engine.as_ref(), committer);
     Ok(Box::new(transaction?).into())
 }
 
@@ -118,7 +118,7 @@ fn transaction_with_committer_impl(
     committer: Box<dyn Committer>,
 ) -> DeltaResult<Handle<ExclusiveTransaction>> {
     let engine = extern_engine.engine();
-    let transaction = snapshot.transaction(committer, engine.as_ref());
+    let transaction = snapshot.transaction().build(engine.as_ref(), committer);
     Ok(Box::new(transaction?).into())
 }
 
@@ -2954,9 +2954,10 @@ mod tests {
             .build(kernel_engine.as_ref())?;
         let mut add_txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), kernel_engine.as_ref())?
+            .transaction()
             .with_engine_info("test-engine/1.0")
-            .with_operation("WRITE".to_string());
+            .with_operation("WRITE".to_string())
+            .build(kernel_engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         let add_files_schema = add_txn.add_files_schema();
         let add_metadata = test_utils::create_add_files_metadata(
             add_files_schema,

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -88,10 +88,11 @@ async fn try_main() -> DeltaResult<()> {
     // Write sample data to the table
     let committer = Box::new(FileSystemCommitter::new());
     let mut txn = snapshot
-        .transaction(committer, &engine)?
+        .transaction()
         .with_operation("INSERT".to_string())
         .with_engine_info("default_engine/write-table-example")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(&engine, committer)?;
 
     // Write the data using the engine
     let write_context = Arc::new(txn.unpartitioned_write_context()?);

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -803,10 +803,11 @@ async fn test_checkpoint_preserves_domain_metadata() -> DeltaResult<()> {
 
     let commit_domain_metadata = |domain: &str, value: &str| -> DeltaResult<()> {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-        let result = txn
+        let txn = snapshot
+            .transaction()
             .with_domain_metadata(domain.to_string(), value.to_string())
-            .commit(&engine)?;
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
+        let result = txn.commit(&engine)?;
         assert!(result.is_committed());
         Ok(())
     };
@@ -879,10 +880,11 @@ async fn test_checkpoint_excludes_tombstoned_domain_metadata() -> DeltaResult<()
 
     // ===== Commit domain metadata for "foo" =====
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-    let result = txn
+    let txn = snapshot
+        .transaction()
         .with_domain_metadata("foo".to_string(), "bar".to_string())
-        .commit(&engine)?;
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
+    let result = txn.commit(&engine)?;
     assert!(result.is_committed());
 
     // Verify domain exists before removal
@@ -894,10 +896,11 @@ async fn test_checkpoint_excludes_tombstoned_domain_metadata() -> DeltaResult<()
 
     // ===== Remove domain metadata for "foo" (tombstone) =====
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-    let result = txn
+    let txn = snapshot
+        .transaction()
         .with_domain_metadata_removed("foo".to_string())
-        .commit(&engine)?;
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
+    let result = txn.commit(&engine)?;
     assert!(result.is_committed());
 
     // Verify domain is gone before checkpoint

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -121,7 +121,8 @@ mod tests {
         // Try to commit a transaction with FileSystemCommitter
         let committer = Box::new(FileSystemCommitter::new());
         let err = snapshot
-            .transaction(committer, &engine)
+            .transaction()
+            .build(&engine, committer)
             .unwrap()
             .commit(&engine)
             .unwrap_err();

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -175,10 +175,11 @@ mod tests {
         // Commit 1: add domainA and domainB via an existing-table transaction.
         let snapshot = Snapshot::builder_for(url.clone()).build(&engine).unwrap();
         let _ = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
+            .transaction()
             .with_domain_metadata("domainA".to_string(), "cfgA".to_string())
             .with_domain_metadata("domainB".to_string(), "cfgB".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
             .commit(&engine)
             .unwrap();
 
@@ -317,9 +318,10 @@ mod tests {
         let (engine, snapshot) = build_two_commit_log();
         let table_root = snapshot.table_root().clone();
         let _ = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
+            .transaction()
             .with_domain_metadata_removed("domainA".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
             .commit(&engine)
             .unwrap();
         let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -34,7 +34,7 @@ use crate::table_configuration::{InCommitTimestampEnablement, TableConfiguration
 use crate::table_features::{physical_to_logical_column_name, ColumnMappingMode, TableFeature};
 use crate::table_properties::TableProperties;
 use crate::transaction::builder::alter_table::AlterTableTransactionBuilder;
-use crate::transaction::Transaction;
+use crate::transaction::builder::update_table::UpdateTableTransactionBuilder;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error, LogCompactionWriter, Version};
 
@@ -847,16 +847,17 @@ impl Snapshot {
         IncrementalScanBuilder::new(self, base_version)
     }
 
-    /// Create a [`Transaction`] for this `SnapshotRef`. With the specified [`Committer`].
+    /// Creates a builder for updating (writing to) this existing table.
     ///
-    /// Note: For tables with clustering enabled, this performs log replay to read clustering
+    /// The returned [`UpdateTableTransactionBuilder`] stages write configuration (operation,
+    /// engine info, blind append, domain metadata, set-transaction, commit info) before building
+    /// a [`Transaction`](crate::transaction::Transaction) via
+    /// [`build`](UpdateTableTransactionBuilder::build).
+    ///
+    /// Note: For tables with clustering enabled, `build` performs log replay to read clustering
     /// columns from domain metadata, which may have a performance cost.
-    pub fn transaction(
-        self: Arc<Self>,
-        committer: Box<dyn Committer>,
-        engine: &dyn Engine,
-    ) -> DeltaResult<Transaction> {
-        Transaction::try_new_existing_table(self, committer, engine)
+    pub fn transaction(self: Arc<Self>) -> UpdateTableTransactionBuilder {
+        UpdateTableTransactionBuilder::new(self)
     }
 
     /// Creates a builder for altering this table's metadata. Currently supports schema change

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -46,7 +46,7 @@ use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
 use crate::transaction::Transaction;
 use crate::utils::{current_time_ms, try_parse_uri};
-use crate::{DeltaResult, Engine, Error, StorageHandler};
+use crate::{DeltaResult, Engine, EngineData, Error, StorageHandler};
 
 /// Table features allowed to be enabled via `delta.feature.*=supported` during CREATE TABLE.
 ///
@@ -733,6 +733,9 @@ pub struct CreateTableTransactionBuilder {
     table_properties: HashMap<String, String>,
     data_layout: DataLayout,
     correlation_id: Option<Arc<str>>,
+    data_change: Option<bool>,
+    domain_metadata_additions: Vec<(String, String)>,
+    engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
 }
 
 impl CreateTableTransactionBuilder {
@@ -748,6 +751,9 @@ impl CreateTableTransactionBuilder {
             table_properties: HashMap::new(),
             data_layout: DataLayout::None,
             correlation_id: None,
+            data_change: None,
+            domain_metadata_additions: Vec::new(),
+            engine_commit_info: None,
         }
     }
 
@@ -839,6 +845,35 @@ impl CreateTableTransactionBuilder {
     /// metric events to the caller's own request or operation id. An empty id is treated as unset.
     pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
+    }
+
+    /// Set whether this transaction changes data. Defaults to `true`. These are recorded at the
+    /// file level.
+    pub fn with_data_change(mut self, data_change: bool) -> Self {
+        self.data_change = Some(data_change);
+        self
+    }
+
+    /// Set domain metadata to be written to the Delta log for the new table.
+    ///
+    /// Note that each domain can only appear once per transaction; duplicates cause the `commit`
+    /// to fail.
+    pub fn with_domain_metadata(mut self, domain: String, configuration: String) -> Self {
+        self.domain_metadata_additions.push((domain, configuration));
+        self
+    }
+
+    /// Set the content of the commitInfo action for this transaction. Kernel always writes a
+    /// commitInfo; this lets engines add their own data. Kernel-owned fields (timestamp,
+    /// inCommitTimestamp, operation, operationParameters, kernelVersion, isBlindAppend, engineInfo,
+    /// txnId) are overridden and should not be set here.
+    pub fn with_commit_info(
+        mut self,
+        engine_commit_info: Box<dyn EngineData>,
+        commit_info_schema: SchemaRef,
+    ) -> Self {
+        self.engine_commit_info = Some((engine_commit_info, commit_info_schema));
         self
     }
 
@@ -966,14 +1001,27 @@ impl CreateTableTransactionBuilder {
         validate_interval_type_write_support(&table_configuration.logical_schema())?;
 
         // Create Transaction<CreateTable> with the effective table configuration
-        Transaction::try_new_create_table(
+        let mut txn = Transaction::try_new_create_table(
             table_configuration,
             self.engine_info,
             committer,
             data_layout_result.system_domain_metadata,
             data_layout_result.clustering_columns,
             self.correlation_id,
-        )
+        )?;
+
+        // Apply staged write configuration.
+        if let Some(data_change) = self.data_change {
+            txn = txn.with_data_change(data_change);
+        }
+        for (domain, configuration) in self.domain_metadata_additions {
+            txn = txn.with_domain_metadata(domain, configuration);
+        }
+        if let Some((engine_commit_info, schema)) = self.engine_commit_info {
+            txn = txn.with_commit_info(engine_commit_info, schema);
+        }
+
+        Ok(txn)
     }
 }
 

--- a/kernel/src/transaction/builder/mod.rs
+++ b/kernel/src/transaction/builder/mod.rs
@@ -7,3 +7,4 @@
 
 pub mod alter_table;
 pub mod create_table;
+pub mod update_table;

--- a/kernel/src/transaction/builder/update_table.rs
+++ b/kernel/src/transaction/builder/update_table.rs
@@ -1,0 +1,200 @@
+//! Builder for update (write) transactions on an existing Delta table.
+//!
+//! This module contains [`UpdateTableTransactionBuilder`], which stages write configuration
+//! (operation, engine info, blind-append, domain metadata, set-transaction, commit info) and
+//! then builds a [`Transaction`] against an existing table.
+//!
+//! Use [`Snapshot::transaction()`](crate::snapshot::Snapshot::transaction) as the entry point
+//! rather than constructing the builder directly.
+
+use std::sync::Arc;
+
+use crate::committer::Committer;
+use crate::schema::SchemaRef;
+use crate::snapshot::SnapshotRef;
+use crate::transaction::Transaction;
+use crate::{DeltaResult, Engine, EngineData};
+
+/// Builder for constructing a [`Transaction`] that updates an existing Delta table.
+///
+/// Write configuration is staged on the builder and applied when [`build`](Self::build) is
+/// called. The resulting [`Transaction`] exposes only data-staging and commit operations
+/// (`add_files`, `remove_files`, `update_deletion_vectors`, write contexts, `commit`).
+///
+/// Created via [`Snapshot::transaction()`](crate::snapshot::Snapshot::transaction).
+///
+/// # Example
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use delta_kernel::Engine;
+/// # use delta_kernel::snapshot::Snapshot;
+/// # use delta_kernel::committer::FileSystemCommitter;
+/// # fn example(engine: Arc<dyn Engine>, table_url: url::Url) -> delta_kernel::DeltaResult<()> {
+/// let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+/// let txn = snapshot
+///     .transaction()
+///     .with_operation("WRITE".to_string())
+///     .with_engine_info("MyApp/1.0")
+///     .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct UpdateTableTransactionBuilder {
+    snapshot: SnapshotRef,
+    operation: Option<String>,
+    engine_info: Option<String>,
+    correlation_id: Option<Arc<str>>,
+    is_blind_append: bool,
+    data_change: Option<bool>,
+    domain_metadata_additions: Vec<(String, String)>,
+    domain_removals: Vec<String>,
+    set_transactions: Vec<(String, i64)>,
+    engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
+}
+
+impl UpdateTableTransactionBuilder {
+    /// Create a new builder from a snapshot of an existing table.
+    ///
+    /// This is typically called via
+    /// [`Snapshot::transaction()`](crate::snapshot::Snapshot::transaction) rather than directly.
+    pub(crate) fn new(snapshot: SnapshotRef) -> Self {
+        Self {
+            snapshot,
+            operation: None,
+            engine_info: None,
+            correlation_id: None,
+            is_blind_append: false,
+            data_change: None,
+            domain_metadata_additions: Vec::new(),
+            domain_removals: Vec::new(),
+            set_transactions: Vec::new(),
+            engine_commit_info: None,
+        }
+    }
+
+    /// Set the operation that this transaction is performing. This string will be persisted in the
+    /// commit and visible to anyone who describes the table history.
+    pub fn with_operation(mut self, operation: String) -> Self {
+        self.operation = Some(operation);
+        self
+    }
+
+    /// Set the engine info field of this transaction's commit info action. This field is optional.
+    pub fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
+        self.engine_info = Some(engine_info.into());
+        self
+    }
+
+    /// Attach an opaque, caller-supplied correlation id for joining this transaction's commit
+    /// metric events to the caller's own request or operation id. An empty id is treated as unset.
+    /// When unset, behavior is unchanged.
+    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+        self.correlation_id = Some(correlation_id.into());
+        self
+    }
+
+    /// Mark this transaction as a blind append.
+    ///
+    /// Blind append transactions should only add new files and avoid write operations that
+    /// depend on existing table state.
+    pub fn with_blind_append(mut self) -> Self {
+        self.is_blind_append = true;
+        self
+    }
+
+    /// Set whether this transaction changes data. Defaults to `true`. Set to `false` for
+    /// operations that only change metadata or move rows between files without logical changes
+    /// (e.g. backfilling statistics, OPTIMIZE).
+    pub fn with_data_change(mut self, data_change: bool) -> Self {
+        self.data_change = Some(data_change);
+        self
+    }
+
+    /// Set domain metadata to be written to the Delta log.
+    ///
+    /// Note that each domain can only appear once per transaction. Setting and removing the same
+    /// domain in a single transaction is disallowed. Duplicate domains cause the `commit` to fail.
+    pub fn with_domain_metadata(mut self, domain: String, configuration: String) -> Self {
+        self.domain_metadata_additions.push((domain, configuration));
+        self
+    }
+
+    /// Remove domain metadata from the Delta log.
+    ///
+    /// If the domain exists in the Delta log, this creates a tombstone to logically delete the
+    /// domain, preserving the previous configuration value. If the domain does not exist, this is
+    /// a no-op. Each domain can only appear once per transaction; duplicates cause the `commit`
+    /// to fail.
+    pub fn with_domain_metadata_removed(mut self, domain: String) -> Self {
+        self.domain_removals.push(domain);
+        self
+    }
+
+    /// Include a SetTransaction (`app_id` and `version`) action for this transaction.
+    ///
+    /// Note that each `app_id` can only appear once per transaction. Duplicate `app_id`s cause the
+    /// `commit` to fail.
+    pub fn with_transaction_id(mut self, app_id: String, version: i64) -> Self {
+        self.set_transactions.push((app_id, version));
+        self
+    }
+
+    /// Set the content of the commitInfo action for this transaction. Kernel always writes a
+    /// commitInfo; this lets engines add their own data. Kernel-owned fields (timestamp,
+    /// inCommitTimestamp, operation, operationParameters, kernelVersion, isBlindAppend, engineInfo,
+    /// txnId) are overridden and should not be set here.
+    pub fn with_commit_info(
+        mut self,
+        engine_commit_info: Box<dyn EngineData>,
+        commit_info_schema: SchemaRef,
+    ) -> Self {
+        self.engine_commit_info = Some((engine_commit_info, commit_info_schema));
+        self
+    }
+
+    /// Validate the table supports writes and build the [`Transaction`], applying all staged
+    /// write configuration.
+    ///
+    /// # Errors
+    ///
+    /// - The table does not support writes (unsupported reader/writer features).
+    /// - Reading clustering columns from the snapshot fails.
+    pub fn build(
+        self,
+        engine: &dyn Engine,
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<Transaction> {
+        let mut txn = Transaction::try_new_existing_table(self.snapshot, committer, engine)?;
+
+        if let Some(operation) = self.operation {
+            txn = txn.with_operation(operation);
+        }
+        if let Some(engine_info) = self.engine_info {
+            txn = txn.with_engine_info(engine_info);
+        }
+        if let Some(correlation_id) = self.correlation_id {
+            txn = txn.with_correlation_id(correlation_id);
+        }
+        if self.is_blind_append {
+            txn = txn.with_blind_append();
+        }
+        if let Some(data_change) = self.data_change {
+            txn = txn.with_data_change(data_change);
+        }
+        for (domain, configuration) in self.domain_metadata_additions {
+            txn = txn.with_domain_metadata(domain, configuration);
+        }
+        for domain in self.domain_removals {
+            txn = txn.with_domain_metadata_removed(domain);
+        }
+        for (app_id, version) in self.set_transactions {
+            txn = txn.with_transaction_id(app_id, version);
+        }
+        if let Some((engine_commit_info, schema)) = self.engine_commit_info {
+            txn = txn.with_commit_info(engine_commit_info, schema);
+        }
+
+        Ok(txn)
+    }
+}

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -233,11 +233,12 @@ mod tests {
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction)> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction()
             .with_operation("WRITE".to_string())
             .fold_with(engine_commit_info, |txn, (data, schema)| {
                 txn.with_commit_info(data, schema)
-            });
+            })
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         Ok((engine, txn))
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -584,21 +584,26 @@ impl<S> Transaction<S> {
     /// 2. Operations that make no logical changes to the contents of the table (i.e. rows are only
     ///    moved from old files to new ones.  OPTIMIZE commands is one example of this type of
     ///    optimizaton).
-    pub fn with_data_change(mut self, data_change: bool) -> Self {
+    #[internal_api]
+    pub(crate) fn with_data_change(mut self, data_change: bool) -> Self {
         self.data_change = data_change;
         self
     }
 
     /// Same as [`Transaction::with_data_change`] but set the value directly instead of
-    /// using a fluent API.
+    /// using a fluent API. Used by the FFI transaction flow.
     #[internal_api]
-    #[allow(dead_code)] // used in FFI
+    #[allow(dead_code)]
     pub(crate) fn set_data_change(&mut self, data_change: bool) {
         self.data_change = data_change;
     }
 
     /// Set the engine info field of this transaction's commit info action. This field is optional.
-    pub fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
+    ///
+    /// Staged on the transaction builders and applied during `build`; not part of the public
+    /// transaction API.
+    #[internal_api]
+    pub(crate) fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
         self.engine_info = Some(engine_info.into());
         self
     }
@@ -606,7 +611,8 @@ impl<S> Transaction<S> {
     /// Attach an opaque, caller-supplied correlation id for joining this transaction's commit
     /// metric events to the caller's own request or operation id. An empty id is treated as unset.
     /// When unset, behavior is unchanged.
-    pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
+    #[internal_api]
+    pub(crate) fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
         self
     }
@@ -623,7 +629,8 @@ impl<S> Transaction<S> {
     /// - isBlindAppend
     /// - engineInfo
     /// - txnId
-    pub fn with_commit_info(
+    #[internal_api]
+    pub(crate) fn with_commit_info(
         mut self,
         engine_commit_info: Box<dyn EngineData>,
         commit_info_schema: SchemaRef,
@@ -637,7 +644,8 @@ impl<S> Transaction<S> {
     /// Note that each app_id can only appear once per transaction. That is, multiple app_ids with
     /// different versions are disallowed in a single transaction. If a duplicate app_id is
     /// included, the `commit` will fail (that is, we don't eagerly check app_id validity here).
-    pub fn with_transaction_id(mut self, app_id: String, version: i64) -> Self {
+    #[internal_api]
+    pub(crate) fn with_transaction_id(mut self, app_id: String, version: i64) -> Self {
         let set_transaction = SetTransaction::new(app_id, version, Some(self.commit_timestamp));
         self.set_transactions.push(set_transaction);
         self
@@ -649,7 +657,8 @@ impl<S> Transaction<S> {
     /// the same domain in a single transaction. If a duplicate domain is included, the commit will
     /// fail (that is, we don't eagerly check domain validity here).
     /// Setting metadata for multiple distinct domains is allowed.
-    pub fn with_domain_metadata(mut self, domain: String, configuration: String) -> Self {
+    #[internal_api]
+    pub(crate) fn with_domain_metadata(mut self, domain: String, configuration: String) -> Self {
         self.user_domain_metadata_additions
             .push(DomainMetadata::new(domain, configuration));
         self
@@ -1933,10 +1942,11 @@ mod tests {
         snapshot: Arc<Snapshot>,
         engine: &dyn Engine,
     ) -> DeltaResult<Transaction> {
-        Ok(snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        snapshot
+            .transaction()
             .with_operation("DELETE".to_string())
-            .with_engine_info("test_engine"))
+            .with_engine_info("test_engine")
+            .build(engine, Box::new(FileSystemCommitter::new()))
     }
 
     // TODO: create a finer-grained unit tests for transactions (issue#1091)
@@ -1951,8 +1961,9 @@ mod tests {
             .build(&engine)
             .unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
-            .with_engine_info("default engine");
+            .transaction()
+            .with_engine_info("default engine")
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
         let schema = txn.add_files_schema();
         let expected = StructType::new_unchecked(vec![
@@ -2030,8 +2041,9 @@ mod tests {
             .build(&engine)
             .unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
-            .with_engine_info("default engine");
+            .transaction()
+            .with_engine_info("default engine")
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
         let write_context = txn.unpartitioned_write_context().unwrap();
 
         // Test with empty prefix
@@ -2060,8 +2072,9 @@ mod tests {
         let (engine, snapshot) = setup_non_dv_table();
         let mut txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
-            .with_engine_info("default engine");
+            .transaction()
+            .with_engine_info("default engine")
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
         // Regression coverage for stale SharedWriteState caching: keep the first context alive
         // while the transaction's effective table config changes.
@@ -2127,7 +2140,8 @@ mod tests {
         ) -> Transaction {
             let (engine, snapshot) = setup_non_dv_table();
             let mut txn = snapshot
-                .transaction(Box::new(FileSystemCommitter::new()), &engine)
+                .transaction()
+                .build(&engine, Box::new(FileSystemCommitter::new()))
                 .unwrap();
             txn.effective_table_config = try_table_config(&txn, schema, writer_features).unwrap();
             txn
@@ -2164,7 +2178,8 @@ mod tests {
         fn base_txn() -> Transaction {
             let (engine, snapshot) = setup_non_dv_table();
             snapshot
-                .transaction(Box::new(FileSystemCommitter::new()), &engine)
+                .transaction()
+                .build(&engine, Box::new(FileSystemCommitter::new()))
                 .unwrap()
         }
 
@@ -2236,8 +2251,9 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?
-            .with_engine_info("default engine");
+            .transaction()
+            .with_engine_info("default engine")
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
         let write_context = txn.partitioned_write_context(HashMap::from([(
             "letter".to_string(),
@@ -2282,7 +2298,8 @@ mod tests {
         let snapshot = Snapshot::builder_for(url).build(&engine)?;
         let txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+            .transaction()
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
         let wc = txn.partitioned_write_context(partition_values)?;
         Ok((snapshot, wc))
     }
@@ -2480,7 +2497,9 @@ mod tests {
         let path = std::fs::canonicalize(PathBuf::from(table_path)).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).build(&engine)?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let txn = snapshot
+            .transaction()
+            .build(&engine, Box::new(FileSystemCommitter::new()))?;
         let result = if call_partitioned {
             txn.partitioned_write_context(HashMap::from([("x".to_string(), Scalar::Integer(1))]))
         } else {
@@ -2684,7 +2703,9 @@ mod tests {
         let (url, tempdir) = copy_test_table("table-without-dv-small")?;
         let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new());
         let snapshot = Snapshot::builder_for(url).build(engine.as_ref())?;
-        let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+        let txn = snapshot
+            .transaction()
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         Ok((engine, txn, tempdir))
     }
 
@@ -2818,7 +2839,9 @@ mod tests {
     #[test]
     fn test_commit_io_error_returns_retryable_transaction() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
-        let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
+        let mut txn = snapshot
+            .transaction()
+            .build(engine.as_ref(), Box::new(IoErrorCommitter))?;
         add_dummy_file(&mut txn);
         let result = txn.commit(engine.as_ref())?;
         assert!(
@@ -3071,9 +3094,10 @@ mod tests {
     fn test_stats_validation_allows_all_null_clustering_column() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
+            .transaction()
             .with_operation("WRITE".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
             .with_clustering_columns_for_test(vec![ColumnName::new(["value"])]);
 
         let add_files = create_test_add_files(vec!["file1.parquet"], vec![TestFileStats::AllNull]);
@@ -3090,9 +3114,10 @@ mod tests {
     fn test_stats_validation_when_clustering_cols_missing_stats() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
+            .transaction()
             .with_operation("WRITE".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
             // Enable clustering columns for this test
             .with_clustering_columns_for_test(vec![ColumnName::new(["value"])]);
 
@@ -3118,9 +3143,10 @@ mod tests {
     fn test_stats_validation_when_clustering_stats_present() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
+            .transaction()
             .with_operation("WRITE".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap()
             // Enable clustering columns for this test
             .with_clustering_columns_for_test(vec![ColumnName::new(["value"])]);
 
@@ -3140,9 +3166,10 @@ mod tests {
     fn test_stats_validation_skipped_without_clustering() {
         let (engine, snapshot) = setup_non_dv_table();
         let txn = snapshot
-            .transaction(Box::new(FileSystemCommitter::new()), &engine)
-            .unwrap()
-            .with_operation("WRITE".to_string());
+            .transaction()
+            .with_operation("WRITE".to_string())
+            .build(&engine, Box::new(FileSystemCommitter::new()))
+            .unwrap();
         // No clustering columns set (default)
 
         // Add files WITHOUT stats
@@ -3180,7 +3207,8 @@ mod tests {
         // Try to commit with a catalog committer to a non-catalog-managed table
         let committer = Box::new(MockCatalogCommitter);
         let err = snapshot
-            .transaction(committer, &engine)
+            .transaction()
+            .build(&engine, committer)
             .unwrap()
             .commit(&engine)
             .unwrap_err();
@@ -3308,7 +3336,7 @@ mod tests {
         assert_eq!(prev_ict, Some(future_ict));
 
         let (committer, captured_ts) = CapturingCommitter::new();
-        let mut txn = snapshot.transaction(Box::new(committer), &engine)?;
+        let mut txn = snapshot.transaction().build(&engine, Box::new(committer))?;
         add_dummy_file(&mut txn);
 
         let result = txn.commit(&engine)?;
@@ -3345,7 +3373,9 @@ mod tests {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
-        let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
+        let mut txn = snapshot
+            .transaction()
+            .build(engine.as_ref(), Box::new(IoErrorCommitter))?;
         add_dummy_file(&mut txn);
         let result = txn.commit(engine.as_ref())?;
         assert!(matches!(result, CommitResult::RetryableTransaction(_)));
@@ -3360,7 +3390,9 @@ mod tests {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
-        let mut txn = snapshot.transaction(Box::new(GenericErrorCommitter), engine.as_ref())?;
+        let mut txn = snapshot
+            .transaction()
+            .build(engine.as_ref(), Box::new(GenericErrorCommitter))?;
         add_dummy_file(&mut txn);
         assert!(txn.commit(engine.as_ref()).is_err());
         let failure = commit_failure_event(&reporter).expect("commit failure event");

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -120,14 +120,27 @@ impl Transaction {
     ///
     /// Blind append transactions should only add new files and avoid write operations that
     /// depend on existing table state.
-    pub fn with_blind_append(mut self) -> Self {
+    ///
+    /// Staged via [`UpdateTableTransactionBuilder::with_blind_append`] and applied here during
+    /// [`build`]; not part of the public transaction API.
+    ///
+    /// [`UpdateTableTransactionBuilder::with_blind_append`]: super::builder::update_table::UpdateTableTransactionBuilder::with_blind_append
+    /// [`build`]: super::builder::update_table::UpdateTableTransactionBuilder::build
+    #[internal_api]
+    pub(crate) fn with_blind_append(mut self) -> Self {
         self.is_blind_append = true;
         self
     }
 
     /// Set the operation that this transaction is performing. This string will be persisted in the
     /// commit and visible to anyone who describes the table history.
-    pub fn with_operation(mut self, operation: String) -> Self {
+    ///
+    /// Staged via [`UpdateTableTransactionBuilder::with_operation`] and applied during [`build`].
+    ///
+    /// [`UpdateTableTransactionBuilder::with_operation`]: super::builder::update_table::UpdateTableTransactionBuilder::with_operation
+    /// [`build`]: super::builder::update_table::UpdateTableTransactionBuilder::build
+    #[internal_api]
+    pub(crate) fn with_operation(mut self, operation: String) -> Self {
         self.operation = Some(operation);
         self
     }
@@ -141,7 +154,14 @@ impl Transaction {
     /// the same domain in a single transaction. If a duplicate domain is included, the `commit`
     /// will fail (that is, we don't eagerly check domain validity here).
     /// Removing metadata for multiple distinct domains is allowed.
-    pub fn with_domain_metadata_removed(mut self, domain: String) -> Self {
+    ///
+    /// Staged via [`UpdateTableTransactionBuilder::with_domain_metadata_removed`] and applied
+    /// during [`build`].
+    ///
+    /// [`UpdateTableTransactionBuilder::with_domain_metadata_removed`]: super::builder::update_table::UpdateTableTransactionBuilder::with_domain_metadata_removed
+    /// [`build`]: super::builder::update_table::UpdateTableTransactionBuilder::build
+    #[internal_api]
+    pub(crate) fn with_domain_metadata_removed(mut self, domain: String) -> Self {
         self.user_domain_removals.push(domain);
         self
     }
@@ -165,7 +185,7 @@ impl Transaction {
     /// # fn example(engine: Arc<dyn Engine>, table_url: url::Url) -> delta_kernel::DeltaResult<()> {
     /// // Create a snapshot and transaction
     /// let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    /// let mut txn = snapshot.clone().transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    /// let mut txn = snapshot.clone().transaction().build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     ///
     /// // Get file metadata from a scan
     /// let scan = snapshot.scan_builder().build()?;
@@ -246,8 +266,9 @@ impl Transaction {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// let mut txn = snapshot.clone().transaction(Box::new(FileSystemCommitter::new()))?
-    ///     .with_operation("UPDATE".to_string());
+    /// let mut txn = snapshot.clone().transaction()
+    ///     .with_operation("UPDATE".to_string())
+    ///     .build(engine, Box::new(FileSystemCommitter::new()))?;
     ///
     /// let scan = snapshot.scan_builder().build()?;
     /// let files: Vec<FilteredEngineData> = scan.scan_metadata(engine)?

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -109,17 +109,16 @@ async fn test_create_table_with_user_domain_metadata() -> DeltaResult<()> {
 
     let schema = simple_schema()?;
 
-    // Create table with domainMetadata feature enabled
-    let txn = create_table(&table_path, schema, "Test/1.0")
-        .with_table_properties([("delta.feature.domainMetadata", "supported")])
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
-
-    // Add user domain metadata during table creation
+    // Add user domain metadata during table creation. Staged on the builder (not the built
+    // transaction) so this exercises CreateTableTransactionBuilder's domain-metadata threading.
     let domain = "app.settings";
     let config = r#"{"version": 1, "enabled": true}"#;
 
-    let _ = txn
+    // Create table with domainMetadata feature enabled
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")])
         .with_domain_metadata(domain.to_string(), config.to_string())
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
     // Load snapshot and verify domain metadata was persisted

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -468,8 +468,9 @@ async fn empty_create_then_add_column(
     );
     let write_err = v0
         .clone()
-        .transaction(committer(), engine.as_ref())?
+        .transaction()
         .with_engine_info("EmptySchemaApp/0.1.0")
+        .build(engine.as_ref(), committer())?
         .unpartitioned_write_context()
         .expect_err("unpartitioned_write_context() must reject empty-schema snapshots");
     assert!(
@@ -959,7 +960,7 @@ async fn add_column_with_orphan_default_metadata_succeeds() -> DeltaResult<()> {
         .expect("CURRENT_DEFAULT metadata must survive ALTER");
     assert_eq!(default.raw_sql(), "42");
 
-    let txn = reloaded.transaction(committer(), engine.as_ref())?;
+    let txn = reloaded.transaction().build(engine.as_ref(), committer())?;
     assert!(
         txn.top_level_column_defaults()?.is_empty(),
         "default metadata must remain inert without allowColumnDefaults",

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -160,10 +160,11 @@ async fn v3_commit_validates_num_records(
         .unwrap();
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
-        .unwrap()
+        .transaction()
         .with_engine_info("Test/1.0")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
+        .unwrap();
     let add_files = create_add_files_metadata(
         txn.add_files_schema(),
         vec![("part-fake.parquet", 1024, 1_000_000, num_records)],

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -623,15 +623,16 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
             vec![Arc::new(Int32Array::from(vec![v as i32]))],
         )
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
-        let mut txn = snap
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        let mut builder = snap
+            .transaction()
             .with_operation("WRITE".to_string())
             .with_data_change(true)
             .with_domain_metadata(format!("d{v}"), format!("cfg{v}"))
             .with_transaction_id(format!("app{v}"), v);
         if v == 3 {
-            txn = txn.with_domain_metadata_removed(removed_domain.to_string());
+            builder = builder.with_domain_metadata_removed(removed_domain.to_string());
         }
+        let mut txn = builder.build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         let write_context = txn.unpartitioned_write_context()?;
         let adds = engine
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
@@ -815,9 +816,10 @@ async fn setup_incremental_below_checkpoint_base<E: TaskExecutor>(
         )
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
         let mut txn = snap
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .transaction()
             .with_operation("WRITE".to_string())
-            .with_data_change(true);
+            .with_data_change(true)
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         let write_context = txn.unpartitioned_write_context()?;
         let adds = engine
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
@@ -2072,9 +2074,10 @@ async fn commit_data<E: TaskExecutor>(
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
     let txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction()
         .with_operation("WRITE".to_string())
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     let mut txn = customize(txn);
     let write_context = txn.unpartitioned_write_context()?;
     let adds = engine

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -140,7 +140,7 @@ async fn commit_reports_added_file_count_not_batch_count() -> DeltaResult<()> {
 }
 
 /// Sets the correlation id on the `Transaction` returned by `build()` and checks it reaches the
-/// commit metric event. The two tests below instead set it on the builder.
+/// commit metric event. The tests below instead set it on the update, create, and alter builders.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
     let (_temp_dir, table_path, setup_engine) = test_table_setup_mt()?;
@@ -222,6 +222,50 @@ async fn alter_table_builder_carries_correlation_id(
     }
     builder
         .add_column(StructField::nullable("extra", DataType::STRING))
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let success = reporter.take_success();
+    assert_eq!(success.commit_version, 1);
+    assert_eq!(success.correlation_id.as_deref(), expected);
+    Ok(())
+}
+
+/// A correlation id set on the update-table *builder* (`Snapshot::transaction()`) reaches the
+/// commit metric event, and an empty id is treated as unset. This pins the `Option<Arc<str>>`
+/// staging on the builder threading through `build()`, since the empty-id normalization lives on
+/// the underlying `Transaction` setter that `build()` delegates to.
+#[rstest]
+#[case::with_id(Some("update-req-1"), Some("update-req-1"))]
+#[case::without_id(None, None)]
+#[case::empty_id_is_unset(Some(""), None)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn update_table_builder_carries_correlation_id(
+    #[case] correlation_id: Option<&str>,
+    #[case] expected: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    create_table(&table_path, simple_schema(), "Test/1.0")
+        .with_table_properties([("delta.feature.domainMetadata", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    // Install the reporter after the create commit so the captured event is the update commit.
+    let reporter = Arc::new(LastCommitSuccess::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let mut builder = snapshot
+        .transaction()
+        .with_operation("WRITE".to_string())
+        .with_domain_metadata("app.settings".to_string(), r#"{"v":1}"#.to_string());
+    if let Some(id) = correlation_id {
+        builder = builder.with_correlation_id(id);
+    }
+    builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_committed();

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -424,10 +424,11 @@ async fn setup_table_with_dms_and_set_txns(
         .unwrap_post_commit_snapshot();
 
     let snap_v1 = snap_v0
-        .transaction(committer(), engine.as_ref())?
+        .transaction()
         .with_operation("WRITE".to_string())
         .with_domain_metadata("myapp.config".to_string(), "v1".to_string())
         .with_transaction_id("my-app".to_string(), 1)
+        .build(engine.as_ref(), committer())?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
 

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -109,7 +109,8 @@ fn assert_top_level_default(
 ) -> DeltaResult<()> {
     let txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?;
+        .transaction()
+        .build(engine, Box::new(FileSystemCommitter::new()))?;
     assert_eq!(
         txn.top_level_column_defaults()?[column].to_scalar()?,
         Some(expected)
@@ -304,7 +305,8 @@ async fn assert_materialized_column_default_round_trips(
     let scalar = {
         let txn = snapshot
             .clone()
-            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+            .transaction()
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
         let defaults = txn.top_level_column_defaults()?;
         defaults["c"]
             .to_scalar()?
@@ -384,7 +386,9 @@ async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
     .await?;
 
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot
+        .transaction()
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
 
     let defaults = txn.top_level_column_defaults()?;
     assert_eq!(defaults.len(), 2, "only b and c declare a default");
@@ -445,7 +449,9 @@ async fn test_load_and_write_tolerate_v3_unverifiable_default(
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
 
     let logging = LoggingTest::new();
-    snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    snapshot
+        .transaction()
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
     assert!(
         logging.logs().contains(warning_text),
         "logs: {}",
@@ -495,7 +501,9 @@ async fn test_load_and_write_allow_orphan_default() -> Result<(), Box<dyn std::e
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
 
     // Write: a write context builds without error.
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot
+        .transaction()
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
     assert!(
         txn.top_level_column_defaults()?.is_empty(),
         "orphaned defaults must not be surfaced without allowColumnDefaults",
@@ -541,7 +549,9 @@ async fn test_variant_column_default_validation_at_snapshot_load(
         }
         None => {
             let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-            let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+            let txn = snapshot
+                .transaction()
+                .build(&engine, Box::new(FileSystemCommitter::new()))?;
             let defaults = txn.top_level_column_defaults()?;
             let column_default = &defaults["v"];
             assert_eq!(column_default.raw_sql(), default_sql);
@@ -582,7 +592,9 @@ async fn test_load_tolerates_unmaterializable_default(
     .await?;
 
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+    let txn = snapshot
+        .transaction()
+        .build(&engine, Box::new(FileSystemCommitter::new()))?;
     let defaults = txn.top_level_column_defaults()?;
 
     let c = &defaults["c"];
@@ -888,7 +900,8 @@ async fn test_column_default_with_iceberg_compat_v3_e2e() -> Result<(), Box<dyn 
     // The default is still keyed by the logical name `c` and parses to its literal.
     let txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     let defaults = txn.top_level_column_defaults()?;
     assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
     drop(defaults);

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -898,9 +898,10 @@ async fn test_materialize_partition_columns_e2e(
 
     // A single commit writing two distinct partitions.
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+        .transaction()
         .with_engine_info("default engine")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     for (d1, d2, p1, p2) in [
         (vec![1, 2, 3], vec![10, 20, 30], "x", 5),
         (vec![4, 5], vec![40, 50], "y", 6),

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -84,8 +84,9 @@ async fn test_row_tracking_remove_gate(
         .unwrap()?
         .scan_files;
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-        .with_data_change(true);
+        .transaction()
+        .with_data_change(true)
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     txn.remove_files(scan_files);
 
     if expect_err {

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -567,7 +567,8 @@ async fn try_write_with_void_schema(schema: SchemaRef) -> KernelError {
         .build(engine.as_ref())
         .expect("snapshot should build");
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .expect("transaction should create");
 
     // Add dummy file metadata to trigger write validation
@@ -764,7 +765,8 @@ async fn write_context_creation_fails_fast_on_invalid_void_schema(
         .build(engine.as_ref())
         .expect("snapshot should build");
     let txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .expect("transaction should create");
 
     let err = if partition_columns.is_empty() {
@@ -800,7 +802,9 @@ async fn write_context_excludes_void_from_physical_schema() -> Result<(), Box<dy
         assert!(logical.field("v").is_some());
     }
 
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
 
     let wc = txn.unpartitioned_write_context()?;
     let physical = wc.physical_schema();
@@ -827,7 +831,9 @@ async fn metadata_only_commit_with_void_in_array_succeeds() -> Result<(), Box<dy
     let table_url = create_table(store, table_location, schema, &[], false, vec![], vec![]).await?;
     let engine = Arc::new(engine);
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
 
     // Commit with NO add_files — this is a metadata-only operation and should succeed
     let result = txn.commit(engine.as_ref());
@@ -874,7 +880,9 @@ async fn write_context_excludes_nested_void_from_physical_schema(
         }
     }
 
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     let wc = txn.unpartitioned_write_context()?;
     let physical = wc.physical_schema();
 
@@ -915,7 +923,9 @@ async fn write_transform_drops_nested_void_fields() -> Result<(), Box<dyn std::e
     let engine = Arc::new(engine);
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
 
-    let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
+    let txn = snapshot
+        .transaction()
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     let wc = txn.unpartitioned_write_context()?;
 
     // The transform expression should mention dropping "b" inside the struct

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -946,13 +946,14 @@ pub async fn insert_data_with<E: TaskExecutor>(
     let arrow_schema = TryFromKernel::try_from_kernel(snapshot.schema().as_ref())?;
     let batch = RecordBatch::try_new(Arc::new(arrow_schema), columns)
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
-    let mut txn = snapshot
-        .transaction(committer, engine.as_ref())?
+    let mut builder = snapshot
+        .transaction()
         .with_operation(operation.to_string())
         .with_data_change(data_change);
     if is_blind_append {
-        txn = txn.with_blind_append();
+        builder = builder.with_blind_append();
     }
+    let mut txn = builder.build(engine.as_ref(), committer)?;
 
     let write_context = txn.unpartitioned_write_context()?;
     let add_files_metadata = engine
@@ -965,7 +966,9 @@ pub async fn insert_data_with<E: TaskExecutor>(
 
 /// Starts a transaction using the passed snapshot using a [`FileSystemCommitter`].
 pub fn begin_transaction(snapshot: Arc<Snapshot>, engine: &dyn Engine) -> DeltaResult<Transaction> {
-    snapshot.transaction(Box::new(FileSystemCommitter::new()), engine)
+    snapshot
+        .transaction()
+        .build(engine, Box::new(FileSystemCommitter::new()))
 }
 
 /// A catalog [`Committer`] for tests: writes every commit directly to the published Delta log
@@ -1367,9 +1370,10 @@ pub async fn write_batch_to_table(
 ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error>> {
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction()
         .with_engine_info("DefaultEngine")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine, Box::new(FileSystemCommitter::new()))?;
     let write_context = if txn.logical_partition_columns().is_empty() {
         assert!(
             partition_values.is_empty(),
@@ -1682,9 +1686,10 @@ pub fn remove_all_and_get_remove_actions(
 
     let mut txn = snapshot
         .clone()
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction()
         .with_engine_info("DefaultEngine")
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine, Box::new(FileSystemCommitter::new()))?;
     for sm in all_scan_metadata {
         txn.remove_files(sm.scan_files);
     }

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1448,9 +1448,10 @@ async fn write_data_commit<E: TaskExecutor>(
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
     let mut txn = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), engine)?
+        .transaction()
         .with_operation("WRITE".to_string())
-        .with_data_change(true);
+        .with_data_change(true)
+        .build(engine, Box::new(FileSystemCommitter::new()))?;
 
     let partition_set: HashSet<&str> = partition_columns.iter().map(String::as_str).collect();
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3012/files) to review incremental changes.
- [**stack/txn/update-builder**](https://github.com/delta-io/delta-kernel-rs/pull/3012) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3012/files)] ← _this PR_
  - [stack/txn/fold-alter](https://github.com/delta-io/delta-kernel-rs/pull/3013) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3013/files/0438f02cd3f6d26c99489e16082d42878349c4ca..fac28806b89f7eb970c5d3ddc81b5175af089a45)]

---------
## What changes are proposed in this pull request?

Replace Snapshot::transaction(committer, engine) with a builder:
snapshot.transaction().with_*(...).build(engine, committer). This matches
the Java kernel's split-builder model and separates transaction configuration
from data-staging + commit.

All nine pre-commit config setters (with_operation, with_engine_info,
with_blind_append, with_data_change, with_domain_metadata,
with_domain_metadata_removed, with_transaction_id, with_correlation_id,
with_commit_info) move onto the builders. On Transaction they become
#[internal_api] (still reachable by FFI and integration tests under the
internal-api feature, but no longer part of the public API). The create_table
builder gains with_data_change/with_domain_metadata/with_commit_info to match.

The FFI extern-C ABI is unchanged: transaction() builds internally, and
set_data_change is retained as #[internal_api] for the FFI mutation flow.

BREAKING CHANGE: Snapshot::transaction() now returns UpdateTableTransactionBuilder
and takes no arguments; finalize with .build(engine, committer). The nine
transaction config setters are no longer public on Transaction; set them on the
builder before build().

Known follow-up: the test_utils begin_transaction/load_and_begin_transaction
helpers still return a built Transaction and configure post-build; migrating
them to the builder is deferred.

Co-authored-by: Isaac

## How was this change tested?
