### PR TITLE
fix: synthesize JSON stats from parsed checkpoint stats

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -202,6 +202,18 @@ static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     ..(checkpoint_action_field()),
 };
 
+/// Schema for actions stored in a leaf checkpoint.
+#[internal_api]
+pub(crate) static LEAF_CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    ..(checkpoint_action_field()),
+};
+
 static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     (&ADD_FIELD),
     (&REMOVE_FIELD),

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -204,6 +204,18 @@ static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     ..(checkpoint_action_field()),
 };
 
+/// Schema for actions stored in a leaf checkpoint.
+#[internal_api]
+pub(crate) static LEAF_CHECKPOINT_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    (&ADD_FIELD),
+    (&REMOVE_FIELD),
+    (&METADATA_FIELD),
+    (&PROTOCOL_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    ..(checkpoint_action_field()),
+};
+
 static ALL_ACTIONS_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     (&ADD_FIELD),
     (&REMOVE_FIELD),

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -10,15 +10,17 @@
 // No in-crate caller yet; following PRs will use this.
 #![allow(dead_code)]
 
+use std::sync::Arc;
+
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME};
+use crate::actions::{ADD_NAME, LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME, STATS_PARSED};
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
-use crate::schema::SchemaRef;
+use crate::schema::{DataType, SchemaRef, StructField};
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, FileMeta};
 
@@ -194,6 +196,31 @@ impl CheckpointShape {
         }
     }
 
+    fn add_field(&self, name: &str) -> Option<&StructField> {
+        let DataType::Struct(add) = self
+            .leaf_checkpoint_schema
+            .as_ref()?
+            .field(ADD_NAME)?
+            .data_type()
+        else {
+            return None;
+        };
+        add.field(name)
+    }
+
+    /// Whether the checkpoint contains JSON-encoded stats.
+    pub(crate) fn has_json_stats(&self) -> bool {
+        self.add_field("stats").is_some()
+    }
+
+    /// Return the checkpoint's complete native parsed-stats schema.
+    pub(crate) fn stats_parsed_schema(&self) -> Option<SchemaRef> {
+        let DataType::Struct(stats) = self.add_field(STATS_PARSED)?.data_type() else {
+            return None;
+        };
+        Some(Arc::new(stats.as_ref().clone()))
+    }
+
     /// Return `stats_schema` when the checkpoint has compatible parsed stats.
     pub(crate) fn compatible_stats_parsed_schema<'a>(
         &self,
@@ -205,6 +232,22 @@ impl CheckpointShape {
                 LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
             })
             .then_some(stats_schema)
+    }
+
+    /// Return `partition_schema` when the checkpoint has compatible parsed partition values.
+    pub(crate) fn compatible_partition_values_parsed_schema(
+        &self,
+        partition_schema: &SchemaRef,
+    ) -> Option<SchemaRef> {
+        self.leaf_checkpoint_schema
+            .as_ref()
+            .filter(|checkpoint_schema| {
+                LogSegment::schema_has_compatible_partition_values_parsed(
+                    checkpoint_schema,
+                    partition_schema,
+                )
+            })
+            .map(|_| partition_schema.clone())
     }
 }
 

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -1,6 +1,10 @@
-//! Resolves a checkpoint shape. This falls into the following cases: no checkpoint,
-//! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
-//! When requested, also retains the schema of the files containing leaf actions.
+//! Resolves a checkpoint shape:
+//! - A single-part checkpoint has one checkpoint leaf storing file actions (`add` and `remove`).
+//! - A multipart checkpoint has one checkpoint leaf per checkpoint part.
+//! - A manifest checkpoint has sidecars as its checkpoint leaves.
+//!
+//! A checkpoint leaf directly stores file actions. When requested, this module also retains the
+//! checkpoint leaf schema.
 //! Driven through a [`PlanExecutor`].
 
 // No in-crate caller yet; following PRs will use this.
@@ -29,17 +33,17 @@ pub(crate) enum CheckpointType {
     Manifest,
 }
 
-/// A snapshot's resolved checkpoint type and leaf-action schema.
+/// A snapshot's resolved checkpoint type and checkpoint leaf schema.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CheckpointShape {
     /// What kind of checkpoint this is.
     pub(crate) checkpoint_type: CheckpointType,
