### PR TITLE
feat: add create_staging_table and create_table to UCClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ dependencies = [
 name = "unity-catalog-delta-rest-client"
 version = "0.26.0"
 dependencies = [
+ "percent-encoding",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -38,9 +38,8 @@ use delta_kernel_unity_catalog::{
 };
 use test_utils::{insert_data_with, read_scan};
 use unity_catalog_delta_client_api::{
-    CreateStagingTableRequest, CreateStagingTableResponse, LoadTableResponse, TableIdentifier,
+    CreateStagingTableRequest, LoadTableResponse, TableIdentifier,
 };
-use unity_catalog_delta_rest_client::http::build_http_client;
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient, UCUpdateTableRestClient};
 use url::Url;
 
@@ -60,22 +59,6 @@ fn client_config(url: &str, token: &str) -> ClientConfig {
 
 fn client(url: &str, token: &str) -> UCClient {
     UCClient::new(client_config(url, token)).expect("failed to build UCClient")
-}
-
-/// Returns the base URL (`<workspace>/api/2.1/unity-catalog/delta/v1/`) plus an authed
-/// `reqwest::Client` for the staging-tables/tables POSTs.
-///
-/// TODO(remove): fold into UCClient once it exposes a typed staging-tables method.
-fn raw_delta_rest_client(url: &str, token: &str) -> (Url, reqwest::Client) {
-    let config = ClientConfig::build(url, token)
-        .build()
-        .expect("failed to build ClientConfig");
-    let base = config
-        .workspace_url
-        .join("delta/v1/")
-        .expect("failed to join delta/v1/ onto workspace URL");
-    let http = build_http_client(&config).expect("failed to build reqwest client");
-    (base, http)
 }
 
 /// Normalize a UC table location to a root URL ending in `/`. UC returns the location without a
@@ -133,9 +116,8 @@ async fn live_load_table_builds_log_tail() {
     );
 }
 
-/// Live CREATE through the full connector flow. The two CREATE endpoints (`staging-tables`,
-/// `tables`) are not yet on the REST client (tracked by #3032), so this test hand-rolls those POSTs
-/// with raw `reqwest` while using kernel for the v0 commit and the typed `tables` body.
+/// Live CREATE through the full connector flow: `UCClient::create_staging_table` to reserve,
+/// kernel for the v0 commit, then `UCClient::create_table` to register.
 ///
 /// The table enables row tracking and clustering so the create body and the write path exercise the
 /// `delta.rowTracking` and `delta.clustering` domains in one round trip: the initial watermark (-1)
@@ -157,37 +139,19 @@ async fn live_create_table() {
     let name = format!("kernel_rs_create_test_{}", uuid::Uuid::new_v4().simple());
     let name = name.as_str();
 
-    let (base, http) = raw_delta_rest_client(&url, &token);
-    let tables_base = base
-        .join(&format!("catalogs/{catalog}/schemas/{schema_name}/"))
-        .expect("tables base URL");
+    let uc_client = client(&url, &token);
 
-    // ===== Step 1: POST staging-tables -> allocate uuid + storage + staging credentials =====
-    let staging_url = tables_base
-        .join("staging-tables")
-        .expect("staging-tables URL");
-    let staging_req = CreateStagingTableRequest {
-        name: name.to_string(),
-    };
-    let staging_req_json =
-        serde_json::to_string_pretty(&staging_req).expect("serialize CreateStagingTableRequest");
-    let staging_resp = http
-        .post(staging_url)
-        .json(&staging_req)
-        .send()
+    // ===== Step 1: reserve a staging table -> allocate uuid + storage + staging credentials =====
+    let resp = uc_client
+        .create_staging_table(
+            &catalog,
+            &schema_name,
+            CreateStagingTableRequest {
+                name: name.to_string(),
+            },
+        )
         .await
-        .expect("staging-tables POST failed");
-    let staging_status = staging_resp.status();
-    if !staging_status.is_success() {
-        let body = staging_resp.text().await.unwrap_or_default();
-        panic!(
-            "staging-tables POST returned {staging_status}\nrequest body:\n{staging_req_json}\nresponse body:\n{body}"
-        );
-    }
-    let resp: CreateStagingTableResponse = staging_resp
-        .json()
-        .await
-        .expect("failed to deserialize CreateStagingTableResponse");
+        .expect("create_staging_table failed");
 
     // ===== Step 2: Build the engine over the staging storage location =====
     let table_root =
@@ -292,23 +256,13 @@ async fn live_create_table() {
             "{key} should be present in the create body"
         );
     }
-    let req_json = serde_json::to_string_pretty(&req).expect("serialize CreateTableRequest");
-    let create_resp = http
-        .post(tables_base.join("tables").expect("tables URL"))
-        .json(&req)
-        .send()
+    uc_client
+        .create_table(&catalog, &schema_name, req)
         .await
-        .expect("tables POST failed");
-    let create_status = create_resp.status();
-    if !create_status.is_success() {
-        let body = create_resp.text().await.unwrap_or_default();
-        panic!(
-            "tables POST returned {create_status}\nrequest body:\n{req_json}\nresponse body:\n{body}"
-        );
-    }
+        .expect("create_table failed");
 
     // ===== Step 7: Verify registration: the table loads and its uuid matches the staging id =====
-    let loaded = client(&url, &token)
+    let loaded = uc_client
         .load_table(&catalog, &schema_name, name)
         .await
         .expect("load_table after create failed");

--- a/docs/user-guide/src/unity_catalog/creating_tables.md
+++ b/docs/user-guide/src/unity_catalog/creating_tables.md
@@ -12,30 +12,24 @@ Before reading this page, make sure you understand
 [Creating a Table](../writing/create_table.md) and the
 [Unity Catalog Integration overview](./overview.md).
 
-> [!NOTE]
-> Steps 1 and 5 call UC endpoints that the Rust `unity-catalog-delta-rest-client`
-> crate does not yet expose. Route those through your connector's own UC client;
-> the request and response wire types live in `unity-catalog-delta-client-api`.
-
 ## Prerequisites
 
 - A three-part table name, Delta schema, and target storage location.
-- A connector-owned UC client that can call UC's staging and create-table
-  endpoints.
+- A `UCClient` (from `unity-catalog-delta-rest-client`).
 
 ## Step 1: Reserve the table in Unity Catalog
 
-POST a `CreateStagingTableRequest` to the UC `staging-tables` endpoint. UC allocates a table ID
-and storage location and returns temporary credentials for the initial commit.
+Call `UCClient::create_staging_table`. UC allocates a table ID and storage location and returns
+temporary credentials for the initial commit.
 
 ```rust,ignore
-use unity_catalog_delta_client_api::{CreateStagingTableRequest, CreateStagingTableResponse};
+use unity_catalog_delta_client_api::CreateStagingTableRequest;
 
-// The `staging-tables` POST is not yet exposed as a method on `UCClient`. Send the request
-// through your connector's own UC HTTP client; the request and response wire types live in
-// `unity-catalog-delta-client-api`.
-let staging_req = CreateStagingTableRequest { name: "my_table".to_string() };
-let staging_info: CreateStagingTableResponse = my_uc_client.post_staging_table(staging_req).await?;
+let staging_info = uc_client
+    .create_staging_table("my_catalog", "my_schema", CreateStagingTableRequest {
+        name: "my_table".to_string(),
+    })
+    .await?;
 let table_id = staging_info.table_id;
 let table_uri = staging_info.location;
 ```
@@ -150,12 +144,13 @@ let create_req = build_uc_create_table_request(&post_commit_snapshot, &engine, "
 
 ## Step 5: Finalize the table in Unity Catalog
 
-POST the `CreateTableRequest` to UC's create-table (`tables`) endpoint to register the table.
+Call `UCClient::create_table` with the request from Step 4 to register the table. It returns the
+registered table as a `LoadTableResponse`.
 
 ```rust,ignore
-// The create-table POST is not yet exposed as a method on `UCClient`. Send the typed
-// `CreateTableRequest` through your connector's own UC HTTP client.
-my_uc_client.post_create_table(create_req).await?;
+uc_client
+    .create_table("my_catalog", "my_schema", create_req)
+    .await?;
 ```
 
 ## Clustered tables

--- a/docs/user-guide/src/unity_catalog/overview.md
+++ b/docs/user-guide/src/unity_catalog/overview.md
@@ -59,10 +59,11 @@ gRPC, or in-memory) without changing the code that depends on these traits.
 
 This crate provides the concrete REST-over-HTTP implementations:
 
-- **`UCClient`**: calls the UC Delta-Tables read APIs. `load_table` returns a
-  table's metadata plus its inline log tail in one call, and
-  `get_table_credentials` vends temporary cloud credentials scoped to the
-  table's storage.
+- **`UCClient`**: calls the UC Delta-Tables APIs. `load_table` returns a table's
+  metadata plus its inline log tail in one call, `get_table_credentials` vends
+  temporary cloud credentials scoped to the table's storage, and
+  `create_staging_table` / `create_table` reserve and register a new
+  catalog-managed table.
 - **`UCUpdateTableRestClient`**: implements `UpdateTableClient` over HTTP. It
   submits staged commits to the UC `update_table` endpoint, where Unity Catalog
   ratifies them.

--- a/unity-catalog-delta-rest-client/Cargo.toml
+++ b/unity-catalog-delta-rest-client/Cargo.toml
@@ -17,6 +17,7 @@ release = false
 unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
 # Hardcodes rustls (always used alongside default-engine-rustls in practice).
 reqwest = { version = "0.13", default-features = false, features = ["charset", "http2", "json", "rustls", "system-proxy"] }
+percent-encoding = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }

