### PR TITLE
fix: dv update respect shorten selection vector

### DIFF
--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -297,26 +297,13 @@ impl Transaction {
             visitor.new_entries.clear();
             visitor.matched_file_indexes.clear();
             visitor.visit_rows_of(&scan_file)?;
-            let (data, mut selection_vector) = scan_file.into_parts();
+            let (data, _) = scan_file.into_parts();
 
             // Update selection vector to keep only files that matched DV descriptors.
             // This ensures we only generate remove/add actions for files being updated.
-            let mut current_matched_index = 0;
-            for (i, selected) in selection_vector.iter_mut().enumerate() {
-                if current_matched_index < visitor.matched_file_indexes.len() {
-                    if visitor.matched_file_indexes[current_matched_index] != i {
-                        *selected = false;
-                    } else {
-                        // `matched_file_indexes` is populated from a FilteredRowVisitor, so every
-                        // matched row was selected in the original scan metadata.
-                        current_matched_index += 1;
-                        matched_dv_files += 1;
-                    }
-                } else {
-                    // Deselect any files after the last matched file
-                    *selected = false;
-                }
-            }
+            let selection_vector =
+                selection_vector_for_matches(data.len(), &visitor.matched_file_indexes);
+            matched_dv_files += visitor.matched_file_indexes.len();
 
             // Append two temporary columns to the scan data: the new DV descriptor and the
             // rewritten stats (with `tightBounds: false`).
@@ -363,6 +350,20 @@ impl Transaction {
         }
         Ok(())
     }
+}
+
+fn selection_vector_for_matches(num_rows: usize, matched_file_indexes: &[usize]) -> Vec<bool> {
+    let mut next_match = 0;
+    (0..num_rows)
+        .map(|row_index| {
+            if matched_file_indexes.get(next_match) == Some(&row_index) {
+                next_match += 1;
+                true
+            } else {
+                false
+            }
+        })
+        .collect()
 }
 
 // =============================================================================

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::actions::{NUM_RECORDS, TIGHT_BOUNDS};
 use delta_kernel::arrow::array::{Int32Array, RecordBatch};
+use delta_kernel::arrow::compute::concat_batches;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -23,7 +24,7 @@ use serde_json::Deserializer;
 use tempfile::tempdir;
 use test_utils::{
     assert_result_error_with_message, begin_transaction, copy_directory, create_default_engine,
-    create_default_engine_mt_executor, insert_data, load_and_begin_transaction,
+    create_default_engine_mt_executor, insert_data, into_record_batch, load_and_begin_transaction,
     read_actions_from_commit, setup_test_tables, test_table_setup,
 };
 use url::Url;
@@ -762,8 +763,13 @@ async fn test_update_deletion_vectors_with_selection_vector(
     // the test will fail.
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut setup_txn = begin_transaction(snapshot.clone(), engine.as_ref())?;
+    let initial_dvs = sequential_dv_descriptors(&file_paths);
+    let initial_dv_ids: HashMap<_, _> = initial_dvs
+        .iter()
+        .map(|(path, dv)| (path.clone(), dv.unique_id()))
+        .collect();
     setup_txn.update_deletion_vectors(
-        sequential_dv_descriptors(&file_paths),
+        initial_dvs,
         get_scan_files(snapshot, engine.as_ref())?
             .into_iter()
             .map(Ok),
@@ -795,16 +801,20 @@ async fn test_update_deletion_vectors_with_selection_vector(
             )
         })
         .collect();
+    let updated_dv_ids: HashMap<_, _> = dv_map
+        .iter()
+        .map(|(path, dv)| (path.clone(), dv.unique_id()))
+        .collect();
 
-    let mut scan_data: Vec<_> = get_scan_files(snapshot, engine.as_ref())?
+    let batches = get_scan_files(snapshot, engine.as_ref())?
         .into_iter()
-        .map(FilteredEngineData::apply_selection_vector)
+        .map(|scan_files| scan_files.apply_selection_vector().map(into_record_batch))
         .collect::<Result<Vec<_>, _>>()?;
