### PR TITLE
refactor: Move plan construction to `Scan`

### DIFF
--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1207,6 +1207,12 @@ impl From<Predicate> for Expression {
     }
 }
 
+impl From<Predicate> for Option<PredicateRef> {
+    fn from(value: Predicate) -> Self {
+        Some(Arc::new(value))
+    }
+}
+
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1207,12 +1207,6 @@ impl From<Predicate> for Expression {
     }
 }
 
-impl From<Predicate> for Option<PredicateRef> {
-    fn from(value: Predicate) -> Self {
-        Some(Arc::new(value))
-    }
-}
-
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,6 +1187,12 @@ impl From<Predicate> for Expression {
     }
 }
 
+impl From<Predicate> for Option<PredicateRef> {
+    fn from(value: Predicate) -> Self {
+        Some(Arc::new(value))
+    }
+}
+
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,12 +1187,6 @@ impl From<Predicate> for Expression {
     }
 }
 
-impl From<Predicate> for Option<PredicateRef> {
-    fn from(value: Predicate) -> Self {
-        Some(Arc::new(value))
-    }
-}
-
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,7 +1084,6 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
-        let log_segment = self.snapshot.log_segment();
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
         let plan_executor = engine.require_plan_executor()?;
@@ -1093,14 +1092,7 @@ impl Scan {
             &self.snapshot,
             self.state_info.physical_stats_schema.as_ref(),
         )?;
-        scan_plan::build_metadata_scan_plan(
-            &self.state_info,
-            log_segment,
-            &shape,
-            &self.stats,
-            &self.partition_values,
-            self.physical_stats_output_schema.as_ref(),
-        )
+        self.build_metadata_scan_plan(&shape)
     }
 
     // Factored out to facilitate testing

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -1,7 +1,7 @@
 //! Declarative metadata scan plans.
 //!
-//! [`build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds, applying
-//! metadata pruning before newest-action-wins replay.
+//! [`Scan::build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds,
+//! applying metadata pruning before newest-action-wins replay.
 
 use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::data_skipping::as_sql_data_skipping_predicate_with_stats_columns;
 use super::state_info::StateInfo;
-use super::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
+use super::{PhysicalPredicate, Scan};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{
     ADD_FIELD, ADD_NAME, ADD_SCHEMA, REMOVE_FIELD, SIDECAR_FIELD, SIDECAR_NAME, STATS_PARSED,
@@ -19,7 +19,6 @@ use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
 };
-use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::{FileType, Load, LoadColumnFileMeta, ScanFile};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
@@ -45,41 +44,30 @@ const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
 const IS_ADD: &str = "is_add";
 const VERSION: &str = "version";
 
-/// Build the live-add metadata plan from checkpoint and commit actions.
-///
-/// Returns `None` for an empty result or a statically false predicate.
-pub(crate) fn build_metadata_scan_plan(
-    state: &StateInfo,
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<Option<Plan>> {
-    // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
-    if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
-        return Ok(None);
-    }
+impl Scan {
+    /// Build the live-add metadata plan from checkpoint and commit actions.
+    ///
+    /// Returns `None` for an empty result or a statically false predicate.
+    pub(super) fn build_metadata_scan_plan(
+        &self,
+        shape: &CheckpointShape,
+    ) -> DeltaResult<Option<Plan>> {
+        let state = &self.state_info;
+        // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
+        if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
 
-    let stats_schema = state.physical_stats_schema.as_ref();
-    let partition_schema = state.physical_partition_schema.as_ref();
-    let prune = stats_skipping_predicate(state);
-    let prune = prune.as_ref();
+        let prune = stats_skipping_predicate(state);
+        let prune = prune.as_ref();
 
-    // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's dedup
-    // carrier and both terminal `{ add }` projections, so every arm agrees on the union schema.
-    let add_field = add_field_with_parsed_stats_and_partitions(stats_schema, partition_schema)?;
-    let (output_expr, output_schema) = metadata_output_projection(
-        &add_field,
-        stats,
-        partition_values,
-        partition_schema,
-        physical_stats_output_schema,
-    )?;
+        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
+        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
+        // union schema.
+        let add_field = self.normalized_add_field()?;
+        let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
-    let commit_actions = commit_arm(log_segment, stats_schema, partition_schema)?.try_fold_with(
-        prune,
-        |p, prune| {
+        let commit_actions = self.commit_arm()?.try_fold_with(prune, |p, prune| {
             // We filter so that:
             // * All remove actions are kept
             // * Add actions that do not match the partition pruning or stats predicate are removed.
@@ -95,155 +83,155 @@ pub(crate) fn build_metadata_scan_plan(
             // `remove.partitionValues` being NULL, or it may be from `partCol` being
             // NULL. Thus, we simply do not prune removes.
             p.filter(Predicate::or(col!("add").is_null(), prune.clone()))
-        },
-    )?;
+        })?;
 
-    let deduped_commit = commit_actions
-        // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
-        // after aggregation.
-        .project_patch(|patch| {
-            patch.replace(
-                ADD_NAME,
-                StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
-                Expr::struct_from([col!("add")]),
-            )
-        })?
-        .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
-            a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
-        })?
-        // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
-        .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
+        let deduped_commit = commit_actions
+            // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
+            // after aggregation.
+            .project_patch(|patch| {
+                patch.replace(
+                    ADD_NAME,
+                    StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
+                    Expr::struct_from([col!("add")]),
+                )
+            })?
+            .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
+                a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
+            })?
+            // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
+            .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
 
-    let checkpoint_adds = checkpoint_arm(log_segment, shape, stats_schema, partition_schema)?
-        .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
+        let checkpoint_adds = self
+            .checkpoint_arm(shape)?
+            .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
 
-    let checkpoint_live_adds = checkpoint_adds
-        .anti_join(
-            deduped_commit.clone(),
-            [ColumnName::new([FILE_ACTION_KEY])],
-            [ColumnName::new([FILE_ACTION_KEY])],
-        )?
-        .project(output_expr.clone(), output_schema.clone())?;
+        let checkpoint_live_adds = checkpoint_adds
+            .anti_join(
+                deduped_commit.clone(),
+                [ColumnName::new([FILE_ACTION_KEY])],
+                [ColumnName::new([FILE_ACTION_KEY])],
+            )?
+            .project(output_expr.clone(), output_schema.clone())?;
 
-    let commit_live_adds = deduped_commit
-        .filter(col!("add").is_not_null())?
-        .project(output_expr, output_schema)?;
+        let commit_live_adds = deduped_commit
+            .filter(col!("add").is_not_null())?
+            .project(output_expr, output_schema)?;
 
