### PR TITLE
refactor: consolidate test engine wrappers behind DelegatingEngine

### DIFF
--- a/kernel/src/engine/mod.rs
+++ b/kernel/src/engine/mod.rs
@@ -51,6 +51,9 @@ pub mod plans;
 #[cfg(test)]
 pub(crate) mod sync;
 
+#[cfg(test)]
+pub(crate) mod test_delegating;
+
 #[cfg(feature = "default-engine-base")]
 pub mod arrow_data;
 #[cfg(feature = "default-engine-base")]

--- a/kernel/src/engine/test_delegating.rs
+++ b/kernel/src/engine/test_delegating.rs
@@ -1,0 +1,95 @@
+//! A test [`Engine`] that forwards to an inner engine, overriding individual handlers.
+
+use std::sync::Arc;
+
+#[cfg(feature = "declarative-plans")]
+use crate::plans::PlanExecutor;
+use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
+
+/// A test [`Engine`] that forwards every handler to `inner`, except those overridden via the
+/// `with_*` setters. Lets a test swap a single handler without re-typing the forwards for the
+/// rest.
+#[allow(dead_code)]
+pub(crate) struct DelegatingEngine {
+    inner: Arc<dyn Engine>,
+    evaluation: Option<Arc<dyn EvaluationHandler>>,
+    storage: Option<Arc<dyn StorageHandler>>,
+    json: Option<Arc<dyn JsonHandler>>,
+    parquet: Option<Arc<dyn ParquetHandler>>,
+    #[cfg(feature = "declarative-plans")]
+    plan_executor: Option<Arc<dyn PlanExecutor>>,
+}
+
+#[allow(dead_code)]
+impl DelegatingEngine {
+    pub(crate) fn new(inner: Arc<dyn Engine>) -> Self {
+        Self {
+            inner,
+            evaluation: None,
+            storage: None,
+            json: None,
+            parquet: None,
+            #[cfg(feature = "declarative-plans")]
+            plan_executor: None,
+        }
+    }
+
+    pub(crate) fn with_evaluation_handler(mut self, handler: Arc<dyn EvaluationHandler>) -> Self {
+        self.evaluation = Some(handler);
+        self
+    }
+
+    pub(crate) fn with_storage_handler(mut self, handler: Arc<dyn StorageHandler>) -> Self {
+        self.storage = Some(handler);
+        self
+    }
+
+    pub(crate) fn with_json_handler(mut self, handler: Arc<dyn JsonHandler>) -> Self {
+        self.json = Some(handler);
+        self
+    }
+
+    pub(crate) fn with_parquet_handler(mut self, handler: Arc<dyn ParquetHandler>) -> Self {
+        self.parquet = Some(handler);
+        self
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    pub(crate) fn with_plan_executor(mut self, executor: Arc<dyn PlanExecutor>) -> Self {
+        self.plan_executor = Some(executor);
+        self
+    }
+}
+
+impl Engine for DelegatingEngine {
+    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
+        self.evaluation
+            .clone()
+            .unwrap_or_else(|| self.inner.evaluation_handler())
+    }
+
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.storage
+            .clone()
+            .unwrap_or_else(|| self.inner.storage_handler())
+    }
+
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.json
+            .clone()
+            .unwrap_or_else(|| self.inner.json_handler())
+    }
+
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.parquet
+            .clone()
+            .unwrap_or_else(|| self.inner.parquet_handler())
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
+        self.plan_executor
+            .clone()
+            .unwrap_or_else(|| self.inner.plan_executor())
+    }
+}

--- a/kernel/src/engine/test_delegating.rs
+++ b/kernel/src/engine/test_delegating.rs
@@ -14,6 +14,18 @@ pub(crate) struct DelegatingEngine {
     storage: Option<Arc<dyn StorageHandler>>,
     json: Option<Arc<dyn JsonHandler>>,
     parquet: Option<Arc<dyn ParquetHandler>>,
+    #[cfg(feature = "declarative-plans")]
+    plan_executor: PlanExecutorOverride,
+}
+
+/// How [`DelegatingEngine`] resolves `plan_executor`. Unlike the other handlers, `None` is
+/// itself a valid override (forcing an engine to report no executor), so it needs a distinct
+/// variant from inheriting the inner engine's executor.
+#[cfg(feature = "declarative-plans")]
+enum PlanExecutorOverride {
+    Inherit,
+    None,
+    Some(Arc<dyn PlanExecutor>),
 }
 
 impl DelegatingEngine {
@@ -23,6 +35,8 @@ impl DelegatingEngine {
             storage: None,
             json: None,
             parquet: None,
+            #[cfg(feature = "declarative-plans")]
+            plan_executor: PlanExecutorOverride::Inherit,
         }
     }
 
