### PR TITLE
docs: document plan expression semantics for executor authors

### DIFF
--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2096,9 +2096,59 @@ mod tests {
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap()
     }
 
-    /// An empty string is not valid JSON, so it does not parse to an empty struct. A single
-    /// unparseable input nulls the whole batch rather than only its own row, while a NULL input
+    /// Base64 would render `0xDEAD` as `3q0=`.
+    #[test]
+    fn test_to_json_encodes_binary_as_hex_and_nests_structs_and_arrays() {
+        let item = Arc::new(ArrowField::new("item", ArrowDataType::Int32, true));
+        let list = ListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2])),
+            Arc::new(Int32Array::from(vec![1, 2])),
+            None,
+        );
+        let inner = Fields::from(vec![Arc::new(ArrowField::new(
+            "z",
+            ArrowDataType::Int32,
+            true,
+        ))]);
+        let nested = StructArray::new(
+            inner.clone(),
+            vec![Arc::new(Int32Array::from(vec![7]))],
+            None,
+        );
+        let fields = Fields::from(vec![
+            Arc::new(ArrowField::new("b", ArrowDataType::Binary, true)),
+            Arc::new(ArrowField::new("l", ArrowDataType::List(item), true)),
+            Arc::new(ArrowField::new("n", ArrowDataType::Struct(inner), true)),
+        ]);
+        let value = StructArray::new(
+            fields.clone(),
+            vec![
+                Arc::new(BinaryArray::from(vec![&[0xDEu8, 0xADu8][..]])),
+                Arc::new(list),
+                Arc::new(nested),
+            ],
+            None,
+        );
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "s",
+            ArrowDataType::Struct(fields),
+            true,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
+
+        let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
+        let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
+        let result = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(result.value(0), r#"{"b":"dead","l":[1,2],"n":{"z":7}}"#);
+    }
+
+    /// An empty string is not valid JSON, so it does not parse to an empty struct. A NULL input
     /// decodes as `{}` and leaves the batch intact.
+    ///
+    /// Nulling the whole batch for one unparseable row is a limitation rather than a guarantee: the
+    /// `arrow-json` error names no row, so the fallback can only blanket the array it was given,
+    /// discarding stats from rows that parsed fine.
     #[rstest]
     #[case::empty_string(vec![Some("")], 1)]
     #[case::malformed(vec![Some("{not json")], 1)]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1092,9 +1092,10 @@ mod tests {
     use super::*;
     use crate::arrow::array::{
         ArrayRef, BinaryArray, BooleanArray, Float64Array, Int32Array, Int64Array,
-        LargeStringArray, MapBuilder, StringArray, StringBuilder, StructArray,
+        LargeStringArray, ListArray, MapBuilder, StringArray, StringBuilder, StructArray,
         TimestampMicrosecondArray,
     };
+    use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
@@ -1901,49 +1902,73 @@ mod tests {
         assert_eq!(result.value(0), expected);
     }
 
-    #[rstest]
-    #[case::present(2, true)]
-    #[case::absent(9, false)]
-    fn test_in_matches_literal_array_membership(#[case] needle: i32, #[case] expected: bool) {
-        let schema = ArrowSchema::new(vec![ArrowField::new("n", ArrowDataType::Int32, true)]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(vec![1]))])
-                .unwrap();
-
-        let elements = ArrayData::try_new(
-            ArrayType::new(DataType::INTEGER, false),
-            vec![Scalar::Integer(1), Scalar::Integer(2), Scalar::Integer(3)],
-        )
-        .unwrap();
-        let pred = Pred::binary(
-            BinaryPredicateOp::In,
-            lit(needle),
-            Expr::Literal(Scalar::Array(elements)),
+    /// `{ n: 1 }` plus a `list` column holding `[1, 2]`, covering both element sources `IN`
+    /// accepts.
+    fn in_batch() -> RecordBatch {
+        let item = Arc::new(ArrowField::new("item", ArrowDataType::Int32, true));
+        let list = ListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2])),
+            Arc::new(Int32Array::from(vec![1, 2])),
+            None,
         );
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("n", ArrowDataType::Int32, true),
+            ArrowField::new("list", ArrowDataType::List(item), true),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Int32Array::from(vec![1])), Arc::new(list)],
+        )
+        .unwrap()
+    }
+
+    fn int_array_literal() -> Expr {
+        let elements =
+            ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), vec![1, 2]).unwrap();
+        Expr::Literal(Scalar::Array(elements))
+    }
+
+    /// A NULL needle is not null-propagating: it answers `false` rather than NULL.
+    #[rstest]
+    #[case::present_in_literal_array(Some(2), true, true)]
+    #[case::absent_from_literal_array(Some(9), false, true)]
+    #[case::null_needle_in_literal_array(None, false, true)]
+    #[case::present_in_list_column(Some(2), true, false)]
+    #[case::absent_from_list_column(Some(9), false, false)]
+    #[case::null_needle_in_list_column(None, false, false)]
+    fn test_in_matches_membership_and_never_nulls(
+        #[case] needle: Option<i32>,
+        #[case] expected: bool,
+        #[case] literal_elements: bool,
+    ) {
+        let batch = in_batch();
+        let needle = match needle {
+            Some(n) => lit(n),
+            None => Expr::null_literal(DataType::INTEGER),
+        };
+        let elements = if literal_elements {
+            int_array_literal()
+        } else {
+            column_expr!("list")
+        };
+
+        let pred = Pred::binary(BinaryPredicateOp::In, needle, elements);
         let result = evaluate_predicate(&pred, &batch, false).unwrap();
+        assert_eq!(result.null_count(), 0);
         assert_eq!(result.value(0), expected);
     }
 
+    /// Only a literal left operand is supported, so a column needle is rejected regardless of where
+    /// the elements come from, as is a right operand that holds no elements at all.
     #[rstest]
-    #[case::column_in_literal_array(true)]
-    #[case::non_array_right_operand(false)]
-    fn test_in_rejects_unsupported_operand_shapes(#[case] array_rhs: bool) {
-        let schema = ArrowSchema::new(vec![ArrowField::new("n", ArrowDataType::Int32, true)]);
-        let batch =
-            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(vec![1]))])
-                .unwrap();
-
-        let rhs = if array_rhs {
-            let elements =
-                ArrayData::try_new(ArrayType::new(DataType::INTEGER, false), vec![1, 2, 3])
-                    .unwrap();
-            Expr::Literal(Scalar::Array(elements))
-        } else {
-            lit(1)
-        };
-        let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), rhs);
+    #[case::column_in_literal_array(int_array_literal())]
+    #[case::column_in_column(column_expr!("list"))]
+    #[case::non_array_right_operand(lit(1))]
+    fn test_in_rejects_unsupported_operand_shapes(#[case] elements: Expr) {
+        let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), elements);
         assert_result_error_with_message(
-            evaluate_predicate(&pred, &batch, false),
+            evaluate_predicate(&pred, &in_batch(), false),
             "Invalid right value for (NOT) IN comparison",
         );
     }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2096,6 +2096,40 @@ mod tests {
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap()
     }
 
