### PR TITLE
fix!: rank uuid-named checkpoints above classic-named ones at the same version

### DIFF
--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,7 +11,7 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
-use crate::path::ParsedLogPath;
+use crate::path::{LogPathFileType, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
 
@@ -109,26 +109,43 @@ pub(crate) enum HintAction {
 impl LastCheckpointHint {
     /// Whether this hint describes the checkpoint a log segment selected -- the `checkpoint_parts`
     /// at `version`. Multiple checkpoints can share a version (e.g. concurrent writers), so a
-    /// matching version alone is not enough; multi-part checkpoints must have the expected parts
-    /// and V2 checkpoints must have the matching file name.
+    /// matching version alone is not enough: the hint's own shape must agree with the selected
+    /// checkpoint's format, and within a format with its parts or file name.
+    ///
+    /// On a mismatch, callers read the checkpoint file itself instead of trusting the hint's
+    /// fields.
     pub(crate) fn applies_to(
         &self,
         version: Version,
         checkpoint_parts: &[ParsedLogPath<FileMeta>],
     ) -> bool {
-        // A multi-part V1 checkpoint is keyed by `(version, numParts)` with deterministic
-        // per-version names, so a matching part count pins the identity. `parts` is absent
-        // for a single-part / classic checkpoint.
-        self.version == version
-            && self.parts.unwrap_or(1) == checkpoint_parts.len()
-            && match &self.v2_checkpoint {
-                // A V2 checkpoint's file name carries a UUID, so it must match the selected part
-                // (`checkpoint_parts.first()`), the file the hint's fields describe.
-                Some(v2) => {
-                    checkpoint_parts.first().map(|p| p.filename.as_str()) == Some(v2.path.as_str())
-                }
-                None => true,
+        let Some(selected) = checkpoint_parts.first() else {
+            return false;
+        };
+        // A hint's format is implied by its fields, as in Delta-Spark's `getFormatEnum`: a
+        // `v2Checkpoint` object means V2, else `parts` means multi-part, else single-file. It must
+        // match the selected checkpoint's format, or the hint describes some other file at this
+        // version and its `checkpointSchema` would be read as that file's.
+        let format_matches = match (&self.v2_checkpoint, self.parts) {
+            // A V2 checkpoint's file name carries a UUID, so it must match the selected part -- the
+            // file the hint's fields describe.
+            (Some(v2), _) => selected.filename == v2.path,
+            // A multi-part checkpoint's names are fully determined by `(version, num_parts)`, so a
+            // matching part count pins the identity.
+            (None, Some(parts)) => {
+                matches!(
+                    selected.file_type,
+                    LogPathFileType::MultiPartCheckpoint { .. }
+                ) && parts == checkpoint_parts.len()
             }
+            // A hint with neither field describes a single whole file, and a uuid-named one would
+            // have come with a `v2Checkpoint` object naming it.
+            (None, None) => {
+                matches!(selected.file_type, LogPathFileType::SinglePartCheckpoint)
+                    && checkpoint_parts.len() == 1
+            }
+        };
+        self.version == version && format_matches
     }
 
     /// Parses a hint from raw `_last_checkpoint` bytes, dropping oversized fields so the retained
@@ -367,7 +384,33 @@ mod tests {
             version: 1,
             ..Default::default()
         };
-        assert!(v1_single.applies_to(1, &[part("00000000000000000001.checkpoint.parquet")]));
+        let classic = "00000000000000000001.checkpoint.parquet";
+        assert!(v1_single.applies_to(1, &[part(classic)]));
+
+        // Format has to match, not just part count: a 1-of-1 multi-part checkpoint and a uuid-named
+        // one each hold one part too.
+        let one_of_one = "00000000000000000001.checkpoint.0000000001.0000000001.parquet";
+        assert!(
+            !v1_single.applies_to(1, &[part(one_of_one)]),
+            "single-file hint applied to a multi-part checkpoint"
+        );
+        assert!(
+            !v1_single.applies_to(1, &[part(selected)]),
+            "single-file hint applied to a uuid-named checkpoint"
+        );
+        // Nor can a multi-part hint describe a single whole file.
+        let v1_one_part = LastCheckpointHint {
+            version: 1,
+            parts: Some(1),
+            ..Default::default()
+        };
+        assert!(v1_one_part.applies_to(1, &[part(one_of_one)]));
+        assert!(
+            !v1_one_part.applies_to(1, &[part(classic)]),
+            "multi-part hint applied to a classic checkpoint"
+        );
+
+        assert!(!v1_single.applies_to(1, &[]), "no checkpoint selected");
     }
 
     /// `sidecarFiles` / `nonFileActions` are dropped only when their count exceeds the threshold --

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -627,7 +627,7 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
 }
 
 #[tokio::test]
-async fn build_snapshot_with_bad_checkpoint_hint_fails() {
+async fn build_snapshot_ignores_checkpoint_hint_with_mismatched_part_count() {
     let checkpoint_metadata = LastCheckpointHint {
         v2_checkpoint: None,
         version: 5,
@@ -649,11 +649,86 @@ async fn build_snapshot_with_bad_checkpoint_hint_fails() {
             delta_path_for_version(3, "checkpoint.parquet"),
             delta_path_for_version(3, "json"),
             delta_path_for_version(4, "json"),
+            // Two complete checkpoints at v5: the classic one the hint describes, and the 2-part
+            // one that outranks it.
+            delta_path_for_version(5, "checkpoint.parquet"),
             delta_path_for_multipart_checkpoint(5, 1, 2),
             delta_path_for_multipart_checkpoint(5, 2, 2),
             delta_path_for_version(5, "json"),
             delta_path_for_version(6, "json"),
             delta_path_for_version(7, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    // The 2-part checkpoint at v5 is selected, so the hint describing the classic one is not
+    // applied.
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(log_segment.checkpoint_version, Some(5));
+    assert_eq!(log_segment.end_version, 7);
+    let checkpoint_filenames = log_segment
+        .listed
+        .checkpoint_parts
+        .iter()
+        .map(|p| p.filename.as_str())
+        .collect_vec();
+    assert_eq!(
+        checkpoint_filenames,
+        vec![
+            "00000000000000000005.checkpoint.0000000001.0000000002.parquet",
+            "00000000000000000005.checkpoint.0000000002.0000000002.parquet",
+        ]
+    );
+
+    // The hint is retained but does not describe the selected checkpoint, so none of its fields are
+    // trusted -- readers fall back to the checkpoint footer.
+    assert!(log_segment.last_checkpoint_metadata.is_some());
+    assert!(log_segment.checkpoint_hint().is_none());
+
+    let commit_versions = log_segment
+        .listed
+        .ascending_commit_files
+        .iter()
+        .map(|c| c.version)
+        .collect_vec();
+    assert_eq!(commit_versions, vec![6, 7]);
+}
+
+/// Two complete checkpoints at v5, one of 2 parts and one of 3, with the hint naming the 3-part
+/// one. The 3-part checkpoint wins on part count, so the hint applies and its fields stay usable.
+#[tokio::test]
+async fn build_snapshot_applies_checkpoint_hint_matching_selected_checkpoint() {
+    let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
+        version: 5,
+        size: 10,
+        parts: Some(3),
+        size_in_bytes: None,
+        num_of_add_files: None,
+        checkpoint_schema: None,
+        checksum: None,
+        tags: None,
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(4, "json"),
+            delta_path_for_multipart_checkpoint(5, 1, 2),
+            delta_path_for_multipart_checkpoint(5, 2, 2),
+            delta_path_for_multipart_checkpoint(5, 1, 3),
+            delta_path_for_multipart_checkpoint(5, 2, 3),
+            delta_path_for_multipart_checkpoint(5, 3, 3),
+            delta_path_for_version(5, "json"),
+            delta_path_for_version(6, "json"),
         ],
         Some(&checkpoint_metadata),
     )
@@ -665,12 +740,12 @@ async fn build_snapshot_with_bad_checkpoint_hint_fails() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
-    );
-    assert_result_error_with_message(
-        log_segment,
-        "Invalid Checkpoint: _last_checkpoint indicated that checkpoint should have 1 parts, but \
-        it has 2",
     )
+    .unwrap();
+
+    assert_eq!(log_segment.checkpoint_version, Some(5));
+    assert_eq!(log_segment.listed.checkpoint_parts.len(), 3);
+    assert!(log_segment.checkpoint_hint().is_some());
 }
 
 #[tokio::test]

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -32,7 +32,8 @@ mod tests;
 ///   contain gaps.
 /// - `ascending_compaction_files`: All compaction commit files found, sorted by version.
 /// - `checkpoint_parts`: All parts of the most recent complete checkpoint (all same version). Empty
-///   if no checkpoint found.
+///   if no checkpoint found. A version can hold several complete checkpoints; see
+///   `group_checkpoint_parts` for which one this is.
 /// - `latest_crc_file`: The CRC file with the highest version, only if version >= checkpoint
 ///   version.
 /// - `latest_commit_file`: The commit file with the highest version, or `None` if no commits were
@@ -101,39 +102,114 @@ pub(crate) fn list_delta_log_from_storage(
     Ok(files)
 }
 
+/// Rank of a checkpoint's [`LogPathFileType`], ordered like Delta-Spark's
+/// `CheckpointInstance.Format` ordinals (`SINGLE` = 0, `WITH_PARTS` = 1), which its comparison uses
+/// as the sort key just after version. A separate enum because `LogPathFileType` also covers
+/// non-checkpoint files, and its variants are not declared in this order.
+///
+/// Named for those ordinals, but the rank follows a checkpoint's *name*, not its spec version: a
+/// classic-named file may itself be a V2 checkpoint carrying sidecars, which is why
+/// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column instead.
+///
+/// TODO: Delta-Spark gives uuid-named checkpoints a third, higher ordinal (`V2` = 2). Promoting
+/// them changes which file a table holding both formats reads, and a json one has no parquet footer
+/// to fall back on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum CheckpointFormatRank {
+    /// [`SinglePartCheckpoint`] and [`UuidCheckpoint`]: one whole file.
+    Single,
+    /// [`MultiPartCheckpoint`]
+    WithParts,
+}
+
+/// Identifies one checkpoint among the checkpoints at a single version, and orders it against its
+/// siblings.
+///
+/// Ordered like Delta-Spark's `CheckpointInstance`, which compares
+/// `(version, format, num_parts, file_name)` -- minus the leading version, because everything
+/// compared here already shares a version. Field order below is therefore the sort order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct CheckpointInstance {
+    format: CheckpointFormatRank,
+    /// How many files this checkpoint spans, or `None` for a single-file checkpoint -- matching
+    /// Delta-Spark's `Option[Int]`, whose `None` also sorts below every `Some`.
+    num_parts: Option<u32>,
+    /// Set only for single-file checkpoints, where the file name is what distinguishes two
+    /// checkpoints at the same version. `None` for a multi-part checkpoint, so that all of its
+    /// parts map to one instance: a multi-part file name is fully determined by
+    /// `(version, part_num, num_parts)`, so `num_parts` already pins the identity.
+    filename: Option<String>,
+}
+
+impl CheckpointInstance {
+    /// The instance shared by every part of the `num_parts`-part checkpoint at this version.
+    fn multi_part(num_parts: u32) -> Self {
+        Self {
+            format: CheckpointFormatRank::WithParts,
+            num_parts: Some(num_parts),
+            filename: None,
+        }
+    }
+
+    /// The instance for a checkpoint that is one whole file.
+    fn single(filename: String) -> Self {
+        Self {
+            format: CheckpointFormatRank::Single,
+            num_parts: None,
+            filename: Some(filename),
+        }
+    }
+
+    /// Whether `part_files` holds every part this checkpoint needs.
+    fn is_complete(&self, part_files: &[ParsedLogPath]) -> bool {
+        // `num_parts` is guaranteed to be non-negative and within `usize` range
+        self.num_parts.unwrap_or(1) as usize == part_files.len()
+    }
+}
+
 /// Groups all checkpoint parts according to the checkpoint they belong to.
 ///
-/// NOTE: There could be a single-part and/or any number of uuid-based checkpoints. They
-/// are all equivalent, and this routine keeps only one of them (arbitrarily chosen).
-#[internal_api]
-fn group_checkpoint_parts(parts: Vec<ParsedLogPath>) -> HashMap<u32, Vec<ParsedLogPath>> {
-    let mut checkpoints: HashMap<u32, Vec<ParsedLogPath>> = HashMap::new();
+/// Several _complete_ checkpoints can legitimately share a version: writers choose how many parts
+/// to split a checkpoint into independently, and a V2 writer embeds a fresh uuid in each file name.
+/// Each distinct checkpoint therefore gets its own [`CheckpointInstance`] key and they never
+/// overwrite one another, so the caller can pick a winner deterministically (see
+/// [`ListingAccumulator::flush_checkpoint_group`]).
+///
+/// `parts` must arrive in ascending file name order, which is what log listing produces: a
+/// multi-part checkpoint only accumulates while its parts arrive in order.
+fn group_checkpoint_parts(
+    parts: Vec<ParsedLogPath>,
+) -> HashMap<CheckpointInstance, Vec<ParsedLogPath>> {
+    debug_assert!(
+        parts.is_sorted_by_key(|p| &p.filename),
+        "checkpoint parts must arrive in ascending file name order"
+    );
+    let mut checkpoints: HashMap<CheckpointInstance, Vec<ParsedLogPath>> = HashMap::new();
     for part_file in parts {
         match &part_file.file_type {
-            SinglePartCheckpoint
-            | UuidCheckpoint
-            | MultiPartCheckpoint {
-                part_num: 1,
-                num_parts: 1,
-            } => {
-                // All single-file checkpoints are equivalent, just keep one
-                checkpoints.insert(1, vec![part_file]);
+            SinglePartCheckpoint | UuidCheckpoint => {
+                // A single-file checkpoint is complete on its own. Keying on file name keeps
+                // distinct same-version checkpoints (e.g. several uuid-named ones) separate.
+                let instance = CheckpointInstance::single(part_file.filename.clone());
+                checkpoints.insert(instance, vec![part_file]);
             }
             MultiPartCheckpoint {
                 part_num: 1,
                 num_parts,
             } => {
-                // Start a new multi-part checkpoint with at least 2 parts
-                checkpoints.insert(*num_parts, vec![part_file]);
+                // Start a new multi-part checkpoint
+                checkpoints.insert(CheckpointInstance::multi_part(*num_parts), vec![part_file]);
             }
             MultiPartCheckpoint {
                 part_num,
                 num_parts,
             } => {
-                // Continue a new multi-part checkpoint with at least 2 parts.
+                // Continue a multi-part checkpoint.
                 // Checkpoint parts are required to be in-order from log listing to build
                 // a multi-part checkpoint
-                if let Some(part_files) = checkpoints.get_mut(num_parts) {
+                if let Some(part_files) =
+                    checkpoints.get_mut(&CheckpointInstance::multi_part(*num_parts))
+                {
                     // `part_num` is guaranteed to be non-negative and within `usize` range
                     if *part_num as usize == 1 + part_files.len() {
                         // Safe to append because all previous parts exist
@@ -159,7 +235,7 @@ fn find_complete_checkpoint_version(ascending_files: &[ParsedLogPath]) -> Option
             let owned: Vec<ParsedLogPath> = parts.cloned().collect();
             group_checkpoint_parts(owned)
                 .iter()
-                .any(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
+                .any(|(instance, part_files)| instance.is_complete(part_files))
                 .then_some(version)
         })
         .last()
@@ -289,8 +365,14 @@ impl ListingAccumulator {
         }
     }
 
-    /// Groups and finds the first complete checkpoint for this version.
-    /// All checkpoints for the same version are equivalent, so we only take one.
+    /// Selects this version's checkpoint: the greatest _complete_ checkpoint in
+    /// [`CheckpointInstance`] order.
+    ///
+    /// Any of a version's complete checkpoints (see [`group_checkpoint_parts`]) replays to the same
+    /// table state, but the choice must be stable across processes, hence the maximum rather than
+    /// whichever entry a [`HashMap`] happens to yield first. Delta-Spark selects the same way:
+    /// group by checkpoint identity, keep the groups complete against their own part count,
+    /// take the max.
     ///
     /// If this version has a complete checkpoint, we can drop the existing commit and
     /// compaction files we collected so far -- except we must keep the latest commit.
@@ -298,8 +380,8 @@ impl ListingAccumulator {
         let pending_checkpoint_parts = std::mem::take(&mut self.pending_checkpoint_parts);
         if let Some((_, complete_checkpoint)) = group_checkpoint_parts(pending_checkpoint_parts)
             .into_iter()
-            // `num_parts` is guaranteed to be non-negative and within `usize` range
-            .find(|(num_parts, part_files)| part_files.len() == *num_parts as usize)
+            .filter(|(instance, part_files)| instance.is_complete(part_files))
+            .max_by(|(a, _), (b, _)| a.cmp(b))
         {
             self.output.checkpoint_parts = complete_checkpoint;
             // Keep the commit at the checkpoint version (if any) before clearing all older commits.
@@ -559,6 +641,10 @@ impl LogSegmentFiles {
     /// List all commit and checkpoint files after the provided checkpoint. It is guaranteed that
     /// all the returned [`ParsedLogPath`]s will have a version less than or equal to the
     /// `end_version`.
+    ///
+    /// The hint only tells us where to start listing; it never influences which checkpoint is
+    /// selected at a version. A hint that turns out to describe a different checkpoint than the one
+    /// selected is logged and ignored, not an error.
     pub(crate) fn list_with_checkpoint_hint(
         checkpoint_metadata: &LastCheckpointHint,
         storage: &dyn StorageHandler,
@@ -587,12 +673,22 @@ impl LogSegmentFiles {
             checkpoint_metadata.version,
             latest_checkpoint.version
         );
-        } else if listed_files.checkpoint_parts.len() != checkpoint_metadata.parts.unwrap_or(1) {
-            return Err(Error::InvalidCheckpoint(format!(
-                "_last_checkpoint indicated that checkpoint should have {} parts, but it has {}",
-                checkpoint_metadata.parts.unwrap_or(1),
-                listed_files.checkpoint_parts.len()
-            )));
+        } else if !checkpoint_metadata
+            .applies_to(latest_checkpoint.version, &listed_files.checkpoint_parts)
+        {
+            // Not corruption: the hint describes a checkpoint other than the one selected at this
+            // version (see `group_checkpoint_parts`). A torn checkpoint instead leaves
+            // `checkpoint_parts` empty, which the caller reports as an error. `applies_to` is also
+            // what makes `LogSegment::checkpoint_hint` yield `None`, so this logs exactly when the
+            // hint's fields are dropped and readers fall back to the checkpoint footer.
+            warn!(
+                version = checkpoint_metadata.version,
+                hint_parts = checkpoint_metadata.parts.unwrap_or(1),
+                selected_parts = listed_files.checkpoint_parts.len(),
+                selected_checkpoint_part = %latest_checkpoint.filename,
+                "_last_checkpoint hint describes a different checkpoint than the one selected at \
+                 this version; ignoring the hint's checkpoint-specific fields"
+            );
         }
         Ok(listed_files)
     }

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -103,23 +103,21 @@ pub(crate) fn list_delta_log_from_storage(
 }
 
 /// Rank of a checkpoint's [`LogPathFileType`], ordered like Delta-Spark's
-/// `CheckpointInstance.Format` ordinals (`SINGLE` = 0, `WITH_PARTS` = 1), which its comparison uses
-/// as the sort key just after version. A separate enum because `LogPathFileType` also covers
-/// non-checkpoint files, and its variants are not declared in this order.
+/// `CheckpointInstance.Format` ordinals (`SINGLE` = 0, `WITH_PARTS` = 1, `V2` = 2), which its
+/// comparison uses as the sort key just after version. A separate enum because `LogPathFileType`
+/// also covers non-checkpoint files, and its variants are not declared in this order.
 ///
 /// Named for those ordinals, but the rank follows a checkpoint's *name*, not its spec version: a
 /// classic-named file may itself be a V2 checkpoint carrying sidecars, which is why
 /// `LogSegment::get_file_actions_schema_and_sidecars` probes for a sidecar column instead.
-///
-/// TODO: Delta-Spark gives uuid-named checkpoints a third, higher ordinal (`V2` = 2). Promoting
-/// them changes which file a table holding both formats reads, and a json one has no parquet footer
-/// to fall back on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum CheckpointFormatRank {
-    /// [`SinglePartCheckpoint`] and [`UuidCheckpoint`]: one whole file.
+    /// [`SinglePartCheckpoint`]
     Single,
     /// [`MultiPartCheckpoint`]
     WithParts,
+    /// [`UuidCheckpoint`]
+    V2,
 }
 
 /// Identifies one checkpoint among the checkpoints at a single version, and orders it against its
@@ -134,8 +132,8 @@ struct CheckpointInstance {
     /// How many files this checkpoint spans, or `None` for a single-file checkpoint -- matching
     /// Delta-Spark's `Option[Int]`, whose `None` also sorts below every `Some`.
     num_parts: Option<u32>,
-    /// Set only for single-file checkpoints, where the file name is what distinguishes two
-    /// checkpoints at the same version. `None` for a multi-part checkpoint, so that all of its
+    /// Set for the single-file formats (`Single`, `V2`), where the file name is what distinguishes
+    /// two checkpoints at the same version. `None` for a multi-part checkpoint, so that all of its
     /// parts map to one instance: a multi-part file name is fully determined by
     /// `(version, part_num, num_parts)`, so `num_parts` already pins the identity.
     filename: Option<String>,
@@ -151,10 +149,10 @@ impl CheckpointInstance {
         }
     }
 
-    /// The instance for a checkpoint that is one whole file.
-    fn single(filename: String) -> Self {
+    /// The instance for a checkpoint that is one whole file, ranked `Single` or `V2` by its name.
+    fn single_file(format: CheckpointFormatRank, filename: String) -> Self {
         Self {
-            format: CheckpointFormatRank::Single,
+            format,
             num_parts: None,
             filename: Some(filename),
         }
@@ -187,10 +185,17 @@ fn group_checkpoint_parts(
     let mut checkpoints: HashMap<CheckpointInstance, Vec<ParsedLogPath>> = HashMap::new();
     for part_file in parts {
         match &part_file.file_type {
+            // A single-file checkpoint is complete on its own. Keying on file name keeps distinct
+            // same-version checkpoints separate -- notably uuid-named ones, since each writer picks
+            // a fresh uuid. Ranking is blind to whether the table declares the `v2Checkpoint`
+            // reader feature, as Delta-Spark's is: the Protocol action lives *inside* the
+            // checkpoint being chosen, so listing cannot know it.
             SinglePartCheckpoint | UuidCheckpoint => {
-                // A single-file checkpoint is complete on its own. Keying on file name keeps
-                // distinct same-version checkpoints (e.g. several uuid-named ones) separate.
-                let instance = CheckpointInstance::single(part_file.filename.clone());
+                let format = match part_file.file_type {
+                    UuidCheckpoint => CheckpointFormatRank::V2,
+                    _ => CheckpointFormatRank::Single,
+                };
+                let instance = CheckpointInstance::single_file(format, part_file.filename.clone());
                 checkpoints.insert(instance, vec![part_file]);
             }
             MultiPartCheckpoint {
@@ -368,11 +373,12 @@ impl ListingAccumulator {
     /// Selects this version's checkpoint: the greatest _complete_ checkpoint in
     /// [`CheckpointInstance`] order.
     ///
-    /// Any of a version's complete checkpoints (see [`group_checkpoint_parts`]) replays to the same
-    /// table state, but the choice must be stable across processes, hence the maximum rather than
-    /// whichever entry a [`HashMap`] happens to yield first. Delta-Spark selects the same way:
-    /// group by checkpoint identity, keep the groups complete against their own part count,
-    /// take the max.
+    /// Any of a version's complete checkpoints (see [`group_checkpoint_parts`]) describes the same
+    /// table state, though not necessarily by the same read path -- a V2 manifest resolves sidecars
+    /// where a V1 checkpoint holds its actions inline. The choice must be stable across processes,
+    /// hence the maximum rather than whichever entry a [`HashMap`] happens to yield first.
+    /// Delta-Spark selects the same way: group by checkpoint identity, keep the groups complete
+    /// against their own part count, take the max.
     ///
     /// If this version has a complete checkpoint, we can drop the existing commit and
     /// compaction files we collected so far -- except we must keep the latest commit.

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1337,3 +1337,307 @@ fn find_complete_checkpoint_version_cases(
 ) {
     assert_eq!(find_complete_checkpoint_version(&files), expected);
 }
+
+/// Builds a `ParsedLogPath` by parsing a real log file name, so `filename`, `extension` and
+/// `file_type` agree. Unlike [`make_parsed_log_path_with_source`], whose url is always
+/// `<version>.json`, this works for checkpoint paths -- whose file name takes part in checkpoint
+/// selection.
+fn parse_log_path(filename: &str) -> ParsedLogPath {
+    let url = Url::parse(&format!("memory:///_delta_log/{filename}")).unwrap();
+    ParsedLogPath::try_from(FileMeta {
+        location: url,
+        last_modified: 0,
+        size: FILESYSTEM_SIZE_MARKER,
+    })
+    .unwrap_or_else(|e| panic!("{filename} is not a log path: {e}"))
+    .unwrap_or_else(|| panic!("{filename} is not a log path"))
+}
+
+fn multipart_checkpoint_name(version: Version, part_num: u32, num_parts: u32) -> String {
+    format!("{version:020}.checkpoint.{part_num:010}.{num_parts:010}.parquet")
+}
+
+/// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a single-part checkpoint sorts below a
+/// multi-part one, more parts beats fewer, and single-file checkpoints break ties on file name.
+#[test]
+fn checkpoint_instance_orders_like_delta_spark() {
+    let classic = CheckpointInstance::single("00000000000000000005.checkpoint.parquet".to_string());
+    let uuid = CheckpointInstance::single(
+        "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet".to_string(),
+    );
+
+    assert!(classic < CheckpointInstance::multi_part(2));
+    assert!(CheckpointInstance::multi_part(2) < CheckpointInstance::multi_part(11));
+    assert!(classic < CheckpointInstance::multi_part(11));
+    // Hex digits all sort below 'p', so a classic checkpoint wins over a uuid-named one.
+    assert!(uuid < classic);
+}
+
+/// Two writers checkpointed the same version with different part counts, and both checkpoints are
+/// complete. The one with more parts wins.
+#[tokio::test]
+async fn two_complete_checkpoints_at_one_version_selects_more_parts() {
+    let mut log_files: Vec<_> = (0..=6)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    for part_num in 1..=2 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 2,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    for part_num in 1..=11 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 11,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (commit_files, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    let selected: Vec<_> = checkpoint_parts.iter().map(|p| &p.filename).collect();
+    let expected: Vec<_> = (1..=11)
+        .map(|p| multipart_checkpoint_name(4, p, 11))
+        .collect();
+    assert_eq!(selected, expected.iter().collect::<Vec<_>>());
+    let commit_versions: Vec<_> = commit_files.iter().map(|c| c.version).collect();
+    assert_eq!(commit_versions, vec![5, 6]);
+}
+
+/// A torn checkpoint loses to a complete one even though it outranks it: rank orders the
+/// candidates, but only complete ones are candidates at all.
+#[tokio::test]
+async fn torn_higher_ranked_checkpoint_loses_to_complete_lower_ranked() {
+    let mut log_files: Vec<_> = (0..=6)
+        .map(|v| (v, LogPathFileType::Commit, CommitSource::Filesystem))
+        .collect();
+    for part_num in 1..=2 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 2,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    // A writer got 3 of its 11 parts out before dying, so this group outranks the 2-part one but is
+    // unusable.
+    for part_num in 1..=3 {
+        log_files.push((
+            4,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 11,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (commit_files, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    let selected: Vec<_> = checkpoint_parts.iter().map(|p| &p.filename).collect();
+    let expected: Vec<_> = (1..=2)
+        .map(|p| multipart_checkpoint_name(4, p, 2))
+        .collect();
+    assert_eq!(selected, expected.iter().collect::<Vec<_>>());
+    let commit_versions: Vec<_> = commit_files.iter().map(|c| c.version).collect();
+    assert_eq!(commit_versions, vec![5, 6]);
+}
+
+/// The same rank-versus-completeness rule when the surviving candidate is a single-file checkpoint:
+/// a torn multi-part group outranks the classic checkpoint but still loses to it.
+#[tokio::test]
+async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
+    let mut log_files = vec![
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (
+            1,
+            LogPathFileType::SinglePartCheckpoint,
+            CommitSource::Filesystem,
+        ),
+    ];
+    for part_num in 1..=2 {
+        log_files.push((
+            1,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num,
+                num_parts: 3,
+            },
+            CommitSource::Filesystem,
+        ));
+    }
+    let (storage, log_root) = create_storage(log_files).await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.parquet"
+    );
+}
+
+/// A uuid-named checkpoint and a complete multi-part checkpoint at one version. The multi-part one
+/// wins: kernel ranks uuid-named (V2) checkpoints alongside classic ones rather than above
+/// multi-part ones as Delta-Spark does.
+#[tokio::test]
+async fn uuid_and_multipart_checkpoints_at_one_version_selects_multipart() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (2, LogPathFileType::Commit, CommitSource::Filesystem),
+        ],
+        &[
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 1, 2)),
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 2, 2)),
+            "_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 2);
+    for part in &checkpoint_parts {
+        assert!(matches!(
+            part.file_type,
+            LogPathFileType::MultiPartCheckpoint { num_parts: 2, .. }
+        ));
+    }
+}
+
+/// Two uuid-named checkpoints at one version each stand alone -- each writer picks a fresh uuid, so
+/// they are distinct checkpoints, not parts of one -- and the greater file name wins.
+#[tokio::test]
+async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![(1, LogPathFileType::Commit, CommitSource::Filesystem)],
+        &[
+            "_delta_log/00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.parquet",
+            "_delta_log/00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet"
+    );
+}
+
+/// A classic checkpoint beats a uuid-named one at the same version: both rank `Single`, and every
+/// hex digit sorts below the `p` of `parquet`.
+#[tokio::test]
+async fn classic_checkpoint_beats_uuid_checkpoint_at_one_version() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (1, LogPathFileType::SinglePartCheckpoint, CommitSource::Filesystem),
+        ],
+        &["_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.parquet"
+    );
+}
+
+/// A 1-of-1 multi-part checkpoint outranks a classic one at the same version, following
+/// Delta-Spark's format ordinals. Both are complete single-file V1 checkpoints, so they replay to
+/// the same state.
+#[tokio::test]
+async fn one_of_one_multipart_checkpoint_beats_classic_checkpoint() {
+    let (storage, log_root) = create_storage(vec![
+        (1, LogPathFileType::Commit, CommitSource::Filesystem),
+        (
+            1,
+            LogPathFileType::SinglePartCheckpoint,
+            CommitSource::Filesystem,
+        ),
+        (
+            1,
+            LogPathFileType::MultiPartCheckpoint {
+                part_num: 1,
+                num_parts: 1,
+            },
+            CommitSource::Filesystem,
+        ),
+    ])
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        multipart_checkpoint_name(1, 1, 1)
+    );
+}
+
+#[rstest]
+// A classic checkpoint and a 1-of-1 multi-part checkpoint at one version: each is complete on its
+// own, and they occupy separate groups.
+#[case::single_and_one_of_one_same_version(
+        vec![
+            parse_log_path(&multipart_checkpoint_name(5, 1, 1)),
+            parse_log_path("00000000000000000005.checkpoint.parquet"),
+        ],
+        Some(5)
+    )]
+// A complete 2-part and a complete 11-part checkpoint at one version.
+#[case::two_complete_multipart_same_version(
+        (1..=2).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=11).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        Some(10)
+    )]
+// A torn 11-part group beside a complete 2-part one at the same version: the version still counts
+// as checkpointed, on the strength of the complete group alone.
+#[case::torn_beside_complete_same_version(
+        (1..=2).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=3).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        Some(10)
+    )]
+// Every group at the version is torn, so the version is not checkpointed.
+#[case::all_torn_same_version(
+        (1..=1).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 2)))
+            .chain((1..=3).map(|p| parse_log_path(&multipart_checkpoint_name(10, p, 11))))
+            .sorted_by_key(|f| f.filename.clone())
+            .collect(),
+        None
+    )]
+fn find_complete_checkpoint_version_same_version_cases(
+    #[case] files: Vec<ParsedLogPath>,
+    #[case] expected: Option<u64>,
+) {
+    assert_eq!(find_complete_checkpoint_version(&files), expected);
+}

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1358,19 +1358,30 @@ fn multipart_checkpoint_name(version: Version, part_num: u32, num_parts: u32) ->
 }
 
 /// Mirrors Delta-Spark's `CheckpointInstanceSuite`: a single-part checkpoint sorts below a
