### PR TITLE
feat: add coroutine-backed declarative scan plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -678,7 +678,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -870,7 +870,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -1024,7 +1024,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1337,6 +1337,7 @@ dependencies = [
  "delta_kernel",
  "delta_kernel_derive",
  "futures",
+ "genawaiter2",
  "hdfs-native",
  "hdfs-native-object-store",
  "indexmap",
@@ -1437,7 +1438,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rstest",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1476,7 +1477,7 @@ version = "0.26.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1547,7 +1548,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1797,7 +1798,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1844,7 +1845,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1862,6 +1863,34 @@ name = "g2poly"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
+name = "genawaiter2"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a954504d991886b6891c97b37ca1bf87ad2174c2126d52cdb52bebea7b1c89e3"
+dependencies = [
+ "genawaiter2-macro",
+ "genawaiter2-proc-macro",
+]
+
+[[package]]
+name = "genawaiter2-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5cc2b187655aae60ff27f3978ffd192b9252c1a5905f53d3340e5836d8a539b"
+
+[[package]]
+name = "genawaiter2-proc-macro"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91467b1ef9d0b102db5ebf041238f26879f49ac323459e16725991ef73e61d2d"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "generic-array"
@@ -2447,7 +2476,7 @@ checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2926,7 +2955,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3197,7 +3226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3207,6 +3236,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
+ "version_check",
 ]
 
 [[package]]
@@ -3254,7 +3309,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3268,7 +3323,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3281,7 +3336,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3622,7 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3823,7 +3878,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -3835,7 +3890,7 @@ checksum = "b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14"
 dependencies = [
  "quote",
  "rand 0.8.5",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4052,7 +4107,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4237,7 +4292,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4249,7 +4304,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4260,6 +4315,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4267,6 +4333,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4286,7 +4363,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4367,7 +4444,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4378,7 +4455,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "test-case-core",
 ]
 
@@ -4400,7 +4477,7 @@ checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4449,7 +4526,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4460,7 +4537,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4558,7 +4635,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4734,7 +4811,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5056,7 +5133,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -5195,7 +5272,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5206,7 +5283,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5543,7 +5620,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5559,7 +5636,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5653,7 +5730,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5680,7 +5757,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5700,7 +5777,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5740,7 +5817,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -43,6 +43,7 @@ delta_kernel_derive = { path = "../derive-macros", version = "0.26.0" }
 bytes = "1.10"
 chrono = "0.4.41"
 crc = "3.2.2"
+genawaiter2 = { version = "0.100", optional = true }
 indexmap = "2.10.0"
 itertools = "0.14"
 percent-encoding = "2"
@@ -115,7 +116,13 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
+declarative-plans = [
+  "internal-api",
+  "dep:genawaiter2",
+  "dep:prost",
+  "dep:prost-build",
+  "dep:protoc-bin-vendored",
+]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress check-constraints
 # work: the SQL predicate parser and, later, `checkConstraints` write enforcement. Remove once

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -13,6 +13,7 @@ use crate::actions::SIDECAR_NAME;
 use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