-    /// Schema of the files containing leaf actions, when requested.
+    /// Schema of the checkpoint leaves, when requested.
     pub(crate) leaf_checkpoint_schema: Option<SchemaRef>,
 }
 
 impl CheckpointShape {
-    /// Resolves `snapshot`'s checkpoint topology without retaining the leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology without retaining the checkpoint leaf schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
@@ -50,7 +54,7 @@ impl CheckpointShape {
         Self::try_new_impl(exec, snapshot, false)
     }
 
-    /// Resolves `snapshot`'s checkpoint topology and retains the leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology and retains the checkpoint leaf schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
@@ -142,7 +146,7 @@ impl CheckpointShape {
             }
             Some([]) => {
                 // A parquet leaf's actions live in its own schema; read it only when requested.
-                // JSON leaves use the canonical JSON action schema.
+                // JSON checkpoint leaves use the canonical JSON action schema.
                 let leaf_schema = match file_type {
                     FileType::Parquet if needs_leaf_schema => {
                         Some(match segment.checkpoint_hint_schema() {
@@ -152,7 +156,8 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                // JSON leaves have no footer, so we assume it has the widest checkpoint schema.
+                // JSON checkpoint leaves have no footer, so use the canonical checkpoint leaf
+                // schema.
                 let leaf_schema = leaf_schema.or_else(|| {
                     (needs_leaf_schema && file_type == FileType::Json)
                         .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())
@@ -369,7 +374,7 @@ mod tests {
         assert_eq!(
             shape.leaf_checkpoint_schema.is_some(),
             needs_leaf_schema && expected_checkpoint != CheckpointType::None,
-            "{table}: retained leaf schema"
+            "{table}: checkpoint leaf schema"
         );
         if let Some(schema) = &shape.leaf_checkpoint_schema {
             assert!(schema.contains("add"), "{table}: retained add action");

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -233,22 +233,6 @@ impl CheckpointShape {
             })
             .then_some(stats_schema)
     }
-
-    /// Return `partition_schema` when the checkpoint has compatible parsed partition values.
-    pub(crate) fn compatible_partition_values_parsed_schema(
-        &self,
-        partition_schema: &SchemaRef,
-    ) -> Option<SchemaRef> {
-        self.leaf_checkpoint_schema
-            .as_ref()
-            .filter(|checkpoint_schema| {
-                LogSegment::schema_has_compatible_partition_values_parsed(
-                    checkpoint_schema,
-                    partition_schema,
-                )
-            })
-            .map(|_| partition_schema.clone())
-    }
 }
 
 /// Read the checkpoint `file`'s `sidecar` column, returning the first referenced sidecar's

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -136,7 +136,7 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                // JSON leaves have no footer, but always use the full canonical action schema.
+                // JSON leaves have no footer, so we assume it has the widest checkpoint schema.
                 let leaf_schema = leaf_schema.or_else(|| {
                     (needs_leaf_schema && file_type == FileType::Json)
                         .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -1,6 +1,6 @@
 //! Resolves a checkpoint shape. This falls into the following cases: no checkpoint,
 //! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
-//! When stats are requested, also reports whether the checkpoint has compatible parsed stats.
+//! When requested, also retains the schema of the files containing leaf actions.
 //! Driven through a [`PlanExecutor`].
 
 // No in-crate caller yet; following PRs will use this.
@@ -9,7 +9,7 @@
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::SIDECAR_NAME;
+use crate::actions::{LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME};
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
@@ -29,23 +29,21 @@ pub(crate) enum CheckpointType {
     Manifest,
 }
 
-/// A snapshot's resolved checkpoint type and parsed-stats schema.
+/// A snapshot's resolved checkpoint type and leaf-action schema.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CheckpointShape {
     /// What kind of checkpoint this is.
     pub(crate) checkpoint_type: CheckpointType,
-    /// The requested stats schema when the checkpoint has a compatible `add.stats_parsed` struct
-    /// to read it from; `None` when stats were not requested or no compatible parsed stats exist.
-    pub(crate) parsed_stats_schema: Option<SchemaRef>,
+    /// Schema of the files containing leaf actions, when requested.
+    pub(crate) leaf_checkpoint_schema: Option<SchemaRef>,
 }
 
 impl CheckpointShape {
-    /// Resolve `snapshot`'s checkpoint shape. Determines the checkpoint type and, when
-    /// `stats_schema` is `Some`, whether the checkpoint contains parsed stats compatible with it.
+    /// Resolve `snapshot`'s checkpoint shape and optionally retain its leaf-action schema.
     pub(crate) fn try_new(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<CheckpointShape> {
         let segment = snapshot.log_segment();
 
@@ -55,16 +53,20 @@ impl CheckpointShape {
             None => {
                 return Ok(CheckpointShape {
                     checkpoint_type: CheckpointType::None,
-                    parsed_stats_schema: None,
+                    leaf_checkpoint_schema: None,
                 })
             }
         };
 
         // Classify from a V2 checkpoint's `_last_checkpoint` hint when possible, else inspect the
         // file.
-        if let Some(shape) =
-            Self::from_v2_checkpoint_hint(exec, segment, root_checkpoint, file_type, stats_schema)?
-        {
+        if let Some(shape) = Self::from_v2_checkpoint_hint(
+            exec,
+            segment,
+            root_checkpoint,
+            file_type,
+            needs_leaf_schema,
+        )? {
             return Ok(shape);
         }
 
@@ -77,22 +79,23 @@ impl CheckpointShape {
                 };
                 // No `sidecar` column means the file actions are inline, so this is a leaf.
                 if !cp_schema.contains(SIDECAR_NAME) {
-                    return Ok(Self::try_new_leaf(Some(cp_schema), stats_schema));
+                    return Ok(Self::new_leaf(needs_leaf_schema.then_some(cp_schema)));
                 }
                 // The `sidecar` column may still be all-null (not a manifest), so scan it to
                 // confirm whether a sidecar is actually present.
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(Some(cp_schema), stats_schema)),
+                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, needs_leaf_schema),
+                    None => Ok(Self::new_leaf(needs_leaf_schema.then_some(cp_schema))),
                 }
             }
             // A JSON checkpoint has no footer schema to inspect, so try to collect a sidecar to
-            // decide if it is a manifest or a leaf. A JSON leaf has no readable schema,
-            // hence no parsed stats.
+            // decide if it is a manifest or a leaf.
             FileType::Json => {
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(None, stats_schema)),
+                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, needs_leaf_schema),
+                    None => Ok(Self::new_leaf(
+                        needs_leaf_schema.then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone()),
+                    )),
                 }
             }
         }
@@ -108,19 +111,19 @@ impl CheckpointShape {
         segment: &LogSegment,
         root_checkpoint: &FileMeta,
         file_type: FileType,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<Option<CheckpointShape>> {
         match segment.checkpoint_hint_sidecars().map(Vec::as_slice) {
             Some([sidecar, ..]) => {
                 let sidecar_meta = sidecar.to_filemeta(&segment.log_root)?;
-                let result = Self::try_new_manifest(exec, sidecar_meta, stats_schema)?;
+                let result = Self::try_new_manifest(exec, sidecar_meta, needs_leaf_schema)?;
                 Ok(Some(result))
             }
             Some([]) => {
-                // A parquet leaf's stats live in its own schema; read it only when stats are
-                // requested. A JSON leaf has no readable schema.
+                // A parquet leaf's actions live in its own schema; read it only when requested.
+                // JSON leaves use the canonical JSON action schema.
                 let leaf_schema = match file_type {
-                    FileType::Parquet if stats_schema.is_some() => {
+                    FileType::Parquet if needs_leaf_schema => {
                         Some(match segment.checkpoint_hint_schema() {
                             Some(schema) => schema,
                             None => exec.read_parquet_footer(root_checkpoint.clone())?.schema,
@@ -128,49 +131,54 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                Ok(Some(Self::try_new_leaf(leaf_schema, stats_schema)))
+                // JSON leaves have no footer, but always use the full canonical action schema.
+                let leaf_schema = leaf_schema.or_else(|| {
+                    (needs_leaf_schema && file_type == FileType::Json)
+                        .then(|| LEAF_CHECKPOINT_ACTIONS_SCHEMA.clone())
+                });
+                Ok(Some(Self::new_leaf(leaf_schema)))
             }
             None => Ok(None),
         }
     }
 
-    /// Build the shape for a manifest checkpoint. Its file actions and their stats live in the
-    /// sidecars, so probe a sidecar's (parquet) footer -- but only when stats were requested. All
+    /// Build the shape for a manifest checkpoint. Its file actions live in the sidecars. All
     /// sidecars of a checkpoint share one schema, so probing the first is sufficient.
     fn try_new_manifest(
         exec: &dyn PlanExecutor,
         sidecar: FileMeta,
-        stats_schema: Option<&SchemaRef>,
+        needs_leaf_schema: bool,
     ) -> DeltaResult<CheckpointShape> {
-        let parsed_stats_schema = match stats_schema {
-            Some(stats_schema) => {
-                let footer_schema = exec.read_parquet_footer(sidecar)?.schema;
-                LogSegment::schema_has_compatible_stats_parsed(footer_schema.as_ref(), stats_schema)
-                    .then(|| stats_schema.clone())
-            }
-            None => None,
-        };
+        let leaf_checkpoint_schema = needs_leaf_schema
+            .then(|| {
+                exec.read_parquet_footer(sidecar)
+                    .map(|footer| footer.schema)
+            })
+            .transpose()?;
         Ok(CheckpointShape {
             checkpoint_type: CheckpointType::Manifest,
-            parsed_stats_schema,
+            leaf_checkpoint_schema,
         })
     }
 
-    /// Build the shape for a leaf checkpoint. Its file actions are inline, so `leaf_schema` carries
-    /// their stats (`None` for a JSON leaf, which has no readable footer schema).
-    fn try_new_leaf(
-        leaf_schema: Option<SchemaRef>,
-        stats_schema: Option<&SchemaRef>,
-    ) -> CheckpointShape {
-        let parsed_stats_schema = stats_schema.filter(|stats_schema| {
-            leaf_schema.as_ref().is_some_and(|leaf_schema| {
-                LogSegment::schema_has_compatible_stats_parsed(leaf_schema.as_ref(), stats_schema)
-            })
-        });
+    fn new_leaf(leaf_checkpoint_schema: Option<SchemaRef>) -> CheckpointShape {
         CheckpointShape {
             checkpoint_type: CheckpointType::Leaf,
-            parsed_stats_schema: parsed_stats_schema.cloned(),
+            leaf_checkpoint_schema,
         }
+    }
+
+    /// Return `stats_schema` when the checkpoint has compatible parsed stats.
+    pub(crate) fn compatible_stats_parsed_schema(
+        &self,
+        stats_schema: &SchemaRef,
+    ) -> Option<SchemaRef> {
+        self.leaf_checkpoint_schema
+            .as_ref()
+            .filter(|checkpoint_schema| {
+                LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
+            })
+            .map(|_| stats_schema.clone())
     }
 }
 
@@ -302,7 +310,10 @@ mod tests {
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
 
         let shape =
-            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.as_ref()).unwrap();
+            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.is_some()).unwrap();
+        let parsed_stats_schema = stats_schema
+            .as_ref()
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
 
         assert_eq!(
             shape.checkpoint_type, expected_checkpoint,
@@ -312,19 +323,19 @@ mod tests {
         match expect_parsed {
             // Stats not requested: no parsed-stats schema regardless of the checkpoint.
             None => assert!(
-                shape.parsed_stats_schema.is_none(),
+                parsed_stats_schema.is_none(),
                 "{table}: stats not requested"
             ),
             // Requested with compatible parsed stats: the requested schema is echoed back.
             Some(true) => assert_eq!(
-                shape.parsed_stats_schema.as_ref(),
+                parsed_stats_schema.as_ref(),
                 stats_schema.as_ref(),
                 "{table}: parsed stats available, schema echoed"
             ),
             // Requested but no compatible parsed stats: `None`.
             Some(false) => assert!(
-                shape.parsed_stats_schema.is_none(),
-                "{table}: no compatible parsed stats"
+                parsed_stats_schema.is_none(),
+                "{table}: no compatible stats"
             ),
         }
     }
@@ -353,8 +364,7 @@ mod tests {
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -391,8 +401,7 @@ mod tests {
             .unwrap();
 
         let exec = CountingExecutor::new();
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert!(
@@ -439,10 +448,10 @@ mod tests {
     }
 
     /// An empty-sidecars hint (`Some([])`) classifies as a leaf without inspecting the checkpoint.
-    /// A JSON leaf never reports parsed stats; a parquet leaf reads its schema only when stats are
+    /// A JSON leaf uses the canonical action schema; a parquet leaf reads its schema only when
     /// requested. `None` here means the hint short-circuited (a fall-through would return `Some`).
     #[rstest]
-    // JSON leaf: no readable schema, so never any parsed stats, and never any I/O.
+    // JSON leaf: use the canonical schema without I/O.
     #[case::json_no_stats("json", false, None, 0)]
     #[case::json_with_stats("json", true, None, 0)]
     // Parquet leaf: no stats requested -> no schema read, no parsed stats.
@@ -467,16 +476,22 @@ mod tests {
             &segment,
             root,
             file_type,
-            stats_schema.as_ref(),
+            request_stats,
         )
         .unwrap()
         .expect("an empty-sidecars hint must classify without falling through");
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Leaf);
-        assert_eq!(
-            shape.parsed_stats_schema.is_some(),
-            expect_parsed == Some(true)
-        );
+        if file_type == FileType::Json && request_stats {
+            assert_eq!(
+                shape.leaf_checkpoint_schema.as_ref(),
+                Some(&*LEAF_CHECKPOINT_ACTIONS_SCHEMA)
+            );
+        }
+        let parsed_stats_schema = stats_schema
+            .as_ref()
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
+        assert_eq!(parsed_stats_schema.is_some(), expect_parsed == Some(true));
         assert_eq!(
             exec.query_scans.load(Ordering::Relaxed),
             0,

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -39,7 +39,12 @@ pub(crate) struct CheckpointShape {
 }
 
 impl CheckpointShape {
-    /// Resolve `snapshot`'s checkpoint shape and optionally retain its leaf-action schema.
+    /// Resolves `snapshot`'s checkpoint topology. When `needs_leaf_schema` is true, also loads and
+    /// retains the schema of the files containing leaf actions. Schema retention does not affect
+    /// checkpoint classification.
+    ///
+    /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
+    /// read.
     pub(crate) fn try_new(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
@@ -169,16 +174,16 @@ impl CheckpointShape {
     }
 
     /// Return `stats_schema` when the checkpoint has compatible parsed stats.
-    pub(crate) fn compatible_stats_parsed_schema(
+    pub(crate) fn compatible_stats_parsed_schema<'a>(
         &self,
-        stats_schema: &SchemaRef,
-    ) -> Option<SchemaRef> {
+        stats_schema: &'a SchemaRef,
+    ) -> Option<&'a SchemaRef> {
         self.leaf_checkpoint_schema
             .as_ref()
-            .filter(|checkpoint_schema| {
+            .is_some_and(|checkpoint_schema| {
                 LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
             })
-            .map(|_| stats_schema.clone())
+            .then_some(stats_schema)
     }
 }
 
@@ -222,9 +227,10 @@ mod tests {
     use super::*;
     use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::sync::SyncEngine;
     use crate::plans::{IoOperation, PlanResult};
     use crate::schema::{DataType, StructField, StructType};
-    use crate::unit_test_utils::load_test_table;
+    use crate::unit_test_utils::{copy_test_table, load_test_table};
 
     /// Counts ops by kind and delegates to `SyncPlanExecutor`, to assert which I/O the fast path
     /// performs.
@@ -328,7 +334,7 @@ mod tests {
             ),
             // Requested with compatible parsed stats: the requested schema is echoed back.
             Some(true) => assert_eq!(
-                parsed_stats_schema.as_ref(),
+                parsed_stats_schema,
                 stats_schema.as_ref(),
                 "{table}: parsed stats available, schema echoed"
             ),
@@ -337,6 +343,17 @@ mod tests {
                 parsed_stats_schema.is_none(),
                 "{table}: no compatible stats"
             ),
+        }
+
+        let needs_leaf_schema = stats_schema.is_some();
+        assert_eq!(
+            shape.leaf_checkpoint_schema.is_some(),
+            needs_leaf_schema && expected_checkpoint != CheckpointType::None,
+            "{table}: retained leaf schema"
+        );
+        if let Some(schema) = &shape.leaf_checkpoint_schema {
+            assert!(schema.contains("add"), "{table}: retained add action");
+            assert!(schema.contains("remove"), "{table}: retained remove action");
         }
     }
 
@@ -356,15 +373,40 @@ mod tests {
         ]))
     }
 
+    #[test]
+    fn incompatible_parsed_stats_schema_is_rejected() {
+        let (_engine, snapshot, _tempdir) =
+            load_test_table("v2-classic-parquet-struct-stats-only").unwrap();
+        let columns =
+            || StructType::new_unchecked([StructField::nullable("value", DataType::LONG)]);
+        let incompatible = Arc::new(StructType::new_unchecked([
+            StructField::nullable(NUM_RECORDS, DataType::LONG),
+            StructField::nullable(MIN_VALUES, columns()),
+            StructField::nullable(MAX_VALUES, columns()),
+        ]));
+
+        let shape = CheckpointShape::try_new(&SyncPlanExecutor::default(), snapshot.as_ref(), true)
+            .unwrap();
+
+        assert!(shape
+            .compatible_stats_parsed_schema(&incompatible)
+            .is_none());
+    }
+
     /// Fast path on a manifest hint: one sidecar footer read, no drain (`query_scans == 0`). Guards
     /// against the optimization silently not firing (result-only checks pass via the drain too).
-    #[test]
-    fn fast_path_skips_checkpoint_drain_when_hint_lists_sidecars() {
+    #[rstest]
+    #[case::without_leaf_schema(false, 0)]
+    #[case::with_leaf_schema(true, 1)]
+    fn fast_path_skips_checkpoint_drain_when_hint_lists_sidecars(
+        #[case] needs_leaf_schema: bool,
+        #[case] expected_footer_reads: usize,
+    ) {
         let (_engine, snapshot, _tempdir) =
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), needs_leaf_schema).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -374,16 +416,25 @@ mod tests {
         );
         assert_eq!(
             exec.footer_reads.load(Ordering::Relaxed),
-            1,
-            "fast path footer-reads exactly the hint's first sidecar"
+            expected_footer_reads,
+            "fast path reads the sidecar footer only when its schema is needed"
         );
+        assert_eq!(shape.leaf_checkpoint_schema.is_some(), needs_leaf_schema);
     }
 
-    /// With the hint removed, a JSON manifest must drain the `sidecar` column (`query_scans >= 1`).
-    #[test]
-    fn resolve_json_manifest_via_drain_without_hint() {
-        let (engine, snapshot, _tempdir) =
-            load_test_table("v2-checkpoints-json-with-sidecars").unwrap();
+    /// Without a hint, a manifest must drain the `sidecar` column (`query_scans >= 1`).
+    #[rstest]
+    #[case::json("v2-checkpoints-json-with-sidecars", false)]
+    #[case::parquet("v2-parquet-sidecars-struct-stats-only", true)]
+    fn resolve_manifest_via_drain_without_hint(
+        #[case] table: &str,
+        #[case] expect_parsed_stats: bool,
+    ) {
+        let (table_root, _tempdir) = copy_test_table(table).unwrap();
+        let engine = Arc::new(SyncEngine::new());
+        let snapshot = Snapshot::builder_for(table_root)
+            .build(engine.as_ref())
+            .unwrap();
         // Remove the hint so resolve must drain.
         let hint = snapshot
             .log_segment()
@@ -407,6 +458,12 @@ mod tests {
         assert!(
             exec.query_scans.load(Ordering::Relaxed) >= 1,
             "must drain, not fast-path"
+        );
+        assert_eq!(
+            shape
+                .compatible_stats_parsed_schema(&probe_stats_schema())
+                .is_some(),
+            expect_parsed_stats
         );
     }
 
@@ -452,13 +509,13 @@ mod tests {
     /// requested. `None` here means the hint short-circuited (a fall-through would return `Some`).
     #[rstest]
     // JSON leaf: use the canonical schema without I/O.
-    #[case::json_no_stats("json", false, None, 0)]
-    #[case::json_with_stats("json", true, None, 0)]
-    // Parquet leaf: no stats requested -> no schema read, no parsed stats.
-    #[case::parquet_no_stats("parquet", false, None, 0)]
+    #[case::json_without_leaf_schema("json", false, None, 0)]
+    #[case::json_with_leaf_schema("json", true, None, 0)]
+    // Parquet leaf: schema not retained -> no footer read or parsed stats.
+    #[case::parquet_without_leaf_schema("parquet", false, None, 0)]
     fn empty_sidecars_hint_classifies_leaf_without_drain(
         #[case] extension: &str,
-        #[case] request_stats: bool,
+        #[case] needs_leaf_schema: bool,
         #[case] expect_parsed: Option<bool>,
         #[case] expected_footer_reads: usize,
     ) {
@@ -468,7 +525,7 @@ mod tests {
             "json" => FileType::Json,
             _ => FileType::Parquet,
         };
-        let stats_schema = request_stats.then(probe_stats_schema);
+        let stats_schema = needs_leaf_schema.then(probe_stats_schema);
         let exec = CountingExecutor::new();
 
         let shape = CheckpointShape::from_v2_checkpoint_hint(
@@ -476,13 +533,13 @@ mod tests {
             &segment,
             root,
             file_type,
-            request_stats,
+            needs_leaf_schema,
         )
         .unwrap()
         .expect("an empty-sidecars hint must classify without falling through");
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Leaf);
-        if file_type == FileType::Json && request_stats {
+        if file_type == FileType::Json && needs_leaf_schema {
             assert_eq!(
                 shape.leaf_checkpoint_schema.as_ref(),
                 Some(&*LEAF_CHECKPOINT_ACTIONS_SCHEMA)

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -6,15 +6,17 @@
 // No in-crate caller yet; following PRs will use this.
 #![allow(dead_code)]
 
+use std::sync::Arc;
+
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME};
+use crate::actions::{ADD_NAME, LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME, STATS_PARSED};
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
-use crate::schema::SchemaRef;
+use crate::schema::{DataType, SchemaRef, StructField};
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, FileMeta};
 
@@ -168,6 +170,31 @@ impl CheckpointShape {
         }
     }
 
+    fn add_field(&self, name: &str) -> Option<&StructField> {
+        let DataType::Struct(add) = self
+            .leaf_checkpoint_schema
+            .as_ref()?
+            .field(ADD_NAME)?
+            .data_type()
+        else {
+            return None;
+        };
+        add.field(name)
+    }
+
+    /// Whether the checkpoint contains JSON-encoded stats.
+    pub(crate) fn has_json_stats(&self) -> bool {
+        self.add_field("stats").is_some()
+    }
+
+    /// Return the checkpoint's complete native parsed-stats schema.
+    pub(crate) fn stats_parsed_schema(&self) -> Option<SchemaRef> {
+        let DataType::Struct(stats) = self.add_field(STATS_PARSED)?.data_type() else {
+            return None;
+        };
+        Some(Arc::new(stats.as_ref().clone()))
+    }
+
     /// Return `stats_schema` when the checkpoint has compatible parsed stats.
     pub(crate) fn compatible_stats_parsed_schema(
         &self,
@@ -179,6 +206,22 @@ impl CheckpointShape {
                 LogSegment::schema_has_compatible_stats_parsed(checkpoint_schema, stats_schema)
             })
             .map(|_| stats_schema.clone())
+    }
+
+    /// Return `partition_schema` when the checkpoint has compatible parsed partition values.
+    pub(crate) fn compatible_partition_values_parsed_schema(
+        &self,
+        partition_schema: &SchemaRef,
+    ) -> Option<SchemaRef> {
+        self.leaf_checkpoint_schema
+            .as_ref()
+            .filter(|checkpoint_schema| {
+                LogSegment::schema_has_compatible_partition_values_parsed(
+                    checkpoint_schema,
+                    partition_schema,
+                )
+            })
+            .map(|_| partition_schema.clone())
     }
 }
 

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -10,12 +10,10 @@
 // No in-crate caller yet; following PRs will use this.
 #![allow(dead_code)]
 
-use std::sync::Arc;
-
 use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
-use crate::actions::{ADD_NAME, LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME, STATS_PARSED};
+use crate::actions::{ADD_NAME, LEAF_CHECKPOINT_ACTIONS_SCHEMA, SIDECAR_NAME};
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
@@ -211,14 +209,6 @@ impl CheckpointShape {
     /// Whether the checkpoint contains JSON-encoded stats.
     pub(crate) fn has_json_stats(&self) -> bool {
         self.add_field("stats").is_some()
-    }
-
-    /// Return the checkpoint's complete native parsed-stats schema.
-    pub(crate) fn stats_parsed_schema(&self) -> Option<SchemaRef> {
-        let DataType::Struct(stats) = self.add_field(STATS_PARSED)?.data_type() else {
-            return None;
-        };
-        Some(Arc::new(stats.as_ref().clone()))
     }
 
     /// Return `stats_schema` when the checkpoint has compatible parsed stats.

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -39,13 +39,29 @@ pub(crate) struct CheckpointShape {
 }
 
 impl CheckpointShape {
-    /// Resolves `snapshot`'s checkpoint topology. When `needs_leaf_schema` is true, also loads and
-    /// retains the schema of the files containing leaf actions. Schema retention does not affect
-    /// checkpoint classification.
+    /// Resolves `snapshot`'s checkpoint topology without retaining the leaf-action schema.
     ///
     /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
     /// read.
     pub(crate) fn try_new(
+        exec: &dyn PlanExecutor,
+        snapshot: &Snapshot,
+    ) -> DeltaResult<CheckpointShape> {
+        Self::try_new_impl(exec, snapshot, false)
+    }
+
+    /// Resolves `snapshot`'s checkpoint topology and retains the leaf-action schema.
+    ///
+    /// Returns an error if checkpoint metadata is invalid or required checkpoint data cannot be
+    /// read.
+    pub(crate) fn try_new_with_leaf_schema(
+        exec: &dyn PlanExecutor,
+        snapshot: &Snapshot,
+    ) -> DeltaResult<CheckpointShape> {
+        Self::try_new_impl(exec, snapshot, true)
+    }
+
+    fn try_new_impl(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
         needs_leaf_schema: bool,
@@ -315,8 +331,12 @@ mod tests {
         let exec = SyncPlanExecutor::default();
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
 
-        let shape =
-            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.is_some()).unwrap();
+        let shape = if stats_schema.is_some() {
+            CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref())
+        } else {
+            CheckpointShape::try_new(&exec, snapshot.as_ref())
+        }
+        .unwrap();
         let parsed_stats_schema = stats_schema
             .as_ref()
             .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
@@ -385,8 +405,11 @@ mod tests {
             StructField::nullable(MAX_VALUES, columns()),
         ]));
 
-        let shape = CheckpointShape::try_new(&SyncPlanExecutor::default(), snapshot.as_ref(), true)
-            .unwrap();
+        let shape = CheckpointShape::try_new_with_leaf_schema(
+            &SyncPlanExecutor::default(),
+            snapshot.as_ref(),
+        )
+        .unwrap();
 
         assert!(shape
             .compatible_stats_parsed_schema(&incompatible)
@@ -406,7 +429,12 @@ mod tests {
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), needs_leaf_schema).unwrap();
+        let shape = if needs_leaf_schema {
+            CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref())
+        } else {
+            CheckpointShape::try_new(&exec, snapshot.as_ref())
+        }
+        .unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -452,7 +480,7 @@ mod tests {
             .unwrap();
 
         let exec = CountingExecutor::new();
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), true).unwrap();
+        let shape = CheckpointShape::try_new_with_leaf_schema(&exec, snapshot.as_ref()).unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert!(

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,6 +1187,12 @@ impl From<Predicate> for Expression {
     }
 }
 
+impl From<Predicate> for Option<PredicateRef> {
+    fn from(value: Predicate) -> Self {
+        Some(Arc::new(value))
+    }
+}
+
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -1187,12 +1187,6 @@ impl From<Predicate> for Expression {
     }
 }
 
-impl From<Predicate> for Option<PredicateRef> {
-    fn from(value: Predicate) -> Self {
-        Some(Arc::new(value))
-    }
-}
-
 impl From<ColumnName> for Predicate {
     fn from(value: ColumnName) -> Self {
         Self::from_expr(value)

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1087,11 +1087,14 @@ impl Scan {
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
         // leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
-        let needs_leaf_schema = self.stats.synthesize_json
+        let shape = if self.stats.synthesize_json
             || self.state_info.physical_stats_schema.is_some()
-            || self.partition_values.parsed_struct;
-        let shape =
-            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot, needs_leaf_schema)?;
+            || self.partition_values.parsed_struct
+        {
+            CheckpointShape::try_new_with_leaf_schema(plan_executor.as_ref(), &self.snapshot)?
+        } else {
+            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot)?
+        };
         self.build_metadata_scan_plan(&shape)
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -199,8 +199,8 @@ impl StatsOptions {
 /// When the typed struct is requested, scan metadata output gains a top-level
 /// `partitionValues_parsed` struct column with one typed nullable field per partition column
 /// (physical names, table partition-column order). On non-partitioned tables the column is
-/// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
-/// when present, otherwise from parsing the string map.
+/// omitted. Values are parsed from the complete `partitionValues` string map; native checkpoint
+/// `partitionValues_parsed` values may be incomplete or use the checkpoint writer's timezone.
 #[derive(Clone, Debug)]
 pub struct PartitionValuesOptions {
     /// Whether to emit the raw `partitionValues` string map.

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,14 +1084,14 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
-        // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
-        // whether the checkpoint carries a compatible parsed-stats column.
+        // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
+        // leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
-        let shape = CheckpointShape::try_new(
-            plan_executor.as_ref(),
-            &self.snapshot,
-            self.state_info.physical_stats_schema.as_ref(),
-        )?;
+        let needs_leaf_schema = self.stats.synthesize_json
+            || self.state_info.physical_stats_schema.is_some()
+            || self.partition_values.parsed_struct;
+        let shape =
+            CheckpointShape::try_new(plan_executor.as_ref(), &self.snapshot, needs_leaf_schema)?;
         self.build_metadata_scan_plan(&shape)
     }
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,8 +1084,11 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
+        if self.state_info.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and retains the
-        // leaf schema when output or pruning requires checkpoint-specific columns.
+        // checkpoint leaf schema when output or pruning requires checkpoint-specific columns.
         let plan_executor = engine.require_plan_executor()?;
         let shape = if self.stats.synthesize_json
             || self.state_info.physical_stats_schema.is_some()

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1084,7 +1084,6 @@ impl Scan {
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
-        let log_segment = self.snapshot.log_segment();
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
         // whether the checkpoint carries a compatible parsed-stats column.
         let plan_executor = engine.require_plan_executor()?;
@@ -1093,14 +1092,7 @@ impl Scan {
             &self.snapshot,
             self.state_info.physical_stats_schema.as_ref(),
         )?;
-        scan_plan::build_metadata_scan_plan(
-            &self.state_info,
-            log_segment,
-            &shape,
-            &self.stats,
-            &self.partition_values,
-            self.physical_stats_output_schema.as_ref(),
-        )
+        self.build_metadata_scan_plan(&shape)
     }
 
     // Factored out to facilitate testing

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -193,18 +193,29 @@ impl StatsOptions {
 }
 
 /// Engine-facing partition value options. Pass to [`ScanBuilder::with_partition_values`] to
-/// declare whether scan metadata output includes the typed `partitionValues_parsed` struct
-/// alongside the raw string map (`fileConstantValues.partitionValues`), which is always present.
+/// declare whether scan metadata output includes the raw `partitionValues` string map, the typed
+/// `partitionValues_parsed` struct, or both.
 ///
 /// When the typed struct is requested, scan metadata output gains a top-level
 /// `partitionValues_parsed` struct column with one typed nullable field per partition column
 /// (physical names, table partition-column order). On non-partitioned tables the column is
 /// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
 /// when present, otherwise from parsing the string map.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct PartitionValuesOptions {
+    /// Whether to emit the raw `partitionValues` string map.
+    pub(crate) string_map: bool,
     /// Whether to emit the typed `partitionValues_parsed` struct column.
     pub(crate) parsed_struct: bool,
+}
+
+impl Default for PartitionValuesOptions {
+    fn default() -> Self {
+        Self {
+            string_map: true,
+            parsed_struct: false,
+        }
+    }
 }
 
 impl PartitionValuesOptions {
@@ -217,6 +228,15 @@ impl PartitionValuesOptions {
     /// consume `partitionValues_parsed` directly instead of parsing the string map per row.
     pub fn with_struct() -> Self {
         Self {
+            string_map: true,
+            parsed_struct: true,
+        }
+    }
+
+    /// Emit only the typed `partitionValues_parsed` struct.
+    pub fn struct_only() -> Self {
+        Self {
+            string_map: false,
             parsed_struct: true,
         }
     }

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -18,6 +18,7 @@ use crate::actions::{
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
+    UnaryExpressionOp,
 };
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
@@ -37,6 +38,7 @@ use crate::{DeltaResult, Error, PlanBuilder};
 // materialize them as one top-level `file_action_key` column that are used by the plan's
 // aggregate and anti-join operators.
 const FILE_ACTION_KEY: &str = "file_action_key";
+const DATA_CHANGE: &str = "dataChange";
 const STATS: &str = "stats";
 const PARTITION_VALUES: &str = "partitionValues";
 const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
@@ -61,9 +63,6 @@ impl Scan {
         let prune = stats_skipping_predicate(state);
         let prune = prune.as_ref();
 
-        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
-        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
-        // union schema.
         let add_field = self.normalized_add_field()?;
         let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
@@ -105,8 +104,16 @@ impl Scan {
                 deduped_commit.clone(),
                 [column_name!(FILE_ACTION_KEY)],
                 [column_name!(FILE_ACTION_KEY)],
-            )?
-            .project(output_expr.clone(), output_schema.clone())?;
+            )?;
+        // A struct-only checkpoint retains its complete parsed stats until reconciliation, then
+        // serializes them only when JSON stats were requested.
+        let checkpoint_live_adds = if self.stats.synthesize_json && !shape.has_json_stats() {
+            checkpoint_live_adds.project_patch(|patch| patch.with_json_add_stats())?
+        } else {
+            checkpoint_live_adds
+        };
+        let checkpoint_live_adds =
+            checkpoint_live_adds.project(output_expr.clone(), output_schema.clone())?;
 
         let commit_live_adds = deduped_commit
             .filter(col!("add").is_not_null())?
@@ -130,20 +137,18 @@ impl Scan {
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
-    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, physical_stats)`
-    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    /// When the checkpoint lacks a native parsed field, the corresponding `FROM_JSON` or
+    /// `MAP_TO_STRUCT` expression replaces it. A parsed field is omitted when its schema is absent.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
         let physical_partitions = self.state_info.physical_partition_schema.as_ref();
-        let source_physical_stats =
-            physical_stats.and_then(|schema| shape.compatible_stats_parsed_schema(schema));
+        let parquet_read_schema = self.checkpoint_parquet_read_schema(shape)?;
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
-                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
+                PlanBuilder::scan_parquet(parts, &[VERSION], parquet_read_schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
                 PlanBuilder::scan_json(
@@ -153,11 +158,17 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    Some(sidecars) => {
+                        PlanBuilder::scan_parquet(sidecars, &[VERSION], parquet_read_schema)
+                    }
                     // Without a complete hint, load the sidecars referenced by the manifest.
-                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                    None => sidecar_actions(
+                        file_type,
+                        parts,
+                        parquet_read_schema,
+                        &log_segment.log_root,
+                    ),
                 }
             }
             (CheckpointType::None, _) | (_, None) => {
@@ -229,6 +240,48 @@ impl Scan {
             })
     }
 
+    fn checkpoint_parquet_read_schema(&self, shape: &CheckpointShape) -> DeltaResult<SchemaRef> {
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let checkpoint_stats_schema = if self.stats.synthesize_json && !shape.has_json_stats() {
+            shape.stats_parsed_schema()
+        } else {
+            stats_schema.and_then(|schema| shape.compatible_stats_parsed_schema(schema))
+        };
+        let checkpoint_partition_schema = partition_schema
+            .and_then(|schema| shape.compatible_partition_values_parsed_schema(schema));
+        let read_json_stats = shape.has_json_stats()
+            && (self.stats.synthesize_json
+                || (stats_schema.is_some() && checkpoint_stats_schema.is_none()));
+        let read_string_partitions = self.partition_values.string_map
+            || (partition_schema.is_some() && checkpoint_partition_schema.is_none());
+
+        let add_patch = SchemaStructPatchBuilder::new()
+            .fold_with(checkpoint_stats_schema.as_ref(), |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(checkpoint_partition_schema.as_ref(), |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        let add_patch = if read_json_stats {
+            add_patch
+        } else {
+            add_patch.drop(STATS)
+        };
+        let add_patch = if read_string_partitions {
+            add_patch
+        } else {
+            add_patch.drop(PARTITION_VALUES)
+        };
+        Ok(schema_ref! {
+            (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
+            nullable (VERSION): LONG,
+        })
+    }
+
     fn normalized_add_field(&self) -> DeltaResult<StructField> {
         let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
         let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
@@ -289,6 +342,13 @@ impl Scan {
             (false, true) => projection.drop(STATS),
         };
 
+        // Raw partition-values output.
+        let projection = if self.partition_values.string_map {
+            projection
+        } else {
+            projection.drop(PARTITION_VALUES)
+        };
+
         // Parsed stats output.
         let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
             (Some(physical_stats), _) => projection.replace(
@@ -324,7 +384,8 @@ impl Scan {
             (None, false) => projection,
         };
 
-        let (add_schema, add_expr) = projection.build()?;
+        let (add_schema, _) = projection.build()?;
+        let add_expr = project_nested_struct_to_schema(column_name!("add"), &add_schema);
         let schema = schema_ref! {
             (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
         };
@@ -403,27 +464,6 @@ fn json_read_schema(include_remove: bool) -> SchemaRef {
     }
 }
 
-/// Read schema for parquet add actions.
-fn parquet_read_schema(
-    physical_stats: Option<&SchemaRef>,
-    physical_partitions: Option<&SchemaRef>,
-) -> DeltaResult<SchemaRef> {
-    let add_patch = SchemaStructPatchBuilder::new()
-        .fold_with(physical_stats, |patch, schema| {
-            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-        })
-        .fold_with(physical_partitions, |patch, schema| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                schema.as_ref().clone(),
-            ))
-        });
-    Ok(schema_ref! {
-        (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
-        nullable (VERSION): LONG,
-    })
-}
-
 /// File identity used for replay.
 static FILE_ACTION_KEY_FIELD: LazyLock<StructField> = LazyLock::new(|| {
     let schema = schema! {
@@ -462,6 +502,8 @@ trait ProjectionStructPatchBuilderExt<'a> {
 
     /// Parses add partition values, preferring a compatible parsed field.
     fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self;
+
+    fn with_json_add_stats(self) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
@@ -469,14 +511,22 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let has_json_stats = self.input_schema().contains_col([ADD_NAME, STATS]);
         let add = [ADD_NAME];
         match physical_stats {
             Some(schema) => {
                 let field = StructField::nullable(STATS_PARSED, schema.as_ref().clone());
-                let expr = Expr::parse_json(col!("add.stats"), Arc::clone(schema));
                 if has_stats_parsed {
                     self
+                } else if has_json_stats {
+                    let expr = Expr::parse_json(col!("add.stats"), Arc::clone(schema));
+                    self.append_at(add, field, expr)
                 } else {
+                    let expr = Expr::struct_from(
+                        schema
+                            .fields()
+                            .map(|field| Expr::null_literal(field.data_type().clone())),
+                    );
                     self.append_at(add, field, expr)
                 }
             }
@@ -494,14 +544,35 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone());
                 let expr = Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES));
                 if has_partition_values_parsed {
-                    let expr = Expr::coalesce([col!(ADD_NAME, PARTITION_VALUES_PARSED), expr]);
-                    self.replace_at(add, PARTITION_VALUES_PARSED, field, expr)
+                    self
                 } else {
                     self.append_at(add, field, expr)
                 }
             }
             None => self,
         }
+    }
+
+    fn with_json_add_stats(self) -> Self {
+        let has_json_stats = self.input_schema().contains_col([ADD_NAME, STATS]);
+        if has_json_stats {
+            return self;
+        }
+
+        let has_stats_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let expr = if has_stats_parsed {
+            Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"))
+        } else {
+            Expr::null_literal(DataType::STRING)
+        };
+        self.insert_after_at(
+            [ADD_NAME],
+            DATA_CHANGE,
+            StructField::nullable(STATS, DataType::STRING),
+            expr,
+        )
     }
 }
 
@@ -662,9 +733,30 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
-        let leaf_checkpoint_schema = parsed_stats
-            .as_ref()
-            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
+        shape_with_schemas(checkpoint_type, parsed_stats, None)
+    }
+
+    fn shape_with_schemas(
+        checkpoint_type: CheckpointType,
+        parsed_stats: Option<SchemaRef>,
+        parsed_partitions: Option<SchemaRef>,
+    ) -> CheckpointShape {
+        let leaf_checkpoint_schema = (checkpoint_type != CheckpointType::None).then(|| {
+            let add_patch = SchemaStructPatchBuilder::new()
+                .fold_with(parsed_stats.as_ref(), |patch, schema| {
+                    patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+                })
+                .fold_with(parsed_partitions.as_ref(), |patch, schema| {
+                    patch.append(StructField::nullable(
+                        PARTITION_VALUES_PARSED,
+                        schema.as_ref().clone(),
+                    ))
+                });
+            schema_ref! {
+                (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA).unwrap())),
+                nullable (VERSION): LONG,
+            }
+        });
         CheckpointShape {
             checkpoint_type,
             leaf_checkpoint_schema,
@@ -813,20 +905,27 @@ mod tests {
     #[rstest::rstest]
     #[case::with_parsed_stats(Some(struct_stats_schema()), true)]
     #[case::without_parsed_stats(None, false)]
-    fn metadata_plan_manifest_sidecar_dynamic_scan_stats_columns(
+    fn metadata_plan_manifest_sidecar_dynamic_scan_metadata_columns(
         #[case] parsed_stats: Option<SchemaRef>,
         #[case] expect_parsed_columns: bool,
+        #[values(false, true)] native_parsed_partitions: bool,
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::with_struct();
+        let partition_values = PartitionValuesOptions::struct_only();
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(stats)
             .with_partition_values(partition_values)
             .build()?;
+        let parsed_partitions = native_parsed_partitions
+            .then(|| scan.state_info.physical_partition_schema.clone().unwrap());
         let plan = scan
-            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .build_metadata_scan_plan(&shape_with_schemas(
+                CheckpointType::Manifest,
+                parsed_stats,
+                parsed_partitions,
+            ))?
             .expect("non-empty");
 
         let dynamic_scan = plan
@@ -843,11 +942,17 @@ mod tests {
                 .is_some(),
             expect_parsed_columns,
         );
-        assert!(
+        assert_eq!(
             add_struct(&dynamic_scan.schema)
                 .field(PARTITION_VALUES_PARSED)
-                .is_none(),
-            "native parsed partition values are not requested yet"
+                .is_some(),
+            native_parsed_partitions,
+        );
+        assert_eq!(
+            add_struct(&dynamic_scan.schema)
+                .field(PARTITION_VALUES)
+                .is_some(),
+            !native_parsed_partitions,
         );
         Ok(())
     }

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -29,7 +29,7 @@ use crate::schema::{
 };
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::transforms::{transform_output_type, ExpressionTransform};
-use crate::utils::{CollectInto, FoldWithOption as _};
+use crate::utils::{require, CollectInto, FoldWithOption as _};
 use crate::{DeltaResult, Error, PlanBuilder};
 
 // === Internal column names ===
@@ -284,7 +284,7 @@ impl Scan {
                 patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
             });
 
-        // JSON stats are read when requested using `StructStats::Json` or needed to derive parsed stats because
+        // JSON stats are read when requested for output or needed to derive parsed stats because
         // the checkpoint has no compatible parsed representation.
         let needs_json_stats = self.stats.synthesize_json
             || (stats_schema.is_some() && checkpoint_parsed_stats_schema.is_none());
@@ -298,10 +298,17 @@ impl Scan {
         // `LogSegment::schema_has_compatible_partition_values_parsed` permits missing fields, and
         // timestamps may use the checkpoint writer's timezone, making them incorrect for other
         // readers. We retain and reparse the complete string map downstream.
-        Ok(schema_ref! {
+        let read_schema = schema_ref! {
             (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
             nullable (VERSION): LONG,
-        })
+        };
+        // TODO: Read native parsed partitions once compatibility validates complete fields and
+        // timestamp semantics.
+        require!(
+            !read_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]),
+            Error::internal_error("checkpoint reads must not use native parsed partition values")
+        );
+        Ok(read_schema)
     }
 
     fn normalized_add_field(&self) -> DeltaResult<StructField> {
@@ -519,7 +526,7 @@ trait ProjectionStructPatchBuilderExt<'a> {
     /// emits a typed null struct so metadata pruning conservatively retains the file.
     fn with_parsed_add_stats(self, physical_stats: Option<&SchemaRef>) -> Self;
 
-    /// Parses add partition values, preferring a compatible parsed field.
+    /// Parses add partition values from the authoritative raw string map.
     fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self;
 
     fn with_json_add_stats(self) -> Self;
@@ -553,20 +560,12 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
     }
 
     fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self {
-        let has_partition_values_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let add = [ADD_NAME];
         match physical_partitions {
-            Some(schema) => {
-                let field = StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone());
-                let expr = Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES));
-                if has_partition_values_parsed {
-                    self
-                } else {
-                    self.append_at(add, field, expr)
-                }
-            }
+            Some(schema) => self.append_at(
+                [ADD_NAME],
+                StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone()),
+                Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES)),
+            ),
             None => self,
         }
     }

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -572,14 +572,7 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             return self;
         }
 
-        let has_stats_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let expr = if has_stats_parsed {
-            Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"))
-        } else {
-            Expr::null_literal(DataType::STRING)
-        };
+        let expr = Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"));
         self.insert_after_at(
             [ADD_NAME],
             DATA_CHANGE,

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -1,7 +1,7 @@
 //! Declarative metadata scan plans.
 //!
-//! [`build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds, applying
-//! metadata pruning before newest-action-wins replay.
+//! [`Scan::build_metadata_scan_plan`] reconciles checkpoint and commit actions into live adds,
+//! applying metadata pruning before newest-action-wins replay.
 
 use std::borrow::Cow;
 use std::sync::{Arc, LazyLock};
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::data_skipping::as_sql_data_skipping_predicate_with_stats_columns;
 use super::state_info::StateInfo;
-use super::{PartitionValuesOptions, PhysicalPredicate, StatsOptions};
+use super::{PhysicalPredicate, Scan};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{
     ADD_FIELD, ADD_NAME, ADD_SCHEMA, REMOVE_FIELD, SIDECAR_FIELD, SIDECAR_NAME, STATS_PARSED,
@@ -19,7 +19,6 @@ use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
 };
-use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::{FileType, Load, LoadColumnFileMeta, ScanFile};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
@@ -45,41 +44,30 @@ const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
 const IS_ADD: &str = "is_add";
 const VERSION: &str = "version";
 
-/// Build the live-add metadata plan from checkpoint and commit actions.
-///
-/// Returns `None` for an empty result or a statically false predicate.
-pub(crate) fn build_metadata_scan_plan(
-    state: &StateInfo,
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<Option<Plan>> {
-    // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
-    if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
-        return Ok(None);
-    }
+impl Scan {
+    /// Build the live-add metadata plan from checkpoint and commit actions.
+    ///
+    /// Returns `None` for an empty result or a statically false predicate.
+    pub(super) fn build_metadata_scan_plan(
+        &self,
+        shape: &CheckpointShape,
+    ) -> DeltaResult<Option<Plan>> {
+        let state = &self.state_info;
+        // A statically-unsatisfiable predicate (e.g. `x > 10 AND FALSE`) skips the whole table.
+        if state.physical_predicate == PhysicalPredicate::StaticSkipAll {
+            return Ok(None);
+        }
 
-    let stats_schema = state.physical_stats_schema.as_ref();
-    let partition_schema = state.physical_partition_schema.as_ref();
-    let prune = stats_skipping_predicate(state);
-    let prune = prune.as_ref();
+        let prune = stats_skipping_predicate(state);
+        let prune = prune.as_ref();
 
-    // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's dedup
-    // carrier and both terminal `{ add }` projections, so every arm agrees on the union schema.
-    let add_field = add_field_with_parsed_stats_and_partitions(stats_schema, partition_schema)?;
-    let (output_expr, output_schema) = metadata_output_projection(
-        &add_field,
-        stats,
-        partition_values,
-        partition_schema,
-        physical_stats_output_schema,
-    )?;
+        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
+        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
+        // union schema.
+        let add_field = self.normalized_add_field()?;
+        let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
-    let commit_actions = commit_arm(log_segment, stats_schema, partition_schema)?.try_fold_with(
-        prune,
-        |p, prune| {
+        let commit_actions = self.commit_arm()?.try_fold_with(prune, |p, prune| {
             // We filter so that:
             // * All remove actions are kept
             // * Add actions that do not match the partition pruning or stats predicate are removed.
@@ -95,155 +83,155 @@ pub(crate) fn build_metadata_scan_plan(
             // `remove.partitionValues` being NULL, or it may be from `partCol` being
             // NULL. Thus, we simply do not prune removes.
             p.filter(Predicate::or(col!("add").is_null(), prune.clone()))
-        },
-    )?;
+        })?;
 
-    let deduped_commit = commit_actions
-        // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
-        // after aggregation.
-        .project_patch(|patch| {
-            patch.replace(
-                ADD_NAME,
-                StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
-                Expr::struct_from([col!("add")]),
-            )
-        })?
-        .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
-            a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
-        })?
-        // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
-        .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
+        let deduped_commit = commit_actions
+            // Wrap `add` so removes, whose inner `add` is null, survive `MaxNonNullBy`. Unwrap it
+            // after aggregation.
+            .project_patch(|patch| {
+                patch.replace(
+                    ADD_NAME,
+                    StructField::not_null(ADD_NAME, schema! { (add_field.clone()) }),
+                    Expr::struct_from([col!("add")]),
+                )
+            })?
+            .aggregate_by([ColumnName::new([FILE_ACTION_KEY])], |a| {
+                a.max_non_null_by(ColumnName::new([ADD_NAME]), ColumnName::new([VERSION]))
+            })?
+            // We unwrap `add.add` to the top level now that MaxNonNullBy is complete.
+            .project_patch(|patch| patch.replace(ADD_NAME, add_field.clone(), col!("add.add")))?;
 
-    let checkpoint_adds = checkpoint_arm(log_segment, shape, stats_schema, partition_schema)?
-        .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
+        let checkpoint_adds = self
+            .checkpoint_arm(shape)?
+            .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
 
-    let checkpoint_live_adds = checkpoint_adds
-        .anti_join(
-            deduped_commit.clone(),
-            [ColumnName::new([FILE_ACTION_KEY])],
-            [ColumnName::new([FILE_ACTION_KEY])],
-        )?
-        .project(output_expr.clone(), output_schema.clone())?;
+        let checkpoint_live_adds = checkpoint_adds
+            .anti_join(
+                deduped_commit.clone(),
+                [ColumnName::new([FILE_ACTION_KEY])],
+                [ColumnName::new([FILE_ACTION_KEY])],
+            )?
+            .project(output_expr.clone(), output_schema.clone())?;
 
-    let commit_live_adds = deduped_commit
-        .filter(col!("add").is_not_null())?
-        .project(output_expr, output_schema)?;
+        let commit_live_adds = deduped_commit
+            .filter(col!("add").is_not_null())?
+            .project(output_expr, output_schema)?;
 
-    PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
-}
+        PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
+    }
 
-/// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
-///
-/// ## SQL equivalent:
-//
-/// SELECT STRUCT(
-///          add.* EXCEPT (
-///            stats_parsed, partitionValues_parsed
-///          ),
-///          add.stats_parsed AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
-/// FROM checkpoint_actions
-/// WHERE add.path IS NOT NULL
-///
-/// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
-/// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
-fn checkpoint_arm(
-    log_segment: &LogSegment,
-    shape: &CheckpointShape,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let source_stats_schema = shape.parsed_stats_schema.as_ref();
-    let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
+    /// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
+    ///
+    /// ## SQL equivalent:
+    //
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (
+    ///            stats_parsed, partitionValues_parsed
+    ///          ),
+    ///          add.stats_parsed AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
+    /// FROM checkpoint_actions
+    /// WHERE add.path IS NOT NULL
+    ///
+    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
+    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
-    let actions = match (&shape.checkpoint_type, checkpoint) {
-        (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            PlanBuilder::scan_parquet(parts, &[VERSION], schema)
-        }
-        (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
-            PlanBuilder::scan_json(
-                parts,
-                &[VERSION],
-                json_read_schema(/* include_remove */ false),
-            )
-        }
-        (CheckpointType::Manifest, Some((file_type, parts))) => {
-            let schema = parquet_read_schema(source_stats_schema, None)?;
-            match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
-                // Without a complete hint, load the sidecars referenced by the manifest.
-                None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+        let actions = match (&shape.checkpoint_type, checkpoint) {
+            (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
-        }
-        (CheckpointType::None, _) | (_, None) => {
-            PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
-        }
-    }?;
+            (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
+                PlanBuilder::scan_json(
+                    parts,
+                    &[VERSION],
+                    json_read_schema(/* include_remove */ false),
+                )
+            }
+            (CheckpointType::Manifest, Some((file_type, parts))) => {
+                let schema = parquet_read_schema(source_stats_schema, None)?;
+                match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
+                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    // Without a complete hint, load the sidecars referenced by the manifest.
+                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                }
+            }
+            (CheckpointType::None, _) | (_, None) => {
+                PlanBuilder::values(json_read_schema(/* include_remove */ false), vec![])
+            }
+        }?;
 
-    actions
-        .filter(col!("add.path").is_not_null())?
-        .project_patch(|patch| {
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| joined_column_expr!("add", col)),
-                )
-        })
-}
+        actions
+            .filter(col!("add.path").is_not_null())?
+            .project_patch(|patch| {
+                patch
+                    .with_parsed_add_stats(stats_schema)
+                    .with_parsed_add_partition_values(partition_schema)
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| joined_column_expr!("add", col)),
+                    )
+            })
+    }
 
-/// Build the normalized commit JSON arm.
-///
-/// ## SQL equivalent:
-///
-/// SELECT STRUCT(
-///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
-///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
-///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
-///        ) AS add,
-///        remove, version, add.path IS NOT NULL AS is_add,
-///        file_key(COALESCE(add, remove)) AS key
-/// FROM json_commits
-/// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
-///
-/// A parsed field is omitted when its schema is absent.
-fn commit_arm(
-    log_segment: &LogSegment,
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<PlanBuilder> {
-    let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
-    PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
-        .filter(Predicate::or(
-            col!("add.path").is_not_null(),
-            col!("remove.path").is_not_null(),
-        ))?
-        .project_patch(|patch| {
-            // Commits never carry source-native parsed columns, so normalize from the raw
-            // encodings.
-            patch
-                .with_parsed_add_stats_and_partitions(stats_schema, partition_schema)
-                .append(
-                    StructField::not_null(IS_ADD, DataType::BOOLEAN),
-                    Expr::from(col!("add.path").is_not_null()),
-                )
-                .append(
-                    FILE_ACTION_KEY_FIELD.clone(),
-                    file_action_key_expr(|col| {
-                        Expr::coalesce([
-                            joined_column_expr!("add", col),
-                            joined_column_expr!("remove", col),
-                        ])
-                    }),
-                )
-        })
+    /// Build the normalized commit JSON arm.
+    ///
+    /// ## SQL equivalent:
+    ///
+    /// SELECT STRUCT(
+    ///          add.* EXCEPT (stats_parsed, partitionValues_parsed),
+    ///          FROM_JSON(add.stats, stats_schema) AS stats_parsed,
+    ///          MAP_TO_STRUCT(add.partitionValues, partition_schema) AS partitionValues_parsed
+    ///        ) AS add,
+    ///        remove, version, add.path IS NOT NULL AS is_add,
+    ///        file_key(COALESCE(add, remove)) AS key
+    /// FROM json_commits
+    /// WHERE add.path IS NOT NULL OR remove.path IS NOT NULL
+    ///
+    /// A parsed field is omitted when its schema is absent.
+    fn commit_arm(&self) -> DeltaResult<PlanBuilder> {
+        let log_segment = self.snapshot.log_segment();
+        let commit_files = log_segment.commit_cover_version_tagged_scan_files()?;
+        PlanBuilder::scan_json(commit_files, &[VERSION], json_read_schema(true))?
+            .filter(Predicate::or(
+                col!("add.path").is_not_null(),
+                col!("remove.path").is_not_null(),
+            ))?
+            .project_patch(|patch| {
+                // Commits never carry source-native parsed columns, so normalize from the raw
+                // encodings.
+                patch
+                    .with_parsed_add_stats(self.state_info.physical_stats_schema.as_ref())
+                    .with_parsed_add_partition_values(
+                        self.state_info.physical_partition_schema.as_ref(),
+                    )
+                    .append(
+                        StructField::not_null(IS_ADD, DataType::BOOLEAN),
+                        Expr::from(col!("add.path").is_not_null()),
+                    )
+                    .append(
+                        FILE_ACTION_KEY_FIELD.clone(),
+                        file_action_key_expr(|col| {
+                            Expr::coalesce([
+                                joined_column_expr!("add", col),
+                                joined_column_expr!("remove", col),
+                            ])
+                        }),
+                    )
+            })
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -368,31 +356,23 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 }
 
 trait ProjectionStructPatchBuilderExt<'a> {
-    /// Parses add stats and partition values, preferring compatible parsed fields.
+    /// Parses add stats, preferring a compatible parsed field.
     ///
     /// When `stats_schema` is present, the input must contain either `add.stats_parsed` or the
     /// fallback `add.stats` JSON field.
-    fn with_parsed_add_stats_and_partitions(
-        self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self;
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self;
+
+    /// Parses add partition values, preferring a compatible parsed field.
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
-    fn with_parsed_add_stats_and_partitions(
-        mut self,
-        stats_schema: Option<&SchemaRef>,
-        partition_schema: Option<&SchemaRef>,
-    ) -> Self {
+    fn with_parsed_add_stats(self, stats_schema: Option<&SchemaRef>) -> Self {
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let has_partition_values_parsed = self
-            .input_schema()
-            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
         let add = [ADD_NAME];
-        self = match stats_schema {
+        match stats_schema {
             Some(ss) => {
                 let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
                 let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
@@ -403,7 +383,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 }
             }
             None => self,
-        };
+        }
+    }
+
+    fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self {
+        let has_partition_values_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let add = [ADD_NAME];
         match partition_schema {
             Some(ps) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
@@ -420,113 +407,111 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
     }
 }
 
-/// The `add` field produced by [`with_parsed_add_stats_and_partitions`].
-fn add_field_with_parsed_stats_and_partitions(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<StructField> {
-    let patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, schema| {
-            patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-        })
-        .fold_with(partition_schema, |patch, schema| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                schema.as_ref().clone(),
-            ))
-        });
-    Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-}
+impl Scan {
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
 
-/// Builds the output projection for requested stats and partition values. The base of this
-/// transformation is constructed by [`add_field_with_parsed_stats_and_partitions`].
-///
-/// The output schema is:
-/// ```text
-/// add: struct<
-///   path: string,
-///   partitionValues: map<string, string>,
-///   size: long,
-///   modificationTime: long,
-///   dataChange: boolean,
-///   stats: string,                         // when JSON stats are requested
-///   tags: map<string, string>,
-///   deletionVector: struct<...>,
-///   baseRowId: long,
-///   defaultRowCommitVersion: long,
-///   clusteringProvider: string,
-///   stats_parsed: struct<...>,             // when parsed stats are requested
-///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-/// >
-/// ```
-/// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-/// partition values are selected independently and omitted for unpartitioned tables. Fields needed
-/// only for pruning are omitted.
-fn metadata_output_projection(
-    add_field: &StructField,
-    stats: &StatsOptions,
-    partition_values: &PartitionValuesOptions,
-    partition_schema: Option<&SchemaRef>,
-    physical_stats_output_schema: Option<&SchemaRef>,
-) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-    let input_schema = schema_ref! { (add_field.clone()) };
-    let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-    let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
 
-    // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-    let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-    let projection = match (stats.synthesize_json, has_json_stats) {
-        (true, true) | (false, false) => projection,
-        (true, false) => {
-            return Err(Error::internal_error(
-                "JSON stats were requested, but add.stats is missing from the metadata schema",
-            ));
-        }
-        (false, true) => projection.drop(STATS),
-    };
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
 
-    // Parsed stats output.
-    let projection = match (physical_stats_output_schema, has_stats_parsed) {
-        (Some(stats_schema), _) => projection.replace(
-            STATS_PARSED,
-            StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-            project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-        ),
-        (None, true) => projection.drop(STATS_PARSED),
-        (None, false) => projection,
-    };
-
-    // Parsed partition-values output.
-    let has_partition_values_parsed =
-        input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-    let partition_output_schema = partition_values
-        .parsed_struct
-        .then_some(partition_schema)
-        .flatten();
-    let projection = match (partition_output_schema, has_partition_values_parsed) {
-        (Some(partition_schema), true) => projection.replace(
-            PARTITION_VALUES_PARSED,
-            StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-            project_nested_struct_to_schema(
-                [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                partition_schema,
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
             ),
-        ),
-        (Some(_), false) => {
-            return Err(Error::internal_error(
-                "parsed partition values were requested, but add.partitionValues_parsed is \
-                 missing",
-            ));
-        }
-        (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-        (None, false) => projection,
-    };
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
 
-    let (add_schema, add_expr) = projection.build()?;
-    let schema = schema_ref! {
-        (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-    };
-    Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Rebuilds `root` to match a narrowed schema while preserving a null parent struct. A direct
@@ -601,47 +586,41 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use crate::actions::{Metadata, Protocol};
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::lit;
+    use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::plans::ir::nodes::Operator;
     use crate::plans::Operation as PlanOperation;
-    use crate::scan::state_info::tests::get_state_info_with_options;
     use crate::scan::{PartitionValuesOptions, StatsOptions};
     use crate::schema::StructType;
+    use crate::snapshot::Snapshot;
+    use crate::table_configuration::TableConfiguration;
     use crate::unit_test_utils::create_log_path;
     use crate::Engine as _;
 
-    fn state(
-        schema: SchemaRef,
-        partition_columns: Vec<String>,
-        predicate: Option<Predicate>,
-        stats: StatsOptions,
-        partition_values: PartitionValuesOptions,
-    ) -> StateInfo {
-        get_state_info_with_options(
-            schema,
-            partition_columns,
-            predicate.map(Arc::new),
-            &[],
+    fn mock_snapshot(log_segment: LogSegment) -> DeltaResult<Arc<Snapshot>> {
+        let metadata = Metadata::try_new(
+            None,
+            None,
+            partitioned_schema(),
+            vec!["p".to_string()],
+            0,
             HashMap::new(),
-            vec![],
-            stats,
-            partition_values,
-        )
-        .expect("state info")
-    }
-
-    fn data_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "x",
-            DataType::LONG,
-        )]))
+        )?;
+        let table_configuration = TableConfiguration::try_new(
+            metadata,
+            Protocol::try_new_legacy(2, 5)?,
+            Url::parse("memory:///")?,
+            0,
+        )?;
+        Ok(Arc::new(Snapshot::new(log_segment, table_configuration)?))
     }
 
     fn partitioned_schema() -> SchemaRef {
@@ -800,15 +779,18 @@ mod tests {
     }
 
     fn struct_stats_schema() -> SchemaRef {
-        state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(5i64))),
-            StatsOptions::all(),
-            PartitionValuesOptions::default(),
-        )
-        .physical_stats_schema
-        .expect("stats schema")
+        let segment = log_segment(log_root(), &[], None);
+        mock_snapshot(segment)
+            .unwrap()
+            .scan_builder()
+            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_stats(StatsOptions::all())
+            .build()
+            .unwrap()
+            .state_info
+            .physical_stats_schema
+            .clone()
+            .expect("stats schema")
     }
 
     // Commit-arm operator sequence without optional pruning.
@@ -835,29 +817,13 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             Some(checkpoint_path(file_type)),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
 
         let mut expected: Vec<&str> = COMMIT_ARM_TAGS.to_vec();
         expected.extend(checkpoint_arm_tags);
@@ -875,23 +841,15 @@ mod tests {
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
         let partition_values = PartitionValuesOptions::with_struct();
-        let state = state(
-            partitioned_schema(),
-            vec!["p".to_string()],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Manifest, parsed_stats),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(stats)
+            .with_partition_values(partition_values)
+            .build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .expect("non-empty");
 
         let load = plan
             .nodes
@@ -916,29 +874,15 @@ mod tests {
 
     #[test]
     fn metadata_plan_commits_only() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             log_root(),
             &["file:///_delta_log/00000000000000000001.json"],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
         assert_eq!(tags(&plan), COMMIT_ARM_TAGS.to_vec());
         Ok(())
     }
@@ -953,75 +897,35 @@ mod tests {
         #[case] file_type: FileType,
         #[case] checkpoint_arm_tags: Vec<&'static str>,
     ) -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(file_type)));
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape,
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan.build_metadata_scan_plan(&shape)?.expect("non-empty");
         assert_eq!(tags(&plan), checkpoint_arm_tags);
         Ok(())
     }
 
     #[test]
     fn metadata_plan_empty_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        assert!(scan.build_metadata_scan_plan(&no_checkpoint())?.is_none());
         Ok(())
     }
 
     #[test]
     fn metadata_plan_static_skip_all_is_none() -> DeltaResult<()> {
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(Predicate::literal(false)),
-            stats.clone(),
-            partition_values.clone(),
-        );
-        assert_eq!(state.physical_predicate, PhysicalPredicate::StaticSkipAll);
         let segment = log_segment(log_root(), &[], None);
