### PR TITLE
feat!: add column defaults ack method

### DIFF
--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -181,7 +181,8 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
     }
 }
 
-/// Validates the column-default metadata on a table's logical schema (see [Errors](#errors)).
+/// Validates the column-default metadata on a table's logical schema and reports whether any
+/// field declares a default (see [Errors](#errors)).
 ///
 /// Run eagerly at [`TableConfiguration`] construction so an invalid table is rejected at load.
 /// Inspects nested fields as well as top-level columns; see [`try_collect_column_defaults`].
@@ -195,9 +196,8 @@ impl<'a> SchemaTransform<'a> for ColumnDefaultCollector<'a> {
 ///
 /// Propagates any error from [`try_collect_column_defaults`]: a `CURRENT_DEFAULT` whose value is
 /// not a string, or a non-NULL default on a Variant column.
-pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<()> {
-    try_collect_column_defaults(schema)?;
-    Ok(())
+pub(crate) fn validate_column_defaults_metadata(schema: &StructType) -> DeltaResult<bool> {
+    Ok(!try_collect_column_defaults(schema)?.is_empty())
 }
 
 /// A nullable field named `name` carrying `raw_sql` as its `CURRENT_DEFAULT` metadata.
@@ -343,16 +343,23 @@ mod tests {
             field_with_default("c", DataType::INTEGER, "42"),
             StructField::nullable("no_default", DataType::STRING),
         ],
+        true,
         None
     )]
-    #[case::no_defaults(vec![StructField::nullable("c", DataType::INTEGER)], None)]
-    #[case::non_string_metadata(vec![field_with_invalid_default("c")], Some("non-string"))]
+    #[case::no_defaults(vec![StructField::nullable("c", DataType::INTEGER)], false, None)]
+    #[case::non_string_metadata(
+        vec![field_with_invalid_default("c")],
+        false,
+        Some("non-string")
+    )]
     #[case::non_null_default_on_array_tolerated(
         vec![field_with_default("arr", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")],
+        true,
         None
     )]
     #[case::non_null_default_on_variant_rejected(
         vec![field_with_default("v", DataType::unshredded_variant(), "1")],
+        false,
         Some("Variant")
     )]
     #[case::nested_default(
@@ -360,15 +367,17 @@ mod tests {
             "s",
             DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
         )],