@@ -38,6 +52,18 @@ impl DelegatingEngine {
 
     pub(crate) fn with_parquet_handler(mut self, handler: Arc<dyn ParquetHandler>) -> Self {
         self.parquet = Some(handler);
+        self
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    pub(crate) fn with_plan_executor(mut self, executor: Arc<dyn PlanExecutor>) -> Self {
+        self.plan_executor = PlanExecutorOverride::Some(executor);
+        self
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    pub(crate) fn without_plan_executor(mut self) -> Self {
+        self.plan_executor = PlanExecutorOverride::None;
         self
     }
 }
@@ -66,7 +92,11 @@ impl Engine for DelegatingEngine {
     }
 
     #[cfg(feature = "declarative-plans")]
-    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        self.inner.plan_executor()
+    fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
+        match &self.plan_executor {
+            PlanExecutorOverride::Inherit => self.inner.plan_executor(),
+            PlanExecutorOverride::None => None,
+            PlanExecutorOverride::Some(executor) => Some(executor.clone()),
+        }
     }
 }

--- a/kernel/src/engine/test_delegating.rs
+++ b/kernel/src/engine/test_delegating.rs
@@ -1,4 +1,4 @@
-//! A test [`Engine`] that forwards to an inner engine, overriding individual handlers.
+//! Test [`Engine`] that delegates handlers to an inner engine.
 
 use std::sync::Arc;
 
@@ -9,34 +9,21 @@ use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandl
 /// A test [`Engine`] that forwards every handler to `inner`, except those overridden via the
 /// `with_*` setters. Lets a test swap a single handler without re-typing the forwards for the
 /// rest.
-#[allow(dead_code)]
 pub(crate) struct DelegatingEngine {
     inner: Arc<dyn Engine>,
-    evaluation: Option<Arc<dyn EvaluationHandler>>,
     storage: Option<Arc<dyn StorageHandler>>,
     json: Option<Arc<dyn JsonHandler>>,
     parquet: Option<Arc<dyn ParquetHandler>>,
-    #[cfg(feature = "declarative-plans")]
-    plan_executor: Option<Arc<dyn PlanExecutor>>,
 }
 
