### PR TITLE
refactor: retain checkpoint leaf schema in CheckpointShape

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -202,6 +202,18 @@ static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     ..(checkpoint_action_field()),
 };
 
+/// Schema for actions stored in a leaf checkpoint.
+#[internal_api]
+pub(crate) static LEAF_CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    ..(checkpoint_action_field()),
+};
+
 static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     (&ADD_FIELD),
     (&REMOVE_FIELD),

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -204,6 +204,18 @@ static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     ..(checkpoint_action_field()),
 };
 
+/// Schema for actions stored in a leaf checkpoint.
+#[internal_api]
+pub(crate) static LEAF_CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    ..(checkpoint_action_field()),
+};
+
 static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     (&ADD_FIELD),
     (&REMOVE_FIELD),

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -1,6 +1,10 @@
-//! Resolves a checkpoint shape. This falls into the following cases: no checkpoint,
-//! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
-//! When requested, also retains the schema of the files containing leaf actions.
+//! Resolves a checkpoint shape:
+//! - A single-part checkpoint has one checkpoint leaf storing file actions (`add` and `remove`).
+//! - A multipart checkpoint has one checkpoint leaf per checkpoint part.
+//! - A manifest checkpoint has sidecars as its checkpoint leaves.
+//!
+//! A checkpoint leaf directly stores file actions. When requested, this module also retains the
+//! checkpoint leaf schema.
 //! Driven through a [`PlanExecutor`].
 
 // No in-crate caller yet; following PRs will use this.
@@ -29,17 +33,17 @@ pub(crate) enum CheckpointType {
     Manifest,
 }
 
-/// A snapshot's resolved checkpoint type and leaf-action schema.
+/// A snapshot's resolved checkpoint type and checkpoint leaf schema.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CheckpointShape {
     /// What kind of checkpoint this is.
     pub(crate) checkpoint_type: CheckpointType,