+    #[rstest]
+    #[case::keeps_on_true(Some(true), false)]
+    #[case::nulls_on_false(Some(false), true)]
+    #[case::nulls_on_null(None, true)]
+    fn test_struct_nullability_predicate_keeps_only_true_rows(
+        #[case] predicate: Option<bool>,
+        #[case] expect_null_struct: bool,
+    ) {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("v", ArrowDataType::Int32, true),
+            ArrowField::new("p", ArrowDataType::Boolean, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(BooleanArray::from(vec![predicate])),
+            ],
+        )
+        .unwrap();
+
+        let output_type = DataType::Struct(Box::new(StructType::new_unchecked(vec![
+            StructField::nullable("v", DataType::INTEGER),
+        ])));
+        let expr = Expr::struct_with_nullability_from(
+            [Arc::new(column_expr!("v"))],
+            Arc::new(Expr::from_pred(Pred::from_expr(column_expr!("p")))),
+        );
+
+        let result = evaluate_expression(&expr, &batch, Some(&output_type)).unwrap();
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        assert_eq!(result.is_null(0), expect_null_struct);
+    }
+
     /// Base64 would render `0xDEAD` as `3q0=`.
     #[test]
     fn test_to_json_encodes_binary_as_hex_and_nests_structs_and_arrays() {

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1091,17 +1091,18 @@ mod tests {
 
     use super::*;
     use crate::arrow::array::{
-        ArrayRef, BinaryArray, BooleanArray, Int32Array, Int64Array, LargeStringArray, MapBuilder,
-        StringArray, StringBuilder, StructArray, TimestampMicrosecondArray,
+        ArrayRef, BinaryArray, BooleanArray, Float64Array, Int32Array, Int64Array,
+        LargeStringArray, MapBuilder, StringArray, StringBuilder, StructArray,
+        TimestampMicrosecondArray,
     };
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
     use crate::expressions::{
-        col, column_expr, column_expr_ref, lit, BinaryExpressionOp, Expression as Expr,
-        ExpressionStructPatchBuilder,
+        col, column_expr, column_expr_ref, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
+        Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, Predicate as Pred,
     };
-    use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
+    use crate::schema::{schema, schema_ref, ArrayType, DataType, StructField, StructType};
     use crate::utils::test_utils::assert_result_error_with_message;
 
     fn create_test_batch() -> RecordBatch {
@@ -1866,6 +1867,200 @@ mod tests {
         assert_result_error_with_message(result, "Incorrect datatype");
     }
 
+    fn divide(left: Expr, right: Expr) -> Expr {
+        Expr::binary(BinaryExpressionOp::Divide, left, right)
+    }
+
+    #[rstest]
+    #[case::equal_non_null(Some(1), Some(1), false)]
+    #[case::unequal_non_null(Some(1), Some(2), true)]
+    #[case::both_null(None, None, false)]
+    #[case::left_null(None, Some(1), true)]
+    #[case::right_null(Some(1), None, true)]
+    fn test_distinct_is_null_safe(
+        #[case] left: Option<i32>,
+        #[case] right: Option<i32>,
+        #[case] expected: bool,
+    ) {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("l", ArrowDataType::Int32, true),
+            ArrowField::new("r", ArrowDataType::Int32, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![left])),
+                Arc::new(Int32Array::from(vec![right])),
+            ],
+        )
+        .unwrap();
+
+        let pred = Pred::distinct(column_expr!("l"), column_expr!("r"));
+        let result = evaluate_predicate(&pred, &batch, false).unwrap();
+        assert_eq!(result.null_count(), 0);
+        assert_eq!(result.value(0), expected);
+    }
+
+    #[rstest]
+    #[case::present(2, true)]
+    #[case::absent(9, false)]
+    fn test_in_matches_literal_array_membership(#[case] needle: i32, #[case] expected: bool) {
+        let schema = ArrowSchema::new(vec![ArrowField::new("n", ArrowDataType::Int32, true)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap();
+
+        let elements = ArrayData::try_new(
+            ArrayType::new(DataType::INTEGER, false),
+            vec![Scalar::Integer(1), Scalar::Integer(2), Scalar::Integer(3)],
+        )
+        .unwrap();
+        let pred = Pred::binary(
+            BinaryPredicateOp::In,
+            lit(needle),
+            Expr::Literal(Scalar::Array(elements)),
+        );
+        let result = evaluate_predicate(&pred, &batch, false).unwrap();
+        assert_eq!(result.value(0), expected);
+    }
+
+    #[rstest]
+    #[case::column_in_literal_array(true)]
+    #[case::non_array_right_operand(false)]
+    fn test_in_rejects_unsupported_operand_shapes(#[case] array_rhs: bool) {
+        let schema = ArrowSchema::new(vec![ArrowField::new("n", ArrowDataType::Int32, true)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap();
+
+        let rhs = if array_rhs {
+            let elements =
+                ArrayData::try_new(ArrayType::new(DataType::INTEGER, false), vec![1, 2, 3])
+                    .unwrap();
+            Expr::Literal(Scalar::Array(elements))
+        } else {
+            lit(1)
+        };
+        let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), rhs);
+        assert_result_error_with_message(
+            evaluate_predicate(&pred, &batch, false),
+            "Invalid right value for (NOT) IN comparison",
+        );
+    }
+
+    #[rstest]
+    #[case::is_null(false, &[false, true])]
+    #[case::is_not_null(true, &[true, false])]
+    fn test_is_null_never_yields_null(#[case] inverted: bool, #[case] expected: &[bool]) {
+        let schema = ArrowSchema::new(vec![ArrowField::new("n", ArrowDataType::Int32, true)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Int32Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+
+        let pred = Pred::is_null(column_expr!("n"));
+        let result = evaluate_predicate(&pred, &batch, inverted).unwrap();
+        assert_eq!(result.null_count(), 0);
+        assert_eq!(result.values().iter().collect::<Vec<_>>(), expected);
+    }
+
+    #[rstest]
+    #[case::and_false_beats_null(JunctionPredicateOp::And, Some(false), None, Some(false))]
+    #[case::and_null_left_false_right(JunctionPredicateOp::And, None, Some(false), Some(false))]
+    #[case::and_true_with_null_is_null(JunctionPredicateOp::And, Some(true), None, None)]
+    #[case::and_both_null_is_null(JunctionPredicateOp::And, None, None, None)]
+    #[case::or_true_beats_null(JunctionPredicateOp::Or, Some(true), None, Some(true))]
+    #[case::or_null_left_true_right(JunctionPredicateOp::Or, None, Some(true), Some(true))]
+    #[case::or_false_with_null_is_null(JunctionPredicateOp::Or, Some(false), None, None)]
+    #[case::or_both_null_is_null(JunctionPredicateOp::Or, None, None, None)]
+    fn test_junction_uses_kleene_logic(
+        #[case] op: JunctionPredicateOp,
+        #[case] left: Option<bool>,
+        #[case] right: Option<bool>,
+        #[case] expected: Option<bool>,
+    ) {
+        let schema = ArrowSchema::new(vec![ArrowField::new("x", ArrowDataType::Int32, false)]);
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap();
+
+        let operand = |v: Option<bool>| match v {
+            Some(b) => Pred::literal(b),
+            None => Pred::null_literal(),
+        };
+        let pred = Pred::junction(op, [operand(left), operand(right)]);
+
+        let result = evaluate_predicate(&pred, &batch, false).unwrap();
+        let actual = result.is_valid(0).then(|| result.value(0));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_divide_integer_truncates_and_rejects_zero_divisor() {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("n", ArrowDataType::Int32, false),
+            ArrowField::new("d", ArrowDataType::Int32, false),
+            ArrowField::new("zero", ArrowDataType::Int32, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(vec![7])),
+                Arc::new(Int32Array::from(vec![2])),
+                Arc::new(Int32Array::from(vec![0])),
+            ],
+        )
+        .unwrap();
+
+        let quotient = evaluate_expression(
+            &divide(column_expr!("n"), column_expr!("d")),
+            &batch,
+            Some(&DataType::INTEGER),
+        )
+        .unwrap();
+        assert_eq!(
+            quotient.as_any().downcast_ref::<Int32Array>().unwrap(),
+            &Int32Array::from(vec![3])
+        );
+
+        let result = evaluate_expression(
+            &divide(column_expr!("n"), column_expr!("zero")),
+            &batch,
+            Some(&DataType::INTEGER),
+        );
+        assert_result_error_with_message(result, "Divide by zero");
+    }
+
+    #[test]
+    fn test_divide_float_by_zero_yields_infinity_and_nan() {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("n", ArrowDataType::Float64, false),
+            ArrowField::new("zero", ArrowDataType::Float64, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Float64Array::from(vec![7.0])),
+                Arc::new(Float64Array::from(vec![0.0])),
+            ],
+        )
+        .unwrap();
+
+        let eval = |expr| {
+            let array = evaluate_expression(&expr, &batch, Some(&DataType::DOUBLE)).unwrap();
+            assert_eq!(array.null_count(), 0);
+            array
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(0)
+        };
+
+        assert!(eval(divide(column_expr!("n"), column_expr!("zero"))).is_infinite());
+        assert!(eval(divide(column_expr!("zero"), column_expr!("zero"))).is_nan());
+    }
+
     fn create_json_batch() -> RecordBatch {
         let schema = ArrowSchema::new(vec![ArrowField::new("json_col", ArrowDataType::Utf8, true)]);
         let json_strings = StringArray::from(vec![
@@ -1874,6 +2069,35 @@ mod tests {
             Some(r#"{"a": 3, "b": "test"}"#),
         ]);
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap()
+    }
+
+    /// An empty string is not valid JSON, so it does not parse to an empty struct. A single
+    /// unparseable input nulls the whole batch rather than only its own row, while a NULL input
+    /// decodes as `{}` and leaves the batch intact.
+    #[rstest]
+    #[case::empty_string(vec![Some("")], 1)]
+    #[case::malformed(vec![Some("{not json")], 1)]
+    #[case::one_bad_input_nulls_whole_batch(vec![Some(""), Some(r#"{"a":1}"#)], 2)]
+    #[case::null_input_is_empty_object(vec![None], 0)]
+    fn test_parse_json_permissively_nulls_unparseable_batches(
+        #[case] input: Vec<Option<&str>>,
+        #[case] expected_null_count: usize,
+    ) {
+        let output_schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
+            "a",
+            DataType::LONG,
+        )]));
+        let schema = ArrowSchema::new(vec![ArrowField::new("s", ArrowDataType::Utf8, true)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(StringArray::from(input.clone()))],
+        )
+        .unwrap();
+
+        let expr = Expr::parse_json(column_expr!("s"), output_schema);
+        let result = evaluate_expression(&expr, &batch, None).expect("parses permissively");
+        assert_eq!(result.len(), input.len());
+        assert_eq!(result.null_count(), expected_null_count);
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2130,7 +2130,7 @@ mod tests {
         assert_eq!(result.is_null(0), expect_null_struct);
     }
 
