### PR TITLE
feat: Batch log replay commits parsing

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -683,6 +683,10 @@ pub trait JsonHandler: AsAny {
     ///
     /// Additionally, engines may not merge engine data across file boundaries.
     ///
+    /// If `physical_schema` contains a [`schema::MetadataColumnSpec::FilePath`] column, the handler
+    /// must populate it on every row with `FileMeta::location.to_string()` for the corresponding
+    /// input file.
+    ///
     /// # Parameters
     ///
     /// - `files` - File metadata for files to be read.

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -1,6 +1,7 @@
 //! Defines [`LogReplayScanner`] used by [`TableChangesScan`] to process commit files and extract
 //! the metadata needed to generate the Change Data Feed.
 
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock};
 
@@ -9,25 +10,22 @@ use tracing::info;
 
 use crate::actions::visitors::{visit_deletion_vector_at, InCommitTimestampVisitor};
 use crate::actions::{
-    Metadata, Protocol, ADD_FIELD, CDC_FIELD, COMMIT_INFO_NAME, LOG_ADD_SCHEMA, METADATA_FIELD,
-    PROTOCOL_FIELD, REMOVE_FIELD,
+    Metadata, Protocol, ADD_FIELD, CDC_FIELD, COMMIT_INFO_NAME, METADATA_FIELD, PROTOCOL_FIELD,
+    REMOVE_FIELD,
 };
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::{column_name, ColumnName};
 use crate::path::{AsUrl, ParsedLogPath};
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::scan::state::DvInfo;
-use crate::schema::{
-    schema_ref, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef, StructType,
-};
+use crate::schema::{schema_ref, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef};
 use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_changes::CdfMode;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{format_features, Operation, TableFeature};
 use crate::utils::require;
 use crate::{
-    DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, PredicateRef,
-    RowVisitor,
+    DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, PredicateRef, RowVisitor,
 };
 
 #[cfg(test)]