-    scan_data.retain(|data| data.len() > 0);
-    assert_eq!(scan_data.len(), 1, "expected one active scan batch");
-    let data = scan_data.pop().unwrap();
-    assert_eq!(data.len(), file_paths.len());
-    let scan_files = FilteredEngineData::try_new(data, selection_vector.to_vec())?;
+    let batch = concat_batches(&batches[0].schema(), &batches)?;
+    let scan_files = FilteredEngineData::try_new(
+        Box::new(ArrowEngineData::new(batch)),
+        selection_vector.to_vec(),
+    )?;
 
     let update_result = txn.update_deletion_vectors(dv_map, std::iter::once(Ok(scan_files)));
     if expect_mismatch {
@@ -818,6 +828,7 @@ async fn test_update_deletion_vectors_with_selection_vector(
     let committed = txn.commit(engine.as_ref())?.unwrap_committed();
     let version = committed.commit_version();
 
+    // Read the commit directly from the (in-memory) store.
     let commit_path = table_url.join(&format!("_delta_log/{version:020}.json"))?;
     let commit_content = store
         .get(&Path::from_url_path(commit_path.path())?)
@@ -859,6 +870,24 @@ async fn test_update_deletion_vectors_with_selection_vector(
         removed_paths, expected,
         "removed paths must be exactly the targeted files"
     );
+
+    let dv_id = |action: &serde_json::Value| {
+        let dv = &action["deletionVector"];
+        format!(
+            "{}{}@{}",
+            dv["storageType"].as_str().unwrap(),
+            dv["pathOrInlineDv"].as_str().unwrap(),
+            dv["offset"].as_i64().unwrap()
+        )
+    };
+    for add in &adds {
+        let path = add["path"].as_str().unwrap();
+        assert_eq!(dv_id(add), updated_dv_ids[path]);
+    }
+    for remove in &removes {
+        let path = remove["path"].as_str().unwrap();
+        assert_eq!(dv_id(remove), initial_dv_ids[path]);
+    }
 
     // Each new add carries its DV and widened tightBounds, with numRecords preserved.
     for add in &adds {

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -740,7 +740,7 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
 #[case::no_updates_short_selection_vector(&[true, true], &[], false)]
 #[case::no_updates_empty_selection_vector(&[], &[], false)]
 #[tokio::test]
-async fn test_update_deletion_vectors_with_selection_vector(
+async fn test_update_deletion_vectors_respects_selection_vector(
     #[case] selection_vector: &[bool],
     #[case] target_indexes: &[usize],
     #[case] expect_mismatch: bool,

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -729,10 +729,20 @@ async fn test_update_deletion_vectors_multiple_files() -> Result<(), Box<dyn std
     Ok(())
 }
 
-/// A DV update over a batch where only some files are targeted: only the matched files get
-/// remove/add pairs.
+#[rstest::rstest]
+#[case::target_in_explicit_prefix(&[true, true], &[0], false)]
+#[case::target_in_implicit_tail(&[true, true], &[3], false)]
+#[case::multiple_targets(&[true, true], &[0, 3], false)]
+#[case::empty_selection_vector(&[], &[3], false)]
+#[case::unselected_rows_are_ignored(&[true, false, true, false], &[2], false)]
+#[case::unselected_target_is_rejected(&[true, false, true, false], &[2, 3], true)]
+#[case::no_updates_short_selection_vector(&[true, true], &[], false)]
+#[case::no_updates_empty_selection_vector(&[], &[], false)]
 #[tokio::test]
-async fn test_update_deletion_vectors_updates_only_matched_files(
+async fn test_update_deletion_vectors_with_selection_vector(
+    #[case] selection_vector: &[bool],
+    #[case] target_indexes: &[usize],
+    #[case] expect_mismatch: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = Arc::new(StructType::try_new(vec![
         StructField::nullable("id", DataType::INTEGER),
@@ -748,8 +758,22 @@ async fn test_update_deletion_vectors_updates_only_matched_files(
     let (store, engine, table_url, file_paths) =
         create_dv_table_with_files("test_table", schema, file_names).await?;
 
-    // Target only files 1 and 3 for a DV update; files 0 and 2 must be left untouched.
-    let targeted = [file_paths[1].clone(), file_paths[3].clone()];
+    // Attach DV to all files first, if later DV updates incorrectly remove the existing DV,
+    // the test will fail.
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
+    let mut setup_txn = begin_transaction(snapshot.clone(), engine.as_ref())?;
+    setup_txn.update_deletion_vectors(
+        sequential_dv_descriptors(&file_paths),
+        get_scan_files(snapshot, engine.as_ref())?
+            .into_iter()
+            .map(Ok),
+    )?;
+    setup_txn.commit(engine.as_ref())?.unwrap_committed();
+
+    let targeted: Vec<String> = target_indexes
+        .iter()
+        .map(|&index| file_paths[index].clone())
+        .collect();
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?
         .with_engine_info("test engine")
@@ -772,12 +796,28 @@ async fn test_update_deletion_vectors_updates_only_matched_files(
         })
         .collect();
 
-    let scan_files = get_scan_files(snapshot, engine.as_ref())?;
-    txn.update_deletion_vectors(dv_map, scan_files.into_iter().map(Ok))?;
+    let mut scan_data: Vec<_> = get_scan_files(snapshot, engine.as_ref())?
+        .into_iter()
+        .map(FilteredEngineData::apply_selection_vector)
+        .collect::<Result<Vec<_>, _>>()?;
+    scan_data.retain(|data| data.len() > 0);
+    assert_eq!(scan_data.len(), 1, "expected one active scan batch");
+    let data = scan_data.pop().unwrap();
+    assert_eq!(data.len(), file_paths.len());
+    let scan_files = FilteredEngineData::try_new(data, selection_vector.to_vec())?;
+
+    let update_result = txn.update_deletion_vectors(dv_map, std::iter::once(Ok(scan_files)));
+    if expect_mismatch {
+        assert_result_error_with_message(
+            update_result,
+            "Number of matched DV files does not match number of new DV descriptors",
+        );
+    } else {
+        update_result?;
+    }
     let committed = txn.commit(engine.as_ref())?.unwrap_committed();
     let version = committed.commit_version();
 
-    // Read the commit directly from the (in-memory) store.
     let commit_path = table_url.join(&format!("_delta_log/{version:020}.json"))?;
     let commit_content = store
         .get(&Path::from_url_path(commit_path.path())?)
@@ -790,21 +830,34 @@ async fn test_update_deletion_vectors_updates_only_matched_files(
     let adds: Vec<&serde_json::Value> = actions.iter().filter_map(|a| a.get("add")).collect();
     let removes: Vec<&serde_json::Value> = actions.iter().filter_map(|a| a.get("remove")).collect();
 
-    // Only the two targeted files produce remove/add pairs.
-    assert_eq!(adds.len(), 2, "only the targeted files should be re-added");
-    assert_eq!(
-        removes.len(),
-        2,
-        "only the targeted files should be removed"
-    );
+    let expected_count = if expect_mismatch {
+        0
+    } else {
+        target_indexes.len()
+    };
+    assert_eq!(adds.len(), expected_count, "unexpected re-added files");
+    assert_eq!(removes.len(), expected_count, "unexpected removed files");
 
     let mut added_paths: Vec<&str> = adds.iter().map(|a| a["path"].as_str().unwrap()).collect();
     added_paths.sort();
-    let mut expected: Vec<&str> = targeted.iter().map(String::as_str).collect();
+    let mut removed_paths: Vec<&str> = removes
+        .iter()
+        .map(|a| a["path"].as_str().unwrap())
+        .collect();
+    removed_paths.sort();
+    let mut expected: Vec<&str> = if expect_mismatch {
+        Vec::new()
+    } else {
+        targeted.iter().map(String::as_str).collect()
+    };
     expected.sort();
     assert_eq!(
         added_paths, expected,
         "re-added paths must be exactly the targeted files"
+    );
+    assert_eq!(
+        removed_paths, expected,
+        "removed paths must be exactly the targeted files"
     );
 
     // Each new add carries its DV and widened tightBounds, with numRecords preserved.


### PR DESCRIPTION
## What changes are proposed in this pull request?
In the past, DV update doesn't fully consider shorten selection vectors. This PR fixes the problem.

Detail example in https://github.com/delta-io/delta-kernel-rs/issues/3043
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?

Test DV update over different selection vectors