-    /// Base64 would render `0xDEAD` as `3q0=`.
+    /// Base64 would render `0xABCD` as `q80=`.
     #[test]
     fn test_to_json_encodes_binary_as_hex_and_nests_structs_and_arrays() {
         let item = Arc::new(ArrowField::new("item", ArrowDataType::Int32, true));
@@ -2158,7 +2158,7 @@ mod tests {
         let value = StructArray::new(
             fields.clone(),
             vec![
-                Arc::new(BinaryArray::from(vec![&[0xDEu8, 0xADu8][..]])),
+                Arc::new(BinaryArray::from(vec![&[0xABu8, 0xCDu8][..]])),
                 Arc::new(list),
                 Arc::new(nested),
             ],
@@ -2174,7 +2174,7 @@ mod tests {
         let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
         let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
         let result = result.as_any().downcast_ref::<StringArray>().unwrap();
-        assert_eq!(result.value(0), r#"{"b":"dead","l":[1,2],"n":{"z":7}}"#);
+        assert_eq!(result.value(0), r#"{"b":"abcd","l":[1,2],"n":{"z":7}}"#);
     }
 
     /// An empty string is not valid JSON, so it does not parse to an empty struct. A NULL input

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -111,10 +111,10 @@ pub enum UnaryExpressionOp {
     ///
     /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as lowercase
     /// hex rather than base64, two digits per byte in the order the bytes appear, so
-    /// `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }` becomes:
+    /// `{ b: 0xABCD, l: [1, 2], n: { z: 7 } }` becomes:
     ///
     /// ```text
-    /// {"b":"dead","l":[1,2],"n":{"z":7}}
+    /// {"b":"abcd","l":[1,2],"n":{"z":7}}
     /// ```
     ToJson,
 }

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -59,49 +59,74 @@ pub type ExpressionStructPatchBuilder = crate::struct_patch::StructPatchBuilder<
 /// A unary predicate operator.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum UnaryPredicateOp {
-    /// Unary Is Null
+    /// SQL `expr IS NULL`: `true` when the input is null and `false` otherwise, never null itself.
+    /// A wrapping `NOT` inverts it to `IS NOT NULL`.
     IsNull,
 }
 
 /// A binary predicate operator.
+///
+/// The ordering and equality comparisons follow SQL three-valued logic, so a NULL operand yields
+/// NULL rather than `false`. [`Distinct`](Self::Distinct) and [`In`](Self::In) instead tolerate
+/// NULL and always answer `true` or `false`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryPredicateOp {
-    /// Comparison Less Than
+    /// `left < right`.
     LessThan,
-    /// Comparison Greater Than
+    /// `left > right`.
     GreaterThan,
-    /// Comparison Equal
+    /// `left = right`.
     Equal,
-    /// Distinct
+    /// SQL `left IS DISTINCT FROM right`: null-safe inequality, treating NULL as an ordinary
+    /// value. `DISTINCT(1, 1)` and `DISTINCT(NULL, NULL)` are `false`; `DISTINCT(NULL, 1)` is
+    /// `true`.
     Distinct,
-    /// IN
+    /// SQL `left IN (elements)`: `true` when `left` equals one of the elements. `left` must be a
+    /// literal, and the elements are either a list-typed column or an [`Expression::Literal`]
+    /// holding a [`Scalar::Array`], never a list of expressions or a subquery. The reverse shape,
+    /// a column tested against a literal array, is unsupported.
     In,
 }
 
 /// A unary expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UnaryExpressionOp {
-    /// Convert struct data to JSON-encoded strings
+    /// Encode a struct as a JSON object string, one string per row: `{ a: 1, b: "x" }` becomes
+    /// `{"a":1,"b":"x"}`. The input must be a struct and the output is STRING. This is the inverse
+    /// of [`ParseJsonExpression`].
     ToJson,
 }
 
-/// A binary expression operator.
+/// A binary arithmetic operator over two numeric operands.
+///
+/// Both operands share a numeric type and the result takes that type. Kernel inserts no implicit
+/// casts, so widening a result (decimal precision or scale, for instance) needs an explicit
+/// [`Expression::cast`] to match a declared output type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryExpressionOp {
-    /// Arithmetic Plus
+    /// `left + right`.
     Plus,
-    /// Arithmetic Minus
+    /// `left - right`.
     Minus,
-    /// Arithmetic Multiply
+    /// `left * right`.
     Multiply,
-    /// Arithmetic Divide
+    /// `left / right`. A zero divisor never yields NULL.
+    ///
+    /// Integer operands divide truncating toward zero, so `7 / 2` is `3`, and a zero divisor
+    /// fails. Float operands follow IEEE 754: `+/-inf` for a non-zero numerator, `NaN` for
+    /// `0.0 / 0.0`.
+    ///
+    /// An engine whose `/` is always fractional must lower integer operands to its own truncating
+    /// operator instead.
     Divide,
 }
 
 /// A variadic expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum VariadicExpressionOp {
-    /// Collapse multiple values into one by taking the first non-null value
+    /// Collapse multiple values into one by taking the first non-null value, or null when every
+    /// input is null. All inputs share one type, which is also the result type. Requires at least
+    /// one input.
     Coalesce,
     /// Construct an Array by evaluating each input expression. For example, the expression
     /// `Array(1, (1 + 2), col("my_int_col"))` evaluates to the array
@@ -114,12 +139,17 @@ pub enum VariadicExpressionOp {
     Array,
 }
 
-/// A junction (AND/OR) predicate operator.
+/// A junction (AND/OR) predicate operator over N child predicates.
+///
+/// Both use SQL three-valued (Kleene) logic, treating a NULL child as unknown rather than false: a
+/// decisive child wins over a NULL sibling, so `AND` is `false` and `OR` is `true` despite the
+/// NULL, and only an undecided junction yields NULL. [`Predicate::junction`] folds an empty
+/// junction to its operator's identity, `true` for `AND` and `false` for `OR`.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum JunctionPredicateOp {
-    /// Conjunction
+    /// `AND(preds...)`: true when every child is true.
     And,
-    /// Disjunction
+    /// `OR(preds...)`: true when any child is true.
     Or,
 }
 