-    PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
-}
+        PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
+    }
 
-/// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
-///
-/// ## SQL equivalent:
-//
-/// SELECT STRUCT(
-///          add.* EXCEPT (
-///            stats_parsed, partitionValues_parsed
-///          ),
-///          add.stats_parsed AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
-/// FROM checkpoint_actions
-/// WHERE add.path IS NOT NULL
-///
-/// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
-/// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
-fn checkpoint_arm(
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let source_stats_schema = shape.parsed_stats_schema.as_ref();
-    let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
+    /// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
+    ///
+    /// ## SQL equivalent:
+    //
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (
+    ///            stats_parsed, partitionValues_parsed
+    ///          ),
+    ///          add.stats_parsed AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
+    /// FROM checkpoint_actions
+    /// WHERE add.path IS NOT NULL
+    ///
+    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
+    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
-    let actions = match (&shape.checkpoint_type, checkpoint) {
-        (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            PlanBuilder::scan_parquet(parts, &[VERSION], schema)
-        }
-        (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
-            PlanBuilder::scan_json(
-                parts,
-                &[VERSION],
-                json_read_schema(/* include_remove */ false),
-            )
-        }
-        (CheckpointType::Manifest, Some((file_type, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
-                // Without a complete hint, load the sidecars referenced by the manifest.
-                None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+        let actions = match (&shape.checkpoint_type, checkpoint) {
+            (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
-        }
-        (CheckpointType::None, _) | (_, None) => {
-            PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
-        }
-    }?;
+            (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
+                PlanBuilder::scan_json(
+                    parts,
+                    &[VERSION],
+                    json_read_schema(/* include_remove */ false),
+                )
+            }
+            (CheckpointType::Manifest, Some((file_type, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
+                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    // Without a complete hint, load the sidecars referenced by the manifest.
+                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                }
+            }
+            (CheckpointType::None, _) | (_, None) => {
+                PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
+            }
+        }?;
 
-    actions
-        .filter(col!("add.path").is_not_null())?
-        .project_patch(|patch| {
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| joined_column_expr!("add", col)),
-                )
-        })
-}
+        actions
+            .filter(col!("add.path").is_not_null())?
+            .project_patch(|patch| {
+                patch
+                    .with_parsed_add_stats(stats_schema)
+                    .with_parsed_add_partition_values(partition_schema)
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| joined_column_expr!("add", col)),
+                    )
+            })
+    }
 
-/// Build the normalized commit JSON arm.
-///
-/// ## SQL equivalent:
-///
-/// SELECT STRUCT(
-///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
-///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        remove, version, add.path IS NOT NULL AS is_add,
-///        file_key(COALESCE(add, remove)) AS key
-/// FROM json_commits
-/// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
-///
-/// A parsed field is omitted when its schema is absent.
-fn commit_arm(
-    log_segment: &LogSegment,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
-    PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
-        .filter(Predicate::or(
-            col!("add.path").is_not_null(),
-            col!("remove.path").is_not_null(),
-        ))?
-        .project_patch(|patch| {
-            // Commits never carry source-native parsed columns, so normalize from the raw
-            // encodings.
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| {
-                        Expr::coalesce([
-                            joined_column_expr!("add", col),
-                            joined_column_expr!("remove", col),
-                        ])
-                    }),
-                )
-        })
+    /// Build the normalized commit JSON arm.
+    ///
+    /// ## SQL equivalent:
+    ///
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
+    ///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        remove, version, add.path IS NOT NULL AS is_add,
+    ///        file_key(COALESCE(add, remove)) AS key
+    /// FROM json_commits
+    /// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
+    ///
+    /// A parsed field is omitted when its schema is absent.
+    fn commit_arm(&self) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
+        PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
+            .filter(Predicate::or(
+                col!("add.path").is_not_null(),
+                col!("remove.path").is_not_null(),
+            ))?
+            .project_patch(|patch| {
+                // Commits never carry source-native parsed columns, so normalize from the raw
+                // encodings.
+                patch
+                    .with_parsed_add_stats(self.state_info.physical_stats_schema.as_ref())
+                    .with_parsed_add_partition_values(
+                        self.state_info.physical_partition_schema.as_ref(),
+                    )
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| {
+                            Expr::coalesce([
+                                joined_column_expr!("add", col),
+                                joined_column_expr!("remove", col),
+                            ])
+                        }),
+                    )
+            })
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -368,31 +356,23 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 }
 
 trait ProjectionStructPatchBuilderExt<'a> {
-    /// Parses add stats and partition values, preferring compatible parsed fields.
+    /// Parses add stats, preferring a compatible parsed field.
     ///
     /// When `stats_schema` is present, the input must contain either `add.stats_parsed` or the
     /// fallback `add.stats` JSON field.
