### PR TITLE
fix: three plan/executor improvements

### DIFF
--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1377,6 +1377,14 @@ fn cast_array_to_type(
         ArrowDataType::Struct(target_fields) => {
             let s = array.as_struct();
             let nulls = s.nulls().cloned();
+            require!(
+                s.columns().len() == target_fields.len(),
+                Error::generic(format!(
+                    "cannot cast struct with {} children to target with {} fields",
+                    s.columns().len(),
+                    target_fields.len()
+                ))
+            );
             let new_children = s
                 .columns()
                 .iter()

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1358,9 +1358,11 @@ pub(crate) fn coerce_columns_to_schema(
 
 /// Casts one Arrow [`Array`] of any type to `target`.
 ///
-/// `Struct` is handled here rather than by [`cast_with_options`] so the parent null buffer survives
-/// the rebuild. Everything else, `Map` and `List` included, goes to [`cast_with_options`], which
-/// rebuilds the container using the field names in `target`.
+/// A struct tracks which of its rows are null separately from its children, so casting a child
+/// means rebuilding the struct around it. This recurses into `Struct` by hand, carrying that
+/// row-level null information onto the rebuilt struct: given a struct column whose row 0 is null,
+/// row 0 is still null after the cast. Everything else, `Map` and `List` included, goes to
+/// [`cast_with_options`], which rebuilds the container using the field names in `target`.
 ///
 /// `opts` decides what a failed leaf cast does: `safe: true` nulls the cell, strict errors.
 fn cast_array_to_type(
@@ -4362,12 +4364,15 @@ mod tests {
 
     // === coerce_columns_to_schema ===
 
-    // Converting a kernel schema is what puts kernel's `key_value` / `element` names on the target,
-    // so these tests build the target that way rather than hand-writing Arrow fields.
+    // Wraps [`TryIntoArrow`] in an `Arc` for brevity at the call sites below. Going through the
+    // kernel conversion is the point: that is what names the map entry `key_value` and the array
+    // element `element`, which hand-written Arrow fields would not.
     fn kernel_target_schema(schema: StructType) -> ArrowSchemaRef {
         Arc::new((&schema).try_into_arrow().unwrap())
     }
 
+    // A one-entry `{"k": "v"}` map whose entry struct is named `entry`. That struct holds the
+    // key/value pair of every entry, and is the field whose name writers disagree on.
     fn map_string_string_with_entry_name(entry: &str) -> MapArray {
         let names = MapFieldNames {
             entry: entry.to_string(),
@@ -4452,12 +4457,30 @@ mod tests {
     // Beyond renaming, this is a real cast: a primitive column converts to the target's type.
     #[test]
     fn test_coerce_columns_casts_primitive_to_target_type() {
-        let col: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
-        let target = kernel_target_schema(schema! { nullable "n": LONG });
+        let col: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3])); // <-- source: Int32
+        let target = kernel_target_schema(schema! { nullable "n": LONG }); // <-- target: Int64
 
         let coerced = coerce_columns_to_schema(vec![col], &target).unwrap();
 
         assert_eq!(coerced[0].data_type(), &ArrowDataType::Int64);
+    }
+
+    // Casting a child rebuilds the struct around it, which must keep the struct's own null rows.
+    #[test]
+    fn test_coerce_columns_preserves_struct_null_rows() {
+        let child: ArrowArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2)]));
+        let fields: ArrowFields = vec![ArrowField::new("n", ArrowDataType::Int32, true)].into();
+        let nulls = NullBuffer::from(vec![false, true]); // <-- row 0 is a null struct
+        let outer = StructArray::try_new(fields, vec![child], Some(nulls)).unwrap();
+
+        // Widening the child to Int64 forces the struct to be rebuilt.
+        let target = kernel_target_schema(schema! { nullable "s": { nullable "n": LONG } });
+        let coerced = coerce_columns_to_schema(vec![Arc::new(outer)], &target).unwrap();
+
+        let out = coerced[0].as_struct();
+        assert!(out.is_null(0), "null struct row must survive the rebuild");
+        assert!(!out.is_null(1));
+        assert_eq!(out.column(0).data_type(), &ArrowDataType::Int64);
     }
 
     #[test]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1356,7 +1356,7 @@ pub(crate) fn coerce_columns_to_schema(
         .collect()
 }
 
-/// Casts one Arrow [`Array`] of any type to `target`.
+/// Casts one Arrow [`ArrowArray`] of any type to `target`.
 ///
 /// A struct tracks which of its rows are null separately from its children, so casting a child
 /// means rebuilding the struct around it. This recurses into `Struct` by hand, carrying that
