### PR TITLE
fix!: remove `interval-type-in-dev` feature flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,8 +258,8 @@ jobs:
         if: matrix.config == 'no-declarative-plans'
         shell: bash
         run: |
-          cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
-          cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,interval-type-in-dev,default-engine-base --doc
+          cargo nextest run --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,default-engine-base -E 'not test(read_table_version_hdfs) and not test(invalid_handle_code)'
+          cargo test --locked -p delta_kernel -p acceptance --no-default-features --features internal-api,prettyprint,test-utils,integration-test,arrow,arrow-conversion,arrow-expression,schema-diff,check-constraints-in-dev,adaptive-metadata-in-dev,default-engine-base --doc
 
   # Fails red on trybuild drift, but kept out of required checks so it never blocks a merge.
   invalid-handle-code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,6 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
   (experimental, in development). Gates `KernelSupport::Supported` for the
   `adaptiveMetadata-preview` reader+writer feature (reads/writes to tables listing it are blocked
   with the cargo feature off).
-- `interval-type-in-dev` -- ANSI interval type support (experimental, in development). With the
-  cargo feature off, creating or writing tables with interval columns is blocked; reads are
-  unaffected.
 - `geo-type-in-dev` -- geospatial type support (geometry and geography columns) (experimental,
   in development). Gates `KernelSupport` for the `geospatial` reader+writer feature: with the
   cargo feature off, any table listing it is rejected; with it on, scans and CDF are supported

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -128,12 +128,6 @@ adaptive-metadata-in-dev = []
 # (geometry/geography) type work. TODO(#2949): remove once full geo support ships.
 geo-type-in-dev = []
 
-# Experimental, temporary feature flag guarding the in-progress ANSI interval-type work.
-# With the flag off, creating and writing tables containing interval columns are blocked; reads
-# are unaffected.
-# TODO(#2840): remove once interval support fully ships.
-interval-type-in-dev = []
-
 # Enables shared Arrow-based engine support modules (arrow_data, arrow_expression,
 # ensure_data_types, parquet_row_group_skipping). Used by the delta_kernel_default_engine crate
 # and the SyncEngine. Keeps `reqwest` only for the gated `Error::Reqwest` variant.

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1620,28 +1620,6 @@ pub(crate) fn schema_contains_non_null_fields(schema: &Schema) -> bool {
     NonNullFieldChecker.transform_struct(schema).is_err()
 }
 