+use crate::plans::state_machines::CoroutineEngine;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::snapshot::Snapshot;
@@ -40,6 +41,135 @@ pub(crate) struct CheckpointShape {
 }
 
 impl CheckpointShape {
+    /// Resolve a checkpoint shape by yielding each required operation to a state-machine driver.
+    pub(crate) async fn try_new_state_machine(
+        engine: &mut CoroutineEngine,
+        segment: &LogSegment,
+        stats_schema: Option<&SchemaRef>,
+    ) -> DeltaResult<CheckpointShape> {
+        let (root_checkpoint, file_type) = match segment.listed.checkpoint_parts.first() {
+            Some(checkpoint) if checkpoint.is_json() => (&checkpoint.location, FileType::Json),
+            Some(checkpoint) => (&checkpoint.location, FileType::Parquet),
+            None => {
+                return Ok(CheckpointShape {
+                    checkpoint_type: CheckpointType::None,
+                    parsed_stats_schema: None,
+                })
+            }
+        };
+
+        if let Some(shape) = Self::from_v2_checkpoint_hint_state_machine(
+            engine,
+            segment,
+            root_checkpoint,
+            file_type,
+            stats_schema,
+        )
+        .await?
+        {
+            return Ok(shape);
+        }
+
+        match file_type {
+            FileType::Parquet => {
+                let cp_schema = match segment.checkpoint_hint_schema() {
+                    Some(schema) => schema,
+                    None => {
+                        read_footer_schema(engine, root_checkpoint.clone(), "checkpoint_schema")
+                            .await?
+                    }
+                };
+                if !cp_schema.contains(SIDECAR_NAME) {
+                    return Ok(Self::try_new_leaf(Some(cp_schema), stats_schema));
+                }
+                match collect_single_sidecar_state_machine(
+                    engine,
+                    root_checkpoint,
+                    file_type,
+                    &segment.log_root,
+                )
+                .await?
+                {
+                    Some(sidecar) => {
+                        Self::try_new_manifest_state_machine(engine, sidecar, stats_schema).await
+                    }
+                    None => Ok(Self::try_new_leaf(Some(cp_schema), stats_schema)),
+                }
+            }
+            FileType::Json => match collect_single_sidecar_state_machine(
+                engine,
+                root_checkpoint,
+                file_type,
+                &segment.log_root,
+            )
+            .await?
+            {
+                Some(sidecar) => {
+                    Self::try_new_manifest_state_machine(engine, sidecar, stats_schema).await
+                }
+                None => Ok(Self::try_new_leaf(None, stats_schema)),
+            },
+        }
+    }
+
+    async fn from_v2_checkpoint_hint_state_machine(
+        engine: &mut CoroutineEngine,
+        segment: &LogSegment,
+        root_checkpoint: &FileMeta,
+        file_type: FileType,
+        stats_schema: Option<&SchemaRef>,
+    ) -> DeltaResult<Option<CheckpointShape>> {
+        match segment.checkpoint_hint_sidecars().map(Vec::as_slice) {
+            Some([sidecar, ..]) => {
+                let sidecar_meta = sidecar.to_filemeta(&segment.log_root)?;
+                let result =
+                    Self::try_new_manifest_state_machine(engine, sidecar_meta, stats_schema)
+                        .await?;
+                Ok(Some(result))
+            }
+            Some([]) => {
+                let leaf_schema = match file_type {
+                    FileType::Parquet if stats_schema.is_some() => {
+                        Some(match segment.checkpoint_hint_schema() {
+                            Some(schema) => schema,
+                            None => {
+                                read_footer_schema(
+                                    engine,
+                                    root_checkpoint.clone(),
+                                    "checkpoint_stats_schema",
+                                )
+                                .await?
+                            }
+                        })
+                    }
+                    _ => None,
+                };
+                Ok(Some(Self::try_new_leaf(leaf_schema, stats_schema)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn try_new_manifest_state_machine(
+        engine: &mut CoroutineEngine,
+        sidecar: FileMeta,
+        stats_schema: Option<&SchemaRef>,
+    ) -> DeltaResult<CheckpointShape> {
+        let parsed_stats_schema = match stats_schema {
+            Some(stats_schema) => {
+                let footer_schema =
+                    read_footer_schema(engine, sidecar, "sidecar_stats_schema").await?;
+                LogSegment::schema_has_compatible_stats_parsed(footer_schema.as_ref(), stats_schema)
+                    .then(|| stats_schema.clone())
+            }
+            None => None,
+        };
+        Ok(CheckpointShape {
+            checkpoint_type: CheckpointType::Manifest,
+            parsed_stats_schema,
+        })
+    }
+
     /// Resolve `snapshot`'s checkpoint shape. Determines the checkpoint type and, when
     /// `stats_schema` is `Some`, whether the checkpoint contains parsed stats compatible with it.
     pub(crate) fn try_new(
@@ -171,6 +301,51 @@ impl CheckpointShape {
             checkpoint_type: CheckpointType::Leaf,
             parsed_stats_schema: parsed_stats_schema.cloned(),
         }
+    }
+}
+
+async fn read_footer_schema(
+    engine: &mut CoroutineEngine,
+    file: FileMeta,
+    step_name: &'static str,
+) -> DeltaResult<SchemaRef> {
+    engine
+        .execute(
+            Operation::IoOperation(crate::plans::IoOperation::parquet_footer(file)),
+            step_name,
+        )
+        .await?
+        .into_parquet_footer()
+        .map(|footer| footer.schema)
+}
+
+async fn collect_single_sidecar_state_machine(
+    engine: &mut CoroutineEngine,
+    file: &FileMeta,
+    file_format: FileType,
+    log_root: &Url,
+) -> DeltaResult<Option<FileMeta>> {
+    let read_schema = LogSegment::sidecar_read_schema();
+    let plan = match file_format {
+        FileType::Parquet => PlanBuilder::scan_parquet([file.clone()], &[], read_schema),
+        FileType::Json => PlanBuilder::scan_json([file.clone()], &[], read_schema),
+    }?
+    .build()?;
+    let data = engine
+        .execute(Operation::QueryPlan(plan), "inspect_checkpoint_sidecars")
+        .await?
+        .into_data()?;
+
+    let mut visitor = SidecarVisitor::default();
+    for batch in data {
+        visitor.visit_rows_of(batch?.as_ref())?;
+        if !visitor.sidecars.is_empty() {
+            break;
+        }
+    }
+    match visitor.sidecars.first() {
+        Some(sidecar) => Ok(Some(sidecar.to_filemeta(log_root)?)),
+        None => Ok(None),
     }
 }
 

--- a/kernel/src/plans/ir/operation.rs
+++ b/kernel/src/plans/ir/operation.rs
@@ -13,7 +13,7 @@ use crate::{FileMeta, FileSlice};
 /// [`PlanExecutor`](crate::plans::PlanExecutor) should perform.
 ///
 /// It can either be an IO operation or a declarative query.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Operation {
     /// A singular I/O operation that returns concretely typed data such as bytes or file metadata.
     IoOperation(IoOperation),
@@ -35,7 +35,7 @@ impl Operation {
 ///
 /// Each variant describes an operation and its parameters. The shape of the result it produces
 /// is documented on the variant in terms of [`PlanResult`](crate::plans::PlanResult).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum IoOperation {
     /// Recursively list files at the given URL.
     ///

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -47,11 +47,14 @@
 //!   payload struct carries its semantics, invariants, and worked examples.
 //! - [`crate::expressions`] defines the expressions and predicates operators evaluate, including
 //!   the type and null semantics an executor must match.
+//! - [`state_machines`] defines resumable workflows for connectors that execute plans one request
+//!   at a time rather than implementing [`PlanExecutor`] directly.
 //!
 //! This module is opt-in behind the `declarative-plans` feature flag.
 mod builder;
 pub mod ir;
 pub mod proto;
+pub mod state_machines;
 
 pub use builder::PlanBuilder;
 use bytes::Bytes;

--- a/kernel/src/plans/state_machines/coroutine.rs
+++ b/kernel/src/plans/state_machines/coroutine.rs
@@ -1,0 +1,227 @@
+//! Coroutine-backed implementation of the state-machine protocol.
+//!
+//! The coroutine is a CPU-only sequencer. It never performs connector I/O itself: each
+//! [`CoroutineEngine::execute`] call yields an operation to the external driver and resumes with
+//! that operation's result. The `rc` generator flavor intentionally makes the machine `!Send`;
+//! callers must drive one machine from one thread at a time.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::{fmt, mem};
+
+use genawaiter2::rc::{Co, Gen};
+use genawaiter2::GeneratorState;
+use uuid::Uuid;
+
+use super::{EngineRequest, EngineResponse, NextStep, StateMachine};
+use crate::plans::{Operation, PlanResult};
+use crate::{DeltaResult, Error};
+
+struct StepYield {
+    request: EngineRequest,
+    step_name: &'static str,
+}
+
+struct StepResume(Option<Result<EngineResponse, Error>>);
+
+impl fmt::Debug for StepResume {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Some(Ok(response)) => f.debug_tuple("StepResume").field(response).finish(),
+            Some(Err(error)) => f.debug_tuple("StepResume").field(error).finish(),
+            None => f.write_str("StepResume(Prime)"),
+        }
+    }
+}
+
+type YieldChannel = Co<StepYield, StepResume>;
+type InnerGen<R> = Gen<StepYield, StepResume, Pin<Box<dyn Future<Output = DeltaResult<R>>>>>;
+
+/// Handle used by coroutine bodies to request connector work.
+pub(crate) struct CoroutineEngine {
+    channel: YieldChannel,
+}
+
+impl CoroutineEngine {
+    /// Yield `operation` to the driver and resume with its plan result.
+    pub(crate) async fn execute(
+        &mut self,
+        operation: Operation,
+        step_name: &'static str,
+    ) -> DeltaResult<PlanResult> {
+        let response = self
+            .channel
+            .yield_(StepYield {
+                request: EngineRequest::Execute(operation),
+                step_name,
+            })
+            .await
+            .0
+            .ok_or_else(|| Error::internal_error("missing state-machine engine response"))??;
+        let EngineResponse::Plan(result) = response;
+        Ok(result)
+    }
+}
+
+/// A state machine implemented as stackless coroutine control flow.
+#[must_use = "a state machine must be driven to completion"]
+pub struct CoroutineSM<R: 'static> {
+    generator: InnerGen<R>,
+    position: Position<R>,
+    id: Uuid,
+    kind: &'static str,
+}
+
+enum Position<R> {
+    Yielded(StepYield),
+    ResultReady(DeltaResult<R>),
+    Done,
+}
+
+impl<R: 'static> CoroutineSM<R> {
+    /// Construct and prime a coroutine workflow.
+    pub(crate) fn new<F, Fut>(kind: &'static str, producer: F) -> DeltaResult<Self>
+    where
+        F: FnOnce(CoroutineEngine, Uuid) -> Fut + 'static,
+        Fut: Future<Output = DeltaResult<R>> + 'static,
+    {
+        let id = Uuid::new_v4();
+        let mut generator: InnerGen<R> = Gen::new(move |channel| {
+            Box::pin(producer(CoroutineEngine { channel }, id))
+                as Pin<Box<dyn Future<Output = DeltaResult<R>>>>
+        });
+        let position = match generator.resume_with(StepResume(None)) {
+            GeneratorState::Yielded(step) => Position::Yielded(step),
+            GeneratorState::Complete(result) => Position::ResultReady(result),
+        };
+        Ok(Self {
+            generator,
+            position,
+            id,
+            kind,
+        })
+    }
+
+    /// Whether the terminal result has been returned to the driver.
+    pub fn is_done(&self) -> bool {
+        matches!(self.position, Position::Done)
+    }
+
+    /// Identifier unique to this state-machine instance.
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// Static workflow kind used for diagnostics.
+    pub fn kind(&self) -> &'static str {
+        self.kind
+    }
+}
+
+impl<R: 'static> StateMachine for CoroutineSM<R> {
+    type Result = R;
+
+    fn get_step(&mut self) -> DeltaResult<NextStep<R>> {
+        match mem::replace(&mut self.position, Position::Done) {
+            Position::Yielded(step) => {
+                let request = step.request.clone();
+                self.position = Position::Yielded(step);
+                Ok(NextStep::Execute(request))
+            }
+            Position::ResultReady(result) => result.map(NextStep::Done),
+            Position::Done => Err(Error::internal_error("state machine already completed")),
+        }
+    }
+
+    fn submit(&mut self, result: Result<EngineResponse, Error>) -> DeltaResult<()> {
+        match mem::replace(&mut self.position, Position::Done) {
+            Position::ResultReady(result) => {
+                self.position = Position::ResultReady(result);
+                Err(Error::internal_error(
+                    "cannot submit when a state-machine result is ready",
+                ))
+            }
+            Position::Done => Err(Error::internal_error(
+                "cannot submit to a completed state machine",
+            )),
+            Position::Yielded(_) => match self.generator.resume_with(StepResume(Some(result))) {
+                GeneratorState::Yielded(step) => {
+                    self.position = Position::Yielded(step);
+                    Ok(())
+                }
+                GeneratorState::Complete(result) => {
+                    self.position = Position::ResultReady(result);
+                    Ok(())
+                }
+            },
+        }
+    }
+
+    fn step_name(&self) -> &'static str {
+        match &self.position {
+            Position::Yielded(step) => step.step_name,
+            Position::ResultReady(_) | Position::Done => "done",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+    use crate::plans::IoOperation;
+
+    fn request(path: &str) -> Operation {
+        Operation::IoOperation(IoOperation::file_listing(Url::parse(path).unwrap()))
+    }
+
+    #[test]
+    fn executes_two_steps_in_order() {
+        let mut sm = CoroutineSM::new("test", |mut engine, _| async move {
+            let _ = engine.execute(request("memory:///a"), "a").await?;
+            let _ = engine.execute(request("memory:///b"), "b").await?;
+            Ok(42)
+        })
+        .unwrap();
+
+        assert_eq!(sm.kind(), "test");
+        assert_eq!(sm.step_name(), "a");
+        assert!(matches!(sm.get_step(), Ok(NextStep::Execute(_))));
+        assert!(matches!(
+            sm.submit(Ok(EngineResponse::Plan(PlanResult::FileMeta(Box::new(
+                std::iter::empty()
+            ))))),
+            Ok(())
+        ));
+        assert_eq!(sm.step_name(), "b");
+        assert!(matches!(sm.get_step(), Ok(NextStep::Execute(_))));
+        assert!(matches!(
+            sm.submit(Ok(EngineResponse::Plan(PlanResult::FileMeta(Box::new(
+                std::iter::empty()
+            ))))),
+            Ok(())
+        ));
+        assert!(matches!(sm.get_step(), Ok(NextStep::Done(42))));
+        assert!(sm.is_done());
+    }
+
+    #[test]
+    fn returns_zero_yield_result_from_first_get_step() {
+        let mut sm = CoroutineSM::new("test", |_, _| async move { Ok(7) }).unwrap();
+        assert!(matches!(sm.get_step(), Ok(NextStep::Done(7))));
+    }
+
+    #[test]
+    fn propagates_executor_error_through_the_body() {
+        let mut sm = CoroutineSM::<()>::new("test", |mut engine, _| async move {
+            engine.execute(request("memory:///a"), "a").await?;
+            Ok(())
+        })
+        .unwrap();
+        let error = Error::generic("executor failed");
+        assert!(sm.submit(Err(error)).is_ok());
+        assert!(sm.get_step().is_err());
+        assert!(sm.is_done());
+    }
+}

--- a/kernel/src/plans/state_machines/mod.rs
+++ b/kernel/src/plans/state_machines/mod.rs
@@ -1,0 +1,11 @@
+//! Resumable kernel workflows driven by connector-owned plan executors.
+//!
+//! [`StateMachine`] defines the request/response protocol exposed to executors, while
+//! [`CoroutineSM`] lets kernel workflows express that protocol as ordinary async control flow.
+
+mod coroutine;
+mod state_machine;
+
+pub(crate) use coroutine::CoroutineEngine;
+pub use coroutine::CoroutineSM;
+pub use state_machine::{EngineRequest, EngineResponse, NextStep, StateMachine};

--- a/kernel/src/plans/state_machines/state_machine.rs
+++ b/kernel/src/plans/state_machines/state_machine.rs
@@ -1,0 +1,57 @@
+//! The executor-facing state-machine protocol.
+
+use crate::plans::{Operation, PlanResult};
+use crate::{DeltaResult, Error};
+
+/// Work requested by a kernel state machine.
+#[derive(Debug, Clone)]
+pub enum EngineRequest {
+    /// Execute a declarative operation and return its [`PlanResult`].
+    Execute(Operation),
+}
+
+/// Successful output returned by an executor for one request.
+pub enum EngineResponse {
+    /// Result of an [`EngineRequest::Execute`] request.
+    Plan(PlanResult),
+}
+
+impl std::fmt::Debug for EngineResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plan(_) => f.write_str("Plan(..)"),
+        }
+    }
+}
+
+/// Result of advancing a state machine with an executor response.
+#[derive(Debug)]
+pub enum NextStep<R> {
+    /// Execute this request and pass its outcome to [`StateMachine::submit`].
+    Execute(EngineRequest),
+    /// The machine completed with `R`.
+    Done(R),
+}
+
+/// A resumable kernel workflow driven one engine request at a time.
+///
+/// Drivers repeatedly call [`Self::get_step`]. For [`NextStep::Execute`], execute the request and
+/// pass its result to [`Self::submit`]; [`NextStep::Done`] contains the terminal value.
+pub trait StateMachine {
+    /// Value produced when the workflow completes.
+    type Result;
+
+    /// Return the next executor request or the workflow's terminal result.
+    fn get_step(&mut self) -> DeltaResult<NextStep<Self::Result>>;
+
+    /// Resume the workflow with the result of its current request.
+    ///
+    /// Engine failures are supplied as [`Error`] so the workflow can either handle them or
+    /// propagate them as its terminal error.
+    ///
+    /// Returns an error if no engine request is awaiting a response.
+    fn submit(&mut self, result: Result<EngineResponse, Error>) -> DeltaResult<()>;
+
+    /// Stable name of the request currently awaiting execution, or `"done"` after completion.
+    fn step_name(&self) -> &'static str;
+}

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -687,6 +687,7 @@ impl HasSelectionVector for ScanMetadata {
 
 /// The result of building a scan over a table. This can be used to get the actual data from
 /// scanning the table.
+#[derive(Clone)]
 pub struct Scan {
     snapshot: SnapshotRef,
     state_info: Arc<StateInfo>,
@@ -1100,6 +1101,42 @@ impl Scan {
             &self.stats,
             &self.partition_values,
             self.physical_stats_output_schema.as_ref(),
+        )
+    }
+
+    #[cfg(feature = "declarative-plans")]
+    /// Builds a resumable state machine that produces the scan's live-add declarative plan.
+    ///
+    /// Unlike [`Self::declarative_metadata_scan_plan`], this method does not require a
+    /// [`PlanExecutor`](crate::plans::PlanExecutor) up front. The returned machine yields each
+    /// checkpoint-inspection operation to the caller and completes with the metadata plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the state machine cannot be initialized. Plan construction and
+    /// executor failures are surfaced while the caller drives the machine.
+    pub fn build_metadata_scan(
+        &self,
+    ) -> DeltaResult<crate::plans::state_machines::CoroutineSM<Plan>> {
+        let scan = self.clone();
+        crate::plans::state_machines::CoroutineSM::new(
+            "scan_metadata",
+            move |mut engine, _id| async move {
+                let shape = CheckpointShape::try_new_state_machine(
+                    &mut engine,
+                    scan.snapshot.log_segment(),
+                    scan.state_info.physical_stats_schema.as_ref(),
+                )
+                .await?;
+                scan_plan::build_metadata_scan_plan_or_empty(
+                    &scan.state_info,
+                    scan.snapshot.log_segment(),
+                    &shape,
+                    &scan.stats,
+                    &scan.partition_values,
+                    scan.physical_stats_output_schema.as_ref(),
+                )
+            },
         )
     }
 

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -132,6 +132,43 @@ pub(crate) fn build_metadata_scan_plan(
     PlanBuilder::union_all([commit_live_adds, checkpoint_live_adds])?.build_opt()
 }
 
+/// Build an always-runnable live-add metadata plan.
+///
+/// Unlike [`build_metadata_scan_plan`], an empty result is represented by an empty `Values` node
+/// instead of `None`.
+pub(crate) fn build_metadata_scan_plan_or_empty(
+    state: &StateInfo,
+    log_segment: &LogSegment,
+    shape: &CheckpointShape,
+    stats: &StatsOptions,
+    partition_values: &PartitionValuesOptions,
+    physical_stats_output_schema: Option<&SchemaRef>,
+) -> DeltaResult<Plan> {
+    if let Some(plan) = build_metadata_scan_plan(
+        state,
+        log_segment,
+        shape,
+        stats,
+        partition_values,
+        physical_stats_output_schema,
+    )? {
+        return Ok(plan);
+    }
+
+    let add_field = add_field_with_parsed_stats_and_partitions(
+        state.physical_stats_schema.as_ref(),
+        state.physical_partition_schema.as_ref(),
+    )?;
+    let (_, output_schema) = metadata_output_projection(
+        &add_field,
+        stats,
+        partition_values,
+        state.physical_partition_schema.as_ref(),
+        physical_stats_output_schema,
+    )?;
+    PlanBuilder::values(output_schema, vec![])?.build()
+}
+
 /// Build normalized checkpoint adds. Returns an empty relation when no checkpoint exists.
 ///
 /// ## SQL equivalent:
@@ -997,6 +1034,20 @@ mod tests {
             state.physical_stats_schema.as_ref(),
         )?
         .is_none());