-#[allow(dead_code)]
 impl DelegatingEngine {
     pub(crate) fn new(inner: Arc<dyn Engine>) -> Self {
         Self {
             inner,
-            evaluation: None,
             storage: None,
             json: None,
             parquet: None,
-            #[cfg(feature = "declarative-plans")]
-            plan_executor: None,
         }
-    }
-
-    pub(crate) fn with_evaluation_handler(mut self, handler: Arc<dyn EvaluationHandler>) -> Self {
-        self.evaluation = Some(handler);
-        self
     }
 
     pub(crate) fn with_storage_handler(mut self, handler: Arc<dyn StorageHandler>) -> Self {
@@ -53,19 +40,11 @@ impl DelegatingEngine {
         self.parquet = Some(handler);
         self
     }
-
-    #[cfg(feature = "declarative-plans")]
-    pub(crate) fn with_plan_executor(mut self, executor: Arc<dyn PlanExecutor>) -> Self {
-        self.plan_executor = Some(executor);
-        self
-    }
 }
 
 impl Engine for DelegatingEngine {
     fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-        self.evaluation
-            .clone()
-            .unwrap_or_else(|| self.inner.evaluation_handler())
+        self.inner.evaluation_handler()
     }
 
     fn storage_handler(&self) -> Arc<dyn StorageHandler> {
@@ -88,8 +67,6 @@ impl Engine for DelegatingEngine {
 
     #[cfg(feature = "declarative-plans")]
     fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        self.plan_executor
-            .clone()
-            .unwrap_or_else(|| self.inner.plan_executor())
+        self.inner.plan_executor()
     }
 }

--- a/kernel/src/log_segment/protocol_metadata_replay.rs
+++ b/kernel/src/log_segment/protocol_metadata_replay.rs
@@ -214,12 +214,12 @@ mod tests {
 
     use crate::engine::sync::SyncEngine;
     #[cfg(feature = "declarative-plans")]
+    use crate::engine::test_delegating::DelegatingEngine;
+    #[cfg(feature = "declarative-plans")]
     use crate::plans::{Operation, PlanExecutor, PlanResult};
     use crate::Snapshot;
     #[cfg(feature = "declarative-plans")]
-    use crate::{
-        DeltaResult, Engine, Error, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler,
-    };
+    use crate::{DeltaResult, Error};
 
     // A [`PlanExecutor`] whose every operation fails, used to prove that a plan-path failure
     // surfaces from P&M replay rather than falling back to legacy replay.
@@ -230,30 +230,6 @@ mod tests {
     impl PlanExecutor for FailingPlanExecutor {
         fn execute_op(&self, _op: Operation) -> DeltaResult<PlanResult> {
             Err(Error::generic("plan executor deliberately failed"))
-        }
-    }
-
-    // Forwards every handler to an inner [`SyncEngine`] but returns a [`FailingPlanExecutor`], so
-    // P&M replay takes the plan path and hits the failure.
-    #[cfg(feature = "declarative-plans")]
-    struct FailingPlanEngine(Arc<SyncEngine>);
-
-    #[cfg(feature = "declarative-plans")]
-    impl Engine for FailingPlanEngine {
-        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-            self.0.evaluation_handler()
-        }
-        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-            self.0.storage_handler()
-        }
-        fn json_handler(&self) -> Arc<dyn JsonHandler> {
-            self.0.json_handler()
-        }
-        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-            self.0.parquet_handler()
-        }
-        fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
-            Some(Arc::new(FailingPlanExecutor))
         }
     }
 
@@ -344,7 +320,8 @@ mod tests {
         let path =
             std::fs::canonicalize(PathBuf::from("./tests/data/app-txn-checkpoint/")).unwrap();
         let url = url::Url::from_directory_path(path).unwrap();
-        let engine = FailingPlanEngine(Arc::new(SyncEngine::new()));
+        let engine = DelegatingEngine::new(Arc::new(SyncEngine::new()))
+            .with_plan_executor(Arc::new(FailingPlanExecutor));
 
         let result = Snapshot::builder_for(url).build(&engine);
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -18,6 +18,7 @@ use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
+use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::ColumnName;
 use crate::last_checkpoint_hint::{LastCheckpointHint, LastCheckpointV2};
 use crate::log_replay::ActionsBatch;
@@ -43,9 +44,9 @@ use crate::utils::test_utils::{
     create_log_path_with_size, string_array_to_engine_data, Action,
 };
 use crate::{
-    DeltaResult, DeltaResultIteratorStatic, EngineData, EvaluationHandler, Expression,
-    FileDataReadResultIterator, FileMeta, JsonHandler, ParquetFooter, ParquetHandler, Predicate,
-    PredicateRef, RowVisitor, StorageHandler,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Expression, FileDataReadResultIterator,
+    FileMeta, JsonHandler, ParquetFooter, ParquetHandler, Predicate, PredicateRef, RowVisitor,
+    StorageHandler,
 };
 
 /// Processes sidecar files for the given checkpoint batch.
@@ -244,39 +245,6 @@ impl ParquetHandler for IgnorePredicateParquetHandler {
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
         self.0.read_parquet_footer(file)
-    }
-}
-
-struct IgnorePredicateEngine {
-    inner: Arc<SyncEngine>,
-    parquet_handler: Arc<IgnorePredicateParquetHandler>,
-}
-
-impl IgnorePredicateEngine {
-    fn new(inner: Arc<SyncEngine>) -> Self {
-        let parquet_handler = Arc::new(IgnorePredicateParquetHandler(inner.parquet_handler()));
-        Self {
-            inner,
-            parquet_handler,
-        }
-    }
-}
-
-impl Engine for IgnorePredicateEngine {
-    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-        self.inner.evaluation_handler()
-    }
-
-    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-        self.inner.storage_handler()
-    }
-
-    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-        self.parquet_handler.clone()
-    }
-
-    fn json_handler(&self) -> Arc<dyn JsonHandler> {
-        self.inner.json_handler()
     }
 }
 
