### PR TITLE
perf: speed up the Miri CI job and widen its coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,8 +418,8 @@ jobs:
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
         # -Zmiri-provenance-gc=1000000 runs Miri's pointer-provenance garbage collector every 1M
-        # basic blocks instead of the default 10k, cutting GC pauses for a ~10-15% speedup. It only
-        # changes GC frequency, so it does not weaken undefined-behavior or data-race detection.
+        # basic blocks instead of the default 10k, reducing GC pauses. It only changes GC
+        # frequency, so it does not weaken undefined-behavior or data-race detection.
         run: |
           pushd ffi
           MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-provenance-gc=1000000" cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,8 +422,8 @@ jobs:
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
         # -Zmiri-provenance-gc=1000000 runs Miri's pointer-provenance garbage collector every 1M
-        # basic blocks instead of the default 10k, cutting GC pauses for a ~10-15% speedup. It only
-        # changes GC frequency, so it does not weaken undefined-behavior or data-race detection.
+        # basic blocks instead of the default 10k, reducing GC pauses. It only changes GC
+        # frequency, so it does not weaken undefined-behavior or data-race detection.
         run: |
           pushd ffi
           MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-provenance-gc=1000000" cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans,vendored-protoc --partition slice:${{ matrix.partition }}/3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,9 +417,12 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
+        # -Zmiri-provenance-gc=1000000 runs Miri's pointer-provenance garbage collector every 1M
+        # basic blocks instead of the default 10k, cutting GC pauses for a ~10-15% speedup. It only
+        # changes GC frequency, so it does not weaken undefined-behavior or data-race detection.
         run: |
           pushd ffi
-          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3
+          MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-provenance-gc=1000000" cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,9 +421,12 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
       - name: Test with Miri
+        # -Zmiri-provenance-gc=1000000 runs Miri's pointer-provenance garbage collector every 1M
+        # basic blocks instead of the default 10k, cutting GC pauses for a ~10-15% speedup. It only
+        # changes GC frequency, so it does not weaken undefined-behavior or data-race detection.
         run: |
           pushd ffi
-          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans,vendored-protoc --partition slice:${{ matrix.partition }}/3
+          MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-provenance-gc=1000000" cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans,vendored-protoc --partition slice:${{ matrix.partition }}/3
 
   coverage:
     runs-on: ubuntu-latest

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -182,3 +182,37 @@ Feature flags:
 - `arrow-59`, `arrow-58`
 - `delta-kernel-unity-catalog`
 - `tracing`
+
+## Testing under Miri
+
+CI runs this crate's tests under Miri (the `miri` job in `build.yml`) to catch undefined
+behavior in the `unsafe` FFI boundary: raw-pointer reads/writes, `unsafe impl Send/Sync`,
+`Handle` conversions (`as_ref` / `clone_as_arc` / `into_inner`), and `free_*`. Miri is a MIR
+interpreter, so it runs 10x-100x slower than native and is billed by the interpreted
+instruction, not wall-clock work.
+
+The consequence: a test is expensive under Miri in proportion to how much *code it executes*,
+not how much it asserts. Tests that construct heavyweight but **safe** machinery -- a
+reqwest/rustls client (crypto init), a multi-threaded tokio runtime, an Arrow/parquet write --
+cost minutes under the interpreter while exercising none of our `unsafe`. That time buys no
+UB detection.
+
+Guidance for adding or triaging FFI tests:
+
+- **Keep under Miri** any test that executes `unsafe` whose correctness Miri can check. This is
+  the reason the job exists; do not skip these for speed.
+- **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
+  1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
+  2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
+     expensive under Miri. Skipping for cost alone (without the coverage argument) is not
+     acceptable -- it silently drops UB coverage.
+- When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
+  `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
+  `ignore` reason or a nearby comment so a future reader can re-check it.
+- Prefer picking the **cheapest** test that crosses a given `unsafe` path over keeping several
+  that cross the same path with more safe work each.
+- `rest_engine` and the checkpoint tests in `lib.rs` document worked examples of this split.
+- `-Zmiri-provenance-gc=1000000` on the Miri step is a pure speed knob (GC frequency) and does
+  not weaken detection. Do NOT add `-Zmiri-disable-stacked-borrows`, `-disable-validation`,
+  `-disable-data-race-detector`, or `-Zmiri-preemption-rate=0`: the first three are unsound, and
+  the last reduces data-race schedule exploration.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -195,3 +195,37 @@ Feature flags:
 - `alloc-tracking` -- installs `peak_alloc` as the tracking global allocator; enables meaningful
   `*_native_bytes` / `alloc_tracking_enabled` getters (cdylib only; conflicts with
   another `#[global_allocator]` if linked as an rlib)
+
+## Testing under Miri
+
+CI runs this crate's tests under Miri (the `miri` job in `build.yml`) to catch undefined
+behavior in the `unsafe` FFI boundary: raw-pointer reads/writes, `unsafe impl Send/Sync`,
+`Handle` conversions (`as_ref` / `clone_as_arc` / `into_inner`), and `free_*`. Miri is a MIR
+interpreter, so it runs 10x-100x slower than native and is billed by the interpreted
+instruction, not wall-clock work.
+
+The consequence: a test is expensive under Miri in proportion to how much *code it executes*,
+not how much it asserts. Tests that construct heavyweight but **safe** machinery -- a
+reqwest/rustls client (crypto init), a multi-threaded tokio runtime, an Arrow/parquet write --
+cost minutes under the interpreter while exercising none of our `unsafe`. That time buys no
+UB detection.
+
+Guidance for adding or triaging FFI tests:
+
+- **Keep under Miri** any test that executes `unsafe` whose correctness Miri can check. This is
+  the reason the job exists; do not skip these for speed.
+- **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
+  1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
+  2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
+     expensive under Miri. Skipping for cost alone (without the coverage argument) is not
+     acceptable -- it silently drops UB coverage.
+- When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
+  `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
+  `ignore` reason or a nearby comment so a future reader can re-check it.
+- Prefer picking the **cheapest** test that crosses a given `unsafe` path over keeping several
+  that cross the same path with more safe work each.
+- `rest_engine` and the checkpoint tests in `lib.rs` document worked examples of this split.
+- `-Zmiri-provenance-gc=1000000` on the Miri step is a pure speed knob (GC frequency) and does
+  not weaken detection. Do NOT add `-Zmiri-disable-stacked-borrows`, `-disable-validation`,
+  `-disable-data-race-detector`, or `-Zmiri-preemption-rate=0`: the first three are unsound, and
+  the last reduces data-race schedule exploration.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -201,14 +201,23 @@ Guidance for adding or triaging FFI tests:
 
 - **Keep under Miri** any test that executes `unsafe` whose correctness Miri can check. This is
   the reason the job exists; do not skip these for speed.
+- **Never add new `unsafe` to a Miri-ignored test.** An ignored test is invisible to Miri, so
+  `unsafe` introduced in one is never checked for undefined behavior, and nothing in CI reports
+  the gap. When a change needs new `unsafe` in an ignored test, either exercise that `unsafe`
+  from a test that runs under Miri, or un-skip the test.
 - **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
-  1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
+  1. Miri cannot run it (e.g. an unsupported foreign function). Before accepting this, check
+     whether the blocker is avoidable: local-filesystem storage reaches `std::fs::hard_link`
+     (`linkat`), which Miri rejects, but in-memory storage does not. Prefer an in-memory store.
   2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
      expensive under Miri. Skip only with the coverage argument; skipping for cost alone drops
      UB coverage.
 - When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
   `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
   `ignore` reason or a nearby comment so a future reader can re-check it.
+- Miri's leak check also flags handles a test itself forgot to free. Triage before assuming a bug
+  in the code under test: a missing `free_*` in the test is a test fix, while an unjoined
+  background thread at teardown can be an artifact of how the test ends.
 - Prefer picking the **cheapest** test that crosses a given `unsafe` path over keeping several
   that cross the same path with more safe work each.
 - `rest_engine` and the checkpoint tests in `lib.rs` document worked examples of this split.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -214,14 +214,23 @@ Guidance for adding or triaging FFI tests:
 
 - **Keep under Miri** any test that executes `unsafe` whose correctness Miri can check. This is
   the reason the job exists; do not skip these for speed.
+- **Never add new `unsafe` to a Miri-ignored test.** An ignored test is invisible to Miri, so
+  `unsafe` introduced in one is never checked for undefined behavior, and nothing in CI reports
+  the gap. When a change needs new `unsafe` in an ignored test, either exercise that `unsafe`
+  from a test that runs under Miri, or un-skip the test.
 - **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
-  1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
+  1. Miri cannot run it (e.g. an unsupported foreign function). Before accepting this, check
+     whether the blocker is avoidable: local-filesystem storage reaches `std::fs::hard_link`
+     (`linkat`), which Miri rejects, but in-memory storage does not. Prefer an in-memory store.
   2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
      expensive under Miri. Skip only with the coverage argument; skipping for cost alone drops
      UB coverage.
 - When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
   `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
   `ignore` reason or a nearby comment so a future reader can re-check it.
+- Miri's leak check also flags handles a test itself forgot to free. Triage before assuming a bug
+  in the code under test: a missing `free_*` in the test is a test fix, while an unjoined
+  background thread at teardown can be an artifact of how the test ends.
 - Prefer picking the **cheapest** test that crosses a given `unsafe` path over keeping several
   that cross the same path with more safe work each.
 - `rest_engine` and the checkpoint tests in `lib.rs` document worked examples of this split.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -217,8 +217,8 @@ Guidance for adding or triaging FFI tests:
 - **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
   1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
   2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
-     expensive under Miri. Skipping for cost alone (without the coverage argument) is not
-     acceptable -- it silently drops UB coverage.
+     expensive under Miri. Skip only with the coverage argument; skipping for cost alone drops
+     UB coverage.
 - When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
   `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
   `ignore` reason or a nearby comment so a future reader can re-check it.

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -204,8 +204,8 @@ Guidance for adding or triaging FFI tests:
 - **`#[cfg_attr(miri, ignore)]` is legitimate for two reasons, and only these two:**
   1. Miri cannot run it (e.g. an unsupported foreign function like `linkat`).
   2. The test executes no `unsafe`, OR only `unsafe` that a kept test already covers, AND it is