--- a/unity-catalog-delta-rest-client/src/clients/uc_client.rs
+++ b/unity-catalog-delta-rest-client/src/clients/uc_client.rs
@@ -1,3 +1,4 @@
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::StatusCode;
 use tracing::instrument;
 use unity_catalog_delta_client_api::{
@@ -9,13 +10,26 @@ use url::Url;
 
 use crate::config::ClientConfig;
 use crate::error::Result;
-use crate::http::{build_http_client, execute_with_retry, handle_empty_response, handle_response};
+use crate::http::{
+    build_http_client, execute_with_retry, execute_without_retry, handle_empty_response,
+    handle_response,
+};
+
+/// Percent-encodes a name for use as a single URL path segment.
+fn encode_segment(name: &str) -> impl std::fmt::Display + '_ {
+    utf8_percent_encode(name, NON_ALPHANUMERIC)
+}
 
 /// Builds the Delta-Tables per-table resource path
 /// (`delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}`) that the `load_table` and
 /// credential-vending endpoints share.
 fn table_path(catalog: &str, schema: &str, table: &str) -> String {
-    format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables/{table}")
+    format!(
+        "delta/v1/catalogs/{}/schemas/{}/tables/{}",
+        encode_segment(catalog),
+        encode_segment(schema),
+        encode_segment(table)
+    )
 }
 
 /// An HTTP client for interacting with the Unity Catalog API.
