### PR TITLE
chore: version the UC crates independently at 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,7 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "delta-kernel-unity-catalog"
-version = "0.26.0"
+version = "0.1.0"
 dependencies = [
  "delta_kernel",
  "delta_kernel_default_engine",
@@ -4842,7 +4842,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unity-catalog-delta-client-api"
-version = "0.26.0"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "unity-catalog-delta-rest-client"
-version = "0.26.0"
+version = "0.1.0"
 dependencies = [
  "percent-encoding",
  "reqwest 0.13.2",

--- a/delta-kernel-unity-catalog/Cargo.toml
+++ b/delta-kernel-unity-catalog/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 readme = "README.md"
 rust-version.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 # for cargo-release
 [package.metadata.release]
@@ -24,8 +24,8 @@ arrow-58 = ["delta_kernel/arrow-58"]
 integration-test = []
 
 [dependencies]
-delta_kernel = { path = "../kernel", features = ["internal-api"] }
-unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
+delta_kernel = { path = "../kernel", version = "0.26.0", features = ["internal-api"] }
+unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api", version = "0.1.0" }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/unity-catalog-delta-client-api/Cargo.toml
+++ b/unity-catalog-delta-client-api/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 readme = "README.md"
 rust-version.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 # for cargo-release
 [package.metadata.release]

--- a/unity-catalog-delta-rest-client/Cargo.toml
+++ b/unity-catalog-delta-rest-client/Cargo.toml
@@ -8,14 +8,14 @@ license.workspace = true
 repository.workspace = true
 readme = "README.md"
 rust-version.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 # for cargo-release
 [package.metadata.release]
 release = false
 
 [dependencies]
-unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api" }
+unity-catalog-delta-client-api = { path = "../unity-catalog-delta-client-api", version = "0.1.0" }
 # Hardcodes rustls (always used alongside default-engine-rustls in practice).
 reqwest = { version = "0.13", default-features = false, features = ["charset", "http2", "json", "rustls", "system-proxy"] }
 percent-encoding = "2"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3062/files) to review incremental changes.
- [**stack/uc-crate-versions**](https://github.com/delta-io/delta-kernel-rs/pull/3062) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3062/files)] ← _this PR_
  - [stack/uc-release-tooling](https://github.com/delta-io/delta-kernel-rs/pull/3066) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3066/files/84b2252ea762b8de22d08d37523948352192b47d..feca1607aba16efb7fdc48207fd050dae764cf6b)]

---------
## What changes are proposed in this pull request?

The delta-kernel-unity-catalog, unity-catalog-delta-client-api, and unity-catalog-delta-rest-client all inherited `version.workspace = true`, which resolves to delta-kernel's version. This change updates the three UC crates so that they all carry version 0.1.0 and can evolve independently.

## How was this change tested?

Existing tests pass.