-        assert!(build_metadata_scan_plan(
-            &state,
-            &segment,
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .is_none());
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_predicate(Predicate::literal(false))
+            .build()?;
+        assert_eq!(
+            scan.state_info.physical_predicate,
+            PhysicalPredicate::StaticSkipAll
+        );
+        assert!(scan
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .is_none());
         Ok(())
     }
 
@@ -1049,15 +953,6 @@ mod tests {
             DeltaResult::<()>::Ok(())
         })?;
 
-        let stats = StatsOptions::default();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            None,
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[
@@ -1066,15 +961,10 @@ mod tests {
             ],
             None,
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
-            &no_checkpoint(),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+        let scan = mock_snapshot(segment)?.scan_builder().build()?;
+        let plan = scan
+            .build_metadata_scan_plan(&no_checkpoint())?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine
@@ -1117,30 +1007,20 @@ mod tests {
         // `stats_parsed` column.
         write_parquet_checkpoint(&store, "_delta_log/00000000000000000000.checkpoint.parquet")?;
 
-        let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::default();
-        let state = state(
-            data_schema(),
-            vec![],
-            Some(col!("x").gt(lit(lower_bound))),
-            stats.clone(),
-            partition_values.clone(),
-        );
         let segment = log_segment(
             Url::parse("memory:///_delta_log/").unwrap(),
             &[],
             Some("memory:///_delta_log/00000000000000000000.checkpoint.parquet"),
         );
-        let plan = build_metadata_scan_plan(
-            &state,
-            &segment,
+        let scan = mock_snapshot(segment)?
+            .scan_builder()
+            .with_stats(StatsOptions::all())
+            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .build()?;
+        let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.
-            &shape(CheckpointType::Leaf, None),
-            &stats,
-            &partition_values,
-            state.physical_stats_schema.as_ref(),
-        )?
-        .expect("non-empty");
+            .build_metadata_scan_plan(&shape(CheckpointType::Leaf, None))?
+            .expect("non-empty");
 
         let engine = SyncEngine::new_with_store(store);
         let mut batches = engine

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -136,12 +136,13 @@ impl Scan {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
         let physical_partitions = self.state_info.physical_partition_schema.as_ref();
-        let source_physical_stats = shape.parsed_stats_schema.as_ref();
+        let source_physical_stats =
+            physical_stats.and_then(|schema| shape.compatible_stats_parsed_schema(schema));
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -152,7 +153,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -661,9 +662,12 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
+        let leaf_checkpoint_schema = parsed_stats
+            .as_ref()
+            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
         CheckpointShape {
             checkpoint_type,
-            parsed_stats_schema: parsed_stats,
+            leaf_checkpoint_schema,
         }
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -137,8 +137,9 @@ impl Scan {
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
-    /// When the checkpoint lacks a native parsed field, the corresponding `FROM_JSON` or
-    /// `MAP_TO_STRUCT` expression replaces it. A parsed field is omitted when its schema is absent.
+    /// When no compatible native field exists, the arm parses JSON or map input. It serializes
+    /// parsed stats when JSON output is requested from a struct-only checkpoint. Requested parsed
+    /// stats require at least one source representation; unrequested fields are omitted.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
@@ -176,7 +177,7 @@ impl Scan {
             }
         }?;
 
-        actions
+        let actions = actions
             .filter(col!("add.path").is_not_null())?
             .project_patch(|patch| {
                 patch
@@ -190,7 +191,13 @@ impl Scan {
                         FILE_ACTION_KEY_FIELD.clone(),
                         file_action_key_expr(|col| joined_column_expr!("add", col)),
                     )
-            })
+            })?;
+
+        if self.stats.synthesize_json && !shape.has_json_stats() {
+            actions.project_patch(|patch| patch.with_json_add_stats())
+        } else {
+            Ok(actions)
+        }
     }
 
     /// Build the normalized commit JSON arm.