@@ -146,8 +160,16 @@ impl UCClient {
         schema: &str,
         request: CreateStagingTableRequest,
     ) -> Result<CreateStagingTableResponse> {
-        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables");
-        self.post_create(path, &request).await
+        let path = format!(
+            "delta/v1/catalogs/{}/schemas/{}/staging-tables",
+            encode_segment(catalog),
+            encode_segment(schema)
+        );
+        let url = self.base_url.join(&path)?;
+        let response =
+            execute_without_retry(|| self.http_client.post(url.clone()).json(&request).send())
+                .await?;
+        handle_response(response).await
     }
 
     /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables`: register a table with the
@@ -160,20 +182,15 @@ impl UCClient {
         schema: &str,
         request: CreateTableRequest,
     ) -> Result<LoadTableResponse> {
-        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables");
-        self.post_create(path, &request).await
-    }
-
-    /// Single-attempt `POST` for the non-idempotent create endpoints. No retry: a create the
-    /// server accepted but whose response was lost would resubmit and fail with a `409` conflict,
-    /// masking success.
-    async fn post_create<Req, Resp>(&self, path: String, request: &Req) -> Result<Resp>
-    where
-        Req: serde::Serialize,
-        Resp: serde::de::DeserializeOwned,
-    {
+        let path = format!(
+            "delta/v1/catalogs/{}/schemas/{}/tables",
+            encode_segment(catalog),
+            encode_segment(schema)
+        );
         let url = self.base_url.join(&path)?;
-        let response = self.http_client.post(url).json(request).send().await?;
+        let response =
+            execute_without_retry(|| self.http_client.post(url.clone()).json(&request).send())
+                .await?;
         handle_response(response).await
     }
 }

--- a/unity-catalog-delta-rest-client/src/clients/uc_client.rs
+++ b/unity-catalog-delta-rest-client/src/clients/uc_client.rs
@@ -1,7 +1,8 @@
 use reqwest::StatusCode;
 use tracing::instrument;
 use unity_catalog_delta_client_api::{
-    CatalogConfig, CommitReport, CredentialsResponse, LoadTableResponse, MetricsReport, Operation,
+    CatalogConfig, CommitReport, CreateStagingTableRequest, CreateStagingTableResponse,
+    CreateTableRequest, CredentialsResponse, LoadTableResponse, MetricsReport, Operation,
     ReportMetricsRequest,
 };
 use url::Url;
@@ -133,5 +134,46 @@ impl UCClient {
         })
         .await?;
         handle_empty_response(response).await
+    }
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables`: reserve a staging
+    /// table, allocating its UUID and storage location and returning temporary credentials for
+    /// the version 0 commit.
+    #[instrument(skip(self, request))]
+    pub async fn create_staging_table(
+        &self,
+        catalog: &str,
+        schema: &str,
+        request: CreateStagingTableRequest,
+    ) -> Result<CreateStagingTableResponse> {
+        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/staging-tables");
+        self.post_create(path, &request).await
+    }
+
+    /// `POST /delta/v1/catalogs/{catalog}/schemas/{schema}/tables`: register a table with the
+    /// catalog after its version 0 commit, promoting the staging table. Returns the registered
+    /// table as a `LoadTableResponse`.
+    #[instrument(skip(self, request))]
+    pub async fn create_table(
+        &self,
+        catalog: &str,
+        schema: &str,
+        request: CreateTableRequest,
+    ) -> Result<LoadTableResponse> {
+        let path = format!("delta/v1/catalogs/{catalog}/schemas/{schema}/tables");
+        self.post_create(path, &request).await
+    }
+
+    /// Single-attempt `POST` for the non-idempotent create endpoints. No retry: a create the
+    /// server accepted but whose response was lost would resubmit and fail with a `409` conflict,
+    /// masking success.
+    async fn post_create<Req, Resp>(&self, path: String, request: &Req) -> Result<Resp>
+    where
+        Req: serde::Serialize,
+        Resp: serde::de::DeserializeOwned,
+    {
+        let url = self.base_url.join(&path)?;
+        let response = self.http_client.post(url).json(request).send().await?;
+        handle_response(response).await
     }
 }