@@ -1375,7 +1375,12 @@ fn cast_array_to_type(
     }
     match target {
         ArrowDataType::Struct(target_fields) => {
-            let s = array.as_struct();
+            let s = array.as_struct_opt().ok_or_else(|| {
+                Error::generic(format!(
+                    "cannot cast {} to a struct target",
+                    array.data_type()
+                ))
+            })?;
             let nulls = s.nulls().cloned();
             require!(
                 s.columns().len() == target_fields.len(),
@@ -4497,5 +4502,56 @@ mod tests {
         let target = kernel_target_schema(schema! { nullable "d": DATE });
 
         assert!(coerce_columns_to_schema(vec![col], &target).is_err());
+    }
+
+    // A primitive source against a struct target: the struct arm must reject it, not panic on the
+    // `as_struct` downcast.
+    #[test]
+    fn test_coerce_columns_non_struct_source_to_struct_target_errors() {
+        let col: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let target = kernel_target_schema(schema! { nullable "s": { nullable "n": INTEGER } });
+
+        let result = coerce_columns_to_schema(vec![col], &target);
+        assert_result_error_with_message(result, "to a struct target");
+    }
+
+    // A struct source with fewer children than the struct target has fields.
+    #[test]
+    fn test_coerce_columns_struct_child_count_mismatch_errors() {
+        let child: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
+        let fields: ArrowFields = vec![ArrowField::new("a", ArrowDataType::Int32, true)].into();
+        let source = StructArray::try_new(fields, vec![child], None).unwrap();
+
+        let target = kernel_target_schema(schema! {
+            nullable "s": { nullable "a": INTEGER, nullable "b": INTEGER },
+        });
+
+        let result = coerce_columns_to_schema(vec![Arc::new(source)], &target);
+        assert_result_error_with_message(result, "cannot cast struct with 1 children");
+    }
+
+    // Recursion must reach through every container: struct -> list -> map, with `entries`/`item`
+    // names at each level, all renamed in one pass.
+    #[test]
+    fn test_coerce_columns_recurses_through_struct_list_map() {
+        let map = map_string_string_with_entry_name("entries"); // <-- writer's name
+        let list_field = Arc::new(ArrowField::new("item", map.data_type().clone(), true));
+        let list = ListArray::new(
+            list_field,
+            OffsetBuffer::from_lengths([1]),
+            Arc::new(map),
+            None,
+        );
+        let outer = StructArray::from(vec![(
+            Arc::new(ArrowField::new("maps", list.data_type().clone(), true)),
+            Arc::new(list) as ArrowArrayRef,
+        )]);
+
+        let target = kernel_target_schema(schema! {
+            nullable "s": { nullable "maps": [ nullable { STRING => nullable STRING } ] },
+        });
+        let coerced = coerce_columns_to_schema(vec![Arc::new(outer)], &target).unwrap();
+
+        assert_eq!(coerced[0].data_type(), target.field(0).data_type());
     }
 }

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1301,7 +1301,7 @@ fn safe_cast_back(decoded: RecordBatch, target: &ArrowSchemaRef) -> DeltaResult<
     let columns = columns
         .into_iter()
         .zip(target.fields().iter())
-        .map(|(arr, field)| safe_cast_array(arr, field.data_type(), &opts))
+        .map(|(arr, field)| cast_array_to_type(arr, field.data_type(), &opts))
         .collect::<DeltaResult<Vec<_>>>()?;
     Ok(RecordBatch::try_new_with_options(
         target.clone(),
@@ -1310,12 +1310,60 @@ fn safe_cast_back(decoded: RecordBatch, target: &ArrowSchemaRef) -> DeltaResult<
     )?)
 }
 
-/// Recursive worker for [`safe_cast_back`]. Recurses through `Struct` containers preserving
-/// the parent null buffer; applies `cast_with_options` at the leaves.
+/// Casts each column to the type of the `target` field at the same position, so the columns can be
+/// assembled into a [`RecordBatch`] with `target` as its schema.
 ///
-/// Delta doesn't track min/max stats for `Array`/`Map`/`Variant`, so a failure-prone leaf
-/// only ever reaches here inside a `Struct`.
-fn safe_cast_array(
+/// A map's inner entry field and an array's inner element field are named by whoever wrote the
+/// file, so they can disagree with what kernel expects:
+///
+/// | Container | Kernel expects | Some writers emit |
+/// |-----------|----------------|-------------------|
+/// | map       | `key_value`    | `entries`         |
+/// | array     | `element`      | `item`            |
+///
+/// Kernel's two names are defined as [`MAP_ROOT_DEFAULT`] (`key_value`) and [`LIST_ARRAY_ROOT`]
+/// (`element`), and [`arrow_conversion`] applies them whenever it converts a kernel schema to an
+/// Arrow schema.
+///
+/// Arrow counts those names as part of the type, so a column whose names differ is unequal to
+/// `target` and [`RecordBatch::try_new`] rejects it. Casting to `target` rebuilds the container
+/// under `target`'s names.
+///
+/// This is a general cast, not a rename: it also converts primitive types (`Int32` to `Int64`) and
+/// renames struct fields. Columns whose type already equals `target` pass through untouched.
+///
+/// # Errors
+///
+/// Casts strictly, so a leaf whose type cannot convert (`Utf8` to `Date32` on a non-date string)
+/// errors rather than nulling the offending cells.
+///
+/// [`MAP_ROOT_DEFAULT`]: crate::engine::arrow_conversion::MAP_ROOT_DEFAULT
+/// [`LIST_ARRAY_ROOT`]: crate::engine::arrow_conversion::LIST_ARRAY_ROOT
+/// [`arrow_conversion`]: crate::engine::arrow_conversion
+#[cfg(test)]
+pub(crate) fn coerce_columns_to_schema(
+    columns: Vec<ArrowArrayRef>,
+    target: &ArrowSchemaRef,
+) -> DeltaResult<Vec<ArrowArrayRef>> {
+    let opts = CastOptions {
+        safe: false,
+        ..Default::default()
+    };
+    columns
+        .into_iter()
+        .zip(target.fields().iter())
+        .map(|(arr, field)| cast_array_to_type(arr, field.data_type(), &opts))
+        .collect()
+}
+
+/// Casts one Arrow [`Array`] of any type to `target`.
+///
+/// `Struct` is handled here rather than by [`cast_with_options`] so the parent null buffer survives
+/// the rebuild. Everything else, `Map` and `List` included, goes to [`cast_with_options`], which
+/// rebuilds the container using the field names in `target`.
+///
+/// `opts` decides what a failed leaf cast does: `safe: true` nulls the cell, strict errors.
+fn cast_array_to_type(
     array: ArrowArrayRef,
     target: &ArrowDataType,
     opts: &CastOptions<'_>,
@@ -1331,7 +1379,7 @@ fn safe_cast_array(
                 .columns()
                 .iter()
                 .zip(target_fields.iter())
-                .map(|(c, f)| safe_cast_array(c.clone(), f.data_type(), opts))
+                .map(|(c, f)| cast_array_to_type(c.clone(), f.data_type(), opts))
                 .collect::<DeltaResult<Vec<_>>>()?;
             Ok(Arc::new(StructArray::try_new(
                 target_fields.clone(),
@@ -1499,17 +1547,17 @@ mod tests {
     use super::*;
     use crate::arrow::array::{
         Array, ArrayRef as ArrowArrayRef, AsArray, BooleanArray, GenericListArray, Int32Array,
-        Int32Builder, Int64Array, MapArray, MapBuilder, StringArray, StringBuilder, StructArray,
-        StructBuilder,
+        Int32Builder, Int64Array, ListArray, MapArray, MapBuilder, MapFieldNames, StringArray,
+        StringBuilder, StructArray, StructBuilder,
     };
     use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use crate::arrow::datatypes::{
-        DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields,
+        DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, Int32Type,
         Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
     };
     use crate::engine::arrow_conversion::TryIntoArrow;
     use crate::schema::{
-        schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec,
+        schema, schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec,
         MetadataValue, StructField, StructType,
     };
     use crate::table_features::ColumnMappingMode;
@@ -4310,5 +4358,113 @@ mod tests {
         assert!(!val_col.is_null(1));
         assert!(!val_col.is_null(2));
         assert!(!val_col.is_null(3));
+    }
+
+    // === coerce_columns_to_schema ===
+
+    // Converting a kernel schema is what puts kernel's `key_value` / `element` names on the target,
+    // so these tests build the target that way rather than hand-writing Arrow fields.
+    fn kernel_target_schema(schema: StructType) -> ArrowSchemaRef {
+        Arc::new((&schema).try_into_arrow().unwrap())
+    }
+
+    fn map_string_string_with_entry_name(entry: &str) -> MapArray {
+        let names = MapFieldNames {
+            entry: entry.to_string(),
+            key: "key".to_string(),
+            value: "value".to_string(),
+        };
+        let mut builder = MapBuilder::new(Some(names), StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("k");
+        builder.values().append_value("v");
+        builder.append(true).unwrap();
+        builder.finish()
+    }
+
+    #[test]
+    fn test_coerce_columns_renames_entries_map_to_key_value() {
+        let map = map_string_string_with_entry_name("entries"); // <-- writer's name
+        let ArrowDataType::Map(entry_field, _) = map.data_type() else {
+            panic!("expected map");
+        };
+        assert_eq!(entry_field.name(), "entries");
+
+        let target = kernel_target_schema(schema! { nullable "m": { STRING => nullable STRING } });
+        let coerced = coerce_columns_to_schema(vec![Arc::new(map)], &target).unwrap();
+
+        let ArrowDataType::Map(out_entry, _) = coerced[0].data_type() else {
+            panic!("expected map");
+        };
+        assert_eq!(out_entry.name(), "key_value"); // <-- kernel's name
+        assert_eq!(coerced[0].data_type(), target.field(0).data_type());
+    }
+
+    #[test]
+    fn test_coerce_columns_renames_list_item_to_element() {
+        // Arrow's `ListArray::from_iter_primitive` names the element field `item`.
+        let list: ListArray =
+            ListArray::from_iter_primitive::<Int32Type, _, _>([Some(vec![Some(1), Some(2)])]);
+        let ArrowDataType::List(elem_field) = list.data_type() else {
+            panic!("expected list");
+        };
+        assert_eq!(elem_field.name(), "item"); // <-- writer's name
+
+        let target = kernel_target_schema(schema! { nullable "l": [ nullable INTEGER ] });
+        let coerced = coerce_columns_to_schema(vec![Arc::new(list)], &target).unwrap();
+
+        let ArrowDataType::List(out_elem) = coerced[0].data_type() else {
+            panic!("expected list");
+        };
+        assert_eq!(out_elem.name(), "element"); // <-- kernel's name
+        assert_eq!(coerced[0].data_type(), target.field(0).data_type());
+    }
+
+    #[test]
+    fn test_coerce_columns_passes_through_matching_columns() {
+        let col: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let target = kernel_target_schema(schema! { nullable "i": INTEGER });
+
+        let coerced = coerce_columns_to_schema(vec![col.clone()], &target).unwrap();
+
+        // An already-matching column is returned as the same allocation (no rebuild).
+        assert!(Arc::ptr_eq(&col, &coerced[0]));
+    }
+
+    // `metaData.configuration` arrives this shape: the map that needs renaming sits one level down,
+    // reachable only through the struct-recursion arm.
+    #[test]
+    fn test_coerce_columns_renames_map_nested_in_struct() {
+        let map = map_string_string_with_entry_name("entries"); // <-- writer's name
+        let config_field = ArrowField::new("config", map.data_type().clone(), true);
+        let outer = StructArray::from(vec![(
+            Arc::new(config_field),
+            Arc::new(map) as ArrowArrayRef,
+        )]);
+
+        let target = kernel_target_schema(schema! {
+            nullable "meta": { nullable "config": { STRING => nullable STRING } },
+        });
+        let coerced = coerce_columns_to_schema(vec![Arc::new(outer)], &target).unwrap();
+
+        assert_eq!(coerced[0].data_type(), target.field(0).data_type());
+    }
+
+    // Beyond renaming, this is a real cast: a primitive column converts to the target's type.
+    #[test]
+    fn test_coerce_columns_casts_primitive_to_target_type() {
+        let col: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let target = kernel_target_schema(schema! { nullable "n": LONG });
+
+        let coerced = coerce_columns_to_schema(vec![col], &target).unwrap();
+
+        assert_eq!(coerced[0].data_type(), &ArrowDataType::Int64);
+    }
+
+    #[test]
+    fn test_coerce_columns_incompatible_leaf_type_errors() {
+        let col: ArrowArrayRef = Arc::new(StringArray::from(vec!["not_a_date"]));
+        let target = kernel_target_schema(schema! { nullable "d": DATE });
+
+        assert!(coerce_columns_to_schema(vec![col], &target).is_err());
     }
 }

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -79,7 +79,7 @@ impl Engine for PlanBasedEngine {
         self.parquet.clone()
     }
 
-    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        self.executor.clone()
+    fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
+        Some(self.executor.clone())
     }
 }

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -93,8 +93,8 @@ impl Engine for SyncEngine {
     }
 
     #[cfg(feature = "declarative-plans")]
-    fn plan_executor(&self) -> Arc<dyn crate::plans::PlanExecutor> {
-        self.plan_executor.clone()
+    fn plan_executor(&self) -> Option<Arc<dyn crate::plans::PlanExecutor>> {
+        Some(self.plan_executor.clone())
     }
 }
 

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -229,10 +229,8 @@ impl SyncPlanExecutor {
                     &file_constant_columns,
                     &file.file_constants,
                 )?;
-                // A file may name its map entry field `entries` and its array element field
-                // `item`, where `output_schema` expects `key_value` and `element`. The
-                // reader keeps the file's names, and Arrow counts them as part of the
-                // type, so translate before asserting the schema.
+                // Reconcile writer-chosen map/list field names to `output_schema`'s before
+                // `try_new` asserts the schema. See `coerce_columns_to_schema`.
                 let columns = coerce_columns_to_schema(columns, &output_schema)?;
                 batches.push(RecordBatch::try_new(output_schema.clone(), columns)?);
             }

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -31,6 +31,7 @@ use crate::arrow::row::{OwnedRow, RowConverter, SortField};
 use crate::engine::arrow_conversion::{TryFromArrow as _, TryFromKernel as _, TryIntoArrow as _};
 use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
 use crate::engine::arrow_expression::{extract_column, ArrowEvaluationHandler};
+use crate::engine::arrow_utils::coerce_columns_to_schema;
 use crate::expressions::{ArrayData, ColumnName, PredicateRef, Scalar};
 use crate::object_store::DynObjectStore;
 use crate::plans::ir::nodes::{
@@ -228,6 +229,11 @@ impl SyncPlanExecutor {
                     &file_constant_columns,
                     &file.file_constants,
                 )?;
+                // A file may name its map entry field `entries` and its array element field
+                // `item`, where `output_schema` expects `key_value` and `element`. The
+                // reader keeps the file's names, and Arrow counts them as part of the
+                // type, so translate before asserting the schema.
+                let columns = coerce_columns_to_schema(columns, &output_schema)?;
                 batches.push(RecordBatch::try_new(output_schema.clone(), columns)?);
             }
         }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1083,12 +1083,13 @@ pub trait Engine: AsAny {
     /// Get the connector provided [`ParquetHandler`].
     fn parquet_handler(&self) -> Arc<dyn ParquetHandler>;
 
-    /// Get the connector provided [`PlanExecutor`].
+    /// Get the connector provided [`PlanExecutor`], or `None` if this engine provides none.
     ///
-    /// The default implementation returns a trivial executor that errors on every operation.
+    /// The default implementation returns `None`. A connector opts into plan-based execution by
+    /// overriding this to return its executor.
     #[cfg(feature = "declarative-plans")]
-    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        Arc::new(())
+    fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
+        None
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1091,6 +1091,17 @@ pub trait Engine: AsAny {
     fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
         None
     }
+
+    /// Get the connector provided [`PlanExecutor`], erroring if this engine provides none.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Unsupported`] when [`plan_executor`](Self::plan_executor) is `None`.
+    #[cfg(feature = "declarative-plans")]
+    fn require_plan_executor(&self) -> DeltaResult<Arc<dyn PlanExecutor>> {
+        self.plan_executor()
+            .ok_or_else(|| Error::unsupported("this engine does not provide a PlanExecutor"))
+    }
 }
 
 // Rustdoc's documentation tests can do some things that regular unit tests can't. Here we are

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -19,7 +19,7 @@ use crate::metrics::ProtocolMetadataSource;
 #[cfg(feature = "declarative-plans")]
 use crate::plans::ir::nodes::FileType;
 #[cfg(feature = "declarative-plans")]
-use crate::plans::{Operation, PlanBuilder};
+use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 #[cfg(feature = "declarative-plans")]
 use crate::schema::column_name;
 use crate::schema::schema_ref;
@@ -122,14 +122,12 @@ impl LogSegment {
         &self,
         engine: &dyn Engine,
     ) -> DeltaResult<(Option<Metadata>, Option<Protocol>)> {
-        // With `declarative-plans`, replay P&M through the declarative plan, falling back to legacy
-        // replay on any plan failure while the plan path is experimental.
+        // Providing a plan executor opts the engine into declarative P&M replay.
         #[cfg(feature = "declarative-plans")]
-        let actions_batches = self.read_pm_batches_via_plan(engine).or_else(|err| {
-            info!("declarative P&M plan failed, using legacy replay: {err}");
-            self.read_pm_batches(engine)
-                .map(|batches| Box::new(batches) as _)
-        })?;
+        let actions_batches = match engine.plan_executor() {
+            Some(exec) => self.read_pm_batches_via_plan(exec.as_ref())?,
+            None => Box::new(self.read_pm_batches(engine)?) as _,
+        };
 
         #[cfg(not(feature = "declarative-plans"))]
         let actions_batches = self.read_pm_batches(engine)?;
@@ -154,7 +152,7 @@ impl LogSegment {
     #[cfg(feature = "declarative-plans")]
     fn read_pm_batches_via_plan(
         &self,
-        engine: &dyn Engine,
+        exec: &dyn PlanExecutor,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<ActionsBatch>> + Send>> {
         let versioned_schema = schema_ref! {
             (&PROTOCOL_FIELD),
@@ -185,8 +183,7 @@ impl LogSegment {
             .build()?;
 
         // NOTE: The plan dedupes all actions, so mark all results as coming from checkpoint
-        let batches = engine
-            .plan_executor()
+        let batches = exec
             .execute_op(Operation::QueryPlan(plan))?
             .into_data()?
             .map(|batch| Ok(ActionsBatch::new(batch?, true)));
@@ -256,5 +253,27 @@ mod tests {
         // read parts 1 and 5 (4 in all instead of 2) because row group skipping is disabled for
         // missing columns, but can still skip part 3 because has valid nullcount stats for P&M.
         assert_eq!(data.len(), 4);
+    }
+
+    // With the `declarative-plans` feature flag on, `SyncEngine` resolves P&M through the
+    // declarative plan.
+    //
+    // This fixture's checkpoint names its map entry fields `entries` where kernel expects
+    // `key_value`. Parquet takes that name from the writer's Arrow schema unless the writer sets
+    // `WriterProperties::coerce_types`, which is off by default, and Arrow's own
+    // `MapFieldNames::default()` is `entries`. So a writer that builds its maps from Arrow defaults
+    // produces a file kernel must translate on read. Spark and kernel both write `key_value`,
+    // covered by `scan_plan::tests::declarative_metadata_reconciles_checkpoint_with_later_commits`.
+    #[test]
+    fn test_snapshot_build_via_plan_over_parquet_checkpoint_with_entries_named_maps() {
+        let path =
+            std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
+        let url = url::Url::from_directory_path(path).unwrap();
+        let engine = SyncEngine::new();
+
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+        assert_eq!(snapshot.version(), 1);
+        assert_eq!(snapshot.schema().fields().count(), 3);
     }
 }

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -206,22 +206,27 @@ impl LogSegment {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    #[cfg(feature = "declarative-plans")]
     use std::sync::Arc;
 
     use itertools::Itertools;
     use test_log::test;
 
     use crate::engine::sync::SyncEngine;
+    #[cfg(feature = "declarative-plans")]
     use crate::plans::{Operation, PlanExecutor, PlanResult};
+    use crate::Snapshot;
+    #[cfg(feature = "declarative-plans")]
     use crate::{
-        DeltaResult, Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot,
-        StorageHandler,
+        DeltaResult, Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler,
     };
 
     // A [`PlanExecutor`] whose every operation fails, used to prove that a plan-path failure
     // surfaces from P&M replay rather than falling back to legacy replay.
+    #[cfg(feature = "declarative-plans")]
     struct FailingPlanExecutor;
 
+    #[cfg(feature = "declarative-plans")]
     impl PlanExecutor for FailingPlanExecutor {
         fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
             Err(Error::generic("plan executor deliberately failed"))
@@ -230,8 +235,10 @@ mod tests {
 
     // Forwards every handler to an inner [`SyncEngine`] but returns a [`FailingPlanExecutor`], so
     // P&M replay takes the plan path and hits the failure.
+    #[cfg(feature = "declarative-plans")]
     struct FailingPlanEngine(Arc<SyncEngine>);
 
+    #[cfg(feature = "declarative-plans")]
     impl Engine for FailingPlanEngine {
         fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
             self.0.evaluation_handler()
@@ -331,6 +338,7 @@ mod tests {
         assert_eq!(snapshot.schema().fields().count(), 5);
     }
 
+    #[cfg(feature = "declarative-plans")]
     #[test]
     fn test_snapshot_build_via_failing_plan_executor_surfaces_error_without_fallback() {
         let path =

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -125,7 +125,7 @@ impl LogSegment {
         // Providing a plan executor opts the engine into declarative P&M replay.
         #[cfg(feature = "declarative-plans")]
         let actions_batches = match engine.plan_executor() {
-            Some(exec) => self.read_pm_batches_via_plan(exec.as_ref())?,
+            Some(executor) => self.read_pm_batches_via_plan(executor.as_ref())?,
             None => Box::new(self.read_pm_batches(engine)?) as _,
         };
 
@@ -152,7 +152,7 @@ impl LogSegment {
     #[cfg(feature = "declarative-plans")]
     fn read_pm_batches_via_plan(
         &self,
-        exec: &dyn PlanExecutor,
+        executor: &dyn PlanExecutor,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<ActionsBatch>> + Send>> {
         let versioned_schema = schema_ref! {
             (&PROTOCOL_FIELD),
@@ -183,7 +183,7 @@ impl LogSegment {
             .build()?;
 
         // NOTE: The plan dedupes all actions, so mark all results as coming from checkpoint
-        let batches = exec
+        let batches = executor
             .execute_op(Operation::QueryPlan(plan))?
             .into_data()?
             .map(|batch| Ok(ActionsBatch::new(batch?, true)));

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -276,4 +276,20 @@ mod tests {
         assert_eq!(snapshot.version(), 1);
         assert_eq!(snapshot.schema().fields().count(), 3);
     }
+
+    // The array counterpart of the test above. This fixture's checkpoint names its array element
+    // fields `item` where kernel expects `element`, so it covers the other half of the naming
+    // disagreement. `metaData.partitionColumns` is the array in question, and it is present in
+    // every `metaData` action, so its element name is checked on every P&M replay.
+    #[test]
+    fn test_snapshot_build_via_plan_over_parquet_checkpoint_with_item_named_arrays() {
+        let path = std::fs::canonicalize(PathBuf::from("./tests/data/parsed-stats/")).unwrap();
+        let url = url::Url::from_directory_path(path).unwrap();
+        let engine = SyncEngine::new();
+
+        let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
+
+        assert_eq!(snapshot.version(), 5);
+        assert_eq!(snapshot.schema().fields().count(), 5);
+    }
 }

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -206,12 +206,49 @@ impl LogSegment {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     use itertools::Itertools;
     use test_log::test;
 
     use crate::engine::sync::SyncEngine;
-    use crate::Snapshot;
+    use crate::plans::{Operation, PlanExecutor, PlanResult};
+    use crate::{
+        DeltaResult, Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot,
+        StorageHandler,
+    };
+
+    // A [`PlanExecutor`] whose every operation fails, used to prove that a plan-path failure
+    // surfaces from P&M replay rather than falling back to legacy replay.
+    struct FailingPlanExecutor;
+
+    impl PlanExecutor for FailingPlanExecutor {
+        fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
+            Err(Error::generic("plan executor deliberately failed"))
+        }
+    }
+
+    // Forwards every handler to an inner [`SyncEngine`] but returns a [`FailingPlanExecutor`], so
+    // P&M replay takes the plan path and hits the failure.
+    struct FailingPlanEngine(Arc<SyncEngine>);
+
+    impl Engine for FailingPlanEngine {
+        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+            self.0.evaluation_handler()
+        }
+        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+            self.0.storage_handler()
+        }
+        fn json_handler(&self) -> Arc<dyn JsonHandler> {
+            self.0.json_handler()
+        }
+        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+            self.0.parquet_handler()
+        }
+        fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
+            Some(Arc::new(FailingPlanExecutor))
+        }
+    }
 
     // NOTE: In addition to testing the meta-predicate for metadata replay, this test also verifies
     // that the parquet reader properly infers nullcount = rowcount for missing columns. The two
@@ -263,7 +300,8 @@ mod tests {
     // `WriterProperties::coerce_types`, which is off by default, and Arrow's own
     // `MapFieldNames::default()` is `entries`. So a writer that builds its maps from Arrow defaults
     // produces a file kernel must translate on read. Spark and kernel both write `key_value`,
-    // covered by `scan_plan::tests::declarative_metadata_reconciles_checkpoint_with_later_commits`.
+    // covered by
+    // `scan_plan::execution_tests::declarative_metadata_reconciles_checkpoint_with_later_commits`.
     #[test]
     fn test_snapshot_build_via_plan_over_parquet_checkpoint_with_entries_named_maps() {
         let path =
@@ -291,5 +329,20 @@ mod tests {
 
         assert_eq!(snapshot.version(), 5);
         assert_eq!(snapshot.schema().fields().count(), 5);
+    }
+
+    #[test]
+    fn test_snapshot_build_via_failing_plan_executor_surfaces_error_without_fallback() {
+        let path =
+            std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
+        let url = url::Url::from_directory_path(path).unwrap();
+        let engine = FailingPlanEngine(Arc::new(SyncEngine::new()));
+
+        let result = Snapshot::builder_for(url).build(&engine);
+
+        assert!(
+            result.is_err(),
+            "plan failure must surface, not fall back to legacy replay"
+        );
     }
 }

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -36,8 +36,8 @@
 //!   so a node's inputs are already evaluated, or compile the DAG into the engine's own plan.
 //!
 //! Every operator, expression, and predicate a plan contains must be handled; returning an error
-//! for an unsupported one is fine, and kernel surfaces it to the caller. The `()` executor below
-//! does this, and the sync engine's `SyncPlanExecutor` is a complete reference implementation.
+//! for an unsupported one is fine, and kernel surfaces it to the caller. The sync engine's
+//! `SyncPlanExecutor` is a complete reference implementation.
 //!
 //! # Where to look
 //!

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -77,17 +77,6 @@ pub trait PlanExecutor: AsAny {
     }
 }
 
-/// The unit type is a trivial [`PlanExecutor`] that rejects every operation. It backs
-/// [`Engine::plan_executor`](crate::Engine::plan_executor)'s default so callers can attempt plan
-/// execution unconditionally and fall back on the resulting error when no real executor exists.
-impl PlanExecutor for () {
-    fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
-        Err(Error::unsupported(
-            "this engine does not provide a PlanExecutor",
-        ))
-    }
-}
-
 /// The result of executing an [`Operation`].
 ///
 /// Each variant describes a different shape of output that a plan can possibly produce.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1030,14 +1030,13 @@ impl Scan {
     ///
     /// # Errors
     ///
-    /// Returns an error if log discovery, checkpoint inspection, or plan construction fails.
+    /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
+    /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
         let log_segment = self.snapshot.log_segment();
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
-        let plan_executor = engine
-            .plan_executor()
-            .ok_or_else(|| Error::unsupported("this engine does not provide a PlanExecutor"))?;
+        let plan_executor = engine.require_plan_executor()?;
         let shape = CheckpointShape::try_new(
             plan_executor.as_ref(),
             &self.snapshot,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1035,7 +1035,9 @@ impl Scan {
         let log_segment = self.snapshot.log_segment();
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
-        let plan_executor = engine.plan_executor();
+        let plan_executor = engine
+            .plan_executor()
+            .ok_or_else(|| Error::unsupported("this engine does not provide a PlanExecutor"))?;
         let shape = CheckpointShape::try_new(
             plan_executor.as_ref(),
             &self.snapshot,

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -908,6 +908,7 @@ mod tests {
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
             .plan_executor()
+            .unwrap()
             .execute_op(PlanOperation::QueryPlan(plan))?
             .into_data()?;
         let batch = batches
@@ -968,6 +969,7 @@ mod tests {
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
             .plan_executor()
+            .unwrap()
             .execute_op(PlanOperation::QueryPlan(plan))?
             .into_data()?;
         let actual_rows = batches.try_fold(0, |rows, batch| {

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -469,3 +469,44 @@ fn assert_declarative_metadata_matches_imperative(
 
     assert_metadata_eq(&actual, &expected, table.description())
 }
+
+// Forwards every handler to an inner [`SyncEngine`] but provides no [`PlanExecutor`], exercising
+// the `None` arm that `declarative_metadata_scan_plan` rejects.
+struct NoPlanEngine(Arc<SyncEngine>);
+
+impl Engine for NoPlanEngine {
+    fn evaluation_handler(&self) -> Arc<dyn crate::EvaluationHandler> {
+        self.0.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn crate::StorageHandler> {
+        self.0.storage_handler()
+    }
+    fn json_handler(&self) -> Arc<dyn crate::JsonHandler> {
+        self.0.json_handler()
+    }
+    fn parquet_handler(&self) -> Arc<dyn crate::ParquetHandler> {
+        self.0.parquet_handler()
+    }
+    fn plan_executor(&self) -> Option<Arc<dyn crate::plans::PlanExecutor>> {
+        None
+    }
+}
+
+#[test]
+fn test_declarative_metadata_scan_plan_no_executor_returns_unsupported() -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(LogState::with_latest_version(4).with_checkpoint_at([2]))
+        .build()
+        .expect("build checkpoint-plus-commits table");
+    let sync_engine = Arc::new(SyncEngine::new_with_store(table.store().clone()));
+    let snapshot = Snapshot::builder_for(table.table_root()).build(sync_engine.as_ref())?;
+    let scan = snapshot.scan_builder().build()?;
+
+    let no_plan_engine = NoPlanEngine(sync_engine);
+    let err = scan
+        .declarative_metadata_scan_plan(&no_plan_engine)
+        .unwrap_err();
+
+    assert!(matches!(err, crate::Error::Unsupported(_)));
+    Ok(())
+}

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -80,6 +80,7 @@ fn declarative_metadata(scan: &Scan, engine: &dyn Engine) -> DeltaResult<Vec<Rec
     };
     let batches = engine
         .plan_executor()
+        .unwrap()
         .execute_op(PlanOperation::QueryPlan(plan))?
         .into_data()?;
 
@@ -302,6 +303,7 @@ fn declarative_metadata_reconstructs_well_formed_stats_and_partitions() -> Delta
         .expect("metadata plan");
     let batches = engine
         .plan_executor()
+        .unwrap()
         .execute_op(PlanOperation::QueryPlan(plan))?
         .into_data()?;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR has 3 improvements (that are all interdependent, so I bundled into one PR):

1. Handle parquet checkpoints files in plans which wrote Maps using field name `entries` instead of `key_value`, and which wrote Arrays using field name `item` instead of `element`. We corce the source schema into our target schema.

2. Do NOT have the plan-based P&M replay fallback to non-plan-based replay.

3. Make the `Engine::plan_executor` API return an optional. Only invoke plan-based routes if the executor is `Some`. This allows connectors to actually _develop_ executors. You depend on kernel. You enable the feature flag. You return `None` so that no production code paths try to invoke your executor. And then you can build your executor iteratively with no production code paths impacted until you're ready.

### This PR affects the following public APIs

`Engine::plan_executor` returns `Option<Arc<dyn PlanExecutor>>` rather than `Arc<dyn PlanExecutor>`, and defaults to `None` instead of an executor that errors on every call. This is gated behind the experimental `declarative-plans` feature.

## How was this change tested?

`test_snapshot_build_via_plan_over_parquet_checkpoint_with_entries_named_maps` builds a snapshot over a fixture checkpoint whose maps are named `entries`, which panics without this fix. Unit tests in `arrow_utils` cover the map and list renames, a map nested in a struct, pass-through of already-matching columns, and the strict cast failure. The `key_value` case was already covered by `declarative_metadata_reconciles_checkpoint_with_later_commits`.