@@ -1518,7 +1486,9 @@ async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
-    let ignore_predicate_engine = IgnorePredicateEngine::new(sync_engine.clone());
+    let ignore_predicate_engine = DelegatingEngine::new(sync_engine.clone()).with_parquet_handler(
+        Arc::new(IgnorePredicateParquetHandler(sync_engine.parquet_handler())),
+    );
     let engine: &dyn Engine = if ignore_predicate {
         &ignore_predicate_engine
     } else {
@@ -1632,7 +1602,9 @@ async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
-    let ignore_predicate_engine = IgnorePredicateEngine::new(sync_engine.clone());
+    let ignore_predicate_engine = DelegatingEngine::new(sync_engine.clone()).with_parquet_handler(
+        Arc::new(IgnorePredicateParquetHandler(sync_engine.parquet_handler())),
+    );
     let engine: &dyn Engine = if ignore_predicate {
         &ignore_predicate_engine
     } else {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -248,6 +248,12 @@ impl ParquetHandler for IgnorePredicateParquetHandler {
     }
 }
 
+fn ignore_predicate_engine(sync_engine: &Arc<SyncEngine>) -> DelegatingEngine {
+    DelegatingEngine::new(sync_engine.clone()).with_parquet_handler(Arc::new(
+        IgnorePredicateParquetHandler(sync_engine.parquet_handler()),
+    ))
+}
+
 /// Writes all actions to a _delta_log/_sidecars file in the store and return the [`FileMeta`].
 /// This function formats the provided filename into the _sidecars subdirectory.
 async fn add_sidecar_to_store(
@@ -1486,9 +1492,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_row_groups(
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
-    let ignore_predicate_engine = DelegatingEngine::new(sync_engine.clone()).with_parquet_handler(
-        Arc::new(IgnorePredicateParquetHandler(sync_engine.parquet_handler())),
-    );
+    let ignore_predicate_engine = ignore_predicate_engine(&sync_engine);
     let engine: &dyn Engine = if ignore_predicate {
         &ignore_predicate_engine
     } else {
@@ -1602,9 +1606,7 @@ async fn test_scan_checkpoint_read_handles_all_remove_sidecar_row_groups(
 ) -> DeltaResult<()> {
     let (store, log_root) = new_in_memory_store();
     let sync_engine = Arc::new(SyncEngine::new_with_store(store.clone()));
-    let ignore_predicate_engine = DelegatingEngine::new(sync_engine.clone()).with_parquet_handler(
-        Arc::new(IgnorePredicateParquetHandler(sync_engine.parquet_handler())),
-    );
+    let ignore_predicate_engine = ignore_predicate_engine(&sync_engine);
     let engine: &dyn Engine = if ignore_predicate {
         &ignore_predicate_engine
     } else {

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -132,8 +132,6 @@ mod tests {
         }
     }
 
-    /// A [`DelegatingEngine`] over a [`SyncEngine`] whose `storage_handler` is a
-    /// [`StubStorageHandler`] configured to yield two list entries.
     fn stub_engine() -> DelegatingEngine {
         DelegatingEngine::new(Arc::new(SyncEngine::new())).with_storage_handler(Arc::new(
             StubStorageHandler {
@@ -196,66 +194,30 @@ mod tests {
             .is::<MeteredParquetHandler>());
     }
 
-    /// Engine that pre-meters a single handler; lets each double-wrap test target one
-    /// guard without tripping the others.
-    struct PreMeteredEngine {
-        inner: DelegatingEngine,
-        meter_storage: bool,
-        meter_json: bool,
-        meter_parquet: bool,
-    }
-
-    impl Engine for PreMeteredEngine {
-        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-            self.inner.evaluation_handler()
-        }
-        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-            if self.meter_storage {
-                Arc::new(MeteredStorageHandler::new(self.inner.storage_handler()))
-            } else {
-                self.inner.storage_handler()
-            }
-        }
-        fn json_handler(&self) -> Arc<dyn JsonHandler> {
-            if self.meter_json {
-                Arc::new(MeteredJsonHandler::new(self.inner.json_handler()))
-            } else {
-                self.inner.json_handler()
-            }
-        }
-        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-            if self.meter_parquet {
-                Arc::new(MeteredParquetHandler::new(self.inner.parquet_handler()))
-            } else {
-                self.inner.parquet_handler()
-            }
-        }
-    }
-
-    fn pre_metered(storage: bool, json: bool, parquet: bool) -> PreMeteredEngine {
-        PreMeteredEngine {
-            inner: stub_engine(),
-            meter_storage: storage,
-            meter_json: json,
-            meter_parquet: parquet,
-        }
-    }
-
     #[test]
     #[should_panic(expected = "storage_handler is already a MeteredStorageHandler")]
     fn new_panics_when_inner_storage_already_metered() {
-        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(true, false, false)));
+        let inner = stub_engine();
+        let metered = Arc::new(MeteredStorageHandler::new(inner.storage_handler()));
+        let engine = DelegatingEngine::new(Arc::new(inner)).with_storage_handler(metered);
+        let _ = MeteredDeltaEngine::new(Arc::new(engine));
     }
 
     #[test]
     #[should_panic(expected = "json_handler is already a MeteredJsonHandler")]
     fn new_panics_when_inner_json_already_metered() {
-        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(false, true, false)));
+        let inner = stub_engine();
+        let metered = Arc::new(MeteredJsonHandler::new(inner.json_handler()));
+        let engine = DelegatingEngine::new(Arc::new(inner)).with_json_handler(metered);
+        let _ = MeteredDeltaEngine::new(Arc::new(engine));
     }
 
     #[test]
     #[should_panic(expected = "parquet_handler is already a MeteredParquetHandler")]
     fn new_panics_when_inner_parquet_already_metered() {
-        let _ = MeteredDeltaEngine::new(Arc::new(pre_metered(false, false, true)));
+        let inner = stub_engine();
+        let metered = Arc::new(MeteredParquetHandler::new(inner.parquet_handler()));
+        let engine = DelegatingEngine::new(Arc::new(inner)).with_parquet_handler(metered);
+        let _ = MeteredDeltaEngine::new(Arc::new(engine));
     }
 }