-     expensive under Miri. Skipping for cost alone (without the coverage argument) is not
-     acceptable -- it silently drops UB coverage.
+     expensive under Miri. Skip only with the coverage argument; skipping for cost alone drops
+     UB coverage.
 - When you skip under reason 2, **prove the coverage is preserved**: the kept tests' set of
   `unsafe` FFI functions must be a superset of the skipped test's. Name the covering test in the
   `ignore` reason or a nearby comment so a future reader can re-check it.

--- a/ffi/src/ffi_test_utils.rs
+++ b/ffi/src/ffi_test_utils.rs
@@ -81,6 +81,18 @@ pub(crate) unsafe fn build_snapshot(
     ok_or_panic(snapshot_builder_build(builder))
 }
 
+/// Wrap an already-seeded object store in an engine handle. Caller must free it.
+///
+/// Needed because `get_default_engine` resolves the store from the URL, so a `memory://` path
+/// builds a fresh (empty) `InMemory` rather than the seeded one.
+#[cfg(test)]
+pub(crate) fn engine_handle_for_store(
+    store: Arc<delta_kernel::object_store::DynObjectStore>,
+) -> crate::handle::Handle<SharedExternEngine> {
+    let engine = DefaultEngineBuilder::new(store).build();
+    engine_to_handle(Arc::new(engine), allocate_err)
+}
+
 /// Create an in-memory engine and snapshot from the given commit data. Returns
 /// `(engine_handle, snapshot_handle)` -- the caller must free both when done.
 #[cfg(test)]

--- a/ffi/src/incremental_scan.rs
+++ b/ffi/src/incremental_scan.rs
@@ -713,10 +713,6 @@ mod tests {
     // contract, not this path; this test holds a real second reference.)
     #[cfg(feature = "default-engine-base")]
     #[tokio::test]
-    // The surviving handle keeps a second engine `Arc` live past the drain, so the background
-    // executor's thread outlives the test; Miri flags the unjoined thread at teardown even though
-    // the assertions pass. Skip under Miri, matching the tokio-FFI tests in `transaction`.
-    #[cfg_attr(miri, ignore)]
     async fn terminal_calls_after_into_summary_error() -> Result<(), Box<dyn std::error::Error>> {
         let (engine, snapshot) = setup(vec![vec![TestAction::Add("A".to_string())]]).await;
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2697,9 +2697,10 @@ mod tests {
     // the first checkpoint.)
     //
     // NOTE: Snapshot::checkpoint requires a multi-threaded tokio task executor to avoid deadlocks.
-    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
-    // is covered by the anchor test_setting_multithread_executor. AlreadyExists/overwrite is safe
-    // kernel logic. Runs under normal cargo test / nextest.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter). Its unsafe FFI
+    // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
+    // version()/SharedSnapshot::as_ref by test_snapshot. AlreadyExists/overwrite is safe kernel
+    // logic. Runs under normal cargo test / nextest.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2743,9 +2744,10 @@ mod tests {
     // `checkpoint_snapshot` returns `AlreadyExists` (same table version). Also validates the
     // `_delta_log/_last_checkpoint` content (version, numOfAddFiles, size, sizeInBytes), which
     // `test_checkpoint_snapshot_sidecar_shape` doesn't cover.
-    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
-    // is covered by the anchor test_setting_multithread_executor. _last_checkpoint content is safe
-    // kernel logic. Runs under normal cargo test / nextest.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter). Its unsafe FFI
+    // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
+    // version()/SharedSnapshot::as_ref by test_snapshot. _last_checkpoint content is safe kernel
+    // logic. Runs under normal cargo test / nextest.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2808,12 +2810,10 @@ mod tests {
     // NOTE: We made this a sync test to simulate the expected case: C code calling FFI APIs to
     // build engine without existing tokio runtime.
     //
-    // This is the Miri anchor for checkpoint FFI. NEVER mark it #[cfg_attr(miri, ignore)]. The
-    // other checkpoint tests are skipped under Miri (they write parquet, which is minutes of safe
-    // work under the interpreter); they are only safe to skip because this test still runs their
-    // shared unsafe under Miri: a success-path checkpoint_snapshot -> Written-handle ->
-    // free_snapshot. It also uniquely covers the engine-builder unsafe (get_engine_builder /
-    // set_builder_with_multithreaded_executor / builder_build). Skipping it silently drops both.
+    // Miri anchor for checkpoint FFI: covers the success-path checkpoint_snapshot -> Written
+    // handle -> free_snapshot that the skipped checkpoint tests share, and uniquely covers
+    // set_builder_with_multithreaded_executor (no other test calls it). Skipping it drops that
+    // coverage under Miri.
     #[cfg(feature = "default-engine-base")]
     #[test]
     fn test_setting_multithread_executor() -> Result<(), Box<dyn std::error::Error>> {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2611,6 +2611,10 @@ mod tests {
     // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter),
     // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
     // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
+    //
+    // DO NOT ADD `unsafe` TO THIS TEST, or to the other Miri-skipped checkpoint tests below. Miri
+    // never runs them, so `unsafe` added here is never checked for undefined behavior and nothing
+    // in CI reports the gap. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2612,9 +2612,8 @@ mod tests {
     // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
     // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
     //
-    // DO NOT ADD `unsafe` TO THIS TEST, or to the other Miri-skipped checkpoint tests below. Miri
-    // never runs them, so `unsafe` added here is never checked for undefined behavior and nothing
-    // in CI reports the gap. Put it in the anchor test instead.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2705,6 +2704,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. AlreadyExists/overwrite is safe kernel
     // logic. Runs under normal cargo test / nextest.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2752,6 +2753,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. _last_checkpoint content is safe kernel
     // logic. Runs under normal cargo test / nextest.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2603,6 +2603,10 @@ mod tests {
     // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter),
     // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
     // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
+    //
+    // DO NOT ADD `unsafe` TO THIS TEST, or to the other Miri-skipped checkpoint tests below. Miri
+    // never runs them, so `unsafe` added here is never checked for undefined behavior and nothing
+    // in CI reports the gap. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2604,9 +2604,8 @@ mod tests {
     // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
     // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
     //
-    // DO NOT ADD `unsafe` TO THIS TEST, or to the other Miri-skipped checkpoint tests below. Miri
-    // never runs them, so `unsafe` added here is never checked for undefined behavior and nothing
-    // in CI reports the gap. Put it in the anchor test instead.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2697,6 +2696,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. AlreadyExists/overwrite is safe kernel
     // logic. Runs under normal cargo test / nextest.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2744,6 +2745,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. _last_checkpoint content is safe kernel
     // logic. Runs under normal cargo test / nextest.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in the anchor test instead.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2608,12 +2608,14 @@ mod tests {
         }),
         4
     )]
-    // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter),
-    // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
-    // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
+    // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter).
+    // Its unsafe (checkpoint_snapshot) is unconditional in `spec`, so the Some(V2WithSidecar) path
+    // adds no unsafe over test_checkpoint_snapshot_v2_with_sidecars_zero_hint_returns_error (runs
+    // under Miri); the checkpoint/free handles are covered by test_setting_multithread_executor.
+    // Sidecar-shape is safe kernel logic. Runs (all cases) under normal cargo test / nextest.
     //
-    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
-    // for undefined behavior. Put it in the anchor test instead.
+    // DO NOT ADD NEW `unsafe` HERE (unsafe not already run by a Miri test): Miri never runs this
+    // test, so unsafe unique to it goes unchecked for undefined behavior. Put it in the anchor.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2704,8 +2706,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. AlreadyExists/overwrite is safe kernel
     // logic. Runs under normal cargo test / nextest.
-    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
-    // for undefined behavior. Put it in the anchor test instead.
+    // DO NOT ADD NEW `unsafe` HERE (unsafe not already run by a Miri test): Miri never runs this
+    // test, so unsafe unique to it goes unchecked for undefined behavior. Put it in the anchor.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2753,8 +2755,8 @@ mod tests {
     // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
     // version()/SharedSnapshot::as_ref by test_snapshot. _last_checkpoint content is safe kernel
     // logic. Runs under normal cargo test / nextest.
-    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
-    // for undefined behavior. Put it in the anchor test instead.
+    // DO NOT ADD NEW `unsafe` HERE (unsafe not already run by a Miri test): Miri never runs this
+    // test, so unsafe unique to it goes unchecked for undefined behavior. Put it in the anchor.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2600,6 +2600,13 @@ mod tests {
         }),
         4
     )]
+    // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter),
+    // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
+    // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_sidecar_shape(
         #[case] is_v2: bool,
@@ -2682,6 +2689,13 @@ mod tests {
     // the first checkpoint.)
     //
     // NOTE: Snapshot::checkpoint requires a multi-threaded tokio task executor to avoid deadlocks.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
+    // is covered by the anchor test_setting_multithread_executor. AlreadyExists/overwrite is safe
+    // kernel logic. Runs under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_second_call_returns_consistent_snapshot(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2721,6 +2735,13 @@ mod tests {
     // `checkpoint_snapshot` returns `AlreadyExists` (same table version). Also validates the
     // `_delta_log/_last_checkpoint` content (version, numOfAddFiles, size, sizeInBytes), which
     // `test_checkpoint_snapshot_sidecar_shape` doesn't cover.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
+    // is covered by the anchor test_setting_multithread_executor. _last_checkpoint content is safe
+    // kernel logic. Runs under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_written_snapshot_is_usable(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2778,6 +2799,13 @@ mod tests {
     // Test checkpoint using FFI engine builder APIs with multithreaded executor.
     // NOTE: We made this a sync test to simulate the expected case: C code calling FFI APIs to
     // build engine without existing tokio runtime.
+    //
+    // This is the Miri anchor for checkpoint FFI. NEVER mark it #[cfg_attr(miri, ignore)]. The
+    // other checkpoint tests are skipped under Miri (they write parquet, which is minutes of safe
+    // work under the interpreter); they are only safe to skip because this test still runs their
+    // shared unsafe under Miri: a success-path checkpoint_snapshot -> Written-handle ->
+    // free_snapshot. It also uniquely covers the engine-builder unsafe (get_engine_builder /
+    // set_builder_with_multithreaded_executor / builder_build). Skipping it silently drops both.
     #[cfg(feature = "default-engine-base")]
     #[test]
     fn test_setting_multithread_executor() -> Result<(), Box<dyn std::error::Error>> {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2608,6 +2608,13 @@ mod tests {
         }),
         4
     )]
