### PR TITLE
docs: add crate metadata and READMEs for the UC crates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,8 @@ cargo +nightly fmt \
 | `delta_kernel_workloads`             | `workloads/`                          | Shared workload spec types + SQL predicate parser                        |
 | `feature_tests`                      | `feature-tests/`                      | Feature flag tests                                                       |
 | `delta-kernel-unity-catalog`         | `delta-kernel-unity-catalog/`         | Unity Catalog integration (UCCommitter, snapshot + create-table helpers) |
-| `unity-catalog-delta-client-api`     | `unity-catalog-delta-client-api/`     | Unity Catalog client traits and shared models                            |
-| `unity-catalog-delta-rest-client`    | `unity-catalog-delta-rest-client/`    | REST/HTTP implementation of the Unity Catalog client API                 |
+| `unity-catalog-delta-client-api`     | `unity-catalog-delta-client-api/`     | Transport-agnostic UC client traits + wire models                        |
+| `unity-catalog-delta-rest-client`    | `unity-catalog-delta-rest-client/`    | REST/HTTP client for the Unity Catalog Delta Tables API                  |
 
 ### Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Delta-kernel-rs is split into a few different crates:
 - derive-macros: A crate for our [derive-macros] to live in
 - ffi: Functionality that enables delta-kernel-rs to be used from `C` or `C++` See the [ffi](ffi)
   directory for more information.
+- unity-catalog-delta-client-api: Transport-agnostic client traits and wire models for the Unity
+  Catalog Delta Tables API
+- unity-catalog-delta-rest-client: REST/HTTP client for the Unity Catalog Delta Tables API
+- delta-kernel-unity-catalog: Unity Catalog integration for the kernel, providing a catalog
+  `Committer` and helpers for catalog-managed tables
 
 ## Building
 By default we build only the `kernel` and `acceptance` crates, which will also build `derive-macros`

--- a/delta-kernel-unity-catalog/Cargo.toml
+++ b/delta-kernel-unity-catalog/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "delta-kernel-unity-catalog"
+description = "Unity Catalog integration for delta_kernel."
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 rust-version.workspace = true
 version.workspace = true
 

--- a/delta-kernel-unity-catalog/README.md
+++ b/delta-kernel-unity-catalog/README.md
@@ -1,0 +1,29 @@
+# delta-kernel-unity-catalog
+
+An experimental/under-construction crate connecting [`delta_kernel`] to Unity Catalog for
+catalog-managed Delta tables. This crate is not intended for production use.
+
+A table with the `catalogManaged` table feature cannot be read or written by accessing the
+transaction log on disk alone. This crate bridges UC's responses into kernel's APIs and implements
+kernel's `Committer` so commits go through the catalog.
+
+It depends on [`unity-catalog-delta-client-api`] for the client contract, not on a concrete HTTP
+client, so you can pair it with [`unity-catalog-delta-rest-client`] or your own implementation.
+
+It provides:
+
+- `UCCommitter`: kernel's `Committer` trait implemented against UC, so commits are staged and
+  ratified through the catalog rather than written straight to the log, plus `publish()` to promote
+  ratified commits. Requires a multi-threaded tokio runtime.
+- `snapshot_builder_from_load_table()` and `log_tail_from_commits()`: build a kernel snapshot from a
+  `load_table` response, including commits UC knows about but has not yet published.
+- `get_required_properties_for_disk()` and `build_uc_create_table_request()`: the table-creation
+  flow.
+- `aws_object_store_options()`: maps UC-vended storage credentials onto object-store options.
+
+See the [Unity Catalog integration guide] for the end-to-end read, write, and create flows.
+
+[`delta_kernel`]: https://crates.io/crates/delta_kernel
+[`unity-catalog-delta-client-api`]: https://github.com/delta-io/delta-kernel-rs/tree/main/unity-catalog-delta-client-api
+[`unity-catalog-delta-rest-client`]: https://github.com/delta-io/delta-kernel-rs/tree/main/unity-catalog-delta-rest-client
+[Unity Catalog integration guide]: https://github.com/delta-io/delta-kernel-rs/blob/main/docs/user-guide/src/unity_catalog/overview.md

--- a/delta-kernel-unity-catalog/README.md
+++ b/delta-kernel-unity-catalog/README.md
@@ -1,7 +1,9 @@
 # delta-kernel-unity-catalog
 
-An experimental/under-construction crate connecting [`delta_kernel`] to Unity Catalog for
-catalog-managed Delta tables. This crate is not intended for production use.
+> [!WARNING]
+> This crate is experimental and under construction. It is not intended for production use.
+
+A crate connecting [`delta_kernel`] to Unity Catalog for catalog-managed Delta tables.
 
 A table with the `catalogManaged` table feature cannot be read or written by accessing the
 transaction log on disk alone. This crate bridges UC's responses into kernel's APIs and implements

--- a/docs/user-guide/src/introduction.md
+++ b/docs/user-guide/src/introduction.md
@@ -107,7 +107,8 @@ without writing any Rust. See the [FFI overview](./ffi/overview.md) for details.
 | `acceptance` | Delta Acceptance Tests (DAT) validation suite |
 | `benchmarks` | Performance benchmarks for the core library |
 | `delta-kernel-unity-catalog` | Unity Catalog integration ([overview](./unity_catalog/overview.md)) |
-| `unity-catalog-delta-rest-client` | REST client for the Unity Catalog API |
+| `unity-catalog-delta-client-api` | Transport-agnostic client traits and wire models for the Unity Catalog Delta Tables API |
+| `unity-catalog-delta-rest-client` | REST/HTTP client for the Unity Catalog Delta Tables API |
 
 ## Getting started
 