-    /// Schema of the files containing leaf actions, when requested.
+    /// Schema of the checkpoint leaves, when requested.
     pub(crate) leaf_checkpoint_schema: Option<SchemaRef>,
 }
 
 impl CheckpointShape {
-    /// Resolves `snapshot`'s checkpoint topology without retaining the leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology without retaining the checkpoint leaf schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
@@ -50,7 +54,7 @@ impl CheckpointShape {
         Self::try_new_impl(exec, snapshot, false)
     }
 
-    /// Resolves `snapshot`'s checkpoint topology and retains the leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology and retains the checkpoint leaf schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
@@ -142,7 +146,7 @@ impl CheckpointShape {
             }
             Some([]) => {
                 // A parquet leaf's actions live in its own schema; read it only when requested.
-                // JSON leaves use the canonical JSON action schema.
+                // JSON checkpoint leaves use the canonical JSON action schema.
                 let leaf_schema = match file_type {
                     FileType::Parquet if needs_leaf_schema => {
                         Some(match segment.checkpoint_hint_schema() {
@@ -152,7 +156,8 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                // JSON leaves have no footer, so we assume it has the widest checkpoint schema.
+                // JSON checkpoint leaves have no footer, so use the canonical checkpoint leaf
+                // schema.
                 let leaf_schema = leaf_schema.or_else(|| {
                     (needs_leaf_schema && file_type == FileType::Json)
                         .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())
@@ -369,7 +374,7 @@ mod tests {
         assert_eq!(
             shape.leaf_checkpoint_schema.is_some(),
             needs_leaf_schema && expected_checkpoint != CheckpointType::None,
-            "{table}: retained leaf schema"
+            "{table}: checkpoint leaf schema"
         );
         if let Some(schema) = &shape.leaf_checkpoint_schema {
             assert!(schema.contains("add"), "{table}: retained add action");

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -136,7 +136,7 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                // JSON leaves have no footer, but always use the full canonical action schema.
+                // JSON leaves have no footer, so we assume it has the widest checkpoint schema.
                 let leaf_schema = leaf_schema.or_else(|| {
                     (needs_leaf_schema && file_type == FileType::Json)
                         .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -1,6 +1,6 @@
 //! Resolves a checkpoint shape. This falls into the following cases: no checkpoint,
 //! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
-//! When stats are requested, also reports whether the checkpoint has compatible parsed stats.
+//! When requested, also retains the schema of the files containing leaf actions.
 //! Driven through a [`PlanExecutor`].
 
 // No in-crate caller yet; following PRs will use this.
@@ -9,7 +9,7 @@
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::SIDECAR_NAME;
+use crate::actions::{LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME};
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
@@ -29,23 +29,21 @@ pub(crate) enum CheckpointType {
     Manifest,
 }
 
-/// A snapshot's resolved checkpoint type and parsed-stats schema.
+/// A snapshot's resolved checkpoint type and leaf-action schema.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CheckpointShape {
     /// What kind of checkpoint this is.
     pub(crate) checkpoint_type: CheckpointType,
-    /// The requested stats schema when the checkpoint has a compatible `add.stats_parsed` struct
-    /// to read it from; `None` when stats were not requested or no compatible parsed stats exist.
-    pub(crate) parsed_stats_schema: Option<SchemaRef>,
+    /// Schema of the files containing leaf actions, when requested.
+    pub(crate) leaf_checkpoint_schema: Option<SchemaRef>,
 }
 
 impl CheckpointShape {
-    /// Resolve `snapshot`'s checkpoint shape. Determines the checkpoint type and, when
-    /// `stats_schema` is `Some`, whether the checkpoint contains parsed stats compatible with it.
+    /// Resolve `snapshot`'s checkpoint shape and optionally retain its leaf-action schema.
     pub(crate) fn try_new(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<CheckpointShape> {
         let segment = snapshot.log_segment();
 
@@ -55,16 +53,20 @@ impl CheckpointShape {
             None => {
                 return Ok(CheckpointShape {
                     checkpoint_type: CheckpointType::None,
-                    parsed_stats_schema: None,
+                    leaf_checkpoint_schema: None,
                 })
             }
         };
 
         // Classify from a V2 checkpoint's `_last_checkpoint` hint when possible, else inspect the
         // file.
-        if let Some(shape) =
-            Self::from_v2_checkpoint_hint(exec, segment, root_checkpoint, file_type, stats_schema)?
-        {
+        if let Some(shape) = Self::from_v2_checkpoint_hint(
+            exec,
+            segment,
+            root_checkpoint,
+            file_type,
+            needs_leaf_schema,
+        )? {
             return Ok(shape);
         }
 
@@ -77,22 +79,23 @@ impl CheckpointShape {
                 };
                 // No `sidecar` column means the file actions are inline, so this is a leaf.
                 if !cp_schema.contains(SIDECAR_NAME) {
-                    return Ok(Self::try_new_leaf(Some(cp_schema), stats_schema));
+                    return Ok(Self::new_leaf(needs_leaf_schema.then_some(cp_schema)));
                 }
                 // The `sidecar` column may still be all-null (not a manifest), so scan it to
                 // confirm whether a sidecar is actually present.
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(Some(cp_schema), stats_schema)),
+                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, needs_leaf_schema),
+                    None => Ok(Self::new_leaf(needs_leaf_schema.then_some(cp_schema))),
                 }
             }
             // A JSON checkpoint has no footer schema to inspect, so try to collect a sidecar to
-            // decide if it is a manifest or a leaf. A JSON leaf has no readable schema,
-            // hence no parsed stats.
+            // decide if it is a manifest or a leaf.
             FileType::Json => {
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(None, stats_schema)),
+                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, needs_leaf_schema),
+                    None => Ok(Self::new_leaf(
+                        needs_leaf_schema.then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone()),
+                    )),
                 }
             }
         }
@@ -108,19 +111,19 @@ impl CheckpointShape {
         segment: &LogSegment,
         root_checkpoint: &FileMeta,
         file_type: FileType,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<Option<CheckpointShape>> {
         match segment.checkpoint_hint_sidecars().map(Vec::as_slice) {
             Some([sidecar, ..]) => {
                 let sidecar_meta = sidecar.to_filemeta(&segment.log_root)?;
-                let result = Self::try_new_manifest(exec, sidecar_meta, stats_schema)?;
+                let result = Self::try_new_manifest(exec, sidecar_meta, needs_leaf_schema)?;
                 Ok(Some(result))
             }
             Some([]) => {
-                // A parquet leaf's stats live in its own schema; read it only when stats are
-                // requested. A JSON leaf has no readable schema.
+                // A parquet leaf's actions live in its own schema; read it only when requested.
+                // JSON leaves use the canonical JSON action schema.
                 let leaf_schema = match file_type {
-                    FileType::Parquet if stats_schema.is_some() => {
+                    FileType::Parquet if needs_leaf_schema => {
                         Some(match segment.checkpoint_hint_schema() {
                             Some(schema) => schema,
                             None => exec.read_parquet_footer(root_checkpoint.clone())?.schema,
@@ -128,49 +131,54 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                Ok(Some(Self::try_new_leaf(leaf_schema, stats_schema)))
+                // JSON leaves have no footer, but always use the full canonical action schema.
+                let leaf_schema = leaf_schema.or_else(|| {
+                    (needs_leaf_schema && file_type == FileType::Json)
+                        .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())
+                });
+                Ok(Some(Self::new_leaf(leaf_schema)))
             }
             None => Ok(None),
         }
     }
 
-    /// Build the shape for a manifest checkpoint. Its file actions and their stats live in the
-    /// sidecars, so probe a sidecar's (parquet) footer -- but only when stats were requested. All
+    /// Build the shape for a manifest checkpoint. Its file actions live in the sidecars. All
     /// sidecars of a checkpoint share one schema, so probing the first is sufficient.
     fn try_new_manifest(
         exec: &dyn PlanExecutor,
         sidecar: FileMeta,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<CheckpointShape> {
-        let parsed_stats_schema = match stats_schema {
-            Some(stats_schema) => {
-                let footer_schema = exec.read_parquet_footer(sidecar)?.schema;
-                LogSegment::schema_has_compatible_stats_parsed(footer_schema.as_ref(), stats_schema)
-                    .then(|| stats_schema.clone())
-            }
-            None => None,
-        };
+        let leaf_checkpoint_schema = needs_leaf_schema
+            .then(|| {
+                exec.read_parquet_footer(sidecar)
+                    .map(|footer| footer.schema)
+            })
+            .transpose()?;
         Ok(CheckpointShape {
             checkpoint_type: CheckpointType::Manifest,
-            parsed_stats_schema,
+            leaf_checkpoint_schema,
         })
     }
 
-    /// Build the shape for a leaf checkpoint. Its file actions are inline, so `leaf_schema` carries
-    /// their stats (`None` for a JSON leaf, which has no readable footer schema).
-    fn try_new_leaf(
-        leaf_schema: Option<SchemaRef>,
-        stats_schema: Option<&SchemaRef>,
-    ) -> CheckpointShape {
-        let parsed_stats_schema = stats_schema.filter(|stats_schema| {
-            leaf_schema.as_ref().is_some_and(|leaf_schema| {
-                LogSegment::schema_has_compatible_stats_parsed(leaf_schema.as_ref(), stats_schema)
-            })
-        });
+    fn new_leaf(leaf_checkpoint_schema: Option<SchemaRef>) -> CheckpointShape {
         CheckpointShape {
             checkpoint_type: CheckpointType::Leaf,
-            parsed_stats_schema: parsed_stats_schema.cloned(),
+            leaf_checkpoint_schema,
         }
+    }
+
+    /// Return `stats_schema` when the checkpoint has compatible parsed stats.
+    pub(crate) fn compatible_stats_parsed_schema(
+        &self,
+        stats_schema: &SchemaRef,
+    ) -> Option<SchemaRef> {
+        self.leaf_checkpoint_schema
+            .as_ref()
+            .filter(|checkpoint_schema| {
+                LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
+            })
+            .map(|_| stats_schema.clone())
     }
 }
 
@@ -302,7 +310,10 @@ mod tests {
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
 
         let shape =
-            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.as_ref()).unwrap();
+            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.is_some()).unwrap();
+        let parsed_stats_schema = stats_schema
+            .as_ref()
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
 
         assert_eq!(
             shape.checkpoint_type, expected_checkpoint,
@@ -312,19 +323,19 @@ mod tests {
         match expect_parsed {
             // Stats not requested: no parsed-stats schema regardless of the checkpoint.
             None => assert!(
-                shape.parsed_stats_schema.is_none(),
+                parsed_stats_schema.is_none(),
                 "{table}: stats not requested"
             ),
             // Requested with compatible parsed stats: the requested schema is echoed back.
             Some(true) => assert_eq!(
-                shape.parsed_stats_schema.as_ref(),
+                parsed_stats_schema.as_ref(),
                 stats_schema.as_ref(),
                 "{table}: parsed stats available, schema echoed"
             ),
             // Requested but no compatible parsed stats: `None`.
             Some(false) => assert!(
-                shape.parsed_stats_schema.is_none(),
-                "{table}: no compatible parsed stats"
+                parsed_stats_schema.is_none(),
+                "{table}: no compatible stats"
             ),
         }
     }
@@ -353,8 +364,7 @@ mod tests {
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -391,8 +401,7 @@ mod tests {
             .unwrap();
 
         let exec = CountingExecutor::new();
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert!(
@@ -439,10 +448,10 @@ mod tests {
     }
 
     /// An empty-sidecars hint (`Some([])`) classifies as a leaf without inspecting the checkpoint.
-    /// A JSON leaf never reports parsed stats; a parquet leaf reads its schema only when stats are
+    /// A JSON leaf uses the canonical action schema; a parquet leaf reads its schema only when
     /// requested. `None` here means the hint short-circuited (a fall-through would return `Some`).
     #[rstest]
-    // JSON leaf: no readable schema, so never any parsed stats, and never any I/O.
+    // JSON leaf: use the canonical schema without I/O.
     #[case::json_no_stats("json", false, None, 0)]
     #[case::json_with_stats("json", true, None, 0)]
     // Parquet leaf: no stats requested -> no schema read, no parsed stats.
@@ -467,16 +476,22 @@ mod tests {
             &segment,
             root,
             file_type,
-            stats_schema.as_ref(),
+            request_stats,
         )
         .unwrap()
         .expect("an empty-sidecars hint must classify without falling through");
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Leaf);
-        assert_eq!(
-            shape.parsed_stats_schema.is_some(),
-            expect_parsed == Some(true)
-        );
+        if file_type == FileType::Json && request_stats {
+            assert_eq!(
+                shape.leaf_checkpoint_schema.as_ref(),
+                Some(&*LEAF_CHECKPOINT_ACTIONS_SCHEMA)
+            );
+        }
+        let parsed_stats_schema = stats_schema
+            .as_ref()
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
+        assert_eq!(parsed_stats_schema.is_some(), expect_parsed == Some(true));
         assert_eq!(
             exec.query_scans.load(Ordering::Relaxed),
             0,

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -39,7 +39,12 @@ pub(crate) struct CheckpointShape {
 }
 
 impl CheckpointShape {
-    /// Resolve `snapshot`'s checkpoint shape and optionally retain its leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology. When `needs_leaf_schema` is true, also loads and
+    /// retains the schema of the files containing leaf actions. Schema retention does not affect
+    /// checkpoint classification.
+    ///
+    /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
+    /// read.
     pub(crate) fn try_new(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
@@ -169,16 +174,16 @@ impl CheckpointShape {
     }
 
     /// Return `stats_schema` when the checkpoint has compatible parsed stats.
-    pub(crate) fn compatible_stats_parsed_schema(
+    pub(crate) fn compatible_stats_parsed_schema<'a>(
         &self,
-        stats_schema: &SchemaRef,
-    ) -> Option<SchemaRef> {
+        stats_schema: &'a SchemaRef,
+    ) -> Option<&'a SchemaRef> {
         self.leaf_checkpoint_schema
             .as_ref()
-            .filter(|checkpoint_schema| {
+            .is_some_and(|checkpoint_schema| {
                 LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
             })
-            .map(|_| stats_schema.clone())
+            .then_some(stats_schema)
     }
 }
 
@@ -222,9 +227,10 @@ mod tests {
     use super::*;
     use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::sync::SyncEngine;
     use crate::plans::{IoOperation, PlanResult};
     use crate::schema::{DataType, StructField, StructType};
-    use crate::unit_test_utils::load_test_table;
+    use crate::unit_test_utils::{copy_test_table, load_test_table};
 
     /// Counts ops by kind and delegates to `SyncPlanExecutor`, to assert which I/O the fast path
     /// performs.
@@ -328,7 +334,7 @@ mod tests {
             ),
             // Requested with compatible parsed stats: the requested schema is echoed back.
             Some(true) => assert_eq!(
-                parsed_stats_schema.as_ref(),
+                parsed_stats_schema,
                 stats_schema.as_ref(),
                 "{table}: parsed stats available, schema echoed"
             ),
@@ -337,6 +343,17 @@ mod tests {
                 parsed_stats_schema.is_none(),
                 "{table}: no compatible stats"
             ),
+        }
+
+        let needs_leaf_schema = stats_schema.is_some();
+        assert_eq!(
+            shape.leaf_checkpoint_schema.is_some(),
+            needs_leaf_schema && expected_checkpoint != CheckpointType::None,
+            "{table}: retained leaf schema"
+        );
+        if let Some(schema) = &shape.leaf_checkpoint_schema {
+            assert!(schema.contains("add"), "{table}: retained add action");
+            assert!(schema.contains("remove"), "{table}: retained remove action");
         }
     }
 
@@ -356,15 +373,40 @@ mod tests {
         ]))
     }
 
+    #[test]
+    fn incompatible_parsed_stats_schema_is_rejected() {
+        let (_engine, snapshot, _tempdir) =
+            load_test_table("v2-classic-parquet-struct-stats-only").unwrap();
+        let columns =
+            || StructType::new_unchecked([StructField::nullable("value", DataType::LONG)]);
+        let incompatible = Arc::new(StructType::new_unchecked([
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(MIN_VALUES, columns()),
+            StructField::nullable(MAX_VALUES, columns()),
+        ]));
+
+        let shape = CheckpointShape::try_new(&SyncPlanExecutor::default(), snapshot.as_ref(), true)
+            .unwrap();
+
+        assert!(shape
+            .compatible_stats_parsed_schema(&incompatible)
+            .is_none());
+    }
+
     /// Fast path on a manifest hint: one sidecar footer read, no drain (`query_scans == 0`). Guards
     /// against the optimization silently not firing (result-only checks pass via the drain too).
-    #[test]
-    fn fast_path_skips_checkpoint_drain_when_hint_lists_sidecars() {
+    #[rstest]
+    #[case::without_leaf_schema(false, 0)]
+    #[case::with_leaf_schema(true, 1)]
+    fn fast_path_skips_checkpoint_drain_when_hint_lists_sidecars(
+        #[case] needs_leaf_schema: bool,
+        #[case] expected_footer_reads: usize,
+    ) {
         let (_engine, snapshot, _tempdir) =
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), needs_leaf_schema).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -374,16 +416,25 @@ mod tests {
         );
         assert_eq!(
             exec.footer_reads.load(Ordering::Relaxed),
-            1,
-            "fast path footer-reads exactly the hint's first sidecar"
+            expected_footer_reads,
+            "fast path reads the sidecar footer only when its schema is needed"
         );
+        assert_eq!(shape.leaf_checkpoint_schema.is_some(), needs_leaf_schema);
     }
 
-    /// With the hint removed, a JSON manifest must drain the `sidecar` column (`query_scans >= 1`).
-    #[test]
-    fn resolve_json_manifest_via_drain_without_hint() {
-        let (engine, snapshot, _tempdir) =
-            load_test_table("v2-checkpoints-json-with-sidecars").unwrap();
+    /// Without a hint, a manifest must drain the `sidecar` column (`query_scans >= 1`).
+    #[rstest]
+    #[case::json("v2-checkpoints-json-with-sidecars", false)]
+    #[case::parquet("v2-parquet-sidecars-struct-stats-only", true)]
+    fn resolve_manifest_via_drain_without_hint(
+        #[case] table: &str,
+        #[case] expect_parsed_stats: bool,
+    ) {
+        let (table_root, _tempdir) = copy_test_table(table).unwrap();
+        let engine = Arc::new(SyncEngine::new());
+        let snapshot = Snapshot::builder_for(table_root)
+            .build(engine.as_ref())
+            .unwrap();
         // Remove the hint so resolve must drain.
         let hint = snapshot
             .log_segment()
@@ -407,6 +458,12 @@ mod tests {
         assert!(
             exec.query_scans.load(Ordering::Relaxed) >= 1,
             "must drain, not fast-path"
+        );
+        assert_eq!(
+            shape
+                .compatible_stats_parsed_schema(&probe_stats_schema())
+                .is_some(),
+            expect_parsed_stats
         );
     }
 
@@ -452,13 +509,13 @@ mod tests {
     /// requested. `None` here means the hint short-circuited (a fall-through would return `Some`).
     #[rstest]
     // JSON leaf: use the canonical schema without I/O.
-    #[case::json_no_stats("json", false, None, 0)]
-    #[case::json_with_stats("json", true, None, 0)]
-    // Parquet leaf: no stats requested -> no schema read, no parsed stats.
-    #[case::parquet_no_stats("parquet", false, None, 0)]
+    #[case::json_without_leaf_schema("json", false, None, 0)]
+    #[case::json_with_leaf_schema("json", true, None, 0)]
+    // Parquet leaf: schema not retained -> no footer read or parsed stats.
+    #[case::parquet_without_leaf_schema("parquet", false, None, 0)]
     fn empty_sidecars_hint_classifies_leaf_without_drain(
         #[case] extension: &str,
-        #[case] request_stats: bool,
+        #[case] needs_leaf_schema: bool,
         #[case] expect_parsed: Option<bool>,
         #[case] expected_footer_reads: usize,
     ) {
@@ -468,7 +525,7 @@ mod tests {
             "json" => FileType::Json,
             _ => FileType::Parquet,
         };
-        let stats_schema = request_stats.then(probe_stats_schema);
+        let stats_schema = needs_leaf_schema.then(probe_stats_schema);
         let exec = CountingExecutor::new();
 
         let shape = CheckpointShape::from_v2_checkpoint_hint(
@@ -476,13 +533,13 @@ mod tests {
             &segment,
             root,
             file_type,
-            request_stats,
+            needs_leaf_schema,
         )
         .unwrap()
         .expect("an empty-sidecars hint must classify without falling through");
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Leaf);
-        if file_type == FileType::Json && request_stats {
+        if file_type == FileType::Json && needs_leaf_schema {
             assert_eq!(
                 shape.leaf_checkpoint_schema.as_ref(),
                 Some(&*LEAF_CHECKPOINT_ACTIONS_SCHEMA)

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -39,13 +39,29 @@ pub(crate) struct CheckpointShape {
 }
 
 impl CheckpointShape {
-    /// Resolves `snapshot`'s checkpoint topology. When `needs_leaf_schema` is true, also loads and
-    /// retains the schema of the files containing leaf actions. Schema retention does not affect
-    /// checkpoint classification.
+    /// Resolves `snapshot`'s checkpoint topology without retaining the leaf-action schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
     pub(crate) fn try_new(
+        exec: &dyn PlanExecutor,
+        snapshot: &Snapshot,
+    ) -> DeltaResult<CheckpointShape> {
+        Self::try_new_impl(exec, snapshot, false)
+    }
+
+    /// Resolves `snapshot`'s checkpoint topology and retains the leaf-action schema.
+    ///
+    /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
+    /// read.
+    pub(crate) fn try_new_with_leaf_schema(
+        exec: &dyn PlanExecutor,
+        snapshot: &Snapshot,
+    ) -> DeltaResult<CheckpointShape> {
+        Self::try_new_impl(exec, snapshot, true)
+    }
+
+    fn try_new_impl(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
         needs_leaf_schema: bool,
@@ -315,8 +331,12 @@ mod tests {
         let exec = SyncPlanExecutor::default();
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
 
-        let shape =
-            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.is_some()).unwrap();
+        let shape = if stats_schema.is_some() {
+            CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref())
+        } else {
+            CheckpointShape::try_new(&exec, snapshot.as_ref())
+        }
+        .unwrap();
         let parsed_stats_schema = stats_schema
             .as_ref()
             .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
@@ -385,8 +405,11 @@ mod tests {
             StructField::nullable(MAX_VALUES, columns()),
         ]));
 
-        let shape = CheckpointShape::try_new(&SyncPlanExecutor::default(), snapshot.as_ref(), true)
-            .unwrap();
+        let shape = CheckpointShape::try_new_with_leaf_schema(
+            &SyncPlanExecutor::default(),
+            snapshot.as_ref(),
+        )
+        .unwrap();
 
         assert!(shape
             .compatible_stats_parsed_schema(&incompatible)
@@ -406,7 +429,12 @@ mod tests {
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), needs_leaf_schema).unwrap();
+        let shape = if needs_leaf_schema {
+            CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref())
+        } else {
+            CheckpointShape::try_new(&exec, snapshot.as_ref())
+        }
+        .unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -452,7 +480,7 @@ mod tests {
             .unwrap();
 
         let exec = CountingExecutor::new();
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
+        let shape = CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref()).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert!(

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,6 +1187,12 @@ impl From<Predicate> for Expression {
     }
 }
 
+impl From<Predicate> for Option<PredicateRef> {
+    fn from(value: Predicate) -> Self {
+        Some(Arc::new(value))
+    }
+}
+
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,12 +1187,6 @@ impl From<Predicate> for Expression {
     }
 }
 
-impl From<Predicate> for Option<PredicateRef> {
-    fn from(value: Predicate) -> Self {
-        Some(Arc::new(value))
-    }
-}
-
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1087,11 +1087,14 @@ impl Scan {
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
         // leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
-        let needs_leaf_schema = self.stats.synthesize_json
+        let shape = if self.stats.synthesize_json
             || self.state_info.physical_stats_schema.is_some()
-            || self.partition_values.parsed_struct;
-        let shape =
-            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot, needs_leaf_schema)?;
+            || self.partition_values.parsed_struct
+        {
+            CheckpointShape::try_new_with_leaf_schema(plan_executor.as_ref(), &self.snapshot)?
+        } else {
+            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot)?
+        };
         self.build_metadata_scan_plan(&shape)
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,14 +1084,14 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
-        // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
-        // whether the checkpoint carries a compatible parsed-stats column.
+        // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
+        // leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
-        let shape = CheckpointShape::try_new(
-            plan_executor.as_ref(),
-            &self.snapshot,
-            self.state_info.physical_stats_schema.as_ref(),
-        )?;
+        let needs_leaf_schema = self.stats.synthesize_json
+            || self.state_info.physical_stats_schema.is_some()
+            || self.partition_values.parsed_struct;
+        let shape =
+            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot, needs_leaf_schema)?;
         self.build_metadata_scan_plan(&shape)
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,8 +1084,11 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
+        if self.state_info.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
-        // leaf schema when output or pruning requires checkpoint-specific columns.
+        // checkpoint leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
         let shape = if self.stats.synthesize_json
             || self.state_info.physical_stats_schema.is_some()

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,7 +1084,6 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
-        let log_segment = self.snapshot.log_segment();
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
         let plan_executor = engine.require_plan_executor()?;
@@ -1093,14 +1092,7 @@ impl Scan {
             &self.snapshot,
             self.state_info.physical_stats_schema.as_ref(),
         )?;
-        scan_plan::build_metadata_scan_plan(
-            &self.state_info,
-            log_segment,
-            &shape,
-            &self.stats,
-            &self.partition_values,
-            self.physical_stats_output_schema.as_ref(),
-        )
+        self.build_metadata_scan_plan(&shape)
     }
 
     // Factored out to facilitate testing

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -1,7 +1,7 @@
 //! Declarative metadata scan plans.
 //!
-//! [`build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds, applying
-//! metadata pruning before newest-action-wins replay.
+//! [`Scan::build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds,
+//! applying metadata pruning before newest-action-wins replay.
 
 use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::data_skipping::as_sql_data_skipping_predicate_with_stats_columns;
 use super::state_info::StateInfo;
-use super::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
+use super::{PhysicalPredicate, Scan};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{
     ADD_FIELD, ADD_NAME, ADD_SCHEMA, REMOVE_FIELD, SIDECAR_FIELD, SIDECAR_NAME, STATS_PARSED,
@@ -19,7 +19,6 @@ use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
 };
-use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::{FileType, Load, LoadColumnFileMeta, ScanFile};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
@@ -45,41 +44,30 @@ const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
 const IS_ADD: &str = "is_add";
 const VERSION: &str = "version";
 
-/// Build the live-add metadata plan from checkpoint and commit actions.
-///
-/// Returns `None` for an empty result or a statically false predicate.
-pub(crate) fn build_metadata_scan_plan(
-    state: &StateInfo,
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<Option<Plan>> {
-    // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
-    if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
-        return Ok(None);
-    }
+impl Scan {
+    /// Build the live-add metadata plan from checkpoint and commit actions.
+    ///
+    /// Returns `None` for an empty result or a statically false predicate.
+    pub(super) fn build_metadata_scan_plan(
+        &self,
+        shape: &CheckpointShape,
+    ) -> DeltaResult<Option<Plan>> {
+        let state = &self.state_info;
+        // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
+        if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
 
-    let stats_schema = state.physical_stats_schema.as_ref();
-    let partition_schema = state.physical_partition_schema.as_ref();
-    let prune = stats_skipping_predicate(state);
-    let prune = prune.as_ref();
+        let prune = stats_skipping_predicate(state);
+        let prune = prune.as_ref();
 
-    // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's dedup
-    // carrier and both terminal `{ add }` projections, so every arm agrees on the union schema.
-    let add_field = add_field_with_parsed_stats_and_partitions(stats_schema, partition_schema)?;
-    let (output_expr, output_schema) = metadata_output_projection(
-        &add_field,
-        stats,
-        partition_values,
-        partition_schema,
-        physical_stats_output_schema,
-    )?;
+        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
+        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
+        // union schema.
+        let add_field = self.normalized_add_field()?;
+        let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
-    let commit_actions = commit_arm(log_segment, stats_schema, partition_schema)?.try_fold_with(
-        prune,
-        |p, prune| {
+        let commit_actions = self.commit_arm()?.try_fold_with(prune, |p, prune| {
             // We filter so that:
             // * All remove actions are kept
             // * Add actions that do not match the partition pruning or stats predicate are removed.
@@ -95,155 +83,155 @@ pub(crate) fn build_metadata_scan_plan(
             // `remove.partitionValues` being NULL, or it may be from `partCol` being
             // NULL. Thus, we simply do not prune removes.
             p.filter(Predicate::or(col!("add").is_null(), prune.clone()))
-        },
-    )?;
+        })?;
 
-    let deduped_commit = commit_actions
-        // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
-        // after aggregation.
-        .project_patch(|patch| {
-            patch.replace(
-                ADD_NAME,
-                StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
-                Expr::struct_from([col!("add")]),
-            )
-        })?
-        .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
-            a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
-        })?
-        // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
-        .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
+        let deduped_commit = commit_actions
+            // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
+            // after aggregation.
+            .project_patch(|patch| {
+                patch.replace(
+                    ADD_NAME,
+                    StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
+                    Expr::struct_from([col!("add")]),
+                )
+            })?
+            .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
+                a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
+            })?
+            // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
+            .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
 
-    let checkpoint_adds = checkpoint_arm(log_segment, shape, stats_schema, partition_schema)?
-        .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
+        let checkpoint_adds = self
+            .checkpoint_arm(shape)?
+            .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
 
-    let checkpoint_live_adds = checkpoint_adds
-        .anti_join(
-            deduped_commit.clone(),
-            [ColumnName::new([FILE_ACTION_KEY])],
-            [ColumnName::new([FILE_ACTION_KEY])],
-        )?
-        .project(output_expr.clone(), output_schema.clone())?;
+        let checkpoint_live_adds = checkpoint_adds
+            .anti_join(
+                deduped_commit.clone(),
+                [ColumnName::new([FILE_ACTION_KEY])],
+                [ColumnName::new([FILE_ACTION_KEY])],
+            )?
+            .project(output_expr.clone(), output_schema.clone())?;
 
-    let commit_live_adds = deduped_commit
-        .filter(col!("add").is_not_null())?
-        .project(output_expr, output_schema)?;
+        let commit_live_adds = deduped_commit
+            .filter(col!("add").is_not_null())?
+            .project(output_expr, output_schema)?;
 
-    PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
-}
+        PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
+    }
 
-/// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
-///
-/// ## SQL equivalent:
-//
-/// SELECT STRUCT(
-///          add.* EXCEPT (
-///            stats_parsed, partitionValues_parsed
-///          ),
-///          add.stats_parsed AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
-/// FROM checkpoint_actions
-/// WHERE add.path IS NOT NULL
-///
-/// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
-/// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
-fn checkpoint_arm(
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let source_stats_schema = shape.parsed_stats_schema.as_ref();
-    let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
+    /// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
+    ///
+    /// ## SQL equivalent:
+    //
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (
+    ///            stats_parsed, partitionValues_parsed
+    ///          ),
+    ///          add.stats_parsed AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
+    /// FROM checkpoint_actions
+    /// WHERE add.path IS NOT NULL
+    ///
+    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
+    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
-    let actions = match (&shape.checkpoint_type, checkpoint) {
-        (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            PlanBuilder::scan_parquet(parts, &[VERSION], schema)
-        }
-        (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
-            PlanBuilder::scan_json(
-                parts,
-                &[VERSION],
-                json_read_schema(/* include_remove */ false),
-            )
-        }
-        (CheckpointType::Manifest, Some((file_type, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
-                // Without a complete hint, load the sidecars referenced by the manifest.
-                None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+        let actions = match (&shape.checkpoint_type, checkpoint) {
+            (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
-        }
-        (CheckpointType::None, _) | (_, None) => {
-            PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
-        }
-    }?;
+            (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
+                PlanBuilder::scan_json(
+                    parts,
+                    &[VERSION],
+                    json_read_schema(/* include_remove */ false),
+                )
+            }
+            (CheckpointType::Manifest, Some((file_type, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
+                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    // Without a complete hint, load the sidecars referenced by the manifest.
+                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                }
+            }
+            (CheckpointType::None, _) | (_, None) => {
+                PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
+            }
+        }?;
 
-    actions
-        .filter(col!("add.path").is_not_null())?
-        .project_patch(|patch| {
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| joined_column_expr!("add", col)),
-                )
-        })
-}
+        actions
+            .filter(col!("add.path").is_not_null())?
+            .project_patch(|patch| {
+                patch
+                    .with_parsed_add_stats(stats_schema)
+                    .with_parsed_add_partition_values(partition_schema)
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| joined_column_expr!("add", col)),
+                    )
+            })
+    }
 
-/// Build the normalized commit JSON arm.
-///
-/// ## SQL equivalent:
-///
-/// SELECT STRUCT(
-///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
-///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        remove, version, add.path IS NOT NULL AS is_add,
-///        file_key(COALESCE(add, remove)) AS key
-/// FROM json_commits
-/// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
-///
-/// A parsed field is omitted when its schema is absent.
-fn commit_arm(
-    log_segment: &LogSegment,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
-    PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
-        .filter(Predicate::or(
-            col!("add.path").is_not_null(),
-            col!("remove.path").is_not_null(),
-        ))?
-        .project_patch(|patch| {
-            // Commits never carry source-native parsed columns, so normalize from the raw
-            // encodings.
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| {
-                        Expr::coalesce([
-                            joined_column_expr!("add", col),
-                            joined_column_expr!("remove", col),
-                        ])
-                    }),
-                )
-        })
+    /// Build the normalized commit JSON arm.
+    ///
+    /// ## SQL equivalent:
+    ///
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
+    ///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        remove, version, add.path IS NOT NULL AS is_add,
+    ///        file_key(COALESCE(add, remove)) AS key
+    /// FROM json_commits
+    /// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
+    ///
+    /// A parsed field is omitted when its schema is absent.
+    fn commit_arm(&self) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
+        PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
+            .filter(Predicate::or(
+                col!("add.path").is_not_null(),
+                col!("remove.path").is_not_null(),
+            ))?
+            .project_patch(|patch| {
+                // Commits never carry source-native parsed columns, so normalize from the raw
+                // encodings.
+                patch
+                    .with_parsed_add_stats(self.state_info.physical_stats_schema.as_ref())
+                    .with_parsed_add_partition_values(
+                        self.state_info.physical_partition_schema.as_ref(),
+                    )
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| {
+                            Expr::coalesce([
+                                joined_column_expr!("add", col),
+                                joined_column_expr!("remove", col),
+                            ])
+                        }),
+                    )
+            })
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -368,31 +356,23 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 }
 
 trait ProjectionStructPatchBuilderExt<'a> {
-    /// Parses add stats and partition values, preferring compatible parsed fields.
+    /// Parses add stats, preferring a compatible parsed field.
     ///
     /// When `stats_schema` is present, the input must contain either `add.stats_parsed` or the
     /// fallback `add.stats` JSON field.
-    fn with_parsed_add_stats_and_partitions(
-        self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self;
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self;
+
+    /// Parses add partition values, preferring a compatible parsed field.
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
-    fn with_parsed_add_stats_and_partitions(
-        mut self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self {
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self {
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let has_partition_values_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
         let add = [ADD_NAME];
-        self = match stats_schema {
+        match stats_schema {
             Some(ss) => {
                 let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
                 let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
@@ -403,7 +383,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 }
             }
             None => self,
-        };
+        }
+    }
+
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self {
+        let has_partition_values_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let add = [ADD_NAME];
         match partition_schema {
             Some(ps) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
@@ -420,113 +407,111 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
     }
 }
 
-/// The `add` field produced by [`with_parsed_add_stats_and_partitions`].
-fn add_field_with_parsed_stats_and_partitions(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<StructField> {
-    let patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, schema| {
-            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-        })
-        .fold_with(partition_schema, |patch, schema| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                schema.as_ref().clone(),
-            ))
-        });
-    Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-}
+impl Scan {
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
 
-/// Builds the output projection for requested stats and partition values. The base of this
-/// transformation is constructed by [`add_field_with_parsed_stats_and_partitions`].
-///
-/// The output schema is:
-/// ```text
-/// add: struct<
-///   path: string,
-///   partitionValues: map<string, string>,
-///   size: long,
-///   modificationTime: long,
-///   dataChange: boolean,
-///   stats: string,                         // when JSON stats are requested
-///   tags: map<string, string>,
-///   deletionVector: struct<...>,
-///   baseRowId: long,
-///   defaultRowCommitVersion: long,
-///   clusteringProvider: string,
-///   stats_parsed: struct<...>,             // when parsed stats are requested
-///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-/// >
-/// ```
-/// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-/// partition values are selected independently and omitted for unpartitioned tables. Fields needed
-/// only for pruning are omitted.
-fn metadata_output_projection(
-    add_field: &StructField,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    partition_schema: Option<&SchemaRef>,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-    let input_schema = schema_ref! { (add_field.clone()) };
-    let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-    let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
 
-    // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-    let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-    let projection = match (stats.synthesize_json, has_json_stats) {
-        (true, true) | (false, false) => projection,
-        (true, false) => {
-            return Err(Error::internal_error(
-                "JSON stats were requested, but add.stats is missing from the metadata schema",
-            ));
-        }
-        (false, true) => projection.drop(STATS),
-    };
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
 
-    // Parsed stats output.
-    let projection = match (physical_stats_output_schema, has_stats_parsed) {
-        (Some(stats_schema), _) => projection.replace(
-            STATS_PARSED,
-            StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-            project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-        ),
-        (None, true) => projection.drop(STATS_PARSED),
-        (None, false) => projection,
-    };
-
-    // Parsed partition-values output.
-    let has_partition_values_parsed =
-        input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-    let partition_output_schema = partition_values
-        .parsed_struct
-        .then_some(partition_schema)
-        .flatten();
-    let projection = match (partition_output_schema, has_partition_values_parsed) {
-        (Some(partition_schema), true) => projection.replace(
-            PARTITION_VALUES_PARSED,
-            StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-            project_nested_struct_to_schema(
-                [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                partition_schema,
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
             ),
-        ),
-        (Some(_), false) => {
-            return Err(Error::internal_error(
-                "parsed partition values were requested, but add.partitionValues_parsed is \
-                 missing",
-            ));
-        }
-        (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-        (None, false) => projection,
-    };
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
 
-    let (add_schema, add_expr) = projection.build()?;
-    let schema = schema_ref! {
-        (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-    };
-    Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Rebuilds `root` to match a narrowed schema while preserving a null parent struct. A direct
@@ -601,47 +586,41 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::actions::{Metadata, Protocol};
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::lit;
+    use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::plans::ir::nodes::Operator;
     use crate::plans::Operation as PlanOperation;
-    use crate::scan::state_info::tests::get_state_info_with_options;
     use crate::scan::{PartitionValuesOptions, StatsOptions};
     use crate::schema::StructType;
+    use crate::snapshot::Snapshot;
+    use crate::table_configuration::TableConfiguration;
     use crate::unit_test_utils::create_log_path;
     use crate::Engine as _;
 
-    fn state(
-        schema: SchemaRef,
-        partition_columns: Vec<String>,
-        predicate: Option<Predicate>,
-        stats: StatsOptions,
-        partition_values: PartitionValuesOptions,
-    ) -> StateInfo {
-        get_state_info_with_options(
-            schema,
-            partition_columns,
-            predicate.map(Arc::new),
-            &[],
+    fn mock_snapshot(log_segment: LogSegment) -> DeltaResult<Arc<Snapshot>> {
+        let metadata = Metadata::try_new(
+            None,
+            None,
+            partitioned_schema(),
+            vec!["p".to_string()],
+            0,
             HashMap::new(),
-            vec![],
-            stats,
-            partition_values,
-        )
-        .expect("state info")
-    }
-
-    fn data_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "x",
-            DataType::LONG,
-        )]))
+        )?;
+        let table_configuration = TableConfiguration::try_new(
+            metadata,
+            Protocol::try_new_legacy(2, 5)?,
+            Url::parse("memory:///")?,
+            0,
+        )?;
+        Ok(Arc::new(Snapshot::new(log_segment, table_configuration)?))
     }
 
     fn partitioned_schema() -> SchemaRef {
@@ -800,15 +779,18 @@ mod tests {
     }
 
     fn struct_stats_schema() -> SchemaRef {
-        state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(5i64))),
-            StatsOptions::all(),
-            PartitionValuesOptions::default(),
-        )
-        .physical_stats_schema
-        .expect("stats schema")
+        let segment = log_segment(log_root(), &[], None);
+        mock_snapshot(segment)
+            .unwrap()
+            .scan_builder()
+            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_stats(StatsOptions::all())
+            .build()
+            .unwrap()
+            .state_info
+            .physical_stats_schema
+            .clone()
+            .expect("stats schema")
     }
 
     // Commit-arm operator sequence without optional pruning.
@@ -835,29 +817,13 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             Some(checkpoint_path(file_type)),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
 
         let mut expected: Vec<&str> = COMMIT_ARM_TAGS.to_vec();
         expected.extend(checkpoint_arm_tags);
@@ -875,23 +841,15 @@ mod tests {
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
         let partition_values = PartitionValuesOptions::with_struct();
-        let state = state(
-            partitioned_schema(),
-            vec!["p".to_string()],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Manifest, parsed_stats),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(stats)
+            .with_partition_values(partition_values)
+            .build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .expect("non-empty");
 
         let load = plan
             .nodes
@@ -916,29 +874,15 @@ mod tests {
 
     #[test]
     fn metadata_plan_commits_only() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
         assert_eq!(tags(&plan), COMMIT_ARM_TAGS.to_vec());
         Ok(())
     }
@@ -953,75 +897,35 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(file_type)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
         assert_eq!(tags(&plan), checkpoint_arm_tags);
         Ok(())
     }
 
     #[test]
     fn metadata_plan_empty_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        assert!(scan.build_metadata_scan_plan(&no_checkpoint())?.is_none());
         Ok(())
     }
 
     #[test]
     fn metadata_plan_static_skip_all_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(Predicate::literal(false)),
-            stats.clone(),
-            partition_values.clone(),
-        );
-        assert_eq!(state.physical_predicate, PhysicalPredicate::StaticSkipAll);
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_predicate(Predicate::literal(false))
+            .build()?;
+        assert_eq!(
+            scan.state_info.physical_predicate,
+            PhysicalPredicate::StaticSkipAll
+        );
+        assert!(scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .is_none());
         Ok(())
     }
 