@@ -242,40 +249,52 @@ impl Scan {
 
     fn checkpoint_parquet_read_schema(&self, shape: &CheckpointShape) -> DeltaResult<SchemaRef> {
         let stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let checkpoint_stats_schema = if self.stats.synthesize_json && !shape.has_json_stats() {
-            shape.stats_parsed_schema()
-        } else {
-            stats_schema.and_then(|schema| shape.compatible_stats_parsed_schema(schema))
-        };
-        let checkpoint_partition_schema = partition_schema
-            .and_then(|schema| shape.compatible_partition_values_parsed_schema(schema));
+        let checkpoint_parsed_stats_schema =
+            if self.stats.synthesize_json && !shape.has_json_stats() {
+                // JSON output must preserve all table-configured stats. `stats_schema` may be
+                // narrowed by `StructStats::Columns` or the data-skipping predicate, so use the
+                // full expected schema.
+                let expected_json_stats_schema = self
+                    .snapshot
+                    .table_configuration()
+                    .build_expected_stats_schemas(None, None)?
+                    .physical;
+                shape
+                    .compatible_stats_parsed_schema(&expected_json_stats_schema)
+                    .cloned()
+            } else {
+                stats_schema
+                    .and_then(|schema| shape.compatible_stats_parsed_schema(schema))
+                    .cloned()
+            };
+        if shape.checkpoint_type != CheckpointType::None
+            && (self.stats.synthesize_json || stats_schema.is_some())
+            && !shape.has_json_stats()
+            && checkpoint_parsed_stats_schema.is_none()
+        {
+            return Err(Error::invalid_checkpoint(
+                "stats were requested, but checkpoint contains neither compatible \
+                 add.stats_parsed nor add.stats",
+            ));
+        }
         let read_json_stats = shape.has_json_stats()
             && (self.stats.synthesize_json
-                || (stats_schema.is_some() && checkpoint_stats_schema.is_none()));
-        let read_string_partitions = self.partition_values.string_map
-            || (partition_schema.is_some() && checkpoint_partition_schema.is_none());
-
-        let add_patch = SchemaStructPatchBuilder::new()
-            .fold_with(checkpoint_stats_schema.as_ref(), |patch, schema| {
+                || (stats_schema.is_some() && checkpoint_parsed_stats_schema.is_none()));
+        let add_patch = SchemaStructPatchBuilder::new().fold_with(
+            checkpoint_parsed_stats_schema.as_ref(),
+            |patch, schema| {
                 patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            })
-            .fold_with(checkpoint_partition_schema.as_ref(), |patch, schema| {
-                patch.append(StructField::nullable(
-                    PARTITION_VALUES_PARSED,
-                    schema.as_ref().clone(),
-                ))
-            });
+            },
+        );
         let add_patch = if read_json_stats {
             add_patch
         } else {
             add_patch.drop(STATS)
         };
-        let add_patch = if read_string_partitions {
-            add_patch
-        } else {
-            add_patch.drop(PARTITION_VALUES)
-        };
+        // Native parsed partitions are not authoritative:
+        // `LogSegment::schema_has_compatible_partition_values_parsed` permits missing fields, and
+        // timestamps may use the checkpoint writer's timezone, making them incorrect for other
+        // readers. We always retain and reparse the complete string map instead.
         Ok(schema_ref! {
             (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
             nullable (VERSION): LONG,
@@ -342,7 +361,6 @@ impl Scan {
             (false, true) => projection.drop(STATS),
         };
 
-        // Raw partition-values output.
         let projection = if self.partition_values.string_map {
             projection
         } else {
@@ -522,12 +540,7 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                     let expr = Expr::parse_json(col!("add.stats"), Arc::clone(schema));
                     self.append_at(add, field, expr)
                 } else {
-                    let expr = Expr::struct_from(
-                        schema
-                            .fields()
-                            .map(|field| Expr::null_literal(field.data_type().clone())),
-                    );
-                    self.append_at(add, field, expr)
+                    self
                 }
             }
             None => self,
@@ -733,25 +746,13 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
-        shape_with_schemas(checkpoint_type, parsed_stats, None)
-    }
-
-    fn shape_with_schemas(
-        checkpoint_type: CheckpointType,
-        parsed_stats: Option<SchemaRef>,
-        parsed_partitions: Option<SchemaRef>,
-    ) -> CheckpointShape {
         let leaf_checkpoint_schema = (checkpoint_type != CheckpointType::None).then(|| {
-            let add_patch = SchemaStructPatchBuilder::new()
-                .fold_with(parsed_stats.as_ref(), |patch, schema| {
+            let add_patch = SchemaStructPatchBuilder::new().fold_with(
+                parsed_stats.as_ref(),
+                |patch, schema| {
                     patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-                })
-                .fold_with(parsed_partitions.as_ref(), |patch, schema| {
-                    patch.append(StructField::nullable(
-                        PARTITION_VALUES_PARSED,
-                        schema.as_ref().clone(),
-                    ))
-                });
+                },
+            );
             schema_ref! {
                 (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA).unwrap())),
                 nullable (VERSION): LONG,
@@ -908,7 +909,6 @@ mod tests {
     fn metadata_plan_manifest_sidecar_dynamic_scan_metadata_columns(
         #[case] parsed_stats: Option<SchemaRef>,
         #[case] expect_parsed_columns: bool,
-        #[values(false, true)] native_parsed_partitions: bool,
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
         let partition_values = PartitionValuesOptions::struct_only();
@@ -918,14 +918,8 @@ mod tests {
             .with_stats(stats)
             .with_partition_values(partition_values)
             .build()?;
-        let parsed_partitions = native_parsed_partitions
-            .then(|| scan.state_info.physical_partition_schema.clone().unwrap());
         let plan = scan
-            .build_metadata_scan_plan(&shape_with_schemas(
-                CheckpointType::Manifest,
-                parsed_stats,
-                parsed_partitions,
-            ))?
+            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
             .expect("non-empty");
 
         let dynamic_scan = plan
@@ -942,18 +936,12 @@ mod tests {
                 .is_some(),
             expect_parsed_columns,
         );
-        assert_eq!(
-            add_struct(&dynamic_scan.schema)
-                .field(PARTITION_VALUES_PARSED)
-                .is_some(),
-            native_parsed_partitions,
-        );
-        assert_eq!(
-            add_struct(&dynamic_scan.schema)
-                .field(PARTITION_VALUES)
-                .is_some(),
-            !native_parsed_partitions,
-        );
+        assert!(add_struct(&dynamic_scan.schema)
+            .field(PARTITION_VALUES_PARSED)
+            .is_none());
+        assert!(add_struct(&dynamic_scan.schema)
+            .field(PARTITION_VALUES)
+            .is_some());
         Ok(())
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -18,6 +18,7 @@ use crate::actions::{
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
     col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
+    UnaryExpressionOp,
 };
 use crate::plans::ir::nodes::{FileType, Load, LoadColumnFileMeta, ScanFile};
 use crate::plans::ir::plan::Plan;
@@ -37,6 +38,7 @@ use crate::{DeltaResult, Error, PlanBuilder};
 // materialize them as one top-level `file_action_key` column that are used by the plan's
 // aggregate and anti-join operators.
 const FILE_ACTION_KEY: &str = "file_action_key";
+const DATA_CHANGE: &str = "dataChange";
 const STATS: &str = "stats";
 const PARTITION_VALUES: &str = "partitionValues";
 const PARTITION_VALUES_PARSED: &str = "partitionValues_parsed";
@@ -61,9 +63,6 @@ impl Scan {
         let prune = stats_skipping_predicate(state);
         let prune = prune.as_ref();
 
-        // The output `add` after reparsing `stats`/`partitionValues`: shared by the commit arm's
-        // dedup carrier and both terminal `{ add }` projections, so every arm agrees on the
-        // union schema.
         let add_field = self.normalized_add_field()?;
         let (output_expr, output_schema) = self.metadata_output_projection(&add_field)?;
 
@@ -105,13 +104,20 @@ impl Scan {
             .checkpoint_arm(shape)?
             .try_fold_with(prune, |p, prune| p.filter(prune.clone()))?;
 
-        let checkpoint_live_adds = checkpoint_adds
-            .anti_join(
-                deduped_commit.clone(),
-                [ColumnName::new([FILE_ACTION_KEY])],
-                [ColumnName::new([FILE_ACTION_KEY])],
-            )?
-            .project(output_expr.clone(), output_schema.clone())?;
+        let checkpoint_live_adds = checkpoint_adds.anti_join(
+            deduped_commit.clone(),
+            [ColumnName::new([FILE_ACTION_KEY])],
+            [ColumnName::new([FILE_ACTION_KEY])],
+        )?;
+        // A struct-only checkpoint retains its complete parsed stats until reconciliation, then
+        // serializes them only when JSON stats were requested.
+        let checkpoint_live_adds = if self.stats.synthesize_json && !shape.has_json_stats() {
+            checkpoint_live_adds.project_patch(|patch| patch.with_json_add_stats())?
+        } else {
+            checkpoint_live_adds
+        };
+        let checkpoint_live_adds =
+            checkpoint_live_adds.project(output_expr.clone(), output_schema.clone())?;
 
         let commit_live_adds = deduped_commit
             .filter(col!("add").is_not_null())?
@@ -135,20 +141,18 @@ impl Scan {
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
-    /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, stats_schema)`
-    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    /// When the checkpoint lacks a native parsed field, the corresponding `FROM_JSON` or
+    /// `MAP_TO_STRUCT` expression replaces it. A parsed field is omitted when its schema is absent.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
         let stats_schema = self.state_info.physical_stats_schema.as_ref();
         let partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let source_stats_schema = stats_schema
-            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
+        let parquet_read_schema = self.checkpoint_parquet_read_schema(shape)?;
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
-                PlanBuilder::scan_parquet(parts, &[VERSION], schema)
+                PlanBuilder::scan_parquet(parts, &[VERSION], parquet_read_schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
                 PlanBuilder::scan_json(
@@ -158,11 +162,17 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
-                    Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
+                    Some(sidecars) => {
+                        PlanBuilder::scan_parquet(sidecars, &[VERSION], parquet_read_schema)
+                    }
                     // Without a complete hint, load the sidecars referenced by the manifest.
-                    None => sidecar_actions(file_type, parts, schema, &log_segment.log_root),
+                    None => sidecar_actions(
+                        file_type,
+                        parts,
+                        parquet_read_schema,
+                        &log_segment.log_root,
+                    ),
                 }
             }
             (CheckpointType::None, _) | (_, None) => {
@@ -234,6 +244,48 @@ impl Scan {
             })
     }
 
+    fn checkpoint_parquet_read_schema(&self, shape: &CheckpointShape) -> DeltaResult<SchemaRef> {
+        let stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let checkpoint_stats_schema = if self.stats.synthesize_json && !shape.has_json_stats() {
+            shape.stats_parsed_schema()
+        } else {
+            stats_schema.and_then(|schema| shape.compatible_stats_parsed_schema(schema))
+        };
+        let checkpoint_partition_schema = partition_schema
+            .and_then(|schema| shape.compatible_partition_values_parsed_schema(schema));
+        let read_json_stats = shape.has_json_stats()
+            && (self.stats.synthesize_json
+                || (stats_schema.is_some() && checkpoint_stats_schema.is_none()));
+        let read_string_partitions = self.partition_values.string_map
+            || (partition_schema.is_some() && checkpoint_partition_schema.is_none());
+
+        let add_patch = SchemaStructPatchBuilder::new()
+            .fold_with(checkpoint_stats_schema.as_ref(), |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(checkpoint_partition_schema.as_ref(), |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        let add_patch = if read_json_stats {
+            add_patch
+        } else {
+            add_patch.drop(STATS)
+        };
+        let add_patch = if read_string_partitions {
+            add_patch
+        } else {
+            add_patch.drop(PARTITION_VALUES)
+        };
+        Ok(schema_ref! {
+            (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
+            nullable (VERSION): LONG,
+        })
+    }
+
     fn normalized_add_field(&self) -> DeltaResult<StructField> {
         let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
         let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
@@ -294,6 +346,13 @@ impl Scan {
             (false, true) => projection.drop(STATS),
         };
 
+        // Raw partition-values output.
+        let projection = if self.partition_values.string_map {
+            projection
+        } else {
+            projection.drop(PARTITION_VALUES)
+        };
+
         // Parsed stats output.
         let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
             (Some(stats_schema), _) => projection.replace(
@@ -332,7 +391,8 @@ impl Scan {
             (None, false) => projection,
         };
 
-        let (add_schema, add_expr) = projection.build()?;
+        let (add_schema, _) = projection.build()?;
+        let add_expr = project_nested_struct_to_schema(column_name!("add"), &add_schema);
         let schema = schema_ref! {
             (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
         };
@@ -411,27 +471,6 @@ fn json_read_schema(include_remove: bool) -> SchemaRef {
     }
 }
 
-/// Read schema for parquet add actions.
-fn parquet_read_schema(
-    stats_schema: Option<&SchemaRef>,
-    partition_schema: Option<&SchemaRef>,
-) -> DeltaResult<SchemaRef> {
-    let add_patch = SchemaStructPatchBuilder::new()
-        .fold_with(stats_schema, |patch, ss| {
-            patch.append(StructField::nullable(STATS_PARSED, ss.as_ref().clone()))
-        })
-        .fold_with(partition_schema, |patch, ps| {
-            patch.append(StructField::nullable(
-                PARTITION_VALUES_PARSED,
-                ps.as_ref().clone(),
-            ))
-        });
-    Ok(schema_ref! {
-        (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
-        nullable (VERSION): LONG,
-    })
-}
-
 /// File identity used for replay.
 static FILE_ACTION_KEY_FIELD: LazyLock<StructField> = LazyLock::new(|| {
     let schema = schema! {
@@ -470,6 +509,8 @@ trait ProjectionStructPatchBuilderExt<'a> {
 
     /// Parses add partition values, preferring a compatible parsed field.
     fn with_parsed_add_partition_values(self, partition_schema: Option<&SchemaRef>) -> Self;
+
+    fn with_json_add_stats(self) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
@@ -477,14 +518,21 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         let has_stats_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let has_json_stats = self.input_schema().contains_col([ADD_NAME, STATS]);
         let add = [ADD_NAME];
         match stats_schema {
             Some(ss) => {
                 let field = StructField::nullable(STATS_PARSED, ss.as_ref().clone());
-                let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
                 if has_stats_parsed {
                     self
+                } else if has_json_stats {
+                    let expr = Expr::parse_json(col!("add.stats"), Arc::clone(ss));
+                    self.append_at(add, field, expr)
                 } else {
+                    let expr = Expr::struct_from(
+                        ss.fields()
+                            .map(|field| Expr::null_literal(field.data_type().clone())),
+                    );
                     self.append_at(add, field, expr)
                 }
             }
@@ -502,14 +550,35 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, ps.as_ref().clone());
                 let expr = Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES));
                 if has_partition_values_parsed {
-                    let expr = Expr::coalesce([col!(ADD_NAME, PARTITION_VALUES_PARSED), expr]);
-                    self.replace_at(add, PARTITION_VALUES_PARSED, field, expr)
+                    self
                 } else {
                     self.append_at(add, field, expr)
                 }
             }
             None => self,
         }
+    }
+
+    fn with_json_add_stats(self) -> Self {
+        let has_json_stats = self.input_schema().contains_col([ADD_NAME, STATS]);
+        if has_json_stats {
+            return self;
+        }
+
+        let has_stats_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let expr = if has_stats_parsed {
+            Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"))
+        } else {
+            Expr::null_literal(DataType::STRING)
+        };
+        self.insert_after_at(
+            [ADD_NAME],
+            DATA_CHANGE,
+            StructField::nullable(STATS, DataType::STRING),
+            expr,
+        )
     }
 }
 
@@ -670,9 +739,30 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
-        let leaf_checkpoint_schema = parsed_stats
-            .as_ref()
-            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
+        shape_with_schemas(checkpoint_type, parsed_stats, None)
+    }
+
+    fn shape_with_schemas(
+        checkpoint_type: CheckpointType,
+        parsed_stats: Option<SchemaRef>,
+        parsed_partitions: Option<SchemaRef>,
+    ) -> CheckpointShape {
+        let leaf_checkpoint_schema = (checkpoint_type != CheckpointType::None).then(|| {
+            let add_patch = SchemaStructPatchBuilder::new()
+                .fold_with(parsed_stats.as_ref(), |patch, schema| {
+                    patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+                })
+                .fold_with(parsed_partitions.as_ref(), |patch, schema| {
+                    patch.append(StructField::nullable(
+                        PARTITION_VALUES_PARSED,
+                        schema.as_ref().clone(),
+                    ))
+                });
+            schema_ref! {
+                (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA).unwrap())),
+                nullable (VERSION): LONG,
+            }
+        });
         CheckpointShape {
             checkpoint_type,
             leaf_checkpoint_schema,
@@ -837,20 +927,27 @@ mod tests {
     #[rstest::rstest]
     #[case::with_parsed_stats(Some(struct_stats_schema()), true)]
     #[case::without_parsed_stats(None, false)]
-    fn metadata_plan_manifest_sidecar_load_stats_columns(
+    fn metadata_plan_manifest_sidecar_load_metadata_columns(
         #[case] parsed_stats: Option<SchemaRef>,
         #[case] expect_parsed_columns: bool,
+        #[values(false, true)] native_parsed_partitions: bool,
     ) -> DeltaResult<()> {
         let stats = StatsOptions::all();
-        let partition_values = PartitionValuesOptions::with_struct();
+        let partition_values = PartitionValuesOptions::struct_only();
         let segment = log_segment(log_root(), &[], Some(checkpoint_path(FileType::Parquet)));
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(stats)
             .with_partition_values(partition_values)
             .build()?;
+        let parsed_partitions = native_parsed_partitions
+            .then(|| scan.state_info.physical_partition_schema.clone().unwrap());
         let plan = scan
-            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .build_metadata_scan_plan(&shape_with_schemas(
+                CheckpointType::Manifest,
+                parsed_stats,
+                parsed_partitions,
+            ))?
             .expect("non-empty");
 
         let load = plan
@@ -865,11 +962,15 @@ mod tests {
             add_struct(&load.schema).field(STATS_PARSED).is_some(),
             expect_parsed_columns,
         );
-        assert!(
+        assert_eq!(
             add_struct(&load.schema)
                 .field(PARTITION_VALUES_PARSED)
-                .is_none(),
-            "native parsed partition values are not requested yet"
+                .is_some(),
+            native_parsed_partitions,
+        );
+        assert_eq!(
+            add_struct(&load.schema).field(PARTITION_VALUES).is_some(),
+            !native_parsed_partitions,
         );
         Ok(())
     }

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -137,9 +137,9 @@ impl Scan {
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
-    /// When no compatible native field exists, the arm parses JSON or map input. It serializes
-    /// parsed stats when JSON output is requested from a struct-only checkpoint. Requested parsed
-    /// stats require at least one source representation; unrequested fields are omitted.
+    /// When no compatible native field exists, the arm parses JSON or map input. Missing stats
+    /// remain null. It serializes parsed stats when JSON output is requested from a struct-only
+    /// checkpoint; unrequested fields are omitted.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
@@ -248,6 +248,18 @@ impl Scan {
     }
 
     fn checkpoint_parquet_read_schema(&self, shape: &CheckpointShape) -> DeltaResult<SchemaRef> {
+        let add_patch = SchemaStructPatchBuilder::new();
+
+        // This determines which parsed stats columns to read from the checkpoint. This happens in
+        // one of the following cases:
+        //     1) The user requested JSON stats, but the checkpoint only has parsed stats. This
+        //        reads the full stats schema so JSON can be synthesized.
+        //     2) The user requested structured stats using `StructStats::All` or
+        //        `StructStats::Columns`.
+        //     3) The user provided a predicate that can be evaluated using parsed stats.
+        //
+        // Cases 2 and 3 are handled by `physical_stats_schema`, which contains the union of columns
+        // needed for structured output and predicate evaluation.
         let stats_schema = self.state_info.physical_stats_schema.as_ref();
         let checkpoint_parsed_stats_schema =
             if self.stats.synthesize_json && !shape.has_json_stats() {
@@ -267,25 +279,16 @@ impl Scan {
                     .and_then(|schema| shape.compatible_stats_parsed_schema(schema))
                     .cloned()
             };
-        if shape.checkpoint_type != CheckpointType::None
-            && (self.stats.synthesize_json || stats_schema.is_some())
-            && !shape.has_json_stats()
-            && checkpoint_parsed_stats_schema.is_none()
-        {
-            return Err(Error::invalid_checkpoint(
-                "stats were requested, but checkpoint contains neither compatible \
-                 add.stats_parsed nor add.stats",
-            ));
-        }
-        let read_json_stats = shape.has_json_stats()
-            && (self.stats.synthesize_json
-                || (stats_schema.is_some() && checkpoint_parsed_stats_schema.is_none()));
-        let add_patch = SchemaStructPatchBuilder::new().fold_with(
-            checkpoint_parsed_stats_schema.as_ref(),
-            |patch, schema| {
+        let add_patch =
+            add_patch.fold_with(checkpoint_parsed_stats_schema.as_ref(), |patch, schema| {
                 patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            },
-        );
+            });
+
+        // JSON stats are read when requested using `StructStats::Json` or needed to derive parsed stats because
+        // the checkpoint has no compatible parsed representation.
+        let needs_json_stats = self.stats.synthesize_json
+            || (stats_schema.is_some() && checkpoint_parsed_stats_schema.is_none());
+        let read_json_stats = shape.has_json_stats() && needs_json_stats;
         let add_patch = if read_json_stats {
             add_patch
         } else {
@@ -294,7 +297,7 @@ impl Scan {
         // Native parsed partitions are not authoritative:
         // `LogSegment::schema_has_compatible_partition_values_parsed` permits missing fields, and
         // timestamps may use the checkpoint writer's timezone, making them incorrect for other
-        // readers. We always retain and reparse the complete string map instead.
+        // readers. We retain and reparse the complete string map downstream.
         Ok(schema_ref! {
             (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
             nullable (VERSION): LONG,
@@ -324,7 +327,7 @@ impl Scan {
     /// ```text
     /// add: struct<
     ///   path: string,
-    ///   partitionValues: map<string, string>,
+    ///   partitionValues: map<string, string>,     // when string partitions are requested
     ///   size: long,
     ///   modificationTime: long,
     ///   dataChange: boolean,
@@ -512,10 +515,8 @@ fn file_action_key_expr(key_col_expr: impl Fn(ColumnName) -> Expr) -> Expr {
 }
 
 trait ProjectionStructPatchBuilderExt<'a> {
-    /// Parses add stats, preferring a compatible parsed field.
-    ///
-    /// When `physical_stats` is present, the input must contain either
-    /// `add.stats_parsed` or the fallback `add.stats` JSON field.
+    /// Parses add stats, preferring a compatible parsed field. When neither representation exists,
+    /// emits a typed null struct so metadata pruning conservatively retains the file.
     fn with_parsed_add_stats(self, physical_stats: Option<&SchemaRef>) -> Self;
 
     /// Parses add partition values, preferring a compatible parsed field.
@@ -540,7 +541,11 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
                     let expr = Expr::parse_json(col!("add.stats"), Arc::clone(schema));
                     self.append_at(add, field, expr)
                 } else {
-                    self
+                    self.append_at(
+                        add,
+                        field,
+                        Expr::null_literal(schema.as_ref().clone().into()),
+                    )
                 }
             }
             None => self,
@@ -572,7 +577,14 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             return self;
         }
 
-        let expr = Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"));
+        let has_stats_parsed = self
+            .input_schema()
+            .contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let expr = if has_stats_parsed {
+            Expr::unary(UnaryExpressionOp::ToJson, col!("add.stats_parsed"))
+        } else {
+            Expr::null_literal(DataType::STRING)
+        };
         self.insert_after_at(
             [ADD_NAME],
             DATA_CHANGE,

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -141,12 +141,13 @@ impl Scan {
         let log_segment = self.snapshot.log_segment();
         let stats_schema = self.state_info.physical_stats_schema.as_ref();
         let partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let source_stats_schema = shape.parsed_stats_schema.as_ref();
+        let source_stats_schema = stats_schema
+            .and_then(|stats_schema| shape.compatible_stats_parsed_schema(stats_schema));
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -157,7 +158,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_stats_schema, None)?;
+                let schema = parquet_read_schema(source_stats_schema.as_ref(), None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -669,9 +670,12 @@ mod tests {
     }
 
     fn shape(checkpoint_type: CheckpointType, parsed_stats: Option<SchemaRef>) -> CheckpointShape {
+        let leaf_checkpoint_schema = parsed_stats
+            .as_ref()
+            .map(|stats| parquet_read_schema(Some(stats), None).unwrap());
         CheckpointShape {
             checkpoint_type,
-            parsed_stats_schema: parsed_stats,
+            leaf_checkpoint_schema,
         }
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -232,6 +232,111 @@ impl Scan {
                     )
             })
     }
+
+    fn normalized_add_field(&self) -> DeltaResult<StructField> {
+        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
+        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
+        let patch = SchemaStructPatchBuilder::new()
+            .fold_with(physical_stats_schema, |patch, schema| {
+                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
+            })
+            .fold_with(physical_partition_schema, |patch, schema| {
+                patch.append(StructField::nullable(
+                    PARTITION_VALUES_PARSED,
+                    schema.as_ref().clone(),
+                ))
+            });
+        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
+    }
+
+    /// Builds the output projection for requested stats and partition values. The base of this
+    /// transformation is constructed by [`Self::normalized_add_field`].
+    ///
+    /// The output schema is:
+    /// ```text
+    /// add: struct<
+    ///   path: string,
+    ///   partitionValues: map<string, string>,
+    ///   size: long,
+    ///   modificationTime: long,
+    ///   dataChange: boolean,
+    ///   stats: string,                         // when JSON stats are requested
+    ///   tags: map<string, string>,
+    ///   deletionVector: struct<...>,
+    ///   baseRowId: long,
+    ///   defaultRowCommitVersion: long,
+    ///   clusteringProvider: string,
+    ///   stats_parsed: struct<...>,             // when parsed stats are requested
+    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
+    /// >
+    /// ```
+    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
+    /// partition values are selected independently and omitted for unpartitioned tables. Fields
+    /// needed only for pruning are omitted.
+    fn metadata_output_projection(
+        &self,
+        add_field: &StructField,
+    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
+        let input_schema = schema_ref! { (add_field.clone()) };
+        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
+        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
+
+        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
+        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
+        let projection = match (self.stats.synthesize_json, has_json_stats) {
+            (true, true) | (false, false) => projection,
+            (true, false) => {
+                return Err(Error::internal_error(
+                    "JSON stats were requested, but add.stats is missing from the metadata schema",
+                ));
+            }
+            (false, true) => projection.drop(STATS),
+        };
+
+        // Parsed stats output.
+        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
+            (Some(stats_schema), _) => projection.replace(
+                STATS_PARSED,
+                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
+                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
+            ),
+            (None, true) => projection.drop(STATS_PARSED),
+            (None, false) => projection,
+        };
+
+        // Parsed partition-values output.
+        let has_partition_values_parsed =
+            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
+        let partition_output_schema = self
+            .partition_values
+            .parsed_struct
+            .then_some(self.state_info.physical_partition_schema.as_ref())
+            .flatten();
+        let projection = match (partition_output_schema, has_partition_values_parsed) {
+            (Some(partition_schema), true) => projection.replace(
+                PARTITION_VALUES_PARSED,
+                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
+                project_nested_struct_to_schema(
+                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
+                    partition_schema,
+                ),
+            ),
+            (Some(_), false) => {
+                return Err(Error::internal_error(
+                    "parsed partition values were requested, but add.partitionValues_parsed is \
+                     missing",
+                ));
+            }
+            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
+            (None, false) => projection,
+        };
+
+        let (add_schema, add_expr) = projection.build()?;
+        let schema = schema_ref! {
+            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
+        };
+        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
+    }
 }
 
 /// Load actions from V2 checkpoint sidecars.
@@ -404,113 +509,6 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
             }
             None => self,
         }
-    }
-}
-
-impl Scan {
-    fn normalized_add_field(&self) -> DeltaResult<StructField> {
-        let physical_stats_schema = self.state_info.physical_stats_schema.as_ref();
-        let physical_partition_schema = self.state_info.physical_partition_schema.as_ref();
-        let patch = SchemaStructPatchBuilder::new()
-            .fold_with(physical_stats_schema, |patch, schema| {
-                patch.append(StructField::nullable(STATS_PARSED, schema.as_ref().clone()))
-            })
-            .fold_with(physical_partition_schema, |patch, schema| {
-                patch.append(StructField::nullable(
-                    PARTITION_VALUES_PARSED,
-                    schema.as_ref().clone(),
-                ))
-            });
-        Ok(StructField::nullable(ADD_NAME, patch.build(&ADD_SCHEMA)?))
-    }
-
-    /// Builds the output projection for requested stats and partition values. The base of this
-    /// transformation is constructed by [`Self::normalized_add_field`].
-    ///
-    /// The output schema is:
-    /// ```text
-    /// add: struct<
-    ///   path: string,
-    ///   partitionValues: map<string, string>,
-    ///   size: long,
-    ///   modificationTime: long,
-    ///   dataChange: boolean,
-    ///   stats: string,                         // when JSON stats are requested
-    ///   tags: map<string, string>,
-    ///   deletionVector: struct<...>,
-    ///   baseRowId: long,
-    ///   defaultRowCommitVersion: long,
-    ///   clusteringProvider: string,
-    ///   stats_parsed: struct<...>,             // when parsed stats are requested
-    ///   partitionValues_parsed: struct<...>,   // when parsed partition values are requested
-    /// >
-    /// ```
-    /// Stats output may contain neither representation, JSON only, parsed only, or both. Parsed
-    /// partition values are selected independently and omitted for unpartitioned tables. Fields
-    /// needed only for pruning are omitted.
-    fn metadata_output_projection(
-        &self,
-        add_field: &StructField,
-    ) -> DeltaResult<(ExpressionRef, SchemaRef)> {
-        let input_schema = schema_ref! { (add_field.clone()) };
-        let has_stats_parsed = input_schema.contains_col([ADD_NAME, STATS_PARSED_NAME]);
-        let projection = ProjectionStructPatchBuilder::new_nested(&input_schema, [ADD_NAME]);
-
-        // JSON stats output. `StatsOptions` allows JSON only, parsed only, both, or neither.
-        let has_json_stats = input_schema.contains_col([ADD_NAME, STATS]);
-        let projection = match (self.stats.synthesize_json, has_json_stats) {
-            (true, true) | (false, false) => projection,
-            (true, false) => {
-                return Err(Error::internal_error(
-                    "JSON stats were requested, but add.stats is missing from the metadata schema",
-                ));
-            }
-            (false, true) => projection.drop(STATS),
-        };
-
-        // Parsed stats output.
-        let projection = match (self.physical_stats_output_schema.as_ref(), has_stats_parsed) {
-            (Some(stats_schema), _) => projection.replace(
-                STATS_PARSED,
-                StructField::nullable(STATS_PARSED, stats_schema.as_ref().clone()),
-                project_nested_struct_to_schema([ADD_NAME, STATS_PARSED_NAME], stats_schema),
-            ),
-            (None, true) => projection.drop(STATS_PARSED),
-            (None, false) => projection,
-        };
-
-        // Parsed partition-values output.
-        let has_partition_values_parsed =
-            input_schema.contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
-        let partition_output_schema = self
-            .partition_values
-            .parsed_struct
-            .then_some(self.state_info.physical_partition_schema.as_ref())
-            .flatten();
-        let projection = match (partition_output_schema, has_partition_values_parsed) {
-            (Some(partition_schema), true) => projection.replace(
-                PARTITION_VALUES_PARSED,
-                StructField::nullable(PARTITION_VALUES_PARSED, partition_schema.as_ref().clone()),
-                project_nested_struct_to_schema(
-                    [ADD_NAME, PARTITION_VALUES_PARSED_NAME],
-                    partition_schema,
-                ),
-            ),
-            (Some(_), false) => {
-                return Err(Error::internal_error(
-                    "parsed partition values were requested, but add.partitionValues_parsed is \
-                     missing",
-                ));
-            }
-            (None, true) => projection.drop(PARTITION_VALUES_PARSED),
-            (None, false) => projection,
-        };
-
-        let (add_schema, add_expr) = projection.build()?;
-        let schema = schema_ref! {
-            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-        };
-        Ok((Arc::new(Expr::struct_from([add_expr])), schema))
     }
 }
 
