### PR TITLE
refactor: share struct fields with arcs

### DIFF
--- a/benchmarks/benches/workload_bench.rs
+++ b/benchmarks/benches/workload_bench.rs
@@ -1,5 +1,6 @@
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering, Ordering as AtomicOrdering};
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -16,6 +17,67 @@ use test_utils::CountingReporter;
 // (not the gitignored, downloaded `workloads/` dir), so it is loaded relative to
 // CARGO_MANIFEST_DIR.
 const REGISTRY_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/bench-registry.json");
+
+struct TrackingAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static BASELINE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            record_allocation(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        LIVE_BYTES.fetch_sub(layout.size(), AtomicOrdering::Relaxed);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() {
+            if new_size >= layout.size() {
+                record_allocation(new_size - layout.size());
+            } else {
+                LIVE_BYTES.fetch_sub(layout.size() - new_size, AtomicOrdering::Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+fn record_allocation(bytes: usize) {
+    let live = LIVE_BYTES.fetch_add(bytes, AtomicOrdering::Relaxed) + bytes;
+    PEAK_BYTES.fetch_max(live, AtomicOrdering::Relaxed);
+}
+
+fn reset_allocation_peak() {
+    let baseline = LIVE_BYTES.load(AtomicOrdering::Relaxed);
+    BASELINE_BYTES.store(baseline, AtomicOrdering::Relaxed);
+    PEAK_BYTES.store(baseline, AtomicOrdering::Relaxed);
+}
+
+fn allocation_peak_delta() -> usize {
+    PEAK_BYTES
+        .load(AtomicOrdering::Relaxed)
+        .saturating_sub(BASELINE_BYTES.load(AtomicOrdering::Relaxed))
+}
 
 // Loads all workloads and sets up a shared runtime, then registers each as a top-level benchmark.
 // For each workload, builds a runner that encapsulates the state (table info, engine, config, etc.)
@@ -51,6 +113,7 @@ fn workload_benchmarks(c: &mut Criterion) {
                             case_name,
                             &config.name,
                         );
+                        let concurrent_base_name = name.clone();
                         let runner = create_read_runner(
                             name,
                             read_spec,
@@ -61,6 +124,29 @@ fn workload_benchmarks(c: &mut Criterion) {
                         )
                         .expect("Failed to create read runner");
                         run_benchmark(c, runner.as_ref(), &reporter);
+                        if case_name == "readMetadataLatest" && config.name == "serial" {
+                            for query_count in [1, 2, 4, 8, 16, 32, 64, 128, 256] {
+                                let concurrent_name =
+                                    format!("{concurrent_base_name}/concurrent{query_count}");
+                                let peak_bytes = AtomicUsize::new(0);
+                                c.bench_function(&concurrent_name, |b| {
+                                    b.iter(|| {
+                                        reset_allocation_peak();
+                                        runner
+                                            .execute_concurrent(query_count)
+                                            .expect("Concurrent execution failed");
+                                        peak_bytes.store(
+                                            allocation_peak_delta(),
+                                            AtomicOrdering::Relaxed,
+                                        );
+                                    })
+                                });
+                                println!(
+                                    "[alloc] {concurrent_name}: peak +{} KiB",
+                                    peak_bytes.load(AtomicOrdering::Relaxed) / 1024
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/benchmarks/src/runners.rs
+++ b/benchmarks/src/runners.rs
@@ -38,6 +38,10 @@ const CATALOG_MANAGED_PROPERTY: &str = "delta.feature.catalogManaged";
 pub trait WorkloadRunner {
     fn execute(&self) -> Result<(), Box<dyn std::error::Error>>;
     fn name(&self) -> &str;
+
+    fn execute_concurrent(&self, _num_queries: usize) -> Result<(), Box<dyn std::error::Error>> {
+        Err("concurrent execution is not supported for this workload".into())
+    }
 }
 
 /// Builds `{table}/{case}` from `table_info.name` and `case_name`.
@@ -341,6 +345,24 @@ impl ReadMetadataRunner {
         }
         Ok(())
     }
+
+    pub fn execute_concurrent(&self, num_queries: usize) -> Result<(), Box<dyn std::error::Error>> {
+        if num_queries == 0 {
+            return Err("num_queries must be greater than 0".into());
+        }
+        std::thread::scope(|scope| {
+            let handles = (0..num_queries)
+                .map(|_| scope.spawn(|| self.execute_serial().map_err(|e| e.to_string())))
+                .collect::<Vec<_>>();
+            for handle in handles {
+                handle
+                    .join()
+                    .map_err(|_| "concurrent query panicked".to_string())??;
+            }
+            Ok::<_, String>(())
+        })
+        .map_err(Into::into)
+    }
 }
 
 impl WorkloadRunner for ReadMetadataRunner {
@@ -353,6 +375,10 @@ impl WorkloadRunner for ReadMetadataRunner {
 
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn execute_concurrent(&self, num_queries: usize) -> Result<(), Box<dyn std::error::Error>> {
+        Self::execute_concurrent(self, num_queries)
     }
 }
 

--- a/derive-macros/src/schema_macro.rs
+++ b/derive-macros/src/schema_macro.rs
@@ -108,12 +108,13 @@ fn emit_struct(
         input.parse::<Token![,]>()?;
     }
     let ctor = if fallible {
-        quote!(try_new)
+        quote!(try_new_refs)
     } else {
-        quote!(new_unchecked)
+        quote!(new_unchecked_refs)
     };
     Ok(quote! {{
-        let mut __fields = ::std::vec::Vec::new();
+        let mut __fields: ::std::vec::Vec<delta_kernel::schema::StructFieldRef> =
+            ::std::vec::Vec::new();
         #( #stmts )*
         delta_kernel::schema::StructType::#ctor(__fields)
     }})
@@ -154,7 +155,9 @@ fn emit_field_entry(
     input.parse::<Token![:]>()?;
     let dtype = emit_type(input, fallible, errors)?;
     Ok(quote! {
-        __fields.push(delta_kernel::schema::StructField::new(#name, #dtype, #nullable));
+        __fields.push(delta_kernel::schema::StructFieldRef::from(
+            delta_kernel::schema::StructField::new(#name, #dtype, #nullable)
+        ));
     })
 }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -239,7 +239,10 @@ impl TryFrom<Format> for Scalar {
         )
         .map(Scalar::Map)?;
         Ok(Scalar::Struct(StructData::try_new(
-            Format::to_schema().into_fields().collect(),
+            Format::to_schema()
+                .into_fields()
+                .map(|field| field.as_ref().clone())
+                .collect(),
             vec![provider, options],
         )?))
     }

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -41,7 +41,7 @@ pub(super) fn create_sidecar_action_batch(
     }
 
     // Derive the sidecar struct schema and sidecar column index from the checkpoint data schema.
-    let checkpoint_data_fields: Vec<&StructField> = checkpoint_data_schema.fields().collect();
+    let checkpoint_data_fields: Vec<_> = checkpoint_data_schema.fields().collect();
     let (sidecar_col_idx, sidecar_field) = checkpoint_data_fields
         .iter()
         .enumerate()
@@ -53,7 +53,10 @@ pub(super) fn create_sidecar_action_batch(
             sidecar_field.data_type()
         )));
     };
-    let sidecar_fields: Vec<StructField> = sidecar_struct.fields().cloned().collect();
+    let sidecar_fields: Vec<StructField> = sidecar_struct
+        .fields()
+        .map(|field| field.as_ref().clone())
+        .collect();
     // Per-row data template (follows checkpoint data schema, all fields null). Each sidecar row is
     // built by cloning this and populating only the `sidecar` field.
     let null_template: Vec<Scalar> = checkpoint_data_fields
@@ -179,7 +182,7 @@ impl SidecarSplitter {
             )));
         }
         let sidecar_output_schema: SchemaRef =
-            StructType::try_new([add_field.clone(), remove_field.clone()])?.into();
+            StructType::try_new_refs([add_field.clone(), remove_field.clone()])?.into();
 
         // Sidecar projector: select only add/remove columns.
         let file_action_projector = eval_handler.new_expression_evaluator(

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -269,7 +269,9 @@ impl CommitMetadata {
     ) -> DeltaResult<Self> {
         let log_root = crate::path::LogRoot::new(table_root)?;
         let protocol = Protocol::try_new_modern(reader_features, writer_features)?;
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let schema = Arc::new(crate::schema::StructType::new_unchecked(Vec::<
+            crate::schema::StructField,
+        >::new()));
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, configuration)?;
         Ok(Self::new(
             log_root,

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -31,7 +31,7 @@ use crate::error::Error;
 use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use crate::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, PrimitiveType, StructField,
-    StructType,
+    StructFieldRef, StructType,
 };
 
 pub(crate) const LIST_ARRAY_ROOT: &str = "element";
@@ -167,7 +167,9 @@ where
 
 /// Converts a kernel [`StructType`] to a `Vec<ArrowField>`.
 fn try_kernel_struct_to_arrow_fields(s: &StructType) -> Result<Vec<ArrowField>, ArrowError> {
-    s.fields().map(|f| f.try_into_arrow()).try_collect()
+    s.fields()
+        .map(|field| field.as_ref().try_into_arrow())
+        .try_collect()
 }
 
 impl TryFromKernel<&StructType> for ArrowSchema {
@@ -184,6 +186,12 @@ impl TryFromKernel<&StructField> for ArrowField {
         metadata.remove(ColumnMetadataKey::ColumnMappingNestedIds.as_ref());
         let arrow_type = kernel_field_into_arrow(f, f.name(), f.data_type())?;
         Ok(ArrowField::new(f.name(), arrow_type, f.is_nullable()).with_metadata(metadata))
+    }
+}
+
+impl TryFromKernel<&StructFieldRef> for ArrowField {
+    fn try_from_kernel(field: &StructFieldRef) -> Result<Self, ArrowError> {
+        Self::try_from_kernel(field.as_ref())
     }
 }
 

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -976,7 +976,7 @@ fn evaluate_map_to_struct(
         .ok_or_else(|| Error::generic("MapToStruct requires maps with string values"))?;
 
     let num_rows = map_array.len();
-    let fields: Vec<&StructField> = output_schema.fields().collect();
+    let fields: Vec<&StructField> = output_schema.fields().map(AsRef::as_ref).collect();
 
     // Pre-build a builder and resolve the PrimitiveType for each output field.
     let mut builders: Vec<Box<dyn ArrayBuilder>> = Vec::with_capacity(fields.len());

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -133,7 +133,7 @@ pub(crate) fn apply_schema_to_struct(
             "Arrow claimed to be a struct but isn't a StructArray",
         ));
     };
-    transform_struct(sa, kernel_fields.fields())
+    transform_struct(sa, kernel_fields.fields().cloned())
 }
 
 // Rebuild a [`ListArray`] under the contract of [`apply_schema_to_inner`] (see that fn's doc

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -679,14 +679,14 @@ fn get_indices(
                         debug!("Inserting a row index column: {}", field.name());
                         reorder_indices.push(ReorderIndex::row_index(
                             requested_position,
-                            Arc::new(field.try_into_arrow()?),
+                            Arc::new(field.as_ref().try_into_arrow()?),
                         ));
                     }
                     Some(MetadataColumnSpec::FilePath) => {
                         debug!("Inserting a file path column: {}", field.name());
                         reorder_indices.push(ReorderIndex::file_path(
                             requested_position,
-                            Arc::new(field.try_into_arrow()?),
+                            Arc::new(field.as_ref().try_into_arrow()?),
                         ));
                     }
                     Some(metadata_spec) => {
@@ -698,7 +698,7 @@ fn get_indices(
                         debug!("Inserting missing and nullable field: {}", field.name());
                         reorder_indices.push(ReorderIndex::missing(
                             requested_position,
-                            Arc::new(field.try_into_arrow()?),
+                            Arc::new(field.as_ref().try_into_arrow()?),
                         ));
                     }
                     None => {
@@ -1467,7 +1467,7 @@ pub(crate) fn build_json_reorder_indices(schema: &StructType) -> DeltaResult<Vec
     }
 
     for (output_pos, field, spec) in metadata_entries {
-        let field = Arc::new(field.try_into_arrow()?);
+        let field = Arc::new(field.as_ref().try_into_arrow()?);
         let rindex = match spec {
             MetadataColumnSpec::FilePath => ReorderIndex::file_path(output_pos, field),
             _ => ReorderIndex::missing(output_pos, field),

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -186,7 +186,7 @@ impl SyncPlanExecutor {
             .fields()
             .filter(|f| !file_constant_columns.contains(f.name()))
             .cloned();
-        let read_schema = Arc::new(StructType::try_new(read_fields)?);
+        let read_schema = Arc::new(StructType::try_new_refs(read_fields)?);
         let output_schema: Arc<ArrowSchema> = Arc::new(schema.as_ref().try_into_arrow()?);
 
         let store = self.storage.store();

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1017,7 +1017,7 @@ impl LogSegment {
         let needs_sidecar = need_file_actions && !sidecar_files.is_empty();
         let needs_add_augmentation = has_stats_parsed || has_partition_values_parsed;
         let augmented_checkpoint_read_schema = if needs_add_augmentation || needs_sidecar {
-            let mut new_fields: Vec<StructField> = if let (true, Some(add_field)) =
+            let mut new_fields: Vec<_> = if let (true, Some(add_field)) =
                 (needs_add_augmentation, action_schema.field("add"))
             {
                 let DataType::Struct(add_struct) = add_field.data_type() else {
@@ -1025,14 +1025,15 @@ impl LogSegment {
                         "add field in action schema must be a struct",
                     ));
                 };
-                let mut add_fields: Vec<StructField> = add_struct.fields().cloned().collect();
+                let mut add_fields: Vec<_> = add_struct.fields().cloned().collect();
 
                 if let (true, Some(ss)) = (has_stats_parsed, stats_schema) {
-                    add_fields.push(StructField::nullable("stats_parsed", ss.clone()));
+                    add_fields.push(StructField::nullable("stats_parsed", ss.clone()).into());
                 }
 
                 if let (true, Some(ps)) = (has_partition_values_parsed, partition_schema) {
-                    add_fields.push(StructField::nullable("partitionValues_parsed", ps.clone()));
+                    add_fields
+                        .push(StructField::nullable("partitionValues_parsed", ps.clone()).into());
                 }
 
                 // Rebuild schema with modified add field
@@ -1042,10 +1043,11 @@ impl LogSegment {
                         if f.name() == "add" {
                             StructField::new(
                                 add_field.name(),
-                                StructType::new_unchecked(add_fields.clone()),
+                                StructType::new_unchecked_refs(add_fields.clone()),
                                 add_field.is_nullable(),
                             )
                             .with_metadata(add_field.metadata.clone())
+                            .into()
                         } else {
                             f.clone()
                         }
@@ -1057,10 +1059,10 @@ impl LogSegment {
 
             // Add sidecar column at top-level for V2 checkpoints
             if needs_sidecar {
-                new_fields.push(StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()));
+                new_fields.push(StructField::nullable(SIDECAR_NAME, Sidecar::to_schema()).into());
             }
 
-            Arc::new(StructType::new_unchecked(new_fields))
+            Arc::new(StructType::new_unchecked_refs(new_fields))
         } else {
             // No modifications needed, use schema as-is
             action_schema.clone()

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -757,14 +757,14 @@ impl AggregateBuilder {
         }
         let mut aggs = Vec::with_capacity(self.aggs.len());
         for (agg, alias) in self.aggs {
-            fields.push(agg.output_field(&self.input_schema, alias)?);
+            fields.push(agg.output_field(&self.input_schema, alias)?.into());
             aggs.push(agg);
         }
         // NOTE: `StructType::try_new` rejects duplicate (case-insensitive) output column names.
         Ok(Aggregate {
             group_by: self.group_by,
             aggs,
-            schema: Arc::new(StructType::try_new(fields)?),
+            schema: Arc::new(StructType::try_new_refs(fields)?),
         })
     }
 }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -717,7 +717,10 @@ impl From<&MapType> for proto_schema::MapType {
 impl From<&StructType> for proto_schema::StructType {
     fn from(struct_type: &StructType) -> Self {
         proto_schema::StructType {
-            fields: struct_type.fields().map(Into::into).collect(),
+            fields: struct_type
+                .fields()
+                .map(|field| field.as_ref().into())
+                .collect(),
         }
     }
 }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -74,7 +74,7 @@ pub(crate) static CHECKPOINT_READ_SCHEMA_NO_STATS: LazyLock<SchemaRef> = LazyLoc
         .filter(|f| f.name() != "stats")
         .cloned()
         .collect();
-    let add_no_stats = StructType::new_unchecked(fields_no_stats);
+    let add_no_stats = StructType::new_unchecked_refs(fields_no_stats);
     Arc::new(StructType::new_unchecked([StructField::nullable(
         ADD_NAME,
         add_no_stats,

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -389,7 +389,7 @@ impl StateInfo {
         );
         let table_partition_schema =
             if (has_predicate || partition_values.parsed_struct) && !partition_columns.is_empty() {
-                let partition_fields: Vec<StructField> = table_configuration
+                let partition_fields: Vec<_> = table_configuration
                     .logical_schema()
                     .fields()
                     .zip(table_configuration.physical_schema().fields())
@@ -399,7 +399,7 @@ impl StateInfo {
                 if partition_fields.is_empty() {
                     None
                 } else {
-                    Some(Arc::new(StructType::new_unchecked(partition_fields)))
+                    Some(Arc::new(StructType::new_unchecked_refs(partition_fields)))
                 }
             } else {
                 None

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -120,7 +120,7 @@ impl SchemaComparison for StructType {
         let lowercase_field_map: HashMap<String, &StructField> = self
             .fields
             .iter()
-            .map(|(name, field)| (name.to_lowercase(), field))
+            .map(|(name, field)| (name.to_lowercase(), field.as_ref()))
             .collect();
         require!(
             lowercase_field_map.len() == self.fields.len(),

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -497,7 +497,7 @@ fn collect_all_fields_with_paths(
         let field_id = get_field_id_for_path(field, &field_path)?;
 
         out.push(FieldWithPath {
-            field: field.clone(),
+            field: field.as_ref().clone(),
             path: field_path.clone(),
             field_id,
         });

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -44,6 +44,11 @@ pub(crate) mod void_utils;
 
 pub type Schema = StructType;
 pub type SchemaRef = Arc<StructType>;
+/// A shared reference to a [`StructField`].
+///
+/// Cloning a field reference allows the same immutable field definition to be reused across
+/// multiple [`StructType`]s without cloning the field's nested data type and metadata.
+pub type StructFieldRef = Arc<StructField>;
 
 /// Sugar for `LazyLock::new(|| `[`schema_ref!`](schema_ref)` { ... })`, yielding a lazy
 /// [`SchemaRef`].
@@ -141,18 +146,24 @@ pub(crate) use delta_kernel_derive::try_schema;
 /// Converts field interpolation inputs in [`schema!`] and [`try_schema!`] to [`StructField`].
 #[internal_api]
 pub(crate) trait ToSchemaField {
-    fn to_schema_field(self) -> StructField;
+    fn to_schema_field(self) -> StructFieldRef;
 }
 
 impl ToSchemaField for StructField {
-    fn to_schema_field(self) -> StructField {
-        self
+    fn to_schema_field(self) -> StructFieldRef {
+        self.into()
     }
 }
 
 impl ToSchemaField for &StructField {
-    fn to_schema_field(self) -> StructField {
-        self.clone()
+    fn to_schema_field(self) -> StructFieldRef {
+        self.clone().into()
+    }
+}
+
+impl ToSchemaField for StructFieldRef {
+    fn to_schema_field(self) -> StructFieldRef {
+        self
     }
 }
 
@@ -160,15 +171,15 @@ impl<T> ToSchemaField for &T
 where
     T: Deref<Target = StructField>,
 {
-    fn to_schema_field(self) -> StructField {
-        self.deref().clone()
+    fn to_schema_field(self) -> StructFieldRef {
+        self.deref().clone().into()
     }
 }
 
 /// A [`StructPatchBuilder`](crate::struct_patch::StructPatchBuilder) whose emitted items are schema
 /// fields, lowered into an output [`StructType`] directly from an input schema via
-/// [`build`](crate::struct_patch::StructPatchBuilder::<StructField>::build).
-pub type SchemaStructPatchBuilder = crate::struct_patch::StructPatchBuilder<StructField>;
+/// [`build`](crate::struct_patch::StructPatchBuilder::<StructFieldRef>::build).
+pub type SchemaStructPatchBuilder = crate::struct_patch::StructPatchBuilder<StructFieldRef>;
 
 /// Converts a type to a [`Schema`] that represents that type. Derivable for struct types using the
 /// [`delta_kernel_derive::ToSchema`] derive macro.
@@ -837,7 +848,7 @@ pub struct StructType {
     // We use indexmap to preserve the order of fields as they are defined in the schema
     // while also allowing for fast lookup by name. The alternative is to do a linear search
     // for each field by name would be potentially quite expensive for large schemas.
-    fields: IndexMap<String, StructField>,
+    fields: IndexMap<String, StructFieldRef>,
     /// The metadata columns in this struct
     // We use a dedicated map for metadata columns to allow for fast lookup without having to
     // iterate over all fields.
@@ -845,7 +856,7 @@ pub struct StructType {
 }
 
 pub struct StructTypeBuilder {
-    fields: IndexMap<String, StructField>,
+    fields: IndexMap<String, StructFieldRef>,
 }
 
 impl Default for StructTypeBuilder {
@@ -867,17 +878,18 @@ impl StructTypeBuilder {
         }
     }
 
-    pub fn add_field(mut self, field: StructField) -> Self {
+    pub fn add_field(mut self, field: impl Into<StructFieldRef>) -> Self {
+        let field = field.into();
         self.fields.insert(field.name.clone(), field);
         self
     }
 
     pub fn build(self) -> DeltaResult<StructType> {
-        StructType::try_new(self.fields.into_values())
+        StructType::try_new_refs(self.fields.into_values())
     }
 
     pub fn build_arc_unchecked(self) -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked(self.fields.into_values()))
+        Arc::new(StructType::new_unchecked_refs(self.fields.into_values()))
     }
 }
 
@@ -890,6 +902,14 @@ impl StructType {
     /// - the schema contains duplicate metadata columns
     /// - the schema contains nested metadata columns
     pub fn try_new(fields: impl IntoIterator<Item = StructField>) -> DeltaResult<Self> {
+        Self::try_new_refs(fields.into_iter().map(Into::into))
+    }
+
+    /// Creates a new [`StructType`] from shared field references.
+    ///
+    /// The field allocations are retained in the resulting struct. Validation is identical to
+    /// [`StructType::try_new`].
+    pub fn try_new_refs(fields: impl IntoIterator<Item = StructFieldRef>) -> DeltaResult<Self> {
         let mut field_map = IndexMap::new();
         let mut metadata_columns = HashMap::new();
         let mut seen_lowercase_names = HashSet::new();
@@ -953,6 +973,12 @@ impl StructType {
     /// Refer to [`StructType::try_new`] for more details on the validation checks.
     #[internal_api]
     pub(crate) fn new_unchecked(fields: impl IntoIterator<Item = StructField>) -> Self {
+        Self::new_unchecked_refs(fields.into_iter().map(Into::into))
+    }
+
+    /// Creates a new [`StructType`] from shared field references without validating them.
+    #[internal_api]
+    pub(crate) fn new_unchecked_refs(fields: impl IntoIterator<Item = StructFieldRef>) -> Self {
         let mut field_map = IndexMap::new();
         let mut metadata_columns = HashMap::new();
 
@@ -980,7 +1006,7 @@ impl StructType {
                 .cloned()
                 .ok_or_else(|| Error::missing_column(name.as_ref()))
         });
-        Self::try_from_results(fields)
+        fields.process_results(|fields| Self::try_new_refs(fields))?
     }
 
     /// Gets a [`SchemaRef`] containing [`StructField`]s of the given names. The order of fields in
@@ -993,7 +1019,12 @@ impl StructType {
 
     /// Adds fields to this [`StructType`], returning a new [`StructType`].
     pub fn add(&self, fields: impl IntoIterator<Item = StructField>) -> DeltaResult<Self> {
-        Self::try_new(self.fields.values().cloned().chain(fields))
+        self.add_refs(fields.into_iter().map(Into::into))
+    }
+
+    /// Adds shared fields to this [`StructType`], returning a new [`StructType`].
+    pub fn add_refs(&self, fields: impl IntoIterator<Item = StructFieldRef>) -> DeltaResult<Self> {
+        Self::try_new_refs(self.fields.values().cloned().chain(fields))
     }
 
     /// Adds a predefined metadata column to this [`StructType`], returning a new [`StructType`].
@@ -1026,7 +1057,7 @@ impl StructType {
     }
 
     /// Gets the field with the given name.
-    pub fn field(&self, name: impl AsRef<str>) -> Option<&StructField> {
+    pub fn field(&self, name: impl AsRef<str>) -> Option<&StructFieldRef> {
         self.fields.get(name.as_ref())
     }
 
@@ -1034,7 +1065,7 @@ impl StructType {
     ///
     /// Returns an error if the path is empty, a field is not found, or an intermediate field is not
     /// a struct type.
-    pub fn field_at<'a>(&'a self, col: &ColumnName) -> DeltaResult<&'a StructField> {
+    pub fn field_at<'a>(&'a self, col: &ColumnName) -> DeltaResult<&'a StructFieldRef> {
         let mut field = None;
         self.visit_fields_of_path(col, |f| field = Some(f))?;
         field.ok_or_else(|| Error::generic("Empty path"))
@@ -1048,7 +1079,7 @@ impl StructType {
     pub(crate) fn visit_fields_of_path<'a>(
         &'a self,
         col: &ColumnName,
-        visit_field: impl FnMut(&'a StructField),
+        visit_field: impl FnMut(&'a StructFieldRef),
     ) -> DeltaResult<()> {
         self.visit_fields_of_path_by(col, |s, name| s.field(name), visit_field)
     }
@@ -1065,7 +1096,7 @@ impl StructType {
     pub(crate) fn fields_of_path<'a>(
         &'a self,
         col: &ColumnName,
-    ) -> DeltaResult<Vec<&'a StructField>> {
+    ) -> DeltaResult<Vec<&'a StructFieldRef>> {
         let mut result = Vec::with_capacity(col.path().len());
         self.visit_fields_of_path(col, |f| result.push(f))?;
         Ok(result)
@@ -1079,10 +1110,10 @@ impl StructType {
         &'a self,
         col: &ColumnName,
         find_field: F,
-        mut visit_field: impl FnMut(&'a StructField),
+        mut visit_field: impl FnMut(&'a StructFieldRef),
     ) -> DeltaResult<()>
     where
-        F: for<'b> Fn(&'b StructType, &str) -> Option<&'b StructField>,
+        F: for<'b> Fn(&'b StructType, &str) -> Option<&'b StructFieldRef>,
     {
         let path = col.path();
         if path.is_empty() {
@@ -1110,33 +1141,33 @@ impl StructType {
     }
 
     /// Gets the field with the given name and its index.
-    pub fn field_with_index(&self, name: impl AsRef<str>) -> Option<(usize, &StructField)> {
+    pub fn field_with_index(&self, name: impl AsRef<str>) -> Option<(usize, &StructFieldRef)> {
         self.fields
             .get_full(name.as_ref())
             .map(|(index, _, field)| (index, field))
     }
 
     /// Gets the field at the given index.
-    pub fn field_at_index(&self, index: usize) -> Option<&StructField> {
+    pub fn field_at_index(&self, index: usize) -> Option<&StructFieldRef> {
         self.fields.get_index(index).map(|(_, field)| field)
     }
 
     /// Gets a reference to all the fields in this struct type.
     pub fn fields(
         &self,
-    ) -> impl ExactSizeIterator<Item = &StructField> + DoubleEndedIterator + FusedIterator {
+    ) -> impl ExactSizeIterator<Item = &StructFieldRef> + DoubleEndedIterator + FusedIterator {
         self.fields.values()
     }
 
     /// Gets an iterator over all the fields in this struct type.
     pub fn into_fields(
         self,
-    ) -> impl ExactSizeIterator<Item = StructField> + DoubleEndedIterator + FusedIterator {
+    ) -> impl ExactSizeIterator<Item = StructFieldRef> + DoubleEndedIterator + FusedIterator {
         self.fields.into_values()
     }
 
     /// Gets a mutable reference to the underlying field map.
-    pub(crate) fn field_map_mut(&mut self) -> &mut IndexMap<String, StructField> {
+    pub(crate) fn field_map_mut(&mut self) -> &mut IndexMap<String, StructFieldRef> {
         &mut self.fields
     }
 
@@ -1164,11 +1195,11 @@ impl StructType {
     /// ```
     #[cfg(any(test, feature = "test-utils"))]
     #[allow(clippy::panic, clippy::expect_used)]
-    pub fn field_at_path<'a>(&'a self, path: &[String]) -> &'a StructField {
+    pub fn field_at_path<'a>(&'a self, path: &[String]) -> &'a StructFieldRef {
         fn find_ci<'a>(
-            mut fields: impl Iterator<Item = &'a StructField>,
+            mut fields: impl Iterator<Item = &'a StructFieldRef>,
             name: &str,
-        ) -> &'a StructField {
+        ) -> &'a StructFieldRef {
             let lowered = name.to_lowercase();
             fields
                 .find(|f| f.name().to_lowercase() == lowered)
@@ -1221,14 +1252,14 @@ impl StructType {
     }
 
     /// Gets a reference to the metadata column with the given spec.
-    pub fn metadata_column(&self, spec: &MetadataColumnSpec) -> Option<&StructField> {
+    pub fn metadata_column(&self, spec: &MetadataColumnSpec) -> Option<&StructFieldRef> {
         self.metadata_columns
             .get(spec)
             .and_then(|index| self.fields.get_index(*index).map(|(_, field)| field))
     }
 
     /// Gets an iterator over all the metadata columns in this struct type.
-    pub fn metadata_columns(&self) -> impl Iterator<Item = &StructField> {
+    pub fn metadata_columns(&self) -> impl Iterator<Item = &StructFieldRef> {
         self.metadata_columns
             .values()
             .filter_map(|index| self.fields.get_index(*index).map(|(_, field)| field))
@@ -1265,7 +1296,7 @@ impl StructType {
 
     /// Validates that there are no metadata columns in the given fields.
     pub(crate) fn ensure_no_metadata_columns(
-        fields: &mut dyn Iterator<Item = &StructField>,
+        fields: &mut dyn Iterator<Item = &StructFieldRef>,
     ) -> DeltaResult<()> {
         for field in fields {
             Self::ensure_no_metadata_columns_in_field(field)?;
@@ -1315,7 +1346,7 @@ impl StructType {
         &self,
         predicate: impl Fn(&StructField) -> bool,
     ) -> DeltaResult<Self> {
-        Self::try_new(self.fields().filter(|f| predicate(f)).cloned())
+        Self::try_new_refs(self.fields().filter(|f| predicate(f)).cloned())
     }
 
     /// Returns an optional [`StructType`] containing only the top-level fields for which
@@ -1383,7 +1414,7 @@ impl Display for StructType {
 }
 
 impl IntoIterator for StructType {
-    type Item = StructField;
+    type Item = StructFieldRef;
     type IntoIter = StructFieldIntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1394,7 +1425,7 @@ impl IntoIterator for StructType {
 }
 
 impl<'a> IntoIterator for &'a StructType {
-    type Item = &'a StructField;
+    type Item = &'a StructFieldRef;
     type IntoIter = StructFieldRefIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -1404,11 +1435,11 @@ impl<'a> IntoIterator for &'a StructType {
     }
 }
 
-/// An iterator that yields owned [`StructField`]s from a [`StructType`].
+/// An iterator that yields shared [`StructFieldRef`]s from a [`StructType`].
 ///
 /// This iterator is returned by the [`IntoIterator`] implementation for [`StructType`] and
-/// consumes the original struct. It yields each field in the order they were defined in the
-/// schema, preserving the insertion order maintained by the underlying [`IndexMap`].
+/// consumes the original struct. It yields each shared field reference in schema order, preserving
+/// the insertion order maintained by the underlying [`IndexMap`].
 ///
 /// # Examples
 ///
@@ -1432,11 +1463,11 @@ impl<'a> IntoIterator for &'a StructType {
 /// [`IndexMap`]: indexmap::IndexMap
 #[derive(Debug)]
 pub struct StructFieldIntoIter {
-    inner: indexmap::map::IntoValues<String, StructField>,
+    inner: indexmap::map::IntoValues<String, StructFieldRef>,
 }
 
 impl Iterator for StructFieldIntoIter {
-    type Item = StructField;
+    type Item = StructFieldRef;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -1473,11 +1504,11 @@ impl DoubleEndedIterator for StructFieldIntoIter {
     }
 }
 
-/// An iterator that yields references to [`StructField`]s from a [`StructType`].
+/// An iterator that yields references to [`StructFieldRef`]s from a [`StructType`].
 ///
 /// This iterator is returned by the [`IntoIterator`] implementation for `&StructType` and by
 /// the [`StructType::fields()`] method. Unlike [`StructFieldIntoIter`], this iterator does not
-/// consume the original struct and yields references to the fields. It preserves the insertion
+/// consume the original struct and yields borrowed shared references. It preserves the insertion
 /// order maintained by the underlying [`IndexMap`].
 ///
 /// This iterator implements [`Clone`], allowing you to create multiple independent iterators
@@ -1514,11 +1545,11 @@ impl DoubleEndedIterator for StructFieldIntoIter {
 /// [`IndexMap`]: indexmap::IndexMap
 #[derive(Debug, Clone)]
 pub struct StructFieldRefIter<'a> {
-    inner: indexmap::map::Values<'a, String, StructField>,
+    inner: indexmap::map::Values<'a, String, StructFieldRef>,
 }
 
 impl<'a> Iterator for StructFieldRefIter<'a> {
-    type Item = &'a StructField;
+    type Item = &'a StructFieldRef;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
@@ -1685,7 +1716,7 @@ impl From<(Vec<ColumnName>, Vec<DataType>)> for ColumnNamesAndTypes {
 struct StructTypeSerDeHelper {
     #[serde(rename = "type")]
     type_name: String,
-    fields: Vec<StructField>,
+    fields: Vec<StructFieldRef>,
 }
 
 impl Serialize for StructType {
@@ -1708,7 +1739,7 @@ impl<'de> Deserialize<'de> for StructType {
         Self: Sized,
     {
         let helper = StructTypeSerDeHelper::deserialize(deserializer)?;
-        StructType::try_new(helper.fields).map_err(serde::de::Error::custom)
+        StructType::try_new_refs(helper.fields).map_err(serde::de::Error::custom)
     }
 }
 
@@ -2412,6 +2443,13 @@ impl DataType {
         Ok(StructType::try_new(fields)?.into())
     }
 
+    /// Create a new struct type with the given shared fields.
+    pub fn try_struct_type_refs(
+        fields: impl IntoIterator<Item = StructFieldRef>,
+    ) -> DeltaResult<Self> {
+        Ok(StructType::try_new_refs(fields)?.into())
+    }
+
     /// Create a new struct type from a fallible iterator of fields.
     pub fn try_struct_type_from_results<E: Into<Error>>(
         fields: impl IntoIterator<Item = Result<StructField, E>>,
@@ -2436,10 +2474,18 @@ impl DataType {
     /// Create a new [`DataType::Variant`] from the provided fields. For unshredded variants, you
     /// should prefer using [`DataType::unshredded_variant`].
     pub fn variant_type(fields: impl IntoIterator<Item = StructField>) -> DeltaResult<Self> {
+        Self::variant_type_refs(fields.into_iter().map(Into::into))
+    }
+
+    /// Create a new [`DataType::Variant`] from shared fields.
+    pub fn variant_type_refs(
+        fields: impl IntoIterator<Item = StructFieldRef>,
+    ) -> DeltaResult<Self> {
         // Different from regular StructTypes, Variants are not allowed to contain metadata columns
         // at all, so we also need to check their top-level primitive types.
-        Ok(DataType::Variant(Box::new(StructType::try_from_results(
-            fields.into_iter().map(|field| {
+        let fields = fields
+            .into_iter()
+            .map(|field| {
                 if field.is_metadata_column() {
                     Err(Error::schema(
                         "Metadata columns are not allowed in Variant types".to_string(),
@@ -2447,7 +2493,10 @@ impl DataType {
                 } else {
                     Ok(field)
                 }
-            }),
+            })
+            .collect::<DeltaResult<Vec<_>>>()?;
+        Ok(DataType::Variant(Box::new(StructType::try_new_refs(
+            fields,
         )?)))
     }
 
@@ -3780,7 +3829,7 @@ mod tests {
         // Test owned iteration (consumes the struct)
         let mut field_names = Vec::new();
         for field in struct_type {
-            field_names.push(field.name);
+            field_names.push(field.name().to_string());
         }
         assert_eq!(field_names, vec!["a", "b"]);
     }
@@ -3884,7 +3933,10 @@ mod tests {
         assert_eq!(ref_names, vec!["zebra", "apple", "banana"]);
 
         // Test consuming iterator maintains order too
-        let owned_names: Vec<_> = struct_type.into_iter().map(|f| f.name).collect();
+        let owned_names: Vec<_> = struct_type
+            .into_iter()
+            .map(|field| field.name().to_string())
+            .collect();
         assert_eq!(owned_names, vec!["zebra", "apple", "banana"]);
     }
 
@@ -3897,16 +3949,16 @@ mod tests {
         let struct_type = StructType::new_unchecked(original_fields.clone());
 
         // Test collecting from reference iterator
-        let collected_refs: Vec<&StructField> = struct_type.fields().collect();
+        let collected_refs: Vec<&StructFieldRef> = struct_type.fields().collect();
         assert_eq!(collected_refs.len(), 2);
         assert_eq!(collected_refs[0].name, "field1");
         assert_eq!(collected_refs[1].name, "field2");
 
         // Test collecting from consuming iterator
-        let collected_owned: Vec<StructField> = struct_type.into_iter().collect();
-        assert_eq!(collected_owned.len(), 2);
-        assert_eq!(collected_owned[0].name, "field1");
-        assert_eq!(collected_owned[1].name, "field2");
+        let collected_refs: Vec<StructFieldRef> = struct_type.into_iter().collect();
+        assert_eq!(collected_refs.len(), 2);
+        assert_eq!(collected_refs[0].name, "field1");
+        assert_eq!(collected_refs[1].name, "field2");
     }
 
     #[test]
@@ -4299,7 +4351,7 @@ mod tests {
             type_name: "struct".into(),
             fields: [(
                 nested_field_with_metadata.name.clone(),
-                nested_field_with_metadata,
+                nested_field_with_metadata.into(),
             )]
             .into_iter()
             .collect(),
@@ -4324,7 +4376,7 @@ mod tests {
             type_name: "struct".into(),
             fields: [(
                 nested_field_with_metadata.name.clone(),
-                nested_field_with_metadata,
+                nested_field_with_metadata.into(),
             )]
             .into_iter()
             .collect(),
@@ -4350,7 +4402,7 @@ mod tests {
             type_name: "struct".into(),
             fields: [(
                 nested_field_with_metadata.name.clone(),
-                nested_field_with_metadata,
+                nested_field_with_metadata.into(),
             )]
             .into_iter()
             .collect(),
@@ -4631,6 +4683,23 @@ mod tests {
         assert_eq!(extended_schema.num_fields(), 2);
         assert_eq!(extended_schema.field_at_index(0).unwrap().name(), "id");
         assert_eq!(extended_schema.field_at_index(1).unwrap().name(), "name");
+    }
+
+    #[test]
+    fn struct_field_refs_are_reused_across_schemas_and_projections() {
+        let shared: StructFieldRef = StructField::nullable("id", DataType::INTEGER).into();
+        let first = StructType::try_new_refs([shared.clone()]).unwrap();
+        let second = StructType::try_new_refs([shared.clone()]).unwrap();
+        let projected = first.project_as_struct(&["id"]).unwrap();
+        let extended = StructTypeBuilder::from_schema(&first)
+            .add_field(StructField::nullable("name", DataType::STRING))
+            .build()
+            .unwrap();
+
+        assert!(Arc::ptr_eq(first.field("id").unwrap(), &shared));
+        assert!(Arc::ptr_eq(second.field("id").unwrap(), &shared));
+        assert!(Arc::ptr_eq(projected.field("id").unwrap(), &shared));
+        assert!(Arc::ptr_eq(extended.field("id").unwrap(), &shared));
     }
 
     #[test]

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 use crate::expressions::{ColumnName, Expression, ExpressionRef};
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{DataType, SchemaRef, StructField, StructFieldRef, StructType};
 use crate::utils::{CollectInto, FoldWithOption as _};
 use crate::{DeltaResult, Error};
 
@@ -553,7 +553,7 @@ impl<Item: ExpressionItem> FieldPatchNode<Item> {
 
 // === Schema lowering ===
 
-impl StructPatchBuilder<StructField> {
+impl StructPatchBuilder<StructFieldRef> {
     /// Builds the output struct schema for this patch over `input_schema`.
     ///
     /// If this builder targets a nested path (via [`new_nested`](Self::new_nested)), the returned
@@ -567,16 +567,16 @@ impl StructPatchBuilder<StructField> {
     /// field patch targets a non-struct field, or the resulting output schema is invalid.
     pub fn build(self, input_schema: &StructType) -> DeltaResult<StructType> {
         let (root, _input_path, source_schema) = self.begin_build(input_schema)?;
-        StructType::try_new(schema_walk(root, source_schema)?)
+        StructType::try_new_refs(schema_walk(root, source_schema)?)
     }
 }
 
-type ProjectionItem = (StructField, ExpressionRef);
+type ProjectionItem = (StructFieldRef, ExpressionRef);
 
 trait SchemaPatchItem {
-    fn into_field(self) -> StructField;
+    fn into_field(self) -> StructFieldRef;
 
-    fn into_fields(items: Vec<Self>) -> impl Iterator<Item = StructField>
+    fn into_fields(items: Vec<Self>) -> impl Iterator<Item = StructFieldRef>
     where
         Self: Sized,
     {
@@ -584,14 +584,14 @@ trait SchemaPatchItem {
     }
 }
 
-impl SchemaPatchItem for StructField {
-    fn into_field(self) -> StructField {
+impl SchemaPatchItem for StructFieldRef {
+    fn into_field(self) -> StructFieldRef {
         self
     }
 }
 
 impl SchemaPatchItem for ProjectionItem {
-    fn into_field(self) -> StructField {
+    fn into_field(self) -> StructFieldRef {
         self.0
     }
 }
@@ -599,7 +599,7 @@ impl SchemaPatchItem for ProjectionItem {
 fn schema_walk<Item: SchemaPatchItem>(
     node: StructPatchNode<Item>,
     input_schema: &StructType,
-) -> DeltaResult<Vec<StructField>> {
+) -> DeltaResult<Vec<StructFieldRef>> {
     let mut fields = node.fields;
     let mut output: Vec<_> = Item::into_fields(node.prepended_fields).collect();
     output.reserve(input_schema.num_fields() + fields.len());
@@ -621,10 +621,10 @@ fn schema_walk<Item: SchemaPatchItem>(
                 let children = schema_walk(*node, nested_schema)?;
                 let field = StructField::new(
                     input_field.name(),
-                    StructType::try_new(children)?,
+                    StructType::try_new_refs(children)?,
                     input_field.nullable,
                 );
-                output.push(field.with_metadata(input_field.metadata.clone()));
+                output.push(field.with_metadata(input_field.metadata.clone()).into());
             }
         }
         output.extend(Item::into_fields(field_patch.insert_after));
@@ -664,7 +664,7 @@ pub struct ProjectionStructPatchBuilder<'a> {
 /// precedes the emitted item in the inner call, matching the inner builder's signatures.
 macro_rules! delegate {
     ($self:ident, $method:ident, $field:expr, $expr:expr $(, $arg:expr)*) => {{
-        $self.inner = $self.inner.$method($($arg,)* ($field, $expr.into()));
+        $self.inner = $self.inner.$method($($arg,)* (($field).into(), $expr.into()));
         $self
     }};
 }
@@ -674,7 +674,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
         &self,
         struct_path: &ColumnName,
         field_name: &str,
-    ) -> DeltaResult<StructField> {
+    ) -> DeltaResult<StructFieldRef> {
         let field_path: ColumnName = [
             self.inner.input_path.clone().unwrap_or_default(),
             struct_path.clone(),
@@ -744,7 +744,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     pub fn replace(
         mut self,
         field_name: impl Into<String>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, replace, field, expr, field_name)
@@ -755,7 +755,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
         mut self,
         struct_path: impl CollectInto<ColumnName>,
         field_name: impl Into<String>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, replace_at, field, expr, struct_path, field_name)
@@ -796,7 +796,11 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     }
 
     /// Emits `field`, produced by `expr`, before all input fields.
-    pub fn prepend(mut self, field: StructField, expr: impl Into<ExpressionRef>) -> Self {
+    pub fn prepend(
+        mut self,
+        field: impl Into<StructFieldRef>,
+        expr: impl Into<ExpressionRef>,
+    ) -> Self {
         delegate!(self, prepend, field, expr)
     }
 
@@ -804,7 +808,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     pub fn prepend_at(
         mut self,
         struct_path: impl CollectInto<ColumnName>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, prepend_at, field, expr, struct_path)
@@ -814,7 +818,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     pub fn insert_after(
         mut self,
         field_name: impl Into<String>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, insert_after, field, expr, field_name)
@@ -825,14 +829,18 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
         mut self,
         struct_path: impl CollectInto<ColumnName>,
         field_name: impl Into<String>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, insert_after_at, field, expr, struct_path, field_name)
     }
 
     /// Emits `field`, produced by `expr`, after all input fields and field-specific insertions.
-    pub fn append(mut self, field: StructField, expr: impl Into<ExpressionRef>) -> Self {
+    pub fn append(
+        mut self,
+        field: impl Into<StructFieldRef>,
+        expr: impl Into<ExpressionRef>,
+    ) -> Self {
         delegate!(self, append, field, expr)
     }
 
@@ -840,7 +848,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     pub fn append_at(
         mut self,
         struct_path: impl CollectInto<ColumnName>,
-        field: StructField,
+        field: impl Into<StructFieldRef>,
         expr: impl Into<ExpressionRef>,
     ) -> Self {
         delegate!(self, append_at, field, expr, struct_path)
@@ -865,7 +873,7 @@ impl<'a> ProjectionStructPatchBuilder<'a> {
     pub fn build(self) -> DeltaResult<(SchemaRef, ExpressionRef)> {
         let (root, input_path, source_schema) = self.inner.begin_build(self.input_schema)?;
         let patch = root.to_expr_patch(input_path);
-        let schema = StructType::try_new(schema_walk(root, source_schema)?)?;
+        let schema = StructType::try_new_refs(schema_walk(root, source_schema)?)?;
         Ok((Arc::new(schema), Arc::new(Expression::StructPatch(patch))))
     }
 }
@@ -1004,7 +1012,12 @@ mod tests {
     #[case::optional_missing_drop(SchemaStructPatchBuilder::new().drop_if_exists("missing"))]
     fn schema_build_preserves_input_schema(#[case] builder: SchemaStructPatchBuilder) {
         let input_schema = schema(&["a", "b"]);
-        assert_eq!(builder.build(&input_schema).unwrap(), input_schema);
+        let output_schema = builder.build(&input_schema).unwrap();
+        assert_eq!(output_schema, input_schema);
+        assert!(input_schema
+            .fields()
+            .zip(output_schema.fields())
+            .all(|(input, output)| Arc::ptr_eq(input, output)));
     }
 
     // Patches that reorder/insert/replace/drop fields, asserted by the resulting field order.
@@ -1074,6 +1087,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(field_names(&output_schema), ["nested", "top"]);
+        assert!(!Arc::ptr_eq(
+            input_schema.field("nested").unwrap(),
+            output_schema.field("nested").unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            input_schema.field("top").unwrap(),
+            output_schema.field("top").unwrap()
+        ));
         let DataType::Struct(nested) = output_schema.field("nested").unwrap().data_type() else {
             panic!("Expected nested struct field");
         };
@@ -1081,6 +1102,18 @@ mod tests {
             field_names(nested),
             ["nested_a", "nested_inserted", "nested_b"]
         );
+        let DataType::Struct(input_nested) = input_schema.field("nested").unwrap().data_type()
+        else {
+            panic!("Expected nested struct field");
+        };
+        assert!(Arc::ptr_eq(
+            input_nested.field("nested_a").unwrap(),
+            nested.field("nested_a").unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            input_nested.field("nested_b").unwrap(),
+            nested.field("nested_b").unwrap()
+        ));
     }
 
     #[rstest]

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -382,12 +382,12 @@ impl TableChanges {
             return Err(mode.boundary_schema_error(start_schema.as_ref(), end_schema.as_ref()));
         }
 
-        let schema = StructType::try_new(
+        let schema = StructType::try_new_refs(
             end_snapshot
                 .schema()
                 .fields()
                 .cloned()
-                .chain(CDF_FIELDS.clone()),
+                .chain(CDF_FIELDS.iter().cloned().map(Into::into)),
         )?;
 
         Ok(TableChanges {
@@ -637,7 +637,13 @@ mod tests {
 
         let table_changes =
             TableChanges::try_new(url.clone(), engine.as_ref(), 0, 0.into()).unwrap();
-        assert_equal(expected_schema, table_changes.schema().fields().cloned());
+        assert_equal(
+            expected_schema,
+            table_changes
+                .schema()
+                .fields()
+                .map(|field| field.as_ref().clone()),
+        );
     }
 
     #[test]

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -62,10 +62,13 @@ pub(crate) fn scan_file_physical_schema(
 ) -> SchemaRef {
     if scan_file.scan_type == CdfScanFileType::Cdc {
         let change_type = StructField::not_null(CHANGE_TYPE_COL_NAME, DataType::STRING);
-        let fields = physical_schema.fields().cloned().chain(Some(change_type));
+        let fields = physical_schema
+            .fields()
+            .cloned()
+            .chain(Some(change_type.into()));
         // NOTE: We don't validate the fields again because CHANGE_TYPE_COL_NAME should never be
         // used anywhere else
-        StructType::new_unchecked(fields).into()
+        StructType::new_unchecked_refs(fields).into()
     } else {
         physical_schema.clone().into()
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -190,7 +190,7 @@ impl TableConfiguration {
                 })
                 .map(|(_, physical_field)| physical_field.clone());
             // Safety: subset of an already-valid schema.
-            Arc::new(StructType::new_unchecked(fields))
+            Arc::new(StructType::new_unchecked_refs(fields))
         };
         let logical_schema_without_partition_columns = {
             let fields = logical_schema
@@ -198,7 +198,7 @@ impl TableConfiguration {
                 .filter(|field| !partition_columns.contains(field.name().as_str()))
                 .cloned();
             // Safety: subset of an already-valid schema.
-            Arc::new(StructType::new_unchecked(fields))
+            Arc::new(StructType::new_unchecked_refs(fields))
         };
 
         let table_config = Self {
@@ -386,7 +386,7 @@ impl TableConfiguration {
                 }
                 field
             })
-            .map(|field: &StructField| {
+            .map(|field| {
                 StructField::new(
                     field.physical_name(column_mapping_mode).to_owned(),
                     field.data_type().clone(),

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -652,7 +652,7 @@ fn assign_nested_cm_ids(schema: &StructType, max_id: &mut i64) -> DeltaResult<St
             let physical = expect_physical_name(field)?;
             let mut nested_ids = NestedFieldIds::new();
             let new_dt = walk(&field.data_type, max_id, &physical, &mut nested_ids)?;
-            let mut new_field = field.clone();
+            let mut new_field = field.as_ref().clone();
             new_field.data_type = new_dt;
             if !nested_ids.is_empty() {
                 insert_nested_field_ids_metadata(&mut new_field, nested_ids);

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -1841,7 +1841,10 @@ mod tests {
         let complex = StripFieldMetadataTransform
             .transform_struct(&with_metadata)
             .into_owned();
-        let mut fields: Vec<StructField> = complex.fields().cloned().collect();
+        let mut fields: Vec<StructField> = complex
+            .fields()
+            .map(|field| field.as_ref().clone())
+            .collect();
         fields.push(StructField::nullable("region", DataType::STRING));
         Arc::new(StructType::try_new(fields).unwrap())
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1310,8 +1310,9 @@ impl<S> Transaction<S> {
                 let commit_versions_array =
                     ArrayData::try_new(ArrayType::new(DataType::LONG, true), commit_versions)?;
 
-                let row_tracking_schema =
-                    with_row_tracking_cols(&Arc::new(StructType::new_unchecked(vec![])))?;
+                let row_tracking_schema = with_row_tracking_cols(&Arc::new(
+                    StructType::new_unchecked(Vec::<StructField>::new()),
+                ))?;
                 add_files_batch.append_columns(
                     row_tracking_schema,
                     vec![base_row_ids_array, commit_versions_array],
@@ -2002,7 +2003,10 @@ mod tests {
             ]
         };
         assert_eq!(field_names, expected_field_names);
-        assert_eq!(schema.field("dataChange"), Some(&*DATA_CHANGE_COLUMN));
+        assert_eq!(
+            schema.field("dataChange").map(AsRef::as_ref),
+            Some(&*DATA_CHANGE_COLUMN)
+        );
         assert_eq!(
             schema.field("stats").unwrap().data_type(),
             &DataType::STRING
@@ -2065,7 +2069,7 @@ mod tests {
             .effective_table_config
             .logical_schema()
             .fields()
-            .cloned()
+            .map(|field| field.as_ref().clone())
             .collect();
         evolved_fields.push(StructField::nullable("fresh_column", DataType::INTEGER));
         let evolved_schema = Arc::new(StructType::new_unchecked(evolved_fields));

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -4,13 +4,14 @@
 //! that validates and applies schema changes to produce an evolved schema.
 
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{DataType, SchemaRef, StructField, StructFieldRef, StructType};
 use crate::table_features::{
     find_max_column_id_in_schema, try_assign_flat_column_mapping_info, validate_column_mapping_id,
     ColumnMappingMode,
@@ -48,7 +49,7 @@ pub(crate) enum SchemaOperation {
 // yields:
 //   [ id: int not null, address: struct { city: string, zip: string } ]
 fn modify_field_at_path(
-    fields: &mut IndexMap<String, StructField>,
+    fields: &mut IndexMap<String, StructFieldRef>,
     path: &[String],
     modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
 ) -> DeltaResult<()> {
@@ -67,6 +68,7 @@ fn modify_field_at_path(
         let (_, field) = fields
             .get_index_mut(idx)
             .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
+        let field = Arc::make_mut(field);
         let DataType::Struct(inner) = &mut field.data_type else {
             return Err(Error::generic(format!(
                 "intermediate field '{first}' is not a struct"
@@ -79,7 +81,7 @@ fn modify_field_at_path(
     let (_, field) = fields
         .get_index_mut(idx)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    modifier(field)
+    modifier(Arc::make_mut(field))
 }
 
 /// The result of applying schema operations.
@@ -185,7 +187,9 @@ pub(crate) fn apply_schema_operations(
                     // evolved schema.
                     field
                 };
-                schema.field_map_mut().insert(field.name().clone(), field);
+                schema
+                    .field_map_mut()
+                    .insert(field.name().clone(), field.into());
             }
             SchemaOperation::SetNullable { column } => {
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
@@ -276,9 +280,9 @@ mod tests {
 
     // === modify_field_at_path tests ===
 
-    // Convert a StructType into the IndexMap<String, StructField> shape that
+    // Convert a StructType into the IndexMap<String, StructFieldRef> shape that
     // `modify_field_at_path` operates on.
-    fn into_field_map(schema: StructType) -> IndexMap<String, StructField> {
+    fn into_field_map(schema: StructType) -> IndexMap<String, StructFieldRef> {
         schema
             .into_fields()
             .map(|f| (f.name().clone(), f))
@@ -293,7 +297,7 @@ mod tests {
     fn modify_field_at_path_test_helper(
         schema: StructType,
         path: &[String],
-    ) -> DeltaResult<IndexMap<String, StructField>> {
+    ) -> DeltaResult<IndexMap<String, StructFieldRef>> {
         let mut fields = into_field_map(schema);
         modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
         Ok(fields)
@@ -429,6 +433,32 @@ mod tests {
         }];
         let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         assert!(result.schema.field_at_path(column.path()).is_nullable());
+    }
+
+    #[test]
+    fn set_nullable_clones_only_the_modified_field() {
+        let schema = simple_schema();
+        let original = schema.clone();
+        let result = apply_schema_operations(
+            schema,
+            vec![SchemaOperation::SetNullable {
+                column: column_name!("id"),
+            }],
+            ColumnMappingMode::None,
+            None,
+        )
+        .unwrap();
+
+        assert!(!Arc::ptr_eq(
+            original.field("id").unwrap(),
+            result.schema.field("id").unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            original.field("name").unwrap(),
+            result.schema.field("name").unwrap()
+        ));
+        assert!(!original.field("id").unwrap().is_nullable());
+        assert!(result.schema.field("id").unwrap().is_nullable());
     }
 
     #[rstest]

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -381,13 +381,14 @@ static NEW_STATS_NAME: &str = "newStats";
 /// This is an intermediate schema used during deletion vector updates before transforming to final
 /// add actions.
 static INTERMEDIATE_DV_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked(
+    Arc::new(StructType::new_unchecked_refs(
         scan_row_schema().fields().cloned().chain([
             StructField::nullable(
                 NEW_DELETION_VECTOR_NAME.to_string(),
                 DeletionVectorDescriptor::to_schema(),
-            ),
-            StructField::nullable(NEW_STATS_NAME.to_string(), DataType::STRING),
+            )
+            .into(),
+            StructField::nullable(NEW_STATS_NAME.to_string(), DataType::STRING).into(),
         ]),
     ))
 });
@@ -628,6 +629,7 @@ impl FilteredRowVisitor for DvMatchVisitor<'_> {
         static DV_SCHEMA_FIELDS: LazyLock<Vec<StructField>> = LazyLock::new(|| {
             DeletionVectorDescriptor::to_schema()
                 .into_fields()
+                .map(|field| field.as_ref().clone())
                 .collect()
         });
         let num_rows = rows.num_rows();

--- a/kernel/src/transforms/mod.rs
+++ b/kernel/src/transforms/mod.rs
@@ -1,5 +1,8 @@
 //! Shared transform infrastructure.
 use std::borrow::{Cow, ToOwned};
+use std::sync::Arc;
+
+use crate::schema::{StructField, StructFieldRef, StructType};
 
 mod carrier;
 mod expression;
@@ -96,6 +99,44 @@ where
     if num_borrowed < num_children {
         let owned = new_children.into_iter().map(Cow::into_owned).collect();
         Carrier::from_inner(Cow::Owned(map_owned(owned)))
+    } else {
+        Carrier::from_inner(Cow::Borrowed(parent))
+    }
+}
+
+/// Rebuilds a struct from transformed fields while retaining shared references for unchanged
+/// fields.
+pub(crate) fn map_struct_field_children<'a, ChildCarrier, ParentCarrier, R>(
+    parent: &'a StructType,
+    children: impl ExactSizeIterator<Item = (&'a StructFieldRef, ChildCarrier)>,
+) -> ParentCarrier
+where
+    ChildCarrier: Carrier<'a, StructField, Residual = R>,
+    ParentCarrier: Carrier<'a, StructType, Residual = R>,
+{
+    let num_children = children.len();
+    let mut num_borrowed = 0;
+    let mut new_children = Vec::with_capacity(num_children);
+
+    for (original, child) in children {
+        if let Some(transformed) = carrier_into_inner_opt!(child) {
+            let field = match transformed {
+                Cow::Borrowed(_) => {
+                    num_borrowed += 1;
+                    original.clone()
+                }
+                Cow::Owned(field) => Arc::new(field),
+            };
+            new_children.push(field);
+        }
+    }
+
+    if new_children.is_empty() {
+        carrier_try_none!();
+    }
+
+    if num_borrowed < num_children {
+        Carrier::from_inner(Cow::Owned(StructType::new_unchecked_refs(new_children)))
     } else {
         Carrier::from_inner(Cow::Borrowed(parent))
     }

--- a/kernel/src/transforms/schema.rs
+++ b/kernel/src/transforms/schema.rs
@@ -2,7 +2,7 @@ use std::borrow::{Cow, ToOwned};
 
 use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructField, StructType};
 use crate::transforms::{
-    map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, transform_output_type,
+    map_owned_or_else, map_owned_pair_or_else, map_struct_field_children, transform_output_type,
     Carrier,
 };
 
@@ -165,8 +165,10 @@ pub trait SchemaTransform<'a> {
 
     /// Recursively transforms a struct's fields (variadic).
     fn recurse_into_struct(&mut self, stype: &'a StructType) -> Self::Output<StructType> {
-        let children = stype.fields().map(|f| self.transform_struct_field(f));
-        map_owned_children_or_else(stype, children, StructType::new_unchecked)
+        let children = stype
+            .fields()
+            .map(|field| (field, self.transform_struct_field(field)));
+        map_struct_field_children(stype, children)
     }
 
     /// Recursively transforms an array's element type (unary).
@@ -260,6 +262,9 @@ impl<'a> SchemaTransform<'a> for SchemaDepthChecker {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+
     use super::*;
     use crate::schema::{DataType, StructField};
 
@@ -349,5 +354,40 @@ mod tests {
         // Depth limit not hit (full traversal required)
         assert_eq!(check_with_call_count(7), (7, 32));
         assert_eq!(check_with_call_count(8), (7, 32));
+    }
+
+    #[test]
+    fn schema_transform_reuses_unchanged_field_refs() {
+        struct MakeIdNullable;
+
+        impl<'a> SchemaTransform<'a> for MakeIdNullable {
+            transform_output_type!(|'a, T| Cow<'a, T>);
+
+            fn transform_struct_field(&mut self, field: &'a StructField) -> Cow<'a, StructField> {
+                if field.name() == "id" {
+                    let mut field = field.clone();
+                    field.nullable = true;
+                    Cow::Owned(field)
+                } else {
+                    self.recurse_into_struct_field(field)
+                }
+            }
+        }
+
+        let input = StructType::try_new([
+            StructField::not_null("id", DataType::LONG),
+            StructField::nullable("name", DataType::STRING),
+        ])
+        .unwrap();
+        let output = MakeIdNullable.transform_struct(&input).into_owned();
+
+        assert!(!Arc::ptr_eq(
+            input.field("id").unwrap(),
+            output.field("id").unwrap()
+        ));
+        assert!(Arc::ptr_eq(
+            input.field("name").unwrap(),
+            output.field("name").unwrap()
+        ));
     }
 }

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -424,7 +424,7 @@ fn build_data_batch(random_seed: i32) -> RecordBatch {
     let rows = ROWS_PER_PARTITION as usize;
 
     // Data schema excludes the `region` partition column.
-    let data_schema = StructType::try_new(
+    let data_schema = StructType::try_new_refs(
         nested_schema_with_all_delta_types()
             .fields()
             .filter(|f| f.name() != "region")

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -467,7 +467,7 @@ fn read_table_data(
         let selected_fields = select_cols
             .iter()
             .map(|col| table_schema.field(col).cloned().unwrap());
-        Arc::new(Schema::new_unchecked(selected_fields))
+        Arc::new(Schema::new_unchecked_refs(selected_fields))
     });
     println!("Read {url:?} with schema {read_schema:#?} and predicate {predicate:#?}");
     let scan = snapshot

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -503,15 +503,21 @@ async fn test_read_and_append_tolerates_stale_column_mapping_when_disabled(
         nullable "id": INTEGER,
         nullable "value": INTEGER
     };
-    let stale_schema = StructType::try_new([
+    let stale_schema = StructType::try_new_refs([
         stale_schema.field("id").unwrap().clone(),
-        stale_schema.field("value").unwrap().clone().add_metadata([
-            ("delta.columnMapping.id", MetadataValue::Number(2)),
-            (
-                "delta.columnMapping.physicalName",
-                MetadataValue::String("col-2f8a".to_string()),
-            ),
-        ]),
+        stale_schema
+            .field("value")
+            .unwrap()
+            .as_ref()
+            .clone()
+            .add_metadata([
+                ("delta.columnMapping.id", MetadataValue::Number(2)),
+                (
+                    "delta.columnMapping.physicalName",
+                    MetadataValue::String("col-2f8a".to_string()),
+                ),
+            ])
+            .into(),
     ])?;
     let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?)?;
     // Create a v0 commit directly to bypass create_table validation (which would reject the

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -678,7 +678,7 @@ async fn setup_and_write(
         .zip(arrow_columns)
         .filter(|(f, _)| !partition_cols.contains(&f.name().as_str()))
         .unzip();
-    let kernel_data_schema = StructType::try_new(data_fields)?;
+    let kernel_data_schema = StructType::try_new_refs(data_fields)?;
     let arrow_data_schema: Arc<ArrowSchema> = Arc::new((&kernel_data_schema).try_into_arrow()?);
     let snapshot = create_partitioned_table(
         &table_path,

--- a/test-utils/src/engine_contract.rs
+++ b/test-utils/src/engine_contract.rs
@@ -149,6 +149,7 @@ fn validate_checkpoint_schema(schema: &SchemaRef) {
             .fields()
             .find(|f| f.name() == name)
             .unwrap_or_else(|| panic!("Field '{name}' not found"))
+            .as_ref()
             .clone()
     }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -800,11 +800,11 @@ pub fn schema_with_column_defaults(
     let augmented_fields: Vec<_> = schema
         .fields()
         .map(|field| match column_defaults.remove(field.name.as_str()) {
-            Some(sql) => field.clone().add_metadata([(
+            Some(sql) => field.as_ref().clone().add_metadata([(
                 ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
                 MetadataValue::String(sql.to_string()),
             )]),
-            None => field.clone(),
+            None => field.as_ref().clone(),
         })
         .collect();
     if !column_defaults.is_empty() {
@@ -1195,6 +1195,7 @@ pub fn resolve_field<'a>(
     }
     current
         .field(last.as_ref())
+        .map(AsRef::as_ref)
         .ok_or_else(|| format!("schema missing field '{display}'"))
 }
 


### PR DESCRIPTION
## Summary

- Store `StructType` fields as `Arc<StructField>` so schemas can reuse field definitions.
- Intern structurally equivalent fields through a global weak cache during schema construction.
- Preserve sharing through schema construction, transforms, patches, projections, evolution, Arrow conversion, and FFI consumers.
- Add concurrent-query allocation instrumentation through 256 concurrent queries.

## Validation

- `cargo check --workspace --all-features`
- `cargo clippy -p delta_kernel --lib --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo +nightly fmt`

## Peak additional live allocations

| Concurrent queries | Without Arc | With Arc | Difference | Percent |
|---:|---:|---:|---:|---:|
| 1 | 2,769 KiB | 2,757 KiB | -12 KiB | -0.43% |
| 2 | 5,455 KiB | 5,490 KiB | +35 KiB | +0.64% |
| 4 | 10,234 KiB | 10,291 KiB | +57 KiB | +0.56% |
| 8 | 20,356 KiB | 20,149 KiB | -207 KiB | -1.02% |
| 16 | 37,473 KiB | 37,705 KiB | +232 KiB | +0.62% |
| 32 | 62,126 KiB | 62,370 KiB | +244 KiB | +0.39% |
| 64 | 111,100 KiB | 113,164 KiB | +2,064 KiB | +1.86% |
| 128 | 190,988 KiB | 183,738 KiB | -7,250 KiB | -3.80% |
| 256 | 347,604 KiB | 338,697 KiB | -8,907 KiB | -2.56% |

Percent is calculated relative to the non-Arc baseline. Values are peak additional live heap allocations during concurrent metadata scans.

## Global StructField cache experiment

| Concurrent queries | Arc without cache | Arc with cache | Change |
|---:|---:|---:|---:|
| 8 | 20,149 KiB | 18,774 KiB | -6.8% |
| 256 | 338,697 KiB | 315,692 KiB | -6.8% |

The cache uses weak references, so it does not keep otherwise-unused fields alive.