### PR TITLE
fix!: deterministically select among complete checkpoints at one version

### DIFF
--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -794,7 +794,7 @@ fn get_earliest_recreatable_commit(
                     }
                 }
             }
-            LogPathFileType::SinglePartCheckpoint | LogPathFileType::UuidCheckpoint => {
+            LogPathFileType::ClassicCheckpoint | LogPathFileType::UuidCheckpoint => {
                 last_complete_checkpoint = Some(parsed_log_path.version);
             }
             LogPathFileType::MultiPartCheckpoint {

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -108,8 +108,8 @@ pub(crate) enum HintAction {
 
 impl LastCheckpointHint {
     /// Whether this hint describes the checkpoint a log segment selected -- its `checkpoint_parts`.
-    /// Multiple checkpoints can share a version (e.g. concurrent writers), so a matching version
-    /// alone is not enough: the hint's own identity must equal the selected checkpoint's.
+    /// Multiple checkpoints can share a version, so a matching version alone is not enough: the
+    /// hint's own identity must equal the selected checkpoint's.
     ///
     /// On a mismatch, callers read the checkpoint file itself instead of trusting the hint's
     /// fields.

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
-use crate::path::{LogPathFileType, ParsedLogPath};
+use crate::path::{CheckpointInstance, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
 
@@ -107,45 +107,33 @@ pub(crate) enum HintAction {
 }
 
 impl LastCheckpointHint {
-    /// Whether this hint describes the checkpoint a log segment selected -- the `checkpoint_parts`
-    /// at `version`. Multiple checkpoints can share a version (e.g. concurrent writers), so a
-    /// matching version alone is not enough: the hint's own shape must agree with the selected
-    /// checkpoint's format, and within a format with its parts or file name.
+    /// Whether this hint describes the checkpoint a log segment selected -- its `checkpoint_parts`.
+    /// Multiple checkpoints can share a version (e.g. concurrent writers), so a matching version
+    /// alone is not enough: the hint's own identity must equal the selected checkpoint's.
     ///
     /// On a mismatch, callers read the checkpoint file itself instead of trusting the hint's
     /// fields.
-    pub(crate) fn applies_to(
-        &self,
-        version: Version,
-        checkpoint_parts: &[ParsedLogPath<FileMeta>],
-    ) -> bool {
+    pub(crate) fn applies_to(&self, checkpoint_parts: &[ParsedLogPath<FileMeta>]) -> bool {
         let Some(selected) = checkpoint_parts.first() else {
             return false;
         };
-        // A hint's format is implied by its fields, as in Delta-Spark's `getFormatEnum`: a
-        // `v2Checkpoint` object means V2, else `parts` means multi-part, else single-file. It must
-        // match the selected checkpoint's format, or the hint describes some other file at this
-        // version and its `checkpointSchema` would be read as that file's.
-        let format_matches = match (&self.v2_checkpoint, self.parts) {
-            // A V2 checkpoint's file name carries a UUID, so it must match the selected part -- the
-            // file the hint's fields describe.
-            (Some(v2), _) => selected.filename == v2.path,
-            // A multi-part checkpoint's names are fully determined by `(version, num_parts)`, so a
-            // matching part count pins the identity.
-            (None, Some(parts)) => {
-                matches!(
-                    selected.file_type,
-                    LogPathFileType::MultiPartCheckpoint { .. }
-                ) && parts == checkpoint_parts.len()
-            }
-            // A hint with neither field describes a single whole file, and a uuid-named one would
-            // have come with a `v2Checkpoint` object naming it.
-            (None, None) => {
-                matches!(selected.file_type, LogPathFileType::SinglePartCheckpoint)
-                    && checkpoint_parts.len() == 1
-            }
-        };
-        self.version == version && format_matches
+        self.version == selected.version
+            && CheckpointInstance::of(selected) == Some(self.implied_instance())
+    }
+
+    /// The checkpoint identity this hint's fields describe, mirroring Delta-Spark's
+    /// `getFormatEnum`: a `v2Checkpoint` object means uuid-named, else `parts` means
+    /// multi-part, else classic-named.
+    fn implied_instance(&self) -> CheckpointInstance {
+        match (&self.v2_checkpoint, self.parts) {
+            (Some(v2), _) => CheckpointInstance::Uuid {
+                filename: v2.path.clone(),
+            },
+            (None, Some(parts)) => CheckpointInstance::MultiPart {
+                num_parts: parts as u32,
+            },
+            (None, None) => CheckpointInstance::Classic,
+        }
     }
 
     /// Parses a hint from raw `_last_checkpoint` bytes, dropping oversized fields so the retained
@@ -364,11 +352,19 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert!(v2.applies_to(1, &[part(selected)]));
-        assert!(!v2.applies_to(2, &[part(selected)]), "wrong version");
-        assert!(!v2.applies_to(1, &[part(other)]), "wrong v2 path");
+        assert!(v2.applies_to(&[part(selected)]));
+        assert!(!v2.applies_to(&[part(other)]), "wrong v2 path");
+        // The hint's version must equal the selected part's version (read from the part).
+        let v2_wrong_version = LastCheckpointHint {
+            version: 2,
+            ..v2.clone()
+        };
+        assert!(
+            !v2_wrong_version.applies_to(&[part(selected)]),
+            "wrong version"
+        );
 
-        // V1 multi-part: keyed by (version, numParts); the file name is not consulted.
+        // V1 multi-part: keyed by (version, numParts) read from the selected part's file name.
         let mp1 = "00000000000000000001.checkpoint.0000000001.0000000002.parquet";
         let mp2 = "00000000000000000001.checkpoint.0000000002.0000000002.parquet";
         let v1_multi = LastCheckpointHint {
@@ -376,8 +372,10 @@ mod tests {
             parts: Some(2),
             ..Default::default()
         };
-        assert!(v1_multi.applies_to(1, &[part(mp1), part(mp2)]));
-        assert!(!v1_multi.applies_to(1, &[part(mp1)]), "wrong part count");
+        assert!(v1_multi.applies_to(&[part(mp1), part(mp2)]));
+        // A hint whose numParts disagrees with the selected checkpoint's declared numParts.
+        let mp1_of_3 = "00000000000000000001.checkpoint.0000000001.0000000003.parquet";
+        assert!(!v1_multi.applies_to(&[part(mp1_of_3)]), "wrong part count");
 
         // V1 single-part: an absent `parts` means one part.
         let v1_single = LastCheckpointHint {
@@ -385,17 +383,17 @@ mod tests {
             ..Default::default()
         };
         let classic = "00000000000000000001.checkpoint.parquet";
-        assert!(v1_single.applies_to(1, &[part(classic)]));
+        assert!(v1_single.applies_to(&[part(classic)]));
 
         // Format has to match, not just part count: a 1-of-1 multi-part checkpoint and a uuid-named
         // one each hold one part too.
         let one_of_one = "00000000000000000001.checkpoint.0000000001.0000000001.parquet";
         assert!(
-            !v1_single.applies_to(1, &[part(one_of_one)]),
+            !v1_single.applies_to(&[part(one_of_one)]),
             "single-file hint applied to a multi-part checkpoint"
         );
         assert!(
-            !v1_single.applies_to(1, &[part(selected)]),
+            !v1_single.applies_to(&[part(selected)]),
             "single-file hint applied to a uuid-named checkpoint"
         );
         // Nor can a multi-part hint describe a single whole file.
@@ -404,13 +402,13 @@ mod tests {
             parts: Some(1),
             ..Default::default()
         };
-        assert!(v1_one_part.applies_to(1, &[part(one_of_one)]));
+        assert!(v1_one_part.applies_to(&[part(one_of_one)]));
         assert!(
-            !v1_one_part.applies_to(1, &[part(classic)]),
+            !v1_one_part.applies_to(&[part(classic)]),
             "multi-part hint applied to a classic checkpoint"
         );
 
-        assert!(!v1_single.applies_to(1, &[]), "no checkpoint selected");
+        assert!(!v1_single.applies_to(&[]), "no checkpoint selected");
     }
 
     /// `sidecarFiles` / `nonFileActions` are dropped only when their count exceeds the threshold --

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
-use crate::path::ParsedLogPath;
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
 
@@ -109,26 +109,43 @@ pub(crate) enum HintAction {
 impl LastCheckpointHint {
     /// Whether this hint describes the checkpoint a log segment selected -- the `checkpoint_parts`
     /// at `version`. Multiple checkpoints can share a version (e.g. concurrent writers), so a
-    /// matching version alone is not enough; multi-part checkpoints must have the expected parts
-    /// and V2 checkpoints must have the matching file name.
+    /// matching version alone is not enough: the hint's own shape must agree with the selected
+    /// checkpoint's format, and within a format with its parts or file name.
+    ///
+    /// On a mismatch, callers read the checkpoint file itself instead of trusting the hint's
+    /// fields.
     pub(crate) fn applies_to(
         &self,
         version: Version,
         checkpoint_parts: &[ParsedLogPath<FileMeta>],
     ) -> bool {
-        // A multi-part V1 checkpoint is keyed by `(version, numParts)` with deterministic
-        // per-version names, so a matching part count pins the identity. `parts` is absent
-        // for a single-part / classic checkpoint.
-        self.version == version
-            && self.parts.unwrap_or(1) == checkpoint_parts.len()
-            && match &self.v2_checkpoint {
-                // A V2 checkpoint's file name carries a UUID, so it must match the selected part
-                // (`checkpoint_parts.first()`), the file the hint's fields describe.
-                Some(v2) => {
-                    checkpoint_parts.first().map(|p| p.filename.as_str()) == Some(v2.path.as_str())
-                }
-                None => true,
+        let Some(selected) = checkpoint_parts.first() else {
+            return false;
+        };
+        // A hint's format is implied by its fields, as in Delta-Spark's `getFormatEnum`: a
+        // `v2Checkpoint` object means V2, else `parts` means multi-part, else single-file. It must
+        // match the selected checkpoint's format, or the hint describes some other file at this
+        // version and its `checkpointSchema` would be read as that file's.
+        let format_matches = match (&self.v2_checkpoint, self.parts) {
+            // A V2 checkpoint's file name carries a UUID, so it must match the selected part -- the
+            // file the hint's fields describe.
+            (Some(v2), _) => selected.filename == v2.path,
+            // A multi-part checkpoint's names are fully determined by `(version, num_parts)`, so a
+            // matching part count pins the identity.
+            (None, Some(parts)) => {
+                matches!(
+                    selected.file_type,
+                    LogPathFileType::MultiPartCheckpoint { .. }
+                ) && parts == checkpoint_parts.len()
             }
+            // A hint with neither field describes a single whole file, and a uuid-named one would
+            // have come with a `v2Checkpoint` object naming it.
+            (None, None) => {
+                matches!(selected.file_type, LogPathFileType::SinglePartCheckpoint)
+                    && checkpoint_parts.len() == 1
+            }
+        };
+        self.version == version && format_matches
     }
 
     /// Parses a hint from raw `_last_checkpoint` bytes, dropping oversized fields so the retained
@@ -367,7 +384,33 @@ mod tests {
             version: 1,
             ..Default::default()
         };
-        assert!(v1_single.applies_to(1, &[part("00000000000000000001.checkpoint.parquet")]));
+        let classic = "00000000000000000001.checkpoint.parquet";
+        assert!(v1_single.applies_to(1, &[part(classic)]));
+
+        // Format has to match, not just part count: a 1-of-1 multi-part checkpoint and a uuid-named
+        // one each hold one part too.
+        let one_of_one = "00000000000000000001.checkpoint.0000000001.0000000001.parquet";
+        assert!(
+            !v1_single.applies_to(1, &[part(one_of_one)]),
+            "single-file hint applied to a multi-part checkpoint"
+        );
+        assert!(
+            !v1_single.applies_to(1, &[part(selected)]),
+            "single-file hint applied to a uuid-named checkpoint"
+        );
+        // Nor can a multi-part hint describe a single whole file.
+        let v1_one_part = LastCheckpointHint {
+            version: 1,
+            parts: Some(1),
+            ..Default::default()
+        };
+        assert!(v1_one_part.applies_to(1, &[part(one_of_one)]));
+        assert!(
+            !v1_one_part.applies_to(1, &[part(classic)]),
+            "multi-part hint applied to a classic checkpoint"
+        );
+
+        assert!(!v1_single.applies_to(1, &[]), "no checkpoint selected");
     }
 
     /// `sidecarFiles` / `nonFileActions` are dropped only when their count exceeds the threshold --

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -107,9 +107,9 @@ pub(crate) enum HintAction {
 }
 
 impl LastCheckpointHint {
-    /// Whether this hint describes the checkpoint a log segment selected -- its `checkpoint_parts`.
-    /// Multiple checkpoints can share a version, so a matching version alone is not enough: the
-    /// hint's own identity must equal the selected checkpoint's.
+    /// Whether this hint describes the checkpoint a log segment selected, given that segment's
+    /// `checkpoint_parts`. Multiple checkpoints can share a version, so a matching version alone is
+    /// not enough: the hint's own identity must equal the selected checkpoint's.
     ///
     /// On a mismatch, callers read the checkpoint file itself instead of trusting the hint's
     /// fields.
@@ -118,22 +118,22 @@ impl LastCheckpointHint {
             return false;
         };
         self.version == selected.version
-            && CheckpointInstance::of(selected) == Some(self.implied_instance())
+            && CheckpointInstance::of(selected) == self.implied_instance()
     }
 
     /// The checkpoint identity this hint's fields describe, mirroring Delta-Spark's
-    /// `getFormatEnum`: a `v2Checkpoint` object means uuid-named, else `parts` means
-    /// multi-part, else classic-named.
-    fn implied_instance(&self) -> CheckpointInstance {
-        match (&self.v2_checkpoint, self.parts) {
+    /// `getFormatEnum`: a `v2Checkpoint` object means uuid-named, else `parts` means multi-part,
+    /// else classic-named. `None` if `parts` overflows `u32`, so no checkpoint can match it.
+    fn implied_instance(&self) -> Option<CheckpointInstance> {
+        Some(match (&self.v2_checkpoint, self.parts) {
             (Some(v2), _) => CheckpointInstance::Uuid {
                 filename: v2.path.clone(),
             },
             (None, Some(parts)) => CheckpointInstance::MultiPart {
-                num_parts: parts as u32,
+                num_parts: parts.try_into().ok()?,
             },
             (None, None) => CheckpointInstance::Classic,
-        }
+        })
     }
 
     /// Parses a hint from raw `_last_checkpoint` bytes, dropping oversized fields so the retained
@@ -332,8 +332,8 @@ mod tests {
         assert!(serde_json::from_slice::<LastCheckpointHint>(bad_type).is_err());
     }
 
-    /// `applies_to` accepts the hint only for the checkpoint a segment selected: the version and
-    /// part count must match, and for a V2 checkpoint the first part's file name must match too.
+    /// `applies_to` accepts the hint only for the checkpoint a segment actually selected: same
+    /// version, and the identity the hint's fields imply must equal the selected checkpoint's.
     #[test]
     fn applies_to_matches_only_the_selected_checkpoint() {
         let root = Url::parse("memory:///_delta_log/").unwrap();
@@ -354,7 +354,6 @@ mod tests {
         };
         assert!(v2.applies_to(&[part(selected)]));
         assert!(!v2.applies_to(&[part(other)]), "wrong v2 path");
-        // The hint's version must equal the selected part's version (read from the part).
         let v2_wrong_version = LastCheckpointHint {
             version: 2,
             ..v2.clone()
@@ -364,7 +363,7 @@ mod tests {
             "wrong version"
         );
 
-        // V1 multi-part: keyed by (version, numParts) read from the selected part's file name.
+        // V1 multi-part: the part count comes from the selected part's file name.
         let mp1 = "00000000000000000001.checkpoint.0000000001.0000000002.parquet";
         let mp2 = "00000000000000000001.checkpoint.0000000002.0000000002.parquet";
         let v1_multi = LastCheckpointHint {
@@ -373,7 +372,6 @@ mod tests {
             ..Default::default()
         };
         assert!(v1_multi.applies_to(&[part(mp1), part(mp2)]));
-        // A hint whose numParts disagrees with the selected checkpoint's declared numParts.
         let mp1_of_3 = "00000000000000000001.checkpoint.0000000001.0000000003.parquet";
         assert!(!v1_multi.applies_to(&[part(mp1_of_3)]), "wrong part count");
 
@@ -385,8 +383,8 @@ mod tests {
         let classic = "00000000000000000001.checkpoint.parquet";
         assert!(v1_single.applies_to(&[part(classic)]));
 
-        // Format has to match, not just part count: a 1-of-1 multi-part checkpoint and a uuid-named
-        // one each hold one part too.
+        // Naming has to match, not just part count: a 1-of-1 multi-part and a uuid-named checkpoint
+        // each hold one part too.
         let one_of_one = "00000000000000000001.checkpoint.0000000001.0000000001.parquet";
         assert!(
             !v1_single.applies_to(&[part(one_of_one)]),

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -257,10 +257,10 @@ impl LogSegment {
     /// The retained `_last_checkpoint` hint, but only when it describes the checkpoint this segment
     /// selected (see [`LastCheckpointHint::applies_to`]) -- so the caller may trust its fields.
     fn checkpoint_hint(&self) -> Option<&LastCheckpointHint> {
-        let version = self.checkpoint_version?;
+        self.checkpoint_version?;
         self.last_checkpoint_metadata
             .as_ref()
-            .filter(|hint| hint.applies_to(version, &self.listed.checkpoint_parts))
+            .filter(|hint| hint.applies_to(&self.listed.checkpoint_parts))
     }
 
     /// The checkpoint schema from the `_last_checkpoint` hint, when the hint describes the selected
@@ -558,7 +558,7 @@ impl LogSegment {
         require!(
             matches!(
                 checkpoint.file_type,
-                LogPathFileType::SinglePartCheckpoint | LogPathFileType::UuidCheckpoint
+                LogPathFileType::ClassicCheckpoint | LogPathFileType::UuidCheckpoint
             ),
             Error::internal_error(format!(
                 "Cannot update LogSegment with checkpoint. Path is not a single-file \
@@ -910,7 +910,7 @@ impl LogSegment {
                 // checkpoints don't have a parquet footer to read.
                 self.read_sidecar_schema_and_files(engine, checkpoint, None, cancellation_token)
             }
-            SinglePartCheckpoint | UuidCheckpoint if checkpoint.extension.as_str() == "parquet" => {
+            ClassicCheckpoint | UuidCheckpoint if checkpoint.extension.as_str() == "parquet" => {
                 // Parquet checkpoint (classic-named or UUID-named): either can be V1 or V2.
                 // Check for sidecar column to distinguish.
                 let checkpoint_schema = Self::read_checkpoint_schema(

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -255,8 +255,9 @@ impl LogSegment {
     }
 
     /// The retained `_last_checkpoint` hint, but only when it describes the checkpoint this segment
-    /// selected (see [`LastCheckpointHint::applies_to`]) -- so the caller may trust its fields.
-    fn checkpoint_hint(&self) -> Option<&LastCheckpointHint> {
+    /// selected (see `LastCheckpointHint::applies_to`), so the caller may trust its fields.
+    #[internal_api]
+    pub(crate) fn checkpoint_hint(&self) -> Option<&LastCheckpointHint> {
         self.checkpoint_version?;
         self.last_checkpoint_metadata
             .as_ref()

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2635,7 +2635,7 @@ fn test_validate_listed_log_file_single_multipart_checkpoint_num_parts_mismatch(
 
 #[test]
 fn test_validate_listed_log_file_multiple_single_part_checkpoints() {
-    // Two SinglePartCheckpoints at the same version: n=2 but neither is a MultiPartCheckpoint
+    // Two ClassicCheckpoints at the same version: n=2 but neither is a MultiPartCheckpoint
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     assert!(LogSegment::try_new(
         LogSegmentFiles {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -28,6 +28,7 @@ use crate::object_store::memory::InMemory;
 use crate::object_store::path::Path;
 use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::ArrowWriter;
+use crate::path::tests::multipart_checkpoint_name;
 use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::scan::test_utils::{
     add_batch_simple, add_batch_with_remove, adds_only_batch, remove_only_batch,
@@ -86,9 +87,8 @@ fn process_sidecars(
 // get an ObjectStore path for a checkpoint file, based on version, part number, and total number of
 // parts
 fn delta_path_for_multipart_checkpoint(version: u64, part_num: u32, num_parts: u32) -> Path {
-    let path =
-        format!("_delta_log/{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet");
-    Path::from(path.as_str())
+    let name = multipart_checkpoint_name(version, part_num, num_parts);
+    Path::from(format!("_delta_log/{name}").as_str())
 }
 
 // Utility method to build a log using a list of log paths and an optional checkpoint hint. The
@@ -626,13 +626,22 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
     )
 }
 
+/// v5 holds three complete checkpoints (classic, 2-part, 3-part), so the 3-part one always wins.
+/// The hint's `parts` decides only whether the hint describes that winner.
+#[rstest]
+#[case::hint_names_winner(Some(3), true)]
+#[case::hint_names_losing_multipart(Some(2), false)]
+#[case::hint_names_losing_classic(None, false)]
 #[tokio::test]
-async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
+async fn build_snapshot_applies_checkpoint_hint_iff_it_names_the_selected_checkpoint(
+    #[case] hint_parts: Option<usize>,
+    #[case] expect_hint_applies: bool,
+) {
     let checkpoint_metadata = LastCheckpointHint {
         v2_checkpoint: None,
         version: 5,
         size: 10,
-        parts: Some(1),
+        parts: hint_parts,
         size_in_bytes: None,
         num_of_add_files: None,
         checkpoint_schema: None,
@@ -649,11 +658,12 @@ async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
             delta_path_for_version(3, "checkpoint.parquet"),
             delta_path_for_version(3, "json"),
             delta_path_for_version(4, "json"),
-            // Two complete checkpoints at v5: the classic one the hint describes, and the 2-part
-            // one that outranks it.
             delta_path_for_version(5, "checkpoint.parquet"),
             delta_path_for_multipart_checkpoint(5, 1, 2),
             delta_path_for_multipart_checkpoint(5, 2, 2),
+            delta_path_for_multipart_checkpoint(5, 1, 3),
+            delta_path_for_multipart_checkpoint(5, 2, 3),
+            delta_path_for_multipart_checkpoint(5, 3, 3),
             delta_path_for_version(5, "json"),
             delta_path_for_version(6, "json"),
             delta_path_for_version(7, "json"),
@@ -662,8 +672,6 @@ async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
     )
     .await;
 
-    // The 2-part checkpoint at v5 is selected, so the hint describing the classic one is not
-    // applied.
     let log_segment = LogSegment::for_snapshot_impl(
         storage.as_ref(),
         log_root,
@@ -684,15 +692,16 @@ async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
     assert_eq!(
         checkpoint_filenames,
         vec![
-            "00000000000000000005.checkpoint.0000000001.0000000002.parquet",
-            "00000000000000000005.checkpoint.0000000002.0000000002.parquet",
+            "00000000000000000005.checkpoint.0000000001.0000000003.parquet",
+            "00000000000000000005.checkpoint.0000000002.0000000003.parquet",
+            "00000000000000000005.checkpoint.0000000003.0000000003.parquet",
         ]
     );
 
-    // The hint is retained but does not describe the selected checkpoint, so none of its fields are
-    // trusted -- readers fall back to the checkpoint footer.
+    // The hint is always retained; describing some other checkpoint only makes its fields
+    // untrustworthy, and readers fall back to the checkpoint footer.
     assert!(log_segment.last_checkpoint_metadata.is_some());
-    assert!(log_segment.checkpoint_hint().is_none());
+    assert_eq!(log_segment.checkpoint_hint().is_some(), expect_hint_applies);
 
     let commit_versions = log_segment
         .listed
@@ -701,51 +710,6 @@ async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
         .map(|c| c.version)
         .collect_vec();
     assert_eq!(commit_versions, vec![6, 7]);
-}
-
-/// Two complete checkpoints at v5, one of 2 parts and one of 3, with the hint naming the 3-part
-/// one. The 3-part checkpoint wins on part count, so the hint applies and its fields stay usable.
-#[tokio::test]
-async fn build_snapshot_applies_checkpoint_hint_matching_selected_checkpoint() {
-    let checkpoint_metadata = LastCheckpointHint {
-        v2_checkpoint: None,
-        version: 5,
-        size: 10,
-        parts: Some(3),
-        size_in_bytes: None,
-        num_of_add_files: None,
-        checkpoint_schema: None,
-        checksum: None,
-        tags: None,
-    };
-
-    let (storage, log_root) = build_log_with_paths_and_checkpoint(
-        &[
-            delta_path_for_version(4, "json"),
-            delta_path_for_multipart_checkpoint(5, 1, 2),
-            delta_path_for_multipart_checkpoint(5, 2, 2),
-            delta_path_for_multipart_checkpoint(5, 1, 3),
-            delta_path_for_multipart_checkpoint(5, 2, 3),
-            delta_path_for_multipart_checkpoint(5, 3, 3),
-            delta_path_for_version(5, "json"),
-            delta_path_for_version(6, "json"),
-        ],
-        Some(&checkpoint_metadata),
-    )
-    .await;
-
-    let log_segment = LogSegment::for_snapshot_impl(
-        storage.as_ref(),
-        log_root,
-        vec![], // log_tail
-        Some(checkpoint_metadata),
-        None,
-    )
-    .unwrap();
-
-    assert_eq!(log_segment.checkpoint_version, Some(5));
-    assert_eq!(log_segment.listed.checkpoint_parts.len(), 3);
-    assert!(log_segment.checkpoint_hint().is_some());
 }
 
 #[tokio::test]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -627,7 +627,7 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
 }
 
 #[tokio::test]
-async fn build_snapshot_with_bad_checkpoint_hint_fails() {
+async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
     let checkpoint_metadata = LastCheckpointHint {
         v2_checkpoint: None,
         version: 5,
@@ -649,11 +649,86 @@ async fn build_snapshot_with_bad_checkpoint_hint_fails() {
             delta_path_for_version(3, "checkpoint.parquet"),
             delta_path_for_version(3, "json"),
             delta_path_for_version(4, "json"),
+            // Two complete checkpoints at v5: the classic one the hint describes, and the 2-part
+            // one that outranks it.
+            delta_path_for_version(5, "checkpoint.parquet"),
             delta_path_for_multipart_checkpoint(5, 1, 2),
             delta_path_for_multipart_checkpoint(5, 2, 2),
             delta_path_for_version(5, "json"),
             delta_path_for_version(6, "json"),
             delta_path_for_version(7, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    // The 2-part checkpoint at v5 is selected, so the hint describing the classic one is not
+    // applied.
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(log_segment.checkpoint_version, Some(5));
+    assert_eq!(log_segment.end_version, 7);
+    let checkpoint_filenames = log_segment
+        .listed
+        .checkpoint_parts
+        .iter()
+        .map(|p| p.filename.as_str())
+        .collect_vec();
+    assert_eq!(
+        checkpoint_filenames,
+        vec![
+            "00000000000000000005.checkpoint.0000000001.0000000002.parquet",
+            "00000000000000000005.checkpoint.0000000002.0000000002.parquet",
+        ]
+    );
+
+    // The hint is retained but does not describe the selected checkpoint, so none of its fields are
+    // trusted -- readers fall back to the checkpoint footer.
+    assert!(log_segment.last_checkpoint_metadata.is_some());
+    assert!(log_segment.checkpoint_hint().is_none());
+
+    let commit_versions = log_segment
+        .listed
+        .ascending_commit_files
+        .iter()
+        .map(|c| c.version)
+        .collect_vec();
+    assert_eq!(commit_versions, vec![6, 7]);
+}
+
+/// Two complete checkpoints at v5, one of 2 parts and one of 3, with the hint naming the 3-part
+/// one. The 3-part checkpoint wins on part count, so the hint applies and its fields stay usable.
+#[tokio::test]
+async fn build_snapshot_applies_checkpoint_hint_matching_selected_checkpoint() {
+    let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
+        version: 5,
+        size: 10,
+        parts: Some(3),
+        size_in_bytes: None,
+        num_of_add_files: None,
+        checkpoint_schema: None,
+        checksum: None,
+        tags: None,
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(4, "json"),
+            delta_path_for_multipart_checkpoint(5, 1, 2),
+            delta_path_for_multipart_checkpoint(5, 2, 2),
+            delta_path_for_multipart_checkpoint(5, 1, 3),
+            delta_path_for_multipart_checkpoint(5, 2, 3),
+            delta_path_for_multipart_checkpoint(5, 3, 3),
+            delta_path_for_version(5, "json"),
+            delta_path_for_version(6, "json"),
         ],
         Some(&checkpoint_metadata),
     )
@@ -665,12 +740,12 @@ async fn build_snapshot_with_bad_checkpoint_hint_fails() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
-    );
-    assert_result_error_with_message(
-        log_segment,
-        "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
-        it has 2",
     )
+    .unwrap();
+
+    assert_eq!(log_segment.checkpoint_version, Some(5));
+    assert_eq!(log_segment.listed.checkpoint_parts.len(), 3);
+    assert!(log_segment.checkpoint_hint().is_some());
 }
 
 #[tokio::test]

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -106,13 +106,13 @@ pub(crate) fn list_delta_log_from_storage(
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.
 ///
-/// Several _complete_ checkpoints can legitimately share a version -- e.g. two multi-part
-/// checkpoints with different part counts, or two uuid-named ones. Each gets its own
-/// [`CheckpointInstance`] key so they never overwrite one another, letting the caller pick a winner
-/// deterministically (see `ListingAccumulator::select_checkpoint_for_group`).
+/// Several _complete_ checkpoints can legitimately share a version, say two multi-part checkpoints
+/// with different part counts, or two uuid-named ones. Each gets its own [`CheckpointInstance`]
+/// key, so the caller can pick a winner deterministically (see
+/// `ListingAccumulator::select_checkpoint_for_group`).
 ///
-/// `parts` must arrive in ascending file name order, which is what log listing produces: a
-/// multi-part checkpoint only accumulates while its parts arrive in order.
+/// `parts` must arrive in ascending file name order, which log listing provides: a multi-part
+/// checkpoint only accumulates while its parts arrive in order.
 #[internal_api]
 fn group_checkpoint_parts(
     parts: Vec<ParsedLogPath>,
@@ -124,9 +124,8 @@ fn group_checkpoint_parts(
     let mut checkpoints: HashMap<CheckpointInstance, Vec<ParsedLogPath>> = HashMap::new();
     for part_file in parts {
         match &part_file.file_type {
-            // A single-file checkpoint is complete on its own. Keying on file name keeps distinct
-            // same-version checkpoints separate -- notably uuid-named ones, since each writer picks
-            // a fresh uuid.
+            // A single-file checkpoint is complete on its own. Keying uuid-named ones on file name
+            // keeps two of them at the same version separate.
             ClassicCheckpoint | UuidCheckpoint => {
                 if let Some(instance) = CheckpointInstance::of(&part_file) {
                     checkpoints.insert(instance, vec![part_file]);
@@ -612,12 +611,9 @@ impl LogSegmentFiles {
             latest_checkpoint.version
         );
         } else if !checkpoint_metadata.applies_to(&listed_files.checkpoint_parts) {
-            // The hint describes a checkpoint other than the one selected at this version (see
-            // `group_checkpoint_parts`) -- expected whenever a writer checkpoints a version another
-            // writer already checkpointed and leaves the hint alone, concurrently or not. Readers
-            // fall back to the checkpoint file's own fields; `applies_to` also makes
-            // `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the hint's
-            // fields are dropped.
+            // Expected whenever a writer checkpoints a version another writer already checkpointed
+            // and leaves the hint alone. `applies_to` also makes `LogSegment::checkpoint_hint`
+            // yield `None`, so this logs exactly when the hint's fields get dropped.
             debug!(
                 version = checkpoint_metadata.version,
                 hint_parts = checkpoint_metadata.parts.unwrap_or(1),

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -20,7 +20,9 @@ use url::Url;
 
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
-use crate::path::{may_begin_listable_log_path, LogPathFileType, ParsedLogPath};
+use crate::path::{
+    may_begin_listable_log_path, CheckpointInstance, LogPathFileType, ParsedLogPath,
+};
 use crate::{DeltaResult, Error, StorageHandler, Version};
 
 #[cfg(test)]
@@ -33,7 +35,7 @@ mod tests;
 /// - `ascending_compaction_files`: All compaction commit files found, sorted by version.
 /// - `checkpoint_parts`: All parts of the most recent complete checkpoint (all same version). Empty
 ///   if no checkpoint found. A version can hold several complete checkpoints; see
-///   `group_checkpoint_parts` for which one this is.
+///   [`group_checkpoint_parts`] for which one this is.
 /// - `latest_crc_file`: The CRC file with the highest version, only if version >= checkpoint
 ///   version.
 /// - `latest_commit_file`: The commit file with the highest version, or `None` if no commits were
@@ -102,79 +104,17 @@ pub(crate) fn list_delta_log_from_storage(
     Ok(files)
 }
 
-/// Rank of a checkpoint's [`LogPathFileType`], ordered like Delta-Spark's
-/// `CheckpointInstance.Format` ordinals (`SINGLE` = 0, `WITH_PARTS` = 1, `V2` = 2), which its
-/// comparison uses as the sort key just after version. A separate enum because `LogPathFileType`
-/// also covers non-checkpoint files, and its variants are not declared in this order.
-///
-/// Named for those ordinals, but the rank follows a checkpoint's *name*, not its spec version: a
-/// classic-named file may itself be a V2 checkpoint carrying sidecars, which is why
-/// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column instead.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum CheckpointFormatRank {
-    /// [`SinglePartCheckpoint`]
-    Single,
-    /// [`MultiPartCheckpoint`]
-    WithParts,
-    /// [`UuidCheckpoint`]
-    V2,
-}
-
-/// Identifies one checkpoint among the checkpoints at a single version, and orders it against its
-/// siblings.
-///
-/// Ordered like Delta-Spark's `CheckpointInstance`, which compares
-/// `(version, format, num_parts, file_name)` -- minus the leading version, because everything
-/// compared here already shares a version. Field order below is therefore the sort order.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct CheckpointInstance {
-    format: CheckpointFormatRank,
-    /// How many files this checkpoint spans, or `None` for a single-file checkpoint -- matching
-    /// Delta-Spark's `Option[Int]`, whose `None` also sorts below every `Some`.
-    num_parts: Option<u32>,
-    /// Set for the single-file formats (`Single`, `V2`), where the file name is what distinguishes
-    /// two checkpoints at the same version. `None` for a multi-part checkpoint, so that all of its
-    /// parts map to one instance: a multi-part file name is fully determined by
-    /// `(version, part_num, num_parts)`, so `num_parts` already pins the identity.
-    filename: Option<String>,
-}
-
-impl CheckpointInstance {
-    /// The instance shared by every part of the `num_parts`-part checkpoint at this version.
-    fn multi_part(num_parts: u32) -> Self {
-        Self {
-            format: CheckpointFormatRank::WithParts,
-            num_parts: Some(num_parts),
-            filename: None,
-        }
-    }
-
-    /// The instance for a checkpoint that is one whole file, ranked `Single` or `V2` by its name.
-    fn single_file(format: CheckpointFormatRank, filename: String) -> Self {
-        Self {
-            format,
-            num_parts: None,
-            filename: Some(filename),
-        }
-    }
-
-    /// Whether `part_files` holds every part this checkpoint needs.
-    fn is_complete(&self, part_files: &[ParsedLogPath]) -> bool {
-        // `num_parts` is guaranteed to be non-negative and within `usize` range
-        self.num_parts.unwrap_or(1) as usize == part_files.len()
-    }
-}
-
 /// Groups all checkpoint parts according to the checkpoint they belong to.
 ///
 /// Several _complete_ checkpoints can legitimately share a version: writers choose how many parts
 /// to split a checkpoint into independently, and a V2 writer embeds a fresh uuid in each file name.
 /// Each distinct checkpoint therefore gets its own [`CheckpointInstance`] key and they never
 /// overwrite one another, so the caller can pick a winner deterministically (see
-/// [`ListingAccumulator::flush_checkpoint_group`]).
+/// `ListingAccumulator::select_checkpoint_for_group`).
 ///
 /// `parts` must arrive in ascending file name order, which is what log listing produces: a
 /// multi-part checkpoint only accumulates while its parts arrive in order.
+#[internal_api]
 fn group_checkpoint_parts(
     parts: Vec<ParsedLogPath>,
 ) -> HashMap<CheckpointInstance, Vec<ParsedLogPath>> {
@@ -187,23 +127,23 @@ fn group_checkpoint_parts(
         match &part_file.file_type {
             // A single-file checkpoint is complete on its own. Keying on file name keeps distinct
             // same-version checkpoints separate -- notably uuid-named ones, since each writer picks
-            // a fresh uuid. Ranking is blind to whether the table declares the `v2Checkpoint`
-            // reader feature, as Delta-Spark's is: the Protocol action lives *inside* the
-            // checkpoint being chosen, so listing cannot know it.
-            SinglePartCheckpoint | UuidCheckpoint => {
-                let format = match part_file.file_type {
-                    UuidCheckpoint => CheckpointFormatRank::V2,
-                    _ => CheckpointFormatRank::Single,
-                };
-                let instance = CheckpointInstance::single_file(format, part_file.filename.clone());
-                checkpoints.insert(instance, vec![part_file]);
+            // a fresh uuid.
+            ClassicCheckpoint | UuidCheckpoint => {
+                if let Some(instance) = CheckpointInstance::of(&part_file) {
+                    checkpoints.insert(instance, vec![part_file]);
+                }
             }
             MultiPartCheckpoint {
                 part_num: 1,
                 num_parts,
             } => {
                 // Start a new multi-part checkpoint
-                checkpoints.insert(CheckpointInstance::multi_part(*num_parts), vec![part_file]);
+                checkpoints.insert(
+                    CheckpointInstance::MultiPart {
+                        num_parts: *num_parts,
+                    },
+                    vec![part_file],
+                );
             }
             MultiPartCheckpoint {
                 part_num,
@@ -212,10 +152,9 @@ fn group_checkpoint_parts(
                 // Continue a multi-part checkpoint.
                 // Checkpoint parts are required to be in-order from log listing to build
                 // a multi-part checkpoint
-                if let Some(part_files) =
-                    checkpoints.get_mut(&CheckpointInstance::multi_part(*num_parts))
-                {
-                    // `part_num` is guaranteed to be non-negative and within `usize` range
+                if let Some(part_files) = checkpoints.get_mut(&CheckpointInstance::MultiPart {
+                    num_parts: *num_parts,
+                }) {
                     if *part_num as usize == 1 + part_files.len() {
                         // Safe to append because all previous parts exist
                         part_files.push(part_file);
@@ -275,7 +214,7 @@ pub(crate) fn should_process_log_file(file: &ParsedLogPath) -> bool {
                 file.location.location,
             );
         }
-        SinglePartCheckpoint | UuidCheckpoint | MultiPartCheckpoint { .. } => {
+        ClassicCheckpoint | UuidCheckpoint | MultiPartCheckpoint { .. } => {
             warn!(
                 "Skipping empty (0 byte) checkpoint file: {}",
                 file.location.location,
@@ -335,7 +274,7 @@ impl ListingAccumulator {
                     file.location
                 );
             }
-            SinglePartCheckpoint | UuidCheckpoint | MultiPartCheckpoint { .. } => {
+            ClassicCheckpoint | UuidCheckpoint | MultiPartCheckpoint { .. } => {
                 self.pending_checkpoint_parts.push(file)
             }
             Crc => {
@@ -354,13 +293,13 @@ impl ListingAccumulator {
     }
 
     /// Called before processing each new file. If `file_version` differs from the current
-    /// `group_version`, finalizes the current group by calling `flush_checkpoint_group`,
+    /// `group_version`, finalizes the current group by calling `select_checkpoint_for_group`,
     /// then advances `group_version` to the new version. On the first call (when
     /// `group_version` is `None`), simply initializes it.
     fn maybe_flush_and_advance(&mut self, file_version: Version) {
         match self.group_version {
             Some(gv) if file_version != gv => {
-                self.flush_checkpoint_group(gv);
+                self.select_checkpoint_for_group(gv);
                 self.group_version = Some(file_version);
             }
             None => {
@@ -370,19 +309,13 @@ impl ListingAccumulator {
         }
     }
 
-    /// Selects this version's checkpoint: the greatest _complete_ checkpoint in
-    /// [`CheckpointInstance`] order.
+    /// Selects this version's checkpoint. Any of a version's complete checkpoints (see
+    /// [`group_checkpoint_parts`]) describes the same table state; the choice must be stable across
+    /// processes (matching Delta-Spark), so we take the greatest in [`CheckpointInstance`] order.
     ///
-    /// Any of a version's complete checkpoints (see [`group_checkpoint_parts`]) describes the same
-    /// table state, though not necessarily by the same read path -- a V2 manifest resolves sidecars
-    /// where a V1 checkpoint holds its actions inline. The choice must be stable across processes,
-    /// hence the maximum rather than whichever entry a [`HashMap`] happens to yield first.
-    /// Delta-Spark selects the same way: group by checkpoint identity, keep the groups complete
-    /// against their own part count, take the max.
-    ///
-    /// If this version has a complete checkpoint, we can drop the existing commit and
-    /// compaction files we collected so far -- except we must keep the latest commit.
-    fn flush_checkpoint_group(&mut self, version: Version) {
+    /// When a complete checkpoint exists we drop the commits/compactions collected so far, keeping
+    /// only the latest commit.
+    fn select_checkpoint_for_group(&mut self, version: Version) {
         let pending_checkpoint_parts = std::mem::take(&mut self.pending_checkpoint_parts);
         if let Some((_, complete_checkpoint)) = group_checkpoint_parts(pending_checkpoint_parts)
             .into_iter()
@@ -498,7 +431,7 @@ impl LogSegmentFiles {
 
         // Flush the final group
         if let Some(gv) = acc.group_version {
-            acc.flush_checkpoint_group(gv);
+            acc.select_checkpoint_for_group(gv);
         }
 
         // Since ascending_commit_files is cleared at each checkpoint, if it's non-empty here
@@ -679,21 +612,19 @@ impl LogSegmentFiles {
             checkpoint_metadata.version,
             latest_checkpoint.version
         );
-        } else if !checkpoint_metadata
-            .applies_to(latest_checkpoint.version, &listed_files.checkpoint_parts)
-        {
-            // Not corruption: the hint describes a checkpoint other than the one selected at this
-            // version (see `group_checkpoint_parts`). A torn checkpoint instead leaves
-            // `checkpoint_parts` empty, which the caller reports as an error. `applies_to` is also
-            // what makes `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the
-            // hint's fields are dropped and readers fall back to the checkpoint footer.
-            warn!(
+        } else if !checkpoint_metadata.applies_to(&listed_files.checkpoint_parts) {
+            // The hint describes a checkpoint other than the one selected at this version (see
+            // `group_checkpoint_parts`) -- expected under concurrent writers. Readers fall back to
+            // the checkpoint file's own fields; `applies_to` also makes
+            // `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the
+            // hint's fields are dropped.
+            debug!(
                 version = checkpoint_metadata.version,
                 hint_parts = checkpoint_metadata.parts.unwrap_or(1),
                 selected_parts = listed_files.checkpoint_parts.len(),
                 selected_checkpoint_part = %latest_checkpoint.filename,
                 "_last_checkpoint hint describes a different checkpoint than the one selected at \
-                 this version; ignoring the hint's checkpoint-specific fields"
+                 this version; using the checkpoint file's own fields"
             );
         }
         Ok(listed_files)

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -32,7 +32,8 @@ mod tests;
 ///   contain gaps.
 /// - `ascending_compaction_files`: All compaction commit files found, sorted by version.
 /// - `checkpoint_parts`: All parts of the most recent complete checkpoint (all same version). Empty
-///   if no checkpoint found.
+///   if no checkpoint found. A version can hold several complete checkpoints; see
+///   `group_checkpoint_parts` for which one this is.
 /// - `latest_crc_file`: The CRC file with the highest version, only if version >= checkpoint
 ///   version.
 /// - `latest_commit_file`: The commit file with the highest version, or `None` if no commits were
@@ -101,39 +102,119 @@ pub(crate) fn list_delta_log_from_storage(
     Ok(files)
 }
 
+/// Rank of a checkpoint's [`LogPathFileType`], ordered like Delta-Spark's
+/// `CheckpointInstance.Format` ordinals (`SINGLE` = 0, `WITH_PARTS` = 1, `V2` = 2), which its
+/// comparison uses as the sort key just after version. A separate enum because `LogPathFileType`
+/// also covers non-checkpoint files, and its variants are not declared in this order.
+///
+/// Named for those ordinals, but the rank follows a checkpoint's *name*, not its spec version: a
+/// classic-named file may itself be a V2 checkpoint carrying sidecars, which is why
+/// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum CheckpointFormatRank {
+    /// [`SinglePartCheckpoint`]
+    Single,
+    /// [`MultiPartCheckpoint`]
+    WithParts,
+    /// [`UuidCheckpoint`]
+    V2,
+}
+
+/// Identifies one checkpoint among the checkpoints at a single version, and orders it against its
+/// siblings.
+///
+/// Ordered like Delta-Spark's `CheckpointInstance`, which compares
+/// `(version, format, num_parts, file_name)` -- minus the leading version, because everything
+/// compared here already shares a version. Field order below is therefore the sort order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct CheckpointInstance {
+    format: CheckpointFormatRank,
+    /// How many files this checkpoint spans, or `None` for a single-file checkpoint -- matching
+    /// Delta-Spark's `Option[Int]`, whose `None` also sorts below every `Some`.
+    num_parts: Option<u32>,
+    /// Set for the single-file formats (`Single`, `V2`), where the file name is what distinguishes
+    /// two checkpoints at the same version. `None` for a multi-part checkpoint, so that all of its
+    /// parts map to one instance: a multi-part file name is fully determined by
+    /// `(version, part_num, num_parts)`, so `num_parts` already pins the identity.
+    filename: Option<String>,
+}
+
+impl CheckpointInstance {
+    /// The instance shared by every part of the `num_parts`-part checkpoint at this version.
+    fn multi_part(num_parts: u32) -> Self {
+        Self {
+            format: CheckpointFormatRank::WithParts,
+            num_parts: Some(num_parts),
+            filename: None,
+        }
+    }
+
+    /// The instance for a checkpoint that is one whole file, ranked `Single` or `V2` by its name.
+    fn single_file(format: CheckpointFormatRank, filename: String) -> Self {
+        Self {
+            format,
+            num_parts: None,
+            filename: Some(filename),
+        }
+    }
+
+    /// Whether `part_files` holds every part this checkpoint needs.
+    fn is_complete(&self, part_files: &[ParsedLogPath]) -> bool {
+        // `num_parts` is guaranteed to be non-negative and within `usize` range
+        self.num_parts.unwrap_or(1) as usize == part_files.len()
+    }
+}
+
 /// Groups all checkpoint parts according to the checkpoint they belong to.
 ///
-/// NOTE: There could be a single-part and/or any number of uuid-based checkpoints. They
-/// are all equivalent, and this routine keeps only one of them (arbitrarily chosen).
-#[internal_api]
-fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedLogPath>> {
-    let mut checkpoints: HashMap<u32, Vec<ParsedLogPath>> = HashMap::new();
+/// Several _complete_ checkpoints can legitimately share a version: writers choose how many parts
+/// to split a checkpoint into independently, and a V2 writer embeds a fresh uuid in each file name.
+/// Each distinct checkpoint therefore gets its own [`CheckpointInstance`] key and they never
+/// overwrite one another, so the caller can pick a winner deterministically (see
+/// [`ListingAccumulator::flush_checkpoint_group`]).
+///
+/// `parts` must arrive in ascending file name order, which is what log listing produces: a
+/// multi-part checkpoint only accumulates while its parts arrive in order.
+fn group_checkpoint_parts(
+    parts: Vec<ParsedLogPath>,
+) -> HashMap<CheckpointInstance, Vec<ParsedLogPath>> {
+    debug_assert!(
+        parts.is_sorted_by_key(|p| &p.filename),
+        "checkpoint parts must arrive in ascending file name order"
+    );
+    let mut checkpoints: HashMap<CheckpointInstance, Vec<ParsedLogPath>> = HashMap::new();
     for part_file in parts {
         match &part_file.file_type {
-            SinglePartCheckpoint
-            | UuidCheckpoint
-            | MultiPartCheckpoint {
-                part_num: 1,
-                num_parts: 1,
-            } => {
-                // All single-file checkpoints are equivalent, just keep one
-                checkpoints.insert(1, vec![part_file]);
+            // A single-file checkpoint is complete on its own. Keying on file name keeps distinct
+            // same-version checkpoints separate -- notably uuid-named ones, since each writer picks
+            // a fresh uuid. Ranking is blind to whether the table declares the `v2Checkpoint`
+            // reader feature, as Delta-Spark's is: the Protocol action lives *inside* the
+            // checkpoint being chosen, so listing cannot know it.
+            SinglePartCheckpoint | UuidCheckpoint => {
+                let format = match part_file.file_type {
+                    UuidCheckpoint => CheckpointFormatRank::V2,
+                    _ => CheckpointFormatRank::Single,
+                };
+                let instance = CheckpointInstance::single_file(format, part_file.filename.clone());
+                checkpoints.insert(instance, vec![part_file]);
             }
             MultiPartCheckpoint {
                 part_num: 1,
                 num_parts,
             } => {
-                // Start a new multi-part checkpoint with at least 2 parts
-                checkpoints.insert(*num_parts, vec![part_file]);
+                // Start a new multi-part checkpoint
+                checkpoints.insert(CheckpointInstance::multi_part(*num_parts), vec![part_file]);
             }
             MultiPartCheckpoint {
                 part_num,
                 num_parts,
             } => {
-                // Continue a new multi-part checkpoint with at least 2 parts.
+                // Continue a multi-part checkpoint.
                 // Checkpoint parts are required to be in-order from log listing to build
                 // a multi-part checkpoint
-                if let Some(part_files) = checkpoints.get_mut(num_parts) {
+                if let Some(part_files) =
+                    checkpoints.get_mut(&CheckpointInstance::multi_part(*num_parts))
+                {
                     // `part_num` is guaranteed to be non-negative and within `usize` range
                     if *part_num as usize == 1 + part_files.len() {
                         // Safe to append because all previous parts exist
@@ -159,7 +240,7 @@ fn find_complete_checkpoint_version(ascending_files: &[ParsedLogPath]) -> Option
             let owned: Vec<ParsedLogPath> = parts.cloned().collect();
             group_checkpoint_parts(owned)
                 .iter()
-                .any(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
+                .any(|(instance, part_files)| instance.is_complete(part_files))
                 .then_some(version)
         })
         .last()
@@ -289,8 +370,15 @@ impl ListingAccumulator {
         }
     }
 
-    /// Groups and finds the first complete checkpoint for this version.
-    /// All checkpoints for the same version are equivalent, so we only take one.
+    /// Selects this version's checkpoint: the greatest _complete_ checkpoint in
+    /// [`CheckpointInstance`] order.
+    ///
+    /// Any of a version's complete checkpoints (see [`group_checkpoint_parts`]) describes the same
+    /// table state, though not necessarily by the same read path -- a V2 manifest resolves sidecars
+    /// where a V1 checkpoint holds its actions inline. The choice must be stable across processes,
+    /// hence the maximum rather than whichever entry a [`HashMap`] happens to yield first.
+    /// Delta-Spark selects the same way: group by checkpoint identity, keep the groups complete
+    /// against their own part count, take the max.
     ///
     /// If this version has a complete checkpoint, we can drop the existing commit and
     /// compaction files we collected so far -- except we must keep the latest commit.
@@ -298,8 +386,8 @@ impl ListingAccumulator {
         let pending_checkpoint_parts = std::mem::take(&mut self.pending_checkpoint_parts);
         if let Some((_, complete_checkpoint)) = group_checkpoint_parts(pending_checkpoint_parts)
             .into_iter()
-            // `num_parts` is guaranteed to be non-negative and within `usize` range
-            .find(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
+            .filter(|(instance, part_files)| instance.is_complete(part_files))
+            .max_by(|(a, _), (b, _)| a.cmp(b))
         {
             self.output.checkpoint_parts = complete_checkpoint;
             // Keep the commit at the checkpoint version (if any) before clearing all older commits.
@@ -559,6 +647,10 @@ impl LogSegmentFiles {
     /// List all commit and checkpoint files after the provided checkpoint. It is guaranteed that
     /// all the returned [`ParsedLogPath`]s will have a version less than or equal to the
     /// `end_version`.
+    ///
+    /// The hint only tells us where to start listing; it never influences which checkpoint is
+    /// selected at a version. A hint that turns out to describe a different checkpoint than the one
+    /// selected is logged and ignored, not an error.
     pub(crate) fn list_with_checkpoint_hint(
         checkpoint_metadata: &LastCheckpointHint,
         storage: &dyn StorageHandler,
@@ -587,12 +679,22 @@ impl LogSegmentFiles {
             checkpoint_metadata.version,
             latest_checkpoint.version
         );
-        } else if listed_files.checkpoint_parts.len() != checkpoint_metadata.parts.unwrap_or(1) {
-            return Err(Error::InvalidCheckpoint(format!(
-                "_last_checkpoint indicated that checkpoint should have {} parts, but it has {}",
-                checkpoint_metadata.parts.unwrap_or(1),
-                listed_files.checkpoint_parts.len()
-            )));
+        } else if !checkpoint_metadata
+            .applies_to(latest_checkpoint.version, &listed_files.checkpoint_parts)
+        {
+            // Not corruption: the hint describes a checkpoint other than the one selected at this
+            // version (see `group_checkpoint_parts`). A torn checkpoint instead leaves
+            // `checkpoint_parts` empty, which the caller reports as an error. `applies_to` is also
+            // what makes `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the
+            // hint's fields are dropped and readers fall back to the checkpoint footer.
+            warn!(
+                version = checkpoint_metadata.version,
+                hint_parts = checkpoint_metadata.parts.unwrap_or(1),
+                selected_parts = listed_files.checkpoint_parts.len(),
+                selected_checkpoint_part = %latest_checkpoint.filename,
+                "_last_checkpoint hint describes a different checkpoint than the one selected at \
+                 this version; ignoring the hint's checkpoint-specific fields"
+            );
         }
         Ok(listed_files)
     }

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -106,11 +106,10 @@ pub(crate) fn list_delta_log_from_storage(
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.
 ///
-/// Several _complete_ checkpoints can legitimately share a version: writers choose how many parts
-/// to split a checkpoint into independently, and a V2 writer embeds a fresh uuid in each file name.
-/// Each distinct checkpoint therefore gets its own [`CheckpointInstance`] key and they never
-/// overwrite one another, so the caller can pick a winner deterministically (see
-/// `ListingAccumulator::select_checkpoint_for_group`).
+/// Several _complete_ checkpoints can legitimately share a version -- e.g. two multi-part
+/// checkpoints with different part counts, or two uuid-named ones. Each gets its own
+/// [`CheckpointInstance`] key so they never overwrite one another, letting the caller pick a winner
+/// deterministically (see `ListingAccumulator::select_checkpoint_for_group`).
 ///
 /// `parts` must arrive in ascending file name order, which is what log listing produces: a
 /// multi-part checkpoint only accumulates while its parts arrive in order.
@@ -614,10 +613,11 @@ impl LogSegmentFiles {
         );
         } else if !checkpoint_metadata.applies_to(&listed_files.checkpoint_parts) {
             // The hint describes a checkpoint other than the one selected at this version (see
-            // `group_checkpoint_parts`) -- expected under concurrent writers. Readers fall back to
-            // the checkpoint file's own fields; `applies_to` also makes
-            // `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the
-            // hint's fields are dropped.
+            // `group_checkpoint_parts`) -- expected whenever a writer checkpoints a version another
+            // writer already checkpointed and leaves the hint alone, concurrently or not. Readers
+            // fall back to the checkpoint file's own fields; `applies_to` also makes
+            // `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the hint's
+            // fields are dropped.
             debug!(
                 version = checkpoint_metadata.version,
                 hint_parts = checkpoint_metadata.parts.unwrap_or(1),

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1337,3 +1337,347 @@ fn find_complete_checkpoint_version_cases(
 ) {
     assert_eq!(find_complete_checkpoint_version(&files), expected);
 }
+
+/// Builds a `ParsedLogPath` by parsing a real log file name, so `filename`, `extension` and
+/// `file_type` agree. Unlike [`make_parsed_log_path_with_source`], whose url is always
+/// `<version>.json`, this works for checkpoint paths -- whose file name takes part in checkpoint
+/// selection.
+fn parse_log_path(filename: &str) -> ParsedLogPath {
+    let url = Url::parse(&format!("memory:///_delta_log/{filename}")).unwrap();
+    ParsedLogPath::try_from(FileMeta {
+        location: url,
+        last_modified: 0,
+        size: FILESYSTEM_SIZE_MARKER,
+    })
+    .unwrap_or_else(|e| panic!("{filename} is not a log path: {e}"))
+    .unwrap_or_else(|| panic!("{filename} is not a log path"))
+}
+
+fn multipart_checkpoint_name(version: Version, part_num: u32, num_parts: u32) -> String {
+    format!("{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
+}
+
+/// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a single-part checkpoint sorts below a
+/// multi-part one, more parts beats fewer, a V2 checkpoint outranks both, and single-file
+/// checkpoints break ties on file name.
+#[test]
+fn checkpoint_instance_orders_like_delta_spark() {
+    let classic = CheckpointInstance::single_file(
+        CheckpointFormatRank::Single,
+        "00000000000000000005.checkpoint.parquet".to_string(),
+    );
+    let uuid_a = CheckpointInstance::single_file(
+        CheckpointFormatRank::V2,
+        "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet".to_string(),
+    );
+    let uuid_b = CheckpointInstance::single_file(
+        CheckpointFormatRank::V2,
+        "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet".to_string(),
+    );
+
+    assert!(classic < CheckpointInstance::multi_part(2));
+    assert!(CheckpointInstance::multi_part(2) < CheckpointInstance::multi_part(11));
+    assert!(classic < CheckpointInstance::multi_part(11));
+    assert!(uuid_a > CheckpointInstance::multi_part(11));
+    assert!(uuid_a > classic);
+    // Two V2 checkpoints at one version break the tie on file name.
+    assert!(uuid_a < uuid_b);
+}
+
+/// Two writers checkpointed the same version with different part counts, and both checkpoints are
+/// complete. The one with more parts wins.
+#[tokio::test]
+async fn two_complete_checkpoints_at_one_version_selects_more_parts() {
+    let mut log_files: Vec<_> = (0..=6)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    for part_num in 1..=2 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 2,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    for part_num in 1..=11 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 11,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (commit_files, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    let selected: Vec<_> = checkpoint_parts.iter().map(|p| &p.filename).collect();
+    let expected: Vec<_> = (1..=11)
+        .map(|p| multipart_checkpoint_name(4, p, 11))
+        .collect();
+    assert_eq!(selected, expected.iter().collect::<Vec<_>>());
+    let commit_versions: Vec<_> = commit_files.iter().map(|c| c.version).collect();
+    assert_eq!(commit_versions, vec![5, 6]);
+}
+
+/// A torn checkpoint loses to a complete one even though it outranks it: rank orders the
+/// candidates, but only complete ones are candidates at all.
+#[tokio::test]
+async fn torn_higher_ranked_checkpoint_loses_to_complete_lower_ranked() {
+    let mut log_files: Vec<_> = (0..=6)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    for part_num in 1..=2 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 2,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    // A writer got 3 of its 11 parts out before dying, so this group outranks the 2-part one but is
+    // unusable.
+    for part_num in 1..=3 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 11,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (commit_files, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    let selected: Vec<_> = checkpoint_parts.iter().map(|p| &p.filename).collect();
+    let expected: Vec<_> = (1..=2)
+        .map(|p| multipart_checkpoint_name(4, p, 2))
+        .collect();
+    assert_eq!(selected, expected.iter().collect::<Vec<_>>());
+    let commit_versions: Vec<_> = commit_files.iter().map(|c| c.version).collect();
+    assert_eq!(commit_versions, vec![5, 6]);
+}
+
+/// The same rank-versus-completeness rule when the surviving candidate is a single-file checkpoint:
+/// a torn multi-part group outranks the classic checkpoint but still loses to it.
+#[tokio::test]
+async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
+    let mut log_files = vec![
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (
+            1,
+            LogPathFileType::SinglePartCheckpoint,
+            CommitSource::Filesystem,
+        ),
+    ];
+    for part_num in 1..=2 {
+        log_files.push((
+            1,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 3,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.parquet"
+    );
+}
+
+/// A uuid-named (V2) checkpoint and a complete multi-part (V1) checkpoint at one version. The V2
+/// one wins, matching Delta-Spark's `Format.V2 > Format.WITH_PARTS`.
+#[tokio::test]
+async fn uuid_and_multipart_checkpoints_at_one_version_selects_uuid() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (2, LogPathFileType::Commit, CommitSource::Filesystem),
+        ],
+        &[
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 1, 2)),
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 2, 2)),
+            "_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+    );
+}
+
+/// Two uuid-named checkpoints at one version each stand alone -- each writer picks a fresh uuid, so
+/// they are distinct checkpoints, not parts of one -- and the greater file name wins.
+#[tokio::test]
+async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![(1, LogPathFileType::Commit, CommitSource::Filesystem)],
+        &[
+            "_delta_log/00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.parquet",
+            "_delta_log/00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet"
+    );
+}
+
+/// A uuid-named (V2) checkpoint beats a classic (V1) one at the same version, matching
+/// Delta-Spark's `Format.V2 > Format.SINGLE`.
+#[tokio::test]
+async fn uuid_checkpoint_beats_classic_checkpoint_at_one_version() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (1, LogPathFileType::SinglePartCheckpoint, CommitSource::Filesystem),
+        ],
+        &["_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+    );
+}
+
+/// A json V2 checkpoint outranks the V1 checkpoints at its version just like a parquet one does.
+/// A json checkpoint has no parquet footer, so selecting it routes schema discovery through the
+/// sidecar path rather than a footer read (see `LogSegment::get_file_actions_schema_and_sidecars`).
+#[tokio::test]
+async fn json_uuid_checkpoint_beats_v1_checkpoints_at_one_version() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (
+                1,
+                LogPathFileType::SinglePartCheckpoint,
+                CommitSource::Filesystem,
+            ),
+        ],
+        &[
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 1, 2)),
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 2, 2)),
+            "_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json"
+    );
+}
+
+/// A 1-of-1 multi-part checkpoint outranks a classic one at the same version, following
+/// Delta-Spark's format ordinals. Both are complete single-file V1 checkpoints, so they replay to
+/// the same state.
+#[tokio::test]
+async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
+    let (storage, log_root) = create_storage(vec![
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (
+            1,
+            LogPathFileType::SinglePartCheckpoint,
+            CommitSource::Filesystem,
+        ),
+        (
+            1,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num: 1,
+                num_parts: 1,
+            },
+            CommitSource::Filesystem,
+        ),
+    ])
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        multipart_checkpoint_name(1, 1, 1)
+    );
+}
+
+#[rstest]
+// A classic checkpoint and a 1-of-1 multi-part checkpoint at one version: each is complete on its
+// own, and they occupy separate groups.
+#[case::single_and_one_of_one_same_version(
+        vec![
+            parse_log_path(&multipart_checkpoint_name(5, 1, 1)),
+            parse_log_path("00000000000000000005.checkpoint.parquet"),
+        ],
+        Some(5)
+    )]
+// A complete 2-part and a complete 11-part checkpoint at one version.
+#[case::two_complete_multipart_same_version(
+        (1..=2).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=11).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        Some(10)
+    )]
+// A torn 11-part group beside a complete 2-part one at the same version: the version still counts
+// as checkpointed, on the strength of the complete group alone.
+#[case::torn_beside_complete_same_version(
+        (1..=2).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=3).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        Some(10)
+    )]
+// Every group at the version is torn, so the version is not checkpointed.
+#[case::all_torn_same_version(
+        (1..=1).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=3).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        None
+    )]
+fn find_complete_checkpoint_version_same_version_cases(
+    #[case] files: Vec<ParsedLogPath>,
+    #[case] expected: Option<u64>,
+) {
+    assert_eq!(find_complete_checkpoint_version(&files), expected);
+}

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1369,9 +1369,9 @@ fn hint_naming_uuid(filename: &str) -> LastCheckpointHint {
     }
 }
 
-/// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a classic checkpoint sorts below a multi-part
-/// one, more parts beats fewer, a uuid (V2) checkpoint outranks both, and two uuid checkpoints at
-/// one version break the tie on file name.
+/// Mirrors Delta-Spark: a classic checkpoint sorts below a multi-part one, more parts beats fewer,
+/// a uuid (V2) checkpoint outranks both, and two uuid checkpoints at one version break the tie on
+/// file name.
 #[test]
 fn checkpoint_instance_orders_like_delta_spark() {
     let classic = CheckpointInstance::Classic;

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -30,7 +30,7 @@ fn log_path_for_file_type(version: Version, file_type: &LogPathFileType) -> Stri
             let uuid = uuid::Uuid::new_v4();
             format!("_delta_log/_staged_commits/{version:020}.{uuid}.json")
         }
-        LogPathFileType::SinglePartCheckpoint => {
+        LogPathFileType::ClassicCheckpoint => {
             format!("_delta_log/{version:020}.checkpoint.parquet")
         }
         LogPathFileType::MultiPartCheckpoint {
@@ -536,7 +536,7 @@ async fn test_listing_stops_at_last_checkpoint_marker() {
         (2, LogPathFileType::Commit, CommitSource::Filesystem),
         (
             2,
-            LogPathFileType::SinglePartCheckpoint,
+            LogPathFileType::ClassicCheckpoint,
             CommitSource::Filesystem,
         ),
         (2, LogPathFileType::Crc, CommitSource::Filesystem),
@@ -600,7 +600,7 @@ async fn test_non_commit_files_at_log_tail_versions_are_preserved() {
         (5, LogPathFileType::Commit, CommitSource::Filesystem),
         (
             7,
-            LogPathFileType::SinglePartCheckpoint,
+            LogPathFileType::ClassicCheckpoint,
             CommitSource::Filesystem,
         ),
         (8, LogPathFileType::Crc, CommitSource::Filesystem),
@@ -679,7 +679,7 @@ async fn backward_scan_single_checkpoint_cases(
     if let Some(cp) = checkpoint_version {
         log_files.push((
             cp,
-            LogPathFileType::SinglePartCheckpoint,
+            LogPathFileType::ClassicCheckpoint,
             CommitSource::Filesystem,
         ));
     }
@@ -724,7 +724,7 @@ fn files_incomplete_in_second_window_complete_in_third_window(
         .collect();
     log_files.push((
         500,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     log_files.push((
@@ -850,7 +850,7 @@ async fn backward_scan_with_log_tail_derives_lower_bound_from_checkpoint() {
         .collect();
     log_files.push((
         5,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     let (storage, log_root) = create_storage(log_files).await;
@@ -899,7 +899,7 @@ async fn backward_scan_with_log_tail_starting_before_checkpoint() {
         .collect();
     log_files.push((
         5,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     log_files.push((6, LogPathFileType::Crc, CommitSource::Filesystem));
@@ -1078,8 +1078,8 @@ async fn test_zero_byte_checkpoint_skipped_older_used(#[case] use_backward_scan:
         (8, LogPathFileType::Commit, false),
         (9, LogPathFileType::Commit, false),
         (10, LogPathFileType::Commit, false),
-        (5, LogPathFileType::SinglePartCheckpoint, false), // valid checkpoint
-        (10, LogPathFileType::SinglePartCheckpoint, true), // empty checkpoint
+        (5, LogPathFileType::ClassicCheckpoint, false), // valid checkpoint
+        (10, LogPathFileType::ClassicCheckpoint, true), // empty checkpoint
     ];
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
@@ -1130,8 +1130,8 @@ async fn test_zero_byte_checkpoint_backward_scan_crosses_windows() {
     let mut log_files: Vec<(Version, LogPathFileType, bool)> = (0u64..=1005)
         .map(|v| (v, LogPathFileType::Commit, false))
         .collect();
-    log_files.push((5, LogPathFileType::SinglePartCheckpoint, false));
-    log_files.push((1005, LogPathFileType::SinglePartCheckpoint, true));
+    log_files.push((5, LogPathFileType::ClassicCheckpoint, false));
+    log_files.push((1005, LogPathFileType::ClassicCheckpoint, true));
 
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
     let counter = CountingStorageHandler::new(storage);
@@ -1254,7 +1254,7 @@ async fn test_list_commits_keeps_commits_across_checkpoint() {
         .collect();
     files.push((
         3,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     let (storage, log_root) = create_storage(files).await;
@@ -1294,7 +1294,7 @@ fn incomplete_then_complete_files() -> Vec<ParsedLogPath> {
     ));
     files.push(make_parsed_log_path_with_source(
         10,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     files
@@ -1310,12 +1310,12 @@ fn two_complete_checkpoints_files() -> Vec<ParsedLogPath> {
         .collect();
     files.push(make_parsed_log_path_with_source(
         5,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     files.push(make_parsed_log_path_with_source(
         10,
-        LogPathFileType::SinglePartCheckpoint,
+        LogPathFileType::ClassicCheckpoint,
         CommitSource::Filesystem,
     ));
     files
@@ -1357,30 +1357,42 @@ fn multipart_checkpoint_name(version: Version, part_num: u32, num_parts: u32) ->
     format!("{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
 }
 
-/// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a single-part checkpoint sorts below a
-/// multi-part one, more parts beats fewer, a V2 checkpoint outranks both, and single-file
-/// checkpoints break ties on file name.
+/// A v5 `_last_checkpoint` hint describing the uuid-named (V2) checkpoint `filename`.
+fn hint_naming_uuid(filename: &str) -> LastCheckpointHint {
+    LastCheckpointHint {
+        version: 5,
+        v2_checkpoint: Some(crate::last_checkpoint_hint::LastCheckpointV2 {
+            path: filename.to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a classic checkpoint sorts below a multi-part
+/// one, more parts beats fewer, a uuid (V2) checkpoint outranks both, and two uuid checkpoints at
+/// one version break the tie on file name.
 #[test]
 fn checkpoint_instance_orders_like_delta_spark() {
-    let classic = CheckpointInstance::single_file(
-        CheckpointFormatRank::Single,
-        "00000000000000000005.checkpoint.parquet".to_string(),
-    );
-    let uuid_a = CheckpointInstance::single_file(
-        CheckpointFormatRank::V2,
-        "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet".to_string(),
-    );
-    let uuid_b = CheckpointInstance::single_file(
-        CheckpointFormatRank::V2,
-        "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet".to_string(),
-    );
+    let classic = CheckpointInstance::Classic;
+    let uuid_a = CheckpointInstance::Uuid {
+        filename: "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+            .to_string(),
+    };
+    let uuid_b = CheckpointInstance::Uuid {
+        filename: "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet"
+            .to_string(),
+    };
 
-    assert!(classic < CheckpointInstance::multi_part(2));
-    assert!(CheckpointInstance::multi_part(2) < CheckpointInstance::multi_part(11));
-    assert!(classic < CheckpointInstance::multi_part(11));
-    assert!(uuid_a > CheckpointInstance::multi_part(11));
+    assert!(classic < CheckpointInstance::MultiPart { num_parts: 2 });
+    assert!(
+        CheckpointInstance::MultiPart { num_parts: 2 }
+            < CheckpointInstance::MultiPart { num_parts: 11 }
+    );
+    assert!(classic < CheckpointInstance::MultiPart { num_parts: 11 });
+    assert!(uuid_a > CheckpointInstance::MultiPart { num_parts: 11 });
     assert!(uuid_a > classic);
-    // Two V2 checkpoints at one version break the tie on file name.
+    // Two uuid checkpoints at one version break the tie on file name.
     assert!(uuid_a < uuid_b);
 }
 
@@ -1476,7 +1488,7 @@ async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
         (
             1,
-            LogPathFileType::SinglePartCheckpoint,
+            LogPathFileType::ClassicCheckpoint,
             CommitSource::Filesystem,
         ),
     ];
@@ -1503,7 +1515,7 @@ async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
 }
 
 /// A uuid-named (V2) checkpoint and a complete multi-part (V1) checkpoint at one version. The V2
-/// one wins, matching Delta-Spark's `Format.V2 > Format.WITH_PARTS`.
+/// one wins, matching Delta-Spark.
 #[tokio::test]
 async fn uuid_and_multipart_checkpoints_at_one_version_selects_uuid() {
     let (storage, log_root) = create_storage_with_raw_paths(
@@ -1552,14 +1564,80 @@ async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
     );
 }
 
-/// A uuid-named (V2) checkpoint beats a classic (V1) one at the same version, matching
-/// Delta-Spark's `Format.V2 > Format.SINGLE`.
+/// End-to-end through the real `_last_checkpoint`-hint listing path: a version holds a complete
+/// multi-part checkpoint plus two uuid-named checkpoints (uuid `bbbb...` > `aaaa...`), so listing
+/// deterministically selects the greater uuid. A hint is retained (`applies_to` is true) only when
+/// it names that selected checkpoint; a hint pointing at any of the losing candidates -- the loser
+/// uuid, the multi-part group, or a phantom classic checkpoint -- is ignored, so readers fall back
+/// to the checkpoint file's own fields. This drives the `Uuid` arm of `applies_to` against real
+/// listed `ParsedLogPath`s, which the hand-built `applies_to` unit test cannot.
+#[rstest]
+#[case::hint_names_winner_uuid(
+    hint_naming_uuid(
+        "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet"
+    ),
+    true
+)]
+#[case::hint_names_loser_uuid(
+    hint_naming_uuid(
+        "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+    ),
+    false
+)]
+#[case::hint_names_losing_multipart(
+    LastCheckpointHint { version: 5, parts: Some(2), ..Default::default() },
+    false
+)]
+#[case::hint_names_phantom_classic(
+    LastCheckpointHint { version: 5, ..Default::default() },
+    false
+)]
+#[tokio::test]
+async fn last_checkpoint_hint_applies_iff_it_names_the_selected_checkpoint(
+    #[case] hint: LastCheckpointHint,
+    #[case] expect_hint_applies: bool,
+) {
+    let winner = "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet";
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (5, LogPathFileType::Commit, CommitSource::Filesystem),
+            (6, LogPathFileType::Commit, CommitSource::Filesystem),
+        ],
+        &[
+            &format!("_delta_log/{}", multipart_checkpoint_name(5, 1, 2)),
+            &format!("_delta_log/{}", multipart_checkpoint_name(5, 2, 2)),
+            "_delta_log/00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet",
+            &format!("_delta_log/{winner}"),
+        ],
+    )
+    .await;
+
+    let listed = LogSegmentFiles::list_with_checkpoint_hint(
+        &hint,
+        storage.as_ref(),
+        &log_root,
+        vec![],
+        None,
+    )
+    .unwrap();
+
+    // Listing always selects the deterministic winner, regardless of what the hint names.
+    assert_eq!(listed.checkpoint_parts.len(), 1);
+    assert_eq!(listed.checkpoint_parts[0].filename, winner);
+    // The hint's fields are trusted only when it names that selected checkpoint.
+    assert_eq!(
+        hint.applies_to(&listed.checkpoint_parts),
+        expect_hint_applies
+    );
+}
+
+/// A uuid-named (V2) checkpoint beats a classic (V1) one at the same version, matching Delta-Spark.
 #[tokio::test]
 async fn uuid_checkpoint_beats_classic_checkpoint_at_one_version() {
     let (storage, log_root) = create_storage_with_raw_paths(
         vec![
             (1, LogPathFileType::Commit, CommitSource::Filesystem),
-            (1, LogPathFileType::SinglePartCheckpoint, CommitSource::Filesystem),
+            (1, LogPathFileType::ClassicCheckpoint, CommitSource::Filesystem),
         ],
         &["_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"],
     )
@@ -1585,7 +1663,7 @@ async fn json_uuid_checkpoint_beats_v1_checkpoints_at_one_version() {
             (1, LogPathFileType::Commit, CommitSource::Filesystem),
             (
                 1,
-                LogPathFileType::SinglePartCheckpoint,
+                LogPathFileType::ClassicCheckpoint,
                 CommitSource::Filesystem,
             ),
         ],
@@ -1607,16 +1685,15 @@ async fn json_uuid_checkpoint_beats_v1_checkpoints_at_one_version() {
     );
 }
 
-/// A 1-of-1 multi-part checkpoint outranks a classic one at the same version, following
-/// Delta-Spark's format ordinals. Both are complete single-file V1 checkpoints, so they replay to
-/// the same state.
+/// A 1-of-1 multi-part checkpoint outranks a classic one at the same version, matching Delta-Spark.
+/// Both are complete single-file V1 checkpoints, so they replay to the same state.
 #[tokio::test]
 async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
     let (storage, log_root) = create_storage(vec![
         (1, LogPathFileType::Commit, CommitSource::Filesystem),
         (
             1,
-            LogPathFileType::SinglePartCheckpoint,
+            LogPathFileType::ClassicCheckpoint,
             CommitSource::Filesystem,
         ),
         (

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -9,6 +9,7 @@ use crate::engine::sync::SyncEngine;
 use crate::object_store::memory::InMemory;
 use crate::object_store::path::Path as ObjectPath;
 use crate::object_store::ObjectStoreExt as _;
+use crate::path::tests::multipart_checkpoint_name;
 use crate::{Engine as _, FileMeta};
 
 // size markers used to identify commit sources in tests
@@ -37,7 +38,8 @@ fn log_path_for_file_type(version: Version, file_type: &LogPathFileType) -> Stri
             part_num,
             num_parts,
         } => {
-            format!("_delta_log/{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
+            let name = multipart_checkpoint_name(version, *part_num, *num_parts);
+            format!("_delta_log/{name}")
         }
         LogPathFileType::Crc => {
             format!("_delta_log/{version:020}.crc")
@@ -1338,23 +1340,11 @@ fn find_complete_checkpoint_version_cases(
     assert_eq!(find_complete_checkpoint_version(&files), expected);
 }
 
-/// Builds a `ParsedLogPath` by parsing a real log file name, so `filename`, `extension` and
-/// `file_type` agree. Unlike [`make_parsed_log_path_with_source`], whose url is always
-/// `<version>.json`, this works for checkpoint paths -- whose file name takes part in checkpoint
-/// selection.
+/// [`crate::path::tests::parse_log_path`] stamped with this module's filesystem size marker. Unlike
+/// [`make_parsed_log_path_with_source`], whose url is always `<version>.json`, this works for
+/// checkpoint paths, whose file name takes part in checkpoint selection.
 fn parse_log_path(filename: &str) -> ParsedLogPath {
-    let url = Url::parse(&format!("memory:///_delta_log/{filename}")).unwrap();
-    ParsedLogPath::try_from(FileMeta {
-        location: url,
-        last_modified: 0,
-        size: FILESYSTEM_SIZE_MARKER,
-    })
-    .unwrap_or_else(|e| panic!("{filename} is not a log path: {e}"))
-    .unwrap_or_else(|| panic!("{filename} is not a log path"))
-}
-
-fn multipart_checkpoint_name(version: Version, part_num: u32, num_parts: u32) -> String {
-    format!("{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
+    crate::path::tests::parse_log_path(filename, FILESYSTEM_SIZE_MARKER)
 }
 
 /// A v5 `_last_checkpoint` hint describing the uuid-named (V2) checkpoint `filename`.
@@ -1369,9 +1359,6 @@ fn hint_naming_uuid(filename: &str) -> LastCheckpointHint {
     }
 }
 
-/// Mirrors Delta-Spark: a classic checkpoint sorts below a multi-part one, more parts beats fewer,
-/// a uuid (V2) checkpoint outranks both, and two uuid checkpoints at one version break the tie on
-/// file name.
 #[test]
 fn checkpoint_instance_orders_like_delta_spark() {
     let classic = CheckpointInstance::Classic;
@@ -1396,8 +1383,7 @@ fn checkpoint_instance_orders_like_delta_spark() {
     assert!(uuid_a < uuid_b);
 }
 
-/// Two writers checkpointed the same version with different part counts, and both checkpoints are
-/// complete. The one with more parts wins.
+/// The reported failure: two writers checkpointed one version with different part counts.
 #[tokio::test]
 async fn two_complete_checkpoints_at_one_version_selects_more_parts() {
     let mut log_files: Vec<_> = (0..=6)
@@ -1437,8 +1423,7 @@ async fn two_complete_checkpoints_at_one_version_selects_more_parts() {
     assert_eq!(commit_versions, vec![5, 6]);
 }
 
-/// A torn checkpoint loses to a complete one even though it outranks it: rank orders the
-/// candidates, but only complete ones are candidates at all.
+/// Rank orders the candidates, but only complete checkpoints are candidates at all.
 #[tokio::test]
 async fn torn_higher_ranked_checkpoint_loses_to_complete_lower_ranked() {
     let mut log_files: Vec<_> = (0..=6)
@@ -1454,8 +1439,7 @@ async fn torn_higher_ranked_checkpoint_loses_to_complete_lower_ranked() {
             CommitSource::Filesystem,
         ));
     }
-    // A writer got 3 of its 11 parts out before dying, so this group outranks the 2-part one but is
-    // unusable.
+    // A writer got 3 of its 11 parts out before dying: outranks the 2-part group, unusable.
     for part_num in 1..=3 {
         log_files.push((
             4,
@@ -1480,8 +1464,7 @@ async fn torn_higher_ranked_checkpoint_loses_to_complete_lower_ranked() {
     assert_eq!(commit_versions, vec![5, 6]);
 }
 
-/// The same rank-versus-completeness rule when the surviving candidate is a single-file checkpoint:
-/// a torn multi-part group outranks the classic checkpoint but still loses to it.
+/// Same rule as above, but the surviving candidate is a single-file checkpoint.
 #[tokio::test]
 async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
     let mut log_files = vec![
@@ -1514,8 +1497,6 @@ async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
     );
 }
 
-/// A uuid-named (V2) checkpoint and a complete multi-part (V1) checkpoint at one version. The V2
-/// one wins, matching Delta-Spark.
 #[tokio::test]
 async fn uuid_and_multipart_checkpoints_at_one_version_selects_uuid() {
     let (storage, log_root) = create_storage_with_raw_paths(
@@ -1541,8 +1522,8 @@ async fn uuid_and_multipart_checkpoints_at_one_version_selects_uuid() {
     );
 }
 
-/// Two uuid-named checkpoints at one version each stand alone -- each writer picks a fresh uuid, so
-/// they are distinct checkpoints, not parts of one -- and the greater file name wins.
+/// Two uuid-named checkpoints at one version are distinct checkpoints, not parts of one, since each
+/// writer picked its own uuid.
 #[tokio::test]
 async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
     let (storage, log_root) = create_storage_with_raw_paths(
@@ -1564,13 +1545,9 @@ async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
     );
 }
 
-/// End-to-end through the real `_last_checkpoint`-hint listing path: a version holds a complete
-/// multi-part checkpoint plus two uuid-named checkpoints (uuid `bbbb...` > `aaaa...`), so listing
-/// deterministically selects the greater uuid. A hint is retained (`applies_to` is true) only when
-/// it names that selected checkpoint; a hint pointing at any of the losing candidates -- the loser
-/// uuid, the multi-part group, or a phantom classic checkpoint -- is ignored, so readers fall back
-/// to the checkpoint file's own fields. This drives the `Uuid` arm of `applies_to` against real
-/// listed `ParsedLogPath`s, which the hand-built `applies_to` unit test cannot.
+/// v5 holds a complete 2-part checkpoint and two uuid-named ones, so listing selects uuid `bbbb`.
+/// Each case points the hint at a different candidate; only the one naming `bbbb` applies. Runs
+/// `applies_to` against listed paths rather than hand-built ones.
 #[rstest]
 #[case::hint_names_winner_uuid(
     hint_naming_uuid(
@@ -1621,17 +1598,15 @@ async fn last_checkpoint_hint_applies_iff_it_names_the_selected_checkpoint(
     )
     .unwrap();
 
-    // Listing always selects the deterministic winner, regardless of what the hint names.
+    // The winner is the same no matter what the hint names.
     assert_eq!(listed.checkpoint_parts.len(), 1);
     assert_eq!(listed.checkpoint_parts[0].filename, winner);
-    // The hint's fields are trusted only when it names that selected checkpoint.
     assert_eq!(
         hint.applies_to(&listed.checkpoint_parts),
         expect_hint_applies
     );
 }
 
-/// A uuid-named (V2) checkpoint beats a classic (V1) one at the same version, matching Delta-Spark.
 #[tokio::test]
 async fn uuid_checkpoint_beats_classic_checkpoint_at_one_version() {
     let (storage, log_root) = create_storage_with_raw_paths(
@@ -1653,7 +1628,6 @@ async fn uuid_checkpoint_beats_classic_checkpoint_at_one_version() {
     );
 }
 
-/// A json V2 checkpoint outranks the V1 checkpoints at its version just like a parquet one does.
 /// A json checkpoint has no parquet footer, so selecting it routes schema discovery through the
 /// sidecar path rather than a footer read (see `LogSegment::get_file_actions_schema_and_sidecars`).
 #[tokio::test]
@@ -1685,8 +1659,7 @@ async fn json_uuid_checkpoint_beats_v1_checkpoints_at_one_version() {
     );
 }
 
-/// A 1-of-1 multi-part checkpoint outranks a classic one at the same version, matching Delta-Spark.
-/// Both are complete single-file V1 checkpoints, so they replay to the same state.
+/// Both are complete single-file V1 checkpoints, so they replay to the same state either way.
 #[tokio::test]
 async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
     let (storage, log_root) = create_storage(vec![
@@ -1718,8 +1691,7 @@ async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
 }
 
 #[rstest]
-// A classic checkpoint and a 1-of-1 multi-part checkpoint at one version: each is complete on its
-// own, and they occupy separate groups.
+// A classic and a 1-of-1 multi-part checkpoint at one version each fill their own group.
 #[case::single_and_one_of_one_same_version(
         vec![
             parse_log_path(&multipart_checkpoint_name(5, 1, 1)),
@@ -1735,8 +1707,7 @@ async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
             .collect(),
         Some(10)
     )]
-// A torn 11-part group beside a complete 2-part one at the same version: the version still counts
-// as checkpointed, on the strength of the complete group alone.
+// A torn 11-part group beside a complete 2-part one: still checkpointed, on the complete group.
 #[case::torn_beside_complete_same_version(
         (1..=2).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
             .chain((1..=3).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -35,7 +35,15 @@ pub(crate) enum LogPathFileType {
     Commit,
     /// Staged commits are commits with UUID filenames, stored in _delta_log/_staged_commits dir.
     StagedCommit,
-    SinglePartCheckpoint,
+    /// A classic-named checkpoint, `<version>.checkpoint.parquet`. The name identifies the
+    /// file-naming scheme, not the checkpoint's spec version: this file may hold a V1 checkpoint
+    /// with its actions inline, or a V2 checkpoint that references sidecars. Only reading the file
+    /// distinguishes them, which is why `LogSegment::get_file_actions_schema_and_sidecars` probes
+    /// for a sidecar column.
+    ClassicCheckpoint,
+    /// A uuid-named checkpoint, `<version>.checkpoint.<uuid>.{parquet,json}`. Always a V2
+    /// checkpoint, since only the V2 spec writes this naming scheme. The uuid means several can
+    /// share a version -- each writer picks a fresh one.
     #[allow(unused)]
     UuidCheckpoint,
     // NOTE: Delta spec doesn't actually say, but checkpoint part numbers are effectively 31-bit
@@ -52,6 +60,64 @@ pub(crate) enum LogPathFileType {
     },
     Crc,
     Unknown,
+}
+
+/// Identifies one checkpoint among those at a single version and orders it against its siblings.
+///
+/// The variant is the checkpoint's naming scheme, read from the file name with no I/O. The naming
+/// scheme and the [checkpoint spec] are independent axes, and only two of the three schemes pin the
+/// spec:
+///
+/// | spec | classic | multi-part | uuid-named |
+/// |------|---------|------------|------------|
+/// | V1   | valid   | valid      | invalid    |
+/// | V2   | valid   | invalid    | valid      |
+///
+/// So a `Classic` checkpoint follows either spec and only its contents say which, which is why
+/// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column.
+///
+/// Variant declaration order is the rank and each payload is that rank's tiebreaker, so the derived
+/// [`Ord`] is the entire comparison (`Uuid` > `MultiPart` > `Classic`, matching Delta-Spark for
+/// cross-engine parity). Reordering the variants changes which checkpoint kernel selects.
+///
+/// [checkpoint spec]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#checkpoint-specs
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[internal_api]
+pub(crate) enum CheckpointInstance {
+    /// `<version>.checkpoint.parquet`. At most one per version, so nothing to break ties on.
+    Classic,
+    /// `<version>.checkpoint.<part_num>.<num_parts>.parquet`. More parts wins.
+    MultiPart { num_parts: u32 },
+    /// `<version>.checkpoint.<uuid>.{json,parquet}`. The greater file name wins.
+    Uuid { filename: String },
+}
+
+impl CheckpointInstance {
+    /// The instance a checkpoint part belongs to, or `None` for a non-checkpoint file.
+    pub(crate) fn of<Location: AsUrl>(part: &ParsedLogPath<Location>) -> Option<Self> {
+        match &part.file_type {
+            LogPathFileType::ClassicCheckpoint => Some(Self::Classic),
+            LogPathFileType::UuidCheckpoint => Some(Self::Uuid {
+                filename: part.filename.clone(),
+            }),
+            LogPathFileType::MultiPartCheckpoint { num_parts, .. } => Some(Self::MultiPart {
+                num_parts: *num_parts,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Whether `part_files` holds every part this checkpoint needs.
+    pub(crate) fn is_complete<Location: AsUrl>(
+        &self,
+        part_files: &[ParsedLogPath<Location>],
+    ) -> bool {
+        let expected = match self {
+            Self::MultiPart { num_parts } => *num_parts as usize,
+            Self::Classic | Self::Uuid { .. } => 1,
+        };
+        expected == part_files.len()
+    }
 }
 
 /// A ParsedLogPath is a well-understood path to a file in the _delta_log directory.
@@ -207,7 +273,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
                 }
             }
             ["crc"] if in_delta_log_dir => LogPathFileType::Crc,
-            ["checkpoint", "parquet"] if in_delta_log_dir => LogPathFileType::SinglePartCheckpoint,
+            ["checkpoint", "parquet"] if in_delta_log_dir => LogPathFileType::ClassicCheckpoint,
             ["checkpoint", uuid, "json" | "parquet"] if in_delta_log_dir => {
                 let Some(_) = parse_path_part::<String>(uuid, UUID_PART_LEN) else {
                     return Ok(None);
@@ -268,7 +334,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     pub(crate) fn should_list(&self) -> bool {
         match self.file_type {
             LogPathFileType::Commit
-            | LogPathFileType::SinglePartCheckpoint
+            | LogPathFileType::ClassicCheckpoint
             | LogPathFileType::UuidCheckpoint
             | LogPathFileType::MultiPartCheckpoint { .. }
             | LogPathFileType::CompactedCommit { .. }
@@ -296,7 +362,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
     pub(crate) fn is_checkpoint(&self) -> bool {
         matches!(
             self.file_type,
-            LogPathFileType::SinglePartCheckpoint
+            LogPathFileType::ClassicCheckpoint
                 | LogPathFileType::MultiPartCheckpoint { .. }
                 | LogPathFileType::UuidCheckpoint
         )
@@ -734,7 +800,7 @@ pub(crate) mod tests {
         assert_eq!(log_path.version, 2);
         assert!(matches!(
             log_path.file_type,
-            LogPathFileType::SinglePartCheckpoint
+            LogPathFileType::ClassicCheckpoint
         ));
         assert!(!log_path.is_commit());
         assert!(log_path.is_checkpoint());
@@ -1023,7 +1089,7 @@ pub(crate) mod tests {
         assert_eq!(log_path.extension, "parquet");
         assert!(matches!(
             log_path.file_type,
-            LogPathFileType::SinglePartCheckpoint
+            LogPathFileType::ClassicCheckpoint
         ));
         assert_eq!(log_path.filename, "00000000000000000010.checkpoint.parquet");
     }
@@ -1087,7 +1153,7 @@ pub(crate) mod tests {
         for (file_type, should_list) in [
             (LogPathFileType::Commit, true),
             (LogPathFileType::StagedCommit, false),
-            (LogPathFileType::SinglePartCheckpoint, true),
+            (LogPathFileType::ClassicCheckpoint, true),
             (LogPathFileType::UuidCheckpoint, true),
             (
                 LogPathFileType::MultiPartCheckpoint {

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -35,13 +35,13 @@ pub(crate) enum LogPathFileType {
     Commit,
     /// Staged commits are commits with UUID filenames, stored in _delta_log/_staged_commits dir.
     StagedCommit,
-    /// A classic-named checkpoint, `<version>.checkpoint.parquet`. The name identifies the
-    /// file-naming scheme, not the checkpoint's spec version: this file may hold a V1 checkpoint
-    /// with its actions inline, or a V2 checkpoint that references sidecars.
+    /// A classic-named checkpoint, `<version>.checkpoint.parquet`. The name is the file-naming
+    /// scheme, not the spec version: this file may hold a V1 checkpoint with its actions inline,
+    /// or a V2 checkpoint that references sidecars.
     ClassicCheckpoint,
-    /// A uuid-named checkpoint, `<version>.checkpoint.<uuid>.{parquet,json}`. Always a V2
-    /// checkpoint, since only the V2 spec writes this naming scheme. The uuid means several can
-    /// share a version -- each writer picks a fresh one.
+    /// A uuid-named checkpoint, `<version>.checkpoint.<uuid>.{parquet,json}`. Always V2, since
+    /// only the V2 spec writes this naming scheme. Each writer picks a fresh uuid, so several
+    /// can share a version.
     #[allow(unused)]
     UuidCheckpoint,
     // NOTE: Delta spec doesn't actually say, but checkpoint part numbers are effectively 31-bit
@@ -62,20 +62,13 @@ pub(crate) enum LogPathFileType {
 
 /// Identifies one checkpoint among those at a single version and orders it against its siblings.
 ///
-/// The variant is the checkpoint's naming scheme, read from the file name with no I/O. The naming
-/// scheme and the [checkpoint spec] are independent axes, and only two of the three schemes pin the
-/// spec:
+/// The variant is the naming scheme, read from the file name with no I/O. Naming scheme and
+/// [checkpoint spec] are independent: only multi-part (always V1) and uuid (always V2) pin the
+/// spec, so a `Classic` checkpoint follows either one and only its contents say which.
 ///
-/// | spec | classic | multi-part | uuid-named |
-/// |------|---------|------------|------------|
-/// | V1   | valid   | valid      | invalid    |
-/// | V2   | valid   | invalid    | valid      |
-///
-/// So a `Classic` checkpoint follows either spec and only its contents say which.
-///
-/// Variant declaration order is the rank and each payload is that rank's tiebreaker, so the derived
-/// [`Ord`] is the entire comparison (`Uuid` > `MultiPart` > `Classic`, matching Delta-Spark for
-/// cross-engine parity). Reordering the variants changes which checkpoint kernel selects.
+/// Variant order is the rank and each payload breaks ties within a rank, so the derived [`Ord`] is
+/// the whole comparison: `Uuid` > `MultiPart` > `Classic`, matching Delta-Spark. Reordering these
+/// changes which checkpoint kernel selects.
 ///
 /// [checkpoint spec]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#checkpoint-specs
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -104,16 +97,20 @@ impl CheckpointInstance {
         }
     }
 
+    /// How many files this checkpoint spans.
+    pub(crate) fn num_parts(&self) -> usize {
+        match self {
+            Self::MultiPart { num_parts } => *num_parts as usize,
+            Self::Classic | Self::Uuid { .. } => 1,
+        }
+    }
+
     /// Whether `part_files` holds every part this checkpoint needs.
     pub(crate) fn is_complete<Location: AsUrl>(
         &self,
         part_files: &[ParsedLogPath<Location>],
     ) -> bool {
-        let expected = match self {
-            Self::MultiPart { num_parts } => *num_parts as usize,
-            Self::Classic | Self::Uuid { .. } => 1,
-        };
-        expected == part_files.len()
+        self.num_parts() == part_files.len()
     }
 }
 
@@ -357,12 +354,7 @@ impl<Location: AsUrl> ParsedLogPath<Location> {
 
     #[internal_api]
     pub(crate) fn is_checkpoint(&self) -> bool {
-        matches!(
-            self.file_type,
-            LogPathFileType::ClassicCheckpoint
-                | LogPathFileType::MultiPartCheckpoint { .. }
-                | LogPathFileType::UuidCheckpoint
-        )
+        CheckpointInstance::of(self).is_some()
     }
 
     #[internal_api]
@@ -589,6 +581,30 @@ pub(crate) mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
     use crate::utils::test_utils::assert_result_error_with_message;
+
+    /// Builds a `ParsedLogPath` by parsing a real log file name, so `filename`, `extension` and
+    /// `file_type` agree. `size` is a parameter because listing tests use it to mark where a file
+    /// came from.
+    pub(crate) fn parse_log_path(filename: &str, size: u64) -> ParsedLogPath {
+        let url = Url::parse(&format!("memory:///_delta_log/{filename}")).unwrap();
+        ParsedLogPath::try_from(FileMeta {
+            location: url,
+            last_modified: 0,
+            size,
+        })
+        .unwrap_or_else(|e| panic!("{filename} is not a log path: {e}"))
+        .unwrap_or_else(|| panic!("{filename} is not a log path"))
+    }
+
+    /// One part of a multi-part checkpoint. Kernel never writes these, so there's no production
+    /// constructor to reuse.
+    pub(crate) fn multipart_checkpoint_name(
+        version: Version,
+        part_num: u32,
+        num_parts: u32,
+    ) -> String {
+        format!("{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
+    }
 
     impl ParsedLogPath<FileMeta> {
         pub(crate) fn create_parsed_published_commit(table_root: &Url, version: Version) -> Self {

--- a/kernel/src/path.rs
+++ b/kernel/src/path.rs
@@ -37,9 +37,7 @@ pub(crate) enum LogPathFileType {
     StagedCommit,
     /// A classic-named checkpoint, `<version>.checkpoint.parquet`. The name identifies the
     /// file-naming scheme, not the checkpoint's spec version: this file may hold a V1 checkpoint
-    /// with its actions inline, or a V2 checkpoint that references sidecars. Only reading the file
-    /// distinguishes them, which is why `LogSegment::get_file_actions_schema_and_sidecars` probes
-    /// for a sidecar column.
+    /// with its actions inline, or a V2 checkpoint that references sidecars.
     ClassicCheckpoint,
     /// A uuid-named checkpoint, `<version>.checkpoint.<uuid>.{parquet,json}`. Always a V2
     /// checkpoint, since only the V2 spec writes this naming scheme. The uuid means several can
@@ -73,8 +71,7 @@ pub(crate) enum LogPathFileType {
 /// | V1   | valid   | valid      | invalid    |
 /// | V2   | valid   | invalid    | valid      |
 ///
-/// So a `Classic` checkpoint follows either spec and only its contents say which, which is why
-/// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column.
+/// So a `Classic` checkpoint follows either spec and only its contents say which.
 ///
 /// Variant declaration order is the rank and each payload is that rank's tiebreaker, so the derived
 /// [`Ord`] is the entire comparison (`Uuid` > `MultiPart` > `Classic`, matching Delta-Spark for

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1663,3 +1663,88 @@ async fn build_v2_table_with_feature<E: TaskExecutor>(
 
     Ok(snapshot)
 }
+
+/// A version holding two complete checkpoints must load from the uuid-named one, since it outranks
+/// the classic-named one, and the resulting snapshot must still read every row.
+///
+/// Kernel only ever writes classic-named checkpoints, so the competing uuid-named file is copied
+/// from the one kernel wrote -- byte-identical, and spec-valid under `v2Checkpoint`. The
+/// `_last_checkpoint` on disk names the classic file either way, so the winning uuid checkpoint is
+/// selected even though the hint points elsewhere.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_selects_uuid_checkpoint_over_classic_at_one_version() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+
+    let schema = schema_ref! { nullable "value": INTEGER };
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot0 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    let result = insert_data(
+        snapshot0,
+        &engine,
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .await?;
+    let CommitResult::CommittedTransaction(committed) = result else {
+        panic!("Expected CommittedTransaction");
+    };
+    let snapshot = committed
+        .post_commit_snapshot()
+        .expect("expected post-commit snapshot");
+    let version = snapshot.version();
+
+    // Writes `<version>.checkpoint.parquet` plus a `_last_checkpoint` naming it.
+    snapshot.checkpoint(
+        engine.as_ref(),
+        Some(&CheckpointSpec::V2(V2CheckpointConfig::NoSidecar)),
+    )?;
+
+    // Add a second complete checkpoint at the same version under a uuid name, which outranks the
+    // classic one. Kernel's write path cannot produce this, so copy the file it did write.
+    let classic_path = load_existing_single_file_checkpoint_path(&table_path, version);
+    let uuid_name = format!("{version:020}.checkpoint.{}.parquet", uuid::Uuid::new_v4());
+    let uuid_path = std::path::Path::new(&table_path)
+        .join("_delta_log")
+        .join(&uuid_name);
+    std::fs::copy(&classic_path, &uuid_path).expect("copy classic checkpoint to a uuid name");
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    assert_eq!(snapshot.version(), version);
+
+    // The uuid-named checkpoint wins, even though `_last_checkpoint` names the classic one.
+    let log_segment = snapshot.log_segment();
+    let selected: Vec<&str> = log_segment
+        .listed
+        .checkpoint_parts
+        .iter()
+        .map(|p| p.filename.as_str())
+        .collect();
+    assert_eq!(
+        selected,
+        vec![uuid_name.as_str()],
+        "expected the uuid-named checkpoint to outrank the classic one"
+    );
+    assert_eq!(log_segment.checkpoint_version, Some(version));
+
+    // The selected checkpoint is readable, so replay over it returns every row.
+    let scan = snapshot.scan_builder().build()?;
+    let batches = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?;
+    assert_batches_sorted_eq!(
+        vec![
+            "+-------+",
+            "| value |",
+            "+-------+",
+            "| 1     |",
+            "| 2     |",
+            "| 3     |",
+            "+-------+",
+        ],
+        &batches
+    );
+
+    Ok(())
+}

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -1665,12 +1665,7 @@ async fn build_v2_table_with_feature<E: TaskExecutor>(
 }
 
 /// A version holding two complete checkpoints must load from the uuid-named one, since it outranks
-/// the classic-named one, and the resulting snapshot must still read every row.
-///
-/// Kernel only ever writes classic-named checkpoints, so the competing uuid-named file is copied
-/// from the one kernel wrote -- byte-identical, and spec-valid under `v2Checkpoint`. The
-/// `_last_checkpoint` on disk names the classic file either way, so the winning uuid checkpoint is
-/// selected even though the hint points elsewhere.
+/// the classic-named one.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn snapshot_selects_uuid_checkpoint_over_classic_at_one_version() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
@@ -1683,39 +1678,48 @@ async fn snapshot_selects_uuid_checkpoint_over_classic_at_one_version() -> Delta
         .commit(engine.as_ref())?;
 
     let snapshot0 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
-    let result = insert_data(
+    let snapshot = insert_data(
         snapshot0,
         &engine,
         vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
     )
-    .await?;
-    let CommitResult::CommittedTransaction(committed) = result else {
-        panic!("Expected CommittedTransaction");
-    };
-    let snapshot = committed
-        .post_commit_snapshot()
-        .expect("expected post-commit snapshot");
+    .await?
+    .unwrap_post_commit_snapshot();
     let version = snapshot.version();
 
-    // Writes `<version>.checkpoint.parquet` plus a `_last_checkpoint` naming it.
+    // Writes `<version>.checkpoint.parquet` plus a `_last_checkpoint` describing it.
     snapshot.checkpoint(
         engine.as_ref(),
         Some(&CheckpointSpec::V2(V2CheckpointConfig::NoSidecar)),
     )?;
 
-    // Add a second complete checkpoint at the same version under a uuid name, which outranks the
-    // classic one. Kernel's write path cannot produce this, so copy the file it did write.
+    // As of v0.27.0 kernel writes only classic names, which this test depends on.
     let classic_path = load_existing_single_file_checkpoint_path(&table_path, version);
+    assert_eq!(
+        classic_path.file_name().unwrap().to_str().unwrap(),
+        format!("{version:020}.checkpoint.parquet"),
+    );
+
+    // Add a second complete checkpoint at this version, uuid-named so it outranks the classic one.
+    // Kernel's write path cannot produce one, so copy the V2 (classic-named) checkpoint it wrote to
+    // a V2 (uuid-named) path: same contents, and both namings are spec-valid under
+    // `v2Checkpoint`.
     let uuid_name = format!("{version:020}.checkpoint.{}.parquet", uuid::Uuid::new_v4());
     let uuid_path = std::path::Path::new(&table_path)
         .join("_delta_log")
         .join(&uuid_name);
     std::fs::copy(&classic_path, &uuid_path).expect("copy classic checkpoint to a uuid name");
 
+    // No path and no `parts` implies the classic checkpoint. Kernel doesn't write the
+    // `v2Checkpoint` field yet (TODO #1052), so a hint can never name a uuid checkpoint.
+    let last_checkpoint = read_last_checkpoint(&table_path);
+    assert_eq!(last_checkpoint["version"].as_u64(), Some(version));
+    assert!(last_checkpoint.get("parts").is_none());
+    assert!(last_checkpoint.get("v2Checkpoint").is_none());
+
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), version);
 
-    // The uuid-named checkpoint wins, even though `_last_checkpoint` names the classic one.
     let log_segment = snapshot.log_segment();
     let selected: Vec<&str> = log_segment
         .listed
@@ -1730,21 +1734,17 @@ async fn snapshot_selects_uuid_checkpoint_over_classic_at_one_version() -> Delta
     );
     assert_eq!(log_segment.checkpoint_version, Some(version));
 
-    // The selected checkpoint is readable, so replay over it returns every row.
+    // The hint implies the classic checkpoint, not the selected uuid one, so its fields get
+    // dropped.
+    assert!(log_segment.checkpoint_hint().is_none());
+
+    // Replay returns the rows written above, so the hand-placed copy is a readable checkpoint.
     let scan = snapshot.scan_builder().build()?;
-    let batches = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?;
-    assert_batches_sorted_eq!(
-        vec![
-            "+-------+",
-            "| value |",
-            "+-------+",
-            "| 1     |",
-            "| 2     |",
-            "| 3     |",
-            "+-------+",
-        ],
-        &batches
-    );
+    let rows: usize = read_scan(&scan, engine.clone() as Arc<dyn Engine>)?
+        .iter()
+        .map(|b| b.num_rows())
+        .sum();
+    assert_eq!(rows, 3);
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Read path only (log listing and snapshot construction). Nothing about what kernel writes changes,
though writes built on a snapshot benefit from the load no longer failing.

A table can legitimately hold more than one *complete* checkpoint at a single version. How many parts
a multi-part checkpoint splits into is a writer-side choice, so two writers checkpointing the same
version can leave a complete 11-part checkpoint beside a complete 2-part one. `PROTOCOL.md` allows
this ("Multiple checkpoints could exist for the same table version... a client can choose which
checkpoint to use"), but kernel handled it nondeterministically, and in one case fatally:

1. `group_checkpoint_parts` keyed groups on `num_parts` alone, and selection took the first complete
   group out of a `HashMap`, so which checkpoint got picked varied between processes. Classic and
   *every* uuid-named checkpoint also shared key `1`, silently overwriting each other.
2. `list_with_checkpoint_hint` treated a `_last_checkpoint` part-count disagreement as
   `Error::InvalidCheckpoint`, so such a table could fail to load outright, depending on which
   checkpoint that process happened to pick.

`CheckpointInstance` now identifies each distinct checkpoint at a version and orders them by naming
scheme, then part count, then file name. Selection takes the maximum. All parts of one multi-part
checkpoint map to the same instance, and single-file checkpoints are distinguished by name.
Completeness is still checked per group against that group's own part count, so an incomplete
checkpoint never masks a complete one. This mirrors Delta-Spark's `CheckpointInstance`, including its
ordinals `SINGLE = 0 < WITH_PARTS = 1 < V2 = 2`. Selection stays blind to the hint: the hint says
where to start listing, never which checkpoint to choose.

The part-count check becomes a `debug!`. `checkpoint_parts` only ever holds a complete checkpoint, so
a torn write leaves it empty and still hits the pre-existing "didn't find any checkpoints" error. A
part-count disagreement therefore proves only that a different complete checkpoint was selected.
Delta-Spark also filters a non-matching hint rather than failing.

### Why uuid-named checkpoints outrank classic-named ones

The uuid rank keeps a uuid-named checkpoint from losing to the classic-named *compatibility file*.
Writers with uuid-named V2 checkpoints enabled are told to [occasionally emit a classic-named V2
checkpoint with the same
content](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#handling-backward-compatibility-while-moving-to-uuid-named-v2-checkpoints),
so older clients that recognize only the classic name can still extract `Protocol` and fail
gracefully. A version holding a uuid-named checkpoint beside its classic-named twin is an expected
shape, not a race. Java kernel's `CheckpointInstance.compareTo` gives this as the reason a V2 instance
sorts above a classic one ("to filter avoid selecting the compatibility file"), and
delta-io/delta#2056, which added V2 read support, said the same: uuid-named checkpoints "are given
higher priority as compared to multi-part/classic checkpoint -- in case multiple checkpoints exist for
same version".

At such a version the old behavior was wrong deterministically, not just nondeterministically: both
files hashed to key `1`, and `.checkpoint.parquet` sorts after `.checkpoint.<uuid>.parquet`, so the
compatibility file always won.

Two properties of the ordering:

- **It ranks on the file name, not the spec version.** The spec's [allowed
  combinations](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#allowed-combinations-for-checkpoint-spec---checkpoint-file-naming)
  permit V2 under either naming scheme, so a classic-named `.checkpoint.parquet` may itself be a V2
  checkpoint carrying sidecars. That's why the read path probes for a sidecar column instead of
  inferring from the name. A classic-named V2 checkpoint therefore still ranks below a multi-part V1
  one, as in Delta-Spark.
- **It is blind to whether the table declares the `v2Checkpoint` reader feature**, as Delta-Spark's
  `getLatestCompleteCheckpointFromList` is. The `Protocol` action lives inside the checkpoint being
  chosen, so listing cannot know it yet. The feature is also removable, so a uuid-named checkpoint on
  disk doesn't imply it's currently enabled. Selecting one is safe either way, since
  `ensure_read_supported` only rejects features it doesn't know and never asserts one is present.

### Behavior changes

- **A 1-of-1 multi-part checkpoint now outranks a classic `.checkpoint.parquet`** at the same version,
  matching the ordinals. Both are complete single-file checkpoints, so they replay to the same state.
- **A uuid-named checkpoint now outranks both classic-named forms.** Where the winner is a *json*
  checkpoint it has no parquet footer, so the file actions schema comes from the first sidecar's footer
  instead. With no sidecars there's no schema at all and data skipping falls back to parsing the inline
  json `stats` string. Sidecars are parquet, so a json checkpoint that has them keeps `stats_parsed`
  pushdown.
- **`LastCheckpointHint::applies_to` now compares checkpoint identity, not part count.** The
  reordering above changes which file gets selected, and a hint with no `parts` describes a single
  whole file while a 1-of-1 multi-part checkpoint also holds one part. A count-only check matched it,
  and the hint's `checkpointSchema` (used *in place of* reading the selected file's parquet footer)
  would then describe a different file. `applies_to` now derives the hint's identity from its fields
  the way Delta-Spark's `getFormatEnum` does, and requires it to match the selected checkpoint's.

**Breaking under the `internal-api` feature:** `group_checkpoint_parts` now returns a map keyed by
`CheckpointInstance`, which is also exported under that feature. `LogSegment::checkpoint_hint` becomes
`pub(crate)` + `#[internal_api]` so integration tests can assert a mismatched hint is dropped.

## How was this change tested?

Unit tests cover:

- Two complete checkpoints at one version: the table loads, and the one with more parts is selected.
  This is the reported failure.
- A version with an *incomplete* checkpoint that outranks a complete one: the complete one is
  selected, and the version still counts as checkpointed.
- A version whose every checkpoint is incomplete: not treated as checkpointed.
- A uuid-named checkpoint at a version that also holds a multi-part one, and one that also holds a
  classic one: the uuid-named checkpoint wins in both.
- The same for a *json* uuid-named checkpoint, the case that reroutes reads away from a parquet footer.
- Two uuid-named checkpoints at one version: the tie breaks on file name.
- A 1-of-1 multi-part checkpoint against a classic one at the same version.
- Instance ordering against Delta-Spark's `CheckpointInstanceSuite`.
- A hint whose identity doesn't match the selected checkpoint's, for each kind of mismatch: the hint
  is rejected.
- A snapshot loading with a hint that describes a different checkpoint than the one selected: the hint
  is dropped rather than raising an error.
- A hint referencing a genuinely incomplete checkpoint: still fails, on the "didn't find any
  checkpoints" branch.
- Tables that already use V2 checkpoints, via the `v2-classic-checkpoint-parquet` fixture tests.

Test helpers for log file names moved into `path.rs`'s test module, removing two copies of the
multi-part checkpoint format string. The general cleanup that suggests is tracked in #3058.

An integration test drives the whole thing through the public API: create a `v2Checkpoint` table,
checkpoint it, copy the classic-named checkpoint kernel wrote to a uuid-named path, then load a fresh
snapshot and assert it selects the uuid one, drops the now-mismatched on-disk `_last_checkpoint`, and
still scans every row.

Every selection assertion names the expected checkpoint rather than just a part count, since
`RandomState` is re-seeded per process and asserting by repetition within one process would prove
nothing.
