### PR TITLE
feat: Utilities for converting between AMT and Delta DV structs

### DIFF
--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -254,21 +254,40 @@ impl DeletionVectorDescriptor {
         }
     }
 
+    /// Decodes a `PersistedRelative` path to its relative-path form
+    /// (`<prefix>/deletion_vector_<uuid>.bin`).
+    ///
+    /// Errors if called on a non-`PersistedRelative` descriptor, if the encoded path is shorter
+    /// than the 20-character z85 UUID suffix, or if that suffix fails to decode into a UUID.
+    pub(crate) fn relative_path(&self) -> DeltaResult<String> {
+        require!(
+            self.storage_type == DeletionVectorStorageType::PersistedRelative,
+            Error::DeletionVector(format!(
+                "relative_path is only valid for PersistedRelative, got {:?}",
+                self.storage_type
+            ))
+        );
+        // Byte-slice rather than char-slice: z85 is ASCII-only, and string slicing would panic if
+        // a non-ASCII byte boundary fell inside the trailing 20-byte window. Mirrors `try_new`.
+        let bytes = self.path_or_inline_dv.as_bytes();
+        require!(
+            bytes.len() >= 20,
+            Error::DeletionVector(format!("Invalid length {}, must be >= 20", bytes.len()))
+        );
+        let prefix_len = bytes.len() - 20;
+        let decoded = z85::decode(&bytes[prefix_len..])
+            .map_err(|_| Error::deletion_vector("Failed to decode DV uuid"))?;
+        let uuid = uuid::Uuid::from_slice(&decoded)
+            .map_err(|err| Error::DeletionVector(err.to_string()))?;
+        let prefix = std::str::from_utf8(&bytes[..prefix_len])
+            .map_err(|_| Error::deletion_vector("DV path prefix is not valid UTF-8"))?;
+        Ok(DeletionVectorPath::relative_path(prefix, &uuid))
+    }
+
     pub fn absolute_path(&self, parent: &Url) -> DeltaResult<Option<Url>> {
         match self.storage_type {
             DeletionVectorStorageType::PersistedRelative => {
-                let path_len = self.path_or_inline_dv.len();
-                require!(
-                    path_len >= 20,
-                    Error::DeletionVector(format!("Invalid length {path_len}, must be >= 20"))
-                );
-                let prefix_len = path_len - 20;
-                let decoded = z85::decode(&self.path_or_inline_dv[prefix_len..])
-                    .map_err(|_| Error::deletion_vector("Failed to decode DV uuid"))?;
-                let uuid = uuid::Uuid::from_slice(&decoded)
-                    .map_err(|err| Error::DeletionVector(err.to_string()))?;
-                let dv_suffix =
-                    DeletionVectorPath::relative_path(&self.path_or_inline_dv[..prefix_len], &uuid);
+                let dv_suffix = self.relative_path()?;
                 let dv_path = parent
                     .join(&dv_suffix)
                     .map_err(|_| Error::DeletionVector(format!("invalid path: {dv_suffix}")))?;

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -257,6 +257,14 @@ impl DeletionVectorDescriptor {
     /// Decodes a `PersistedRelative` path to its relative-path form
     /// (`<prefix>/deletion_vector_<uuid>.bin`).
     ///
+    /// The encoded path is an optional random prefix followed by a fixed-length 20-character z85
+    /// UUID; the prefix becomes a directory component, and is omitted entirely when absent:
+    ///
+    /// ```text
+    /// "ab^-aqEH.-t@S}K{vb[*k^" -> "ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin"
+    /// "vBn[lx{q8@P<9BNH/isA"   -> "deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin"
+    /// ```
+    ///
     /// Errors if called on a non-`PersistedRelative` descriptor, if the encoded path is shorter
     /// than the 20-character z85 UUID suffix, or if that suffix fails to decode into a UUID.
     pub(crate) fn relative_path(&self) -> DeltaResult<String> {

--- a/kernel/src/actions/deletion_vector.rs
+++ b/kernel/src/actions/deletion_vector.rs
@@ -644,6 +644,74 @@ mod tests {
         assert_eq!(dv_url, example.absolute_path(&parent).unwrap().unwrap());
     }
 
+    fn dv_with_path(
+        storage_type: DeletionVectorStorageType,
+        path_or_inline_dv: &str,
+    ) -> DeletionVectorDescriptor {
+        DeletionVectorDescriptor {
+            storage_type,
+            path_or_inline_dv: path_or_inline_dv.to_string(),
+            offset: Some(1),
+            size_in_bytes: 36,
+            cardinality: 2,
+        }
+    }
+
+    #[rstest::rstest]
+    // z85 UUID with a random prefix -> `<prefix>/deletion_vector_<uuid>.bin`.
+    #[case(
+        "ab^-aqEH.-t@S}K{vb[*k^",
+        "ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin"
+    )]
+    // Bare 20-char z85 UUID, no prefix.
+    #[case(
+        "vBn[lx{q8@P<9BNH/isA",
+        "deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin"
+    )]
+    fn test_relative_path_decodes(#[case] encoded: &str, #[case] expected: &str) {
+        let dv = dv_with_path(DeletionVectorStorageType::PersistedRelative, encoded);
+        assert_eq!(dv.relative_path().unwrap(), expected);
+    }
+
+    #[rstest::rstest]
+    // Non-relative storage types are rejected by the guard.
+    #[case(
+        DeletionVectorStorageType::PersistedAbsolute,
+        "s3://mytable/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin",
+        "only valid for PersistedRelative"
+    )]
+    #[case(
+        DeletionVectorStorageType::Inline,
+        "^Bg9^0rr910000000000iXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L",
+        "only valid for PersistedRelative"
+    )]
+    // Path shorter than the 20-byte z85 UUID suffix.
+    #[case(
+        DeletionVectorStorageType::PersistedRelative,
+        "short",
+        "Invalid length"
+    )]
+    // A non-ASCII byte straddling the trailing-20-byte window must error, not panic. `é` is two
+    // bytes, so this 21-byte path leaves `prefix_len == 1` inside the multi-byte `é`; byte-slicing
+    // (vs the pre-fix char-slicing) errors cleanly instead of panicking.
+    #[case(
+        DeletionVectorStorageType::PersistedRelative,
+        "éaaaaaaaaaaaaaaaaaaa",
+        "Failed to decode DV uuid"
+    )]
+    fn test_relative_path_errors(
+        #[case] storage_type: DeletionVectorStorageType,
+        #[case] path_or_inline_dv: &str,
+        #[case] expected_error: &str,
+    ) {
+        let dv = dv_with_path(storage_type, path_or_inline_dv);
+        let err = dv.relative_path().unwrap_err().to_string();
+        assert!(
+            err.contains(expected_error),
+            "error {err:?} did not contain {expected_error:?}"
+        );
+    }
+
     #[test]
     fn test_magic_number_constants() {
         assert_eq!(ROARING_BITMAP_PORTABLE_MAGIC, 1681511377);

--- a/kernel/src/content_tree/dv_conversion.rs
+++ b/kernel/src/content_tree/dv_conversion.rs
@@ -41,9 +41,9 @@ pub(crate) fn extract_deletion_vector_content(
             ));
         }
     };