-    fn with_parsed_add_stats_and_partitions(
-        self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self;
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self;
+
+    /// Parses add partition values, preferring a compatible parsed field.
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
-    fn with_parsed_add_stats_and_partitions(
-        mut self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self {
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self {
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let has_partition_values_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
         let add = [ADD_NAME];
-        self = match stats_schema {
+        match stats_schema {
             Some(ss) => {
                 let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
                 let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
@@ -403,7 +383,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 }
             }
             None => self,
-        };
+        }
+    }
+
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self {
+        let has_partition_values_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let add = [ADD_NAME];
         match partition_schema {
             Some(ps) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
@@ -420,113 +407,111 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
     }
 }
 
-/// The `add` field produced by [`with_parsed_add_stats_and_partitions`].
-fn add_field_with_parsed_stats_and_partitions(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<StructField> {
-    let patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, schema| {
-            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-        })
-        .fold_with(partition_schema, |patch, schema| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                schema.as_ref().clone(),
-            ))
-        });
-    Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-}
+impl Scan {
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
 
-/// Builds the output projection for requested stats and partition values. The base of this
-/// transformation is constructed by [`add_field_with_parsed_stats_and_partitions`].
-///
-/// The output schema is:
-/// ```text
-/// add: struct<
-///   path: string,
-///   partitionValues: map<string, string>,
-///   size: long,
-///   modificationTime: long,
-///   dataChange: boolean,
-///   stats: string,                         // when JSON stats are requested
-///   tags: map<string, string>,
-///   deletionVector: struct<...>,
-///   baseRowId: long,
-///   defaultRowCommitVersion: long,
-///   clusteringProvider: string,
-///   stats_parsed: struct<...>,             // when parsed stats are requested
-///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-/// >
-/// ```
-/// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-/// partition values are selected independently and omitted for unpartitioned tables. Fields needed
-/// only for pruning are omitted.
-fn metadata_output_projection(
-    add_field: &StructField,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    partition_schema: Option<&SchemaRef>,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-    let input_schema = schema_ref! { (add_field.clone()) };
-    let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-    let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
 
-    // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-    let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-    let projection = match (stats.synthesize_json, has_json_stats) {
-        (true, true) | (false, false) => projection,
-        (true, false) => {
-            return Err(Error::internal_error(
-                "JSON stats were requested, but add.stats is missing from the metadata schema",
-            ));
-        }
-        (false, true) => projection.drop(STATS),
-    };
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
 
-    // Parsed stats output.
-    let projection = match (physical_stats_output_schema, has_stats_parsed) {
-        (Some(stats_schema), _) => projection.replace(
-            STATS_PARSED,
-            StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-            project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-        ),
-        (None, true) => projection.drop(STATS_PARSED),
-        (None, false) => projection,
-    };
-
-    // Parsed partition-values output.
-    let has_partition_values_parsed =
-        input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-    let partition_output_schema = partition_values
-        .parsed_struct
-        .then_some(partition_schema)
-        .flatten();
-    let projection = match (partition_output_schema, has_partition_values_parsed) {
-        (Some(partition_schema), true) => projection.replace(
-            PARTITION_VALUES_PARSED,
-            StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-            project_nested_struct_to_schema(
-                [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                partition_schema,
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
             ),
-        ),
-        (Some(_), false) => {
-            return Err(Error::internal_error(
-                "parsed partition values were requested, but add.partitionValues_parsed is \
-                 missing",
-            ));
-        }
-        (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-        (None, false) => projection,
-    };
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
 
-    let (add_schema, add_expr) = projection.build()?;
-    let schema = schema_ref! {
-        (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-    };
-    Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Rebuilds `root` to match a narrowed schema while preserving a null parent struct. A direct
@@ -601,47 +586,41 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::actions::{Metadata, Protocol};
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::lit;
+    use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::plans::ir::nodes::Operator;
     use crate::plans::Operation as PlanOperation;
-    use crate::scan::state_info::tests::get_state_info_with_options;
     use crate::scan::{PartitionValuesOptions, StatsOptions};
     use crate::schema::StructType;
+    use crate::snapshot::Snapshot;
+    use crate::table_configuration::TableConfiguration;
     use crate::unit_test_utils::create_log_path;
     use crate::Engine as _;
 
-    fn state(
-        schema: SchemaRef,
-        partition_columns: Vec<String>,
-        predicate: Option<Predicate>,
-        stats: StatsOptions,
-        partition_values: PartitionValuesOptions,
-    ) -> StateInfo {
-        get_state_info_with_options(
-            schema,
-            partition_columns,
-            predicate.map(Arc::new),
-            &[],
+    fn mock_snapshot(log_segment: LogSegment) -> DeltaResult<Arc<Snapshot>> {
+        let metadata = Metadata::try_new(
+            None,
+            None,
+            partitioned_schema(),
+            vec!["p".to_string()],
+            0,
             HashMap::new(),
-            vec![],
-            stats,
-            partition_values,
-        )
-        .expect("state info")
-    }
-
-    fn data_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "x",
-            DataType::LONG,
-        )]))
+        )?;
+        let table_configuration = TableConfiguration::try_new(
+            metadata,
+            Protocol::try_new_legacy(2, 5)?,
+            Url::parse("memory:///")?,
+            0,
+        )?;
+        Ok(Arc::new(Snapshot::new(log_segment, table_configuration)?))
     }
 
     fn partitioned_schema() -> SchemaRef {
@@ -800,15 +779,18 @@ mod tests {
     }
 
     fn struct_stats_schema() -> SchemaRef {
-        state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(5i64))),
-            StatsOptions::all(),
-            PartitionValuesOptions::default(),
-        )
-        .physical_stats_schema
-        .expect("stats schema")
+        let segment = log_segment(log_root(), &[], None);
+        mock_snapshot(segment)
+            .unwrap()
+            .scan_builder()
+            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_stats(StatsOptions::all())
+            .build()
+            .unwrap()
+            .state_info
+            .physical_stats_schema
+            .clone()
+            .expect("stats schema")
     }
 
     // Commit-arm operator sequence without optional pruning.
@@ -835,29 +817,13 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             Some(checkpoint_path(file_type)),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
 
         let mut expected: Vec<&str> = COMMIT_ARM_TAGS.to_vec();
         expected.extend(checkpoint_arm_tags);
@@ -875,23 +841,15 @@ mod tests {
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
         let partition_values = PartitionValuesOptions::with_struct();
-        let state = state(
-            partitioned_schema(),
-            vec!["p".to_string()],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Manifest, parsed_stats),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(stats)
+            .with_partition_values(partition_values)
+            .build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .expect("non-empty");
 
         let load = plan
             .nodes
@@ -916,29 +874,15 @@ mod tests {
 
     #[test]
     fn metadata_plan_commits_only() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
         assert_eq!(tags(&plan), COMMIT_ARM_TAGS.to_vec());
         Ok(())
     }
@@ -953,75 +897,35 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(file_type)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
         assert_eq!(tags(&plan), checkpoint_arm_tags);
         Ok(())
     }
 
     #[test]
     fn metadata_plan_empty_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        assert!(scan.build_metadata_scan_plan(&no_checkpoint())?.is_none());
         Ok(())
     }
 
     #[test]
     fn metadata_plan_static_skip_all_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(Predicate::literal(false)),
-            stats.clone(),
-            partition_values.clone(),
-        );
-        assert_eq!(state.physical_predicate, PhysicalPredicate::StaticSkipAll);
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_predicate(Predicate::literal(false))
+            .build()?;
+        assert_eq!(
+            scan.state_info.physical_predicate,
+            PhysicalPredicate::StaticSkipAll
+        );
+        assert!(scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .is_none());
         Ok(())
     }
 
@@ -1049,15 +953,6 @@ mod tests {
             DeltaResult::<()>::Ok(())
         })?;
 
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[
@@ -1066,15 +961,10 @@ mod tests {
             ],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
@@ -1117,30 +1007,20 @@ mod tests {
         // `stats_parsed` column.
         write_parquet_checkpoint(&store, "_delta_log/00000000000000000000.checkpoint.parquet")?;
 
-        let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(lower_bound))),
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[],
             Some("memory:///_delta_log/00000000000000000000.checkpoint.parquet"),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(StatsOptions::all())
+            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .build()?;
+        let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -1,7 +1,7 @@
 //! Declarative metadata scan plans.
 //!