@@ -1049,15 +953,6 @@ mod tests {
             DeltaResult::<()>::Ok(())
         })?;
 
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[
@@ -1066,15 +961,10 @@ mod tests {
             ],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
@@ -1117,30 +1007,20 @@ mod tests {
         // `stats_parsed` column.
         write_parquet_checkpoint(&store, "_delta_log/00000000000000000000.checkpoint.parquet")?;
 
-        let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(lower_bound))),
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[],
             Some("memory:///_delta_log/00000000000000000000.checkpoint.parquet"),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(StatsOptions::all())
+            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .build()?;
+        let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -136,12 +136,13 @@ impl Scan {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
         let physical_partitions = self.state_info.physical_partition_schema.as_ref();
-        let source_physical_stats = shape.parsed_stats_schema.as_ref();
+        let source_physical_stats =
+            physical_stats.and_then(|schema| shape.compatible_stats_parsed_schema(schema));
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -152,7 +153,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -661,9 +662,12 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
+        let leaf_checkpoint_schema = parsed_stats
+            .as_ref()
+            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
         CheckpointShape {
             checkpoint_type,
-            parsed_stats_schema: parsed_stats,
+            leaf_checkpoint_schema,
         }
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -147,7 +147,7 @@ impl Scan {
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
+                let schema = parquet_read_schema(source_stats_schema, None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -158,7 +158,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
+                let schema = parquet_read_schema(source_stats_schema, None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -141,12 +141,13 @@ impl Scan {
         let log_segment = self.snapshot.log_segment();
         let stats_schema = self.state_info.physical_stats_schema.as_ref();
         let partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let source_stats_schema = stats_schema
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -157,7 +158,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -669,9 +670,12 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
+        let leaf_checkpoint_schema = parsed_stats
+            .as_ref()
+            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
         CheckpointShape {
             checkpoint_type,
-            parsed_stats_schema: parsed_stats,
+            leaf_checkpoint_schema,
         }
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -232,6 +232,111 @@ impl Scan {
                     )
             })
     }
+
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
+
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
+
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
+            ),
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
+
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -404,113 +509,6 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             }
             None => self,
         }
