### PR TITLE
feat!: gate vendored protoc behind its own feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,9 +192,9 @@ jobs:
       - name: lint without default features - packages which don't depend on kernel with features enabled
         run: cargo clippy --locked --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
       - name: check kernel declarative-plans feature-only build
-        run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans
+        run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc
       - name: lint kernel declarative-plans feature-only build
-        run: cargo clippy --locked -p delta_kernel --no-default-features --features declarative-plans --tests -- -D warnings
+        run: cargo clippy --locked -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc --tests -- -D warnings
       - name: check kernel builds with default-engine-native-tls
         run: cargo build --locked -p feature_tests --features default-engine-native-tls
       - name: test native-tls backend has no crypto provider conflict
@@ -423,7 +423,7 @@ jobs:
       - name: Test with Miri
         run: |
           pushd ffi
-          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans --partition slice:${{ matrix.partition }}/3
+          MIRIFLAGS=-Zmiri-disable-isolation cargo miri nextest run --locked --features default-engine-rustls,delta-kernel-unity-catalog,declarative-plans,vendored-protoc --partition slice:${{ matrix.partition }}/3
 
   coverage:
     runs-on: ubuntu-latest

--- a/datafusion-executor/Cargo.toml
+++ b/datafusion-executor/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.88"
 [dependencies]
 delta_kernel = { path = "../kernel", version = "0.26.0", default-features = false, features = [
   "declarative-plans",
+  "vendored-protoc",
   "arrow-58",
   "default-engine-base",
 ] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -69,6 +69,8 @@ default-engine-base = ["delta_kernel/default-engine-base", "dep:delta_kernel_def
 # the plan executor with `ArrowEvaluationHandler`
 declarative-plans = ["delta_kernel/declarative-plans", "dep:prost", "arrow", "default-engine-base"]
 
+vendored-protoc = ["delta_kernel/vendored-protoc"]
+
 tracing = [ "tracing-core", "tracing-subscriber" ]
 internal-api = []
 test-ffi = []

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -115,7 +115,12 @@ arrow-expression = ["need-arrow"]
 schema-diff = []
 
 # Declarative plan IR (experimental).
-declarative-plans = ["internal-api", "dep:prost", "dep:prost-build", "dep:protoc-bin-vendored"]
+declarative-plans = ["internal-api", "dep:prost", "dep:prost-build"]
+
+# Sources a prebuilt `protoc` for the codegen `declarative-plans` runs, so the build needs no
+# system protobuf install. Leave it off to pass `protoc` through the `PROTOC` env var instead;
+# a build that pins a hermetic toolchain cannot use a downloaded binary.
+vendored-protoc = ["dep:protoc-bin-vendored"]
 
 # Experimental, temporary, test-only feature flag guarding the in-progress check-constraints
 # work: the SQL predicate parser and, later, `checkConstraints` write enforcement. Remove once
@@ -148,6 +153,7 @@ default-engine-base = [
 rustc_version = "0.4.1"
 # Proto codegen, only pulled in / run under the `declarative-plans` feature.
 prost-build = { version = "0.13", optional = true }
+# Prebuilt `protoc` for that codegen, only pulled in under the `vendored-protoc` feature.
 protoc-bin-vendored = { version = "3.2", optional = true }
 
 [dev-dependencies]

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -9,7 +9,7 @@ fn main() {
 
     // Generate prost bindings for the declarative-plans proto schema only when the feature is
     // enabled. Off-by-default consumers don't pay the protoc / codegen cost and don't pull in
-    // prost-build / protoc-bin-vendored.
+    // prost-build.
     #[cfg(feature = "declarative-plans")]
     compile_proto_definitions();
 }
@@ -33,9 +33,8 @@ fn compile_proto_definitions() {
         .map(|f| format!("{proto_dir}/{f}"))
         .collect();
 
-    // Point prost-build at a vendored `protoc` so the build doesn't require a system install.
-    let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc binary");
-    std::env::set_var("PROTOC", protoc);
+    #[cfg(feature = "vendored-protoc")]
+    set_vendored_protoc();
 
     // Don't propagate `.proto` comments into the generated code as doc comments: they contain
     // angle-bracket generics (`Vec<...>`, `Option<...>`) that rustdoc would parse as unclosed
@@ -44,4 +43,13 @@ fn compile_proto_definitions() {
         .disable_comments(["."])
         .compile_protos(&files, &[proto_dir])
         .expect("failed to compile .proto files");
+}
+
+#[cfg(all(feature = "declarative-plans", feature = "vendored-protoc"))]
+fn set_vendored_protoc() {
+    // Leave a caller-supplied `protoc` alone, so a pinned toolchain wins over the vendored binary.
+    if std::env::var_os("PROTOC").is_none() {
+        let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc binary");
+        std::env::set_var("PROTOC", protoc);
+    }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, `declarative-plans` pulled in `protoc-bin-vendored` and `build.rs` set `PROTOC` from it unconditionally.  Consequently, a build that already has a `protoc` had no way to take the feature without the download, which breaks anything pinning a hermetic toolchain.

Editing `build.rs` alone would not fix it, because `dep:protoc-bin-vendored` in the feature list keeps the crate in the resolved graph whether or not anything calls it.

The fix: `vendored-protoc` now gates the dependency, and `build.rs` fills in `PROTOC` only when the caller left it unset. Kernel CI, `datafusion-executor`, and `ffi` enable it, so builds that want a bundled `protoc` don't need to change.

### This PR affects the following public APIs

`declarative-plans` no longer implies `protoc-bin-vendored`. Consumers relying on it for `protoc` should add `vendored-protoc`. Consumers setting `PROTOC` themselves need no change.

## How was this change tested?

Existing CI, plus `vendored-protoc` on the three commands that name features explicitly (both `declarative-plans` feature-only checks and the miri leg). The `--all-features` legs pick it up on their own.

Locally, both combinations:

- `--features declarative-plans,vendored-protoc` builds and passes clippy.
- `--features declarative-plans` with `PROTOC` set externally builds, and `cargo tree -e build` confirms `protoc-bin-vendored` is absent from the graph.