-//! [`build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds, applying
-//! metadata pruning before newest-action-wins replay.
+//! [`Scan::build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds,
+//! applying metadata pruning before newest-action-wins replay.
 
 use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::data_skipping::as_sql_data_skipping_predicate_with_stats_columns;
 use super::state_info::StateInfo;
-use super::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
+use super::{PhysicalPredicate, Scan};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{
     ADD_FIELD, ADD_NAME, ADD_SCHEMA, REMOVE_FIELD, SIDECAR_FIELD, SIDECAR_NAME, STATS_PARSED,
@@ -19,7 +19,6 @@ use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
 };
-use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
@@ -45,41 +44,30 @@ const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
 const IS_ADD: &str = "is_add";
 const VERSION: &str = "version";
 
-/// Build the live-add metadata plan from checkpoint and commit actions.
-///
-/// Returns `None` for an empty result or a statically false predicate.
-pub(crate) fn build_metadata_scan_plan(
-    state: &StateInfo,
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<Option<Plan>> {
-    // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
-    if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
-        return Ok(None);
-    }
+impl Scan {
+    /// Build the live-add metadata plan from checkpoint and commit actions.
+    ///
+    /// Returns `None` for an empty result or a statically false predicate.
+    pub(super) fn build_metadata_scan_plan(
+        &self,
+        shape: &CheckpointShape,
+    ) -> DeltaResult<Option<Plan>> {
+        let state = &self.state_info;
+        // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
+        if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
 
-    let stats_schema = state.physical_stats_schema.as_ref();
-    let partition_schema = state.physical_partition_schema.as_ref();
-    let prune = stats_skipping_predicate(state);
-    let prune = prune.as_ref();
+        let prune = stats_skipping_predicate(state);
+        let prune = prune.as_ref();
 
-    // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's dedup
-    // carrier and both terminal `{ add }` projections, so every arm agrees on the union schema.
-    let add_field = add_field_with_parsed_stats_and_partitions(stats_schema, partition_schema)?;
-    let (output_expr, output_schema) = metadata_output_projection(
-        &add_field,
-        stats,
-        partition_values,
-        partition_schema,
-        physical_stats_output_schema,
-    )?;
+        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
+        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
+        // union schema.
+        let add_field = self.normalized_add_field()?;
+        let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
-    let commit_actions = commit_arm(log_segment, stats_schema, partition_schema)?.try_fold_with(
-        prune,
-        |p, prune| {
+        let commit_actions = self.commit_arm()?.try_fold_with(prune, |p, prune| {
             // We filter so that:
             // * All remove actions are kept
             // * Add actions that do not match the partition pruning or stats predicate are removed.
@@ -95,155 +83,155 @@ pub(crate) fn build_metadata_scan_plan(
             // `remove.partitionValues` being NULL, or it may be from `partCol` being
             // NULL. Thus, we simply do not prune removes.
             p.filter(Predicate::or(col!("add").is_null(), prune.clone()))
-        },
-    )?;
+        })?;
 
-    let deduped_commit = commit_actions
-        // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
-        // after aggregation.
-        .project_patch(|patch| {
-            patch.replace(
-                ADD_NAME,
-                StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
-                Expr::struct_from([col!("add")]),
-            )
-        })?
-        .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
-            a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
-        })?
-        // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
-        .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
+        let deduped_commit = commit_actions
+            // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
+            // after aggregation.
+            .project_patch(|patch| {
+                patch.replace(
+                    ADD_NAME,
+                    StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
+                    Expr::struct_from([col!("add")]),
+                )
+            })?
+            .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
+                a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
+            })?
+            // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
+            .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
 
-    let checkpoint_adds = checkpoint_arm(log_segment, shape, stats_schema, partition_schema)?
-        .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
+        let checkpoint_adds = self
+            .checkpoint_arm(shape)?
+            .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
 
-    let checkpoint_live_adds = checkpoint_adds
-        .anti_join(
-            deduped_commit.clone(),
-            [ColumnName::new([FILE_ACTION_KEY])],
-            [ColumnName::new([FILE_ACTION_KEY])],
-        )?
-        .project(output_expr.clone(), output_schema.clone())?;
+        let checkpoint_live_adds = checkpoint_adds
+            .anti_join(
+                deduped_commit.clone(),
+                [ColumnName::new([FILE_ACTION_KEY])],
+                [ColumnName::new([FILE_ACTION_KEY])],
+            )?
+            .project(output_expr.clone(), output_schema.clone())?;
 
-    let commit_live_adds = deduped_commit
-        .filter(col!("add").is_not_null())?
-        .project(output_expr, output_schema)?;
+        let commit_live_adds = deduped_commit
+            .filter(col!("add").is_not_null())?
+            .project(output_expr, output_schema)?;
 
-    PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
-}
+        PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
+    }
 
-/// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
-///
-/// ## SQL equivalent:
-//
-/// SELECT STRUCT(
-///          add.* EXCEPT (
-///            stats_parsed, partitionValues_parsed
-///          ),
-///          add.stats_parsed AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
-/// FROM checkpoint_actions
-/// WHERE add.path IS NOT NULL
-///
-/// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
-/// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
-fn checkpoint_arm(
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let source_stats_schema = shape.parsed_stats_schema.as_ref();
-    let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
+    /// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
+    ///
+    /// ## SQL equivalent:
+    //
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (
+    ///            stats_parsed, partitionValues_parsed
+    ///          ),
+    ///          add.stats_parsed AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
+    /// FROM checkpoint_actions
+    /// WHERE add.path IS NOT NULL
+    ///
+    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
+    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
-    let actions = match (&shape.checkpoint_type, checkpoint) {
-        (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            PlanBuilder::scan_parquet(parts, &[VERSION], schema)
-        }
-        (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
-            PlanBuilder::scan_json(
-                parts,
-                &[VERSION],
-                json_read_schema(/* include_remove */ false),
-            )
-        }
-        (CheckpointType::Manifest, Some((file_type, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
-                // Without a complete hint, load the sidecars referenced by the manifest.
-                None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+        let actions = match (&shape.checkpoint_type, checkpoint) {
+            (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
-        }
-        (CheckpointType::None, _) | (_, None) => {
-            PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
-        }
-    }?;
+            (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
+                PlanBuilder::scan_json(
+                    parts,
+                    &[VERSION],
+                    json_read_schema(/* include_remove */ false),
+                )
+            }
+            (CheckpointType::Manifest, Some((file_type, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
+                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    // Without a complete hint, load the sidecars referenced by the manifest.
+                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                }
+            }
+            (CheckpointType::None, _) | (_, None) => {
+                PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
+            }
+        }?;
 
-    actions
-        .filter(col!("add.path").is_not_null())?
-        .project_patch(|patch| {
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| joined_column_expr!("add", col)),
-                )
-        })
-}
+        actions
+            .filter(col!("add.path").is_not_null())?
+            .project_patch(|patch| {
+                patch
+                    .with_parsed_add_stats(stats_schema)
+                    .with_parsed_add_partition_values(partition_schema)
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| joined_column_expr!("add", col)),
+                    )
+            })
+    }
 