-/// multi-part one, more parts beats fewer, and single-file checkpoints break ties on file name.
+/// multi-part one, more parts beats fewer, a V2 checkpoint outranks both, and single-file
+/// checkpoints break ties on file name.
 #[test]
 fn checkpoint_instance_orders_like_delta_spark() {
-    let classic = CheckpointInstance::single("00000000000000000005.checkpoint.parquet".to_string());
-    let uuid = CheckpointInstance::single(
+    let classic = CheckpointInstance::single_file(
+        CheckpointFormatRank::Single,
+        "00000000000000000005.checkpoint.parquet".to_string(),
+    );
+    let uuid_a = CheckpointInstance::single_file(
+        CheckpointFormatRank::V2,
         "00000000000000000005.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet".to_string(),
+    );
+    let uuid_b = CheckpointInstance::single_file(
+        CheckpointFormatRank::V2,
+        "00000000000000000005.checkpoint.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.parquet".to_string(),
     );
 
     assert!(classic < CheckpointInstance::multi_part(2));
     assert!(CheckpointInstance::multi_part(2) < CheckpointInstance::multi_part(11));
     assert!(classic < CheckpointInstance::multi_part(11));
-    // Hex digits all sort below 'p', so a classic checkpoint wins over a uuid-named one.
-    assert!(uuid < classic);
+    assert!(uuid_a > CheckpointInstance::multi_part(11));
+    assert!(uuid_a > classic);
+    // Two V2 checkpoints at one version break the tie on file name.
+    assert!(uuid_a < uuid_b);
 }
 
 /// Two writers checkpointed the same version with different part counts, and both checkpoints are
@@ -1491,11 +1502,10 @@ async fn torn_multipart_checkpoint_loses_to_classic_checkpoint() {
     );
 }
 