-#[cfg(not(feature = "interval-type-in-dev"))]
-struct UsesIntervalType;
-
-#[cfg(not(feature = "interval-type-in-dev"))]
-impl<'a> SchemaTransform<'a> for UsesIntervalType {
-    transform_output_type!(|'a, T| Result<(), ()>);
-
-    fn transform_primitive(&mut self, ptype: &'a PrimitiveType) -> Result<(), ()> {
-        if ptype.is_interval() {
-            Err(())
-        } else {
-            Ok(())
-        }
-    }
-}
-
-/// Returns whether `schema` contains an ANSI interval type at any nesting level.
-#[cfg(not(feature = "interval-type-in-dev"))]
-pub(crate) fn schema_contains_interval_type(schema: &Schema) -> bool {
-    UsesIntervalType.transform_struct(schema).is_err()
-}
-
 /// Normalizes column name field names to match the casing in the schema.
 ///
 /// Walks each field name through the schema's struct hierarchy, replacing user-provided
@@ -3749,64 +3727,6 @@ mod tests {
     #[case::variant_skipped(variant_only_schema(), false)]
     fn test_schema_contains_non_null_fields(#[case] schema: StructType, #[case] expected: bool) {
         assert_eq!(schema_contains_non_null_fields(&schema), expected);
-    }
-
-    #[cfg(not(feature = "interval-type-in-dev"))]
-    #[test]
-    fn test_schema_contains_interval_type() {
-        for interval in [DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME] {
-            let schemas = [
-                (
-                    "top-level",
-                    StructType::new_unchecked([StructField::nullable("iv", interval.clone())]),
-                ),
-                (
-                    "nested struct",
-                    StructType::new_unchecked([StructField::nullable(
-                        "nested",
-                        StructType::new_unchecked([StructField::nullable(
-                            "inner_iv",
-                            interval.clone(),
-                        )]),
-                    )]),
-                ),
-                (
-                    "array element",
-                    StructType::new_unchecked([StructField::nullable(
-                        "array",
-                        ArrayType::new(interval.clone(), true),
-                    )]),
-                ),
-                (
-                    "map value",
-                    StructType::new_unchecked([StructField::nullable(
-                        "map",
-                        MapType::new(DataType::STRING, interval.clone(), true),
-                    )]),
-                ),
-                (
-                    "map key",
-                    StructType::new_unchecked([StructField::nullable(
-                        "map",
-                        MapType::new(interval.clone(), DataType::STRING, true),
-                    )]),
-                ),
-            ];
-
-            for (case, schema) in schemas {
-                assert!(
-                    schema_contains_interval_type(&schema),
-                    "expected {case} schema to contain {interval:?}"
-                );
-            }
-        }
-
-        for schema in [
-            StructType::new_unchecked([StructField::not_null("id", DataType::INTEGER)]),
-            variant_only_schema(),
-        ] {
-            assert!(!schema_contains_interval_type(&schema));
-        }
     }
 
     #[test]

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -4,8 +4,6 @@
 
 use std::collections::HashSet;
 
-#[cfg(not(feature = "interval-type-in-dev"))]
-use crate::schema::schema_contains_interval_type;
 use crate::schema::{StructField, StructType};
 use crate::table_features::ColumnMappingMode;
 use crate::transforms::SchemaTransform;
@@ -32,24 +30,6 @@ pub(crate) fn validate_schema(
     // collects errors. The return value is intentionally discarded.
     validator.transform_struct(schema);
     validator.into_result()
-}
-
-/// Validates that this build supports writing the schema's data types.
-#[cfg(feature = "interval-type-in-dev")]
-pub(crate) fn validate_interval_type_write_support(_: &StructType) -> DeltaResult<()> {
-    Ok(())
-}
-
-/// Validates that this build supports writing the schema's data types.
-#[cfg(not(feature = "interval-type-in-dev"))]
-pub(crate) fn validate_interval_type_write_support(schema: &StructType) -> DeltaResult<()> {
-    if schema_contains_interval_type(schema) {
-        return Err(Error::unsupported(
-            "Writing interval columns requires the 'interval-type-in-dev' cargo feature",
-        ));
-    }
-
-    Ok(())
 }
 
 /// Schema visitor that validates field names, detects duplicates, and rejects

--- a/kernel/src/schema/void_utils.rs
+++ b/kernel/src/schema/void_utils.rs
@@ -11,7 +11,6 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use super::validation::validate_interval_type_write_support;
 use super::{DataType, PrimitiveType, Schema, SchemaRef, StructField, StructType};
 use crate::expressions::ExpressionStructPatchBuilder;
 use crate::transforms::{transform_output_type, SchemaTransform};
@@ -71,10 +70,7 @@ pub(crate) fn strip_void_from_schema(schema: SchemaRef) -> SchemaRef {
 ///   values to drop them.
 /// - A struct contains no non-void fields (would produce an empty Parquet struct)
 /// - The table schema contains no non-void columns (would produce an empty Parquet schema)
-/// - The schema contains an ANSI interval type and the `interval-type-in-dev` feature is disabled
 pub(crate) fn validate_schema_for_write(schema: &Schema) -> DeltaResult<()> {
-    validate_interval_type_write_support(schema)?;
-
     ValidateForWrite {
         container_depth: 0,
         depth: 0,
@@ -198,17 +194,6 @@ mod tests {
     };
 
     // ---- validate_schema_for_write tests ----
-
-    #[cfg(not(feature = "interval-type-in-dev"))]
-    #[rstest::rstest]
-    fn test_interval_type_requires_write_support(
-        #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,
-    ) {
-        let schema = StructType::new_unchecked([StructField::nullable("iv", interval)]);
-
-        let error = validate_schema_for_write(&schema).unwrap_err().to_string();
-        assert!(error.contains("interval-type-in-dev"));
-    }
 
     #[test]
     fn test_validator_catches_void_in_map_from_json() {

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -17,7 +17,7 @@ use crate::actions::{DomainMetadata, Metadata, Protocol};
 use crate::clustering::{create_clustering_domain_metadata, validate_clustering_columns};
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
-use crate::schema::validation::{validate_interval_type_write_support, validate_schema};
+use crate::schema::validation::validate_schema;
 use crate::schema::variant_utils::schema_contains_variant_type;
 use crate::schema::{
     normalize_column_names_to_schema_casing, schema_contains_non_null_fields, DataType, SchemaRef,
@@ -956,7 +956,6 @@ impl CreateTableTransactionBuilder {
 
         // Build TableConfiguration directly for the new table
         let table_configuration = TableConfiguration::try_new(metadata, protocol, table_url, 0)?;
-        validate_interval_type_write_support(&table_configuration.logical_schema())?;
 
         // Create Transaction<CreateTable> with the effective table configuration
         Transaction::try_new_create_table(

--- a/kernel/tests/integration/create_table/iceberg_compat.rs
+++ b/kernel/tests/integration/create_table/iceberg_compat.rs
@@ -93,9 +93,7 @@ fn v3_create_table_rejects_void_column(#[case] void_field: StructField) -> Delta
 }
 
 /// IcebergV3 has no interval type, so icebergCompatV3 omits intervals from
-/// its type allowlist. Enabling V3 alongside an interval column must fail at `.build(...)`. This
-/// holds regardless of the `interval-type-in-dev` gate, since the V3 allowlist is the rejection
-/// point and runs before any kernel-support check.
+/// its type allowlist. Enabling V3 alongside an interval column must fail at `.build(...)`.
 #[rstest]
 fn v3_create_table_rejects_interval_column(
     #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,

--- a/kernel/tests/integration/create_table/interval.rs
+++ b/kernel/tests/integration/create_table/interval.rs
@@ -10,22 +10,6 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use test_utils::test_table_setup;
 
-#[cfg(not(feature = "interval-type-in-dev"))]
-#[test]
-fn test_create_table_interval_blocked_when_feature_off() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::not_null("id", DataType::INTEGER),
-        StructField::nullable("iv", DataType::INTERVAL_DAY_TIME),
-    ])?);
-
-    let result = create_table(&table_path, schema, "Test/1.0")
-        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
-
-    test_utils::assert_result_error_with_message(result, "interval-type-in-dev");
-    Ok(())
-}
-
 #[rstest::rstest]
 fn test_create_table_rejects_interval_clustering(
     #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,
@@ -60,8 +44,7 @@ fn test_create_table_rejects_interval_clustering(
     Ok(())
 }
 
-#[cfg(feature = "interval-type-in-dev")]
-mod feature_enabled {
+mod supported {
     use delta_kernel::schema::SchemaRef;
     use delta_kernel::snapshot::Snapshot;
     use delta_kernel::table_features::ColumnMappingMode;

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -943,7 +943,6 @@ async fn partition_pruning_honors_rfc3339_offset_partition_values(
     Ok(())
 }
 
-#[cfg(feature = "interval-type-in-dev")]
 #[rstest]
 #[case::year_month(
     DataType::INTERVAL_YEAR_MONTH,

--- a/kernel/tests/integration/features/interval.rs
+++ b/kernel/tests/integration/features/interval.rs
@@ -6,9 +6,13 @@ use delta_kernel::schema::{DataType, StructField, StructType};
 use delta_kernel::Snapshot;
 use test_utils::{create_table, engine_store_setup};
 
-async fn build_scan_over_interval_table(
-    name: &str,
-    interval: DataType,
+#[rstest::rstest]
+#[case::year_month("interval_read_ym", DataType::INTERVAL_YEAR_MONTH)]
+#[case::day_time("interval_read_dt", DataType::INTERVAL_DAY_TIME)]
+#[tokio::test]
+async fn test_build_scan_over_interval_table(
+    #[case] name: &str,
+    #[case] interval: DataType,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
         "iv", interval,
@@ -18,17 +22,5 @@ async fn build_scan_over_interval_table(
 
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
     snapshot.scan_builder().build()?;
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_scan_interval_table_is_not_gated_by_cargo_feature(
-) -> Result<(), Box<dyn std::error::Error>> {
-    for (name, interval) in [
-        ("interval_read_ym", DataType::INTERVAL_YEAR_MONTH),
-        ("interval_read_dt", DataType::INTERVAL_DAY_TIME),
-    ] {
-        build_scan_over_interval_table(name, interval).await?;
-    }
     Ok(())
 }

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -4,36 +4,8 @@ use std::sync::Arc;
 
 use delta_kernel::schema::{DataType, StructField, StructType};
 use test_utils::load_and_begin_transaction;
-#[cfg(not(feature = "interval-type-in-dev"))]
-use test_utils::{create_table, engine_store_setup};
 
-/// Writing interval data is gated by the `interval-type-in-dev` cargo feature.
-#[cfg(not(feature = "interval-type-in-dev"))]
-#[tokio::test]
-async fn test_write_interval_table_gate() -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "iv",
-        DataType::INTERVAL_DAY_TIME,
-    )])?);
-
-    let (store, engine, table_location) =
-        engine_store_setup("test_interval_requires_feature", None);
-    let table_url = create_table(store, table_location, schema, &[], true, vec![], vec![]).await?;
-
-    let transaction = load_and_begin_transaction(table_url, &engine)?;
-    let err = transaction
-        .unpartitioned_write_context()
-        .expect_err("interval write contexts should be blocked when the cargo feature is disabled")
-        .to_string();
-    assert!(
-        err.contains("interval-type-in-dev"),
-        "error must explain the missing cargo feature; got: {err}",
-    );
-    Ok(())
-}
-
-#[cfg(feature = "interval-type-in-dev")]
-mod feature_enabled {
+mod supported {
     use std::collections::HashMap;
 
     use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, STATS_PARSED};

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -132,9 +132,7 @@ async fn test_write_partitioned_normal_values_roundtrip(
 }
 
 /// Writes an interval partition column, asserts the partitionValues entry is the Spark ANSI
-/// interval literal (CM=None), and verifies the value round-trips through a scan. Gated on
-/// `interval-type-in-dev` because writing an interval table requires interval writer support.
-#[cfg(feature = "interval-type-in-dev")]
+/// interval literal (CM=None), and verifies the value round-trips through a scan.
 #[rstest]
 #[case::year_month(
     DataType::INTERVAL_YEAR_MONTH,
@@ -202,7 +200,6 @@ async fn test_write_partitioned_interval_roundtrip(
 
 /// Materialized interval partition columns are written into the Parquet file as physical integer
 /// values and still round-trip through scan output as logical partition columns.
-#[cfg(feature = "interval-type-in-dev")]
 #[rstest]
 #[case::year_month(
     DataType::INTERVAL_YEAR_MONTH,
@@ -687,7 +684,6 @@ macro_rules! assert_col {
     };
 }
 
-#[cfg(feature = "interval-type-in-dev")]
 fn assert_interval_value(batch: &RecordBatch, column_name: &str, expected: &Scalar) {
     match expected {
         Scalar::IntervalYearMonth(months) => {
@@ -774,7 +770,6 @@ fn cm_mode_str(mode: ColumnMappingMode) -> &'static str {
     }
 }
 
-#[cfg(feature = "interval-type-in-dev")]
 fn create_interval_partitioned_table(
     table_path: &str,
     engine: &dyn delta_kernel::Engine,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove the `interval-type-in-dev` feature flag now that interval type implementation is complete. This unblocks create table, blind appends, scalars & partition values.

## How was this change tested?

Unit and integration tests still pass.