-/// Build the normalized commit JSON arm.
-///
-/// ## SQL equivalent:
-///
-/// SELECT STRUCT(
-///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
-///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        remove, version, add.path IS NOT NULL AS is_add,
-///        file_key(COALESCE(add, remove)) AS key
-/// FROM json_commits
-/// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
-///
-/// A parsed field is omitted when its schema is absent.
-fn commit_arm(
-    log_segment: &LogSegment,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
-    PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
-        .filter(Predicate::or(
-            col!("add.path").is_not_null(),
-            col!("remove.path").is_not_null(),
-        ))?
-        .project_patch(|patch| {
-            // Commits never carry source-native parsed columns, so normalize from the raw
-            // encodings.
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| {
-                        Expr::coalesce([
-                            joined_column_expr!("add", col),
-                            joined_column_expr!("remove", col),
-                        ])
-                    }),
-                )
-        })
+    /// Build the normalized commit JSON arm.
+    ///
+    /// ## SQL equivalent:
+    ///
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
+    ///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        remove, version, add.path IS NOT NULL AS is_add,
+    ///        file_key(COALESCE(add, remove)) AS key
+    /// FROM json_commits
+    /// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
+    ///
+    /// A parsed field is omitted when its schema is absent.
+    fn commit_arm(&self) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
+        PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
+            .filter(Predicate::or(
+                col!("add.path").is_not_null(),
+                col!("remove.path").is_not_null(),
+            ))?
+            .project_patch(|patch| {
+                // Commits never carry source-native parsed columns, so normalize from the raw
+                // encodings.
+                patch
+                    .with_parsed_add_stats(self.state_info.physical_stats_schema.as_ref())
+                    .with_parsed_add_partition_values(
+                        self.state_info.physical_partition_schema.as_ref(),
+                    )
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| {
+                            Expr::coalesce([
+                                joined_column_expr!("add", col),
+                                joined_column_expr!("remove", col),
+                            ])
+                        }),
+                    )
+            })
+    }
 }
 
 /// Read actions from V2 checkpoint sidecars.
@@ -368,31 +356,23 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 }
 
 trait ProjectionStructPatchBuilderExt<'a> {
-    /// Parses add stats and partition values, preferring compatible parsed fields.
+    /// Parses add stats, preferring a compatible parsed field.
     ///
     /// When `stats_schema` is present, the input must contain either `add.stats_parsed` or the
     /// fallback `add.stats` JSON field.
-    fn with_parsed_add_stats_and_partitions(
-        self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self;
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self;
+
+    /// Parses add partition values, preferring a compatible parsed field.
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
-    fn with_parsed_add_stats_and_partitions(
-        mut self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self {
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self {
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let has_partition_values_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
         let add = [ADD_NAME];
-        self = match stats_schema {
+        match stats_schema {
             Some(ss) => {
                 let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
                 let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
@@ -403,7 +383,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 }
             }
             None => self,
-        };
+        }
+    }
+
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self {
+        let has_partition_values_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let add = [ADD_NAME];
         match partition_schema {
             Some(ps) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
@@ -420,113 +407,111 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
     }
 }
 
-/// The `add` field produced by [`with_parsed_add_stats_and_partitions`].
-fn add_field_with_parsed_stats_and_partitions(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<StructField> {
-    let patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, schema| {
-            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-        })
-        .fold_with(partition_schema, |patch, schema| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                schema.as_ref().clone(),
-            ))
-        });
-    Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-}
+impl Scan {
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
 
-/// Builds the output projection for requested stats and partition values. The base of this
-/// transformation is constructed by [`add_field_with_parsed_stats_and_partitions`].
-///
-/// The output schema is:
-/// ```text
-/// add: struct<
-///   path: string,
-///   partitionValues: map<string, string>,
-///   size: long,
-///   modificationTime: long,
-///   dataChange: boolean,
-///   stats: string,                         // when JSON stats are requested
-///   tags: map<string, string>,
-///   deletionVector: struct<...>,
-///   baseRowId: long,
-///   defaultRowCommitVersion: long,
-///   clusteringProvider: string,
-///   stats_parsed: struct<...>,             // when parsed stats are requested
-///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-/// >
-/// ```
-/// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-/// partition values are selected independently and omitted for unpartitioned tables. Fields needed
-/// only for pruning are omitted.
-fn metadata_output_projection(
-    add_field: &StructField,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    partition_schema: Option<&SchemaRef>,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-    let input_schema = schema_ref! { (add_field.clone()) };
-    let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-    let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
 
-    // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-    let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-    let projection = match (stats.synthesize_json, has_json_stats) {
-        (true, true) | (false, false) => projection,
-        (true, false) => {
-            return Err(Error::internal_error(
-                "JSON stats were requested, but add.stats is missing from the metadata schema",
-            ));
-        }
-        (false, true) => projection.drop(STATS),
-    };
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
 
-    // Parsed stats output.
-    let projection = match (physical_stats_output_schema, has_stats_parsed) {
-        (Some(stats_schema), _) => projection.replace(
-            STATS_PARSED,
-            StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-            project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-        ),
-        (None, true) => projection.drop(STATS_PARSED),
-        (None, false) => projection,
-    };
-
-    // Parsed partition-values output.
-    let has_partition_values_parsed =
-        input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-    let partition_output_schema = partition_values
-        .parsed_struct
-        .then_some(partition_schema)
-        .flatten();
-    let projection = match (partition_output_schema, has_partition_values_parsed) {
-        (Some(partition_schema), true) => projection.replace(
-            PARTITION_VALUES_PARSED,
-            StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-            project_nested_struct_to_schema(
-                [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                partition_schema,
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
             ),
-        ),
-        (Some(_), false) => {
-            return Err(Error::internal_error(
-                "parsed partition values were requested, but add.partitionValues_parsed is \
-                 missing",
-            ));
-        }
-        (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-        (None, false) => projection,
-    };
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
 
-    let (add_schema, add_expr) = projection.build()?;
-    let schema = schema_ref! {
-        (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-    };
-    Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Rebuilds `root` to match a narrowed schema while preserving a null parent struct. A direct
@@ -601,47 +586,41 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::actions::{Metadata, Protocol};
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::lit;
+    use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::plans::ir::nodes::Operator;
     use crate::plans::Operation as PlanOperation;
-    use crate::scan::state_info::tests::get_state_info_with_options;
     use crate::scan::{PartitionValuesOptions, StatsOptions};
     use crate::schema::StructType;
+    use crate::snapshot::Snapshot;
+    use crate::table_configuration::TableConfiguration;
     use crate::unit_test_utils::create_log_path;
     use crate::Engine as _;
 
-    fn state(
-        schema: SchemaRef,
-        partition_columns: Vec<String>,
-        predicate: Option<Predicate>,
-        stats: StatsOptions,
-        partition_values: PartitionValuesOptions,
-    ) -> StateInfo {
-        get_state_info_with_options(
-            schema,
-            partition_columns,
-            predicate.map(Arc::new),
-            &[],
+    fn mock_snapshot(log_segment: LogSegment) -> DeltaResult<Arc<Snapshot>> {
+        let metadata = Metadata::try_new(
+            None,
+            None,
+            partitioned_schema(),
+            vec!["p".to_string()],
+            0,
             HashMap::new(),
-            vec![],
-            stats,
-            partition_values,
-        )
-        .expect("state info")
-    }
-
-    fn data_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "x",
-            DataType::LONG,
-        )]))
+        )?;
+        let table_configuration = TableConfiguration::try_new(
+            metadata,
+            Protocol::try_new_legacy(2, 5)?,
+            Url::parse("memory:///")?,
+            0,
+        )?;
+        Ok(Arc::new(Snapshot::new(log_segment, table_configuration)?))
     }
 
     fn partitioned_schema() -> SchemaRef {
@@ -786,15 +765,18 @@ mod tests {
     }
 
     fn struct_stats_schema() -> SchemaRef {
-        state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(5i64))),
-            StatsOptions::all(),
-            PartitionValuesOptions::default(),
-        )
-        .physical_stats_schema
-        .expect("stats schema")
+        let segment = log_segment(log_root(), &[], None);
+        mock_snapshot(segment)
+            .unwrap()
+            .scan_builder()
+            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_stats(StatsOptions::all())
+            .build()
+            .unwrap()
+            .state_info
+            .physical_stats_schema
+            .clone()
+            .expect("stats schema")
     }
 
     // Commit-arm operator sequence without optional pruning.