+        true,
         None
     )]
     fn validate_column_defaults_cases(
         #[case] fields: Vec<StructField>,
+        #[case] expected_has_default: bool,
         #[case] expected_error: Option<&str>,
     ) {
         let schema = StructType::try_new(fields).unwrap();
         match (validate_column_defaults_metadata(&schema), expected_error) {
-            (Ok(()), None) => {}
+            (Ok(has_default), None) => assert_eq!(has_default, expected_has_default),
             (Err(e), Some(needle)) => assert!(e.to_string().contains(needle), "got: {e}"),
             (result, expected) => panic!("unexpected outcome: {result:?} vs {expected:?}"),
         }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -108,6 +108,8 @@ pub(crate) struct TableConfiguration {
     protocol: Protocol,
     /// Logical schema: field names are the user-facing (logical) column names.
     logical_schema: SchemaRef,
+    /// Whether any field in the logical schema declares a column default.
+    has_column_with_default: bool,
     /// The subset of the logical schema that remains after excluding partition columns.
     logical_schema_without_partition_columns: SchemaRef,
     /// Physical schema for all columns (field names respect column mapping mode).
@@ -203,8 +205,9 @@ impl TableConfiguration {
             Arc::new(StructType::new_unchecked(fields))
         };
 
-        let table_config = Self {
+        let mut table_config = Self {
             logical_schema,
+            has_column_with_default: false,
             logical_schema_without_partition_columns,
             physical_schema,
             physical_data_schema_without_partition_columns,
@@ -222,8 +225,10 @@ impl TableConfiguration {
         validate_timestamp_ntz_feature_support(&table_config)?;
         validate_variant_type_feature_support(&table_config)?;
         // Reject corrupt column-default metadata (a non-string `CURRENT_DEFAULT`, or a non-`NULL`
-        // default on a Variant column).
-        validate_column_defaults_metadata(&table_config.logical_schema)?;
+        // default on a Variant column) and retain whether the validated schema declares any column
+        // defaults.
+        table_config.has_column_with_default =
+            validate_column_defaults_metadata(&table_config.logical_schema)?;
         // Reject tables with geo-typed columns that don't declare the `geospatial` feature.
         #[cfg(feature = "geo-type-in-dev")]
         validate_geospatial_feature_support(&table_config)?;
@@ -485,6 +490,13 @@ impl TableConfiguration {
     /// `&self`-bound borrows from the schema (e.g. `&DataType` of a field).
     pub(crate) fn logical_schema_ref(&self) -> &SchemaRef {
         &self.logical_schema
+    }
+
+    /// Whether any field in the logical schema declares a column default.
+    ///
+    /// This includes nested fields and is independent of the `allowColumnDefaults` feature.
+    pub(crate) fn has_column_with_default(&self) -> bool {
+        self.has_column_with_default
     }
 
     /// The physical schema ([`SchemaRef`]) of this table at this version.

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -67,6 +67,7 @@ impl AlterTableTransaction {
             system_domain_metadata_additions: vec![],
             user_domain_removals: vec![],
             data_change: false,
+            column_defaults_acknowledged: false,
             engine_commit_info: None,
             // TODO(#2446): match delta-spark's per-op isBlindAppend policy
             // (ADD/DROP/DROP NOT NULL -> true, SET NOT NULL -> false). Hardcoded false for

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -170,6 +170,7 @@ impl CreateTableTransaction {
             system_domain_metadata_additions: system_domain_metadata,
             user_domain_removals: vec![],
             data_change: true,
+            column_defaults_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -241,8 +241,9 @@ pub struct Transaction<S = ExistingTable> {
     user_domain_removals: Vec<String>,
     // Whether this transaction contains any logical data changes.
     data_change: bool,
-    // TODO(#2499): Replace this state when Engine responsibilities encode column-default handling.
-    // Whether the connector acknowledged responsibility for applying column defaults.
+    // TODO(#2499): Replace this state when Conntector responsibilities encode column-default
+    // handling. Whether the connector acknowledged responsibility for applying column
+    // defaults.
     column_defaults_acknowledged: bool,
     // Whether this transaction should be marked as a blind append.
     is_blind_append: bool,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -241,6 +241,8 @@ pub struct Transaction<S = ExistingTable> {
     user_domain_removals: Vec<String>,
     // Whether this transaction contains any logical data changes.
     data_change: bool,
+    // Whether the connector acknowledged responsibility for applying column defaults.
+    column_defaults_acknowledged: bool,
     // Whether this transaction should be marked as a blind append.
     is_blind_append: bool,
     // Files matched by update_deletion_vectors() with new DV descriptors appended. These are used
@@ -382,6 +384,7 @@ impl<S> Transaction<S> {
         // Validate that the schema supports data writes when files are being added. Reads and
         // metadata-only commits are always allowed.
         if !self.add_files_metadata.is_empty() {
+            self.ensure_column_defaults_acknowledged()?;
             validate_schema_for_write(&self.effective_table_config.logical_schema())?;
         }
 
@@ -805,6 +808,21 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
+    /// Rejects data writes when the connector has not acknowledged column-default handling.
+    fn ensure_column_defaults_acknowledged(&self) -> DeltaResult<()> {
+        require!(
+            self.column_defaults_acknowledged
+                || !self
+                    .effective_table_config
+                    .is_feature_enabled(&TableFeature::AllowColumnDefaults),
+            Error::invalid_transaction_state(
+                "Writing data to a table with allowColumnDefaults requires calling \
+                 Transaction::ack_column_defaults() first",
+            )
+        );
+        Ok(())
+    }
+
     /// Returns true if this is a create-table transaction.
     /// A create-table transaction has no read snapshot (no pre-existing table).
     fn is_create_table(&self) -> bool {
@@ -897,6 +915,18 @@ impl<S> Transaction<S> {
 // Data file methods -- only available on transaction types that support data files
 // =============================================================================
 impl<S: SupportsDataFiles> Transaction<S> {
+    // TODO(#2499): Remove this API when Engine responsibilities encode column-default handling.
+    /// Acknowledges that the connector applies column defaults before writing data files.
+    ///
+    /// Call this before requesting a write context for a table that enables the
+    /// `allowColumnDefaults` feature. The connector must materialize every omitted column's
+    /// default itself; this method records that responsibility but does not apply any defaults.
+    /// Without this acknowledgement, write-context creation and commits containing added files
+    /// fail with an error.
+    pub fn ack_column_defaults(&mut self) {
+        self.column_defaults_acknowledged = true;
+    }
+
     /// Returns the expected schema for file statistics.
     ///
     /// The schema structure is derived from table configuration:
@@ -1000,7 +1030,9 @@ impl<S: SupportsDataFiles> Transaction<S> {
     ///
     /// Connectors use this to discover which columns have defaults, then call
     /// [`ColumnDefault::to_scalar`] on each (or fall back to [`ColumnDefault::raw_sql`] when the
-    /// kernel cannot parse the default) to materialize the column before writing.
+    /// kernel cannot parse the default) to materialize the column before writing. After handling
+    /// every omitted column, call [`ack_column_defaults`](Self::ack_column_defaults) before
+    /// requesting a write context.
     ///
     /// Keys are `String` rather than [`ColumnName`] because the kernel currently surfaces defaults
     /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
@@ -1100,7 +1132,9 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// target directory (Hive-style paths when column mapping is off, random prefix when on).
     ///
     /// Returns an error if the table is not partitioned (use
-    /// [`unpartitioned_write_context`](Self::unpartitioned_write_context) instead).
+    /// [`unpartitioned_write_context`](Self::unpartitioned_write_context) instead), or if the
+    /// table enables `allowColumnDefaults` and [`ack_column_defaults`](Self::ack_column_defaults)
+    /// has not been called.
     ///
     /// [`write_dir`]: WriteContext::write_dir
     /// [`logical_to_physical`]: WriteContext::logical_to_physical
@@ -1109,6 +1143,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
         partition_values: HashMap<String, Scalar>,
     ) -> DeltaResult<WriteContext> {
         self.ensure_schema_non_empty_for_write_context()?;
+        self.ensure_column_defaults_acknowledged()?;
         self.validate_for_data_write()?;
         let shared = self.shared_write_state()?;
         require!(
@@ -1156,9 +1191,12 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Creates a write context for writing data to an unpartitioned table.
     ///
     /// Returns an error if the table has partition columns (use
-    /// [`partitioned_write_context`](Self::partitioned_write_context) instead).
+    /// [`partitioned_write_context`](Self::partitioned_write_context) instead), or if the table
+    /// enables `allowColumnDefaults` and [`ack_column_defaults`](Self::ack_column_defaults) has not
+    /// been called.
     pub fn unpartitioned_write_context(&self) -> DeltaResult<WriteContext> {
         self.ensure_schema_non_empty_for_write_context()?;
+        self.ensure_column_defaults_acknowledged()?;
         self.validate_for_data_write()?;
         let shared = self.shared_write_state()?;
         require!(
@@ -2242,6 +2280,45 @@ mod tests {
         }
 
         #[test]
+        fn write_context_requires_explicit_column_defaults_acknowledgement() {
+            let schema =
+                StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
+                    .unwrap();
+            let mut txn = txn_with_schema(schema);
+
+            let defaults = txn.top_level_column_defaults().unwrap();
+            assert_eq!(
+                defaults["c"].to_scalar().unwrap(),
+                Some(Scalar::Integer(42))
+            );
+            drop(defaults);
+
+            let error = txn
+                .unpartitioned_write_context()
+                .expect_err("inspecting defaults must not implicitly acknowledge them");
+            assert!(matches!(&error, Error::InvalidTransactionState(_)));
+            assert!(error.to_string().contains("ack_column_defaults"));
+
+            txn.ack_column_defaults();
+            txn.unpartitioned_write_context()
+                .expect("acknowledging defaults must allow write-context creation");
+        }
+
+        #[test]
+        fn commit_rejects_added_files_without_column_defaults_acknowledgement() {
+            let schema =
+                StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+            let mut txn = txn_with_schema(schema);
+            add_dummy_file(&mut txn);
+
+            let error = txn
+                .commit(&SyncEngine::new())
+                .expect_err("added files must require explicit column-default acknowledgement");
+            assert!(matches!(&error, Error::InvalidTransactionState(_)));
+            assert!(error.to_string().contains("ack_column_defaults"));
+        }
+
+        #[test]
         fn load_rejects_malformed_default() {
             let schema = StructType::try_new(vec![field_with_invalid_default("c")]).unwrap();
 
@@ -2260,6 +2337,8 @@ mod tests {
             // Orphaned column-default metadata (no `allowColumnDefaults` feature) is tolerated.
             let txn = txn_with_schema_and_writer_features(schema, []);
             assert!(txn.top_level_column_defaults().unwrap().is_empty());
+            txn.unpartitioned_write_context()
+                .expect("orphaned defaults must not require acknowledgement");
         }
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -241,6 +241,7 @@ pub struct Transaction<S = ExistingTable> {
     user_domain_removals: Vec<String>,
     // Whether this transaction contains any logical data changes.
     data_change: bool,
+    // TODO(#2499): Replace this state when Engine responsibilities encode column-default handling.
     // Whether the connector acknowledged responsibility for applying column defaults.
     column_defaults_acknowledged: bool,
     // Whether this transaction should be marked as a blind append.
@@ -807,16 +808,17 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
-    /// Rejects write-context creation when the connector has not acknowledged column-default
-    /// handling.
+    /// Rejects write-context creation when a table declares column defaults and the connector has
+    /// not acknowledged handling them.
     fn ensure_column_defaults_acknowledged(&self) -> DeltaResult<()> {
         require!(
             self.column_defaults_acknowledged
                 || !self
                     .effective_table_config
-                    .is_feature_enabled(&TableFeature::AllowColumnDefaults),
+                    .is_feature_enabled(&TableFeature::AllowColumnDefaults)
+                || !self.effective_table_config.has_column_with_default(),
             Error::invalid_transaction_state(
-                "Writing data to a table with allowColumnDefaults requires calling \
+                "Writing data to a table with column defaults requires calling \
                  Transaction::ack_column_defaults() first",
             )
         );
@@ -919,9 +921,10 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Acknowledges that the connector applies column defaults before writing data files.
     ///
     /// Call this before requesting a write context for a table that enables the
-    /// `allowColumnDefaults` feature. The connector must materialize every omitted column's
-    /// default itself; this method records that responsibility but does not apply any defaults.
-    /// Without this acknowledgement, write-context creation fails with an error.
+    /// `allowColumnDefaults` feature and declares at least one column default. The connector must
+    /// materialize every omitted column's default itself; this method records that responsibility
+    /// but does not apply any defaults. Without this acknowledgement, write-context creation fails
+    /// with an error.
     pub fn ack_column_defaults(&mut self) {
         self.column_defaults_acknowledged = true;
     }
@@ -1024,6 +1027,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
         self.effective_table_config.logical_partition_columns()
     }
 
+    // TODO(#2630): Expose nested column defaults through the transaction API.
     /// Returns the column default for every top-level column in this table's logical schema that
     /// declares one, keyed by logical column name.
     ///
@@ -1132,8 +1136,8 @@ impl<S: SupportsDataFiles> Transaction<S> {
     ///
     /// Returns an error if the table is not partitioned (use
     /// [`unpartitioned_write_context`](Self::unpartitioned_write_context) instead), or if the
-    /// table enables `allowColumnDefaults` and [`ack_column_defaults`](Self::ack_column_defaults)
-    /// has not been called.
+    /// table enables `allowColumnDefaults`, declares at least one column default, and
+    /// [`ack_column_defaults`](Self::ack_column_defaults) has not been called.
     ///
     /// [`write_dir`]: WriteContext::write_dir
     /// [`logical_to_physical`]: WriteContext::logical_to_physical
@@ -1191,8 +1195,8 @@ impl<S: SupportsDataFiles> Transaction<S> {
     ///
     /// Returns an error if the table has partition columns (use
     /// [`partitioned_write_context`](Self::partitioned_write_context) instead), or if the table
-    /// enables `allowColumnDefaults` and [`ack_column_defaults`](Self::ack_column_defaults) has not
-    /// been called.
+    /// enables `allowColumnDefaults`, declares at least one column default, and
+    /// [`ack_column_defaults`](Self::ack_column_defaults) has not been called.
     pub fn unpartitioned_write_context(&self) -> DeltaResult<WriteContext> {
         self.ensure_schema_non_empty_for_write_context()?;
         self.ensure_column_defaults_acknowledged()?;

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -384,7 +384,6 @@ impl<S> Transaction<S> {
         // Validate that the schema supports data writes when files are being added. Reads and
         // metadata-only commits are always allowed.
         if !self.add_files_metadata.is_empty() {
-            self.ensure_column_defaults_acknowledged()?;
             validate_schema_for_write(&self.effective_table_config.logical_schema())?;
         }
 
@@ -808,7 +807,8 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
-    /// Rejects data writes when the connector has not acknowledged column-default handling.
+    /// Rejects write-context creation when the connector has not acknowledged column-default
+    /// handling.
     fn ensure_column_defaults_acknowledged(&self) -> DeltaResult<()> {
         require!(
             self.column_defaults_acknowledged
@@ -921,8 +921,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Call this before requesting a write context for a table that enables the
     /// `allowColumnDefaults` feature. The connector must materialize every omitted column's
     /// default itself; this method records that responsibility but does not apply any defaults.
-    /// Without this acknowledgement, write-context creation and commits containing added files
-    /// fail with an error.
+    /// Without this acknowledgement, write-context creation fails with an error.
     pub fn ack_column_defaults(&mut self) {
         self.column_defaults_acknowledged = true;
     }
@@ -2280,45 +2279,6 @@ mod tests {
         }
 
         #[test]
-        fn write_context_requires_explicit_column_defaults_acknowledgement() {
-            let schema =
-                StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
-                    .unwrap();
-            let mut txn = txn_with_schema(schema);
-
-            let defaults = txn.top_level_column_defaults().unwrap();
-            assert_eq!(
-                defaults["c"].to_scalar().unwrap(),
-                Some(Scalar::Integer(42))
-            );
-            drop(defaults);
-
-            let error = txn
-                .unpartitioned_write_context()
-                .expect_err("inspecting defaults must not implicitly acknowledge them");
-            assert!(matches!(&error, Error::InvalidTransactionState(_)));
-            assert!(error.to_string().contains("ack_column_defaults"));
-
-            txn.ack_column_defaults();
-            txn.unpartitioned_write_context()
-                .expect("acknowledging defaults must allow write-context creation");
-        }
-
-        #[test]
-        fn commit_rejects_added_files_without_column_defaults_acknowledgement() {
-            let schema =
-                StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
-            let mut txn = txn_with_schema(schema);
-            add_dummy_file(&mut txn);
-
-            let error = txn
-                .commit(&SyncEngine::new())
-                .expect_err("added files must require explicit column-default acknowledgement");
-            assert!(matches!(&error, Error::InvalidTransactionState(_)));
-            assert!(error.to_string().contains("ack_column_defaults"));
-        }
-
-        #[test]
         fn load_rejects_malformed_default() {
             let schema = StructType::try_new(vec![field_with_invalid_default("c")]).unwrap();
 
@@ -2337,8 +2297,6 @@ mod tests {
             // Orphaned column-default metadata (no `allowColumnDefaults` feature) is tolerated.
             let txn = txn_with_schema_and_writer_features(schema, []);
             assert!(txn.top_level_column_defaults().unwrap().is_empty());
-            txn.unpartitioned_write_context()
-                .expect("orphaned defaults must not require acknowledgement");
         }
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -103,6 +103,7 @@ impl Transaction {
             system_domain_metadata_additions: vec![],
             user_domain_removals: vec![],
             data_change: true,
+            column_defaults_acknowledged: false,
             engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -255,6 +255,62 @@ async fn test_blind_append_to_column_defaults_table_is_supported(
     Ok(())
 }
 
+#[rstest]
+#[case::unpartitioned("unpartitioned", &[])]
+#[case::partitioned("partitioned", &["p"])]
+#[tokio::test]
+async fn write_context_requires_explicit_column_defaults_acknowledgement(
+    #[case] label: &str,
+    #[case] partition_columns: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let base = StructType::try_new(vec![
+        StructField::nullable("c", DataType::INTEGER),
+        StructField::nullable("p", DataType::INTEGER),
+    ])?;
+    let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
+    let table_name = format!("write_context_ack_{label}");
+    let (store, engine, table_location) = engine_store_setup(&table_name, None);
+    let table_url = create_table(
+        store,
+        table_location,
+        schema,
+        partition_columns,
+        true,
+        vec![],
+        vec!["allowColumnDefaults"],
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    let mut txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+
+    let defaults = txn.top_level_column_defaults()?;
+    assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
+    drop(defaults);
+
+    let partition_values = HashMap::from([("p".to_string(), Scalar::Integer(7))]);
+    let error = if partition_columns.is_empty() {
+        txn.unpartitioned_write_context()
+    } else {
+        txn.partitioned_write_context(partition_values.clone())
+    }
+    .expect_err("inspecting defaults must not implicitly acknowledge them");
+    assert!(matches!(
+        &error,
+        delta_kernel::Error::InvalidTransactionState(_)
+    ));
+    assert!(error.to_string().contains("ack_column_defaults"));
+
+    txn.ack_column_defaults();
+    if partition_columns.is_empty() {
+        txn.unpartitioned_write_context()?;
+    } else {
+        txn.partitioned_write_context(partition_values)?;
+    }
+
+    Ok(())
+}
+
 /// Creates a single-column table, materializes its default through the connector-facing API,
 /// and asserts the metadata and written value round-trip.
 async fn assert_materialized_column_default_round_trips(

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -259,16 +259,21 @@ async fn test_blind_append_to_column_defaults_table_is_supported(
 #[case::unpartitioned("unpartitioned", &[])]
 #[case::partitioned("partitioned", &["p"])]
 #[tokio::test]
-async fn write_context_requires_explicit_column_defaults_acknowledgement(
+async fn write_context_acknowledgement_depends_on_column_defaults(
     #[case] label: &str,
     #[case] partition_columns: &[&str],
+    #[values(false, true)] has_default: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let base = StructType::try_new(vec![
         StructField::nullable("c", DataType::INTEGER),
         StructField::nullable("p", DataType::INTEGER),
     ])?;
-    let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
-    let table_name = format!("write_context_ack_{label}");
+    let schema = if has_default {
+        schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?
+    } else {
+        Arc::new(base)
+    };
+    let table_name = format!("write_context_ack_{label}_{has_default}");
     let (store, engine, table_location) = engine_store_setup(&table_name, None);
     let table_url = create_table(
         store,
@@ -285,23 +290,29 @@ async fn write_context_requires_explicit_column_defaults_acknowledgement(
     let mut txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
 
     let defaults = txn.top_level_column_defaults()?;
-    assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
+    if has_default {
+        assert_eq!(defaults["c"].to_scalar()?, Some(Scalar::Integer(42)));
+    } else {
+        assert!(defaults.is_empty());
+    }
     drop(defaults);
 
     let partition_values = HashMap::from([("p".to_string(), Scalar::Integer(7))]);
-    let error = if partition_columns.is_empty() {
-        txn.unpartitioned_write_context()
-    } else {
-        txn.partitioned_write_context(partition_values.clone())
-    }
-    .expect_err("inspecting defaults must not implicitly acknowledge them");
-    assert!(matches!(
-        &error,
-        delta_kernel::Error::InvalidTransactionState(_)
-    ));
-    assert!(error.to_string().contains("ack_column_defaults"));
+    if has_default {
+        let error = if partition_columns.is_empty() {
+            txn.unpartitioned_write_context()
+        } else {
+            txn.partitioned_write_context(partition_values.clone())
+        }
+        .expect_err("inspecting defaults must not implicitly acknowledge them");
+        assert!(matches!(
+            &error,
+            delta_kernel::Error::InvalidTransactionState(_)
+        ));
+        assert!(error.to_string().contains("ack_column_defaults"));
 
-    txn.ack_column_defaults();
+        txn.ack_column_defaults();
+    }
     if partition_columns.is_empty() {
         txn.unpartitioned_write_context()?;
     } else {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1029,6 +1029,7 @@ pub async fn insert_data_with<E: TaskExecutor>(
         .transaction(committer, engine.as_ref())?
         .with_operation(operation.to_string())
         .with_data_change(data_change);
+    txn.ack_column_defaults();
     if is_blind_append {
         txn = txn.with_blind_append();
     }
@@ -1449,6 +1450,7 @@ pub async fn write_batch_to_table(
         .transaction(Box::new(FileSystemCommitter::new()), engine)?
         .with_engine_info("DefaultEngine")
         .with_data_change(true);
+    txn.ack_column_defaults();
     let write_context = if txn.logical_partition_columns().is_empty() {
         assert!(
             partition_values.is_empty(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a method for acknowledging column defaults on Transactions and checks on WriteContext creation. This is a temporary fix until engine responsibilities is implemented in kernel.

## How was this change tested?

Added new tests and updated old tests

## Resources

Tracking Issue - #2630