--- a/kernel/src/metrics/metered_engine.rs
+++ b/kernel/src/metrics/metered_engine.rs
@@ -93,6 +93,7 @@ mod tests {
 
     use super::*;
     use crate::engine::sync::SyncEngine;
+    use crate::engine::test_delegating::DelegatingEngine;
     use crate::metrics::MetricEvent;
     use crate::utils::test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
     use crate::{DeltaResult, FileMeta, FileSlice};
@@ -131,50 +132,27 @@ mod tests {
         }
     }
 
-    /// Engine that delegates everything to a [`SyncEngine`] except `storage_handler`, which
-    /// returns a [`StubStorageHandler`] configured to yield two list entries.
-    struct StubEngine {
-        sync: Arc<SyncEngine>,
-        storage: Arc<dyn StorageHandler>,
-    }
-
-    impl StubEngine {
-        fn new() -> Self {
-            Self {
-                sync: Arc::new(SyncEngine::new()),
-                storage: Arc::new(StubStorageHandler {
-                    list_results: vec![
-                        FileMeta {
-                            location: Url::parse("memory:///_delta_log/00000000000000000000.json")
-                                .unwrap(),
-                            last_modified: 0,
-                            size: 0,
-                        },
-                        FileMeta {
-                            location: Url::parse("memory:///_delta_log/00000000000000000001.json")
-                                .unwrap(),
-                            last_modified: 0,
-                            size: 0,
-                        },
-                    ],
-                }),
-            }
-        }
-    }
-
-    impl Engine for StubEngine {
-        fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-            self.sync.evaluation_handler()
-        }
-        fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-            Arc::clone(&self.storage)
-        }
-        fn json_handler(&self) -> Arc<dyn JsonHandler> {
-            self.sync.json_handler()
-        }
-        fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-            self.sync.parquet_handler()
-        }
+    /// A [`DelegatingEngine`] over a [`SyncEngine`] whose `storage_handler` is a
+    /// [`StubStorageHandler`] configured to yield two list entries.
+    fn stub_engine() -> DelegatingEngine {
+        DelegatingEngine::new(Arc::new(SyncEngine::new())).with_storage_handler(Arc::new(
+            StubStorageHandler {
+                list_results: vec![
+                    FileMeta {
+                        location: Url::parse("memory:///_delta_log/00000000000000000000.json")
+                            .unwrap(),
+                        last_modified: 0,
+                        size: 0,
+                    },
+                    FileMeta {
+                        location: Url::parse("memory:///_delta_log/00000000000000000001.json")
+                            .unwrap(),
+                        last_modified: 0,
+                        size: 0,
+                    },
+                ],
+            },
+        ))
     }
 
     #[test]