@@ -821,29 +803,13 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             Some(checkpoint_path(file_type)),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
 
         let mut expected: Vec<&str> = COMMIT_ARM_TAGS.to_vec();
         expected.extend(checkpoint_arm_tags);
@@ -861,23 +827,15 @@ mod tests {
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
         let partition_values = PartitionValuesOptions::with_struct();
-        let state = state(
-            partitioned_schema(),
-            vec!["p".to_string()],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Manifest, parsed_stats),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(stats)
+            .with_partition_values(partition_values)
+            .build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .expect("non-empty");
 
         let dynamic_scan = plan
             .nodes
@@ -904,29 +862,15 @@ mod tests {
 
     #[test]
     fn metadata_plan_commits_only() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
         assert_eq!(tags(&plan), COMMIT_ARM_TAGS.to_vec());
         Ok(())
     }
@@ -941,75 +885,35 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(file_type)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
         assert_eq!(tags(&plan), checkpoint_arm_tags);
         Ok(())
     }
 
     #[test]
     fn metadata_plan_empty_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        assert!(scan.build_metadata_scan_plan(&no_checkpoint())?.is_none());
         Ok(())
     }
 
     #[test]
     fn metadata_plan_static_skip_all_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(Predicate::FALSE),
-            stats.clone(),
-            partition_values.clone(),
-        );
-        assert_eq!(state.physical_predicate, PhysicalPredicate::StaticSkipAll);
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_predicate(Predicate::literal(false))
+            .build()?;
+        assert_eq!(
+            scan.state_info.physical_predicate,
+            PhysicalPredicate::StaticSkipAll
+        );
+        assert!(scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .is_none());
         Ok(())
     }
 
@@ -1037,15 +941,6 @@ mod tests {
             DeltaResult::<()>::Ok(())
         })?;
 
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[
@@ -1054,15 +949,10 @@ mod tests {
             ],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
@@ -1105,30 +995,20 @@ mod tests {
         // `stats_parsed` column.
         write_parquet_checkpoint(&store, "_delta_log/00000000000000000000.checkpoint.parquet")?;
 
-        let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(lower_bound))),
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[],
             Some("memory:///_delta_log/00000000000000000000.checkpoint.parquet"),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(StatsOptions::all())
+            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .build()?;
+        let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -232,6 +232,111 @@ impl Scan {
                     )
             })
     }
+
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
+
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
+
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
+            ),
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
+
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Read actions from V2 checkpoint sidecars.
@@ -404,113 +509,6 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             }
             None => self,
         }
-    }
-}
-
-impl Scan {
-    fn normalized_add_field(&self) -> DeltaResult<StructField> {
-        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let patch = SchemaStructPatchBuilder::new()
-            .fold_with(physical_stats_schema, |patch, schema| {
-                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            })
-            .fold_with(physical_partition_schema, |patch, schema| {
-                patch.append(StructField::nullable(
-                    PARTITION_VALUES_PARSED,
-                    schema.as_ref().clone(),
-                ))
-            });
-        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-    }
-
-    /// Builds the output projection for requested stats and partition values. The base of this
-    /// transformation is constructed by [`Self::normalized_add_field`].
-    ///
-    /// The output schema is:
-    /// ```text
-    /// add: struct<
-    ///   path: string,
-    ///   partitionValues: map<string, string>,
-    ///   size: long,
-    ///   modificationTime: long,
-    ///   dataChange: boolean,
-    ///   stats: string,                         // when JSON stats are requested
-    ///   tags: map<string, string>,
-    ///   deletionVector: struct<...>,
-    ///   baseRowId: long,
-    ///   defaultRowCommitVersion: long,
-    ///   clusteringProvider: string,
-    ///   stats_parsed: struct<...>,             // when parsed stats are requested
-    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-    /// >
-    /// ```
-    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-    /// partition values are selected independently and omitted for unpartitioned tables. Fields
-    /// needed only for pruning are omitted.
-    fn metadata_output_projection(
-        &self,
-        add_field: &StructField,
-    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-        let input_schema = schema_ref! { (add_field.clone()) };
-        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
-
-        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-        let projection = match (self.stats.synthesize_json, has_json_stats) {
-            (true, true) | (false, false) => projection,
-            (true, false) => {
-                return Err(Error::internal_error(
-                    "JSON stats were requested, but add.stats is missing from the metadata schema",
-                ));
-            }
-            (false, true) => projection.drop(STATS),
-        };
-
-        // Parsed stats output.
-        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
-            (Some(stats_schema), _) => projection.replace(
-                STATS_PARSED,
-                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-            ),
-            (None, true) => projection.drop(STATS_PARSED),
-            (None, false) => projection,
-        };
-
-        // Parsed partition-values output.
-        let has_partition_values_parsed =
-            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let partition_output_schema = self
-            .partition_values
-            .parsed_struct
-            .then_some(self.state_info.physical_partition_schema.as_ref())
-            .flatten();
-        let projection = match (partition_output_schema, has_partition_values_parsed) {
-            (Some(partition_schema), true) => projection.replace(
-                PARTITION_VALUES_PARSED,
-                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-                project_nested_struct_to_schema(
-                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                    partition_schema,
-                ),
-            ),
-            (Some(_), false) => {
-                return Err(Error::internal_error(
-                    "parsed partition values were requested, but add.partitionValues_parsed is \
-                     missing",
-                ));
-            }
-            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-            (None, false) => projection,
-        };
-
-        let (add_schema, add_expr) = projection.build()?;
-        let schema = schema_ref! {
-            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-        };
-        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
     }
 }
 