-    // Add 8 bytes to convert from Delta's size (bitmap only) to Iceberg's size (full blob):
-    // - 4 bytes: size prefix
-    // - 4 bytes: CRC checksum
+    // Add 8 bytes to convert from Delta's size to Iceberg's size (full blob): Delta's
+    // `sizeInBytes` counts the 4-byte magic + bitmap; Iceberg's full-blob size adds the 4-byte
+    // length prefix and the 4-byte trailing CRC.
     Ok(DeletionVectorInfo {
         location,
         // Absent offset defaults to 1: a persisted DV file opens with a 1-byte version header, so
@@ -74,8 +74,11 @@ static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 /// Visits rows in one pass, accumulating decoded DV columns.
 ///
 /// For rows with a DV: decodes path (base85 UUID -> relative path), widens offset/sizeInBytes
-/// to LONG, adds 8 to sizeInBytes (Delta -> Iceberg framing), stores cardinality.
-/// For rows without a DV: pushes Null scalars for all 4 columns.
+/// to LONG, adds 8 to sizeInBytes (Delta -> Iceberg framing), stores cardinality. Rows without a
+/// DV push a null in every column.
+///
+/// Columns accumulate directly in their final [`Scalar`] form so they can be moved into
+/// [`ArrayData`] without a second pass to translate them.
 ///
 /// One batch per visitor: the accumulated columns are appended to a single [`EngineData`] via
 /// [`Self::append_decoded_dv_columns`], so visit exactly the batch you pass there. Reusing one
@@ -98,6 +101,30 @@ impl DecodedDvVisitor {
             decoded_cardinalities: Vec::with_capacity(n),
             is_log_batch,
         }
+    }
+
+    /// Appends one row to every column, so the columns can only advance in lockstep. Both arms
+    /// build the same tuple shape, which is what ties a new column to a compile error in each arm
+    /// rather than to a silently short column.
+    fn push_row(&mut self, decoded: Option<DeletionVectorInfo>) {
+        let (location, offset, size_in_bytes, cardinality) = match decoded {
+            Some(dv) => (
+                Scalar::String(dv.location),
+                Scalar::Long(dv.offset),
+                Scalar::Long(dv.size_in_bytes),
+                Scalar::Long(dv.cardinality),
+            ),
+            None => (
+                Scalar::Null(DataType::STRING),
+                Scalar::Null(DataType::LONG),
+                Scalar::Null(DataType::LONG),
+                Scalar::Null(DataType::LONG),
+            ),
+        };
+        self.decoded_paths.push(location);
+        self.decoded_offsets.push(offset);
+        self.decoded_sizes.push(size_in_bytes);
+        self.decoded_cardinalities.push(cardinality);
     }
 
     /// Visitor for scan-transform rows, where DV fields are projected at `deletionVector.*`.
@@ -182,36 +209,20 @@ impl RowVisitor for DecodedDvVisitor {
             // Labels are the bare leaf field names so error messages are correct for both the
             // scan-row (`deletionVector.*`) and log-batch (`add.deletionVector.*`) shapes.
             let storage_type_opt: Option<String> = getters[0].get_opt(i, "storageType")?;
-            if let Some(storage_type_str) = storage_type_opt {
-                let storage_type: DeletionVectorStorageType = storage_type_str.parse()?;
-                let path_or_inline_dv: String = getters[1].get(i, "pathOrInlineDv")?;
-                let offset: Option<i32> = getters[2].get_opt(i, "offset")?;
-                let size_in_bytes: i32 = getters[3].get(i, "sizeInBytes")?;
-                let cardinality: i64 = getters[4].get(i, "cardinality")?;
-
-                let dv = DeletionVectorDescriptor {
-                    storage_type,
-                    path_or_inline_dv,
-                    offset,
-                    size_in_bytes,
-                    cardinality,
-                };
-                let deletion_vector = extract_deletion_vector_content(&dv)?;
-                self.decoded_paths
-                    .push(Scalar::String(deletion_vector.location));
-                self.decoded_offsets
-                    .push(Scalar::Long(deletion_vector.offset));
-                self.decoded_sizes
-                    .push(Scalar::Long(deletion_vector.size_in_bytes));
-                self.decoded_cardinalities
-                    .push(Scalar::Long(deletion_vector.cardinality));
-            } else {
-                self.decoded_paths.push(Scalar::Null(DataType::STRING));
-                self.decoded_offsets.push(Scalar::Null(DataType::LONG));
-                self.decoded_sizes.push(Scalar::Null(DataType::LONG));
-                self.decoded_cardinalities
-                    .push(Scalar::Null(DataType::LONG));
-            }
+            let decoded = match storage_type_opt {
+                Some(storage_type_str) => {
+                    let dv = DeletionVectorDescriptor {
+                        storage_type: storage_type_str.parse()?,
+                        path_or_inline_dv: getters[1].get(i, "pathOrInlineDv")?,
+                        offset: getters[2].get_opt(i, "offset")?,
+                        size_in_bytes: getters[3].get(i, "sizeInBytes")?,
+                        cardinality: getters[4].get(i, "cardinality")?,
+                    };
+                    Some(extract_deletion_vector_content(&dv)?)
+                }
+                None => None,
+            };
+            self.push_row(decoded);
         }
         Ok(())
     }
@@ -220,6 +231,7 @@ impl RowVisitor for DecodedDvVisitor {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use test_utils::assert_result_error_with_message;
 
     use super::*;
     use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
@@ -285,6 +297,21 @@ mod tests {
         }
     }
 