@@ -182,7 +160,7 @@ mod tests {
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(Arc::clone(&reporter) as _);
 
-        let engine = MeteredDeltaEngine::new(Arc::new(StubEngine::new()));
+        let engine = MeteredDeltaEngine::new(Arc::new(stub_engine()));
         let url = Url::parse("memory:///_delta_log/").unwrap();
         let iter = engine.storage_handler().list_from(&url).unwrap();
         let _: Vec<_> = iter.collect();
@@ -201,7 +179,7 @@ mod tests {
 
     #[test]
     fn evaluation_handler_passes_through() {
-        let inner: Arc<dyn Engine> = Arc::new(StubEngine::new());
+        let inner: Arc<dyn Engine> = Arc::new(stub_engine());
         let inner_eval = inner.evaluation_handler();
 
         let engine = MeteredDeltaEngine::new(inner);
@@ -210,7 +188,7 @@ mod tests {
 
     #[test]
     fn json_and_parquet_handlers_are_metered() {
-        let engine = MeteredDeltaEngine::new(Arc::new(StubEngine::new()));
+        let engine = MeteredDeltaEngine::new(Arc::new(stub_engine()));
         assert!(engine.json_handler().any_ref().is::<MeteredJsonHandler>());
         assert!(engine
             .parquet_handler()
@@ -221,7 +199,7 @@ mod tests {
     /// Engine that pre-meters a single handler; lets each double-wrap test target one
     /// guard without tripping the others.
     struct PreMeteredEngine {
-        inner: StubEngine,
+        inner: DelegatingEngine,
         meter_storage: bool,
         meter_json: bool,
         meter_parquet: bool,
@@ -256,7 +234,7 @@ mod tests {
 
     fn pre_metered(storage: bool, json: bool, parquet: bool) -> PreMeteredEngine {
         PreMeteredEngine {
-            inner: StubEngine::new(),
+            inner: stub_engine(),
             meter_storage: storage,
             meter_json: json,
             meter_parquet: parquet,

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -11,6 +11,7 @@ use crate::arrow::record_batch::RecordBatch;
 use crate::arrow::util::pretty::pretty_format_batches;
 use crate::engine::arrow_data::EngineDataArrowExt as _;
 use crate::engine::sync::SyncEngine;
+use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::{column_expr, Expression as Expr, Predicate as Pred};
 use crate::plans::ir::nodes::Operator;
 use crate::plans::Operation as PlanOperation;
@@ -470,28 +471,6 @@ fn assert_declarative_metadata_matches_imperative(
     assert_metadata_eq(&actual, &expected, table.description())
 }
 
-// Forwards every handler to an inner [`SyncEngine`] but provides no [`PlanExecutor`], exercising
-// the `None` arm that `declarative_metadata_scan_plan` rejects.
-struct NoPlanEngine(Arc<SyncEngine>);
-
-impl Engine for NoPlanEngine {
-    fn evaluation_handler(&self) -> Arc<dyn crate::EvaluationHandler> {
-        self.0.evaluation_handler()
-    }
-    fn storage_handler(&self) -> Arc<dyn crate::StorageHandler> {
-        self.0.storage_handler()
-    }
-    fn json_handler(&self) -> Arc<dyn crate::JsonHandler> {
-        self.0.json_handler()
-    }
-    fn parquet_handler(&self) -> Arc<dyn crate::ParquetHandler> {
-        self.0.parquet_handler()
-    }
-    fn plan_executor(&self) -> Option<Arc<dyn crate::plans::PlanExecutor>> {
-        None
-    }
-}
-
 #[test]
 fn test_declarative_metadata_scan_plan_no_executor_returns_unsupported() -> DeltaResult<()> {
     let table = TestTableBuilder::new()
@@ -502,7 +481,7 @@ fn test_declarative_metadata_scan_plan_no_executor_returns_unsupported() -> Delt
     let snapshot = Snapshot::builder_for(table.table_root()).build(sync_engine.as_ref())?;
     let scan = snapshot.scan_builder().build()?;
 
-    let no_plan_engine = NoPlanEngine(sync_engine);
+    let no_plan_engine = DelegatingEngine::new(sync_engine).without_plan_executor();
     let err = scan
         .declarative_metadata_scan_plan(&no_plan_engine)
         .unwrap_err();

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -17,6 +17,7 @@ use crate::committer::FileSystemCommitter;
 use crate::engine::arrow_data::ArrowEngineData;
 use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::engine::sync::SyncEngine;
+use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::{
     column_expr, column_name, column_pred, Expression as Expr, Predicate as Pred,
 };
@@ -30,8 +31,8 @@ use crate::schema::{
 };
 use crate::transaction::create_table::create_table;
 use crate::{
-    DeltaResultIteratorStatic, Engine, EngineData, EvaluationHandler, FileDataReadResultIterator,
-    FileMeta, JsonHandler, ParquetFooter, ParquetHandler, PredicateRef, Snapshot, StorageHandler,
+    DeltaResultIteratorStatic, Engine, EngineData, FileDataReadResultIterator, FileMeta,
+    ParquetFooter, ParquetHandler, PredicateRef, Snapshot,
 };
 
 fn field_names(s: &StructArray) -> Vec<String> {
@@ -1766,6 +1767,19 @@ struct RecordingParquetHandler {
     reads: Mutex<Vec<RecordedParquetRead>>,
 }
 
+impl RecordingParquetHandler {
+    fn new(inner: Arc<dyn ParquetHandler>) -> Self {
+        Self {
+            inner,
+            reads: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn take_reads(&self) -> Vec<RecordedParquetRead> {
+        std::mem::take(&mut *self.reads.lock().unwrap())
+    }
+}
+
 impl ParquetHandler for RecordingParquetHandler {
     fn read_parquet_files(
         &self,
@@ -1795,45 +1809,6 @@ impl ParquetHandler for RecordingParquetHandler {
     }
 }
 
-struct RecordingParquetEngine {
-    inner: Arc<SyncEngine>,
-    parquet: Arc<RecordingParquetHandler>,
-}
-
-impl RecordingParquetEngine {
-    fn new(inner: Arc<SyncEngine>) -> Self {
-        Self {
-            parquet: Arc::new(RecordingParquetHandler {
-                inner: inner.parquet_handler(),
-                reads: Mutex::new(Vec::new()),
-            }),
-            inner,
-        }
-    }
-
-    fn take_reads(&self) -> Vec<RecordedParquetRead> {
-        std::mem::take(&mut *self.parquet.reads.lock().unwrap())
-    }
-}
-
-impl Engine for RecordingParquetEngine {
-    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-        self.inner.evaluation_handler()
-    }
-
-    fn json_handler(&self) -> Arc<dyn JsonHandler> {
-        self.inner.json_handler()
-    }
-
-    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-        self.parquet.clone()
-    }
-
-    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-        self.inner.storage_handler()
-    }
-}
-
 #[rstest]
 #[case::all_struct(StatsOptions::all_struct(), false, false)]
 #[case::all(StatsOptions::all(), true, false)]
@@ -1857,9 +1832,11 @@ fn test_checkpoint_stats_projection_matches_requested_output(
             fs::canonicalize(PathBuf::from(format!("./tests/data/{table}/"))).unwrap()
         });
     let url = Url::from_directory_path(path).unwrap();
-    let engine = RecordingParquetEngine::new(Arc::new(SyncEngine::new()));
+    let sync = Arc::new(SyncEngine::new());
+    let recorder = Arc::new(RecordingParquetHandler::new(sync.parquet_handler()));
+    let engine = DelegatingEngine::new(sync).with_parquet_handler(recorder.clone());
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
-    engine.take_reads();
+    recorder.take_reads();
 
     let predicate: Option<PredicateRef> = skip_stats
         .then(|| Arc::new(Pred::gt(column_expr!("id"), Expr::literal(0i64))) as PredicateRef);
@@ -1873,7 +1850,7 @@ fn test_checkpoint_stats_projection_matches_requested_output(
         action.unwrap();
     }
 
-    let reads = engine.take_reads();
+    let reads = recorder.take_reads();
     let compatible_structured_stats = table != "v2-checkpoints-parquet-with-sidecars";
     let expect_parsed_stats = !skip_stats && compatible_structured_stats;
     let expect_json_stats = !skip_stats && (request_json_stats || !expect_parsed_stats);
@@ -1977,9 +1954,11 @@ fn test_checkpoint_predicate_reaches_parquet_handler(
 ) {
     let path = std::fs::canonicalize(PathBuf::from(format!("./tests/data/{table}/"))).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
-    let engine = RecordingParquetEngine::new(Arc::new(SyncEngine::new()));
+    let sync = Arc::new(SyncEngine::new());
+    let recorder = Arc::new(RecordingParquetHandler::new(sync.parquet_handler()));
+    let engine = DelegatingEngine::new(sync).with_parquet_handler(recorder.clone());
     let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
-    engine.take_reads();
+    recorder.take_reads();
 
     let scan = snapshot
         .scan_builder()
@@ -1990,7 +1969,7 @@ fn test_checkpoint_predicate_reaches_parquet_handler(
         action.unwrap();
     }
 
-    let reads = engine.take_reads();
+    let reads = recorder.take_reads();
     assert!(
         reads.iter().any(|read| {
             read.files
@@ -2304,28 +2283,6 @@ impl ParquetHandler for EmptyParquetHandler {
     }
 }
 
-/// An [`Engine`] that delegates everything to a [`SyncEngine`] except `parquet_handler`, which
-/// returns [`EmptyParquetHandler`].
-struct EmptyParquetEngine(Arc<SyncEngine>);
-
-impl Engine for EmptyParquetEngine {
-    fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler> {
-        self.0.evaluation_handler()
-    }
-
-    fn json_handler(&self) -> Arc<dyn JsonHandler> {
-        self.0.json_handler()
-    }
-
-    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
-        Arc::new(EmptyParquetHandler)
-    }
-
-    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
-        self.0.storage_handler()
-    }
-}
-
 /// When a file's Add action stats report `numRecords > 0` and the parquet handler returns an empty
 /// iterator, `execute` must surface an error rather than silently producing no rows.
 #[test]
@@ -2333,7 +2290,10 @@ fn execute_errors_when_parquet_returns_empty_for_file_with_positive_stats() {
     let path =
         std::fs::canonicalize(PathBuf::from("./tests/data/table-without-dv-small/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(EmptyParquetEngine(Arc::new(SyncEngine::new())));
+    let engine = Arc::new(
+        DelegatingEngine::new(Arc::new(SyncEngine::new()))
+            .with_parquet_handler(Arc::new(EmptyParquetHandler)),
+    );
 
     let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
     let scan = snapshot.scan_builder().build().unwrap();
@@ -2354,7 +2314,10 @@ fn execute_errors_when_parquet_returns_empty_for_file_with_positive_stats() {
 fn execute_does_not_error_when_parquet_returns_empty_and_stats_absent() {
     let path = std::fs::canonicalize(PathBuf::from("./tests/data/table-with-cdf/")).unwrap();
     let url = url::Url::from_directory_path(path).unwrap();
-    let engine = Arc::new(EmptyParquetEngine(Arc::new(SyncEngine::new())));
+    let engine = Arc::new(
+        DelegatingEngine::new(Arc::new(SyncEngine::new()))
+            .with_parquet_handler(Arc::new(EmptyParquetHandler)),
+    );
 
     let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
     let scan = snapshot.scan_builder().build().unwrap();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Replace the hand-rolled `#[cfg(test)]` `Engine` wrappers with one `DelegatingEngine` that forwards to an inner engine and lets a test override individual handlers.

## How was this change tested?

Existing tests, unchanged.