@@ -769,7 +767,7 @@ mod tests {
         mock_snapshot(segment)
             .unwrap()
             .scan_builder()
-            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_predicate(Arc::new(col!("x").gt(lit(5i64))))
             .with_stats(StatsOptions::all())
             .build()
             .unwrap()
@@ -905,7 +903,7 @@ mod tests {
         let segment = log_segment(log_root(), &[], None);
         let scan = mock_snapshot(segment)?
             .scan_builder()
-            .with_predicate(Predicate::literal(false))
+            .with_predicate(Arc::new(Predicate::literal(false)))
             .build()?;
         assert_eq!(
             scan.state_info.physical_predicate,
@@ -1003,7 +1001,7 @@ mod tests {
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(StatsOptions::all())
-            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .with_predicate(Arc::new(col!("x").gt(lit(lower_bound))))
             .build()?;
         let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -232,6 +232,111 @@ impl Scan {
                     )
             })
     }
+
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
+
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
+
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
+            ),
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
+
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -404,113 +509,6 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             }
             None => self,
         }
-    }
-}
-
-impl Scan {
-    fn normalized_add_field(&self) -> DeltaResult<StructField> {
-        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let patch = SchemaStructPatchBuilder::new()
-            .fold_with(physical_stats_schema, |patch, schema| {
-                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            })
-            .fold_with(physical_partition_schema, |patch, schema| {
-                patch.append(StructField::nullable(
-                    PARTITION_VALUES_PARSED,
-                    schema.as_ref().clone(),
-                ))
-            });
-        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-    }
-
-    /// Builds the output projection for requested stats and partition values. The base of this
-    /// transformation is constructed by [`Self::normalized_add_field`].
-    ///
-    /// The output schema is:
-    /// ```text
-    /// add: struct<
-    ///   path: string,
-    ///   partitionValues: map<string, string>,
-    ///   size: long,
-    ///   modificationTime: long,
-    ///   dataChange: boolean,
-    ///   stats: string,                         // when JSON stats are requested
-    ///   tags: map<string, string>,
-    ///   deletionVector: struct<...>,
-    ///   baseRowId: long,
-    ///   defaultRowCommitVersion: long,
-    ///   clusteringProvider: string,
-    ///   stats_parsed: struct<...>,             // when parsed stats are requested
-    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-    /// >
-    /// ```
-    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-    /// partition values are selected independently and omitted for unpartitioned tables. Fields
-    /// needed only for pruning are omitted.
-    fn metadata_output_projection(
-        &self,
-        add_field: &StructField,
-    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-        let input_schema = schema_ref! { (add_field.clone()) };
-        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
-
-        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-        let projection = match (self.stats.synthesize_json, has_json_stats) {
-            (true, true) | (false, false) => projection,
-            (true, false) => {
-                return Err(Error::internal_error(
-                    "JSON stats were requested, but add.stats is missing from the metadata schema",
-                ));
-            }
-            (false, true) => projection.drop(STATS),
-        };
-
-        // Parsed stats output.
-        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
-            (Some(stats_schema), _) => projection.replace(
-                STATS_PARSED,
-                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-            ),
-            (None, true) => projection.drop(STATS_PARSED),
-            (None, false) => projection,
-        };
-
-        // Parsed partition-values output.
-        let has_partition_values_parsed =
-            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let partition_output_schema = self
-            .partition_values
-            .parsed_struct
-            .then_some(self.state_info.physical_partition_schema.as_ref())
-            .flatten();
-        let projection = match (partition_output_schema, has_partition_values_parsed) {
-            (Some(partition_schema), true) => projection.replace(
-                PARTITION_VALUES_PARSED,
-                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-                project_nested_struct_to_schema(
-                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                    partition_schema,
-                ),
-            ),
-            (Some(_), false) => {
-                return Err(Error::internal_error(
-                    "parsed partition values were requested, but add.partitionValues_parsed is \
-                     missing",
-                ));
-            }
-            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-            (None, false) => projection,
-        };
-
-        let (add_schema, add_expr) = projection.build()?;
-        let schema = schema_ref! {
-            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-        };
-        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
     }
 }
 