@@ -783,7 +781,7 @@ mod tests {
         mock_snapshot(segment)
             .unwrap()
             .scan_builder()
-            .with_predicate(col!("x").gt(lit(5i64)))
+            .with_predicate(Arc::new(col!("x").gt(lit(5i64))))
             .with_stats(StatsOptions::all())
             .build()
             .unwrap()
@@ -917,7 +915,7 @@ mod tests {
         let segment = log_segment(log_root(), &[], None);
         let scan = mock_snapshot(segment)?
             .scan_builder()
-            .with_predicate(Predicate::literal(false))
+            .with_predicate(Arc::new(Predicate::literal(false)))
             .build()?;
         assert_eq!(
             scan.state_info.physical_predicate,
@@ -1015,7 +1013,7 @@ mod tests {
         let scan = mock_snapshot(segment)?
             .scan_builder()
             .with_stats(StatsOptions::all())
-            .with_predicate(col!("x").gt(lit(lower_bound)))
+            .with_predicate(Arc::new(col!("x").gt(lit(lower_bound))))
             .build()?;
         let plan = scan
             // Leaf with no compatible parsed stats -> parse add.stats instead.

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -142,7 +142,7 @@ impl Scan {
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -153,7 +153,7 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats.as_ref(), None)?;
+                let schema = parquet_read_schema(source_physical_stats, None)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -52,7 +52,15 @@ fn normalized_metadata_batch(
     if let Some(partitions) = partitions_parsed {
         columns.push(("partitionValues_parsed", partitions));
     }
-    Ok(RecordBatch::try_from_iter(columns)?)
+    // Arrow infers non-nullable fields for all-valid computed arrays; these metadata fields remain
+    // nullable by contract.
+    Ok(RecordBatch::try_from_iter_with_nullable(
+        columns.into_iter().map(|(name, column)| {
+            let nullable = matches!(name, STATS | STATS_PARSED | PARTITION_VALUES_PARSED)
+                || column.is_nullable();
+            (name, column, nullable)
+        }),
+    )?)
 }
 
 fn imperative_metadata(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<RecordBatch>> {
@@ -159,14 +167,14 @@ fn without_columns(batches: &[RecordBatch], excluded: &[&str]) -> DeltaResult<Ve
     batches
         .iter()
         .map(|batch| {
-            RecordBatch::try_from_iter(
+            RecordBatch::try_from_iter_with_nullable(
                 batch
                     .schema()
                     .fields()
                     .iter()
                     .zip(batch.columns())
                     .filter(|(field, _)| !excluded.contains(&field.name().as_str()))
-                    .map(|(field, column)| (field.name(), column.clone())),
+                    .map(|(field, column)| (field.name(), column.clone(), field.is_nullable())),
             )
             .map_err(Into::into)
         })
@@ -393,7 +401,6 @@ const ADD_FIELDS: &[&str] = &[
     "add.size",
     "add.modificationTime",
     "add.dataChange",
-    "add.partitionValues",
     "add.deletionVector.storageType",
     "add.deletionVector.pathOrInlineDv",
     "add.deletionVector.offset",
@@ -404,6 +411,7 @@ const ADD_FIELDS: &[&str] = &[
     "add.tags",
     "add.clusteringProvider",
 ];
+const STRING_PARTITION_FIELDS: &[&str] = &["add.partitionValues"];
 const ALL_STATS_PARSED_FIELDS: &[&str] = &[
     "add.stats_parsed.numRecords",
     "add.stats_parsed.nullCount.id",
@@ -444,58 +452,105 @@ const JSON_STATS_FIELDS: &[&str] = &["add.stats"];
 const PARTITION_PARSED_FIELDS: &[&str] = &["add.partitionValues_parsed.part"];
 
 #[rstest]
-#[should_panic(expected = "requested JSON stats must be populated")]
 #[case::json_only_string_map(
     StatsOptions::json_only(),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS, JSON_STATS_FIELDS]
+    &[ADD_FIELDS, JSON_STATS_FIELDS, STRING_PARTITION_FIELDS]
 )]
-#[should_panic(expected = "requested JSON stats must be populated")]
 #[case::json_only_with_struct(
     StatsOptions::json_only(),
     PartitionValuesOptions::with_struct(),
+    &[
+        ADD_FIELDS,
+        JSON_STATS_FIELDS,
+        STRING_PARTITION_FIELDS,
+        PARTITION_PARSED_FIELDS,
+    ]
+)]
+#[case::json_only_struct_only(
+    StatsOptions::json_only(),
+    PartitionValuesOptions::struct_only(),
     &[ADD_FIELDS, JSON_STATS_FIELDS, PARTITION_PARSED_FIELDS]
 )]
 #[case::all_struct_string_map(
     StatsOptions::all_struct(),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS, ALL_STATS_PARSED_FIELDS]
+    &[ADD_FIELDS, ALL_STATS_PARSED_FIELDS, STRING_PARTITION_FIELDS]
 )]
 #[case::all_struct_with_struct(
     StatsOptions::all_struct(),
     PartitionValuesOptions::with_struct(),
