### PR TITLE
feat(ffi): track peak native memory via optional tracking allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "paste",
+ "peak_alloc",
  "prost 0.13.5",
  "rand 0.9.2",
  "rstest",
@@ -3055,6 +3056,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "peak_alloc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc90935a8dd139fdf341762773687a1e361d3f54b396a55d9dd1f7001e484bb"
 
 [[package]]
 name = "pem-rfc7468"

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -31,7 +31,8 @@ the caller's memory space.
 - `src/schema_visitor.rs` -- visitor pattern for schema traversal
 - `src/ffi_tracing.rs` -- log/tracing and metrics callback registration (`#[cfg(feature = "tracing")]`)
 - `src/ffi_metrics.rs` -- `repr(C)` mirror of kernel `MetricEvent` types (`#[cfg(feature = "tracing")]`)
-- `src/alloc_stats.rs` -- tracking global allocator and native-heap counters (`alloc-tracking`)
+- `src/alloc_stats.rs` -- `peak_alloc` global allocator and native-heap FFI getters
+  (`alloc-tracking`)
 
 ## Read Flow
 
@@ -165,6 +166,6 @@ Feature flags:
 - `arrow-59`, `arrow-58`
 - `delta-kernel-unity-catalog`
 - `tracing`
-- `alloc-tracking` -- installs a tracking global allocator; enables meaningful
+- `alloc-tracking` -- installs `peak_alloc` as the tracking global allocator; enables meaningful
   `*_native_bytes` / `alloc_tracking_enabled` getters (cdylib only; conflicts with
   another `#[global_allocator]` if linked as an rlib)

--- a/ffi/CLAUDE.md
+++ b/ffi/CLAUDE.md
@@ -31,6 +31,7 @@ the caller's memory space.
 - `src/schema_visitor.rs` -- visitor pattern for schema traversal
 - `src/ffi_tracing.rs` -- log/tracing and metrics callback registration (`#[cfg(feature = "tracing")]`)
 - `src/ffi_metrics.rs` -- `repr(C)` mirror of kernel `MetricEvent` types (`#[cfg(feature = "tracing")]`)
+- `src/alloc_stats.rs` -- tracking global allocator and native-heap counters (`alloc-tracking`)
 
 ## Read Flow
 
@@ -164,3 +165,6 @@ Feature flags:
 - `arrow-59`, `arrow-58`
 - `delta-kernel-unity-catalog`
 - `tracing`