@@ -84,117 +82,170 @@ pub(crate) fn table_changes_action_iter_with_mode(
     physical_predicate: Option<(PredicateRef, SchemaRef)>,
     mode: CdfMode,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
+    let replay_schema = replay_schema()?;
+
     // Skip against the raw `{ add, remove, ... }` action batch: table_changes must resolve
     // deletion vector pairs before filtering, so unlike the scan path it operates on raw
     // batches with stats parsed from `add.stats` JSON.
     let filter = physical_predicate
-        .and_then(|(predicate, _ref_schema)| {
+        .and_then(|(predicate, _)| {
             DataSkippingFilter::for_raw_action_batch(
                 engine.as_ref(),
                 predicate,
                 start_table_configuration,
-                LOG_ADD_SCHEMA.clone(),
+                replay_schema.clone(),
             )
         })
         .map(Arc::new);
 
     let mut current_configuration = start_table_configuration.clone();
     let commit_files = commit_files.into_iter().collect_vec();
+    // One read lets engines overlap object-store I/O while grouping batches incrementally with
+    // one-batch lookahead.
+    let commit_batches = read_commit_batches(engine.as_ref(), commit_files, replay_schema.clone())?;
 
-    // Submit all commits in each phase together so engines can overlap object-store reads. CDF
-    // validation still processes the regrouped batches in ascending commit order, and prepare
-    // batches remain unfiltered so deletion-vector resolution sees every add/remove pair.
-    let prepare_groups = read_commits_grouped(
-        engine.as_ref(),
-        &commit_files,
-        &PreparePhaseVisitor::schema(),
-        None,
-    )?;
-    let scan_groups = read_commits_grouped(
-        engine.as_ref(),
-        &commit_files,
-        &FileActionSelectionVisitor::schema(),
-        None,
-    )?;
-
-    let result = commit_files
-        .into_iter()
-        .zip(prepare_groups)
-        .zip(scan_groups)
-        .map(
-            move |((commit_file, prepare_actions), scan_actions)| -> DeltaResult<_> {
-                let scanner = LogReplayScanner::try_new(
-                    &mut current_configuration,
-                    commit_file,
-                    prepare_actions,
-                    &table_schema,
-                    mode,
-                )?;
-                scanner.into_scan_batches(engine.clone(), scan_actions, filter.clone())
-            },
-        ) //Iterator-Result-Iterator-Result
+    let result = commit_batches
+        .map(move |commit_data| -> DeltaResult<_> {
+            let CommitBatches {
+                commit,
+                action_batches,
+            } = commit_data?;
+            let scanner = LogReplayScanner::try_new(
+                &mut current_configuration,
+                commit,
+                action_batches,
+                &table_schema,
+                mode,
+            )?;
+            scanner.into_scan_batches(engine.clone(), replay_schema.clone(), filter.clone())
+        }) //Iterator-Result-Iterator-Result
         .flatten_ok() // Iterator-Result-Result
         .map(|x| x?); // Iterator-Result
     Ok(result)
 }
 
-/// Reads the requested commits together and returns their batches grouped by commit.
-fn read_commits_grouped(
+fn replay_schema() -> DeltaResult<SchemaRef> {
+    PreparePhaseVisitor::schema()
+        .add_metadata_column(FILE_PATH_COLUMN_NAME, MetadataColumnSpec::FilePath)
+        .map(Arc::new)
+}
+
+fn read_commit_batches(
     engine: &dyn Engine,
-    commit_files: &[ParsedLogPath],
-    schema: &StructType,
-    predicate: Option<PredicateRef>,
-) -> DeltaResult<Vec<Vec<Box<dyn EngineData>>>> {
+    commit_files: Vec<ParsedLogPath>,
+    schema: SchemaRef,
+) -> DeltaResult<CommitBatchIterator> {
     let locations = commit_files
         .iter()
         .map(|commit_file| commit_file.location.clone())
         .collect_vec();
-    let schema_with_file_path =
-        Arc::new(schema.add_metadata_column(FILE_PATH_COLUMN_NAME, MetadataColumnSpec::FilePath)?);
-    let batches =
-        engine
-            .json_handler()
-            .read_json_files(&locations, schema_with_file_path, predicate)?;
-
-    group_commit_batches(&locations, batches)
+    let batches = engine
+        .json_handler()
+        .read_json_files(&locations, schema, None)?;
+    Ok(CommitBatchIterator::new(commit_files, batches))
 }
 
-fn group_commit_batches(
-    locations: &[FileMeta],
+struct CommitBatches {
+    commit: ParsedLogPath,
+    action_batches: Vec<Box<dyn EngineData>>,
+}
+
+struct CommitBatchIterator {
+    commits: std::iter::Enumerate<std::vec::IntoIter<ParsedLogPath>>,
+    file_indices: HashMap<String, usize>,
     batches: FileDataReadResultIterator,
-) -> DeltaResult<Vec<Vec<Box<dyn EngineData>>>> {
-    let file_indices: HashMap<_, _> = locations
-        .iter()
-        .enumerate()
-        .map(|(index, file)| (file.location.to_string(), index))
-        .collect();
-    let mut groups: Vec<Vec<Box<dyn EngineData>>> = locations.iter().map(|_| Vec::new()).collect();
-    for batch in batches {
-        let batch = batch?;
-        if batch.is_empty() {
-            continue;
+    pending_batch: Option<Box<dyn EngineData>>,
+    errored: bool,
+}
+
+impl CommitBatchIterator {
+    fn new(commit_files: Vec<ParsedLogPath>, batches: FileDataReadResultIterator) -> Self {
+        let file_indices = commit_files
+            .iter()
+            .enumerate()
+            .map(|(index, commit)| (commit.location.location.to_string(), index))
+            .collect();
+        Self {
+            commits: commit_files.into_iter().enumerate(),
+            file_indices,
+            batches,
+            pending_batch: None,
+            errored: false,
+        }
+    }
+
+    fn next_batch(&mut self) -> Option<DeltaResult<Box<dyn EngineData>>> {
+        self.pending_batch
+            .take()
+            .map(Ok)
+            .or_else(|| self.batches.next())
+    }
+
+    fn try_next_commit(&mut self) -> DeltaResult<Option<CommitBatches>> {
+        let Some((commit_index, commit)) = self.commits.next() else {
+            return Ok(None);
+        };
+        let mut action_batches = Vec::new();
+
+        while let Some(batch) = self.next_batch() {
+            let batch = batch?;
+            if batch.is_empty() {
+                continue;
+            }
+
+            let mut visitor = FilePathVisitor::default();
+            visitor.visit_rows_of(batch.as_ref())?;
+            let path = visitor.file_path.ok_or_else(|| {
+                Error::internal_error("table_changes received a JSON batch without a file path")
+            })?;
+            let batch_index = *self.file_indices.get(&path).ok_or_else(|| {
+                Error::internal_error(format!(
+                    "table_changes received a JSON batch for unrequested commit file {path}"
+                ))
+            })?;
+
+            match batch_index.cmp(&commit_index) {
+                Ordering::Less => {
+                    return Err(Error::internal_error(format!(
+                        "table_changes received an out-of-order JSON batch for commit file {path}"
+                    )))
+                }
+                Ordering::Equal => action_batches.push(batch),
+                Ordering::Greater => {
+                    self.pending_batch = Some(batch);
+                    break;
+                }
+            }
         }
 
-        let mut visitor = FilePathVisitor::default();
-        visitor.visit_rows_of(batch.as_ref())?;
-        let path = visitor.file_path.ok_or_else(|| {
-            Error::internal_error("table_changes received a JSON batch without a file path")
-        })?;
-        let group_index = file_indices.get(&path).ok_or_else(|| {
-            Error::internal_error(format!(
-                "table_changes received a JSON batch for unrequested commit file {path}"
-            ))
-        })?;
-        groups[*group_index].push(batch);
+        Ok(Some(CommitBatches {
+            commit,
+            action_batches,
+        }))
     }
-    Ok(groups)
+}
+
+impl Iterator for CommitBatchIterator {
+    type Item = DeltaResult<CommitBatches>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.errored {
+            return None;
+        }
+        match self.try_next_commit() {
+            Ok(Some(commit)) => Some(Ok(commit)),
+            Ok(None) => None,
+            Err(error) => {
+                self.errored = true;
+                Some(Err(error))
+            }
+        }
+    }
 }
 
 const FILE_PATH_COLUMN_NAME: &str = "_file";
 
 /// Reads the file path that identifies a JSON batch's source commit.
-///
-/// The JSON handler does not merge file boundaries, so the first row identifies the batch.
 #[derive(Default)]
 struct FilePathVisitor {
     file_path: Option<String>,
@@ -216,6 +267,7 @@ impl RowVisitor for FilePathVisitor {
             ))
         );
         if row_count > 0 {
+            // JSON batches cannot span files, so the first row identifies the source file.
             self.file_path = getters[0]
                 .get_str(0, FILE_PATH_COLUMN_NAME)?
                 .map(ToString::to_string);
@@ -262,10 +314,8 @@ impl RowVisitor for FilePathVisitor {
 ///     - If a `cdc` action was found in the prepare phase, only `cdc` actions are selected
 ///     - Otherwise, select `add` and `remove` actions. Note that only `remove` actions that do not
 ///       share a path with an `add` action are selected.
-///
-/// Both phases materialize their JSON batches across the requested version range before commit
-/// processing, so peak memory grows with the actions in that range.
 struct LogReplayScanner {
+    action_batches: Vec<Box<dyn EngineData>>,
     // True if a `cdc` action was found after running [`LogReplayScanner::try_new`]
     has_cdc_action: bool,
     // A map from path to the deletion vector from the remove action. It is guaranteed that there
@@ -290,12 +340,12 @@ impl LogReplayScanner {
     fn try_new(
         table_configuration: &mut TableConfiguration,
         commit_file: ParsedLogPath,
-        prepare_phase_actions: Vec<Box<dyn EngineData>>,
+        action_batches: Vec<Box<dyn EngineData>>,
         table_schema: &SchemaRef,
         mode: CdfMode,
     ) -> DeltaResult<Self> {
         let mut in_commit_timestamp_opt = None;
-        if let Some(actions) = prepare_phase_actions.first() {
+        if let Some(actions) = action_batches.first() {
             let mut visitor = InCommitTimestampVisitor::default();
             visitor.visit_rows_of(actions.as_ref())?;
             in_commit_timestamp_opt = visitor.in_commit_timestamp;
@@ -305,7 +355,7 @@ impl LogReplayScanner {
         let mut add_paths = HashSet::default();
         let mut has_cdc_action = false;
 
-        for actions in prepare_phase_actions {
+        for actions in &action_batches {
             let mut visitor = PreparePhaseVisitor {
                 add_paths: &mut add_paths,
                 remove_dvs: &mut remove_dvs,
@@ -408,6 +458,7 @@ impl LogReplayScanner {
         );
 
         Ok(LogReplayScanner {
+            action_batches,
             timestamp,
             commit_file,
             has_cdc_action,
@@ -420,10 +471,11 @@ impl LogReplayScanner {
     fn into_scan_batches(
         self,
         engine: Arc<dyn Engine>,
-        scan_phase_actions: Vec<Box<dyn EngineData>>,
+        input_schema: SchemaRef,
         filter: Option<Arc<DataSkippingFilter>>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
         let Self {
+            action_batches,
             has_cdc_action,
             remove_dvs,
             commit_file,
@@ -432,30 +484,30 @@ impl LogReplayScanner {
         } = self;
         let remove_dvs = Arc::new(remove_dvs);
 
-        let action_iter = scan_phase_actions.into_iter();
         let commit_version = commit_file
             .version
             .try_into()
             .map_err(|_| Error::generic("Failed to convert commit version to i64"))?;
         let evaluator = engine.evaluation_handler().new_expression_evaluator(
-            LOG_ADD_SCHEMA.clone(),
+            input_schema,
             Arc::new(cdf_scan_row_expression(timestamp, commit_version)),
             cdf_scan_row_schema().into(),
         )?;
 
-        let result = action_iter.map(move |actions| -> DeltaResult<_> {
+        let batches = action_batches.into_iter();
+        let result = batches.map(move |batch| -> DeltaResult<_> {
             // Apply data skipping to get back a selection vector for actions that passed skipping.
             // We start our selection vector based on what was filtered. We will add to this vector
             // below if a file has been removed. Note: None implies all files passed data skipping.
             let selection_vector = match &filter {
-                Some(filter) => filter.apply(actions.as_ref())?,
-                None => vec![true; actions.len()],
+                Some(filter) => filter.apply(batch.as_ref())?,
+                None => vec![true; batch.len()],
             };
 
             let mut visitor =
                 FileActionSelectionVisitor::new(&remove_dvs, selection_vector, has_cdc_action);
-            visitor.visit_rows_of(actions.as_ref())?;
-            let scan_metadata = evaluator.evaluate(actions.as_ref())?;
+            visitor.visit_rows_of(batch.as_ref())?;
+            let scan_metadata = evaluator.evaluate(batch.as_ref())?;
             Ok(TableChangesScanMetadata {
                 scan_metadata,
                 selection_vector: visitor.selection_vector,
@@ -567,18 +619,10 @@ impl<'a> FileActionSelectionVisitor<'a> {
             remove_dvs,
         }
     }
-    fn schema() -> SchemaRef {
-        schema_ref! {
-            (&CDC_FIELD),
-            (&ADD_FIELD),
-            (&REMOVE_FIELD),
-        }
-    }
 }
 
 impl RowVisitor for FileActionSelectionVisitor<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
-        // Note: The order of the names and types is based on [`FileActionSelectionVisitor::schema`]
         static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
             const STRING: DataType = DataType::STRING;
             const BOOLEAN: DataType = DataType::BOOLEAN;

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -2,7 +2,6 @@
 //! the metadata needed to generate the Change Data Feed.
 
 use std::collections::{HashMap, HashSet};
-use std::slice;
 use std::sync::{Arc, LazyLock};
 
 use itertools::Itertools;
@@ -18,13 +17,18 @@ use crate::expressions::{column_name, ColumnName};
 use crate::path::{AsUrl, ParsedLogPath};
 use crate::scan::data_skipping::DataSkippingFilter;
 use crate::scan::state::DvInfo;
-use crate::schema::{schema_ref, ColumnNamesAndTypes, DataType, SchemaRef};
+use crate::schema::{
+    schema_ref, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef, StructType,
+};
 use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_changes::CdfMode;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{format_features, Operation, TableFeature};
 use crate::utils::require;
-use crate::{DeltaResult, Engine, EngineData, Error, PredicateRef, RowVisitor};
+use crate::{
+    DeltaResult, Engine, EngineData, Error, FileDataReadResultIterator, FileMeta, PredicateRef,
+    RowVisitor,
+};
 
 #[cfg(test)]
 mod tests;
@@ -95,21 +99,129 @@ pub(crate) fn table_changes_action_iter_with_mode(
         .map(Arc::new);
 
     let mut current_configuration = start_table_configuration.clone();
+    let commit_files = commit_files.into_iter().collect_vec();
+
+    // Submit all commits in each phase together so engines can overlap object-store reads. CDF
+    // validation still processes the regrouped batches in ascending commit order, and prepare
+    // batches remain unfiltered so deletion-vector resolution sees every add/remove pair.
+    let prepare_groups = read_commits_grouped(
+        engine.as_ref(),
+        &commit_files,
+        &PreparePhaseVisitor::schema(),
+        None,
+    )?;
+    let scan_groups = read_commits_grouped(
+        engine.as_ref(),
+        &commit_files,
+        &FileActionSelectionVisitor::schema(),
+        None,
+    )?;
+
     let result = commit_files
         .into_iter()
-        .map(move |commit_file| -> DeltaResult<_> {
-            let scanner = LogReplayScanner::try_new(
-                engine.as_ref(),
-                &mut current_configuration,
-                commit_file,
-                &table_schema,
-                mode,
-            )?;
-            scanner.into_scan_batches(engine.clone(), filter.clone())
-        }) //Iterator-Result-Iterator-Result
+        .zip(prepare_groups)
+        .zip(scan_groups)
+        .map(
+            move |((commit_file, prepare_actions), scan_actions)| -> DeltaResult<_> {
+                let scanner = LogReplayScanner::try_new(
+                    &mut current_configuration,
+                    commit_file,
+                    prepare_actions,
+                    &table_schema,
+                    mode,
+                )?;
+                scanner.into_scan_batches(engine.clone(), scan_actions, filter.clone())
+            },
+        ) //Iterator-Result-Iterator-Result
         .flatten_ok() // Iterator-Result-Result
         .map(|x| x?); // Iterator-Result
     Ok(result)
+}
+
+/// Reads the requested commits together and returns their batches grouped by commit.
+fn read_commits_grouped(
+    engine: &dyn Engine,
+    commit_files: &[ParsedLogPath],
+    schema: &StructType,
+    predicate: Option<PredicateRef>,
+) -> DeltaResult<Vec<Vec<Box<dyn EngineData>>>> {
+    let locations = commit_files
+        .iter()
+        .map(|commit_file| commit_file.location.clone())
+        .collect_vec();
+    let schema_with_file_path =
+        Arc::new(schema.add_metadata_column(FILE_PATH_COLUMN_NAME, MetadataColumnSpec::FilePath)?);
+    let batches =
+        engine
+            .json_handler()
+            .read_json_files(&locations, schema_with_file_path, predicate)?;
+
+    group_commit_batches(&locations, batches)
+}
+
+fn group_commit_batches(
+    locations: &[FileMeta],
+    batches: FileDataReadResultIterator,
+) -> DeltaResult<Vec<Vec<Box<dyn EngineData>>>> {
+    let file_indices: HashMap<_, _> = locations
+        .iter()
+        .enumerate()
+        .map(|(index, file)| (file.location.to_string(), index))
+        .collect();
+    let mut groups: Vec<Vec<Box<dyn EngineData>>> = locations.iter().map(|_| Vec::new()).collect();
+    for batch in batches {
+        let batch = batch?;
+        if batch.is_empty() {
+            continue;
+        }
+
+        let mut visitor = FilePathVisitor::default();
+        visitor.visit_rows_of(batch.as_ref())?;
+        let path = visitor.file_path.ok_or_else(|| {
+            Error::internal_error("table_changes received a JSON batch without a file path")
+        })?;
+        let group_index = file_indices.get(&path).ok_or_else(|| {
+            Error::internal_error(format!(
+                "table_changes received a JSON batch for unrequested commit file {path}"
+            ))
+        })?;
+        groups[*group_index].push(batch);
+    }
+    Ok(groups)
+}
+
+const FILE_PATH_COLUMN_NAME: &str = "_file";
+
+/// Reads the file path that identifies a JSON batch's source commit.
+///
+/// The JSON handler does not merge file boundaries, so the first row identifies the batch.
+#[derive(Default)]
+struct FilePathVisitor {
+    file_path: Option<String>,
+}
+
+impl RowVisitor for FilePathVisitor {
+    fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
+        static NAMES_AND_TYPES: LazyLock<ColumnNamesAndTypes> =
+            LazyLock::new(|| (vec![column_name!("_file")], vec![DataType::STRING]).into());
+        NAMES_AND_TYPES.as_ref()
+    }
+
+    fn visit<'b>(&mut self, row_count: usize, getters: &[&'b dyn GetData<'b>]) -> DeltaResult<()> {
+        require!(
+            getters.len() == 1,
+            Error::InternalError(format!(
+                "Wrong number of FilePathVisitor getters: {}",
+                getters.len()
+            ))
+        );
+        if row_count > 0 {
+            self.file_path = getters[0]
+                .get_str(0, FILE_PATH_COLUMN_NAME)?
+                .map(ToString::to_string);
+        }
+        Ok(())
+    }
 }
 
 /// Processes a single commit file from the log to generate an iterator of
@@ -151,9 +263,8 @@ pub(crate) fn table_changes_action_iter_with_mode(
 ///     - Otherwise, select `add` and `remove` actions. Note that only `remove` actions that do not
 ///       share a path with an `add` action are selected.
 ///
-/// Note: As a consequence of the two phases, LogReplayScanner will iterate over each action in the
-/// commit twice. It also may use an unbounded amount of memory, proportional to the number of
-/// `add` + `remove` actions in the _single_ commit.
+/// Both phases materialize their JSON batches across the requested version range before commit
+/// processing, so peak memory grows with the actions in that range.
 struct LogReplayScanner {
     // True if a `cdc` action was found after running [`LogReplayScanner::try_new`]
     has_cdc_action: bool,
@@ -177,34 +288,14 @@ impl LogReplayScanner {
     ///
     /// For more details, see the documentation for [`LogReplayScanner`].
     fn try_new(
-        engine: &dyn Engine,
         table_configuration: &mut TableConfiguration,
         commit_file: ParsedLogPath,
+        prepare_phase_actions: Vec<Box<dyn EngineData>>,
         table_schema: &SchemaRef,
         mode: CdfMode,
     ) -> DeltaResult<Self> {
-        let visitor_schema = PreparePhaseVisitor::schema();
-
-        // Note: We do not perform data skipping yet because we need to visit all add and
-        // remove actions for deletion vector resolution to be correct.
-        //
-        // Consider a scenario with a pair of add/remove actions with the same path. The add
-        // action has file statistics, while the remove action does not (stats is optional for
-        // remove). In this scenario we might skip the add action, while the remove action remains.
-        // As a result, we would read the file path for the remove action, which is unnecessary
-        // because all of the rows will be filtered by the predicate. Instead, we wait until
-        // deletion vectors are resolved so that we can skip both actions in the pair.
-        let mut action_iter = engine
-            .json_handler()
-            .read_json_files(
-                slice::from_ref(&commit_file.location),
-                visitor_schema,
-                None, // not safe to apply data skipping yet
-            )?
-            .peekable();
-
         let mut in_commit_timestamp_opt = None;
-        if let Some(Ok(actions)) = action_iter.peek() {
+        if let Some(actions) = prepare_phase_actions.first() {
             let mut visitor = InCommitTimestampVisitor::default();
             visitor.visit_rows_of(actions.as_ref())?;
             in_commit_timestamp_opt = visitor.in_commit_timestamp;
@@ -214,9 +305,7 @@ impl LogReplayScanner {
         let mut add_paths = HashSet::default();
         let mut has_cdc_action = false;
 
-        for actions in action_iter {
-            let actions = actions?;
-
+        for actions in prepare_phase_actions {
             let mut visitor = PreparePhaseVisitor {
                 add_paths: &mut add_paths,
                 remove_dvs: &mut remove_dvs,
@@ -331,6 +420,7 @@ impl LogReplayScanner {
     fn into_scan_batches(
         self,
         engine: Arc<dyn Engine>,
+        scan_phase_actions: Vec<Box<dyn EngineData>>,
         filter: Option<Arc<DataSkippingFilter>>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
         let Self {
@@ -342,12 +432,7 @@ impl LogReplayScanner {
         } = self;
         let remove_dvs = Arc::new(remove_dvs);
 
-        let schema = FileActionSelectionVisitor::schema();
-        let action_iter = engine.json_handler().read_json_files(
-            slice::from_ref(&commit_file.location),
-            schema,
-            None,
-        )?;
+        let action_iter = scan_phase_actions.into_iter();
         let commit_version = commit_file
             .version
             .try_into()
@@ -359,8 +444,6 @@ impl LogReplayScanner {
         )?;
 
         let result = action_iter.map(move |actions| -> DeltaResult<_> {
-            let actions = actions?;
-
             // Apply data skipping to get back a selection vector for actions that passed skipping.
             // We start our selection vector based on what was filtered. We will add to this vector
             // below if a file has been removed. Note: None implies all files passed data skipping.

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -7,17 +7,23 @@ use rstest::rstest;
 use test_utils::LoggingTest;
 
 use super::{
-    table_changes_action_iter, table_changes_action_iter_with_mode, TableChangesScanMetadata,
+    group_commit_batches, read_commits_grouped, table_changes_action_iter,
+    table_changes_action_iter_with_mode, LogReplayScanner, PreparePhaseVisitor,
+    TableChangesScanMetadata,
 };
 use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
+use crate::arrow::array::{RecordBatch, StringArray};
+use crate::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::sync::SyncEngine;
 use crate::expressions::{column_expr, BinaryPredicateOp, Scalar};
 use crate::log_segment::LogSegment;
+use crate::metrics::{MeteredDeltaEngine, MetricEvent};
 use crate::path::ParsedLogPath;
 use crate::scan::state::DvInfo;
 use crate::scan::PhysicalPredicate;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
-use crate::table_changes::log_replay::LogReplayScanner;
+use crate::table_changes::scan_file::scan_metadata_to_scan_file;
 use crate::table_changes::test_utils::{
     row_tracking_metadata, row_tracking_table_config, test_deletion_vector,
 };
@@ -25,8 +31,11 @@ use crate::table_changes::CdfMode;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{ColumnMappingMode, TableFeature};
 use crate::table_properties::{ENABLE_ROW_TRACKING, ROW_TRACKING_SUSPENDED};
-use crate::utils::test_utils::{assert_result_error_with_message, Action, LocalMockTable};
-use crate::{DeltaResult, Engine, Error, Predicate, Version};
+use crate::utils::test_utils::{
+    assert_result_error_with_message, install_thread_local_metrics_reporter, Action,
+    CapturingReporter, LocalMockTable,
+};
+use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, Predicate, Version};
 
 fn get_schema() -> SchemaRef {
     Arc::new(StructType::new_unchecked([
@@ -170,6 +179,166 @@ fn result_to_sv(iter: impl Iterator<Item = DeltaResult<TableChangesScanMetadata>
         .flatten_ok()
         .try_collect()
         .unwrap()
+}
+
+fn file_path_batch(path: &str, row_count: usize) -> Box<dyn EngineData> {
+    let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        "_file",
+        ArrowDataType::Utf8,
+        false,
+    )]));
+    let paths = Arc::new(StringArray::from(vec![path; row_count]));
+    let batch = RecordBatch::try_new(schema, vec![paths]).unwrap();
+    Box::new(ArrowEngineData::new(batch))
+}
+
+fn nullable_file_path_batch(path: Option<&str>) -> Box<dyn EngineData> {
+    let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        "_file",
+        ArrowDataType::Utf8,
+        true,
+    )]));
+    let paths = Arc::new(StringArray::from(vec![path]));
+    let batch = RecordBatch::try_new(schema, vec![paths]).unwrap();
+    Box::new(ArrowEngineData::new(batch))
+}
+
+fn prepare_actions_for_commit(
+    engine: &dyn Engine,
+    commit: &ParsedLogPath,
+) -> Vec<Box<dyn EngineData>> {
+    read_commits_grouped(
+        engine,
+        std::slice::from_ref(commit),
+        &PreparePhaseVisitor::schema(),
+        None,
+    )
+    .unwrap()
+    .pop()
+    .unwrap()
+}
+
+#[test]
+fn groups_multiple_batches_without_shifting_over_empty_commits() {
+    let locations = vec![
+        FileMeta::new(url::Url::parse("memory:///0.json").unwrap(), 0, 0),
+        FileMeta::new(url::Url::parse("memory:///1.json").unwrap(), 0, 0),
+        FileMeta::new(url::Url::parse("memory:///2.json").unwrap(), 0, 0),
+    ];
+    let batches = vec![
+        Ok::<_, Error>(file_path_batch("memory:///0.json", 1)),
+        Ok(file_path_batch("memory:///0.json", 1)),
+        Ok(file_path_batch("memory:///1.json", 0)),
+        Ok(file_path_batch("memory:///2.json", 1)),
+    ];
+
+    let groups = group_commit_batches(&locations, Box::new(batches.into_iter())).unwrap();
+
+    assert_eq!(groups.iter().map(Vec::len).collect_vec(), vec![2, 0, 1]);
+}
+
+#[rstest]
+#[case(None, "without a file path")]
+#[case(Some("memory:///unexpected.json"), "unrequested commit file")]
+fn rejects_batch_without_requested_file_path(
+    #[case] batch_path: Option<&str>,
+    #[case] expected_error: &str,
+) {
+    let locations = vec![FileMeta::new(
+        url::Url::parse("memory:///requested.json").unwrap(),
+        0,
+        0,
+    )];
+    let batches = vec![Ok::<_, Error>(nullable_file_path_batch(batch_path))];
+
+    let result = group_commit_batches(&locations, Box::new(batches.into_iter()));
+
+    assert_result_error_with_message(result, expected_error);
+}
+
+#[tokio::test]
+async fn batches_each_json_phase_across_the_commit_range() {
+    let reporter = Arc::new(CapturingReporter::default());
+    let _guard = install_thread_local_metrics_reporter(reporter.clone());
+    let engine: Arc<dyn Engine> = Arc::new(MeteredDeltaEngine::new(Arc::new(SyncEngine::new())));
+    let mut mock_table = LocalMockTable::new();
+    for version in 0..3 {
+        mock_table
+            .commit([Action::Add(Add {
+                path: format!("file_{version}.parquet"),
+                data_change: true,
+                ..Default::default()
+            })])
+            .await;
+    }
+
+    let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None).unwrap();
+    let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+    let table_config = get_default_table_config(&table_root_url);
+
+    let scan_metadata =
+        table_changes_action_iter(engine, &table_config, commits, get_schema(), None).unwrap();
+    let scan_files: Vec<_> = scan_metadata_to_scan_file(scan_metadata)
+        .map_ok(|scan_file| (scan_file.commit_version, scan_file.path))
+        .try_collect()
+        .unwrap();
+
+    assert_eq!(
+        scan_files,
+        vec![
+            (0, "file_0.parquet".to_string()),
+            (1, "file_1.parquet".to_string()),
+            (2, "file_2.parquet".to_string()),
+        ]
+    );
+    let json_read_file_counts = reporter
+        .events()
+        .into_iter()
+        .filter_map(|event| match event {
+            MetricEvent::JsonReadCompleted(event) => Some(event.num_files),
+            _ => None,
+        })
+        .collect_vec();
+    assert_eq!(json_read_file_counts, vec![3, 3]);
+}
+
+#[tokio::test]
+async fn empty_commit_does_not_shift_following_actions() {
+    let engine = Arc::new(SyncEngine::new());
+    let mut mock_table = LocalMockTable::new();
+    mock_table
+        .commit([Action::Add(Add {
+            path: "file_0.parquet".to_string(),
+            data_change: true,
+            ..Default::default()
+        })])
+        .await;
+    mock_table.commit(std::iter::empty()).await;
+    mock_table
+        .commit([Action::Add(Add {
+            path: "file_2.parquet".to_string(),
+            data_change: true,
+            ..Default::default()
+        })])
+        .await;
+
+    let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None).unwrap();
+    let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+    let table_config = get_default_table_config(&table_root_url);
+    let scan_metadata =
+        table_changes_action_iter(engine, &table_config, commits, get_schema(), None).unwrap();
+    let scan_files: Vec<_> = scan_metadata_to_scan_file(scan_metadata)
+        .map_ok(|scan_file| (scan_file.commit_version, scan_file.path))
+        .try_collect()
+        .unwrap();
+
+    assert_eq!(
+        scan_files,
+        vec![
+            (0, "file_0.parquet".to_string()),
+            (2, "file_2.parquet".to_string()),
+        ]
+    );
 }
 
 #[tokio::test]
@@ -1218,10 +1387,11 @@ async fn file_meta_timestamp() {
     let file_meta_ts = commit.location.last_modified;
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
+    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
-        engine.as_ref(),
         &mut table_config,
         commit,
+        prepare_actions,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1506,10 +1676,11 @@ async fn test_timestamp_with_ict_enabled() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
+    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
-        engine.as_ref(),
         &mut table_config,
         commit,
+        prepare_actions,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1557,10 +1728,11 @@ async fn test_timestamp_with_ict_disabled() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
+    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
-        engine.as_ref(),
         &mut table_config,
         commit.clone(),
+        prepare_actions,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1615,10 +1787,11 @@ async fn test_timestamp_with_commit_info_not_first() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
+    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
     let result = LogReplayScanner::try_new(
-        engine.as_ref(),
         &mut table_config,
         commit,
+        prepare_actions,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     );

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use itertools::Itertools;
@@ -7,8 +8,8 @@ use rstest::rstest;
 use test_utils::LoggingTest;
 
 use super::{
-    group_commit_batches, read_commits_grouped, table_changes_action_iter,
-    table_changes_action_iter_with_mode, LogReplayScanner, PreparePhaseVisitor,
+    read_commit_batches, replay_schema, table_changes_action_iter,
+    table_changes_action_iter_with_mode, CommitBatchIterator, LogReplayScanner,
     TableChangesScanMetadata,
 };
 use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
@@ -35,7 +36,7 @@ use crate::utils::test_utils::{
     assert_result_error_with_message, install_thread_local_metrics_reporter, Action,
     CapturingReporter, LocalMockTable,
 };
-use crate::{DeltaResult, Engine, EngineData, Error, FileMeta, Predicate, Version};
+use crate::{DeltaResult, Engine, EngineData, Error, Predicate, Version};
 
 fn get_schema() -> SchemaRef {
     Arc::new(StructType::new_unchecked([
@@ -203,38 +204,50 @@ fn nullable_file_path_batch(path: Option<&str>) -> Box<dyn EngineData> {
     Box::new(ArrowEngineData::new(batch))
 }
 
-fn prepare_actions_for_commit(
+fn action_batches_for_commit(
     engine: &dyn Engine,
     commit: &ParsedLogPath,
 ) -> Vec<Box<dyn EngineData>> {
-    read_commits_grouped(
-        engine,
-        std::slice::from_ref(commit),
-        &PreparePhaseVisitor::schema(),
-        None,
-    )
-    .unwrap()
-    .pop()
-    .unwrap()
+    read_commit_batches(engine, vec![commit.clone()], replay_schema().unwrap())
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .action_batches
+}
+
+fn test_commits(count: u64) -> Vec<ParsedLogPath> {
+    let table_root = url::Url::parse("memory:///").unwrap();
+    (0..count)
+        .map(|version| ParsedLogPath::create_parsed_published_commit(&table_root, version))
+        .collect()
 }
 
 #[test]
 fn groups_multiple_batches_without_shifting_over_empty_commits() {
-    let locations = vec![
-        FileMeta::new(url::Url::parse("memory:///0.json").unwrap(), 0, 0),
-        FileMeta::new(url::Url::parse("memory:///1.json").unwrap(), 0, 0),
-        FileMeta::new(url::Url::parse("memory:///2.json").unwrap(), 0, 0),
-    ];
+    let commits = test_commits(3);
+    let paths = commits
+        .iter()
+        .map(|commit| commit.location.location.to_string())
+        .collect_vec();
     let batches = vec![
-        Ok::<_, Error>(file_path_batch("memory:///0.json", 1)),
-        Ok(file_path_batch("memory:///0.json", 1)),
-        Ok(file_path_batch("memory:///1.json", 0)),
-        Ok(file_path_batch("memory:///2.json", 1)),
+        Ok::<_, Error>(file_path_batch(&paths[0], 1)),
+        Ok(file_path_batch(&paths[0], 1)),
+        Ok(file_path_batch(&paths[1], 0)),
+        Ok(file_path_batch(&paths[2], 1)),
     ];
 
-    let groups = group_commit_batches(&locations, Box::new(batches.into_iter())).unwrap();
+    let grouped_batches: Vec<_> = CommitBatchIterator::new(commits, Box::new(batches.into_iter()))
+        .try_collect()
+        .unwrap();
 
-    assert_eq!(groups.iter().map(Vec::len).collect_vec(), vec![2, 0, 1]);
+    assert_eq!(
+        grouped_batches
+            .iter()
+            .map(|group| group.action_batches.len())
+            .collect_vec(),
+        vec![2, 0, 1]
+    );
 }
 
 #[rstest]
@@ -244,20 +257,40 @@ fn rejects_batch_without_requested_file_path(
     #[case] batch_path: Option<&str>,
     #[case] expected_error: &str,
 ) {
-    let locations = vec![FileMeta::new(
-        url::Url::parse("memory:///requested.json").unwrap(),
-        0,
-        0,
-    )];
+    let commits = test_commits(1);
     let batches = vec![Ok::<_, Error>(nullable_file_path_batch(batch_path))];
 
-    let result = group_commit_batches(&locations, Box::new(batches.into_iter()));
+    let mut commit_batches = CommitBatchIterator::new(commits, Box::new(batches.into_iter()));
+    let result = commit_batches.next().unwrap();
 
     assert_result_error_with_message(result, expected_error);
+    assert!(commit_batches.next().is_none());
+}
+
+#[test]
+fn streams_commit_batches_without_materializing_the_full_range() {
+    let commits = test_commits(3);
+    let batches = commits
+        .iter()
+        .map(|commit| file_path_batch(commit.location.location.as_str(), 1))
+        .collect_vec();
+    let batches_read = Arc::new(AtomicUsize::new(0));
+    let counter = batches_read.clone();
+    let batches = batches.into_iter().map(move |batch| {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Ok::<_, Error>(batch)
+    });
+    let mut commit_batches = CommitBatchIterator::new(commits, Box::new(batches));
+
+    let first = commit_batches.next().unwrap().unwrap();
+
+    assert_eq!(first.commit.version, 0);
+    assert_eq!(first.action_batches.len(), 1);
+    assert_eq!(batches_read.load(Ordering::Relaxed), 2);
 }
 
 #[tokio::test]
-async fn batches_each_json_phase_across_the_commit_range() {
+async fn reads_full_commit_range_once() {
     let reporter = Arc::new(CapturingReporter::default());
     let _guard = install_thread_local_metrics_reporter(reporter.clone());
     let engine: Arc<dyn Engine> = Arc::new(MeteredDeltaEngine::new(Arc::new(SyncEngine::new())));
@@ -299,7 +332,7 @@ async fn batches_each_json_phase_across_the_commit_range() {
             _ => None,
         })
         .collect_vec();
-    assert_eq!(json_read_file_counts, vec![3, 3]);
+    assert_eq!(json_read_file_counts, vec![3]);
 }
 
 #[tokio::test]
@@ -1387,11 +1420,11 @@ async fn file_meta_timestamp() {
     let file_meta_ts = commit.location.last_modified;
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
-    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
+    let action_batches = action_batches_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
         &mut table_config,
         commit,
-        prepare_actions,
+        action_batches,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1676,11 +1709,11 @@ async fn test_timestamp_with_ict_enabled() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
-    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
+    let action_batches = action_batches_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
         &mut table_config,
         commit,
-        prepare_actions,
+        action_batches,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1728,11 +1761,11 @@ async fn test_timestamp_with_ict_disabled() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
-    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
+    let action_batches = action_batches_for_commit(engine.as_ref(), &commit);
     let scanner = LogReplayScanner::try_new(
         &mut table_config,
         commit.clone(),
-        prepare_actions,
+        action_batches,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     )
@@ -1787,11 +1820,11 @@ async fn test_timestamp_with_commit_info_not_first() {
     let commit = commits.next().unwrap();
     let table_root_url = url::Url::from_directory_path(mock_table.table_root()).unwrap();
     let mut table_config = get_default_table_config(&table_root_url);
-    let prepare_actions = prepare_actions_for_commit(engine.as_ref(), &commit);
+    let action_batches = action_batches_for_commit(engine.as_ref(), &commit);
     let result = LogReplayScanner::try_new(
         &mut table_config,
         commit,
-        prepare_actions,
+        action_batches,
         &get_schema(),
         CdfMode::ChangeDataFeed,
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR batches Change Data Feed commit JSON reads across the requested version range. Each CDF processing now submits all commit files in one `read_json_files` call, allowing engines to overlap reads.

Batches are regrouped by their `_file` metadata before commits are processed in order. The grouping supports multiple batches per commit, empty commits, and zero-row batches, while rejecting missing or unexpected file paths.

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
No
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Tests verify range-wide batching, correct commit attribution after empty commits, multi-batch grouping, and invalid path handling.