+    // Skipped under Miri: writes checkpoint parquet (minutes of safe work under the interpreter),
+    // and its unsafe is covered by the anchor test_setting_multithread_executor. Sidecar-shape is
+    // safe kernel logic. Runs (all cases) under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_sidecar_shape(
         #[case] is_v2: bool,
@@ -2690,6 +2697,13 @@ mod tests {
     // the first checkpoint.)
     //
     // NOTE: Snapshot::checkpoint requires a multi-threaded tokio task executor to avoid deadlocks.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
+    // is covered by the anchor test_setting_multithread_executor. AlreadyExists/overwrite is safe
+    // kernel logic. Runs under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_second_call_returns_consistent_snapshot(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2729,6 +2743,13 @@ mod tests {
     // `checkpoint_snapshot` returns `AlreadyExists` (same table version). Also validates the
     // `_delta_log/_last_checkpoint` content (version, numOfAddFiles, size, sizeInBytes), which
     // `test_checkpoint_snapshot_sidecar_shape` doesn't cover.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
+    // is covered by the anchor test_setting_multithread_executor. _last_checkpoint content is safe
+    // kernel logic. Runs under normal cargo test / nextest.
+    #[cfg_attr(
+        miri,
+        ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
+    )]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_checkpoint_snapshot_written_snapshot_is_usable(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2786,6 +2807,13 @@ mod tests {
     // Test checkpoint using FFI engine builder APIs with multithreaded executor.
     // NOTE: We made this a sync test to simulate the expected case: C code calling FFI APIs to
     // build engine without existing tokio runtime.
+    //
+    // This is the Miri anchor for checkpoint FFI. NEVER mark it #[cfg_attr(miri, ignore)]. The
+    // other checkpoint tests are skipped under Miri (they write parquet, which is minutes of safe
+    // work under the interpreter); they are only safe to skip because this test still runs their
+    // shared unsafe under Miri: a success-path checkpoint_snapshot -> Written-handle ->
+    // free_snapshot. It also uniquely covers the engine-builder unsafe (get_engine_builder /
+    // set_builder_with_multithreaded_executor / builder_build). Skipping it silently drops both.
     #[cfg(feature = "default-engine-base")]
     #[test]
     fn test_setting_multithread_executor() -> Result<(), Box<dyn std::error::Error>> {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2689,9 +2689,10 @@ mod tests {
     // the first checkpoint.)
     //
     // NOTE: Snapshot::checkpoint requires a multi-threaded tokio task executor to avoid deadlocks.
-    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
-    // is covered by the anchor test_setting_multithread_executor. AlreadyExists/overwrite is safe
-    // kernel logic. Runs under normal cargo test / nextest.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter). Its unsafe FFI
+    // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
+    // version()/SharedSnapshot::as_ref by test_snapshot. AlreadyExists/overwrite is safe kernel
+    // logic. Runs under normal cargo test / nextest.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2735,9 +2736,10 @@ mod tests {
     // `checkpoint_snapshot` returns `AlreadyExists` (same table version). Also validates the
     // `_delta_log/_last_checkpoint` content (version, numOfAddFiles, size, sizeInBytes), which
     // `test_checkpoint_snapshot_sidecar_shape` doesn't cover.
-    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter), and its unsafe
-    // is covered by the anchor test_setting_multithread_executor. _last_checkpoint content is safe
-    // kernel logic. Runs under normal cargo test / nextest.
+    // Skipped under Miri: writes checkpoint parquet (minutes under the interpreter). Its unsafe FFI
+    // (checkpoint_snapshot, free_snapshot) is covered by test_setting_multithread_executor, and
+    // version()/SharedSnapshot::as_ref by test_snapshot. _last_checkpoint content is safe kernel
+    // logic. Runs under normal cargo test / nextest.
     #[cfg_attr(
         miri,
         ignore = "writes checkpoint parquet (no unique unsafe); minutes under Miri"
@@ -2800,12 +2802,10 @@ mod tests {
     // NOTE: We made this a sync test to simulate the expected case: C code calling FFI APIs to
     // build engine without existing tokio runtime.
     //
-    // This is the Miri anchor for checkpoint FFI. NEVER mark it #[cfg_attr(miri, ignore)]. The
-    // other checkpoint tests are skipped under Miri (they write parquet, which is minutes of safe
-    // work under the interpreter); they are only safe to skip because this test still runs their
-    // shared unsafe under Miri: a success-path checkpoint_snapshot -> Written-handle ->
-    // free_snapshot. It also uniquely covers the engine-builder unsafe (get_engine_builder /
-    // set_builder_with_multithreaded_executor / builder_build). Skipping it silently drops both.
+    // Miri anchor for checkpoint FFI: covers the success-path checkpoint_snapshot -> Written
+    // handle -> free_snapshot that the skipped checkpoint tests share, and uniquely covers
+    // set_builder_with_multithreaded_executor (no other test calls it). Skipping it drops that
+    // coverage under Miri.
     #[cfg(feature = "default-engine-base")]
     #[test]
     fn test_setting_multithread_executor() -> Result<(), Box<dyn std::error::Error>> {

--- a/ffi/src/rest_engine.rs
+++ b/ffi/src/rest_engine.rs
@@ -377,6 +377,29 @@ mod tests {
     use crate::ffi_test_utils::allocate_err;
     use crate::kernel_string_slice;
 
+    // ================================ Miri policy for this module ================================
+    //
+    // CI runs these tests under Miri to catch undefined behavior in this module's `unsafe` FFI:
+    // the raw-pointer reads in `take_auth_pairs_from_c`, the `unsafe impl Send/Sync for
+    // FfiAuthHeaderProvider`, and `FfiAuthHeaderProvider::collect` (which dereferences a
+    // `*mut CAuthHeaders` the C caller filled in). Miri interprets MIR instead of running native
+    // code, so it is far slower than a normal run; we skip tests it cannot usefully check.
+    //
+    // The tests are grouped by their relationship to `unsafe`, in file order:
+    //
+    //   1. Pure-logic tests: no `unsafe`, cheap. Run under Miri because there is no reason not to.
+    //
+    //   2. Unsafe-FFI tests: execute this module's `unsafe` directly. These are why the Miri job
+    //      exists; never mark them `#[cfg_attr(miri, ignore)]`.
+    //
+    //   3. Client-build tests: `#[cfg_attr(miri, ignore)]`. They execute no `unsafe` from this
+    //      crate (the lone unsafe call sits behind a per-request closure they never fire) and are
+    //      slow under Miri because `build_rest_client` builds the reqwest/rustls crypto stack.
+    //      Skipping them drops no coverage: group 2 already covers the only `unsafe` they touch.
+    //      See that group's banner for details.
+    //
+    // =============================================================================================
+
     fn test_allocate_error() -> AllocateErrorFn {
         allocate_err
     }
@@ -450,6 +473,8 @@ mod tests {
         }
     }
 
+    // === Group 1: pure-logic tests (no unsafe; run under Miri, cheap) ===
+
     #[test]
     fn rest_builder_option_keys_match_c_exports() {
         option_key_bytes_match_const(
@@ -501,6 +526,13 @@ mod tests {
         assert!(rest_endpoint_config_from_c(&config).is_err());
     }
 
+    // === Group 2: unsafe-FFI tests (MUST run under Miri) ===
+    //
+    // These exercise `take_auth_pairs_from_c` (raw-pointer reads of a C-filled `*mut CAuthHeaders`)
+    // and `FfiAuthHeaderProvider::collect` (which upcalls the C callback and dereferences its
+    // output): the undefined-behavior surface Miri exists to check here. Never mark any test in
+    // this group `#[cfg_attr(miri, ignore)]`.
+
     #[test]
     fn auth_pairs_from_c_takes_handles() {
         let mut storage = MaybeUninit::<CAuthHeaders>::uninit();
@@ -550,78 +582,28 @@ mod tests {
         assert_eq!(ttl, Some(Duration::from_millis(60_000)));
     }
 
-    #[test]
-    fn build_succeeds_with_refreshing_auth_callback() {
-        let rest = rest_builder_state_from_ffi(
-            &test_c_rest_endpoint_config(),
-            Some(fill_auth_direct),
-            None,
-            test_allocate_error(),
-        )
-        .unwrap();
-        assert!(build_rest_object_store(&test_base_url(), &HashMap::new(), &rest).is_ok());
-    }
+    // === Group 3: client-build tests (call build_rest_object_store) ===
+    //
+    // None of these execute this crate's `unsafe`: `build_rest_object_store` has no `unsafe`, and
+    // its one unsafe path (`FfiAuthHeaderProvider::collect`) sits behind a per-request closure that
+    // only fires when the store serves an HTTP request, which these build-only tests never do.
+    // Their only Miri-relevant cost is `build_rest_client`, which builds the reqwest/rustls client
+    // and initializes the crypto provider: minutes of safe arithmetic under the interpreter.
+    //
+    // Split accordingly:
+    //
+    //   3a. Input rejected BEFORE `build_rest_client` runs. Cheap, so kept under Miri.
+    //
+    //   3b. Client built fully (success cases, plus errors parsed AFTER the build). Marked
+    //       `#[cfg_attr(miri, ignore)]`: they run no `unsafe`, so skipping drops no coverage
+    //       (group 2 already covers the unsafe FFI). They still run under `cargo test` / nextest.
 
-    #[test]
-    fn build_succeeds_with_header_options_fallback() {
-        let mut options = HashMap::new();
-        options.insert(
-            format!("{}Authorization", REST_BUILDER_OPTION_HEADER_PREFIX),
-            "Bearer x".into(),
-        );
-        assert!(
-            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state()).is_ok()
-        );
-    }
-
-    #[test]
-    fn build_succeeds_with_prefixes_and_resilience_options() {
-        let prefix = "/TablesById/u";
-        let mut config = test_c_rest_endpoint_config();
-        config.files_prefix = kernel_string_slice!(prefix);
-        config.entry_strip_prefix = kernel_string_slice!(prefix);
-        let rest = rest_builder_state_from_ffi(&config, None, None, test_allocate_error()).unwrap();
-
-        let mut options = HashMap::new();
-        options.insert(
-            format!("{}Authorization", REST_BUILDER_OPTION_HEADER_PREFIX),
-            "Bearer x".into(),
-        );
-        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "3".into());
-        options.insert(
-            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
-            "true".into(),
-        );
-        assert!(build_rest_object_store(&test_base_url(), &options, &rest).is_ok());
-    }
+    // --- 3a: rejected before the client is built (cheap; run under Miri) ---
 
     #[test]
     fn build_rejects_invalid_timeout() {
         let mut options = HashMap::new();
         options.insert(REST_BUILDER_OPTION_TLS_TIMEOUT_SECS.into(), "nope".into());
-        assert!(
-            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn build_rejects_invalid_max_retries() {
-        let mut options = HashMap::new();
-        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "nope".into());
-        assert!(
-            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn build_rejects_invalid_verify_on_ambiguous() {
-        let mut options = HashMap::new();
-        options.insert(
-            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
-            "nope".into(),
-        );
         assert!(
             build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
                 .is_err()
@@ -647,6 +629,100 @@ mod tests {
         options.insert(
             REST_BUILDER_OPTION_TLS_CERT_PATH.into(),
             "/x/cert.pem".into(),
+        );
+        assert!(
+            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
+                .is_err()
+        );
+    }
+
+    // --- 3b: build the reqwest/rustls client (no unsafe; ~minutes under Miri, so skipped) ---
+    //
+    // Every test below is `#[cfg_attr(miri, ignore)]` because it reaches `build_rest_client` and
+    // pays the full rustls crypto-init cost under the interpreter while executing none of this
+    // crate's `unsafe`. See the group-3 banner above.
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
+    )]
+    fn build_succeeds_with_refreshing_auth_callback() {
+        let rest = rest_builder_state_from_ffi(
+            &test_c_rest_endpoint_config(),
+            Some(fill_auth_direct),
+            None,
+            test_allocate_error(),
+        )
+        .unwrap();
+        assert!(build_rest_object_store(&test_base_url(), &HashMap::new(), &rest).is_ok());
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
+    )]
+    fn build_succeeds_with_header_options_fallback() {
+        let mut options = HashMap::new();
+        options.insert(
+            format!("{}Authorization", REST_BUILDER_OPTION_HEADER_PREFIX),
+            "Bearer x".into(),
+        );
+        assert!(
+            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state()).is_ok()
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
+    )]
+    fn build_succeeds_with_prefixes_and_resilience_options() {
+        let prefix = "/TablesById/u";
+        let mut config = test_c_rest_endpoint_config();
+        config.files_prefix = kernel_string_slice!(prefix);
+        config.entry_strip_prefix = kernel_string_slice!(prefix);
+        let rest = rest_builder_state_from_ffi(&config, None, None, test_allocate_error()).unwrap();
+
+        let mut options = HashMap::new();
+        options.insert(
+            format!("{}Authorization", REST_BUILDER_OPTION_HEADER_PREFIX),
+            "Bearer x".into(),
+        );
+        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "3".into());
+        options.insert(
+            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
+            "true".into(),
+        );
+        assert!(build_rest_object_store(&test_base_url(), &options, &rest).is_ok());
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
+    )]
+    fn build_rejects_invalid_max_retries() {
+        let mut options = HashMap::new();
+        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "nope".into());
+        assert!(
+            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
+                .is_err()
+        );
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
+    )]
+    fn build_rejects_invalid_verify_on_ambiguous() {
+        let mut options = HashMap::new();
+        options.insert(
+            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
+            "nope".into(),
         );
         assert!(
             build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())

--- a/ffi/src/rest_engine.rs
+++ b/ffi/src/rest_engine.rs
@@ -656,6 +656,9 @@ mod tests {
     // Every test below is `#[cfg_attr(miri, ignore)]` because it builds the client and pays the
     // full rustls crypto-init cost under the interpreter. Their `unsafe` is already run under Miri
     // by groups 1-2, so skipping drops no coverage. See the group-3 banner above.
+    //
+    // DO NOT ADD `unsafe` TO A TEST BELOW. Miri never runs them, so `unsafe` added here is never
+    // checked for undefined behavior and nothing in CI reports the gap. Put it in a group 1-2 test.
 
     #[test]
     #[cfg_attr(

--- a/ffi/src/rest_engine.rs
+++ b/ffi/src/rest_engine.rs
@@ -330,8 +330,6 @@ pub(crate) fn build_rest_object_store(
             })
             .transpose()?,
     };
-    let client = build_rest_client(&tls)?;
-
     let max_retries = options
         .get(REST_BUILDER_OPTION_RETRY_MAX_RETRIES)
         .map(|s| {
@@ -348,6 +346,10 @@ pub(crate) fn build_rest_object_store(
         REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS,
         options.get(REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS),
     )?;
+
+    // Validate every option before building the client: constructing the reqwest/rustls client
+    // initializes a crypto provider, which is minutes of work under the Miri interpreter.
+    let client = build_rest_client(&tls)?;
 
     Ok(Arc::new(
         RestObjectStore::new(base_url.to_string(), client, auth, Arc::new(config))
@@ -580,14 +582,15 @@ mod tests {
     //
     //   3a. Rejected cheaply, before rustls crypto init. Kept under Miri.
     //
-    //   3b. Client built fully (success cases, plus errors parsed after the build). Marked
-    //       `#[cfg_attr(miri, ignore)]`: skipping drops no coverage (groups 1-2 already cover
-    //       their `unsafe`). They still run under `cargo test` / nextest.
+    //   3b. Client built fully (the success cases). Marked `#[cfg_attr(miri, ignore)]`: skipping
+    //       drops no coverage (groups 1-2 already cover their `unsafe`). They still run under
+    //       `cargo test` / nextest.
 
-    // --- 3a: rejected before rustls crypto init (cheap; run under Miri) ---
+    // === 3a: rejected before rustls crypto init (cheap; run under Miri) ===
     //
-    // Invalid timeout and header value reject inside `build_rest_object_store`; partial mTLS
-    // rejects inside `build_rest_client` but before `builder.build()`, so no crypto stack is built.
+    // `build_rest_object_store` validates every option before building the client, so a bad option
+    // rejects without paying crypto init. Partial mTLS rejects inside `build_rest_client` itself,
+    // but before `builder.build()`, so no crypto stack is built either.
 
     #[test]
     fn build_rejects_invalid_timeout() {
@@ -625,11 +628,34 @@ mod tests {
         );
     }
 
-    // --- 3b: build the reqwest/rustls client (~minutes under Miri, so skipped) ---
+    #[test]
+    fn build_rejects_invalid_max_retries() {
+        let mut options = HashMap::new();
+        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "nope".into());
+        assert!(
+            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn build_rejects_invalid_verify_on_ambiguous() {
+        let mut options = HashMap::new();
+        options.insert(
+            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
+            "nope".into(),
+        );
+        assert!(
+            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
+                .is_err()
+        );
+    }
+
+    // === 3b: build the reqwest/rustls client (~minutes under Miri, so skipped) ===
     //
-    // Every test below is `#[cfg_attr(miri, ignore)]` because it reaches `build_rest_client` and
-    // pays the full rustls crypto-init cost under the interpreter. Their `unsafe` is already run
-    // under Miri by groups 1-2, so skipping drops no coverage. See the group-3 banner above.
+    // Every test below is `#[cfg_attr(miri, ignore)]` because it builds the client and pays the
+    // full rustls crypto-init cost under the interpreter. Their `unsafe` is already run under Miri
+    // by groups 1-2, so skipping drops no coverage. See the group-3 banner above.
 
     #[test]
     #[cfg_attr(
@@ -686,36 +712,5 @@ mod tests {
             "true".into(),
         );
         assert!(build_rest_object_store(&test_base_url(), &options, &rest).is_ok());
-    }
-
-    #[test]
-    #[cfg_attr(
-        miri,
-        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
-    )]
-    fn build_rejects_invalid_max_retries() {
-        let mut options = HashMap::new();
-        options.insert(REST_BUILDER_OPTION_RETRY_MAX_RETRIES.into(), "nope".into());
-        assert!(
-            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
-                .is_err()
-        );
-    }
-
-    #[test]
-    #[cfg_attr(
-        miri,
-        ignore = "builds reqwest/rustls client (no unsafe); crypto init is minutes under Miri"
-    )]
-    fn build_rejects_invalid_verify_on_ambiguous() {
-        let mut options = HashMap::new();
-        options.insert(
-            REST_BUILDER_OPTION_PUT_VERIFY_ON_AMBIGUOUS.into(),
-            "nope".into(),
-        );
-        assert!(
-            build_rest_object_store(&test_base_url(), &options, &test_rest_builder_state())
-                .is_err()
-        );
     }
 }

--- a/ffi/src/rest_engine.rs
+++ b/ffi/src/rest_engine.rs
@@ -657,8 +657,9 @@ mod tests {
     // full rustls crypto-init cost under the interpreter. Their `unsafe` is already run under Miri
     // by groups 1-2, so skipping drops no coverage. See the group-3 banner above.
     //
-    // DO NOT ADD `unsafe` TO A TEST BELOW. Miri never runs them, so `unsafe` added here is never
-    // checked for undefined behavior and nothing in CI reports the gap. Put it in a group 1-2 test.
+    // DO NOT ADD NEW `unsafe` TO A TEST BELOW (unsafe groups 1-2 don't already run). Miri never
+    // runs them, so unsafe unique to them goes unchecked for undefined behavior and nothing in CI
+    // reports the gap. Put it in a group 1-2 test.
 
     #[test]
     #[cfg_attr(

--- a/ffi/src/rest_engine.rs
+++ b/ffi/src/rest_engine.rs
@@ -377,28 +377,13 @@ mod tests {
     use crate::ffi_test_utils::allocate_err;
     use crate::kernel_string_slice;
 
-    // ================================ Miri policy for this module ================================
+    // Miri policy for this module. See ffi/CLAUDE.md "Testing under Miri" for the policy;
+    // tests below are grouped by their relationship to `unsafe`, in file order:
     //
-    // CI runs these tests under Miri to catch undefined behavior in this module's `unsafe` FFI:
-    // the raw-pointer reads in `take_auth_pairs_from_c`, the `unsafe impl Send/Sync for
-    // FfiAuthHeaderProvider`, and `FfiAuthHeaderProvider::collect` (which dereferences a
-    // `*mut CAuthHeaders` the C caller filled in). Miri interprets MIR instead of running native
-    // code, so it is far slower than a normal run; we skip tests it cannot usefully check.
-    //
-    // The tests are grouped by their relationship to `unsafe`, in file order:
-    //
-    //   1. Pure-logic tests: no `unsafe`, cheap. Run under Miri because there is no reason not to.
-    //
-    //   2. Unsafe-FFI tests: execute this module's `unsafe` directly. These are why the Miri job
-    //      exists; never mark them `#[cfg_attr(miri, ignore)]`.
-    //
-    //   3. Client-build tests: `#[cfg_attr(miri, ignore)]`. They execute no `unsafe` from this
-    //      crate (the lone unsafe call sits behind a per-request closure they never fire) and are
-    //      slow under Miri because `build_rest_client` builds the reqwest/rustls crypto stack.
-    //      Skipping them drops no coverage: group 2 already covers the only `unsafe` they touch.
-    //      See that group's banner for details.
-    //
-    // =============================================================================================
+    //   1. Pure-logic tests: no `unsafe`. Run under Miri.
+    //   2. Unsafe-FFI tests: exercise this module's `unsafe` directly. Run under Miri.
+    //   3. Client-build tests: reach `build_rest_client`. Their `unsafe` is a subset of what groups
+    //      1-2 run under Miri, so the slow ones are `#[cfg_attr(miri, ignore)]`.
 
     fn test_allocate_error() -> AllocateErrorFn {
         allocate_err
@@ -526,12 +511,11 @@ mod tests {
         assert!(rest_endpoint_config_from_c(&config).is_err());
     }
 
-    // === Group 2: unsafe-FFI tests (MUST run under Miri) ===
+    // === Group 2: unsafe-FFI tests (kept under Miri) ===
     //
     // These exercise `take_auth_pairs_from_c` (raw-pointer reads of a C-filled `*mut CAuthHeaders`)
     // and `FfiAuthHeaderProvider::collect` (which upcalls the C callback and dereferences its
-    // output): the undefined-behavior surface Miri exists to check here. Never mark any test in
-    // this group `#[cfg_attr(miri, ignore)]`.
+    // output): the undefined-behavior surface Miri checks here.
 
     #[test]
     fn auth_pairs_from_c_takes_handles() {
@@ -584,21 +568,26 @@ mod tests {
 
     // === Group 3: client-build tests (call build_rest_object_store) ===
     //
-    // None of these execute this crate's `unsafe`: `build_rest_object_store` has no `unsafe`, and
-    // its one unsafe path (`FfiAuthHeaderProvider::collect`) sits behind a per-request closure that
-    // only fires when the store serves an HTTP request, which these build-only tests never do.
-    // Their only Miri-relevant cost is `build_rest_client`, which builds the reqwest/rustls client
-    // and initializes the crypto provider: minutes of safe arithmetic under the interpreter.
+    // These execute no `unsafe` beyond what groups 1-2 already run under Miri.
+    // `build_rest_object_store` has no `unsafe`; the `try_from_slice` in their config setup
+    // (via `rest_endpoint_config_from_c`) is covered by group 1, and
+    // `FfiAuthHeaderProvider::collect` by group 2 (it sits behind a per-request closure these
+    // build-only tests never fire). Their only Miri-relevant cost is `build_rest_client`, which
+    // builds the reqwest/rustls client and initializes the crypto provider: minutes of safe
+    // arithmetic under the interpreter.
     //
     // Split accordingly:
     //
-    //   3a. Input rejected BEFORE `build_rest_client` runs. Cheap, so kept under Miri.
+    //   3a. Rejected cheaply, before rustls crypto init. Kept under Miri.
     //
-    //   3b. Client built fully (success cases, plus errors parsed AFTER the build). Marked
-    //       `#[cfg_attr(miri, ignore)]`: they run no `unsafe`, so skipping drops no coverage
-    //       (group 2 already covers the unsafe FFI). They still run under `cargo test` / nextest.
+    //   3b. Client built fully (success cases, plus errors parsed after the build). Marked
+    //       `#[cfg_attr(miri, ignore)]`: skipping drops no coverage (groups 1-2 already cover
+    //       their `unsafe`). They still run under `cargo test` / nextest.
 
-    // --- 3a: rejected before the client is built (cheap; run under Miri) ---
+    // --- 3a: rejected before rustls crypto init (cheap; run under Miri) ---
+    //
+    // Invalid timeout and header value reject inside `build_rest_object_store`; partial mTLS
+    // rejects inside `build_rest_client` but before `builder.build()`, so no crypto stack is built.
 
     #[test]
     fn build_rejects_invalid_timeout() {
@@ -636,11 +625,11 @@ mod tests {
         );
     }
 
-    // --- 3b: build the reqwest/rustls client (no unsafe; ~minutes under Miri, so skipped) ---
+    // --- 3b: build the reqwest/rustls client (~minutes under Miri, so skipped) ---
     //
     // Every test below is `#[cfg_attr(miri, ignore)]` because it reaches `build_rest_client` and
-    // pays the full rustls crypto-init cost under the interpreter while executing none of this
-    // crate's `unsafe`. See the group-3 banner above.
+    // pays the full rustls crypto-init cost under the interpreter. Their `unsafe` is already run
+    // under Miri by groups 1-2, so skipping drops no coverage. See the group-3 banner above.
 
     #[test]
     #[cfg_attr(

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -800,7 +800,7 @@ mod tests {
     use delta_kernel_ffi::error::KernelError;
     use delta_kernel_ffi::ffi_test_utils::{
         allocate_err, allocate_str, assert_extern_result_error_with_message, build_snapshot,
-        ok_or_panic, recover_error, recover_string,
+        engine_handle_for_store, ok_or_panic, recover_error, recover_string,
     };
     use delta_kernel_ffi::tests::get_default_engine;
     use itertools::Itertools;
@@ -1305,22 +1305,19 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_partitioned_write_context_rejects_unpartitioned_table(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
             "number",
             DataType::INTEGER,
         )])?);
-        let (_tmp_test_dir, tables) =
-            setup_local_test_tables(schema, &[], "test_unpartitioned").await?;
+        let tables = setup_test_tables(schema, &[], None, "test_unpartitioned").await?;
 
-        for (table_url, _engine, _store, _table_name) in tables {
-            let table_path = table_url.to_file_path().unwrap();
-            let table_path_str = table_path.to_str().unwrap();
-            let engine = get_default_engine(table_path_str);
+        for (table_url, _engine, store, _table_name) in tables {
+            let table_url_str = table_url.as_str();
+            let engine = engine_handle_for_store(store);
             let txn = ok_or_panic(unsafe {
-                transaction(kernel_string_slice!(table_path_str), engine.shallow_copy())
+                transaction(kernel_string_slice!(table_url_str), engine.shallow_copy())
             });
 
             // Supplying partition values for a non-partitioned table is an error, and the call
@@ -1336,7 +1333,11 @@ mod tests {
                 )
             });
             let result = unsafe {
-                get_partitioned_write_context(txn, partition_values, engine.shallow_copy())
+                get_partitioned_write_context(
+                    txn.shallow_copy(),
+                    partition_values,
+                    engine.shallow_copy(),
+                )
             };
             let err = match result {
                 ExternResult::Err(e) => unsafe { recover_error(e) },
@@ -1347,6 +1348,7 @@ mod tests {
                 "unexpected error: {}",
                 err.message
             );
+            unsafe { free_transaction(txn) };
             unsafe { free_engine(engine) };
         }
 

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1356,7 +1356,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_visit_partition_values_surfaces_null() -> Result<(), Box<dyn std::error::Error>> {
         // A null partition value must surface across the visitor as `is_null = true` with an
         // empty value slice (the documented C contract).
@@ -1364,15 +1363,13 @@ mod tests {
             StructField::nullable("number", DataType::INTEGER),
             StructField::nullable("part", DataType::INTEGER),
         ])?);
-        let (_tmp_test_dir, tables) =
-            setup_local_test_tables(schema, &["part"], "test_null_partition").await?;
+        let tables = setup_test_tables(schema, &["part"], None, "test_null_partition").await?;
 
-        for (table_url, _engine, _store, _table_name) in tables {
-            let table_path = table_url.to_file_path().unwrap();
-            let table_path_str = table_path.to_str().unwrap();
-            let engine = get_default_engine(table_path_str);
+        for (table_url, _engine, store, _table_name) in tables {
+            let table_url_str = table_url.as_str();
+            let engine = engine_handle_for_store(store);
             let txn = ok_or_panic(unsafe {
-                transaction(kernel_string_slice!(table_path_str), engine.shallow_copy())
+                transaction(kernel_string_slice!(table_url_str), engine.shallow_copy())
             });
 
             let partition_values = partition_value_map_new();
@@ -1389,7 +1386,11 @@ mod tests {
                 )
             });
             let write_context = ok_or_panic(unsafe {
-                get_partitioned_write_context(txn, partition_values, engine.shallow_copy())
+                get_partitioned_write_context(
+                    txn.shallow_copy(),
+                    partition_values,
+                    engine.shallow_copy(),
+                )
             });
 
             let mut collected: Vec<(String, String, bool)> = Vec::new();
@@ -1402,6 +1403,7 @@ mod tests {
             assert_eq!(collected, vec![("part".to_string(), String::new(), true)]);
 
             unsafe { free_write_context(write_context) };
+            unsafe { free_transaction(txn) };
             unsafe { free_engine(engine) };
         }
 
@@ -1409,7 +1411,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_visit_partition_values_is_sorted_by_key() -> Result<(), Box<dyn std::error::Error>>
     {
         // Multiple partition columns must be visited in deterministic (sorted) key order,
@@ -1419,15 +1420,14 @@ mod tests {
             StructField::nullable("region", DataType::STRING),
             StructField::nullable("year", DataType::INTEGER),
         ])?);
-        let (_tmp_test_dir, tables) =
-            setup_local_test_tables(schema, &["year", "region"], "test_multi_partition").await?;
+        let tables =
+            setup_test_tables(schema, &["year", "region"], None, "test_multi_partition").await?;
 
-        for (table_url, _engine, _store, _table_name) in tables {
-            let table_path = table_url.to_file_path().unwrap();
-            let table_path_str = table_path.to_str().unwrap();
-            let engine = get_default_engine(table_path_str);
+        for (table_url, _engine, store, _table_name) in tables {
+            let table_url_str = table_url.as_str();
+            let engine = engine_handle_for_store(store);
             let txn = ok_or_panic(unsafe {
-                transaction(kernel_string_slice!(table_path_str), engine.shallow_copy())
+                transaction(kernel_string_slice!(table_url_str), engine.shallow_copy())
             });
 
             let partition_values = partition_value_map_new();
@@ -1452,7 +1452,11 @@ mod tests {
                 )
             });
             let write_context = ok_or_panic(unsafe {
-                get_partitioned_write_context(txn, partition_values, engine.shallow_copy())
+                get_partitioned_write_context(
+                    txn.shallow_copy(),
+                    partition_values,
+                    engine.shallow_copy(),
+                )
             });
 
             let mut collected: Vec<(String, String, bool)> = Vec::new();
@@ -1466,6 +1470,7 @@ mod tests {
             assert_eq!(keys, vec!["region", "year"]);
 
             unsafe { free_write_context(write_context) };
+            unsafe { free_transaction(txn) };
             unsafe { free_engine(engine) };
         }
 
@@ -2077,15 +2082,16 @@ mod tests {
     /// fields. Returns `(table_path, engine_handle, builder_handle)`. The caller is responsible
     /// for freeing/consuming the engine and builder handles.
     fn create_table_builder(
-        tmp_dir: &tempfile::TempDir,
+        store: &Arc<DynObjectStore>,
+        table_url: &Url,
         fields: Vec<StructField>,
     ) -> (
         String,
         Handle<SharedExternEngine>,
         Handle<ExclusiveCreateTableBuilder>,
     ) {
-        let table_path = tmp_dir.path().to_str().unwrap().to_string();
-        let engine = get_default_engine(&table_path);
+        let table_path = table_url.to_string();
+        let engine = engine_handle_for_store(Arc::clone(store));
         let engine_info = "test-engine/1.0";
         let schema_arg = EngineSchema {
             schema: &fields as *const Vec<StructField> as *mut c_void,
@@ -2117,11 +2123,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_basic() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("name", DataType::STRING),
@@ -2151,20 +2158,28 @@ mod tests {
     }
 
     /// Reads the v0 commit file (`_delta_log/00..00.json`) of a freshly created table.
-    fn read_v0_commit(tmp_dir: &tempfile::TempDir) -> String {
-        let path = tmp_dir
-            .path()
-            .join("_delta_log")
-            .join("00000000000000000000.json");
-        std::fs::read_to_string(path).expect("v0 commit file should exist")
+    async fn read_v0_commit(store: &Arc<DynObjectStore>, table_url: &Url) -> String {
+        let path = table_url
+            .join("_delta_log/00000000000000000000.json")
+            .expect("valid commit url");
+        let path = Path::from_url_path(path.path()).expect("valid object store path");
+        let bytes = store
+            .get(&path)
+            .await
+            .expect("v0 commit file should exist")
+            .bytes()
+            .await
+            .expect("v0 commit body");
+        String::from_utf8(bytes.to_vec()).expect("v0 commit is utf-8")
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_with_clustering_columns() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("name", DataType::STRING),
@@ -2186,7 +2201,7 @@ mod tests {
         // A clustered create records the `delta.clustering` domain metadata (listing the
         // clustering columns, JSON-escaped inside the configuration string) and adds the
         // `clustering` writer feature to the protocol.
-        let log = read_v0_commit(&tmp_dir);
+        let log = read_v0_commit(&store, &table_url).await;
         assert!(
             log.contains("delta.clustering"),
             "missing clustering domain metadata: {log}"
@@ -2205,13 +2220,14 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_with_partition_columns() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         // Partitioning requires at least one non-partition column, so partition on `date`
         // while keeping `id` as data.
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("date", DataType::STRING),
@@ -2231,7 +2247,7 @@ mod tests {
         build_and_commit(builder, &engine);
 
         // A partitioned create records the partition columns in the table metadata.
-        let log = read_v0_commit(&tmp_dir);
+        let log = read_v0_commit(&store, &table_url).await;
         assert!(
             log.contains(r#""partitionColumns":["date"]"#),
             "missing partitionColumns in metadata: {log}"
@@ -2242,12 +2258,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_with_multiple_clustering_columns(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("name", DataType::STRING),
@@ -2268,7 +2285,7 @@ mod tests {
         });
         build_and_commit(builder, &engine);
 
-        let log = read_v0_commit(&tmp_dir);
+        let log = read_v0_commit(&store, &table_url).await;
         assert!(
             log.contains(r#"[[\"id\"],[\"name\"]]"#),
             "clustering column order not preserved: {log}"
@@ -2279,12 +2296,13 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_data_layout_last_call_wins() -> Result<(), Box<dyn std::error::Error>>
     {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("date", DataType::STRING),
@@ -2315,7 +2333,7 @@ mod tests {
         });
         build_and_commit(builder, &engine);
 
-        let log = read_v0_commit(&tmp_dir);
+        let log = read_v0_commit(&store, &table_url).await;
         assert!(
             log.contains(r#""partitionColumns":["date"]"#),
             "partition layout should win: {log}"
@@ -2340,9 +2358,11 @@ mod tests {
     fn test_with_data_layout_impl_propagates_column_error() {
         // A column-collection error must short-circuit the shared lowering and drop the consumed
         // builder, never producing a layout or a dangling handle.
-        let tmp_dir = tempdir().unwrap();
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (_table_path, engine, builder_handle) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
         let builder = unsafe { *builder_handle.into_inner() };
@@ -2355,11 +2375,12 @@ mod tests {
     /// CREATE TABLE: the committed transaction must expose a post-commit snapshot at version 0
     /// without re-listing the log.
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_post_commit_snapshot_create_table() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
 
@@ -2441,11 +2462,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_create_table_with_properties() {
-        let tmp_dir = tempdir().unwrap();
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
 
@@ -2501,7 +2523,8 @@ mod tests {
     /// Builds a create-table transaction and its unpartitioned write context, optionally
     /// enabling column mapping. Returns handles the caller must free.
     fn cm_table_write_context(
-        tmp_dir: &tempfile::TempDir,
+        store: &Arc<DynObjectStore>,
+        table_url: &Url,
         cm_mode: Option<&str>,
     ) -> (
         Handle<SharedExternEngine>,
@@ -2509,7 +2532,8 @@ mod tests {
         Handle<SharedWriteContext>,
     ) {
         let (_table_path, engine, mut builder) = create_table_builder(
-            tmp_dir,
+            store,
+            table_url,
             vec![
                 StructField::nullable("id", DataType::INTEGER),
                 StructField::nullable("name", DataType::STRING),
@@ -2539,8 +2563,9 @@ mod tests {
     #[case::name_mode(Some("name"))]
     #[case::id_mode(Some("id"))]
     fn test_write_context_accessors(#[case] cm_mode: Option<&str>) {
-        let tmp_dir = tempdir().unwrap();
-        let (engine, txn, write_context) = cm_table_write_context(&tmp_dir, cm_mode);
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
+        let (engine, txn, write_context) = cm_table_write_context(&store, &table_url, cm_mode);
 
         let logical = unsafe { get_write_schema(write_context.shallow_copy()) };
         let physical = unsafe { get_physical_write_schema(write_context.shallow_copy()) };
@@ -2605,20 +2630,22 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_already_exists() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
 
         // Create the table first time -- should succeed
         let (_table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
         build_and_commit(builder, &engine);
 
         // Try to create the same table again -- build should error (table already exists)
         let (_, engine2, builder2) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
         let result = unsafe { create_table_builder_build(builder2, engine2.shallow_copy()) };
@@ -2656,10 +2683,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_table_build_with_empty_schema_succeeds(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         // CREATE TABLE with no columns is permitted by the Delta protocol; users may
         // populate the schema later via ALTER TABLE ADD COLUMN.
-        let (_table_path, engine, builder) = create_table_builder(&tmp_dir, vec![]);
+        let (_table_path, engine, builder) = create_table_builder(&store, &table_url, vec![]);
 
         let txn =
             ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
@@ -2670,11 +2698,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_with_custom_committer() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_create_table", None);
         let (table_path, engine, builder) = create_table_builder(
-            &tmp_dir,
+            &store,
+            &table_url,
             vec![StructField::nullable("id", DataType::INTEGER)],
         );
         let table_path_str = table_path.as_str();

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -970,6 +970,8 @@ mod tests {
     #[tokio::test]
     // Keeps local storage: `canonicalize` on the FFI-returned write path has no in-memory
     // equivalent.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in a test that runs under Miri.
     #[cfg_attr(
         miri,
         ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"
@@ -1150,6 +1152,8 @@ mod tests {
     #[tokio::test]
     // Keeps local storage: the test creates the Hive partition directory on disk, which an object
     // store does not have.
+    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
+    // for undefined behavior. Put it in a test that runs under Miri.
     #[cfg_attr(
         miri,
         ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1736,7 +1736,6 @@ mod tests {
 
     #[cfg(feature = "delta-kernel-unity-catalog")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[cfg_attr(miri, ignore)]
     async fn test_transaction_with_uc_committer() -> Result<(), Box<dyn std::error::Error>> {
         use delta_kernel_ffi::{
             get_snapshot_builder, snapshot_builder_build, snapshot_builder_set_max_catalog_version,
@@ -1776,12 +1775,9 @@ mod tests {
             StructField::nullable("string", DataType::STRING),
         ]));
 
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_local_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
-
         // Create a catalog-managed table so UCCommitter (a catalog committer) is allowed.
         let (store, _test_engine, table_location) =
-            test_utils::engine_store_setup("test_uc_table", Some(&tmp_dir_local_url));
+            test_utils::engine_store_setup("test_uc_table", None);
         let table_url = test_utils::create_table(
             store.clone(),
             table_location,
@@ -1794,9 +1790,8 @@ mod tests {
         .await?;
 
         {
-            let table_path = table_url.to_file_path().unwrap();
-            let table_path_str = table_path.to_str().unwrap();
-            let engine = get_default_engine(table_path_str);
+            let table_path_str = table_url.as_str();
+            let engine = engine_handle_for_store(Arc::clone(&store));
 
             let snapshot = unsafe {
                 let mut ptr = ok_or_panic(get_snapshot_builder(
@@ -1826,7 +1821,11 @@ mod tests {
             };
 
             let txn = ok_or_panic(unsafe {
-                transaction_with_committer(snapshot, engine.shallow_copy(), uc_committer)
+                transaction_with_committer(
+                    snapshot.shallow_copy(),
+                    engine.shallow_copy(),
+                    uc_committer,
+                )
             });
             unsafe { set_data_change(txn.shallow_copy(), false) };
 
@@ -1865,12 +1864,14 @@ mod tests {
                     .as_ref()
                     .add_files_schema()
             };
-            let file_info = write_parquet_file(
-                table_path_str,
+            let file_info = put_parquet_file(
+                &store,
+                &table_url,
                 "uc_test_file.parquet",
                 &batch,
                 parquet_schema.as_ref().try_into_arrow()?,
-            )?;
+            )
+            .await?;
 
             let file_info_engine_data = ok_or_panic(unsafe {
                 get_engine_data(file_info.array, &file_info.schema, allocate_err)
@@ -1960,6 +1961,7 @@ mod tests {
             unsafe { free_snapshot(republished_snapshot) };
             unsafe { free_snapshot(published_snapshot) };
             unsafe { free_snapshot(post_commit_snapshot) };
+            unsafe { free_snapshot(snapshot) };
             unsafe { free_committed_transaction(committed) };
 
             let context = recover_test_context(context).unwrap();

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -968,7 +968,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
+    // Keeps local storage: `canonicalize` on the FFI-returned write path has no in-memory
+    // equivalent.
+    #[cfg_attr(
+        miri,
+        ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"
+    )]
     async fn test_basic_append() -> Result<(), Box<dyn std::error::Error>> {
         let schema = Arc::new(StructType::try_new(vec![
             StructField::nullable("number", DataType::INTEGER),
@@ -1143,7 +1148,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
+    // Keeps local storage: the test creates the Hive partition directory on disk, which an object
+    // store does not have.
+    #[cfg_attr(
+        miri,
+        ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"
+    )]
     async fn test_partitioned_append() -> Result<(), Box<dyn std::error::Error>> {
         // Partition column `part` is listed last in the schema; the physical write schema must
         // exclude it (CM=none, partition columns are not materialized).

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -937,6 +937,36 @@ mod tests {
         create_file_metadata(file_path, file_size_bytes, num_rows, metadata_schema)
     }
 
+    /// Write `batch` as parquet into `store` at `file_path` and return its Add-action metadata.
+    ///
+    /// The store-based counterpart to [`write_parquet_file`], for tests that must avoid
+    /// `std::fs` so they can run under Miri.
+    async fn put_parquet_file(
+        store: &Arc<DynObjectStore>,
+        table_url: &Url,
+        file_path: &str,
+        batch: &RecordBatch,
+        metadata_schema: ArrowSchema,
+    ) -> Result<ArrowFFIData, Box<dyn std::error::Error>> {
+        let mut buf = Vec::new();
+        let props = WriterProperties::builder().build();
+        let mut writer = ArrowWriter::try_new(&mut buf, batch.schema(), Some(props))?;
+        writer.write(batch)?;
+        let res = writer.close()?;
+
+        let file_size_bytes = buf.len() as u64;
+        let url = table_url.join(file_path)?;
+        let path = Path::from_url_path(url.path())?;
+        store.put(&path, buf.into()).await?;
+
+        create_file_metadata(
+            file_path,
+            file_size_bytes,
+            res.file_metadata().num_rows(),
+            metadata_schema,
+        )
+    }
+
     #[tokio::test]
     #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_basic_append() -> Result<(), Box<dyn std::error::Error>> {
@@ -2408,11 +2438,11 @@ mod tests {
     /// just-committed version. Also verifies that calling the accessor a second time yields an
     /// independent handle (Arc clone).
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_post_commit_snapshot_existing_table() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_post_commit_existing", None);
         // create_table_with_one_file commits v0 (create) and v1 (file add).
-        let (table_path, engine) = create_table_with_one_file(&tmp_dir)?;
+        let (table_path, engine) = create_table_with_one_file(&store, &table_url).await?;
 
         // Blind no-op commit on top of v1 -> v2.
         let txn = ok_or_panic(unsafe {
@@ -2736,16 +2766,17 @@ mod tests {
 
     /// Helper: create a table, write one parquet file, and return (table_path, engine_handle).
     /// The caller is responsible for freeing the engine handle.
-    fn create_table_with_one_file(
-        tmp_dir: &tempfile::TempDir,
+    async fn create_table_with_one_file(
+        store: &Arc<DynObjectStore>,
+        table_url: &Url,
     ) -> Result<(String, Handle<SharedExternEngine>), Box<dyn std::error::Error>> {
-        let table_path = tmp_dir.path().to_str().unwrap();
+        let table_path = table_url.as_str();
         let fields = vec![
             StructField::nullable("number", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),
         ];
 
-        let engine = get_default_engine(table_path);
+        let engine = engine_handle_for_store(Arc::clone(store));
 
         // Create the table
         let engine_info = "test-engine/1.0";
@@ -2788,12 +2819,14 @@ mod tests {
         });
 
         let parquet_schema = unsafe { txn.shallow_copy().as_ref().add_files_schema() };
-        let file_info = write_parquet_file(
-            table_path,
+        let file_info = put_parquet_file(
+            store,
+            table_url,
             "file1.parquet",
             &batch,
             parquet_schema.as_ref().try_into_arrow()?,
-        )?;
+        )
+        .await?;
         let file_info_engine_data = ok_or_panic(unsafe {
             get_engine_data(
                 file_info.array,
@@ -2839,8 +2872,9 @@ mod tests {
     /// return the components needed for remove_files tests. Caller must free the engine handle
     /// (and txn if not committed).
     #[allow(clippy::type_complexity)]
-    fn setup_remove_files_test(
-        tmp_dir: &tempfile::TempDir,
+    async fn setup_remove_files_test(
+        store: &Arc<DynObjectStore>,
+        table_url: &Url,
     ) -> Result<
         (
             Box<dyn delta_kernel::EngineData>,
@@ -2852,7 +2886,7 @@ mod tests {
         ),
         Box<dyn std::error::Error>,
     > {
-        let (table_path, engine) = create_table_with_one_file(tmp_dir)?;
+        let (table_path, engine) = create_table_with_one_file(store, table_url).await?;
         let table_path_str = table_path.as_str();
 
         let kernel_engine = unsafe { engine.as_ref() }.engine();
@@ -2886,11 +2920,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_remove_files_with_null_sv_commits_and_removes_all(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_dir = tempdir()?;
-        let (data, sv, txn, engine, kernel_engine, table_path) = setup_remove_files_test(&tmp_dir)?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_remove_files", None);
+        let (data, sv, txn, engine, kernel_engine, table_path) =
+            setup_remove_files_test(&store, &table_url).await?;
         let data_handle: Handle<ExclusiveEngineData> = data.into();
 
         // Pass the original SV as u8 values
@@ -3106,16 +3141,16 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_remove_files_with_non_empty_sv_exercises_from_raw_parts(
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Exercises the from_raw_parts code path in the remove_files FFI wrapper by passing
         // a non-null selection vector pointer with non-zero length. The null-SV test always
         // passes a null pointer because scan_metadata for a single-file table returns an
         // empty selection vector.
-        let tmp_dir = tempdir()?;
+        let (store, _test_engine, table_url) =
+            test_utils::engine_store_setup("test_remove_files_sv", None);
         let (data, _sv, txn, engine, _kernel_engine, _table_path) =
-            setup_remove_files_test(&tmp_dir)?;
+            setup_remove_files_test(&store, &table_url).await?;
         let num_rows = data.len();
         assert!(num_rows > 0);
         let data_handle: Handle<ExclusiveEngineData> = data.into();

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1581,7 +1581,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_domain_metadata_system_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp_test_dir = tempdir()?;
@@ -1620,7 +1619,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_domain_metadata_duplicate_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp_test_dir = tempdir()?;
@@ -1668,7 +1666,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_domain_metadata_rejected_without_feature(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp_test_dir = tempdir()?;
@@ -2541,7 +2538,6 @@ mod tests {
     #[case::no_column_mapping(None)]
     #[case::name_mode(Some("name"))]
     #[case::id_mode(Some("id"))]
-    #[cfg_attr(miri, ignore)]
     fn test_write_context_accessors(#[case] cm_mode: Option<&str>) {
         let tmp_dir = tempdir().unwrap();
         let (engine, txn, write_context) = cm_table_write_context(&tmp_dir, cm_mode);
@@ -2658,7 +2654,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_create_table_build_with_empty_schema_succeeds(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tmp_dir = tempdir()?;

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1533,13 +1533,11 @@ mod tests {
     /// Create a table with the `domainMetadata` writer feature enabled and return the table
     /// URL, object store, and FFI engine handle.
     async fn setup_domain_metadata_table(
-        dir_url: &Url,
         name: &str,
     ) -> Result<(Url, Arc<DynObjectStore>, Handle<SharedExternEngine>), Box<dyn std::error::Error>>
     {
         let schema = Arc::new(try_schema! { nullable "id": INTEGER }?);
-        let (store, _test_engine, table_location) =
-            test_utils::engine_store_setup(name, Some(dir_url));
+        let (store, _test_engine, table_location) = test_utils::engine_store_setup(name, None);
         let table_url = test_utils::create_table(
             store.clone(),
             table_location,
@@ -1550,21 +1548,14 @@ mod tests {
             vec!["domainMetadata"],
         )
         .await?;
-        let table_path = table_url.to_file_path().unwrap();
-        let table_path_str = table_path.to_str().unwrap();
-        let engine = get_default_engine(table_path_str);
+        let engine = engine_handle_for_store(Arc::clone(&store));
         Ok((table_url, store, engine))
     }
 
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_domain_metadata_add_and_remove() -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
-        let (table_url, store, engine) =
-            setup_domain_metadata_table(&tmp_dir_url, "test_dm").await?;
-        let table_path = table_url.to_file_path().unwrap();
-        let table_path_str = table_path.to_str().unwrap();
+        let (table_url, store, engine) = setup_domain_metadata_table("test_dm").await?;
+        let table_path_str = table_url.as_str();
 
         // === Transaction 1: add domain metadata ===
         let txn = ok_or_panic(unsafe {
@@ -1618,12 +1609,8 @@ mod tests {
     #[tokio::test]
     async fn test_domain_metadata_system_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
-        let (table_url, _store, engine) =
-            setup_domain_metadata_table(&tmp_dir_url, "test_dm_sys").await?;
-        let table_path = table_url.to_file_path().unwrap();
-        let table_path_str = table_path.to_str().unwrap();
+        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_sys").await?;
+        let table_path_str = table_url.as_str();
 
         // with_domain_metadata succeeds (validation is lazy), but commit should fail
         let txn = ok_or_panic(unsafe {
@@ -1656,12 +1643,8 @@ mod tests {
     #[tokio::test]
     async fn test_domain_metadata_duplicate_domain_rejected_at_commit(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
-        let (table_url, _store, engine) =
-            setup_domain_metadata_table(&tmp_dir_url, "test_dm_dup").await?;
-        let table_path = table_url.to_file_path().unwrap();
-        let table_path_str = table_path.to_str().unwrap();
+        let (table_url, _store, engine) = setup_domain_metadata_table("test_dm_dup").await?;
+        let table_path_str = table_url.as_str();
 
         // Adding the same domain twice should cause commit to fail
         let txn = ok_or_panic(unsafe {
@@ -2972,7 +2955,6 @@ mod tests {
 
     /// End-to-end FFI round trip for connector-authored deletion vector updates.
     #[tokio::test]
-    #[cfg_attr(miri, ignore)]
     async fn test_dv_update_round_trip_via_ffi() -> Result<(), Box<dyn std::error::Error>> {
         use delta_kernel::actions::deletion_vector_writer::{
             KernelDeletionVector, StreamingDeletionVectorWriter,
@@ -2983,16 +2965,13 @@ mod tests {
             dv_descriptor_map_insert, dv_descriptor_map_new, dv_descriptor_new,
             transaction_update_deletion_vectors, KernelDvStorageType,
         };
-        use test_utils::{create_default_engine, record_batch_to_bytes};
-
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
+        use test_utils::record_batch_to_bytes;
 
         // Build a DV-enabled table; create_table sets delta.enableDeletionVectors for the
         // writer feature.
         let schema = Arc::new(try_schema! { nullable "id": INTEGER }?);
         let (store, _test_engine, table_location) =
-            test_utils::engine_store_setup("test_dv_ffi", Some(&tmp_dir_url));
+            test_utils::engine_store_setup("test_dv_ffi", None);
         let table_url = test_utils::create_table(
             store.clone(),
             table_location.clone(),
@@ -3021,7 +3000,11 @@ mod tests {
             .await?;
 
         // Add the file via a kernel transaction so the table has something to scan.
-        let kernel_engine: Arc<dyn delta_kernel::Engine> = create_default_engine(&table_url)?;
+        // Build the kernel engine over the seeded store: `create_default_engine` resolves a fresh
+        // store from the URL, which for `memory://` would not see this table.
+        let kernel_engine: Arc<dyn delta_kernel::Engine> = Arc::new(
+            delta_kernel_default_engine::DefaultEngineBuilder::new(Arc::clone(&store)).build(),
+        );
         let snapshot = delta_kernel::snapshot::Snapshot::builder_for(table_url.clone())
             .build(kernel_engine.as_ref())?;
         let mut add_txn = snapshot
@@ -3053,9 +3036,8 @@ mod tests {
             .await?;
 
         // === FFI surface under test ===
-        let table_path = table_url.to_file_path().unwrap();
-        let table_path_str = table_path.to_str().unwrap();
-        let engine = get_default_engine(table_path_str);
+        let table_path_str = table_url.as_str();
+        let engine = engine_handle_for_store(Arc::clone(&store));
         let txn = ok_or_panic(unsafe {
             transaction(kernel_string_slice!(table_path_str), engine.shallow_copy())
         });

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -970,8 +970,9 @@ mod tests {
     #[tokio::test]
     // Keeps local storage: `canonicalize` on the FFI-returned write path has no in-memory
     // equivalent.
-    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
-    // for undefined behavior. Put it in a test that runs under Miri.
+    // DO NOT ADD NEW `unsafe` HERE (unsafe not already run by a Miri test): Miri never runs this
+    // test, so unsafe unique to it goes unchecked for undefined behavior. Put it in a test that
+    // runs under Miri.
     #[cfg_attr(
         miri,
         ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"
@@ -1152,8 +1153,9 @@ mod tests {
     #[tokio::test]
     // Keeps local storage: the test creates the Hive partition directory on disk, which an object
     // store does not have.
-    // DO NOT ADD `unsafe` HERE: Miri never runs this test, so `unsafe` added here is never checked
-    // for undefined behavior. Put it in a test that runs under Miri.
+    // DO NOT ADD NEW `unsafe` HERE (unsafe not already run by a Miri test): Miri never runs this
+    // test, so unsafe unique to it goes unchecked for undefined behavior. Put it in a test that
+    // runs under Miri.
     #[cfg_attr(
         miri,
         ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"

--- a/ffi/src/transaction/transaction_id.rs
+++ b/ffi/src/transaction/transaction_id.rs
@@ -78,40 +78,31 @@ mod tests {
 
     use delta_kernel::schema::{DataType, StructField, StructType};
     use delta_kernel::Snapshot;
-    use tempfile::tempdir;
     use test_utils::setup_test_tables;
-    use url::Url;
 
     use super::*;
-    use crate::ffi_test_utils::ok_or_panic;
-    use crate::kernel_string_slice;
-    use crate::tests::get_default_engine;
+    use crate::ffi_test_utils::{engine_handle_for_store, ok_or_panic};
     use crate::transaction::{commit, free_committed_transaction, transaction};
+    use crate::{free_engine, free_snapshot, kernel_string_slice};
 
     #[cfg(feature = "default-engine-base")]
     #[tokio::test]
-    #[cfg_attr(miri, ignore)] // FIXME: re-enable miri (can't call foreign function `linkat` on OS `linux`)
     async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
-        // Create a temporary local directory for use during this test
-        let tmp_test_dir = tempdir()?;
-        let tmp_dir_local_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
-
         // create a simple table: one int column named 'number'
         let schema = Arc::new(
             StructType::try_new(vec![StructField::nullable("number", DataType::INTEGER)]).unwrap(),
         );
 
-        for (table_url, engine, _store, _table_name) in
-            setup_test_tables(schema, &[], Some(&tmp_dir_local_url), "test_table").await?
+        for (table_url, engine, store, _table_name) in
+            setup_test_tables(schema, &[], None, "test_table").await?
         {
-            let table_path = table_url.to_file_path().unwrap();
-            let table_path_str = table_path.to_str().unwrap();
-            let default_engine_handle = get_default_engine(table_path_str);
+            let table_url_str = table_url.as_str();
+            let default_engine_handle = engine_handle_for_store(store);
 
             // Start the transaction
             let txn = ok_or_panic(unsafe {
                 transaction(
-                    kernel_string_slice!(table_path_str),
+                    kernel_string_slice!(table_url_str),
                     default_engine_handle.shallow_copy(),
                 )
             });
@@ -150,10 +141,12 @@ mod tests {
             assert_eq!(snapshot.get_app_id_version("app_id2", &engine)?, Some(2));
             assert_eq!(snapshot.get_app_id_version("app_id3", &engine)?, None);
 
-            // Check versions through ffi handles
+            // Check versions through ffi handles. `get_app_id_version` borrows the handle, so
+            // one handle serves all three calls and is freed once at the end.
+            let snapshot_handle: Handle<SharedSnapshot> = snapshot.clone().into();
             let version1 = ok_or_panic(unsafe {
                 get_app_id_version(
-                    Handle::from(snapshot.clone()),
+                    snapshot_handle.shallow_copy(),
                     kernel_string_slice!(app_id1),
                     default_engine_handle.shallow_copy(),
                 )
@@ -162,7 +155,7 @@ mod tests {
 
             let version2 = ok_or_panic(unsafe {
                 get_app_id_version(
-                    Handle::from(snapshot.clone()),
+                    snapshot_handle.shallow_copy(),
                     kernel_string_slice!(app_id2),
                     default_engine_handle.shallow_copy(),
                 )
@@ -172,12 +165,15 @@ mod tests {
             let app_id3 = "app_id3";
             let version3 = ok_or_panic(unsafe {
                 get_app_id_version(
-                    Handle::from(snapshot.clone()),
+                    snapshot_handle.shallow_copy(),
                     kernel_string_slice!(app_id3),
                     default_engine_handle.shallow_copy(),
                 )
             });
             assert_eq!(version3, OptionalValue::None);
+
+            unsafe { free_snapshot(snapshot_handle) };
+            unsafe { free_engine(default_engine_handle) };
         }
         Ok(())
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Miri job catches undefined behavior at the `unsafe` FFI boundary, and it was the CI critical path at ~19 minutes on the slowest shard. This PR cuts that while raising coverage: 323 tests run under Miri, against 305 on main.

The rule: a test earns its place under Miri only if it runs `unsafe` that Miri can check. Cost tracks how much code a test runs, not how much it asserts. So we skip tests that spend minutes interpreting safe machinery (crypto init, parquet writes) while crossing no `unsafe` a cheaper kept test does not already cover, and for each we confirm a kept test covers its `unsafe`. Going the other way, tests that were skipped only because local-filesystem storage hit a syscall Miri cannot interpret now use in-memory storage and run, which is where coverage grows. The policy is recorded at each skip site and in `ffi/CLAUDE.md`.

## How was this change tested?

Full Miri suite: 323 tests, 0 failures, no undefined behavior, no leaks. Native suite 334/334.

Timing of the `Test with Miri` step on this PR versus the same three-shard job on main:

| | slowest shard | all three shards |
| --- | --- | --- |
| main | ~19 min | ~50 min |
| this PR | ~9.5 min | ~26 min |