+
+        let plan = build_metadata_scan_plan_or_empty(
+            &state,
+            &segment,
+            &no_checkpoint(),
+            &stats,
+            &partition_values,
+            state.physical_stats_schema.as_ref(),
+        )?;
+        assert_eq!(plan.nodes.len(), 1);
+        let Operator::Values(values) = &plan.nodes[0].op else {
+            panic!("empty metadata plan must contain a Values node");
+        };
+        assert!(values.rows.is_empty());
         Ok(())
     }
 

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -17,6 +17,7 @@ use crate::engine::sync::SyncEngine;
 use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::{column_expr, column_name, Expression as Expr, Predicate as Pred};
 use crate::plans::ir::nodes::Operator;
+use crate::plans::state_machines::{EngineRequest, EngineResponse, NextStep, StateMachine as _};
 use crate::plans::Operation as PlanOperation;
 use crate::scan::{PartitionValuesOptions, Scan, StatsOptions, StructStats};
 use crate::unit_test_utils::load_test_table;
@@ -125,6 +126,23 @@ fn declarative_metadata(scan: &Scan, engine: &dyn Engine) -> DeltaResult<Vec<Rec
         )?);
     }
     Ok(projected)
+}
+
+fn drive_metadata_state_machine(
+    scan: &Scan,
+    engine: &dyn Engine,
+) -> DeltaResult<crate::plans::ir::plan::Plan> {
+    let executor = engine.require_plan_executor()?;
+    let mut sm = scan.build_metadata_scan()?;
+    loop {
+        match sm.get_step()? {
+            NextStep::Execute(EngineRequest::Execute(operation)) => {
+                let response = EngineResponse::Plan(executor.execute_op(operation)?);
+                sm.submit(Ok(response))?;
+            }
+            NextStep::Done(plan) => return Ok(plan),
+        }
+    }
 }
 
 fn metadata_row_count(batches: &[RecordBatch]) -> usize {
@@ -278,6 +296,25 @@ fn declarative_metadata_scans_sidecars_from_checkpoint_hint(
             .iter()
             .any(|file| file.meta.location.path().contains("/_sidecars/"))
     }));