--- a/unity-catalog-delta-rest-client/src/http.rs
+++ b/unity-catalog-delta-rest-client/src/http.rs
@@ -75,6 +75,14 @@ where
     Err(Error::MaxRetriesExceeded)
 }
 
+pub async fn execute_without_retry<F, Fut>(f: F) -> Result<Response>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = std::result::Result<Response, reqwest::Error>>,
+{
+    f().await.map_err(Error::from)
+}
+
 /// Handle HTTP response and deserialize.
 pub async fn handle_response<T>(response: Response) -> Result<T>
 where

--- a/unity-catalog-delta-rest-client/tests/integration_live_server.rs
+++ b/unity-catalog-delta-rest-client/tests/integration_live_server.rs
@@ -9,12 +9,8 @@
 //! 'test(live_)'
 #![cfg(feature = "integration-test")]
 
-use unity_catalog_delta_client_api::{
-    CreateStagingTableRequest, CreateStagingTableResponse, Operation,
-};
-use unity_catalog_delta_rest_client::http::build_http_client;
+use unity_catalog_delta_client_api::{CreateStagingTableRequest, Operation};
 use unity_catalog_delta_rest_client::{ClientConfig, UCClient};
-use url::Url;
 
 /// Reads the server URL + token from the environment, or `None` to skip the test.
 fn server_env() -> Option<(String, String)> {
@@ -28,22 +24,6 @@ fn client(url: &str, token: &str) -> UCClient {
         .build()
         .expect("failed to build ClientConfig");
     UCClient::new(config).expect("failed to build UCClient")
-}
-
-/// Returns the Delta-Tables base URL (`<workspace>/delta/v1/catalogs/{c}/schemas/{s}/`) plus an
-/// authed `reqwest::Client` for the hand-rolled staging-tables POST.
-///
-/// TODO(remove): fold into UCClient once it exposes a typed staging-tables method.
-fn raw_delta_client(url: &str, token: &str, catalog: &str, schema: &str) -> (Url, reqwest::Client) {
-    let config = ClientConfig::build(url, token)
-        .build()
-        .expect("failed to build ClientConfig");
-    let base = config
-        .workspace_url
-        .join(&format!("delta/v1/catalogs/{catalog}/schemas/{schema}/"))
-        .expect("failed to join delta/v1 path onto workspace URL");
-    let http = build_http_client(&config).expect("failed to build reqwest client");
-    (base, http)
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -185,26 +165,13 @@ async fn live_create_staging_table() {
     let schema = std::env::var("UC_TEST_SCHEMA").unwrap_or_else(|_| "default".to_string());
     let table = "delta_rest_client_staging_test";
 
-    let (base, http) = raw_delta_client(&url, &token, &catalog, &schema);
-
     let req = CreateStagingTableRequest {
         name: table.to_string(),
     };
-    let resp = http
-        .post(base.join("staging-tables").expect("staging-tables URL"))
-        .json(&req)
-        .send()
+    let staging = client(&url, &token)
+        .create_staging_table(&catalog, &schema, req)
         .await
-        .expect("staging-tables POST failed");
-    let status = resp.status();
-    let body = resp.text().await.unwrap_or_default();
-    assert!(
-        status.is_success(),
-        "staging-tables POST returned {status}: {body}"
-    );
-
-    let staging: CreateStagingTableResponse =
-        serde_json::from_str(&body).expect("failed to deserialize CreateStagingTableResponse");
+        .expect("create_staging_table failed");
     assert!(
         !staging.table_id.is_empty(),
         "expected an allocated table id"


### PR DESCRIPTION
## What changes are proposed in this pull request?
This change adds create_staging_table and create_table to UCClient. Connectors can now use these APIs instead of manually creating these POST requests. 

## How was this change tested?
- rewired UC server tests to use these new helpers
- existing UTs, E2E UC tests pass.