-/// A uuid-named checkpoint and a complete multi-part checkpoint at one version. The multi-part one
-/// wins: kernel ranks uuid-named (V2) checkpoints alongside classic ones rather than above
-/// multi-part ones as Delta-Spark does.
+/// A uuid-named (V2) checkpoint and a complete multi-part (V1) checkpoint at one version. The V2
+/// one wins, matching Delta-Spark's `Format.V2 > Format.WITH_PARTS`.
 #[tokio::test]
-async fn uuid_and_multipart_checkpoints_at_one_version_selects_multipart() {
+async fn uuid_and_multipart_checkpoints_at_one_version_selects_uuid() {
     let (storage, log_root) = create_storage_with_raw_paths(
         vec![
             (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -1512,13 +1522,11 @@ async fn uuid_and_multipart_checkpoints_at_one_version_selects_multipart() {
     let (_, _, checkpoint_parts, _, _, _) =
         list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
 
-    assert_eq!(checkpoint_parts.len(), 2);
-    for part in &checkpoint_parts {
-        assert!(matches!(
-            part.file_type,
-            LogPathFileType::MultiPartCheckpoint { num_parts: 2, .. }
-        ));
-    }
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+    );
 }
 
 /// Two uuid-named checkpoints at one version each stand alone -- each writer picks a fresh uuid, so
@@ -1544,10 +1552,10 @@ async fn two_uuid_checkpoints_at_one_version_select_greater_filename() {
     );
 }
 
-/// A classic checkpoint beats a uuid-named one at the same version: both rank `Single`, and every
-/// hex digit sorts below the `p` of `parquet`.
+/// A uuid-named (V2) checkpoint beats a classic (V1) one at the same version, matching
+/// Delta-Spark's `Format.V2 > Format.SINGLE`.
 #[tokio::test]
-async fn classic_checkpoint_beats_uuid_checkpoint_at_one_version() {
+async fn uuid_checkpoint_beats_classic_checkpoint_at_one_version() {
     let (storage, log_root) = create_storage_with_raw_paths(
         vec![
             (1, LogPathFileType::Commit, CommitSource::Filesystem),
@@ -1563,7 +1571,39 @@ async fn classic_checkpoint_beats_uuid_checkpoint_at_one_version() {
     assert_eq!(checkpoint_parts.len(), 1);
     assert_eq!(
         checkpoint_parts[0].filename,
-        "00000000000000000001.checkpoint.parquet"
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.parquet"
+    );
+}
+
+/// A json V2 checkpoint outranks the V1 checkpoints at its version just like a parquet one does.
+/// A json checkpoint has no parquet footer, so selecting it routes schema discovery through the
+/// sidecar path rather than a footer read (see `LogSegment::get_file_actions_schema_and_sidecars`).
+#[tokio::test]
+async fn json_uuid_checkpoint_beats_v1_checkpoints_at_one_version() {
+    let (storage, log_root) = create_storage_with_raw_paths(
+        vec![
+            (1, LogPathFileType::Commit, CommitSource::Filesystem),
+            (
+                1,
+                LogPathFileType::SinglePartCheckpoint,
+                CommitSource::Filesystem,
+            ),
+        ],
+        &[
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 1, 2)),
+            &format!("_delta_log/{}", multipart_checkpoint_name(1, 2, 2)),
+            "_delta_log/00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json",
+        ],
+    )
+    .await;
+
+    let (_, _, checkpoint_parts, _, _, _) =
+        list_and_destructure(storage.as_ref(), &log_root, vec![], None, None);
+
+    assert_eq!(checkpoint_parts.len(), 1);
+    assert_eq!(
+        checkpoint_parts[0].filename,
+        "00000000000000000001.checkpoint.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json"
     );
 }
 


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3047/files/eade317dfb8ce395e705cc59747c8007976b8d13..906a5deee20bf8070f82761dd2a86ba476aee6c5) to review incremental changes.
- [stack/checkpoint-determinism](https://github.com/delta-io/delta-kernel-rs/pull/3046) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3046/files)]
  - [**stack/v2-checkpoint-rank**](https://github.com/delta-io/delta-kernel-rs/pull/3047) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3047/files/eade317dfb8ce395e705cc59747c8007976b8d13..906a5deee20bf8070f82761dd2a86ba476aee6c5)] <-- this PR

---------
## What changes are proposed in this pull request?

Read path (log listing / snapshot construction), like #3046. Nothing about what kernel *writes*
changes, though it does change which checkpoint file a read resolves through.

Delta-Spark gives uuid-named checkpoints their own format ordinal above both V1 naming forms --
`Format.SINGLE = 0`, `WITH_PARTS = 1`, `V2 = 2` -- and its `CheckpointInstanceSuite` pins
`ci1_v2 > ci1_withparts_2 > ci1_single_1`. Kernel ranked a uuid-named checkpoint alongside a classic
single-part one, so at a version holding both it could pick either. This adds the third rank and
routes `UuidCheckpoint` to it, completing the parity #3046 started.

The reason to prefer uuid-named is not performance. The Java kernel's `CheckpointInstance.compareTo`
gives it directly: a V2 instance sorts above a classic one *"to filter avoid selecting the
compatibility file"*. Writers with uuid-named v2 checkpoints enabled are told to [occasionally emit a
classic-named v2 checkpoint with the same
content](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#handling-backward-compatibility-while-moving-to-uuid-named-v2-checkpoints),
so that older clients recognizing only the classic name can still extract `Protocol` and fail
gracefully. A version holding a uuid-named checkpoint beside its classic-named compatibility twin is
therefore an expected shape, not a race -- and it is the one case where the old code was
*deterministically* wrong rather than merely nondeterministic: both hashed to the same key, and
`.checkpoint.parquet` sorts after `.checkpoint.<uuid>.parquet`, so the compatibility file always won.
delta-io/delta#2056, which added V2 read support, stated the intent the same way: uuid-named
checkpoints "are given higher priority as compared to multi-part/classic checkpoint -- in case
multiple checkpoints exist for same version".

Two properties of the ordering:

- **It ranks on the file *name*, not the spec version.** A classic-named `.checkpoint.parquet` can
  itself be a V2 checkpoint carrying sidecars -- the spec's [allowed
  combinations](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#allowed-combinations-for-checkpoint-spec---checkpoint-file-naming)
  permit V2 under either naming scheme -- which is why the read path probes for a sidecar column
  rather than inferring from the name. So this does not make kernel "prefer V2 checkpoints": a
  classic-named V2 checkpoint still ranks below a multi-part V1 one, exactly as in Delta-Spark.
- **It is blind to whether the table declares the `v2Checkpoint` reader feature**, as Delta-Spark's
  `getLatestCompleteCheckpointFromList` is: the `Protocol` action lives *inside* the checkpoint being
  chosen, so listing cannot know it yet. The feature is also removable, so a uuid-named checkpoint on
  disk does not imply it is currently enabled.

No hint change is needed. After #3046 a hint must already agree with the selected checkpoint's format,
and a hint describing a uuid-named checkpoint carries a `v2Checkpoint` object naming the file.

Also collapses `single`/`v2` into one `single_file(format, filename)` constructor, since they differed
only in that field.

One consequence for reads: ties among uuid checkpoints break on file name, which is uncorrelated with
the read path each resolves through. A json checkpoint has no parquet footer, so its file actions
schema comes from the first sidecar's footer instead; with no sidecars there is no schema at all and
data skipping falls back to parsing the inline json `stats` string. Sidecars are parquet, so a json
checkpoint that has them keeps `stats_parsed` pushdown -- the axis is inline-vs-sidecar, not
json-vs-parquet.

## How was this change tested?

Unit tests assert that:

- A uuid-named checkpoint is selected over a multi-part one at the same version, and over a classic
  one -- the two cases this reordering changes. #3046's tests for the old outcome have their
  assertions flipped here.
- A *json* uuid-named checkpoint wins the same way, the case that reroutes reads away from a parquet
  footer.
- Two uuid-named checkpoints at one version still break the tie on file name.
- Instance ordering matches Delta-Spark's `CheckpointInstanceSuite` (`v2 > withparts_2 > single`).
- Tables that already use V2 checkpoints still read correctly, via the existing
  `v2-classic-checkpoint-parquet` fixture tests.

Promoting V2 cannot raise a spurious unsupported-feature error: `ensure_read_supported` only rejects
features it does not know, never asserts one is *present*.