+    Ok(())
+}
+
+#[rstest]
+#[case::no_checkpoint("basic_partitioned")]
+#[case::parquet_manifest("v2-checkpoints-parquet-with-sidecars")]
+#[case::json_leaf("v2-checkpoints-json-without-sidecars")]
+fn metadata_state_machine_matches_direct_plan(#[case] table: &str) -> DeltaResult<()> {
+    let (engine, snapshot, _tempdir) = load_test_table(table)?;
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::all())
+        .build()?;
+
+    let direct = scan
+        .declarative_metadata_scan_plan(engine.as_ref())?
+        .expect("metadata plan");
+    let state_machine = drive_metadata_state_machine(&scan, engine.as_ref())?;
+    assert_eq!(format!("{direct:?}"), format!("{state_machine:?}"));
     Ok(())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a connector-driven coroutine protocol for declarative plan workflows and expose
`Scan::build_metadata_scan()` as a resumable metadata-scan plan builder.

Checkpoint inspection remains internal to the coroutine. The completed coroutine always emits a
runnable `Plan`, including an empty `Values` plan when the scan has no metadata rows.

### This PR affects the following public APIs

- Adds the `plans::state_machines` API (`CoroutineSM`, `StateMachine`, requests, responses, and
  next steps).
- Adds `Scan::build_metadata_scan() -> CoroutineSM<Plan>` behind `declarative-plans`.

## How was this change tested?

- `cargo +nightly fmt --check`
- `cargo check -p delta_kernel --all-features --tests`
- `cargo test -p delta_kernel --lib --all-features checkpoint_shape`
- `cargo test -p delta_kernel --lib --all-features plans::state_machines`
- `cargo test -p delta_kernel --lib --all-features metadata_state_machine_matches_direct_plan`
- `cargo test -p delta_kernel --lib --all-features metadata_plan_empty_is_none`
- `cargo clippy -p delta_kernel --all-features --tests -- -D warnings`