@@ -269,9 +299,19 @@ pub struct VariadicExpression {
     pub exprs: Vec<Expression>,
 }
 
-/// An expression that parses a JSON string into a struct with the given schema.
-/// This is the inverse of `ToJson` - it converts a JSON-encoded string column into a
-/// struct column.
+/// An expression that parses a JSON string column into a struct column of `output_schema`, the
+/// inverse of [`UnaryExpressionOp::ToJson`].
+///
+/// Unparseable input must degrade to NULL rather than fail the query, since kernel parses stats
+/// with this operator and data skipping treats null stats as "include the file". Which NULL an
+/// engine produces is up to it. An empty string is not valid JSON here, and this operator does not
+/// share [`MapToStructExpression`]'s empty-string-to-NULL behavior.
+///
+/// The default engine parses permissively: a NULL input decodes as an empty object, so every field
+/// is NULL, and a single input that is not valid JSON nulls the whole batch, not just its own row.
+/// A leaf value that does not fit its declared type yields a NULL for that field when the type is
+/// one of the failure-tolerant leaves (timestamp, date, decimal); any other type mismatch nulls the
+/// whole struct.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParseJsonExpression {
     /// The expression that evaluates to a STRING column containing JSON objects.
@@ -386,13 +426,22 @@ where
 pub enum Expression {
     /// A literal value.
     Literal(Scalar),
-    /// A column reference by name.
+    /// A column reference by name. A [`ColumnName`] is a path, so a multi-segment name like
+    /// `add.stats.numRecords` descends one nested struct field per segment, matching by name.
     Column(ColumnName),
     /// A predicate treated as a boolean expression
     Predicate(Box<Predicate>), // should this be Arc?
-    /// A struct computed from a Vec of expressions.
-    /// The optional nullability predicate, if provided and evaluates to false/null, makes the
-    /// entire struct null.
+    /// A struct computed from one expression per output field, in field order.
+    ///
+    /// Field names and nullability come from the surrounding output schema (the evaluator's
+    /// `result_type`, such as a [`Project`]'s target field), and each field expression's type is
+    /// validated against the schema, so building a struct takes both. The expression count must
+    /// equal the output field count.
+    ///
+    /// The optional nullability predicate nulls the whole struct for rows where it is false or
+    /// null.
+    ///
+    /// [`Project`]: crate::plans::ir::nodes::Project
     Struct(Vec<ExpressionRef>, Option<ExpressionRef>),
     /// A sparse patch of a struct. More efficient than `Struct` for wide schemas
     /// where only a few fields change, achieving O(changes) instead of O(schema_width) complexity.
@@ -418,7 +467,8 @@ pub enum Expression {
     /// all rows -- almost certainly NOT what the query author intended. Use `Expression::Opaque`
     /// for expressions kernel doesn't understand but which engine can still evaluate.
     Unknown(String),
-    /// Parse a JSON string expression into a struct with the given schema.
+    /// Parse a JSON string expression into a struct with the given schema. Malformed and empty
+    /// input is engine-defined; see [`ParseJsonExpression`].
     ParseJson(ParseJsonExpression),
     /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
     /// [`MapToStructExpression`] for how values are parsed.
@@ -552,7 +602,8 @@ impl ParseJsonExpression {
 /// the output struct column: a `key` -> `value` mapping in the map means the struct field named
 /// `key` receives `value`, parsed into the field's target type via [`PrimitiveType::parse_scalar`].
 /// An empty-string value is the exception (aligning with Spark): it casts to itself for string, to
-/// empty bytes for binary, and to null for every other type.
+/// empty bytes for binary, and to null for every other type. This empty-string rule is specific to
+/// this operator; [`ParseJsonExpression`] does not share it.
 ///
 /// - Missing keys produce null values
 /// - A value that cannot be parsed as its target field type returns [`Error::ParseError`]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -101,13 +101,9 @@ pub enum BinaryPredicateOp {
 /// A unary expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UnaryExpressionOp {
-    /// Encode a struct as a JSON object string, one string per row. The input must be a struct and
-    /// the output is STRING. A NULL input row produces a NULL string rather than `"null"`. This is
-    /// the inverse of [`ParseJsonExpression`].
-    ///
-    /// ```sql
-    /// to_json(expr)
-    /// ```
+    /// SQL `to_json(expr)`: encode a struct as a JSON object string, one string per row. The input
+    /// must be a struct and the output is STRING. A NULL input row produces a NULL string rather
+    /// than `"null"`. This is the inverse of [`ParseJsonExpression`].
     ///
     /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as lowercase
     /// hex rather than base64, two digits per byte in the order the bytes appear, so
@@ -331,22 +327,18 @@ pub struct VariadicExpression {
 /// struct of null fields is unspecified, since data skipping treats the two alike.
 ///
 /// An empty string is not valid JSON here, so it is unparseable. This operator does not share
-/// [`MapToStructExpression`]'s empty-string-to-NULL behavior.
-///
-/// ```sql
-/// -- SQL equivalent, in a dialect whose from_json is permissive rather than strict
-/// from_json(json_expr, output_schema)
-/// ```
+/// [`MapToStructExpression`]'s empty-string-to-NULL behavior. It is SQL `from_json(json_expr,
+/// output_schema)` in a dialect whose `from_json` is permissive rather than strict.
 ///
 /// # Default engine behavior
 ///
-/// The default engine builds on `arrow-json`, whose typed decoders reject a whole batch when one
-/// cell fails to parse. It works around that for the leaf types that fail most often (timestamp,
-/// date, decimal) by decoding them as strings and safe-casting back, so a bad value in one of those
-/// degrades to a NULL for that field alone. Anything the workaround does not cover, namely
-/// structurally invalid JSON and a type mismatch on any other leaf, falls back to nulling the
-/// entire batch rather than the offending row. A NULL input decodes as `{}`, leaving every field
-/// NULL without disturbing the rest of the batch.
+/// `arrow-json`'s typed decoders reject a whole batch when one cell fails to parse. The default
+/// engine works around that for the leaf types that fail most often (timestamp, date, decimal) by
+/// decoding them as strings and safe-casting back, so a bad value in one of those degrades to a
+/// NULL for that field alone. Anything the workaround does not cover, namely structurally invalid
+/// JSON and a type mismatch on any other leaf, falls back to nulling the entire batch rather than
+/// the offending row. A NULL input decodes as `{}`, leaving every field NULL without disturbing the
+/// rest of the batch.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParseJsonExpression {
     /// The expression that evaluates to a STRING column containing JSON objects.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -81,19 +81,40 @@ pub enum BinaryPredicateOp {
     /// value. `DISTINCT(1, 1)` and `DISTINCT(NULL, NULL)` are `false`; `DISTINCT(NULL, 1)` is
     /// `true`.
     Distinct,
-    /// SQL `left IN (elements)`: `true` when `left` equals one of the elements. `left` must be a
-    /// literal, and the elements are either a list-typed column or an [`Expression::Literal`]
-    /// holding a [`Scalar::Array`], never a list of expressions or a subquery. The reverse shape,
-    /// a column tested against a literal array, is unsupported.
+    /// SQL `left IN (elements)`: `true` when `left` equals one of the elements, and `false`
+    /// otherwise, including when `left` is NULL. `left` must be a literal, and the elements are
+    /// either a list-typed column or an [`Expression::Literal`] holding a [`Scalar::Array`], never
+    /// a list of expressions or a subquery:
+    ///
+    /// ```sql
+    /// 2 IN (1, 2, 3)         -- literal elements
+    /// 2 IN (SELECT ...)      -- unsupported: no subquery form
+    /// col IN (1, 2, 3)       -- unsupported: the left operand must be a literal
+    /// ```
+    ///
+    /// Testing a literal against a list column is the shape data skipping uses, and it is the
+    /// reason the operands sit this way around rather than the more familiar
+    /// column-on-the-left form.
     In,
 }
 
 /// A unary expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UnaryExpressionOp {
-    /// Encode a struct as a JSON object string, one string per row: `{ a: 1, b: "x" }` becomes
-    /// `{"a":1,"b":"x"}`. The input must be a struct and the output is STRING. This is the inverse
-    /// of [`ParseJsonExpression`].
+    /// Encode a struct as a JSON object string, one string per row. The input must be a struct and
+    /// the output is STRING. A NULL input row produces a NULL string rather than `"null"`. This is
+    /// the inverse of [`ParseJsonExpression`].
+    ///
+    /// ```sql
+    /// to_json(expr)
+    /// ```
+    ///
+    /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as a hex
+    /// string, not base64, so a struct `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }` becomes:
+    ///
+    /// ```text
+    /// {"b":"dead","l":[1,2],"n":{"z":7}}
+    /// ```
     ToJson,
 }
 
@@ -112,26 +133,27 @@ pub enum BinaryExpressionOp {
     Multiply,
     /// `left / right`. A zero divisor never yields NULL.
     ///
-    /// Integer operands divide truncating toward zero, so `7 / 2` is `3`, and a zero divisor
-    /// fails. Float operands follow IEEE 754: `+/-inf` for a non-zero numerator, `NaN` for
-    /// `0.0 / 0.0`.
+    /// Integer operands divide truncating toward zero, and a zero divisor fails. Float operands
+    /// follow IEEE 754: `+/-inf` for a non-zero numerator, `NaN` for `0.0 / 0.0`. In a dialect
+    /// whose `/` is always fractional, the integer case is the other division operator:
     ///
-    /// An engine whose `/` is always fractional must lower integer operands to its own truncating
-    /// operator instead.
+    /// ```sql
+    /// 7 DIV 2      -- 3, this operator over integers
+    /// 7 / 2        -- 3.5, NOT this operator
+    /// ```
     Divide,
 }
 
 /// A variadic expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum VariadicExpressionOp {
-    /// Collapse multiple values into one by taking the first non-null value, or null when every
-    /// input is null. All inputs share one type, which is also the result type. Requires at least
-    /// one input.
+    /// SQL `COALESCE(exprs...)`: the first non-null value, or null when every input is null. All
+    /// inputs share one type, which is also the result type. Requires at least one input.
     Coalesce,
-    /// Construct an Array by evaluating each input expression. For example, the expression
-    /// `Array(1, (1 + 2), col("my_int_col"))` evaluates to the array
-    /// `[1, 3, <my_int_col value>]` per row. All inputs must share the same element type.
-    /// Requires at least one element; the element type is inferred from the inputs.
+    /// SQL `ARRAY(exprs...)`: an array built by evaluating each input per row, so
+    /// `ARRAY(1, 1 + 2, my_int_col)` yields `[1, 3, <my_int_col value>]`. All inputs must share
+    /// the same element type. Requires at least one element; the element type is inferred from
+    /// the inputs.
     ///
     /// For static array literals whose elements are all compile-time constants, use
     /// [`Scalar::Array`] instead. The difference is that `Array` is evaluated at runtime, while
@@ -147,9 +169,9 @@ pub enum VariadicExpressionOp {
 /// junction to its operator's identity, `true` for `AND` and `false` for `OR`.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum JunctionPredicateOp {
-    /// `AND(preds...)`: true when every child is true.
+    /// SQL `a AND b AND ...`: true when every child is true.
     And,
-    /// `OR(preds...)`: true when any child is true.
+    /// SQL `a OR b OR ...`: true when any child is true.
     Or,
 }
 
@@ -302,16 +324,28 @@ pub struct VariadicExpression {
 /// An expression that parses a JSON string column into a struct column of `output_schema`, the
 /// inverse of [`UnaryExpressionOp::ToJson`].
 ///
-/// Unparseable input must degrade to NULL rather than fail the query, since kernel parses stats
-/// with this operator and data skipping treats null stats as "include the file". Which NULL an
-/// engine produces is up to it. An empty string is not valid JSON here, and this operator does not
-/// share [`MapToStructExpression`]'s empty-string-to-NULL behavior.
+/// Unparseable input must degrade to NULL rather than fail the query, because kernel parses
+/// `add.stats` with this operator and data skipping reads null stats as "include the file". The
+/// required part is that it does not error; whether a given row comes back as a null struct or as a
+/// struct of null fields is unspecified, since data skipping treats the two alike.
 ///
-/// The default engine parses permissively: a NULL input decodes as an empty object, so every field
-/// is NULL, and a single input that is not valid JSON nulls the whole batch, not just its own row.
-/// A leaf value that does not fit its declared type yields a NULL for that field when the type is
-/// one of the failure-tolerant leaves (timestamp, date, decimal); any other type mismatch nulls the
-/// whole struct.
+/// An empty string is not valid JSON here, so it is unparseable. This operator does not share
+/// [`MapToStructExpression`]'s empty-string-to-NULL behavior.
+///
+/// ```sql
+/// -- SQL equivalent, in a dialect whose from_json is permissive rather than strict
+/// from_json(json_expr, output_schema)
+/// ```
+///
+/// # Default engine behavior
+///
+/// The default engine builds on `arrow-json`, whose typed decoders reject a whole batch when one
+/// cell fails to parse. It works around that for the leaf types that fail most often (timestamp,
+/// date, decimal) by decoding them as strings and safe-casting back, so a bad value in one of those
+/// degrades to a NULL for that field alone. Anything the workaround does not cover, namely
+/// structurally invalid JSON and a type mismatch on any other leaf, falls back to nulling the
+/// entire batch rather than the offending row. A NULL input decodes as `{}`, leaving every field
+/// NULL without disturbing the rest of the batch.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ParseJsonExpression {
     /// The expression that evaluates to a STRING column containing JSON objects.
@@ -467,8 +501,9 @@ pub enum Expression {
     /// all rows -- almost certainly NOT what the query author intended. Use `Expression::Opaque`
     /// for expressions kernel doesn't understand but which engine can still evaluate.
     Unknown(String),
-    /// Parse a JSON string expression into a struct with the given schema. Malformed and empty
-    /// input is engine-defined; see [`ParseJsonExpression`].
+    /// Parse a JSON string expression into a struct with the given schema. Unparseable input,
+    /// which includes an empty string, must yield NULL rather than error; see
+    /// [`ParseJsonExpression`].
     ParseJson(ParseJsonExpression),
     /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
     /// [`MapToStructExpression`] for how values are parsed.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -110,8 +110,8 @@ pub enum UnaryExpressionOp {
     /// ```
     ///
     /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as lowercase
-    /// hex, two digits per byte, rather than base64, so `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }`
-    /// becomes:
+    /// hex rather than base64, two digits per byte in the order the bytes appear, so
+    /// `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }` becomes:
     ///
     /// ```text
     /// {"b":"dead","l":[1,2],"n":{"z":7}}
@@ -473,8 +473,12 @@ pub enum Expression {
     /// validated against the schema, so building a struct takes both. The expression count must
     /// equal the output field count.
     ///
-    /// The optional nullability predicate nulls the whole struct for rows where it is false or
-    /// null.
+    /// The optional nullability predicate says when to *keep* the struct: a row survives only
+    /// where it is true, and nulls entirely where it is false or null.
+    ///
+    /// ```sql
+    /// CASE WHEN keep_pred THEN struct(expr1, expr2, ...) END
+    /// ```
     ///
     /// [`Project`]: crate::plans::ir::nodes::Project
     Struct(Vec<ExpressionRef>, Option<ExpressionRef>),

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -109,8 +109,9 @@ pub enum UnaryExpressionOp {
     /// to_json(expr)
     /// ```
     ///
-    /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as a hex
-    /// string, not base64, so a struct `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }` becomes:
+    /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as lowercase
+    /// hex, two digits per byte, rather than base64, so `{ b: 0xDEAD, l: [1, 2], n: { z: 7 } }`
+    /// becomes:
     ///
     /// ```text
     /// {"b":"dead","l":[1,2],"n":{"z":7}}

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -361,7 +361,9 @@ impl Scalar {
         Some(result)
     }
 
-    /// Attempts to divide two scalars, returning None if they were incompatible.
+    /// Attempts to divide two scalars, truncating toward zero. Returns None if they were
+    /// incompatible, if `other` is zero, or on overflow. Only the integral types divide; a float or
+    /// decimal operand is treated as incompatible.
     pub fn try_div(&self, other: &Scalar) -> Option<Scalar> {
         use Scalar::*;
         let result = match (self, other) {
@@ -1084,6 +1086,18 @@ mod tests {
     use crate::expressions::{column_expr, BinaryPredicateOp};
     use crate::utils::test_utils::assert_result_error_with_message;
     use crate::{Expression as Expr, Predicate as Pred};
+
+    #[rstest]
+    #[case::truncates(Scalar::Integer(7), Scalar::Integer(2), Some(Scalar::Integer(3)))]
+    #[case::zero_divisor(Scalar::Integer(7), Scalar::Integer(0), None)]
+    #[case::floats_unsupported(Scalar::Double(7.0), Scalar::Double(2.0), None)]
+    fn test_try_div_truncates_and_returns_none_for_zero_divisor_and_floats(
+        #[case] left: Scalar,
+        #[case] right: Scalar,
+        #[case] expected: Option<Scalar>,
+    ) {
+        assert_eq!(left.try_div(&right), expected);
+    }
 
     #[test]
     fn test_void_parse_scalar() {

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -636,11 +636,17 @@ impl Agg {
     /// (no rows)        ->  NULL
     /// ```
     ///
-    /// Equivalent to SQL `max_by(value, key) FILTER (WHERE value IS NOT NULL)`: `max_by` already
-    /// ignores NULL keys, and the filter additionally drops NULL values. The filter is required,
-    /// not decorative: an engine's native `max_by` typically retains NULL values, so lowering
-    /// to it unfiltered returns NULL whenever the greatest-key row has a NULL value, instead of
-    /// the next-greatest row that has one.
+    /// A native `max_by` ignores NULL keys but keeps NULL values, so it needs help to drop the
+    /// latter. Either of these is equivalent; the third form is the one to avoid:
+    ///
+    /// ```sql
+    /// max_by(value, key) FILTER (WHERE value IS NOT NULL)
+    /// max_by(value, CASE WHEN value IS NOT NULL THEN key END)  -- nulls the key instead
+    /// max_by(value, key)                                       -- WRONG: keeps NULL values
+    /// ```
+    ///
+    /// The wrong form returns NULL whenever the greatest-key row has a NULL value, rather than the
+    /// next-greatest row that has one.
     ///
     /// In systems without `max_by`, it can also be expressed using window functions:
     ///

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -19,15 +19,12 @@ use crate::{DeltaResult, Error, FileMeta};
 // Operator: enumerates every operator kind
 // ============================================================================
 
-/// Plan node operators.
+/// Plan node operators, grouped below by input arity. Each variant wraps a payload struct
+/// documenting that operator's semantics, invariants, and output shape.
 ///
-/// Output schemas are stored on the payload struct for operators whose caller
-/// declares them (`ScanParquet`, `ScanJson`, `Values`, `Load`, `Project`,
-/// `Aggregate`); the remaining operators pass an input's schema through
-/// unchanged:
-/// - `Filter` from its input.
-/// - `UnionAll` from its inputs' common schema.
-/// - `SemiJoin` from the probe input.
+/// An operator that reshapes its rows (a source, projection, aggregation, or file load) carries a
+/// caller-declared `schema` field holding its output schema. The rest emit rows they were given, so
+/// they inherit an input's schema; each payload's docs name which input.
 #[derive(Debug, Clone, Display)]
 pub enum Operator {
     // === Source operators (0 inputs) =========================================
@@ -640,7 +637,10 @@ impl Agg {
     /// ```
     ///
     /// Equivalent to SQL `max_by(value, key) FILTER (WHERE value IS NOT NULL)`: `max_by` already
-    /// ignores NULL keys, and the filter additionally drops NULL values.
+    /// ignores NULL keys, and the filter additionally drops NULL values. The filter is required,
+    /// not decorative: an engine's native `max_by` typically retains NULL values, so lowering
+    /// to it unfiltered returns NULL whenever the greatest-key row has a NULL value, instead of
+    /// the next-greatest row that has one.
     ///
     /// In systems without `max_by`, it can also be expressed using window functions:
     ///

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -637,16 +637,20 @@ impl Agg {
     /// ```
     ///
     /// A native `max_by` ignores NULL keys but keeps NULL values, so it needs help to drop the
-    /// latter. Either of these is equivalent; the third form is the one to avoid:
+    /// latter. Both of the first two forms below do that, and are equivalent:
     ///
     /// ```sql
+    /// -- CORRECT: the filter drops NULL-value rows before aggregating
     /// max_by(value, key) FILTER (WHERE value IS NOT NULL)
-    /// max_by(value, CASE WHEN value IS NOT NULL THEN key END)  -- nulls the key instead
-    /// max_by(value, key)                                       -- WRONG: keeps NULL values
-    /// ```
     ///
-    /// The wrong form returns NULL whenever the greatest-key row has a NULL value, rather than the
-    /// next-greatest row that has one.
+    /// -- CORRECT: nulls the key on NULL-value rows, which max_by then ignores anyway. Use this
+    /// -- where FILTER is unavailable, such as a DataFrame API with no filtered-aggregate form.
+    /// max_by(value, CASE WHEN value IS NOT NULL THEN key END)
+    ///
+    /// -- WRONG: keeps NULL values, so it returns NULL whenever the greatest-key row has one
+    /// -- instead of the next-greatest row that does not
+    /// max_by(value, key)
+    /// ```
     ///
     /// In systems without `max_by`, it can also be expressed using window functions:
     ///

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -1,4 +1,52 @@
-//! This module defines the concept of a PlanExecutor and its associated input + output types.
+//! Declarative plans: the kernel describes data work as a relational plan; the engine executes it.
+//!
+//! Kernel does no I/O or data processing itself. When an operation needs data work, kernel builds a
+//! plan and hands it to the engine's [`PlanExecutor`], which compiles it into the engine's own
+//! representation (a Spark or DataFusion logical plan, an iterator pipeline) and runs it. The
+//! engine therefore applies its own optimizer, parallelism, and async I/O to all of kernel's data
+//! work, not just leaf scans.
+//!
+//! # What a plan is
+//!
+//! A [`Plan`](ir::plan::Plan) is a DAG of relational operators ([`Operator`](ir::nodes::Operator)):
+//! sources, transforms, and set combinators. Most map one-to-one onto a SQL operator, so a plan
+//! reads like a query. The live-add metadata plan built in `scan::scan_plan`, for example, is
+//! roughly:
+//!
+//! ```sql
+//! -- commits: keep the newest action per file, then keep only the live adds
+//! SELECT add FROM (
+//!     SELECT max_by(action, version) AS add FROM commits GROUP BY file_key
+//! ) WHERE add IS NOT NULL
+//! UNION ALL
+//! -- checkpoint adds that no newer commit superseded
+//! SELECT c.add FROM checkpoint c
+//! LEFT ANTI JOIN commit_keys k ON c.file_key = k.file_key
+//! ```
+//!
+//! # Writing an executor
+//!
+//! An executor implements [`PlanExecutor::execute_op`], dispatching on the [`Operation`] it
+//! receives and returning the matching [`PlanResult`] variant:
+//!
+//! - [`Operation::IoOperation`] is a single I/O request; each [`IoOperation`] variant documents the
+//!   [`PlanResult`] it must return.
+//! - [`Operation::QueryPlan`] is a [`Plan`](ir::plan::Plan), returning [`PlanResult::Data`]. Either
+//!   evaluate [`Plan::nodes`](ir::plan::Plan::nodes) in slice order, which is topologically sorted
+//!   so a node's inputs are already evaluated, or compile the DAG into the engine's own plan.
+//!
+//! Every operator, expression, and predicate a plan contains must be handled; returning an error
+//! for an unsupported one is fine, and kernel surfaces it to the caller. The `()` executor below
+//! does this, and the sync engine's `SyncPlanExecutor` is a complete reference implementation.
+//!
+//! # Where to look
+//!
+//! - [`PlanBuilder`] builds plans through a fluent, schema-validating API, each method documenting
+//!   its operator with a runnable example.
+//! - [`ir::nodes`] is the operator catalog: each [`Operator`](ir::nodes::Operator) variant's
+//!   payload struct carries its semantics, invariants, and worked examples.
+//! - [`crate::expressions`] defines the expressions and predicates operators evaluate, including
+//!   the type and null semantics an executor must match.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 mod builder;

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -37,10 +37,27 @@
 //! ```
 //!
 //! Field `a` is untouched and passes through in place, which is what makes the patch cost
-//! `O(edits)` rather than `O(struct width)`. Only the expression side of a
-//! [`ProjectionStructPatchBuilder`] is sparse, since a schema has to enumerate every output field.
-//! The `_at` variants (e.g. [`insert_after_at`](StructPatchBuilder::insert_after_at)) apply the
-//! same edits to a nested struct named by path.
+//! `O(edits)` rather than `O(struct width)`. The `_at` variants (e.g.
+//! [`insert_after_at`](StructPatchBuilder::insert_after_at)) apply the same edits to a nested
+//! struct named by path.
+//!
+//! # Flattening to a dense projection
+//!
+//! An engine whose projection operator takes one expression per output column has to expand the
+//! patch, which is the walk the example above traces. Emit
+//! [`prepended_fields`](ExpressionStructPatch::prepended_fields), then visit the input struct's
+//! fields in order: look each one up in
+//! [`field_patches`](ExpressionStructPatch::field_patches), emit the field itself when the entry is
+//! absent or sets [`keep_input`](ExpressionFieldPatch::keep_input), and emit that entry's
+//! [`insertions`](ExpressionFieldPatch::insertions) after it. An entry that keeps nothing and
+//! inserts nothing drops the field. Finish with
+//! [`appended_fields`](ExpressionStructPatch::appended_fields). A nested patch arrives as an
+//! [`Expression::StructPatch`] insertion, so the same walk recurses with that patch's
+//! [`input_path`](ExpressionStructPatch::input_path) as the struct to expand against.
+//!
+//! [`ProjectionStructPatchBuilder`] hands back the flattened schema already, so a caller building
+//! both halves can pair its dense field list with the expressions this walk produces rather than
+//! deriving the field names again.
 
 use std::collections::{hash_map, HashMap};
 use std::sync::Arc;

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -12,6 +12,35 @@
 //!   produces an output [`StructType`] directly from an input schema.
 //! * [`ProjectionStructPatchBuilder`] pairs each output field with the expression that produces it
 //!   and lowers both at once to a matched ([`SchemaRef`], `[ExpressionRef`]) pair.
+//!
+//! # Worked example
+//!
+//! Every builder call names one edit relative to an input field:
+//!
+//! ```ignore
+//! builder
+//!     .prepend(first)
+//!     .insert_after("a", x)
+//!     .replace("b", bb)
+//!     .drop("c")
+//!     .append(last)
+//! ```
+//!
+//! Applied to `{ a, b, c }`, walking the input fields in order:
+//!
+//! ```text
+//! input field:   (none)     a              b          c        (none)
+//! edit:          prepend    keep +after    replace    drop     append
+//! emits:         first      a, x           bb         nothing  last
+//!
+//! output:        { first, a, x, bb, last }
+//! ```
+//!
+//! Field `a` is untouched and passes through in place, which is what makes the patch cost
+//! `O(edits)` rather than `O(struct width)`. Only the expression side of a
+//! [`ProjectionStructPatchBuilder`] is sparse, since a schema has to enumerate every output field.
+//! The `_at` variants (e.g. [`insert_after_at`](StructPatchBuilder::insert_after_at)) apply the
+//! same edits to a nested struct named by path.
 
 use std::collections::{hash_map, HashMap};
 use std::sync::Arc;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Feedback from writing a plan executor against these APIs was that the expression op enums document syntax but not semantics, so the contract had to be reconstructed from kernel's arrow evaluator. This documents that contract and adds tests for it.

## How was this change tested?

New unit tests cover each documented behavior that had none, including integer and float division, Kleene AND/OR, `IS NULL`, `try_div`, and `ParseJson` over empty and malformed input.