+    &[
+        ADD_FIELDS,
+        ALL_STATS_PARSED_FIELDS,
+        STRING_PARTITION_FIELDS,
+        PARTITION_PARSED_FIELDS,
+    ]
+)]
+#[case::all_struct_struct_only(
+    StatsOptions::all_struct(),
+    PartitionValuesOptions::struct_only(),
     &[ADD_FIELDS, ALL_STATS_PARSED_FIELDS, PARTITION_PARSED_FIELDS]
 )]
 #[case::struct_columns_string_map(
     StatsOptions::struct_columns(vec![column_name!("id")]),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS, ID_STATS_PARSED_FIELDS]
+    &[ADD_FIELDS, ID_STATS_PARSED_FIELDS, STRING_PARTITION_FIELDS]
 )]
 #[case::struct_columns_with_struct(
     StatsOptions::struct_columns(vec![column_name!("id")]),
     PartitionValuesOptions::with_struct(),
+    &[
+        ADD_FIELDS,
+        ID_STATS_PARSED_FIELDS,
+        STRING_PARTITION_FIELDS,
+        PARTITION_PARSED_FIELDS,
+    ]
+)]
+#[case::struct_columns_struct_only(
+    StatsOptions::struct_columns(vec![column_name!("id")]),
+    PartitionValuesOptions::struct_only(),
     &[ADD_FIELDS, ID_STATS_PARSED_FIELDS, PARTITION_PARSED_FIELDS]
 )]
 #[case::empty_struct_columns_string_map(
     StatsOptions::struct_columns(vec![]),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS]