+- `alloc-tracking` -- installs a tracking global allocator; enables meaningful
+  `*_native_bytes` / `alloc_tracking_enabled` getters (cdylib only; conflicts with
+  another `#[global_allocator]` if linked as an rlib)

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -31,6 +31,7 @@ delta_kernel_default_engine = { path = "../default-engine", default-features = f
 delta_kernel_ffi_macros = { path = "../ffi-proc-macros", version = "0.26.0" }
 delta-kernel-unity-catalog = { path = "../delta-kernel-unity-catalog", optional = true }
 unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api", optional = true }
+peak_alloc = { version = "0.3.0", optional = true }
 
 [build-dependencies]
 cbindgen = "0.29.2"
@@ -80,4 +81,4 @@ geo-type-in-dev = ["delta_kernel/geo-type-in-dev"]
 # `*_native_bytes` FFI getters. Off by default. Only enable when building the cdylib:
 # this crate is also an rlib, so `#[global_allocator]` applies to any Rust binary that
 # links it and conflicts with a binary that installs its own (jemalloc, dhat, ...).
-alloc-tracking = []
+alloc-tracking = ["dep:peak_alloc"]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -75,3 +75,9 @@ test-ffi = []
 # Experimental, in-development feature flag gating in-progress geospatial
 # (geometry/geography) type support. TODO(#2949): remove once full geo support ships.
 geo-type-in-dev = ["delta_kernel/geo-type-in-dev"]
+
+# Tracking global allocator for process-wide native live/peak bytes, readable via the
+# `*_native_bytes` FFI getters. Off by default. Only enable when building the cdylib:
+# this crate is also an rlib, so `#[global_allocator]` applies to any Rust binary that
+# links it and conflicts with a binary that installs its own (jemalloc, dhat, ...).
+alloc-tracking = []

--- a/ffi/src/alloc_stats.rs
+++ b/ffi/src/alloc_stats.rs
@@ -1,236 +1,92 @@
-//! Process-wide accounting of the kernel's Rust-allocated native heap via
-//! [`TrackingAlloc`] (installed as `#[global_allocator]` under `alloc-tracking`).
+//! FFI access to `peak_alloc`'s process-wide Rust allocation counters.
 //!
 //! # Scope
 //!
-//! Counters record requested [`Layout::size`] only, so they are a lower bound on
-//! process RSS (C/`mmap` allocations and allocator overhead are outside the path).
-//! Process-global: shared across concurrent work; [`peak_native_bytes`] is a
-//! process-wide high-water mark since the library was loaded (or the last
-//! [`reset_peak_native_bytes`]), not a per-operation figure. Updates use `Relaxed`
-//! ordering -- advisory stats: two atomic RMWs per allocation (`fetch_add` +
-//! `fetch_max`) and one per deallocation.
+//! Counters record requested allocation sizes only, so they are a lower bound on process RSS:
+//! C/`mmap` allocations and allocator overhead are not included. Values are process-global and
+//! advisory, rather than measurements for a single operation. `peak_alloc` uses relaxed atomic
+//! operations to update its counters. Its peak reset is not coordinated with allocation, so callers
+//! must serialize a reset against native work when they require a meaningful post-reset peak.
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Live-bytes and peak-bytes counters. Split out from [`TrackingAlloc`] so the arithmetic can be
-/// unit-tested against a local instance without touching the process-global allocator state.
-struct Counters {
-    current: AtomicU64,
-    peak: AtomicU64,
-}
-
-impl Counters {
-    const fn new() -> Self {
-        Self {
-            current: AtomicU64::new(0),
-            peak: AtomicU64::new(0),
-        }
-    }
-
-    #[inline]
-    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
-    fn record_alloc(&self, n: usize) {
-        let new_current = self.current.fetch_add(n as u64, Ordering::Relaxed) + n as u64;
-        self.peak.fetch_max(new_current, Ordering::Relaxed);
-    }
-
-    /// Leave `peak` unchanged on dealloc.
-    #[inline]
-    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
-    fn record_dealloc(&self, n: usize) {
-        self.current.fetch_sub(n as u64, Ordering::Relaxed);
-    }
-
-    /// Record a successful resize from `old` to `new` bytes as a single net update.
-    #[inline]
-    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
-    fn record_realloc(&self, old: usize, new: usize) {
-        match new.checked_sub(old) {
-            Some(growth) => self.record_alloc(growth),
-            None => self.record_dealloc(old - new),
-        }
-    }
-
-    fn peak_bytes(&self) -> u64 {
-        self.peak.load(Ordering::Relaxed)
-    }
-
-    fn current_bytes(&self) -> u64 {
-        self.current.load(Ordering::Relaxed)
-    }
-
-    /// Set peak to current live bytes, returning the peak that was cleared.
-    ///
-    /// After `store`/`swap`, a concurrent alloc can leave `peak < current`; `fetch_max`
-    /// repairs that invariant.
-    fn take_peak(&self) -> u64 {
-        let current = self.current.load(Ordering::Relaxed);
-        let previous = self.peak.swap(current, Ordering::Relaxed);
-        self.peak
-            .fetch_max(self.current.load(Ordering::Relaxed), Ordering::Relaxed);
-        previous
-    }
-}
-
-static COUNTERS: Counters = Counters::new();
-
-/// A [`GlobalAlloc`] that forwards every request to the [`System`] allocator while maintaining the
-/// process-global [`COUNTERS`].
-///
-/// Constructed only via `#[global_allocator]` when `alloc-tracking` is enabled.
-#[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
-struct TrackingAlloc;
+#[cfg(feature = "alloc-tracking")]
+use peak_alloc::PeakAlloc;
 
 #[cfg(feature = "alloc-tracking")]
 #[global_allocator]
-static GLOBAL_ALLOC: TrackingAlloc = TrackingAlloc;
+static GLOBAL_ALLOC: PeakAlloc = PeakAlloc;
 
-// SAFETY: every method forwards to the corresponding `System` method with the exact same
-// arguments, so the allocator contract is upheld. The counter updates only read/write atomics and
-// never touch the returned memory, so they cannot violate allocation safety. Counters are adjusted
-// only when `System` reports success (non-null pointer) to keep `current` in step with live bytes.
-unsafe impl GlobalAlloc for TrackingAlloc {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = System.alloc(layout);
-        if !ptr.is_null() {
-            COUNTERS.record_alloc(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ptr = System.alloc_zeroed(layout);
-        if !ptr.is_null() {
-            COUNTERS.record_alloc(layout.size());
-        }
-        ptr
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        System.dealloc(ptr, layout);
-        COUNTERS.record_dealloc(layout.size());
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        let new_ptr = System.realloc(ptr, layout, new_size);
-        // On failure `System.realloc` leaves the original allocation intact, so live bytes are
-        // unchanged. On success the block moves from `layout.size()` to `new_size` bytes.
-        if !new_ptr.is_null() {
-            COUNTERS.record_realloc(layout.size(), new_size);
-        }
-        new_ptr
-    }
-}
-
-/// Whether this library was built with allocation tracking. The `*_native_bytes` getters return
-/// zeros when false.
+/// Whether this library was built with allocation tracking.
+///
+/// The `*_native_bytes` getters return zero when this is false.
 #[no_mangle]
 pub extern "C" fn alloc_tracking_enabled() -> bool {
     cfg!(feature = "alloc-tracking")
 }
 
-/// Peak native bytes ever simultaneously live since the library was loaded or the last
-/// [`reset_peak_native_bytes`].
+/// Reported peak simultaneously live native bytes since the library was loaded or reset.
 ///
-/// Process-wide (not per-operation). Counts Rust [`Layout::size`] only (excludes C/`mmap`
-/// allocations and allocator overhead). Returns 0 if built without `alloc-tracking`.
+/// The value is process-wide, not per-operation, and counts requested Rust allocation sizes only.
+/// Returns zero when built without `alloc-tracking`.
 #[no_mangle]
 pub extern "C" fn peak_native_bytes() -> u64 {
-    COUNTERS.peak_bytes()
+    #[cfg(feature = "alloc-tracking")]
+    {
+        GLOBAL_ALLOC.peak_usage() as u64
+    }
+    #[cfg(not(feature = "alloc-tracking"))]
+    {
+        0
+    }
 }
 
 /// Native bytes currently live (allocated but not yet freed).
 ///
-/// Process-wide. Counts Rust [`Layout::size`] only. Returns 0 if built without `alloc-tracking`.
-#[no_mangle]
-pub extern "C" fn current_native_bytes() -> u64 {
-    COUNTERS.current_bytes()
-}
-
-/// Set peak to the current live total and return the peak that was cleared.
-///
-/// Process-global: not safe as a per-task baseline under concurrency. Callers that need a
-/// single-tenant measurement must serialize resets against the work they measure. Returns 0 if
+/// The value is process-wide and counts requested Rust allocation sizes only. Returns zero when
 /// built without `alloc-tracking`.
 #[no_mangle]
-pub extern "C" fn reset_peak_native_bytes() -> u64 {
-    COUNTERS.take_peak()
+pub extern "C" fn current_native_bytes() -> u64 {
+    #[cfg(feature = "alloc-tracking")]
+    {
+        GLOBAL_ALLOC.current_usage() as u64
+    }
+    #[cfg(not(feature = "alloc-tracking"))]
+    {
+        0
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use rstest::rstest;
-
-    use super::Counters;
-
-    #[derive(Clone, Copy)]
-    enum Op {
-        Alloc(usize),
-        Dealloc(usize),
-        Realloc { old: usize, new: usize },
-        TakePeak,
+/// Resets the peak to the current live total and returns the peak sampled immediately before reset.
+///
+/// This is process-global and cannot provide a per-task baseline while allocation is concurrent.
+/// `peak_alloc` samples and resets separately, so concurrent allocation can cause the returned
+/// value to understate the cleared peak and leave the reported peak lower than the current total.
+/// Returns zero when built without `alloc-tracking`.
+#[no_mangle]
+pub extern "C" fn reset_peak_native_bytes() -> u64 {
+    #[cfg(feature = "alloc-tracking")]
+    {
+        let previous_peak = GLOBAL_ALLOC.peak_usage() as u64;
+        GLOBAL_ALLOC.reset_peak_usage();
+        previous_peak
     }
-
-    #[rstest]
-    #[case::alloc_raises_current_and_peak(&[Op::Alloc(4096)], 4096, 4096)]
-    #[case::dealloc_lowers_current_but_not_peak(
-        &[Op::Alloc(8192), Op::Dealloc(8192)],
-        0,
-        8192
-    )]
-    #[case::peak_tracks_max_not_last(
-        &[Op::Alloc(1000), Op::Alloc(500), Op::Dealloc(500), Op::Alloc(200)],
-        1200,
-        1500
-    )]
-    #[case::take_peak_returns_cleared_and_drops_to_current(
-        &[Op::Alloc(1024), Op::Dealloc(512), Op::TakePeak],
-        512,
-        512
-    )]
-    #[case::realloc_growth_raises_peak(
-        &[Op::Alloc(100), Op::Realloc { old: 100, new: 300 }],
-        300,
-        300
-    )]
-    #[case::realloc_shrink_keeps_peak(
-        &[Op::Alloc(300), Op::Realloc { old: 300, new: 100 }],
-        100,
-        300
-    )]
-    fn counter_arithmetic(#[case] ops: &[Op], #[case] current: u64, #[case] peak: u64) {
-        let c = Counters::new();
-        let mut cleared_peak = None;
-        for op in ops {
-            match *op {
-                Op::Alloc(n) => c.record_alloc(n),
-                Op::Dealloc(n) => c.record_dealloc(n),
-                Op::Realloc { old, new } => c.record_realloc(old, new),
-                Op::TakePeak => cleared_peak = Some(c.take_peak()),
-            }
-        }
-        assert_eq!((c.current_bytes(), c.peak_bytes()), (current, peak));
-        if let Some(cleared) = cleared_peak {
-            // TakePeak after Alloc(1024)+Dealloc(512) cleared peak 1024.
-            assert_eq!(cleared, 1024);
-        }
+    #[cfg(not(feature = "alloc-tracking"))]
+    {
+        0
     }
+}
+
+#[cfg(all(test, not(feature = "alloc-tracking")))]
+mod disabled_tests {
+    use super::{
+        alloc_tracking_enabled, current_native_bytes, peak_native_bytes, reset_peak_native_bytes,
+    };
 
     #[test]
-    fn take_peak_repairs_peak_ge_current_after_store() {
-        // Simulate the concurrent-alloc race: after swap sets peak to a stale current, a
-        // later fetch_max must restore peak >= current.
-        let c = Counters::new();
-        c.record_alloc(100);
-        let previous = c.take_peak();
-        assert_eq!(previous, 100);
-        assert!(c.peak_bytes() >= c.current_bytes());
-        c.record_alloc(50);
-        assert!(c.peak_bytes() >= c.current_bytes());
-        assert_eq!(c.current_bytes(), 150);
-        assert_eq!(c.peak_bytes(), 150);
+    fn getters_report_disabled_tracking() {
+        assert!(!alloc_tracking_enabled());
+        assert_eq!(peak_native_bytes(), 0);
+        assert_eq!(current_native_bytes(), 0);
+        assert_eq!(reset_peak_native_bytes(), 0);
     }
 }
 
@@ -246,7 +102,7 @@ mod global_allocator_tests {
     #[test]
     fn installed_global_allocator_accounts_a_large_allocation() {
         assert!(alloc_tracking_enabled());
-        let _cleared = reset_peak_native_bytes();
+        let _ = reset_peak_native_bytes();
         let before = current_native_bytes();
 
         let buf = vec![0u8; N];
@@ -258,8 +114,8 @@ mod global_allocator_tests {
         assert!(peak_native_bytes() >= during);
 
         drop(buf);
-        // Real peak now exceeds real current, which also pins each getter to the right
-        // counter: swapping them inverts this.
-        assert!(peak_native_bytes() > current_native_bytes());
+        let previous_peak = reset_peak_native_bytes();
+        assert!(previous_peak >= during);
+        assert!(peak_native_bytes() >= current_native_bytes());
     }
 }

--- a/ffi/src/alloc_stats.rs
+++ b/ffi/src/alloc_stats.rs
@@ -1,0 +1,265 @@
+//! Process-wide accounting of the kernel's Rust-allocated native heap via
+//! [`TrackingAlloc`] (installed as `#[global_allocator]` under `alloc-tracking`).
+//!
+//! # Scope
+//!
+//! Counters record requested [`Layout::size`] only, so they are a lower bound on
+//! process RSS (C/`mmap` allocations and allocator overhead are outside the path).
+//! Process-global: shared across concurrent work; [`peak_native_bytes`] is a
+//! process-wide high-water mark since the library was loaded (or the last
+//! [`reset_peak_native_bytes`]), not a per-operation figure. Updates use `Relaxed`
+//! ordering -- advisory stats: two atomic RMWs per allocation (`fetch_add` +
+//! `fetch_max`) and one per deallocation.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Live-bytes and peak-bytes counters. Split out from [`TrackingAlloc`] so the arithmetic can be
+/// unit-tested against a local instance without touching the process-global allocator state.
+struct Counters {
+    current: AtomicU64,
+    peak: AtomicU64,
+}
+
+impl Counters {
+    const fn new() -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            peak: AtomicU64::new(0),
+        }
+    }
+
+    #[inline]
+    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
+    fn record_alloc(&self, n: usize) {
+        let new_current = self.current.fetch_add(n as u64, Ordering::Relaxed) + n as u64;
+        self.peak.fetch_max(new_current, Ordering::Relaxed);
+    }
+
+    /// Leave `peak` unchanged on dealloc.
+    #[inline]
+    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
+    fn record_dealloc(&self, n: usize) {
+        self.current.fetch_sub(n as u64, Ordering::Relaxed);
+    }
+
+    /// Record a successful resize from `old` to `new` bytes as a single net update.
+    #[inline]
+    #[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
+    fn record_realloc(&self, old: usize, new: usize) {
+        match new.checked_sub(old) {
+            Some(growth) => self.record_alloc(growth),
+            None => self.record_dealloc(old - new),
+        }
+    }
+
+    fn peak_bytes(&self) -> u64 {
+        self.peak.load(Ordering::Relaxed)
+    }
+
+    fn current_bytes(&self) -> u64 {
+        self.current.load(Ordering::Relaxed)
+    }
+
+    /// Set peak to current live bytes, returning the peak that was cleared.
+    ///
+    /// After `store`/`swap`, a concurrent alloc can leave `peak < current`; `fetch_max`
+    /// repairs that invariant.
+    fn take_peak(&self) -> u64 {
+        let current = self.current.load(Ordering::Relaxed);
+        let previous = self.peak.swap(current, Ordering::Relaxed);
+        self.peak
+            .fetch_max(self.current.load(Ordering::Relaxed), Ordering::Relaxed);
+        previous
+    }
+}
+
+static COUNTERS: Counters = Counters::new();
+
+/// A [`GlobalAlloc`] that forwards every request to the [`System`] allocator while maintaining the
+/// process-global [`COUNTERS`].
+///
+/// Constructed only via `#[global_allocator]` when `alloc-tracking` is enabled.
+#[cfg_attr(not(feature = "alloc-tracking"), allow(dead_code))]
+struct TrackingAlloc;
+
+#[cfg(feature = "alloc-tracking")]
+#[global_allocator]
+static GLOBAL_ALLOC: TrackingAlloc = TrackingAlloc;
+
+// SAFETY: every method forwards to the corresponding `System` method with the exact same
+// arguments, so the allocator contract is upheld. The counter updates only read/write atomics and
+// never touch the returned memory, so they cannot violate allocation safety. Counters are adjusted
+// only when `System` reports success (non-null pointer) to keep `current` in step with live bytes.
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            COUNTERS.record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            COUNTERS.record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        COUNTERS.record_dealloc(layout.size());
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        // On failure `System.realloc` leaves the original allocation intact, so live bytes are
+        // unchanged. On success the block moves from `layout.size()` to `new_size` bytes.
+        if !new_ptr.is_null() {
+            COUNTERS.record_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+/// Whether this library was built with allocation tracking. The `*_native_bytes` getters return
+/// zeros when false.
+#[no_mangle]
+pub extern "C" fn alloc_tracking_enabled() -> bool {
+    cfg!(feature = "alloc-tracking")
+}
+
+/// Peak native bytes ever simultaneously live since the library was loaded or the last
+/// [`reset_peak_native_bytes`].
+///
+/// Process-wide (not per-operation). Counts Rust [`Layout::size`] only (excludes C/`mmap`
+/// allocations and allocator overhead). Returns 0 if built without `alloc-tracking`.
+#[no_mangle]
+pub extern "C" fn peak_native_bytes() -> u64 {
+    COUNTERS.peak_bytes()
+}
+
+/// Native bytes currently live (allocated but not yet freed).
+///
+/// Process-wide. Counts Rust [`Layout::size`] only. Returns 0 if built without `alloc-tracking`.
+#[no_mangle]
+pub extern "C" fn current_native_bytes() -> u64 {
+    COUNTERS.current_bytes()
+}
+
+/// Set peak to the current live total and return the peak that was cleared.
+///
+/// Process-global: not safe as a per-task baseline under concurrency. Callers that need a
+/// single-tenant measurement must serialize resets against the work they measure. Returns 0 if
+/// built without `alloc-tracking`.
+#[no_mangle]
+pub extern "C" fn reset_peak_native_bytes() -> u64 {
+    COUNTERS.take_peak()
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::Counters;
+
+    #[derive(Clone, Copy)]
+    enum Op {
+        Alloc(usize),
+        Dealloc(usize),
+        Realloc { old: usize, new: usize },
+        TakePeak,
+    }
+
+    #[rstest]
+    #[case::alloc_raises_current_and_peak(&[Op::Alloc(4096)], 4096, 4096)]
+    #[case::dealloc_lowers_current_but_not_peak(
+        &[Op::Alloc(8192), Op::Dealloc(8192)],
+        0,
+        8192
+    )]
+    #[case::peak_tracks_max_not_last(
+        &[Op::Alloc(1000), Op::Alloc(500), Op::Dealloc(500), Op::Alloc(200)],
+        1200,
+        1500
+    )]
+    #[case::take_peak_returns_cleared_and_drops_to_current(
+        &[Op::Alloc(1024), Op::Dealloc(512), Op::TakePeak],
+        512,
+        512
+    )]
+    #[case::realloc_growth_raises_peak(
+        &[Op::Alloc(100), Op::Realloc { old: 100, new: 300 }],
+        300,
+        300
+    )]
+    #[case::realloc_shrink_keeps_peak(
+        &[Op::Alloc(300), Op::Realloc { old: 300, new: 100 }],
+        100,
+        300
+    )]
+    fn counter_arithmetic(#[case] ops: &[Op], #[case] current: u64, #[case] peak: u64) {
+        let c = Counters::new();
+        let mut cleared_peak = None;
+        for op in ops {
+            match *op {
+                Op::Alloc(n) => c.record_alloc(n),
+                Op::Dealloc(n) => c.record_dealloc(n),
+                Op::Realloc { old, new } => c.record_realloc(old, new),
+                Op::TakePeak => cleared_peak = Some(c.take_peak()),
+            }
+        }
+        assert_eq!((c.current_bytes(), c.peak_bytes()), (current, peak));
+        if let Some(cleared) = cleared_peak {
+            // TakePeak after Alloc(1024)+Dealloc(512) cleared peak 1024.
+            assert_eq!(cleared, 1024);
+        }
+    }
+
+    #[test]
+    fn take_peak_repairs_peak_ge_current_after_store() {
+        // Simulate the concurrent-alloc race: after swap sets peak to a stale current, a
+        // later fetch_max must restore peak >= current.
+        let c = Counters::new();
+        c.record_alloc(100);
+        let previous = c.take_peak();
+        assert_eq!(previous, 100);
+        assert!(c.peak_bytes() >= c.current_bytes());
+        c.record_alloc(50);
+        assert!(c.peak_bytes() >= c.current_bytes());
+        assert_eq!(c.current_bytes(), 150);
+        assert_eq!(c.peak_bytes(), 150);
+    }
+}
+
+#[cfg(all(test, feature = "alloc-tracking"))]
+mod global_allocator_tests {
+    use super::{
+        alloc_tracking_enabled, current_native_bytes, peak_native_bytes, reset_peak_native_bytes,
+    };
+
+    // Far above incidental harness allocation, so the bounds below cannot be met by noise.
+    const N: usize = 8 * 1024 * 1024;
+
+    #[test]
+    fn installed_global_allocator_accounts_a_large_allocation() {
+        assert!(alloc_tracking_enabled());
+        let _cleared = reset_peak_native_bytes();
+        let before = current_native_bytes();
+
+        let buf = vec![0u8; N];
+        let during = current_native_bytes();
+        assert!(
+            during >= before + N as u64,
+            "alloc not tracked: {before} -> {during}"
+        );
+        assert!(peak_native_bytes() >= during);
+
+        drop(buf);
+        // Real peak now exceeds real current, which also pins each getter to the right
+        // counter: swapping them inverts this.
+        assert!(peak_native_bytes() > current_native_bytes());
+    }
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -47,6 +47,8 @@ use handle::Handle;
 // relies on `crate::`
 extern crate self as delta_kernel_ffi;
 
+mod alloc_stats;
+
 pub mod commit_range;
 mod domain_metadata;
 pub use domain_metadata::get_domain_metadata;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add an `alloc-tracking` feature that installs a `#[global_allocator]` shim
over the System allocator, maintaining process-wide live-bytes and peak-bytes
counters for the kernel's Rust-allocated native heap. Expose C ABI getters
(`alloc_tracking_enabled`, `peak_native_bytes`, `current_native_bytes`,
`reset_peak_native_bytes`) so a foreign caller can read the high-water mark.

The counters and getters compile unconditionally (returning 0 / false when
the feature is off) so the exported C ABI is stable across build flags; only
the global allocator install is gated. Scope is process-global: the FFI
library is loaded once per process, so peak is a process-wide high-water
mark, not per-operation.

Co-authored-by: Isaac

## How was this change tested?