-    }
-}
-
-impl Scan {
-    fn normalized_add_field(&self) -> DeltaResult<StructField> {
-        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let patch = SchemaStructPatchBuilder::new()
-            .fold_with(physical_stats_schema, |patch, schema| {
-                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            })
-            .fold_with(physical_partition_schema, |patch, schema| {
-                patch.append(StructField::nullable(
-                    PARTITION_VALUES_PARSED,
-                    schema.as_ref().clone(),
-                ))
-            });
-        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-    }
-
-    /// Builds the output projection for requested stats and partition values. The base of this
-    /// transformation is constructed by [`Self::normalized_add_field`].
-    ///
-    /// The output schema is:
-    /// ```text
-    /// add: struct<
-    ///   path: string,
-    ///   partitionValues: map<string, string>,
-    ///   size: long,
-    ///   modificationTime: long,
-    ///   dataChange: boolean,
-    ///   stats: string,                         // when JSON stats are requested
-    ///   tags: map<string, string>,
-    ///   deletionVector: struct<...>,
-    ///   baseRowId: long,
-    ///   defaultRowCommitVersion: long,
-    ///   clusteringProvider: string,
-    ///   stats_parsed: struct<...>,             // when parsed stats are requested
-    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-    /// >
-    /// ```
-    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-    /// partition values are selected independently and omitted for unpartitioned tables. Fields
-    /// needed only for pruning are omitted.
-    fn metadata_output_projection(
-        &self,
-        add_field: &StructField,
-    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-        let input_schema = schema_ref! { (add_field.clone()) };
-        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
-
-        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-        let projection = match (self.stats.synthesize_json, has_json_stats) {
-            (true, true) | (false, false) => projection,
-            (true, false) => {
-                return Err(Error::internal_error(
-                    "JSON stats were requested, but add.stats is missing from the metadata schema",
-                ));
-            }
-            (false, true) => projection.drop(STATS),
-        };
-
-        // Parsed stats output.
-        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
-            (Some(stats_schema), _) => projection.replace(
-                STATS_PARSED,
-                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-            ),
-            (None, true) => projection.drop(STATS_PARSED),
-            (None, false) => projection,
-        };
-
-        // Parsed partition-values output.
-        let has_partition_values_parsed =
-            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let partition_output_schema = self
-            .partition_values
-            .parsed_struct
-            .then_some(self.state_info.physical_partition_schema.as_ref())
-            .flatten();
-        let projection = match (partition_output_schema, has_partition_values_parsed) {
-            (Some(partition_schema), true) => projection.replace(
-                PARTITION_VALUES_PARSED,
-                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-                project_nested_struct_to_schema(
-                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                    partition_schema,
-                ),
-            ),
-            (Some(_), false) => {
-                return Err(Error::internal_error(
-                    "parsed partition values were requested, but add.partitionValues_parsed is \
-                     missing",
-                ));
-            }
-            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-            (None, false) => projection,
-        };
-
-        let (add_schema, add_expr) = projection.build()?;
-        let schema = schema_ref! {
-            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-        };
-        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
     }
 }
 