+    /// The absolute path an [`absolute_dv`] descriptor must pass through verbatim.
+    const ABSOLUTE_DV_PATH: &str =
+        "s3://another-bucket/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin";
+
+    /// A `PersistedAbsolute` DV, whose path is used as-is rather than z85-decoded.
+    fn absolute_dv() -> DeletionVectorDescriptor {
+        DeletionVectorDescriptor {
+            storage_type: DeletionVectorStorageType::PersistedAbsolute,
+            path_or_inline_dv: ABSOLUTE_DV_PATH.to_string(),
+            offset: Some(9),
+            size_in_bytes: 12,
+            cardinality: 3,
+        }
+    }
+
     /// Builds the DV descriptor struct scalar, with leaves ordered to match
     /// [`DeletionVectorDescriptor::to_schema`].
     fn dv_scalar(dv: &DeletionVectorDescriptor) -> Scalar {
@@ -319,10 +346,9 @@ mod tests {
     }
 
     impl DvColumnShape {
-        /// Schema projecting the DV struct at this shape's location.
-        fn schema(self) -> SchemaRef {
-            let dv_field =
-                StructField::nullable("deletionVector", DeletionVectorDescriptor::to_schema());
+        /// Schema projecting `dv_schema` at this shape's location.
+        fn schema(self, dv_schema: StructType) -> SchemaRef {
+            let dv_field = StructField::nullable("deletionVector", dv_schema);
             let root = match self {
                 DvColumnShape::ScanRow => StructType::new_unchecked([dv_field]),
                 DvColumnShape::LogBatch => StructType::new_unchecked([StructField::nullable(
@@ -334,16 +360,13 @@ mod tests {
         }
 
         /// Wraps a DV struct scalar (or a null placeholder) at this shape's root field, matching
-        /// [`Self::schema`].
-        fn root_scalar(self, dv: Scalar) -> Scalar {
+        /// [`Self::schema`] for the same `dv_schema`.
+        fn root_scalar(self, dv_schema: StructType, dv: Scalar) -> Scalar {
             match self {
                 DvColumnShape::ScanRow => dv,
                 DvColumnShape::LogBatch => Scalar::Struct(
                     StructData::try_new(
-                        vec![StructField::nullable(
-                            "deletionVector",
-                            DeletionVectorDescriptor::to_schema(),
-                        )],
+                        vec![StructField::nullable("deletionVector", dv_schema)],
                         vec![dv],
                     )
                     .unwrap(),
@@ -351,10 +374,21 @@ mod tests {
             }
         }
 
+        /// Builds a single-row `EngineData` holding `dv` under this shape's `deletionVector` field,
+        /// typed as `dv_schema`.
+        fn engine_data_for(self, dv_schema: StructType, dv: Scalar) -> Box<dyn EngineData> {
+            let row = vec![self.root_scalar(dv_schema.clone(), dv)];
+            SyncEngine::new()
+                .evaluation_handler()
+                .create_many(self.schema(dv_schema), &[row.as_slice()])
+                .unwrap()
+        }
+
         /// Builds an `EngineData` with one row per entry in `dvs`; `None` yields a row whose DV
         /// field is null, `Some(dv)` embeds the given descriptor.
         fn engine_data(self, dvs: &[Option<DeletionVectorDescriptor>]) -> Box<dyn EngineData> {
-            let dv_type = DataType::from(DeletionVectorDescriptor::to_schema());
+            let dv_schema = DeletionVectorDescriptor::to_schema();
+            let dv_type = DataType::from(dv_schema.clone());
             let rows: Vec<Vec<Scalar>> = dvs
                 .iter()
                 .map(|dv| {
@@ -362,13 +396,13 @@ mod tests {
                         Some(dv) => dv_scalar(dv),
                         None => Scalar::Null(dv_type.clone()),
                     };
-                    vec![self.root_scalar(scalar)]
+                    vec![self.root_scalar(dv_schema.clone(), scalar)]
                 })
                 .collect();
             let row_refs: Vec<&[Scalar]> = rows.iter().map(Vec::as_slice).collect();
             SyncEngine::new()
                 .evaluation_handler()
-                .create_many(self.schema(), &row_refs)
+                .create_many(self.schema(dv_schema), &row_refs)
                 .unwrap()
         }
 
@@ -432,18 +466,20 @@ mod tests {
     fn test_visitor_mixed_rows(
         #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Two rows: one with a DV, one without, in a single batch.
-        let columns = decode(shape, &[Some(sample_dv()), None])?;
+        // One batch mixing all three row kinds: a relative DV (z85-decoded), an absolute DV (path
+        // verbatim), and a row with no DV at all.
+        let columns = decode(shape, &[Some(sample_dv()), Some(absolute_dv()), None])?;
         assert_eq!(
             columns.locations,
             vec![
                 Some("ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin".to_string()),
+                Some(ABSOLUTE_DV_PATH.to_string()),
                 None,
             ]
         );
-        assert_eq!(columns.offsets, vec![Some(4), None]);
-        assert_eq!(columns.sizes, vec![Some(48), None]);
-        assert_eq!(columns.cardinalities, vec![Some(6), None]);
+        assert_eq!(columns.offsets, vec![Some(4), Some(9), None]);
+        assert_eq!(columns.sizes, vec![Some(48), Some(20), None]);
+        assert_eq!(columns.cardinalities, vec![Some(6), Some(3), None]);
         Ok(())
     }
 
@@ -464,6 +500,38 @@ mod tests {
         decoder.visit_rows_of(data.as_ref())?;
         assert_eq!(decoder.has_any_dv(), expected);
         Ok(())
+    }
+
+    /// A row whose `storageType` is set but whose required `pathOrInlineDv` leaf is null must
+    /// error, not be silently treated as a DV-less row. `ensure_data_types` deliberately skips
+    /// nullability, so a malformed log can present this even though the derived schema marks the
+    /// leaf non-null -- hence the all-nullable schema variant here.
+    #[rstest]
+    fn test_visitor_storage_type_present_with_null_required_leaf_errors(
+        #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
+    ) {
+        let nullable_dv_schema = StructType::new_unchecked(
+            DeletionVectorDescriptor::to_schema()
+                .fields()
+                .map(|f| StructField::nullable(f.name(), f.data_type().clone())),
+        );
+        let partial_dv = Scalar::Struct(
+            StructData::try_new(
+                nullable_dv_schema.fields().cloned().collect(),
+                vec![
+                    Scalar::String(DeletionVectorStorageType::PersistedRelative.to_string()),
+                    Scalar::Null(DataType::STRING), // pathOrInlineDv missing
+                    Scalar::Integer(4),
+                    Scalar::Integer(40),
+                    Scalar::Long(6),
+                ],
+            )
+            .unwrap(),
+        );
+        let data = shape.engine_data_for(nullable_dv_schema, partial_dv);
+
+        let mut decoder = shape.visitor(1);
+        assert_result_error_with_message(decoder.visit_rows_of(data.as_ref()), "pathOrInlineDv");
     }
 
     #[rstest]

--- a/kernel/src/content_tree/dv_conversion.rs
+++ b/kernel/src/content_tree/dv_conversion.rs
@@ -5,8 +5,7 @@ use crate::content_tree::DeletionVectorInfo;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{ArrayData, Scalar};
 use crate::schema::{
-    column_name, ArrayType, ColumnName, ColumnNamesAndTypes, DataType, SchemaRef, StructField,
-    StructType,
+    column_name, ArrayType, ColumnName, DataType, SchemaRef, StructField, StructType,
 };
 use crate::{DeltaResult, EngineData, Error};
 
@@ -71,6 +70,43 @@ static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     ]))
 });
 
+/// Types of the DV descriptor leaves [`DecodedDvVisitor`] decodes, in getter order. Shared across
+/// all source layouts: only the *names* (the projection path to the DV struct) vary per layout, so
+/// they live on the visitor as [`DecodedDvVisitor::names`] rather than here.
+static DV_LEAF_TYPES: LazyLock<Vec<DataType>> = LazyLock::new(|| {
+    vec![
+        DataType::STRING,
+        DataType::STRING,
+        DataType::INTEGER,
+        DataType::INTEGER,
+        DataType::LONG,
+    ]
+});
+
+/// Projection paths locating the DV descriptor leaves in scan-transform rows, where the DV struct
+/// is projected at `deletionVector`. Pass to [`DecodedDvVisitor::new`].
+static SCAN_ROW_DV_COLUMNS: LazyLock<Vec<ColumnName>> = LazyLock::new(|| {
+    vec![
+        column_name!("deletionVector.storageType"),
+        column_name!("deletionVector.pathOrInlineDv"),
+        column_name!("deletionVector.offset"),
+        column_name!("deletionVector.sizeInBytes"),
+        column_name!("deletionVector.cardinality"),
+    ]
+});
+
+/// Projection paths locating the DV descriptor leaves in raw log batches, where the DV struct is
+/// nested under `add.deletionVector`. Pass to [`DecodedDvVisitor::new`].
+static ADD_DV_COLUMNS: LazyLock<Vec<ColumnName>> = LazyLock::new(|| {
+    vec![
+        column_name!("add.deletionVector.storageType"),
+        column_name!("add.deletionVector.pathOrInlineDv"),
+        column_name!("add.deletionVector.offset"),
+        column_name!("add.deletionVector.sizeInBytes"),
+        column_name!("add.deletionVector.cardinality"),
+    ]
+});
+
 /// Visits rows in one pass, accumulating decoded DV columns.
 ///
 /// For rows with a DV: decodes path (base85 UUID -> relative path), widens offset/sizeInBytes
@@ -84,22 +120,30 @@ static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 /// [`Self::append_decoded_dv_columns`], so visit exactly the batch you pass there. Reusing one
 /// visitor across batches would append the concatenated columns onto only the last batch, with
 /// mismatched row counts.
+///
+/// The visitor is layout-agnostic: it reads getters positionally and shares the leaf *types* (via
+/// [`DV_LEAF_TYPES`]). The projection locating the DV struct in the source layout is injected at
+/// construction as [`Self::names`] (e.g. [`SCAN_ROW_DV_COLUMNS`] or [`ADD_DV_COLUMNS`]), so the
+/// visitor is self-describing and drives [`RowVisitor::visit_rows_of`] directly.
 struct DecodedDvVisitor {
+    /// Projection paths to the DV descriptor leaves, in getter order, matching [`DV_LEAF_TYPES`].
+    names: &'static [ColumnName],
     decoded_paths: Vec<Scalar>,
     decoded_offsets: Vec<Scalar>,
     decoded_sizes: Vec<Scalar>,
     decoded_cardinalities: Vec<Scalar>,
-    is_log_batch: bool,
 }
 
 impl DecodedDvVisitor {
-    fn with_capacity(n: usize, is_log_batch: bool) -> Self {
+    /// Builds a visitor reading the DV descriptor leaves at `names` (see [`SCAN_ROW_DV_COLUMNS`] /
+    /// [`ADD_DV_COLUMNS`]), pre-sized for `n` rows.
+    fn new(names: &'static [ColumnName], n: usize) -> Self {
         Self {
+            names,
             decoded_paths: Vec::with_capacity(n),
             decoded_offsets: Vec::with_capacity(n),
             decoded_sizes: Vec::with_capacity(n),
             decoded_cardinalities: Vec::with_capacity(n),
-            is_log_batch,
         }
     }
 
@@ -127,16 +171,6 @@ impl DecodedDvVisitor {
         self.decoded_cardinalities.push(cardinality);
     }
 
-    /// Visitor for scan-transform rows, where DV fields are projected at `deletionVector.*`.
-    fn for_scan_rows(n: usize) -> Self {
-        Self::with_capacity(n, false)
-    }
-
-    /// Visitor for raw log batches, where DV fields are nested under `add.deletionVector.*`.
-    fn for_log_batch(n: usize) -> Self {
-        Self::with_capacity(n, true)
-    }
-
     fn has_any_dv(&self) -> bool {
         self.decoded_paths.iter().any(|s| !s.is_null())
     }
@@ -159,45 +193,7 @@ impl DecodedDvVisitor {
 
 impl RowVisitor for DecodedDvVisitor {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
-        if self.is_log_batch {
-            static LOG_BATCH: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-                let names = vec![
-                    column_name!("add.deletionVector.storageType"),
-                    column_name!("add.deletionVector.pathOrInlineDv"),
-                    column_name!("add.deletionVector.offset"),
-                    column_name!("add.deletionVector.sizeInBytes"),
-                    column_name!("add.deletionVector.cardinality"),
-                ];
-                let types = vec![
-                    DataType::STRING,
-                    DataType::STRING,
-                    DataType::INTEGER,
-                    DataType::INTEGER,
-                    DataType::LONG,
-                ];
-                (names, types).into()
-            });
-            LOG_BATCH.as_ref()
-        } else {
-            static SCAN_ROW: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-                let names = vec![
-                    column_name!("deletionVector.storageType"),
-                    column_name!("deletionVector.pathOrInlineDv"),
-                    column_name!("deletionVector.offset"),
-                    column_name!("deletionVector.sizeInBytes"),
-                    column_name!("deletionVector.cardinality"),
-                ];
-                let types = vec![
-                    DataType::STRING,
-                    DataType::STRING,
-                    DataType::INTEGER,
-                    DataType::INTEGER,
-                    DataType::LONG,
-                ];
-                (names, types).into()
-            });
-            SCAN_ROW.as_ref()
-        }
+        (self.names, &DV_LEAF_TYPES)
     }
 
     fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
@@ -237,7 +233,7 @@ mod tests {
     use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
     use crate::engine::sync::SyncEngine;
     use crate::expressions::StructData;
-    use crate::schema::ToSchema;
+    use crate::schema::{ColumnNamesAndTypes, ToSchema};
     use crate::Engine;
 
     /// Decoded DV columns read back from an augmented batch, one entry per row.
@@ -406,10 +402,12 @@ mod tests {
                 .unwrap()
         }
 
-        fn visitor(self, n: usize) -> DecodedDvVisitor {
+        /// Projection paths locating the DV struct leaves for this shape, matching
+        /// [`Self::schema`].
+        fn columns(self) -> &'static [ColumnName] {
             match self {
-                DvColumnShape::ScanRow => DecodedDvVisitor::for_scan_rows(n),
-                DvColumnShape::LogBatch => DecodedDvVisitor::for_log_batch(n),
+                DvColumnShape::ScanRow => &SCAN_ROW_DV_COLUMNS,
+                DvColumnShape::LogBatch => &ADD_DV_COLUMNS,
             }
         }
     }
@@ -423,7 +421,7 @@ mod tests {
         dvs: &[Option<DeletionVectorDescriptor>],
     ) -> Result<DecodedColumnsVisitor, Box<dyn std::error::Error>> {
         let data = shape.engine_data(dvs);
-        let mut decoder = shape.visitor(dvs.len());
+        let mut decoder = DecodedDvVisitor::new(shape.columns(), dvs.len());
         decoder.visit_rows_of(data.as_ref())?;
 
         let augmented = decoder.append_decoded_dv_columns(data.as_ref())?;
@@ -496,7 +494,7 @@ mod tests {
         let dvs: Vec<Option<DeletionVectorDescriptor>> =
             presence.iter().map(|p| p.map(|()| sample_dv())).collect();
         let data = DvColumnShape::ScanRow.engine_data(&dvs);
-        let mut decoder = DvColumnShape::ScanRow.visitor(dvs.len());
+        let mut decoder = DecodedDvVisitor::new(DvColumnShape::ScanRow.columns(), dvs.len());
         decoder.visit_rows_of(data.as_ref())?;
         assert_eq!(decoder.has_any_dv(), expected);
         Ok(())
@@ -530,7 +528,7 @@ mod tests {
         );
         let data = shape.engine_data_for(nullable_dv_schema, partial_dv);
 
-        let mut decoder = shape.visitor(1);
+        let mut decoder = DecodedDvVisitor::new(shape.columns(), 1);
         assert_result_error_with_message(decoder.visit_rows_of(data.as_ref()), "pathOrInlineDv");
     }
 

--- a/kernel/src/content_tree/dv_conversion.rs
+++ b/kernel/src/content_tree/dv_conversion.rs
@@ -1,0 +1,570 @@
+use std::sync::{Arc, LazyLock};
+
+use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
+use crate::content_tree::DeletionVectorInfo;
+use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
+use crate::expressions::{ArrayData, Scalar};
+use crate::schema::{
+    column_name, ArrayType, ColumnName, ColumnNamesAndTypes, DataType, SchemaRef, StructField,
+    StructType,
+};
+use crate::{DeltaResult, EngineData, Error};
+
+/// Extracts deletion vector content from a DeletionVectorDescriptor.
+///
+/// This function decodes the `path_or_inline_dv` field based on the storage type:
+///
+/// - `PersistedRelative`: The format is `<random prefix - optional><base85 encoded uuid>`. The UUID
+///   is 20 characters (base85 encoded), and any characters before that are the optional random
+///   prefix. Decodes to the table-root-relative path `<prefix>/deletion_vector_<uuid>.bin`.
+///
+/// - `PersistedAbsolute`: The `path_or_inline_dv` contains the absolute path to the DV file.
+///
+/// - `Inline`: Currently not supported - returns an error. Inline DVs would need to be persisted
+///   first before being added to metadata.
+pub(crate) fn extract_deletion_vector_content(
+    dv: &DeletionVectorDescriptor,
+) -> DeltaResult<DeletionVectorInfo> {
+    let location = match dv.storage_type {
+        DeletionVectorStorageType::PersistedAbsolute => {
+            // Use absolute path as-is
+            dv.path_or_inline_dv.clone()
+        }
+        DeletionVectorStorageType::PersistedRelative => {
+            // Decode to relative path
+            dv.relative_path()?
+        }
+        DeletionVectorStorageType::Inline => {
+            return Err(Error::DeletionVector(
+                "Inline deletion vectors are not supported. They must be persisted first."
+                    .to_string(),
+            ));
+        }
+    };
+    // Add 8 bytes to convert from Delta's size (bitmap only) to Iceberg's size (full blob):
+    // - 4 bytes: size prefix
+    // - 4 bytes: CRC checksum
+    Ok(DeletionVectorInfo {
+        location,
+        // Absent offset defaults to 1: a persisted DV file opens with a 1-byte version header, so
+        // the first blob starts at byte 1. Matches `DeletionVectorDescriptor::read`.
+        offset: dv.offset.map_or(1, i64::from),
+        size_in_bytes: dv.size_in_bytes as i64 + 8,
+        cardinality: dv.cardinality,
+    })
+}
+
+/// Intermediate flat decoded-DV columns: path resolved (base85-decoded for relative DVs, verbatim
+/// for absolute), sizes widened to LONG, `+8` bytes for Iceberg framing.
+const DV_LOCATION: &str = "_dv_location";
+const DV_OFFSET: &str = "_dv_offset";
+const DV_SIZE_IN_BYTES: &str = "_dv_size_in_bytes";
+const DV_CARDINALITY: &str = "_dv_cardinality";
+
+/// Schema of [`DV_LOCATION`] etc., for [`EngineData::append_columns`].
+static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(StructType::new_unchecked(vec![
+        StructField::nullable(DV_LOCATION, DataType::STRING),
+        StructField::nullable(DV_OFFSET, DataType::LONG),
+        StructField::nullable(DV_SIZE_IN_BYTES, DataType::LONG),
+        StructField::nullable(DV_CARDINALITY, DataType::LONG),
+    ]))
+});
+
+/// Visits rows in one pass, accumulating decoded DV columns.
+///
+/// For rows with a DV: decodes path (base85 UUID -> relative path), widens offset/sizeInBytes
+/// to LONG, adds 8 to sizeInBytes (Delta -> Iceberg framing), stores cardinality.
+/// For rows without a DV: pushes Null scalars for all 4 columns.
+///
+/// One batch per visitor: the accumulated columns are appended to a single [`EngineData`] via
+/// [`Self::append_decoded_dv_columns`], so visit exactly the batch you pass there. Reusing one
+/// visitor across batches would append the concatenated columns onto only the last batch, with
+/// mismatched row counts.
+struct DecodedDvVisitor {
+    decoded_paths: Vec<Scalar>,
+    decoded_offsets: Vec<Scalar>,
+    decoded_sizes: Vec<Scalar>,
+    decoded_cardinalities: Vec<Scalar>,
+    is_log_batch: bool,
+}
+
+impl DecodedDvVisitor {
+    fn with_capacity(n: usize, is_log_batch: bool) -> Self {
+        Self {
+            decoded_paths: Vec::with_capacity(n),
+            decoded_offsets: Vec::with_capacity(n),
+            decoded_sizes: Vec::with_capacity(n),
+            decoded_cardinalities: Vec::with_capacity(n),
+            is_log_batch,
+        }
+    }
+
+    /// Visitor for scan-transform rows, where DV fields are projected at `deletionVector.*`.
+    fn for_scan_rows(n: usize) -> Self {
+        Self::with_capacity(n, false)
+    }
+
+    /// Visitor for raw log batches, where DV fields are nested under `add.deletionVector.*`.
+    fn for_log_batch(n: usize) -> Self {
+        Self::with_capacity(n, true)
+    }
+
+    fn has_any_dv(&self) -> bool {
+        self.decoded_paths.iter().any(|s| !s.is_null())
+    }
+
+    fn append_decoded_dv_columns(self, data: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
+        data.append_columns(
+            DV_DECODED_FLAT_SCHEMA.clone(),
+            vec![
+                ArrayData::try_new(ArrayType::new(DataType::STRING, true), self.decoded_paths)?,
+                ArrayData::try_new(ArrayType::new(DataType::LONG, true), self.decoded_offsets)?,
+                ArrayData::try_new(ArrayType::new(DataType::LONG, true), self.decoded_sizes)?,
+                ArrayData::try_new(
+                    ArrayType::new(DataType::LONG, true),
+                    self.decoded_cardinalities,
+                )?,
+            ],
+        )
+    }
+}
+
+impl RowVisitor for DecodedDvVisitor {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        if self.is_log_batch {
+            static LOG_BATCH: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+                let names = vec![
+                    column_name!("add.deletionVector.storageType"),
+                    column_name!("add.deletionVector.pathOrInlineDv"),
+                    column_name!("add.deletionVector.offset"),
+                    column_name!("add.deletionVector.sizeInBytes"),
+                    column_name!("add.deletionVector.cardinality"),
+                ];
+                let types = vec![
+                    DataType::STRING,
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    DataType::INTEGER,
+                    DataType::LONG,
+                ];
+                (names, types).into()
+            });
+            LOG_BATCH.as_ref()
+        } else {
+            static SCAN_ROW: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+                let names = vec![
+                    column_name!("deletionVector.storageType"),
+                    column_name!("deletionVector.pathOrInlineDv"),
+                    column_name!("deletionVector.offset"),
+                    column_name!("deletionVector.sizeInBytes"),
+                    column_name!("deletionVector.cardinality"),
+                ];
+                let types = vec![
+                    DataType::STRING,
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    DataType::INTEGER,
+                    DataType::LONG,
+                ];
+                (names, types).into()
+            });
+            SCAN_ROW.as_ref()
+        }
+    }
+
+    fn visit<'a>(&mut self, row_count: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
+        for i in 0..row_count {
+            // `storageType` is a required (non-null) field of the DV descriptor, so it is null
+            // for a row iff the whole `deletionVector` struct is null (the visitor unions parent
+            // null masks into leaves). We use it as the presence check, then `get` the other
+            // required fields infallibly.
+            // Labels are the bare leaf field names so error messages are correct for both the
+            // scan-row (`deletionVector.*`) and log-batch (`add.deletionVector.*`) shapes.
+            let storage_type_opt: Option<String> = getters[0].get_opt(i, "storageType")?;
+            if let Some(storage_type_str) = storage_type_opt {
+                let storage_type: DeletionVectorStorageType = storage_type_str.parse()?;
+                let path_or_inline_dv: String = getters[1].get(i, "pathOrInlineDv")?;
+                let offset: Option<i32> = getters[2].get_opt(i, "offset")?;
+                let size_in_bytes: i32 = getters[3].get(i, "sizeInBytes")?;
+                let cardinality: i64 = getters[4].get(i, "cardinality")?;
+
+                let dv = DeletionVectorDescriptor {
+                    storage_type,
+                    path_or_inline_dv,
+                    offset,
+                    size_in_bytes,
+                    cardinality,
+                };
+                let deletion_vector = extract_deletion_vector_content(&dv)?;
+                self.decoded_paths
+                    .push(Scalar::String(deletion_vector.location));
+                self.decoded_offsets
+                    .push(Scalar::Long(deletion_vector.offset));
+                self.decoded_sizes
+                    .push(Scalar::Long(deletion_vector.size_in_bytes));
+                self.decoded_cardinalities
+                    .push(Scalar::Long(deletion_vector.cardinality));
+            } else {
+                self.decoded_paths.push(Scalar::Null(DataType::STRING));
+                self.decoded_offsets.push(Scalar::Null(DataType::LONG));
+                self.decoded_sizes.push(Scalar::Null(DataType::LONG));
+                self.decoded_cardinalities
+                    .push(Scalar::Null(DataType::LONG));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
+    use crate::engine::sync::SyncEngine;
+    use crate::expressions::StructData;
+    use crate::schema::ToSchema;
+    use crate::Engine;
+
+    /// Decoded DV columns read back from an augmented batch, one entry per row.
+    #[derive(Default)]
+    struct DecodedColumnsVisitor {
+        locations: Vec<Option<String>>,
+        offsets: Vec<Option<i64>>,
+        sizes: Vec<Option<i64>>,
+        cardinalities: Vec<Option<i64>>,
+    }
+
+    impl RowVisitor for DecodedColumnsVisitor {
+        fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+            static COLUMNS: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
+                let names = vec![
+                    ColumnName::new([DV_LOCATION]),
+                    ColumnName::new([DV_OFFSET]),
+                    ColumnName::new([DV_SIZE_IN_BYTES]),
+                    ColumnName::new([DV_CARDINALITY]),
+                ];
+                let types = vec![
+                    DataType::STRING,
+                    DataType::LONG,
+                    DataType::LONG,
+                    DataType::LONG,
+                ];
+                (names, types).into()
+            });
+            COLUMNS.as_ref()
+        }
+
+        fn visit<'a>(
+            &mut self,
+            row_count: usize,
+            getters: &[&'a dyn GetData<'a>],
+        ) -> DeltaResult<()> {
+            for i in 0..row_count {
+                self.locations.push(getters[0].get_opt(i, DV_LOCATION)?);
+                self.offsets.push(getters[1].get_opt(i, DV_OFFSET)?);
+                self.sizes.push(getters[2].get_opt(i, DV_SIZE_IN_BYTES)?);
+                self.cardinalities
+                    .push(getters[3].get_opt(i, DV_CARDINALITY)?);
+            }
+            Ok(())
+        }
+    }
+
+    /// A `PersistedRelative` DV whose z85 UUID decodes to
+    /// `ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin`.
+    fn sample_dv() -> DeletionVectorDescriptor {
+        DeletionVectorDescriptor {
+            storage_type: DeletionVectorStorageType::PersistedRelative,
+            path_or_inline_dv: "ab^-aqEH.-t@S}K{vb[*k^".to_string(),
+            offset: Some(4),
+            size_in_bytes: 40,
+            cardinality: 6,
+        }
+    }
+
+    /// Builds the DV descriptor struct scalar, with leaves ordered to match
+    /// [`DeletionVectorDescriptor::to_schema`].
+    fn dv_scalar(dv: &DeletionVectorDescriptor) -> Scalar {
+        let offset = dv
+            .offset
+            .map(Scalar::Integer)
+            .unwrap_or(Scalar::Null(DataType::INTEGER));
+        Scalar::Struct(
+            StructData::try_new(
+                DeletionVectorDescriptor::to_schema()
+                    .fields()
+                    .cloned()
+                    .collect(),
+                vec![
+                    Scalar::String(dv.storage_type.to_string()),
+                    Scalar::String(dv.path_or_inline_dv.clone()),
+                    offset,
+                    Scalar::Integer(dv.size_in_bytes),
+                    Scalar::Long(dv.cardinality),
+                ],
+            )
+            .unwrap(),
+        )
+    }
+
+    /// Column shape the [`DecodedDvVisitor`] reads from: scan-transform rows expose the DV struct
+    /// at `deletionVector`, raw log batches nest it under `add.deletionVector`.
+    #[derive(Clone, Copy)]
+    enum DvColumnShape {
+        ScanRow,
+        LogBatch,
+    }
+
+    impl DvColumnShape {
+        /// Schema projecting the DV struct at this shape's location.
+        fn schema(self) -> SchemaRef {
+            let dv_field =
+                StructField::nullable("deletionVector", DeletionVectorDescriptor::to_schema());
+            let root = match self {
+                DvColumnShape::ScanRow => StructType::new_unchecked([dv_field]),
+                DvColumnShape::LogBatch => StructType::new_unchecked([StructField::nullable(
+                    "add",
+                    StructType::new_unchecked([dv_field]),
+                )]),
+            };
+            Arc::new(root)
+        }
+
+        /// Wraps a DV struct scalar (or a null placeholder) at this shape's root field, matching
+        /// [`Self::schema`].
+        fn root_scalar(self, dv: Scalar) -> Scalar {
+            match self {
+                DvColumnShape::ScanRow => dv,
+                DvColumnShape::LogBatch => Scalar::Struct(
+                    StructData::try_new(
+                        vec![StructField::nullable(
+                            "deletionVector",
+                            DeletionVectorDescriptor::to_schema(),
+                        )],
+                        vec![dv],
+                    )
+                    .unwrap(),
+                ),
+            }
+        }
+
+        /// Builds an `EngineData` with one row per entry in `dvs`; `None` yields a row whose DV
+        /// field is null, `Some(dv)` embeds the given descriptor.
+        fn engine_data(self, dvs: &[Option<DeletionVectorDescriptor>]) -> Box<dyn EngineData> {
+            let dv_type = DataType::from(DeletionVectorDescriptor::to_schema());
+            let rows: Vec<Vec<Scalar>> = dvs
+                .iter()
+                .map(|dv| {
+                    let scalar = match dv {
+                        Some(dv) => dv_scalar(dv),
+                        None => Scalar::Null(dv_type.clone()),
+                    };
+                    vec![self.root_scalar(scalar)]
+                })
+                .collect();
+            let row_refs: Vec<&[Scalar]> = rows.iter().map(Vec::as_slice).collect();
+            SyncEngine::new()
+                .evaluation_handler()
+                .create_many(self.schema(), &row_refs)
+                .unwrap()
+        }
+
+        fn visitor(self, n: usize) -> DecodedDvVisitor {
+            match self {
+                DvColumnShape::ScanRow => DecodedDvVisitor::for_scan_rows(n),
+                DvColumnShape::LogBatch => DecodedDvVisitor::for_log_batch(n),
+            }
+        }
+    }
+
+    /// Decodes `dvs` through the shape's visitor, appends the decoded columns, and reads them
+    /// back with [`DecodedColumnsVisitor`]. A row's decoded columns are all `None` exactly when
+    /// its source `deletionVector` struct was null, so the visited columns carry the actual
+    /// per-row nullability directly -- no separate presence flag is needed.
+    fn decode(
+        shape: DvColumnShape,
+        dvs: &[Option<DeletionVectorDescriptor>],
+    ) -> Result<DecodedColumnsVisitor, Box<dyn std::error::Error>> {
+        let data = shape.engine_data(dvs);
+        let mut decoder = shape.visitor(dvs.len());
+        decoder.visit_rows_of(data.as_ref())?;
+
+        let augmented = decoder.append_decoded_dv_columns(data.as_ref())?;
+        let mut columns = DecodedColumnsVisitor::default();
+        columns.visit_rows_of(augmented.as_ref())?;
+        Ok(columns)
+    }
+
+    #[rstest]
+    fn test_visitor_decodes_dv_row(
+        #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let columns = decode(shape, &[Some(sample_dv())])?;
+        assert_eq!(
+            columns.locations,
+            vec![Some(
+                "ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin".to_string()
+            )]
+        );
+        assert_eq!(columns.offsets, vec![Some(4)]);
+        assert_eq!(columns.sizes, vec![Some(48)]); // 40 + 8 for Iceberg framing
+        assert_eq!(columns.cardinalities, vec![Some(6)]);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_visitor_row_without_dv_is_null(
+        #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // A null source struct decodes to nulls across all four columns.
+        let columns = decode(shape, &[None])?;
+        assert_eq!(columns.locations, vec![None]);
+        assert_eq!(columns.offsets, vec![None]);
+        assert_eq!(columns.sizes, vec![None]);
+        assert_eq!(columns.cardinalities, vec![None]);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_visitor_mixed_rows(
+        #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Two rows: one with a DV, one without, in a single batch.
+        let columns = decode(shape, &[Some(sample_dv()), None])?;
+        assert_eq!(
+            columns.locations,
+            vec![
+                Some("ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin".to_string()),
+                None,
+            ]
+        );
+        assert_eq!(columns.offsets, vec![Some(4), None]);
+        assert_eq!(columns.sizes, vec![Some(48), None]);
+        assert_eq!(columns.cardinalities, vec![Some(6), None]);
+        Ok(())
+    }
+
+    #[rstest]
+    // Empty and all-null batches carry no DV; any non-null row flips `has_any_dv`.
+    #[case(&[], false)]
+    #[case(&[None], false)]
+    #[case(&[Some(()), None], true)]
+    #[case(&[Some(())], true)]
+    fn test_has_any_dv(
+        #[case] presence: &[Option<()>],
+        #[case] expected: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let dvs: Vec<Option<DeletionVectorDescriptor>> =
+            presence.iter().map(|p| p.map(|()| sample_dv())).collect();
+        let data = DvColumnShape::ScanRow.engine_data(&dvs);
+        let mut decoder = DvColumnShape::ScanRow.visitor(dvs.len());
+        decoder.visit_rows_of(data.as_ref())?;
+        assert_eq!(decoder.has_any_dv(), expected);
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_visitor_empty_batch_yields_no_rows(
+        #[values(DvColumnShape::ScanRow, DvColumnShape::LogBatch)] shape: DvColumnShape,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // A zero-row batch appends four empty decoded columns without error.
+        let columns = decode(shape, &[])?;
+        assert!(columns.locations.is_empty());
+        assert!(columns.offsets.is_empty());
+        assert!(columns.sizes.is_empty());
+        assert!(columns.cardinalities.is_empty());
+        Ok(())
+    }
+
+    /// Builds a descriptor from `(storage_type, path_or_inline_dv, offset, size_in_bytes)`,
+    /// with `cardinality` fixed at 6.
+    fn dv(input: (DeletionVectorStorageType, &str, Option<i32>, i32)) -> DeletionVectorDescriptor {
+        let (storage_type, path_or_inline_dv, offset, size_in_bytes) = input;
+        DeletionVectorDescriptor {
+            storage_type,
+            path_or_inline_dv: path_or_inline_dv.to_string(),
+            offset,
+            size_in_bytes,
+            cardinality: 6,
+        }
+    }
+
+    // `size_in_bytes` gains +8 (4-byte size prefix + 4-byte CRC) to convert Delta's bitmap-only
+    // size to Iceberg's full-blob size. `expected` is (location, offset, size_in_bytes).
+    #[rstest]
+    // Persisted-relative with a "ab" prefix; z85 UUID decodes to d2c639aa-...-d3fe2512ff61.
+    #[case::relative_with_prefix(
+        (DeletionVectorStorageType::PersistedRelative, "ab^-aqEH.-t@S}K{vb[*k^", Some(4), 40),
+        ("ab/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin", 4, 48)
+    )]
+    // Persisted-relative with no prefix (bare 20-char z85 UUID).
+    #[case::relative_no_prefix(
+        (DeletionVectorStorageType::PersistedRelative, "vBn[lx{q8@P<9BNH/isA", Some(1), 36),
+        ("deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin", 1, 44)
+    )]
+    // Persisted-absolute preserves the path verbatim.
+    #[case::absolute(
+        (
+            DeletionVectorStorageType::PersistedAbsolute,
+            "s3://another-bucket/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin",
+            Some(4),
+            40,
+        ),
+        ("s3://another-bucket/deletion_vector_d2c639aa-8816-431a-aaf6-d3fe2512ff61.bin", 4, 48)
+    )]
+    // Absent offset defaults to 1 (the byte after the DV file's version header).
+    #[case::relative_no_offset_defaults_to_one(
+        (DeletionVectorStorageType::PersistedRelative, "vBn[lx{q8@P<9BNH/isA", None, 36),
+        ("deletion_vector_61d16c75-6994-46b7-a15b-8b538852e50e.bin", 1, 44)
+    )]
+    fn test_extract_deletion_vector_content(
+        #[case] input: (DeletionVectorStorageType, &str, Option<i32>, i32),
+        #[case] expected: (&str, i64, i64),
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (expected_location, expected_offset, expected_size_in_bytes) = expected;
+        let deletion_vector = extract_deletion_vector_content(&dv(input))?;
+
+        assert_eq!(deletion_vector.location, expected_location);
+        assert_eq!(deletion_vector.offset, expected_offset);
+        assert_eq!(deletion_vector.size_in_bytes, expected_size_in_bytes);
+        assert_eq!(deletion_vector.cardinality, 6);
+        Ok(())
+    }
+
+    #[rstest]
+    // Inline DVs must be persisted before conversion.
+    #[case::inline_not_supported(
+        (
+            DeletionVectorStorageType::Inline,
+            "^Bg9^0rr910000000000iXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L",
+            None,
+            44,
+        ),
+        "Inline deletion vectors are not supported"
+    )]
+    // Persisted-relative path shorter than the 20-char z85 UUID suffix.
+    #[case::invalid_relative_path(
+        (DeletionVectorStorageType::PersistedRelative, "short", Some(1), 36),
+        "Invalid length"
+    )]
+    // Non-ASCII byte straddling the trailing-20-byte window must error, not panic (byte-slicing).
+    #[case::non_ascii_relative_path(
+        (DeletionVectorStorageType::PersistedRelative, "éaaaaaaaaaaaaaaaaaaa", Some(1), 36),
+        "Failed to decode DV uuid"
+    )]
+    fn test_extract_deletion_vector_content_error(
+        #[case] input: (DeletionVectorStorageType, &str, Option<i32>, i32),
+        #[case] expected_error: &str,
+    ) {
+        let err = extract_deletion_vector_content(&dv(input))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(expected_error),
+            "error {err:?} did not contain {expected_error:?}"
+        );
+    }
+}

--- a/kernel/src/content_tree/mod.rs
+++ b/kernel/src/content_tree/mod.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 #![allow(unreachable_pub)]
 
+mod dv_conversion;
 pub(crate) mod stats;
 
 use std::collections::HashMap;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add utility methods to do conversion between the semantics of AMT DV struct and Delta's DV struct. 

This includes visitors for two schemas that will need conversion:
1. Scan schema - used for DV updates
2. Delta log schema - used for compacting delta log entries into the AMT.

Refactors a relative_path method from the DV utility so it can be shared in the new module.

## How was this change tested?

Added unit tests.