+    &[ADD_FIELDS, STRING_PARTITION_FIELDS]
 )]
 #[case::empty_struct_columns_with_struct(
     StatsOptions::struct_columns(vec![]),
     PartitionValuesOptions::with_struct(),
+    &[ADD_FIELDS, STRING_PARTITION_FIELDS, PARTITION_PARSED_FIELDS]
+)]
+#[case::empty_struct_columns_struct_only(
+    StatsOptions::struct_columns(vec![]),
+    PartitionValuesOptions::struct_only(),
     &[ADD_FIELDS, PARTITION_PARSED_FIELDS]
 )]
-#[should_panic(expected = "requested JSON stats must be populated")]
 #[case::all_string_map(
     StatsOptions::all(),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS, ALL_STATS_PARSED_FIELDS, JSON_STATS_FIELDS]
+    &[
+        ADD_FIELDS,
+        ALL_STATS_PARSED_FIELDS,
+        JSON_STATS_FIELDS,
+        STRING_PARTITION_FIELDS,
+    ]
 )]
-#[should_panic(expected = "requested JSON stats must be populated")]
 #[case::all_with_struct(
     StatsOptions::all(),
     PartitionValuesOptions::with_struct(),
+    &[
+        ADD_FIELDS,
+        ALL_STATS_PARSED_FIELDS,
+        JSON_STATS_FIELDS,
+        STRING_PARTITION_FIELDS,
+        PARTITION_PARSED_FIELDS,
+    ]
+)]
+#[case::all_struct_only(
+    StatsOptions::all(),
+    PartitionValuesOptions::struct_only(),
     &[
         ADD_FIELDS,
         ALL_STATS_PARSED_FIELDS,
@@ -506,11 +561,16 @@ const PARTITION_PARSED_FIELDS: &[&str] = &["add.partitionValues_parsed.part"];
 #[case::none_string_map(
     StatsOptions::none(),
     PartitionValuesOptions::string_map_only(),
-    &[ADD_FIELDS]
+    &[ADD_FIELDS, STRING_PARTITION_FIELDS]
 )]
 #[case::none_with_struct(
     StatsOptions::none(),
     PartitionValuesOptions::with_struct(),
+    &[ADD_FIELDS, STRING_PARTITION_FIELDS, PARTITION_PARSED_FIELDS]
+)]
+#[case::none_struct_only(
+    StatsOptions::none(),
+    PartitionValuesOptions::struct_only(),
     &[ADD_FIELDS, PARTITION_PARSED_FIELDS]
 )]
 fn declarative_metadata_has_exact_leaf_schema_across_output_options(
@@ -520,6 +580,8 @@ fn declarative_metadata_has_exact_leaf_schema_across_output_options(
 ) {
     (|| -> DeltaResult<()> {
         let json_requested = stats.synthesize_json;
+        let string_partitions_requested = partition_values.string_map;
+        let parsed_partitions_requested = partition_values.parsed_struct;
         let (engine, snapshot, _tempdir) =
             load_test_table("v1-multi-part-partitioned-struct-stats-only")?;
         let scan = snapshot
@@ -567,6 +629,53 @@ fn declarative_metadata_has_exact_leaf_schema_across_output_options(
             .collect();
         expected.sort_unstable();
         assert_eq!(leaf_paths(&actual), expected);
+
+        let partition_values = |field_name| -> DeltaResult<Vec<String>> {
+            let batches = actual
+                .iter()
+                .map(|batch| {
+                    let add = batch
+                        .column_by_name(ADD_NAME)
+                        .expect("add column")
+                        .as_any()
+                        .downcast_ref::<StructArray>()
+                        .expect("add struct");
+                    RecordBatch::try_from_iter([(
+                        field_name,
+                        add.column_by_name(field_name)
+                            .unwrap_or_else(|| panic!("add.{field_name}"))
+                            .clone(),
+                    )])
+                    .map_err(Into::into)
+                })
+                .collect::<DeltaResult<Vec<_>>>()?;
+            let formatted = pretty_format_batches(&batches)?.to_string();
+            let mut values: Vec<_> = formatted
+                .lines()
+                .filter_map(|line| {
+                    let value = line.trim().strip_prefix('|')?.strip_suffix('|')?.trim();
+                    value.starts_with("{part:").then(|| value.to_string())
+                })
+                .collect();
+            values.sort_unstable();
+            Ok(values)
+        };
+        let expected_partitions = [
+            "{part: 0}".to_string(),
+            "{part: 1}".to_string(),
+            "{part: 1}".to_string(),
+            "{part: 2}".to_string(),
+            "{part: 2}".to_string(),
+        ];
+        if string_partitions_requested {
+            assert_eq!(partition_values(PARTITION_VALUES)?, expected_partitions);
+        }
+        if parsed_partitions_requested {
+            assert_eq!(
+                partition_values(PARTITION_VALUES_PARSED)?,
+                expected_partitions
+            );
+        }
         Ok(())
     })()
     .unwrap()
@@ -664,8 +773,16 @@ fn declarative_metadata_output_options_across_log_shapes(
         .with_sidecars_if_enabled(None),
     FeatureSet::new().v2_checkpoint()
 )]
-// TODO: https://github.com/delta-io/delta-kernel-rs/issues/3040
-#[should_panic(expected = "requested JSON stats must be populated")]
+#[case::v1_with_commit(
+    LogState::with_latest_version(2).with_checkpoint_at([1]),
+    FeatureSet::new()
+)]
+#[case::v2_with_commit(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([1])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint()
+)]
 fn declarative_metadata_synthesizes_json_for_struct_only_checkpoints(
     #[case] log_state: LogState,
     #[case] features: FeatureSet,
@@ -718,17 +835,45 @@ fn assert_metadata_output_options(
                 0,
                 "requested JSON stats must be populated"
             );
+            for stats in stats.iter().flatten() {
+                let stats: serde_json::Value = serde_json::from_str(stats)?;
+                for path in [
+                    "/numRecords",
+                    "/nullCount/value",
+                    "/minValues/value",
+                    "/maxValues/value",
+                    "/tightBounds",
+                ] {
+                    assert!(
+                        stats.pointer(path).is_some(),
+                        "missing JSON stats field {path}"
+                    );
+                }
+            }
         }
     }
 
-    if json_requested {
+    let imperative_is_missing_json_stats = json_requested
+        && expected.iter().any(|batch| {
+            batch
+                .column_by_name(STATS)
+                .is_some_and(|stats| stats.null_count() > 0)
+        });
+    if imperative_is_missing_json_stats {
+        // The imperative path cannot synthesize JSON for struct-only checkpoints.
+        assert_metadata_eq(
+            &without_columns(&actual, &[STATS])?,
+            &without_columns(&expected, &[STATS])?,
+            "metadata output options across log shapes",
+        )?;
+    } else if json_requested {
         assert_metadata_eq(
             &actual,
             &expected,
             "metadata output options across log shapes",
         )?;
     } else {
-        // Imperative metadata exposes source JSON even when it was not requested.
+        // The imperative path exposes source JSON even when it was not requested.
         assert_metadata_eq(
             &actual,
             &without_columns(&expected, &[STATS])?,

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -139,21 +139,32 @@ fn metadata_row_count(batches: &[RecordBatch]) -> usize {
     batches.iter().map(RecordBatch::num_rows).sum()
 }
 
+fn sorted_pretty_lines(batches: &[RecordBatch]) -> DeltaResult<Vec<String>> {
+    let formatted = pretty_format_batches(batches)?.to_string();
+    let mut lines: Vec<_> = formatted.lines().map(str::to_string).collect();
+    let len = lines.len();
+    if len > 3 {
+        lines[2..len - 1].sort_unstable();
+    }
+    Ok(lines)
+}
+
+fn assert_sorted_batches_eq(expected: &[&str], actual: &[RecordBatch]) -> DeltaResult<()> {
+    let formatted = pretty_format_batches(actual)?.to_string();
+    let mut actual: Vec<_> = formatted
+        .lines()
+        .filter(|line| line.starts_with("| {") || line.starts_with("| null"))
+        .collect();
+    actual.sort_unstable();
+    assert_eq!(expected, actual, "{formatted}");
+    Ok(())
+}
+
 fn assert_metadata_eq(
     actual: &[RecordBatch],
     expected: &[RecordBatch],
     context: &str,
 ) -> DeltaResult<()> {
-    fn sorted_pretty_lines(batches: &[RecordBatch]) -> DeltaResult<Vec<String>> {
-        let formatted = pretty_format_batches(batches)?.to_string();
-        let mut lines: Vec<_> = formatted.lines().map(str::to_string).collect();
-        let len = lines.len();
-        if len > 3 {
-            lines[2..len - 1].sort_unstable();
-        }
-        Ok(lines)
-    }
-
     if let (Some(actual), Some(expected)) = (actual.first(), expected.first()) {
         assert_eq!(actual.schema(), expected.schema(), "{context}");
     }
@@ -745,14 +756,6 @@ fn declarative_metadata_projects_nested_column_mapped_stats() -> DeltaResult<()>
     checkpoint_struct_stats(),
     StatsOptions::all_struct()
 )]
-#[case::v2_checkpoint_without_stats(
-    LogState::with_latest_version(2)
-        .with_checkpoint_at([2])
-        .with_sidecars_if_enabled(None),
-    FeatureSet::new().v2_checkpoint(),
-    no_checkpoint_stats(),
-    StatsOptions::all_struct()
-)]
 fn declarative_metadata_output_options_across_log_shapes(
     #[case] log_state: LogState,
     #[case] features: FeatureSet,
@@ -760,6 +763,34 @@ fn declarative_metadata_output_options_across_log_shapes(
     #[case] stats: StatsOptions,
 ) -> DeltaResult<()> {
     assert_metadata_output_options(log_state, features, table_config, stats)
+}
+
+#[rstest]
+#[case::v1(
+    LogState::with_latest_version(2).with_checkpoint_at([2]),
+    FeatureSet::new()
+)]
+#[case::v2(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([2])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint()
+)]
+fn declarative_metadata_errors_when_requested_stats_are_absent(
+    #[case] log_state: LogState,
+    #[case] features: FeatureSet,
+    #[values(
+        StatsOptions::json_only(),
+        StatsOptions::all_struct(),
+        StatsOptions::all()
+    )]
+    stats: StatsOptions,
+) {
+    let error = assert_metadata_output_options(log_state, features, no_checkpoint_stats(), stats)
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("checkpoint contains neither compatible add.stats_parsed nor add.stats"));
 }
 
 #[rstest]
@@ -789,6 +820,60 @@ fn declarative_metadata_synthesizes_json_for_struct_only_checkpoints(
     #[values(StatsOptions::json_only(), StatsOptions::all())] stats: StatsOptions,
 ) {
     assert_metadata_output_options(log_state, features, checkpoint_struct_stats(), stats).unwrap();
+}
+
+#[rstest]
+#[case::v1(
+    LogState::with_latest_version(2).with_checkpoint_at([2]),
+    FeatureSet::new()
+)]
+#[case::v2(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([2])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint()
+)]
+fn declarative_metadata_serializes_temporal_struct_stats_as_strings(
+    #[case] log_state: LogState,
+    #[case] features: FeatureSet,
+) -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(log_state)
+        .with_features(features)
+        .with_table_config(checkpoint_struct_stats().data_skipping_stats_columns([
+            "clust_date",
+            "clust_ts",
+            "clust_ts_ntz",
+        ]))
+        .with_data_layout(DataLayoutConfig::ClusteredAllTypes)
+        .build()
+        .expect("build struct-stats table");
+    let engine = SyncEngine::new_with_store(table.store().clone());
+    let snapshot = Snapshot::builder_for(table.table_root()).build(&engine)?;
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::json_only())
+        .build()?;
+    let actual = declarative_metadata(&scan, &engine)?;
+    let stats_batches: Vec<_> = actual
+        .iter()
+        .map(|batch| {
+            RecordBatch::try_from_iter([(
+                STATS,
+                batch
+                    .column_by_name(STATS)
+                    .expect("requested JSON stats")
+                    .clone(),
+            )])
+        })
+        .collect::<Result<_, _>>()?;
+    assert_sorted_batches_eq(
+        &[
+            r#"| {"numRecords":10,"nullCount":{"clust_date":4,"clust_ts":4,"clust_ts_ntz":4},"minValues":{"clust_date":"2022-01-09","clust_ts":"2022-01-09T00:00:00.298Z","clust_ts_ntz":"2022-01-09T00:00:00.298"},"maxValues":{"clust_date":"2022-01-16","clust_ts":"2022-01-16T00:00:00.298Z","clust_ts_ntz":"2022-01-16T00:00:00.298"},"tightBounds":true} |"#,
+            r#"| {"numRecords":10,"nullCount":{"clust_date":4,"clust_ts":4,"clust_ts_ntz":4},"minValues":{"clust_date":"2024-10-05","clust_ts":"2024-10-05T00:00:00.298Z","clust_ts_ntz":"2024-10-05T00:00:00.298"},"maxValues":{"clust_date":"2024-10-12","clust_ts":"2024-10-12T00:00:00.298Z","clust_ts_ntz":"2024-10-12T00:00:00.298"},"tightBounds":true} |"#,
+        ],
+        &stats_batches,
+    )
 }
 
 fn assert_metadata_output_options(

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -1068,21 +1068,32 @@ fn assert_declarative_metadata_matches_imperative(
     assert_metadata_eq(&actual, &expected, table.description())
 }
 
-#[test]
-fn test_declarative_metadata_scan_plan_no_executor_returns_unsupported() -> DeltaResult<()> {
+#[rstest]
+#[case::requires_executor(None, true)]
+#[case::static_skip_all(Some(Pred::FALSE), false)]
+fn declarative_metadata_scan_plan_requires_executor_unless_statically_skipped(
+    #[case] predicate: Option<Pred>,
+    #[case] requires_executor: bool,
+) -> DeltaResult<()> {
     let table = TestTableBuilder::new()
         .with_log_state(LogState::with_latest_version(4).with_checkpoint_at([2]))
         .build()
         .expect("build checkpoint-plus-commits table");
     let sync_engine = Arc::new(SyncEngine::new_with_store(table.store().clone()));
     let snapshot = Snapshot::builder_for(table.table_root()).build(sync_engine.as_ref())?;
-    let scan = snapshot.scan_builder().build()?;
+    let builder = snapshot.scan_builder();
+    let builder = match predicate {
+        Some(predicate) => builder.with_predicate(Arc::new(predicate)),
+        None => builder,
+    };
+    let scan = builder.build()?;
 
     let no_plan_engine = DelegatingEngine::new(sync_engine).without_plan_executor();
-    let err = scan
-        .declarative_metadata_scan_plan(&no_plan_engine)
-        .unwrap_err();
-
-    assert!(matches!(err, crate::Error::Unsupported(_)));
+    let result = scan.declarative_metadata_scan_plan(&no_plan_engine);
+    if requires_executor {
+        assert!(matches!(result, Err(crate::Error::Unsupported(_))));
+    } else {
+        assert!(result?.is_none());
+    }
     Ok(())
 }

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -776,21 +776,51 @@ fn declarative_metadata_output_options_across_log_shapes(
         .with_sidecars_if_enabled(None),
     FeatureSet::new().v2_checkpoint()
 )]
-fn declarative_metadata_errors_when_requested_stats_are_absent(
+fn declarative_metadata_handles_absent_stats(
     #[case] log_state: LogState,
     #[case] features: FeatureSet,
     #[values(
         StatsOptions::json_only(),
         StatsOptions::all_struct(),
-        StatsOptions::all()
+        StatsOptions::all(),
+        StatsOptions::struct_columns(vec![])
     )]
     stats: StatsOptions,
-) {
-    let error = assert_metadata_output_options(log_state, features, no_checkpoint_stats(), stats)
-        .unwrap_err();
-    assert!(error
-        .to_string()
-        .contains("checkpoint contains neither compatible add.stats_parsed nor add.stats"));
+) -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(log_state)
+        .with_features(features)
+        .with_table_config(no_checkpoint_stats())
+        .with_data_layout(DataLayoutConfig::PartitionedAllTypes)
+        .build()
+        .expect("build no-stats table");
+    let engine = SyncEngine::new_with_store(table.store().clone());
+    let snapshot = Snapshot::builder_for(table.table_root()).build(&engine)?;
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(stats.clone())
+        .with_predicate(Arc::new(column_expr!("value").gt(Expr::literal(i32::MAX))))
+        .build()?;
+    let actual = declarative_metadata(&scan, &engine)?;
+    assert!(metadata_row_count(&actual) > 0);
+
+    for batch in &actual {
+        if stats.synthesize_json {
+            let json = batch.column_by_name(STATS).expect("requested JSON stats");
+            assert_eq!(json.null_count(), batch.num_rows());
+        } else {
+            assert!(batch.column_by_name(STATS).is_none());
+        }
+        if matches!(stats.struct_stats, StructStats::All) {
+            let parsed = batch
+                .column_by_name(STATS_PARSED)
+                .expect("requested parsed stats");
+            assert_eq!(parsed.null_count(), batch.num_rows());
+        } else {
+            assert!(batch.column_by_name(STATS_PARSED).is_none());
+        }
+    }
+    Ok(())
 }
 
 #[rstest]

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -27,6 +27,7 @@ use crate::{DeltaResult, Engine, PredicateRef, Snapshot};
 fn normalized_metadata_batch(
     field: impl Fn(&str) -> ArrayRef,
     json_stats: Option<ArrayRef>,
+    partition_values: Option<ArrayRef>,
     stats_parsed: Option<ArrayRef>,
     partitions_parsed: Option<ArrayRef>,
 ) -> DeltaResult<RecordBatch> {
@@ -38,8 +39,10 @@ fn normalized_metadata_batch(
     if let Some(stats) = json_stats {
         columns.push(("stats", stats));
     }
+    if let Some(partition_values) = partition_values {
+        columns.push(("partitionValues", partition_values));
+    }
     columns.extend([
-        ("partitionValues", field("partitionValues")),
         ("deletionVector", field("deletionVector")),
         ("baseRowId", field("baseRowId")),
         ("defaultRowCommitVersion", field("defaultRowCommitVersion")),
@@ -92,6 +95,10 @@ fn imperative_metadata(scan: Scan, engine: &dyn Engine) -> DeltaResult<Vec<Recor
                 .column_by_name(STATS)
                 .or_else(|| constants.column_by_name(STATS))
                 .cloned(),
+            batch
+                .column_by_name(PARTITION_VALUES)
+                .or_else(|| constants.column_by_name(PARTITION_VALUES))
+                .cloned(),
             batch.column_by_name("stats_parsed").cloned(),
             batch.column_by_name("partitionValues_parsed").cloned(),
         )?);
@@ -128,6 +135,7 @@ fn declarative_metadata(scan: &Scan, engine: &dyn Engine) -> DeltaResult<Vec<Rec
                     .clone()
             },
             add.column_by_name(STATS).cloned(),
+            add.column_by_name(PARTITION_VALUES).cloned(),
             add.column_by_name(STATS_PARSED).cloned(),
             add.column_by_name(PARTITION_VALUES_PARSED).cloned(),
         )?);