@@ -783,7 +781,7 @@ mod tests {
         mock_snapshot(segment)
             .unwrap()
             .scan_builder()
-            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_predicate(Arc::new(col!("x").gt(lit(5i64))))
             .with_stats(StatsOptions::all())
             .build()
             .unwrap()
@@ -917,7 +915,7 @@ mod tests {
         let segment = log_segment(log_root(), &[], None);
         let scan = mock_snapshot(segment)?
             .scan_builder()
-            .with_predicate(Predicate::literal(false))
+            .with_predicate(Arc::new(Predicate::literal(false)))
             .build()?;
         assert_eq!(
             scan.state_info.physical_predicate,
@@ -1015,7 +1013,7 @@ mod tests {
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(StatsOptions::all())
-            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .with_predicate(Arc::new(col!("x").gt(lit(lower_bound))))
             .build()?;
         let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -142,7 +142,7 @@ impl Scan {
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -153,7 +153,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -1068,21 +1068,32 @@ fn assert_declarative_metadata_matches_imperative(
     assert_metadata_eq(&actual, &expected, table.description())
 }
 
-#[test]
-fn test_declarative_metadata_scan_plan_no_executor_returns_unsupported() -> DeltaResult<()> {
+#[rstest]
+#[case::requires_executor(None, true)]
+#[case::static_skip_all(Some(Pred::FALSE), false)]
+fn declarative_metadata_scan_plan_requires_executor_unless_statically_skipped(
+    #[case] predicate: Option<Pred>,
+    #[case] requires_executor: bool,
+) -> DeltaResult<()> {
     let table = TestTableBuilder::new()
         .with_log_state(LogState::with_latest_version(4).with_checkpoint_at([2]))
         .build()
         .expect("build checkpoint-plus-commits table");
     let sync_engine = Arc::new(SyncEngine::new_with_store(table.store().clone()));
     let snapshot = Snapshot::builder_for(table.table_root()).build(sync_engine.as_ref())?;
-    let scan = snapshot.scan_builder().build()?;
+    let builder = snapshot.scan_builder();
+    let builder = match predicate {
+        Some(predicate) => builder.with_predicate(Arc::new(predicate)),
+        None => builder,
+    };
+    let scan = builder.build()?;
 
     let no_plan_engine = DelegatingEngine::new(sync_engine).without_plan_executor();
-    let err = scan
-        .declarative_metadata_scan_plan(&no_plan_engine)
-        .unwrap_err();
-
-    assert!(matches!(err, crate::Error::Unsupported(_)));
+    let result = scan.declarative_metadata_scan_plan(&no_plan_engine);
+    if requires_executor {
+        assert!(matches!(result, Err(crate::Error::Unsupported(_))));
+    } else {
+        assert!(result?.is_none());
+    }
     Ok(())
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3044/files) to review incremental changes.
- [stack/scan_plan_options](https://github.com/delta-io/delta-kernel-rs/pull/3015) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3015/files)] [MERGED]
  - [stack/scan_plan_refactor](https://github.com/delta-io/delta-kernel-rs/pull/3039) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3039/files)] [MERGED]
    - [**stack/scan_plan_checkpoint_shape**](https://github.com/delta-io/delta-kernel-rs/pull/3044) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3044/files)] ← _this PR_
      - [stack/scan_plan_stats_json](https://github.com/delta-io/delta-kernel-rs/pull/3045) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3045/files/2119ae63b34078f7fa7714aecdc454f6350fafdf..464819dd5654edeff5c27025327616217ba11a41)]

---------
## What changes are proposed in this pull request?

Retain the effective leaf-action schema in `CheckpointShape`. For manifest checkpoints this is the sidecar schema; for leaf checkpoints it is the checkpoint schema. Schema discovery is skipped when no checkpoint-specific fields are needed.

Consumers can use the retained schema to validate parsed stats without coupling checkpoint discovery to a particular requested stats schema.

## How was this change tested?

- Checkpoint-shape unit coverage for V1, V2, multipart, inline, and sidecar checkpoints
- `cargo test -p delta_kernel --lib --all-features`
- Workspace clippy and documentation checks
