### PR TITLE
ci: split no-declarative-plans tests into a parallel job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,14 @@ jobs:
         run: cargo build --locked -p feature_tests --features default-engine-rustls
       - name: test rustls TLS backend feature-tests
         run: cargo test --locked -p feature_tests --features default-engine-rustls
+  # Runs the test suite under two feature configurations, one per matrix leg, so they build and
+  # run in parallel: `all-features` is the full workspace suite; `no-declarative-plans` runs
+  # kernel + acceptance with every kernel feature except declarative-plans, to exercise the
+  # cfg(not(feature = "declarative-plans")) paths and the feature-off build. The job `name`
+  # keeps the all-features leg reporting as `test (<os>)` so it stays the same required status
+  # check, and the cache `key` keeps each configuration's target dir in its own cache entry.
   test:
+    name: test (${{ matrix.os }}${{ matrix.config == 'no-declarative-plans' && ', no-decl' || '' }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -207,6 +214,9 @@ jobs:
           - macOS-latest
           - ubuntu-latest
           - windows-latest
+        config:
+          - all-features
+          - no-declarative-plans
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -223,49 +233,29 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-bin: false
+          key: ${{ matrix.config }}
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
-      - name: test
-        run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
-      - name: doc tests
-        run: cargo test --locked --workspace --all-features --doc
-      - name: trybuild tests
-        if: steps.filter.outputs.ffi == 'true'
-        run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
-      - name: metrics deadlock test
+      - name: all-features tests
+        if: matrix.config == 'all-features'
         shell: bash
+        env:
+          FFI_CHANGED: ${{ steps.filter.outputs.ffi }}
         run: |
+          cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+          cargo test --locked --workspace --all-features --doc
+          if [ "$FFI_CHANGED" = "true" ]; then
+            cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
+          fi
           output=$(cargo run --profile test --example metrics-tester)
           grep -q 'invalid_field' <<< "$output"
           grep -q 'Invalid uuid' <<< "$output"
-
-  # Runs kernel + acceptance without declarative-plans so the
-  # cfg(not(feature = "declarative-plans")) paths and the feature-off build are exercised on every
-  # OS. A separate job from `test` so the two feature configurations build and run in parallel.
-  # Enumerates every kernel feature except declarative-plans.
-  test-no-decl:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - macOS-latest
-          - ubuntu-latest
-          - windows-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - name: Install minimal stable
-        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
-        with:
-          cache: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          cache-bin: false
-          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
-      - name: test (no declarative-plans)
-        run: cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
-      - name: doc tests (no declarative-plans)
-        run: cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base --doc
+      - name: no-declarative-plans tests
+        if: matrix.config == 'no-declarative-plans'
+        shell: bash
+        run: |
+          cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+          cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base --doc
 
   # Fails red on trybuild drift, but kept out of required checks so it never blocks a merge.
   invalid-handle-code:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,13 +229,6 @@ jobs:
         run: cargo nextest run --locked --workspace --all-features -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
       - name: doc tests
         run: cargo test --locked --workspace --all-features --doc
-      # Also run kernel + acceptance WITHOUT declarative-plans so the
-      # cfg(not(feature = "declarative-plans")) paths get exercised. Enumerates every kernel
-      # feature except declarative-plans.
-      - name: test (no declarative-plans)
-        run: cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
-      - name: doc tests (no declarative-plans)
-        run: cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base --doc
       - name: trybuild tests
         if: steps.filter.outputs.ffi == 'true'
         run: cargo test --locked --package delta_kernel_ffi --features internal-api -- invalid_handle_code
@@ -245,6 +238,34 @@ jobs:
           output=$(cargo run --profile test --example metrics-tester)
           grep -q 'invalid_field' <<< "$output"
           grep -q 'Invalid uuid' <<< "$output"
+
+  # Runs kernel + acceptance without declarative-plans so the
+  # cfg(not(feature = "declarative-plans")) paths and the feature-off build are exercised on every
+  # OS. A separate job from `test` so the two feature configurations build and run in parallel.
+  # Enumerates every kernel feature except declarative-plans.
+  test-no-decl:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macOS-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Install minimal stable
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          cache: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-bin: false
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@98ec31d284eb962f41c14065e9391a955aa810cf # nextest
+      - name: test (no declarative-plans)
+        run: cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+      - name: doc tests (no declarative-plans)
+        run: cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base --doc
 
   # Fails red on trybuild drift, but kept out of required checks so it never blocks a merge.
   invalid-handle-code:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Speeds up the `test` CI job. It ran two feature configurations one after the other on a single runner: the full `--all-features` suite, then a `no-declarative-plans` run of kernel + acceptance.

This PR runs them as two matrix legs (`all-features`, `no-declarative-plans`) in parallel, so each OS's wall-clock is the slower leg instead of the sum of both. Coverage does not change: every OS still runs both configurations. The job `name` keeps the all-features leg reporting as `test (<os>)`, so it stays the same required check; the no-declarative-plans leg reports as `test (<os>, no-decl)`, and each configuration keeps its own cache entry.

### Performance

`test` job wall-clock, before (main) vs after (warm cache):

| Job | Before | After |
|-----|--------|-------|
| test (windows-latest) | 15.2m | 8.6m |
| test (macOS-latest) | 12.1m | 8.3m |
| test (ubuntu-latest) | 9.3m | 5.5m |

Once the Miri fix (#3035) lands, `test (windows-latest)` is the CI critical path, and this takes it from about 15m to about 9m.

The "after" numbers are the warm-cache steady state. Splitting the cache by configuration adds two new cache keys that `main` has not written yet, so this PR's own CI runs cold on both legs and looks slower than the table. That corrects itself on the first push to `main` after merge: the post-merge run writes both keys, and every PR after that restores them warm.

## Follow-up for maintainers

The new `test (<os>, no-decl)` jobs are not required status checks yet. Add them to `main` branch protection after this merges. The existing `test (<os>)` checks keep their names and keep reporting, so no open PR gets stuck waiting.

## How was this change tested?

Workflow-only change, validated by CI on this PR: both configurations run and pass on all three OSes.