### PR TITLE
fix: treat _last_checkpoint as advisory when its checkpoint is gone

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -165,14 +165,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         ],
     ),
     (
-        "Cannot fall back to log replay when checkpoint files are missing or incomplete",
-        &[
-            "corrupt_incomplete_multipart_checkpoint/",
-            "ckp_incomplete_multipart/",
-            "ckp_missing_checkpoint_file/",
-        ],
-    ),
-    (
         "Cannot cast list to non-list data types during type widening",
         &[
             "tw_array_element/specs/tw_array_element_read_",

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -386,16 +386,36 @@ impl LogSegment {
         //    end_version, list from that checkpoint TO end_version (falls back to v0 if no
         //    checkpoint found)
         // 4. no usable_hint,      end_version is None  --> list from v0 unbounded
+        //
+        // A stale hint (cases 1 and 2 returning `None`) degrades to cases 3 and 4. Both retry paths
+        // only ever select a *complete* checkpoint, so neither can rediscover the unusable one the
+        // hint named. The retry's result is then checked below to be self-contained, so a log
+        // truncated behind the vanished checkpoint fails rather than silently reconstructing
+        // partial state.
 
-        let listed_files = match (usable_hint, end_version) {
-            // Cases 1 and 2
-            (Some(cp), end_version) => LogSegmentFiles::list_with_checkpoint_hint(
+        let hinted_files = match usable_hint {
+            // Cases 1 and 2. The hinted path consumes the log_tail, but a stale hint falls through
+            // to the arms below, which need it too.
+            Some(cp) => LogSegmentFiles::list_with_checkpoint_hint(
                 cp,
                 storage,
                 &log_root,
-                log_tail,
+                log_tail.clone(),
                 end_version,
             )?,
+            None => None,
+        };
+
+        // A hint the listing disproved must not be retained: `last_checkpoint_version()` is not
+        // gated by `LastCheckpointHint::applies_to`, and `CheckpointWriter::finalize` uses it to
+        // skip writing `_last_checkpoint` whenever the hint names a higher version than the
+        // snapshot -- which would leave the bad hint in place and prevent the table from healing.
+        let hint_was_stale = usable_hint.is_some() && hinted_files.is_none();
+
+        let listed_files = match (hinted_files, end_version) {
+            // The listing found a usable checkpoint at or after the hint's version -- not
+            // necessarily the one the hint named.
+            (Some(listed), _) => listed,
             // Case 3
             (None, Some(end)) => LogSegmentFiles::list_with_backward_checkpoint_scan(
                 storage, &log_root, log_tail, end,
@@ -404,7 +424,30 @@ impl LogSegment {
             (None, None) => LogSegmentFiles::list(storage, &log_root, log_tail, None, None)?,
         };
 
-        LogSegment::try_new(listed_files, log_root, time_travel_version, checkpoint_hint)
+        // Only after discarding a stale hint: the retry must have produced a segment that can
+        // reconstruct the table on its own. A checkpoint-less segment starting above version 0
+        // means the commits below it were cleaned up under the very checkpoint the hint
+        // named, so replaying what survived would silently omit every file added before it.
+        // The hint is the evidence that distinguishes this from a log that legitimately
+        // begins mid-range, so this check belongs here and not in `try_new` --
+        // `for_table_changes` and `for_timestamp_conversion` build checkpoint-less mid-log
+        // segments by contract.
+        if hint_was_stale && listed_files.checkpoint_parts.is_empty() {
+            if let Some(first_commit) = listed_files.ascending_commit_files.first() {
+                require!(
+                    first_commit.version == 0,
+                    Error::invalid_checkpoint(format!(
+                        "_last_checkpoint named a checkpoint that is missing, and the remaining log \
+                         has no checkpoint and starts at version {} (expected 0); the log appears \
+                         truncated without a checkpoint",
+                        first_commit.version
+                    ))
+                );
+            }
+        }
+
+        let retained_hint = checkpoint_hint.filter(|_| !hint_was_stale);
+        LogSegment::try_new(listed_files, log_root, time_travel_version, retained_hint)
     }
 
     /// Constructs a [`LogSegment`] to be used for `TableChanges`. For a TableChanges between

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -394,8 +394,7 @@ impl LogSegment {
         // partial state.
 
         let hinted_files = match usable_hint {
-            // Cases 1 and 2. The hinted path consumes the log_tail, but a stale hint falls through
-            // to the arms below, which need it too.
+            // Cases 1 and 2
             Some(cp) => LogSegmentFiles::list_with_checkpoint_hint(
                 cp,
                 storage,
@@ -406,44 +405,22 @@ impl LogSegment {
             None => None,
         };
 
-        // A hint the listing disproved must not be retained: `last_checkpoint_version()` is not
-        // gated by `LastCheckpointHint::applies_to`, and `CheckpointWriter::finalize` uses it to
-        // skip writing `_last_checkpoint` whenever the hint names a higher version than the
-        // snapshot -- which would leave the bad hint in place and prevent the table from healing.
         let hint_was_stale = usable_hint.is_some() && hinted_files.is_none();
 
-        let listed_files = match (hinted_files, end_version) {
-            // The listing found a usable checkpoint at or after the hint's version -- not
-            // necessarily the one the hint named.
-            (Some(listed), _) => listed,
-            // Case 3
-            (None, Some(end)) => LogSegmentFiles::list_with_backward_checkpoint_scan(
-                storage, &log_root, log_tail, end,
-            )?,
-            // Case 4
-            (None, None) => LogSegmentFiles::list(storage, &log_root, log_tail, None, None)?,
+        let listed_files = match hinted_files {
+            // The listing found a usable checkpoint at or after the hint's version
+            Some(listed) => listed,
+            // Cases 3 and 4, also reached when a hint turned out stale.
+            None => match end_version {
+                Some(end) => LogSegmentFiles::list_with_backward_checkpoint_scan(
+                    storage, &log_root, log_tail, end,
+                )?,
+                None => LogSegmentFiles::list(storage, &log_root, log_tail, None, None)?,
+            },
         };
 
-        // Only after discarding a stale hint: the retry must have produced a segment that can
-        // reconstruct the table on its own. A checkpoint-less segment starting above version 0
-        // means the commits below it were cleaned up under the very checkpoint the hint
-        // named, so replaying what survived would silently omit every file added before it.
-        // The hint is the evidence that distinguishes this from a log that legitimately
-        // begins mid-range, so this check belongs here and not in `try_new` --
-        // `for_table_changes` and `for_timestamp_conversion` build checkpoint-less mid-log
-        // segments by contract.
-        if hint_was_stale && listed_files.checkpoint_parts.is_empty() {
-            if let Some(first_commit) = listed_files.ascending_commit_files.first() {
-                require!(
-                    first_commit.version == 0,
-                    Error::invalid_checkpoint(format!(
-                        "_last_checkpoint named a checkpoint that is missing, and the remaining log \
-                         has no checkpoint and starts at version {} (expected 0); the log appears \
-                         truncated without a checkpoint",
-                        first_commit.version
-                    ))
-                );
-            }
+        if hint_was_stale {
+            validate_stale_hint_fallback(&listed_files)?;
         }
 
         let retained_hint = checkpoint_hint.filter(|_| !hint_was_stale);
@@ -1614,6 +1591,26 @@ fn validate_checkpoint_commit_gap(
             ))
         );
     }
+    Ok(())
+}
+
+/// Validates that a segment built after discarding a stale `_last_checkpoint` hint can reconstruct
+/// the table on its own: a checkpoint-less segment starting above version 0 means the commits below
+/// it were cleaned up under the checkpoint the hint named, so replaying what survived would
+/// silently omit every file added before it.
+fn validate_stale_hint_fallback(listed: &LogSegmentFiles) -> DeltaResult<()> {
+    let Some(first_commit) = listed.ascending_commit_files.first() else {
+        return Ok(()); // an empty segment is rejected by `validate_end_version`
+    };
+    require!(
+        !listed.checkpoint_parts.is_empty() || first_commit.version == 0,
+        Error::invalid_checkpoint(format!(
+            "_last_checkpoint named a checkpoint that is missing, and the remaining log has no \
+             checkpoint and starts at version {} (expected 0); the log appears truncated without \
+             a checkpoint",
+            first_commit.version
+        ))
+    );
     Ok(())
 }
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -517,6 +517,8 @@ async fn build_snapshot_with_out_of_date_last_checkpoint() {
         None,
     )
     .unwrap();
+    assert_eq!(log_segment.last_checkpoint_version(), Some(3));
+
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
@@ -581,12 +583,6 @@ async fn build_snapshot_with_correct_last_multipart_checkpoint() {
 
 #[tokio::test]
 async fn build_snapshot_with_missing_checkpoint_part_from_hint_falls_back() {
-    // The hinted checkpoint at version 5 declares 3 parts but only 2 are present, so it is not a
-    // usable checkpoint. The hint is advisory, and the table still reconstructs from the complete
-    // checkpoint at version 3 plus commits 4-7, so the load succeeds from there rather than
-    // failing. Delta Spark (`getLogSegmentWithMaxExclusiveCheckpointVersion`) and the Java kernel
-    // (`findFallbackCheckpointVersion`) behave the same way: neither distinguishes a checkpoint
-    // that was deleted from one whose parts are incomplete.
     let checkpoint_metadata = LastCheckpointHint {
         v2_checkpoint: None,
         version: 5,
@@ -632,6 +628,10 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_falls_back() {
     assert_eq!(log_segment.checkpoint_version, Some(3));
     assert_eq!(log_segment.listed.checkpoint_parts.len(), 1);
     assert_eq!(log_segment.listed.checkpoint_parts[0].version, 3);
+
+    // The disproved hint must be dropped, or `CheckpointWriter::finalize` keeps skipping the
+    // `_last_checkpoint` write and the table can never heal.
+    assert_eq!(log_segment.last_checkpoint_version(), None);
 
     let versions = log_segment
         .listed
@@ -730,20 +730,10 @@ async fn build_snapshot_applies_checkpoint_hint_iff_it_names_the_selected_checkp
 
 #[tokio::test]
 async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_commits() {
-    // The `_last_checkpoint` hint points at version 3, but every checkpoint file has been deleted
-    // (log cleanup, or a partial delete that spared `_last_checkpoint`, whose name does not match
-    // the checkpoint pattern). The commits are all intact, so the table is fully reconstructible
-    // from the JSON log: the stale hint must be ignored rather than reported as corruption.
     let checkpoint_metadata = LastCheckpointHint {
-        v2_checkpoint: None,
         version: 3,
         size: 10,
-        parts: None,
-        size_in_bytes: None,
-        num_of_add_files: None,
-        checkpoint_schema: None,
-        checksum: None,
-        tags: None,
+        ..Default::default()
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -770,6 +760,7 @@ async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_commits(
     assert_eq!(log_segment.checkpoint_version, None);
     assert!(log_segment.listed.checkpoint_parts.is_empty());
 
+    assert_eq!(log_segment.last_checkpoint_version(), None);
     let versions = log_segment
         .listed
         .ascending_commit_files
@@ -781,19 +772,10 @@ async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_commits(
 
 #[tokio::test]
 async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_earlier_checkpoint() {
-    // The hinted checkpoint at version 5 is gone, but an earlier complete checkpoint at version 3
-    // survives. Falling back to a listing from version 0 must root the segment at that earlier
-    // checkpoint rather than replaying every commit.
     let checkpoint_metadata = LastCheckpointHint {
-        v2_checkpoint: None,
         version: 5,
         size: 10,
-        parts: None,
-        size_in_bytes: None,
-        num_of_add_files: None,
-        checkpoint_schema: None,
-        checksum: None,
-        tags: None,
+        ..Default::default()
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
@@ -827,6 +809,7 @@ async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_earlier_
     assert_eq!(log_segment.listed.checkpoint_parts.len(), 1);
     assert_eq!(log_segment.listed.checkpoint_parts[0].version, 3);
 
+    assert_eq!(log_segment.last_checkpoint_version(), None);
     let versions = log_segment
         .listed
         .ascending_commit_files
@@ -837,27 +820,64 @@ async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_earlier_
 }
 
 #[tokio::test]
-async fn build_snapshot_with_deleted_checkpoint_from_hint_and_truncated_log_fails() {
-    // Log cleanup deleted commits 0-98 because the checkpoint at version 99 covered them, and that
-    // checkpoint was then lost while `_last_checkpoint` survived. The surviving commits cannot
-    // reconstruct the table on their own, so the stale hint must NOT be treated as recoverable --
-    // falling back here would return a snapshot silently missing every file added before v99.
+async fn build_snapshot_with_deleted_checkpoint_from_hint_and_time_travel_falls_back() {
     let checkpoint_metadata = LastCheckpointHint {
-        v2_checkpoint: None,
-        version: 99,
+        version: 5,
         size: 10,
-        parts: None,
-        size_in_bytes: None,
-        num_of_add_files: None,
-        checkpoint_schema: None,
-        checksum: None,
-        tags: None,
+        ..Default::default()
     };
 
     let (storage, log_root) = build_log_with_paths_and_checkpoint(
         &[
-            // The checkpoint at version 99 named by the hint has been deleted, and commits 0-98
-            // were already cleaned up under it.
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(2, "json"),
+            delta_path_for_version(3, "checkpoint.parquet"),
+            delta_path_for_version(3, "json"),
+            delta_path_for_version(4, "json"),
+            // The checkpoint at version 5 named by the hint has been deleted.
+            delta_path_for_version(5, "json"),
+            delta_path_for_version(6, "json"),
+            delta_path_for_version(7, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        Some(6),
+    )
+    .unwrap();
+
+    assert_eq!(log_segment.end_version, 6);
+    assert_eq!(log_segment.checkpoint_version, Some(3));
+    assert_eq!(log_segment.listed.checkpoint_parts.len(), 1);
+    assert_eq!(log_segment.listed.checkpoint_parts[0].version, 3);
+    assert_eq!(log_segment.last_checkpoint_version(), None);
+
+    let versions = log_segment
+        .listed
+        .ascending_commit_files
+        .into_iter()
+        .map(|f| f.version)
+        .collect_vec();
+    assert_eq!(versions, vec![4, 5, 6]);
+}
+
+#[tokio::test]
+async fn build_snapshot_with_deleted_checkpoint_from_hint_and_truncated_log_fails() {
+    let checkpoint_metadata = LastCheckpointHint {
+        version: 99,
+        size: 10,
+        ..Default::default()
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
             delta_path_for_version(99, "json"),
             delta_path_for_version(100, "json"),
             delta_path_for_version(101, "json"),

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -580,7 +580,13 @@ async fn build_snapshot_with_correct_last_multipart_checkpoint() {
 }
 
 #[tokio::test]
-async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
+async fn build_snapshot_with_missing_checkpoint_part_from_hint_falls_back() {
+    // The hinted checkpoint at version 5 declares 3 parts but only 2 are present, so it is not a
+    // usable checkpoint. The hint is advisory, and the table still reconstructs from the complete
+    // checkpoint at version 3 plus commits 4-7, so the load succeeds from there rather than
+    // failing. Delta Spark (`getLogSegmentWithMaxExclusiveCheckpointVersion`) and the Java kernel
+    // (`findFallbackCheckpointVersion`) behave the same way: neither distinguishes a checkpoint
+    // that was deleted from one whose parts are incomplete.
     let checkpoint_metadata = LastCheckpointHint {
         v2_checkpoint: None,
         version: 5,
@@ -619,11 +625,21 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
-    );
-    assert_result_error_with_message(
-        log_segment,
-        "Invalid Checkpoint: Had a _last_checkpoint hint but didn't find any checkpoints",
     )
+    .unwrap();
+
+    assert_eq!(log_segment.end_version, 7);
+    assert_eq!(log_segment.checkpoint_version, Some(3));
+    assert_eq!(log_segment.listed.checkpoint_parts.len(), 1);
+    assert_eq!(log_segment.listed.checkpoint_parts[0].version, 3);
+
+    let versions = log_segment
+        .listed
+        .ascending_commit_files
+        .into_iter()
+        .map(|f| f.version)
+        .collect_vec();
+    assert_eq!(versions, vec![4, 5, 6, 7]);
 }
 
 /// v5 holds three complete checkpoints (classic, 2-part, 3-part), so the 3-part one always wins.
@@ -710,6 +726,157 @@ async fn build_snapshot_applies_checkpoint_hint_iff_it_names_the_selected_checkp
         .map(|c| c.version)
         .collect_vec();
     assert_eq!(commit_versions, vec![6, 7]);
+}
+
+#[tokio::test]
+async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_commits() {
+    // The `_last_checkpoint` hint points at version 3, but every checkpoint file has been deleted
+    // (log cleanup, or a partial delete that spared `_last_checkpoint`, whose name does not match
+    // the checkpoint pattern). The commits are all intact, so the table is fully reconstructible
+    // from the JSON log: the stale hint must be ignored rather than reported as corruption.
+    let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
+        version: 3,
+        size: 10,
+        parts: None,
+        size_in_bytes: None,
+        num_of_add_files: None,
+        checkpoint_schema: None,
+        checksum: None,
+        tags: None,
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(2, "json"),
+            delta_path_for_version(3, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(log_segment.end_version, 3);
+    assert_eq!(log_segment.checkpoint_version, None);
+    assert!(log_segment.listed.checkpoint_parts.is_empty());
+
+    let versions = log_segment
+        .listed
+        .ascending_commit_files
+        .into_iter()
+        .map(|f| f.version)
+        .collect_vec();
+    assert_eq!(versions, vec![0, 1, 2, 3]);
+}
+
+#[tokio::test]
+async fn build_snapshot_with_deleted_checkpoint_from_hint_falls_back_to_earlier_checkpoint() {
+    // The hinted checkpoint at version 5 is gone, but an earlier complete checkpoint at version 3
+    // survives. Falling back to a listing from version 0 must root the segment at that earlier
+    // checkpoint rather than replaying every commit.
+    let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
+        version: 5,
+        size: 10,
+        parts: None,
+        size_in_bytes: None,
+        num_of_add_files: None,
+        checkpoint_schema: None,
+        checksum: None,
+        tags: None,
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            delta_path_for_version(0, "json"),
+            delta_path_for_version(1, "json"),
+            delta_path_for_version(2, "json"),
+            delta_path_for_version(3, "checkpoint.parquet"),
+            delta_path_for_version(3, "json"),
+            delta_path_for_version(4, "json"),
+            // The checkpoint at version 5 named by the hint has been deleted.
+            delta_path_for_version(5, "json"),
+            delta_path_for_version(6, "json"),
+            delta_path_for_version(7, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(log_segment.end_version, 7);
+    assert_eq!(log_segment.checkpoint_version, Some(3));
+    assert_eq!(log_segment.listed.checkpoint_parts.len(), 1);
+    assert_eq!(log_segment.listed.checkpoint_parts[0].version, 3);
+
+    let versions = log_segment
+        .listed
+        .ascending_commit_files
+        .into_iter()
+        .map(|f| f.version)
+        .collect_vec();
+    assert_eq!(versions, vec![4, 5, 6, 7]);
+}
+
+#[tokio::test]
+async fn build_snapshot_with_deleted_checkpoint_from_hint_and_truncated_log_fails() {
+    // Log cleanup deleted commits 0-98 because the checkpoint at version 99 covered them, and that
+    // checkpoint was then lost while `_last_checkpoint` survived. The surviving commits cannot
+    // reconstruct the table on their own, so the stale hint must NOT be treated as recoverable --
+    // falling back here would return a snapshot silently missing every file added before v99.
+    let checkpoint_metadata = LastCheckpointHint {
+        v2_checkpoint: None,
+        version: 99,
+        size: 10,
+        parts: None,
+        size_in_bytes: None,
+        num_of_add_files: None,
+        checkpoint_schema: None,
+        checksum: None,
+        tags: None,
+    };
+
+    let (storage, log_root) = build_log_with_paths_and_checkpoint(
+        &[
+            // The checkpoint at version 99 named by the hint has been deleted, and commits 0-98
+            // were already cleaned up under it.
+            delta_path_for_version(99, "json"),
+            delta_path_for_version(100, "json"),
+            delta_path_for_version(101, "json"),
+        ],
+        Some(&checkpoint_metadata),
+    )
+    .await;
+
+    let log_segment = LogSegment::for_snapshot_impl(
+        storage.as_ref(),
+        log_root,
+        vec![], // log_tail
+        Some(checkpoint_metadata),
+        None,
+    );
+    assert_result_error_with_message(
+        log_segment,
+        "the remaining log has no checkpoint and starts at version 99",
+    )
 }
 
 #[tokio::test]

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -3,7 +3,7 @@
 //! 1. `list_commits`: Lists all commit files between the provided start and end versions.
 //! 2. `list`: Lists all commit and checkpoint files between the provided start and end versions.
 //! 3. `list_with_checkpoint_hint`: Lists all commit and checkpoint files after the provided
-//!    checkpoint hint.
+//!    checkpoint hint, or `None` if that hint turned out to be stale.
 //! 4. `list_with_backward_checkpoint_scan`: Scans backward from an end version in 1000-version
 //!    windows until a complete checkpoint is found or the log is exhausted.
 //!
@@ -588,7 +588,7 @@ impl LogSegmentFiles {
         log_root: &Url,
         log_tail: Vec<ParsedLogPath>,
         end_version: Option<Version>,
-    ) -> DeltaResult<Self> {
+    ) -> DeltaResult<Option<Self>> {
         let listed_files = Self::list(
             storage,
             log_root,
@@ -598,11 +598,12 @@ impl LogSegmentFiles {
         )?;
 
         let Some(latest_checkpoint) = listed_files.checkpoint_parts.last() else {
-            // Kernel should not compensate for corrupt tables, so we fail if we can't find a
-            // checkpoint
-            return Err(Error::invalid_checkpoint(
-                "Had a _last_checkpoint hint but didn't find any checkpoints",
-            ));
+            info!(
+                hint_version = checkpoint_metadata.version,
+                "_last_checkpoint names a checkpoint that is missing or incomplete; treating the \
+                 hint as stale and listing without it"
+            );
+            return Ok(None);
         };
         if latest_checkpoint.version != checkpoint_metadata.version {
             info!(
@@ -623,7 +624,7 @@ impl LogSegmentFiles {
                  this version; using the checkpoint file's own fields"
             );
         }
-        Ok(listed_files)
+        Ok(Some(listed_files))
     }
 
     /// Returns a [`LogSegmentFiles`] ending at `end_version`, rooted at the most recent complete

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -23,7 +23,7 @@ use crate::path::LogPathFileType::*;
 use crate::path::{
     may_begin_listable_log_path, CheckpointInstance, LogPathFileType, ParsedLogPath,
 };
-use crate::{DeltaResult, Error, StorageHandler, Version};
+use crate::{DeltaResult, StorageHandler, Version};
 
 #[cfg(test)]
 mod tests;

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -598,7 +598,7 @@ impl LogSegmentFiles {
         )?;
 
         let Some(latest_checkpoint) = listed_files.checkpoint_parts.last() else {
-            info!(
+            warn!(
                 hint_version = checkpoint_metadata.version,
                 "_last_checkpoint names a checkpoint that is missing or incomplete; treating the \
                  hint as stale and listing without it"

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -1596,6 +1596,7 @@ async fn last_checkpoint_hint_applies_iff_it_names_the_selected_checkpoint(
         vec![],
         None,
     )
+    .unwrap()
     .unwrap();
 
     // The winner is the same no matter what the hint names.


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Loading a snapshot fails with `InvalidCheckpoint` when `_last_checkpoint` names a checkpoint that has
  been deleted, even though the log still holds every commit needed to reconstruct the table.
- `_last_checkpoint` is advisory, so a stale hint is now discarded and the log is listed as if the hint
  were absent, instead of failing the load.

## How was this change tested?

- New unit tests: the deleted-checkpoint fallback, falling back to an earlier surviving checkpoint, the
  time-travel retry via `list_with_backward_checkpoint_scan`, and the truncated-log guard. The two
  existing corruption tests still fail as before.
- Retires the strict `EXPECTED_KERNEL_FAILURES` entry "Cannot fall back to log replay when checkpoint
  files are missing or incomplete" -- its three workloads now pass, and the harness panics if a listed
  workload starts passing.
- `cargo test -p delta_kernel --all-features` 8508 passed / 0 failed; acceptance suite 3457 / 0.