--- a/unity-catalog-delta-client-api/Cargo.toml
+++ b/unity-catalog-delta-client-api/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "unity-catalog-delta-client-api"
+description = "Transport-agnostic client traits and wire models for the Unity Catalog Delta Tables API."
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 rust-version.workspace = true
 version.workspace = true
 

--- a/unity-catalog-delta-client-api/README.md
+++ b/unity-catalog-delta-client-api/README.md
@@ -1,0 +1,22 @@
+# unity-catalog-delta-client-api
+
+An experimental/under-construction crate defining the client API contract for the Unity Catalog
+Delta Tables API. This crate is not intended for production use.
+
+It has no network dependencies, so any transport can implement it. The REST implementation lives in
+[`unity-catalog-delta-rest-client`], and [`delta-kernel-unity-catalog`] depends on this crate rather
+than on a concrete client.
+
+It provides:
+
+- `UpdateTableClient`: the trait for committing a new version to a UC-managed table, which
+  `delta-kernel-unity-catalog`'s `UCCommitter` dispatches through.
+- Serde wire models for the UC Delta Tables endpoints: `load_table`, credential vending, `/config`,
+  table and staging-table creation, `update_table`, and metrics reporting.
+
+Only `update_table` (the commit RPC) sits behind a trait. Read and credential-vending flows are
+connector-driven: connectors call concrete client methods, or bring their own HTTP plumbing, then
+hand the responses to `delta-kernel-unity-catalog` helpers.
+
+[`unity-catalog-delta-rest-client`]: https://github.com/delta-io/delta-kernel-rs/tree/main/unity-catalog-delta-rest-client
+[`delta-kernel-unity-catalog`]: https://github.com/delta-io/delta-kernel-rs/tree/main/delta-kernel-unity-catalog

--- a/unity-catalog-delta-client-api/README.md
+++ b/unity-catalog-delta-client-api/README.md
@@ -1,7 +1,9 @@
 # unity-catalog-delta-client-api
 
-An experimental/under-construction crate defining the client API contract for the Unity Catalog
-Delta Tables API. This crate is not intended for production use.
+> [!WARNING]
+> This crate is experimental and under construction. It is not intended for production use.
+
+A crate defining the client API contract for the Unity Catalog Delta Tables API.
 
 It has no network dependencies, so any transport can implement it. The REST implementation lives in
 [`unity-catalog-delta-rest-client`], and [`delta-kernel-unity-catalog`] depends on this crate rather

--- a/unity-catalog-delta-client-api/src/lib.rs
+++ b/unity-catalog-delta-client-api/src/lib.rs
@@ -2,25 +2,15 @@
 //! surface.
 //!
 //! This crate defines the transport-agnostic [`UpdateTableClient`] trait that
-//! kernel-uc's `UCCommitter` dispatches through, plus serde-friendly wire
-//! models for the connector-driven endpoints (`load_table`, credentials,
-//! `/config`). Concrete HTTP implementations live in
-//! `unity-catalog-delta-rest-client`.
+//! `delta-kernel-unity-catalog`'s `UCCommitter` dispatches through, plus
+//! serde-friendly wire models for the connector-driven endpoints
+//! (`load_table`, credentials, `/config`). Concrete HTTP implementations live
+//! in `unity-catalog-delta-rest-client`.
 //!
 //! Only `update_table` (the commit RPC) is behind a trait. Read and
 //! credential-vending flows are connector-driven: connectors call concrete
 //! REST methods (or bring their own HTTP plumbing) and hand the responses to
-//! kernel-uc helpers.
-//!
-//! # Testing
-//!
-//! Enable the `test-utils` feature for an in-memory `UpdateTableClient`
-//! implementation suitable for unit tests:
-//!
-//! ```toml
-//! [dev-dependencies]
-//! unity-catalog-delta-client-api = { version = "...", features = ["test-utils"] }
-//! ```
+//! `delta-kernel-unity-catalog` helpers.
 
 pub mod clients;
 pub mod credentials;

--- a/unity-catalog-delta-rest-client/Cargo.toml
+++ b/unity-catalog-delta-rest-client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "unity-catalog-delta-rest-client"
+description = "REST/HTTP client for the Unity Catalog Delta Tables API."
 edition.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 rust-version.workspace = true
 version.workspace = true
 

--- a/unity-catalog-delta-rest-client/README.md
+++ b/unity-catalog-delta-rest-client/README.md
@@ -5,8 +5,8 @@ intended for production use.
 
 It provides two REST structs:
 
-- `UCClient`: concrete HTTP methods for the connector-driven read endpoints (`load_table`,
-  credential vending, `/config`).
+- `UCClient`: concrete HTTP methods for the connector-driven endpoints: `load_table`, credential
+  vending, `/config`, table and staging-table creation, and metrics reporting.
 - `UCUpdateTableRestClient`: an implementation of the `UpdateTableClient` trait (from
   `unity-catalog-delta-client-api`) against the `update_table` commit endpoint.
 

--- a/unity-catalog-delta-rest-client/README.md
+++ b/unity-catalog-delta-rest-client/README.md
@@ -1,7 +1,9 @@
 # unity-catalog-delta-rest-client
 
-An experimental/under-construction Rust client for the Unity Catalog Delta APIs. This crate is not
-intended for production use.
+> [!WARNING]
+> This crate is experimental and under construction. It is not intended for production use.
+
+A Rust client for the Unity Catalog Delta APIs.
 
 It provides two REST structs:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change adds a `README.md` to both `delta-kernel-unity-catalog`and `unity-catalog-delta-client-api` so they don't render an empty crates.io landing page. This change also fixes some stale crate descriptions in various .md files.

## How was this change tested?
Docs-only change, so existing CI should suffice.