@@ -783,7 +781,7 @@ mod tests {
         mock_snapshot(segment)
             .unwrap()
             .scan_builder()
-            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_predicate(Arc::new(col!("x").gt(lit(5i64))))
             .with_stats(StatsOptions::all())
             .build()
             .unwrap()
@@ -917,7 +915,7 @@ mod tests {
         let segment = log_segment(log_root(), &[], None);
         let scan = mock_snapshot(segment)?
             .scan_builder()
-            .with_predicate(Predicate::literal(false))
+            .with_predicate(Arc::new(Predicate::literal(false)))
             .build()?;
         assert_eq!(
             scan.state_info.physical_predicate,
@@ -1015,7 +1013,7 @@ mod tests {
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(StatsOptions::all())
-            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .with_predicate(Arc::new(col!("x").gt(lit(lower_bound))))
             .build()?;
         let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -129,24 +129,24 @@ impl Scan {
     ///            stats_parsed, partitionValues_parsed
     ///          ),
     ///          add.stats_parsed AS stats_parsed,
-    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///          MAP_TO_STRUCT(add.partitionValues, physical_partitions) AS partitionValues_parsed
     ///        ) AS add,
     ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
-    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
+    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, physical_stats)`
     /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
-        let stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let physical_stats = self.state_info.physical_stats_schema.as_ref();
+        let physical_partitions = self.state_info.physical_partition_schema.as_ref();
+        let source_physical_stats = shape.parsed_stats_schema.as_ref();
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -157,7 +157,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -173,8 +173,8 @@ impl Scan {
             .filter(col!("add.path").is_not_null())?
             .project_patch(|patch| {
                 patch
-                    .with_parsed_add_stats(stats_schema)
-                    .with_parsed_add_partition_values(partition_schema)
+                    .with_parsed_add_stats(physical_stats)
+                    .with_parsed_add_partition_values(physical_partitions)
                     .append(
                         StructField::not_null(IS_ADD, DataType::BOOLEAN),
                         Expr::from(col!("add.path").is_not_null()),
@@ -192,8 +192,8 @@ impl Scan {
     ///
     /// SELECT STRUCT(
     ///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
-    ///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
-    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///          FROM_JSON(add.stats, physical_stats) AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, physical_partitions) AS partitionValues_parsed
     ///        ) AS add,
     ///        remove, version, add.path IS NOT NULL AS is_add,
     ///        file_key(COALESCE(add, remove)) AS key
@@ -295,10 +295,10 @@ impl Scan {
 
         // Parsed stats output.
         let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
-            (Some(stats_schema), _) => projection.replace(
+            (Some(physical_stats), _) => projection.replace(
                 STATS_PARSED,
-                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
+                StructField::nullable(STATS_PARSED, physical_stats.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], physical_stats),
             ),
             (None, true) => projection.drop(STATS_PARSED),
             (None, false) => projection,
@@ -307,19 +307,16 @@ impl Scan {
         // Parsed partition-values output.
         let has_partition_values_parsed =
             input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let partition_output_schema = self
+        let physical_partitions = self
             .partition_values
             .parsed_struct
             .then_some(self.state_info.physical_partition_schema.as_ref())
             .flatten();
-        let projection = match (partition_output_schema, has_partition_values_parsed) {
-            (Some(partition_schema), true) => projection.replace(
+        let projection = match (physical_partitions, has_partition_values_parsed) {
+            (Some(schema), true) => projection.replace(
                 PARTITION_VALUES_PARSED,
-                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-                project_nested_struct_to_schema(
-                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                    partition_schema,
-                ),
+                StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, PARTITION_VALUES_PARSED_NAME], schema),
             ),
             (Some(_), false) => {
                 return Err(Error::internal_error(
@@ -412,17 +409,17 @@ fn json_read_schema(include_remove: bool) -> SchemaRef {
 
 /// Read schema for parquet add actions.
 fn parquet_read_schema(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
+    physical_stats: Option<&SchemaRef>,
+    physical_partitions: Option<&SchemaRef>,
 ) -> DeltaResult<SchemaRef> {
     let add_patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, ss| {
-            patch.append(StructField::nullable(STATS_PARSED, ss.as_ref().clone()))
+        .fold_with(physical_stats, |patch, schema| {
+            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
         })
-        .fold_with(partition_schema, |patch, ps| {
+        .fold_with(physical_partitions, |patch, schema| {
             patch.append(StructField::nullable(
                 PARTITION_VALUES_PARSED,
-                ps.as_ref().clone(),
+                schema.as_ref().clone(),
             ))
         });
     Ok(schema_ref! {
@@ -463,24 +460,24 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 trait ProjectionStructPatchBuilderExt<'a> {
     /// Parses add stats, preferring a compatible parsed field.
     ///
-    /// When `stats_schema` is present, the input must contain either `add.stats_parsed` or the
-    /// fallback `add.stats` JSON field.
-    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self;
+    /// When `physical_stats` is present, the input must contain either
+    /// `add.stats_parsed` or the fallback `add.stats` JSON field.
+    fn with_parsed_add_stats(self, physical_stats: Option<&SchemaRef>) -> Self;
 
     /// Parses add partition values, preferring a compatible parsed field.
-    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
+    fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
-    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self {
+    fn with_parsed_add_stats(self, physical_stats: Option<&SchemaRef>) -> Self {
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
         let add = [ADD_NAME];
-        match stats_schema {
-            Some(ss) => {
-                let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
-                let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
+        match physical_stats {
+            Some(schema) => {
+                let field = StructField::nullable(STATS_PARSED, schema.as_ref().clone());
+                let expr = Expr::parse_json(col!("add.stats"), Arc::clone(schema));
                 if has_stats_parsed {
                     self
                 } else {
@@ -491,14 +488,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         }
     }
 
-    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self {
+    fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self {
         let has_partition_values_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
         let add = [ADD_NAME];
-        match partition_schema {
-            Some(ps) => {
-                let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
+        match physical_partitions {
+            Some(schema) => {
+                let field = StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone());
                 let expr = Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES));
                 if has_partition_values_parsed {
                     let expr = Expr::coalesce([col!(ADD_NAME, PARTITION_VALUES_PARSED), expr]);


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3039/files) to review incremental changes.
- [stack/scan_plan_options](https://github.com/delta-io/delta-kernel-rs/pull/3015) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3015/files)] [MERGED]
  - [**stack/scan_plan_refactor**](https://github.com/delta-io/delta-kernel-rs/pull/3039) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3039/files)] ← _this PR_
    - [stack/scan_plan_checkpoint_shape](https://github.com/delta-io/delta-kernel-rs/pull/3044) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3044/files/f9e5721ce9edbbd89afab8d377d1da3679cad73b..4a0a6f6675842bb99148e0aa85e4f57c1127163b)]
      - [stack/scan_plan_stats_json](https://github.com/delta-io/delta-kernel-rs/pull/3045) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3045/files/4a0a6f6675842bb99148e0aa85e4f57c1127163b..58db22121c2684b944ddf5434a66e65f1a771ad9)]
    - [stack/scan_plan_stats_source](https://github.com/delta-io/delta-kernel-rs/pull/3019) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3019/files/2223fcf2e142ba7714cc6c9e19d5b275425665de..397cc5e52be52cade4d31911c22328868338a5a6)]

---------
## What changes are proposed in this pull request?

Move declarative metadata plan construction onto `Scan`, so checkpoint, commit, normalization, and output-projection helpers access shared scan state through `self`. Split stats and partition-value normalization into focused helpers.

This is a behavior-preserving refactor stacked on #3015.

## How was this change tested?

- `cargo +nightly fmt --check`
- workspace clippy with all features
- workspace Arrow-only clippy without default features
- `cargo doc --workspace --all-features --no-deps`
- `cargo nextest run --workspace --all-features`