@@ -298,6 +306,73 @@ fn declarative_metadata_scans_sidecars_from_checkpoint_hint(
             .any(|file| file.meta.location.path().contains("/_sidecars/"))
     }));
     Ok(())
+}
+
+#[rstest]
+#[should_panic(expected = "checkpoint JSON stats must be retained for missing parsed columns")]
+#[case::requested(
+    StatsOptions::struct_columns(vec![column_name!("age")]),
+    None,
+)]
+#[should_panic(expected = "checkpoint JSON stats must be retained for missing parsed columns")]
+#[case::predicate(
+    StatsOptions::none(),
+    Some(column_expr!("age").gt(Expr::literal(0i64))),
+)]
+#[should_panic(expected = "checkpoint JSON stats must be retained for missing parsed columns")]
+#[case::requested_and_predicate(
+    StatsOptions::struct_columns(vec![column_name!("name")]),
+    Some(column_expr!("age").gt(Expr::literal(0i64))),
+)]
+fn declarative_metadata_reads_json_for_columns_missing_from_parsed_stats(
+    #[case] stats: StatsOptions,
+    #[case] predicate: Option<Pred>,
+) {
+    (|| -> DeltaResult<()> {
+        // This table's parsed stats contain id, name, age, salary, and ts_col. The synthetic
+        // checkpoint shape below retains only numRecords to model incomplete native stats.
+        let (_engine, snapshot, _tempdir) = load_test_table("parsed-stats")?;
+        let builder = snapshot.scan_builder().with_stats(stats);
+        let builder = match predicate {
+            Some(predicate) => builder.with_predicate(Arc::new(predicate)),
+            None => builder,
+        };
+        let scan = builder.build()?;
+
+        // Compatibility accepts missing fields. It should expose which parsed columns are absent
+        // so the scan can retain JSON as a fallback for only those columns.
+        let partial_stats = Arc::new(StructType::new_unchecked([StructField::nullable(
+            "numRecords",
+            DataType::LONG,
+        )]));
+        let add = SchemaStructPatchBuilder::new()
+            .append(StructField::nullable(STATS_PARSED, partial_stats))
+            .build(&ADD_SCHEMA)?;
+        let shape = CheckpointShape {
+            checkpoint_type: CheckpointType::Leaf,
+            leaf_checkpoint_schema: Some(schema_ref! {
+                (StructField::nullable(ADD_NAME, add)),
+                nullable (VERSION): LONG,
+            }),
+        };
+        let plan = scan
+            .build_metadata_scan_plan(&shape)?
+            .expect("metadata plan");
+        let checkpoint = plan
+            .nodes
+            .iter()
+            .find_map(|node| match &node.op {
+                Operator::ScanParquet(scan) => Some(scan),
+                _ => None,
+            })
+            .expect("checkpoint parquet scan");
+        assert!(
+            checkpoint.schema.contains_col([ADD_NAME, STATS]),
+            "checkpoint JSON stats must be retained for missing parsed columns"
+        );
+        Ok(())
+    })()
+    .unwrap()
 }
 
 #[rstest]
@@ -756,13 +831,48 @@ fn declarative_metadata_projects_nested_column_mapped_stats() -> DeltaResult<()>
     checkpoint_struct_stats(),
     StatsOptions::all_struct()
 )]
+#[case::v1_checkpoint_json_columns(
+    LogState::with_latest_version(2).with_checkpoint_at([2]),
+    FeatureSet::new(),
+    checkpoint_json_stats(),
+    StatsOptions::struct_columns(vec![column_name!("value")])
+)]
+#[case::v1_mixed_json_columns(
+    LogState::with_latest_version(2).with_checkpoint_at([1]),
+    FeatureSet::new(),
+    checkpoint_json_stats(),
+    StatsOptions::struct_columns(vec![column_name!("value")])
+)]
+#[case::v2_checkpoint_json_columns(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([2])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint(),
+    checkpoint_json_stats(),
+    StatsOptions::struct_columns(vec![column_name!("value")])
+)]
+#[case::v2_mixed_json_columns(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([1])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint(),
+    checkpoint_json_stats(),
+    StatsOptions::struct_columns(vec![column_name!("value")])
+)]
 fn declarative_metadata_output_options_across_log_shapes(
     #[case] log_state: LogState,
     #[case] features: FeatureSet,
     #[case] table_config: TableConfig,
     #[case] stats: StatsOptions,
 ) -> DeltaResult<()> {
-    assert_metadata_output_options(log_state, features, table_config, stats)
+    assert_metadata_output_options(
+        log_state,
+        features,
+        table_config,
+        DataLayoutConfig::PartitionedAllTypes,
+        stats,
+        None,
+    )
 }
 
 #[rstest]
@@ -773,6 +883,16 @@ fn declarative_metadata_output_options_across_log_shapes(
 #[case::v2(
     LogState::with_latest_version(2)
         .with_checkpoint_at([2])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint()
+)]
+#[case::v1_with_commit(
+    LogState::with_latest_version(2).with_checkpoint_at([1]),
+    FeatureSet::new()
+)]
+#[case::v2_with_commit(
+    LogState::with_latest_version(2)
+        .with_checkpoint_at([1])
         .with_sidecars_if_enabled(None),
     FeatureSet::new().v2_checkpoint()
 )]
@@ -848,8 +968,17 @@ fn declarative_metadata_synthesizes_json_for_struct_only_checkpoints(
     #[case] log_state: LogState,
     #[case] features: FeatureSet,
     #[values(StatsOptions::json_only(), StatsOptions::all())] stats: StatsOptions,
-) {
-    assert_metadata_output_options(log_state, features, checkpoint_struct_stats(), stats).unwrap();
+    #[values(false, true)] with_predicate: bool,
+) -> DeltaResult<()> {
+    let predicate = with_predicate.then(|| column_expr!("clust_int").gt(Expr::literal(0i32)));
+    assert_metadata_output_options(
+        log_state,
+        features,
+        checkpoint_struct_stats(),
+        DataLayoutConfig::ClusteredAllTypes,
+        stats,
+        predicate,
+    )
 }
 
 #[rstest]
@@ -910,32 +1039,45 @@ fn assert_metadata_output_options(
     log_state: LogState,
     features: FeatureSet,
     table_config: TableConfig,
+    data_layout: DataLayoutConfig,
     stats: StatsOptions,
+    predicate: Option<Pred>,
 ) -> DeltaResult<()> {
     let json_requested = stats.synthesize_json;
+    let parsed_stats_requested = match &stats.struct_stats {
+        StructStats::None => false,
+        StructStats::Columns(columns) => !columns.is_empty(),
+        StructStats::All => true,
+    };
     let table = TestTableBuilder::new()
         .with_log_state(log_state)
         .with_features(features)
         .with_table_config(table_config)
-        .with_data_layout(DataLayoutConfig::PartitionedAllTypes)
+        .with_data_layout(data_layout)
         .build()
         .expect("build output-options table");
     let engine = SyncEngine::new_with_store(table.store().clone());
     let snapshot = Snapshot::builder_for(table.table_root()).build(&engine)?;
-    let expected = imperative_metadata(
-        snapshot
-            .clone()
-            .scan_builder()
-            .with_stats(stats.clone())
-            .with_partition_values(PartitionValuesOptions::with_struct())
-            .build()?,
-        &engine,
-    )?;
-    let scan = snapshot
+    let predicate = predicate.map(Arc::new);
+    let expected_builder = snapshot
+        .clone()
+        .scan_builder()
+        .with_stats(stats.clone())
+        .with_partition_values(PartitionValuesOptions::with_struct());
+    let expected_builder = match &predicate {
+        Some(predicate) => expected_builder.with_predicate(predicate.clone()),
+        None => expected_builder,
+    };
+    let expected = imperative_metadata(expected_builder.build()?, &engine)?;
+    let scan_builder = snapshot
         .scan_builder()
         .with_stats(stats)
-        .with_partition_values(PartitionValuesOptions::with_struct())
-        .build()?;
+        .with_partition_values(PartitionValuesOptions::with_struct());
+    let scan_builder = match predicate {
+        Some(predicate) => scan_builder.with_predicate(predicate),
+        None => scan_builder,
+    };
+    let scan = scan_builder.build()?;
     let actual = declarative_metadata(&scan, &engine)?;
 
     if json_requested {
@@ -974,24 +1116,37 @@ fn assert_metadata_output_options(
                 .column_by_name(STATS)
                 .is_some_and(|stats| stats.null_count() > 0)
         });
-    if imperative_is_missing_json_stats {
-        // The imperative path cannot synthesize JSON for struct-only checkpoints.
+    let imperative_has_incomplete_json_stats = json_requested
+        && expected.iter().any(|batch| {
+            batch
+                .column_by_name(STATS)
+                .and_then(|stats| stats.as_any().downcast_ref::<StringArray>())
+                .into_iter()
+                .flat_map(|stats| stats.iter().flatten())
+                .any(|stats| {
+                    serde_json::from_str::<serde_json::Value>(stats)
+                        .is_ok_and(|stats| stats.pointer("/minValues/value").is_none())
+                })
+        });
+    // The imperative path exposes source and predicate stats even when they were not requested.
+    let ignored_imperative_stats = match (json_requested, parsed_stats_requested) {
+        (true, true) => &[][..],
+        (true, false) => &[STATS_PARSED][..],
+        (false, true) => &[STATS][..],
+        (false, false) => &[STATS, STATS_PARSED][..],
+    };
+    let expected = without_columns(&expected, ignored_imperative_stats)?;
+    if imperative_is_missing_json_stats || imperative_has_incomplete_json_stats {
+        // The imperative path cannot synthesize complete JSON for struct-only checkpoints.
         assert_metadata_eq(
             &without_columns(&actual, &[STATS])?,
             &without_columns(&expected, &[STATS])?,
             "metadata output options across log shapes",
         )?;
-    } else if json_requested {
+    } else {
         assert_metadata_eq(
             &actual,
             &expected,
-            "metadata output options across log shapes",
-        )?;
-    } else {
-        // The imperative path exposes source JSON even when it was not requested.
-        assert_metadata_eq(
-            &actual,
-            &without_columns(&expected, &[STATS])?,
             "metadata output options across log shapes",
         )?;
     }
@@ -1246,6 +1401,8 @@ fn declarative_metadata_pruning_keeps_remove_for_checkpoint_reconciliation() -> 
 }
 
 #[rstest]
+#[case::with_struct(PartitionValuesOptions::with_struct())]
+#[case::struct_only(PartitionValuesOptions::struct_only())]
 fn declarative_metadata_prunes_across_v1_log_states(
     #[values(
         LogState::with_latest_version(4),
@@ -1261,18 +1418,23 @@ fn declarative_metadata_prunes_across_v1_log_states(
         )
     )]
     pruning: (Pred, usize),
+    #[case] partition_values: PartitionValuesOptions,
 ) -> DeltaResult<()> {
     assert_declarative_metadata_matches_imperative(
         log_state,
         FeatureSet::new(),
         pruning.0,
         pruning.1,
+        partition_values,
     )
 }
 
 #[rstest]
+#[case::with_struct(PartitionValuesOptions::with_struct())]
+#[case::struct_only(PartitionValuesOptions::struct_only())]
 fn declarative_metadata_partition_prunes_v2_checkpoints(
     #[values(2, 4)] checkpoint_version: u64,
+    #[case] partition_values: PartitionValuesOptions,
 ) -> DeltaResult<()> {
     let log_state = LogState::with_latest_version(4)
         .with_checkpoint_at([checkpoint_version])
@@ -1282,6 +1444,7 @@ fn declarative_metadata_partition_prunes_v2_checkpoints(
         FeatureSet::new().v2_checkpoint(),
         col!("part_string").eq(lit("part_2000")),
         1,
+        partition_values,
     )
 }
 
@@ -1290,6 +1453,7 @@ fn assert_declarative_metadata_matches_imperative(
     features: FeatureSet,
     predicate: Pred,
     expected_count: usize,
+    partition_values: PartitionValuesOptions,
 ) -> DeltaResult<()> {
     let table = TestTableBuilder::new()
         .with_log_state(log_state)
@@ -1307,7 +1471,7 @@ fn assert_declarative_metadata_matches_imperative(
             .scan_builder()
             .with_predicate(predicate.clone())
             .with_stats(StatsOptions::all())
-            .with_partition_values(PartitionValuesOptions::with_struct())
+            .with_partition_values(partition_values.clone())
             .build()?,
         &engine,
     )?;
@@ -1321,10 +1485,30 @@ fn assert_declarative_metadata_matches_imperative(
         .scan_builder()
         .with_predicate(predicate)
         .with_stats(StatsOptions::all())
-        .with_partition_values(PartitionValuesOptions::with_struct())
+        .with_partition_values(partition_values.clone())
         .build()?;
     let actual = declarative_metadata(&scan, &engine)?;
 
+    for batch in &actual {
+        assert_eq!(
+            batch.column_by_name(PARTITION_VALUES).is_some(),
+            partition_values.string_map
+        );
+        assert_eq!(
+            batch.column_by_name(PARTITION_VALUES_PARSED).is_some(),
+            partition_values.parsed_struct
+        );
+    }
+
+    let expected = if partition_values.string_map {
+        expected
+    } else {
+        // The imperative path still exposes the source map for `struct_only()`.
+        assert!(expected
+            .iter()
+            .all(|batch| batch.column_by_name(PARTITION_VALUES).is_some()));
+        without_columns(&expected, &[PARTITION_VALUES])?
+    };
     assert_metadata_eq(&actual, &expected, table.description())
 }
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3045/files/2119ae63b34078f7fa7714aecdc454f6350fafdf..464819dd5654edeff5c27025327616217ba11a41) to review incremental changes.
- [stack/scan_plan_options](https://github.com/delta-io/delta-kernel-rs/pull/3015) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3015/files)] [MERGED]
  - [stack/scan_plan_refactor](https://github.com/delta-io/delta-kernel-rs/pull/3039) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3039/files)] [MERGED]
    - [stack/scan_plan_checkpoint_shape](https://github.com/delta-io/delta-kernel-rs/pull/3044) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3044/files)]
      - [**stack/scan_plan_stats_json**](https://github.com/delta-io/delta-kernel-rs/pull/3045) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3045/files/2119ae63b34078f7fa7714aecdc454f6350fafdf..464819dd5654edeff5c27025327616217ba11a41)] ← _this PR_

---------
## What changes are proposed in this pull request?

Select checkpoint stats and partition sources from `CheckpointShape`. Compatible native parsed fields are read directly; otherwise the plan reconstructs them from JSON stats or partition maps without fallback coalesces.

When JSON stats are requested from a struct-only checkpoint, the plan retains the complete parsed-stats struct through reconciliation and serializes it after deduplication. Native JSON stats remain unchanged.

## How was this change tested?

- V1 and V2 struct-only checkpoints, with and without later commits
- JSON-only and combined JSON/structured stats output
- Complete parsed stats and partition leaf schemas, pruning, reconciliation, and stats-free checkpoints
- `cargo test -p delta_kernel --lib --all-features` (4,412 passed; 38 ignored)
- Workspace clippy and documentation checks
