### PR TITLE
fix!: report exact JSON write sizes

### DIFF
--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -135,10 +135,7 @@ async fn write_json_file_impl(
     buffer: Vec<u8>,
     overwrite: bool,
 ) -> DeltaResult<FileSize> {
-    let size = buffer
-        .len()
-        .try_into()
-        .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
+    let size = buffer.len() as FileSize;
     let put_mode = if overwrite {
         PutMode::Overwrite
     } else {
@@ -891,9 +888,9 @@ mod tests {
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        let written_size = result?;
+        let written_size = result.unwrap();
         assert_eq!(written_size, 32);
-        assert_eq!(written_size, store.head(&object_path).await?.size);
+        assert_eq!(written_size, store.head(&object_path).await.unwrap().size);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -904,9 +901,9 @@ mod tests {
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            let written_size = result?;
+            let written_size = result.unwrap();
             assert_eq!(written_size, 28);
-            assert_eq!(written_size, store.head(&object_path).await?.size);
+            assert_eq!(written_size, store.head(&object_path).await.unwrap().size);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
@@ -927,12 +924,20 @@ mod tests {
         let store = Arc::new(InMemory::new());
         let handler =
             DefaultJsonHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
-        let path = Url::parse("memory:///test/data/empty.json")?;
+        let path = Url::parse("memory:///test/data/empty.json").unwrap();
         let object_path = Path::from("/test/data/empty.json");
 
-        let written_size = handler.write_json_file(&path, Box::new(std::iter::empty()), false)?;
-        let stored_meta = store.head(&object_path).await?;
-        let stored_bytes = store.get(&object_path).await?.bytes().await?;
+        let written_size = handler
+            .write_json_file(&path, Box::new(std::iter::empty()), false)
+            .unwrap();
+        let stored_meta = store.head(&object_path).await.unwrap();
+        let stored_bytes = store
+            .get(&object_path)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
 
         assert_eq!(written_size, 0);
         assert_eq!(stored_meta.size, 0);

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -896,6 +896,7 @@ mod tests {
         // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
         // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
+        assert_eq!(write_result.size, store.head(&object_path).await?.size);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -911,6 +912,7 @@ mod tests {
             // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
             // 28 = 2 * (10 + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
+            assert_eq!(write_result.size, store.head(&object_path).await?.size);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -21,7 +21,7 @@ use delta_kernel::object_store::{
 use delta_kernel::schema::SchemaRef;
 use delta_kernel::{
     CancellationTokenRef, DeltaResult, DeltaResultIterator, EngineData, Error,
-    FileDataReadResultIterator, FileMeta, JsonHandler, JsonWriteResult, PredicateRef,
+    FileDataReadResultIterator, FileMeta, FileSize, JsonHandler, PredicateRef,
 };
 use futures::stream::{self, BoxStream};
 use futures::{ready, StreamExt, TryStreamExt};
@@ -134,7 +134,7 @@ async fn write_json_file_impl(
     path: Url,
     buffer: Vec<u8>,
     overwrite: bool,
-) -> DeltaResult<JsonWriteResult> {
+) -> DeltaResult<FileSize> {
     let size = buffer
         .len()
         .try_into()
@@ -151,7 +151,7 @@ async fn write_json_file_impl(
         object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(path.to_string()),
         e => e.into(),
     })?;
-    Ok(JsonWriteResult::new(size))
+    Ok(size)
 }
 
 impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
@@ -200,7 +200,7 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<JsonWriteResult> {
+    ) -> DeltaResult<FileSize> {
         self.task_executor.block_on(write_json_file_impl(
             self.store.clone(),
             path.clone(),
@@ -891,12 +891,9 @@ mod tests {
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful and reports the expected size.
-        let write_result = result?;
-        // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
-        // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
-        assert_eq!(write_result.size, 32);
-        assert_eq!(write_result.size, store.head(&object_path).await?.size);
+        let written_size = result?;
+        assert_eq!(written_size, 32);
+        assert_eq!(written_size, store.head(&object_path).await?.size);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -907,12 +904,9 @@ mod tests {
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful and reports the expected size.
-            let write_result = result?;
-            // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
-            // 28 = 2 * (10 + 3 value + 1 newline).
-            assert_eq!(write_result.size, 28);
-            assert_eq!(write_result.size, store.head(&object_path).await?.size);
+            let written_size = result?;
+            assert_eq!(written_size, 28);
+            assert_eq!(written_size, store.head(&object_path).await?.size);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
@@ -936,12 +930,11 @@ mod tests {
         let path = Url::parse("memory:///test/data/empty.json")?;
         let object_path = Path::from("/test/data/empty.json");
 
-        let write_result = handler.write_json_file(&path, Box::new(std::iter::empty()), false)?;
+        let written_size = handler.write_json_file(&path, Box::new(std::iter::empty()), false)?;
         let stored_meta = store.head(&object_path).await?;
         let stored_bytes = store.get(&object_path).await?.bytes().await?;
 
-        // Zero rows serialize to zero bytes.
-        assert_eq!(write_result.size, 0);
+        assert_eq!(written_size, 0);
         assert_eq!(stored_meta.size, 0);
         assert!(stored_bytes.is_empty());
         Ok(())

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -891,14 +891,9 @@ mod tests {
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful and reports the stored size.
+        // Verify the first write is successful and reports the expected size.
         let write_result = result?;
-        assert_eq!(write_result.size, store.head(&object_path).await?.size);
-        let stored_bytes = store.get(&object_path).await?.bytes().await?;
-        assert_eq!(
-            write_result.size,
-            u64::try_from(stored_bytes.len()).unwrap()
-        );
+        assert_eq!(write_result.size, 32);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -909,14 +904,9 @@ mod tests {
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful and reports the replaced size.
+            // Verify the second write is successful and reports the expected size.
             let write_result = result?;
-            assert_eq!(write_result.size, store.head(&object_path).await?.size);
-            let stored_bytes = store.get(&object_path).await?.bytes().await?;
-            assert_eq!(
-                write_result.size,
-                u64::try_from(stored_bytes.len()).unwrap()
-            );
+            assert_eq!(write_result.size, 28);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -893,14 +893,11 @@ mod tests {
 
         // Verify the first write is successful and reports the stored size.
         let write_result = result?;
-        assert_eq!(
-            write_result.size,
-            Some(store.head(&object_path).await?.size)
-        );
+        assert_eq!(write_result.size, store.head(&object_path).await?.size);
         let stored_bytes = store.get(&object_path).await?.bytes().await?;
         assert_eq!(
             write_result.size,
-            Some(u64::try_from(stored_bytes.len()).unwrap())
+            u64::try_from(stored_bytes.len()).unwrap()
         );
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
@@ -914,14 +911,11 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the replaced size.
             let write_result = result?;
-            assert_eq!(
-                write_result.size,
-                Some(store.head(&object_path).await?.size)
-            );
+            assert_eq!(write_result.size, store.head(&object_path).await?.size);
             let stored_bytes = store.get(&object_path).await?.bytes().await?;
             assert_eq!(
                 write_result.size,
-                Some(u64::try_from(stored_bytes.len()).unwrap())
+                u64::try_from(stored_bytes.len()).unwrap()
             );
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
@@ -950,7 +944,7 @@ mod tests {
         let stored_meta = store.head(&object_path).await?;
         let stored_bytes = store.get(&object_path).await?.bytes().await?;
 
-        assert_eq!(write_result.size, Some(0));
+        assert_eq!(write_result.size, 0);
         assert_eq!(stored_meta.size, 0);
         assert!(stored_bytes.is_empty());
         Ok(())

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -886,7 +886,7 @@ mod tests {
         let object_path = Path::from("/test/data/00000000000000000001.json");
 
         // First write with no existing file
-        let data = create_test_data(vec!["rémi", "ウィルソン"])?;
+        let data = create_test_data(vec!["remi", "wilson"])?;
         let filtered_data = Ok(FilteredEngineData::with_all_rows_selected(data));
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
@@ -903,10 +903,7 @@ mod tests {
             Some(u64::try_from(stored_bytes.len()).unwrap())
         );
         let json = read_json_file(&store, &object_path).await?;
-        assert_eq!(
-            json,
-            vec![json!({"dog": "rémi"}), json!({"dog": "ウィルソン"})]
-        );
+        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
         // Second write with existing file
         let data = create_test_data(vec!["seb", "tia"])?;

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -853,13 +853,9 @@ mod tests {
     async fn read_json_file(
         store: &Arc<InMemory>,
         path: &Path,
-    ) -> DeltaResult<(Vec<serde_json::Value>, u64)> {
+    ) -> DeltaResult<Vec<serde_json::Value>> {
         let content = store.get(path).await?;
         let file_bytes = content.bytes().await?;
-        let file_size = file_bytes
-            .len()
-            .try_into()
-            .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
         let file_string =
             String::from_utf8(file_bytes.to_vec()).map_err(|e| object_store::Error::Generic {
                 store: "memory",
@@ -869,7 +865,7 @@ mod tests {
             .into_iter::<serde_json::Value>()
             .flatten()
             .collect();
-        Ok((json, file_size))
+        Ok(json)
     }
 
     #[tokio::test]
@@ -901,8 +897,12 @@ mod tests {
             write_result.size,
             Some(store.head(&object_path).await?.size)
         );
-        let (json, stored_body_size) = read_json_file(&store, &object_path).await?;
-        assert_eq!(write_result.size, Some(stored_body_size));
+        let stored_bytes = store.get(&object_path).await?.bytes().await?;
+        assert_eq!(
+            write_result.size,
+            Some(u64::try_from(stored_bytes.len()).unwrap())
+        );
+        let json = read_json_file(&store, &object_path).await?;
         assert_eq!(
             json,
             vec![json!({"dog": "rémi"}), json!({"dog": "ウィルソン"})]
@@ -921,8 +921,12 @@ mod tests {
                 write_result.size,
                 Some(store.head(&object_path).await?.size)
             );
-            let (json, stored_body_size) = read_json_file(&store, &object_path).await?;
-            assert_eq!(write_result.size, Some(stored_body_size));
+            let stored_bytes = store.get(&object_path).await?.bytes().await?;
+            assert_eq!(
+                write_result.size,
+                Some(u64::try_from(stored_bytes.len()).unwrap())
+            );
+            let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
             // Verify the second write fails with FileAlreadyExists error

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -853,9 +853,13 @@ mod tests {
     async fn read_json_file(
         store: &Arc<InMemory>,
         path: &Path,
-    ) -> DeltaResult<Vec<serde_json::Value>> {
+    ) -> DeltaResult<(Vec<serde_json::Value>, u64)> {
         let content = store.get(path).await?;
         let file_bytes = content.bytes().await?;
+        let file_size = file_bytes
+            .len()
+            .try_into()
+            .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
         let file_string =
             String::from_utf8(file_bytes.to_vec()).map_err(|e| object_store::Error::Generic {
                 store: "memory",
@@ -865,7 +869,7 @@ mod tests {
             .into_iter::<serde_json::Value>()
             .flatten()
             .collect();
-        Ok(json)
+        Ok((json, file_size))
     }
 
     #[tokio::test]
@@ -886,7 +890,7 @@ mod tests {
         let object_path = Path::from("/test/data/00000000000000000001.json");
 
         // First write with no existing file
-        let data = create_test_data(vec!["remi", "wilson"])?;
+        let data = create_test_data(vec!["rémi", "ウィルソン"])?;
         let filtered_data = Ok(FilteredEngineData::with_all_rows_selected(data));
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
@@ -897,8 +901,12 @@ mod tests {
             write_result.size,
             Some(store.head(&object_path).await?.size)
         );
-        let json = read_json_file(&store, &object_path).await?;
-        assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
+        let (json, stored_body_size) = read_json_file(&store, &object_path).await?;
+        assert_eq!(write_result.size, Some(stored_body_size));
+        assert_eq!(
+            json,
+            vec![json!({"dog": "rémi"}), json!({"dog": "ウィルソン"})]
+        );
 
         // Second write with existing file
         let data = create_test_data(vec!["seb", "tia"])?;
@@ -913,7 +921,8 @@ mod tests {
                 write_result.size,
                 Some(store.head(&object_path).await?.size)
             );
-            let json = read_json_file(&store, &object_path).await?;
+            let (json, stored_body_size) = read_json_file(&store, &object_path).await?;
+            assert_eq!(write_result.size, Some(stored_body_size));
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
             // Verify the second write fails with FileAlreadyExists error
@@ -925,6 +934,24 @@ mod tests {
             }
         }
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_write_empty_json_file_reports_zero_size() -> DeltaResult<()> {
+        let store = Arc::new(InMemory::new());
+        let handler =
+            DefaultJsonHandler::new(store.clone(), Arc::new(TokioBackgroundExecutor::new()));
+        let path = Url::parse("memory:///test/data/empty.json")?;
+        let object_path = Path::from("/test/data/empty.json");
+
+        let write_result = handler.write_json_file(&path, Box::new(std::iter::empty()), false)?;
+        let stored_meta = store.head(&object_path).await?;
+        let stored_bytes = store.get(&object_path).await?.bytes().await?;
+
+        assert_eq!(write_result.size, Some(0));
+        assert_eq!(stored_meta.size, 0);
+        assert!(stored_bytes.is_empty());
         Ok(())
     }
 

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -893,6 +893,7 @@ mod tests {
 
         // Verify the first write is successful and reports the expected size.
         let write_result = result?;
+        // 32 = (10 JSON + 4 "remi" + 1 newline) + (10 JSON + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
@@ -906,6 +907,7 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the expected size.
             let write_result = result?;
+            // 28 = 2 * (10 JSON + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
@@ -934,6 +936,7 @@ mod tests {
         let stored_meta = store.head(&object_path).await?;
         let stored_bytes = store.get(&object_path).await?.bytes().await?;
 
+        // Zero rows serialize to zero bytes.
         assert_eq!(write_result.size, 0);
         assert_eq!(stored_meta.size, 0);
         assert!(stored_bytes.is_empty());

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -21,7 +21,7 @@ use delta_kernel::object_store::{
 use delta_kernel::schema::SchemaRef;
 use delta_kernel::{
     CancellationTokenRef, DeltaResult, DeltaResultIterator, EngineData, Error,
-    FileDataReadResultIterator, FileMeta, JsonHandler, PredicateRef,
+    FileDataReadResultIterator, FileMeta, JsonHandler, JsonWriteResult, PredicateRef,
 };
 use futures::stream::{self, BoxStream};
 use futures::{ready, StreamExt, TryStreamExt};
@@ -134,7 +134,11 @@ async fn write_json_file_impl(
     path: Url,
     buffer: Vec<u8>,
     overwrite: bool,
-) -> DeltaResult<()> {
+) -> DeltaResult<JsonWriteResult> {
+    let size = buffer
+        .len()
+        .try_into()
+        .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
     let put_mode = if overwrite {
         PutMode::Overwrite
     } else {
@@ -147,7 +151,7 @@ async fn write_json_file_impl(
         object_store::Error::AlreadyExists { .. } => Error::FileAlreadyExists(path.to_string()),
         e => e.into(),
     })?;
-    Ok(())
+    Ok(JsonWriteResult::new(size))
 }
 
 impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
@@ -196,7 +200,7 @@ impl<E: TaskExecutor> JsonHandler for DefaultJsonHandler<E> {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()> {
+    ) -> DeltaResult<JsonWriteResult> {
         self.task_executor.block_on(write_json_file_impl(
             self.store.clone(),
             path.clone(),
@@ -887,8 +891,12 @@ mod tests {
         let result =
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful
-        assert!(result.is_ok());
+        // Verify the first write is successful and reports the stored size.
+        let write_result = result?;
+        assert_eq!(
+            write_result.size,
+            Some(store.head(&object_path).await?.size)
+        );
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -899,8 +907,12 @@ mod tests {
             handler.write_json_file(&path, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful
-            assert!(result.is_ok());
+            // Verify the second write is successful and reports the replaced size.
+            let write_result = result?;
+            assert_eq!(
+                write_result.size,
+                Some(store.head(&object_path).await?.size)
+            );
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/default-engine/src/json.rs
+++ b/default-engine/src/json.rs
@@ -893,7 +893,8 @@ mod tests {
 
         // Verify the first write is successful and reports the expected size.
         let write_result = result?;
-        // 32 = (10 JSON + 4 "remi" + 1 newline) + (10 JSON + 6 "wilson" + 1 newline).
+        // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
+        // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
         let json = read_json_file(&store, &object_path).await?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
@@ -907,7 +908,8 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the expected size.
             let write_result = result?;
-            // 28 = 2 * (10 JSON + 3 value + 1 newline).
+            // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
+            // 28 = 2 * (10 + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
             let json = read_json_file(&store, &object_path).await?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -150,12 +150,12 @@ impl<C: UpdateTableClient> UCCommitter<C> {
             Box::new(actions),
             false,
         ) {
-            Ok(write_result) => {
+            Ok(written_size) => {
                 info!("wrote version 0 commit file for UC table creation");
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    write_result.size,
+                    written_size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }
@@ -314,9 +314,11 @@ mod tests {
     use std::collections::HashMap;
     use std::fs;
 
+    use delta_kernel::arrow::array::{Array, RecordBatch, StringArray};
     use delta_kernel::committer::{CatalogCommit, CommitMetadata};
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
     use delta_kernel::object_store::local::LocalFileSystem;
-    use delta_kernel::Version;
+    use delta_kernel::{EngineData, FilteredEngineData, Version};
     use delta_kernel_default_engine::DefaultEngine;
     use unity_catalog_delta_client_api::error::Result;
 
@@ -366,13 +368,21 @@ mod tests {
         let commit_metadata = catalog_managed_commit_metadata(table_root.clone(), 0);
         let committer = test_committer();
         let engine = DefaultEngine::builder(Arc::new(LocalFileSystem::new())).build();
+        let action: Box<dyn EngineData> = Box::new(ArrowEngineData::new(
+            RecordBatch::try_from_iter(vec![(
+                "test",
+                Arc::new(StringArray::from(vec!["value"])) as Arc<dyn Array>,
+            )])
+            .unwrap(),
+        ));
+        let actions = Box::new(std::iter::once(Ok(
+            FilteredEngineData::with_all_rows_selected(action),
+        )));
 
         // Create the _delta_log directory
         fs::create_dir_all(tmp_dir.path().join("_delta_log")).unwrap();
 
-        let result = committer
-            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
-            .unwrap();
+        let result = committer.commit(&engine, actions, commit_metadata).unwrap();
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert!(
@@ -383,9 +393,10 @@ mod tests {
                     "expected published path for version 0, got: {}",
                     file_meta.location
                 );
-                assert_eq!(file_meta.size, 0);
-                // Verify the file was written to disk
                 let commit_path = tmp_dir.path().join("_delta_log/00000000000000000000.json");
+                let stored_size = fs::metadata(&commit_path).unwrap().len();
+                assert!(file_meta.size > 0);
+                assert_eq!(file_meta.size, stored_size);
                 assert!(commit_path.exists(), "000.json should exist on disk");
             }
             CommitResponse::Conflict { .. } => {

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -7,7 +7,7 @@ use delta_kernel::committer::{
 use delta_kernel::{
     DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FileMeta, FilteredEngineData,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 use unity_catalog_delta_client_api::{
     Commit, DeltaTableRequirement, DeltaTableUpdate, TableIdentifier, UpdateTableClient,
     UpdateTableRequest,
@@ -152,14 +152,10 @@ impl<C: UpdateTableClient> UCCommitter<C> {
         ) {
             Ok(write_result) => {
                 info!("wrote version 0 commit file for UC table creation");
-                let size = write_result.size.unwrap_or_else(|| {
-                    warn!("JSON handler did not report the committed file size; using zero");
-                    0
-                });
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    size,
+                    write_result.size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -7,7 +7,7 @@ use delta_kernel::committer::{
 use delta_kernel::{
     DeltaResult, DeltaResultIterator, Engine, Error as DeltaError, FileMeta, FilteredEngineData,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use unity_catalog_delta_client_api::{
     Commit, DeltaTableRequirement, DeltaTableUpdate, TableIdentifier, UpdateTableClient,
     UpdateTableRequest,
@@ -150,12 +150,16 @@ impl<C: UpdateTableClient> UCCommitter<C> {
             Box::new(actions),
             false,
         ) {
-            Ok(()) => {
+            Ok(write_result) => {
                 info!("wrote version 0 commit file for UC table creation");
+                let size = write_result.size.unwrap_or_else(|| {
+                    warn!("JSON handler did not report the committed file size; using zero");
+                    0
+                });
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    0,
+                    size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -397,7 +397,6 @@ mod tests {
                 let stored_size = fs::metadata(&commit_path).unwrap().len();
                 assert!(file_meta.size > 0);
                 assert_eq!(file_meta.size, stored_size);
-                assert!(commit_path.exists(), "000.json should exist on disk");
             }
             CommitResponse::Conflict { .. } => {
                 panic!("expected Committed for version 0, got Conflict")

--- a/docs/user-guide/src/catalog_managed/committer.md
+++ b/docs/user-guide/src/catalog_managed/committer.md
@@ -149,8 +149,9 @@ staged path, in-commit timestamp, and maximum published version:
         commit_metadata.max_published_version(),
     )?;
 
-    // Return the staged file metadata on success. Use the in-commit timestamp
-    // as the logical commit time rather than the filesystem mtime.
+    // Use the in-commit timestamp as the logical commit time (not the filesystem
+    // mtime, which reflects when the file was written rather than when the
+    // commit took effect).
     Ok(CommitResponse::Committed {
         file_meta: FileMeta::new(
             staged_path,

--- a/docs/user-guide/src/catalog_managed/committer.md
+++ b/docs/user-guide/src/catalog_managed/committer.md
@@ -133,10 +133,8 @@ fn commit(
 ### Step 2: Ratify through the catalog
 
 Call your catalog's commit API to ratify the staged commit. The exact arguments
-vary by catalog; Unity Catalog's `CommitRequest`, for example, carries the table
-id, commit version, staged filename, in-commit timestamp, and the maximum
-published version. Your catalog's API may look different. Here is the general
-shape:
+vary by catalog. The general shape below passes the table identity, commit version,
+staged path, in-commit timestamp, and maximum published version:
 
 ```rust,ignore
     // Tell the catalog about the staged commit.

--- a/docs/user-guide/src/catalog_managed/committer.md
+++ b/docs/user-guide/src/catalog_managed/committer.md
@@ -124,7 +124,9 @@ fn commit(
     // Write actions to _staged_commits/<version>.<uuid>.json. `actions` is
     // already a Box<dyn Iterator<...>>, so pass it directly (do not re-box).
     let staged_path = commit_metadata.staged_commit_path()?;
-    engine.json_handler().write_json_file(&staged_path, actions, false)?;
+    let written_size = engine
+        .json_handler()
+        .write_json_file(&staged_path, actions, false)?;
     // ...
 ```
 
@@ -149,17 +151,13 @@ shape:
         commit_metadata.max_published_version(),
     )?;
 
-    // Return the staged file metadata on success. HEAD the file via
-    // engine.storage_handler().head() to get the real byte size, and use
-    // the in-commit timestamp as the logical commit time (not the filesystem
-    // mtime, which reflects when the file was written rather than when the
-    // commit took effect).
-    let staged_file = engine.storage_handler().head(&staged_path)?;
+    // Return the staged file metadata on success. Use the in-commit timestamp
+    // as the logical commit time rather than the filesystem mtime.
     Ok(CommitResponse::Committed {
         file_meta: FileMeta::new(
             staged_path,
             commit_metadata.in_commit_timestamp(),
-            staged_file.size,
+            written_size,
         ),
     })
 }
@@ -237,7 +235,9 @@ impl Committer for MyCatalogCommitter {
     ) -> DeltaResult<CommitResponse> {
         // 1. Stage: write actions to _staged_commits/
         let staged_path = commit_metadata.staged_commit_path()?;
-        engine.json_handler().write_json_file(&staged_path, actions, false)?;
+        let written_size = engine
+            .json_handler()
+            .write_json_file(&staged_path, actions, false)?;
 
         // 2. Ratify: register the staged commit with the catalog. ratify_commit
         //    is an imagined example API; your catalog's signature will differ.
@@ -249,15 +249,13 @@ impl Committer for MyCatalogCommitter {
             commit_metadata.max_published_version(),
         )?;
 
-        // 3. Return success. HEAD the staged file to get the real byte size,
-        //    and use the in-commit timestamp as the logical commit time (not
-        //    the filesystem mtime).
-        let staged_file = engine.storage_handler().head(&staged_path)?;
+        // 3. Return success using the in-commit timestamp as the logical
+        //    commit time rather than the filesystem mtime.
         Ok(CommitResponse::Committed {
             file_meta: FileMeta::new(
                 staged_path,
                 commit_metadata.in_commit_timestamp(),
-                staged_file.size,
+                written_size,
             ),
         })
     }

--- a/docs/user-guide/src/catalog_managed/committer.md
+++ b/docs/user-guide/src/catalog_managed/committer.md
@@ -133,8 +133,10 @@ fn commit(
 ### Step 2: Ratify through the catalog
 
 Call your catalog's commit API to ratify the staged commit. The exact arguments
-vary by catalog. The general shape below passes the table identity, commit version,
-staged path, in-commit timestamp, and maximum published version:
+vary by catalog; Unity Catalog's `CommitRequest`, for example, carries the table
+id, commit version, staged filename, in-commit timestamp, and the maximum
+published version. Your catalog's API may look different. Here is the general
+shape:
 
 ```rust,ignore
     // Tell the catalog about the staged commit.
@@ -149,7 +151,8 @@ staged path, in-commit timestamp, and maximum published version:
         commit_metadata.max_published_version(),
     )?;
 
-    // Use the in-commit timestamp as the logical commit time (not the filesystem
+    // Return the staged file metadata on success and use
+    // the in-commit timestamp as the logical commit time (not the filesystem
     // mtime, which reflects when the file was written rather than when the
     // commit took effect).
     Ok(CommitResponse::Committed {
@@ -248,8 +251,8 @@ impl Committer for MyCatalogCommitter {
             commit_metadata.max_published_version(),
         )?;
 
-        // 3. Return success using the in-commit timestamp as the logical
-        //    commit time rather than the filesystem mtime.
+        // 3. Return success and use the in-commit timestamp as the logical commit time (not
+        //    the filesystem mtime).
         Ok(CommitResponse::Committed {
             file_meta: FileMeta::new(
                 staged_path,

--- a/docs/user-guide/src/concepts/engine_trait.md
+++ b/docs/user-guide/src/concepts/engine_trait.md
@@ -55,7 +55,7 @@ files themselves are parquet and are read by the `ParquetHandler` below.
 | `parse_json(strings, schema)` | Parse JSON strings into columnar `EngineData` |
 | `read_json_files(files, schema, predicate)` | Read JSON files and return `EngineData` (predicate is an optional hint) |
 | `read_json_files_with_cancellation(files, schema, predicate, token)` | As above, but a cooperative engine can abandon the read when `token` fires. Optional to override — see [Cancellation](#cancellation) |
-| `write_json_file(path, data, overwrite)` | Atomically write a stream of `FilteredEngineData` rows as a newline-delimited JSON file (one JSON object per row, nulls omitted) |
+| `write_json_file(path, data, overwrite)` | Atomically write a stream of `FilteredEngineData` rows as a newline-delimited JSON file (one JSON object per row, nulls omitted) and return its exact serialized byte size |
 
 ### ParquetHandler
 

--- a/docs/user-guide/src/connector/implementing_engine.md
+++ b/docs/user-guide/src/connector/implementing_engine.md
@@ -93,7 +93,7 @@ pub trait JsonHandler {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()>;
+    ) -> DeltaResult<FileSize>;
 }
 ```
 
@@ -109,7 +109,8 @@ pub trait JsonHandler {
 
 - **`write_json_file`**: Must write newline-delimited JSON (one JSON object per line). Null
   columns should be omitted from the output to save space. The write must be atomic. If
-  `overwrite` is false and the file exists, fail with an error.
+  `overwrite` is false and the file exists, fail with an error. On success, return the exact
+  number of serialized bytes written to the file.
 
 ### Default implementation
 

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -163,8 +163,9 @@ mod tests {
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
-                // 214 = 19 prefix + 36 UUID + 46 format + 53 schema
-                //     + 22 partitions + 16 timestamp + 21 config + 1 newline.
+                // 177 fixed JSON bytes = 19 prefix + 46 format + 53 schema + 22 partitions
+                //     + 16 timestamp + 21 config.
+                // 214 = 177 fixed JSON + 36 UUID + 1 newline.
                 assert_eq!(file_meta.size, 214);
                 assert!(file_meta
                     .location

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -134,7 +134,7 @@ mod tests {
     async fn test_filesystem_committer_returns_valid_commit_response() {
         let storage = Arc::new(InMemory::new());
         let table_root = Url::parse("memory:///").unwrap();
-        let engine = SyncEngine::new_with_store(storage.clone());
+        let engine = SyncEngine::new_with_store(storage);
 
         let committer = FileSystemCommitter::new();
         let log_root = LogRoot::new(table_root).unwrap();
@@ -159,17 +159,11 @@ mod tests {
         )));
 
         let result = committer.commit(&engine, actions, commit_metadata).unwrap();
-        let stored_size = storage
-            .head(&Path::from("_delta_log/00000000000000000001.json"))
-            .await
-            .unwrap()
-            .size;
 
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
-                assert!(file_meta.size > 0);
-                assert_eq!(file_meta.size, stored_size);
+                assert_eq!(file_meta.size, 214);
                 assert!(file_meta
                     .location
                     .as_str()

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -42,7 +42,7 @@ impl Committer for FileSystemCommitter {
             Box::new(actions),
             false,
         ) {
-            Ok(write_result) => {
+            Ok(written_size) => {
                 info!(
                     committed_version = version,
                     "Committed delta file via filesystem committer"
@@ -50,7 +50,7 @@ impl Committer for FileSystemCommitter {
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    write_result.size,
+                    written_size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }
@@ -168,10 +168,7 @@ mod tests {
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
-                // 177 fixed JSON bytes = 19 prefix + 46 format + 53 schema + 22 partitions
-                //     + 16 timestamp + 21 config.
-                // 214 = 177 fixed JSON + 36 UUID + 1 newline.
-                assert_eq!(file_meta.size, 214);
+                assert!(file_meta.size > 0);
                 assert_eq!(file_meta.size, stored_size);
                 assert!(file_meta
                     .location

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -1,6 +1,6 @@
 //! File system committer for non-catalog-managed tables.
 
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use super::commit_types::{CommitMetadata, CommitResponse};
 use super::publish_types::PublishMetadata;
@@ -42,17 +42,22 @@ impl Committer for FileSystemCommitter {
             Box::new(actions),
             false,
         ) {
-            Ok(()) => {
+            Ok(write_result) => {
                 info!(
                     committed_version = version,
                     "Committed delta file via filesystem committer"
                 );
-                // For now, we don't need the real size of the written file, so we can use 0.
-                // If we need this in the future, we can get it from StorageHandler::head.
+                let size = write_result.size.unwrap_or_else(|| {
+                    warn!(
+                        committed_version = version,
+                        "JSON handler did not report the committed file size; using zero"
+                    );
+                    0
+                });
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    0,
+                    size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }
@@ -91,13 +96,52 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::actions::{Metadata, Protocol};
+    use crate::actions::{Metadata, Protocol, LOG_METADATA_SCHEMA};
     use crate::committer::{CommitProtocolMetadata, CommitType};
     use crate::engine::sync::SyncEngine;
+    use crate::engine::test_delegating::DelegatingEngine;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::path::LogRoot;
+    use crate::{
+        EngineData, FileDataReadResultIterator, IntoEngineData, JsonHandler, JsonWriteResult,
+        PredicateRef, SchemaRef,
+    };
+
+    struct SizeOmittingJsonHandler {
+        inner: Arc<dyn JsonHandler>,
+    }
+
+    impl JsonHandler for SizeOmittingJsonHandler {
+        fn parse_json(
+            &self,
+            json_strings: Box<dyn EngineData>,
+            output_schema: SchemaRef,
+        ) -> DeltaResult<Box<dyn EngineData>> {
+            self.inner.parse_json(json_strings, output_schema)
+        }
+
+        fn read_json_files(
+            &self,
+            files: &[FileMeta],
+            physical_schema: SchemaRef,
+            predicate: Option<PredicateRef>,
+        ) -> DeltaResult<FileDataReadResultIterator> {
+            self.inner
+                .read_json_files(files, physical_schema, predicate)
+        }
+
+        fn write_json_file(
+            &self,
+            path: &Url,
+            data: DeltaResultIterator<'_, FilteredEngineData>,
+            overwrite: bool,
+        ) -> DeltaResult<JsonWriteResult> {
+            self.inner.write_json_file(path, data, overwrite)?;
+            Ok(JsonWriteResult::without_size())
+        }
+    }
 
     #[tokio::test]
     async fn disallow_filesystem_committer_for_catalog_managed_tables() {
@@ -135,13 +179,17 @@ mod tests {
     async fn test_filesystem_committer_returns_valid_commit_response() {
         let storage = Arc::new(InMemory::new());
         let table_root = Url::parse("memory:///").unwrap();
-        let engine = SyncEngine::new_with_store(storage);
+        let engine = SyncEngine::new_with_store(storage.clone());
 
         let committer = FileSystemCommitter::new();
         let log_root = LogRoot::new(table_root).unwrap();
         let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
         let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
+        let action = metadata
+            .clone()
+            .into_engine_data(LOG_METADATA_SCHEMA.clone(), &engine)
+            .unwrap();
         let commit_metadata = CommitMetadata::new(
             log_root,
             1,
@@ -151,19 +199,60 @@ mod tests {
             CommitProtocolMetadata::try_new(Some(protocol), Some(metadata), None, None).unwrap(),
             vec![],
         );
-        let actions = Box::new(std::iter::empty());
+        let actions = Box::new(std::iter::once(Ok(
+            FilteredEngineData::with_all_rows_selected(action),
+        )));
 
         let result = committer.commit(&engine, actions, commit_metadata).unwrap();
+        let stored_size = storage
+            .head(&Path::from("_delta_log/00000000000000000001.json"))
+            .await
+            .unwrap()
+            .size;
 
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
-                assert_eq!(file_meta.size, 0);
+                assert!(file_meta.size > 0);
+                assert_eq!(file_meta.size, stored_size);
                 assert!(file_meta
                     .location
                     .as_str()
                     .ends_with("00000000000000000001.json"));
             }
+            CommitResponse::Conflict { .. } => panic!("Expected Committed, got Conflict"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_filesystem_committer_succeeds_without_reported_file_size() {
+        let storage = Arc::new(InMemory::new());
+        let table_root = Url::parse("memory:///").unwrap();
+        let base_engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(storage));
+        let json_handler = Arc::new(SizeOmittingJsonHandler {
+            inner: base_engine.json_handler(),
+        });
+        let engine = DelegatingEngine::new(base_engine).with_json_handler(json_handler);
+
+        let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
+        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
+        let commit_metadata = CommitMetadata::new(
+            LogRoot::new(table_root).unwrap(),
+            1,
+            CommitType::PathBasedWrite,
+            12345,
+            Some(0),
+            CommitProtocolMetadata::try_new(Some(protocol), Some(metadata), None, None).unwrap(),
+            vec![],
+        );
+
+        let result = FileSystemCommitter::new()
+            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
+            .unwrap();
+
+        match result {
+            CommitResponse::Committed { file_meta } => assert_eq!(file_meta.size, 0),
             CommitResponse::Conflict { .. } => panic!("Expected Committed, got Conflict"),
         }
     }

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -134,7 +134,7 @@ mod tests {
     async fn test_filesystem_committer_returns_valid_commit_response() {
         let storage = Arc::new(InMemory::new());
         let table_root = Url::parse("memory:///").unwrap();
-        let engine = SyncEngine::new_with_store(storage);
+        let engine = SyncEngine::new_with_store(storage.clone());
 
         let committer = FileSystemCommitter::new();
         let log_root = LogRoot::new(table_root).unwrap();
@@ -159,6 +159,11 @@ mod tests {
         )));
 
         let result = committer.commit(&engine, actions, commit_metadata).unwrap();
+        let stored_size = storage
+            .head(&Path::from("_delta_log/00000000000000000001.json"))
+            .await
+            .unwrap()
+            .size;
 
         match result {
             CommitResponse::Committed { file_meta } => {
@@ -167,6 +172,7 @@ mod tests {
                 //     + 16 timestamp + 21 config.
                 // 214 = 177 fixed JSON + 36 UUID + 1 newline.
                 assert_eq!(file_meta.size, 214);
+                assert_eq!(file_meta.size, stored_size);
                 assert!(file_meta
                     .location
                     .as_str()

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -163,6 +163,8 @@ mod tests {
         match result {
             CommitResponse::Committed { file_meta } => {
                 assert_eq!(file_meta.last_modified, 12345);
+                // 214 = 19 prefix + 36 UUID + 46 format + 53 schema
+                //     + 22 partitions + 16 timestamp + 21 config + 1 newline.
                 assert_eq!(file_meta.size, 214);
                 assert!(file_meta
                     .location

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -1,6 +1,6 @@
 //! File system committer for non-catalog-managed tables.
 
-use tracing::{info, instrument, warn};
+use tracing::{info, instrument};
 
 use super::commit_types::{CommitMetadata, CommitResponse};
 use super::publish_types::PublishMetadata;
@@ -47,17 +47,10 @@ impl Committer for FileSystemCommitter {
                     committed_version = version,
                     "Committed delta file via filesystem committer"
                 );
-                let size = write_result.size.unwrap_or_else(|| {
-                    warn!(
-                        committed_version = version,
-                        "JSON handler did not report the committed file size; using zero"
-                    );
-                    0
-                });
                 let file_meta = FileMeta::new(
                     published_commit_path,
                     commit_metadata.in_commit_timestamp(),
-                    size,
+                    write_result.size,
                 );
                 Ok(CommitResponse::Committed { file_meta })
             }
@@ -99,49 +92,11 @@ mod tests {
     use crate::actions::{Metadata, Protocol, LOG_METADATA_SCHEMA};
     use crate::committer::{CommitProtocolMetadata, CommitType};
     use crate::engine::sync::SyncEngine;
-    use crate::engine::test_delegating::DelegatingEngine;
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::path::LogRoot;
-    use crate::{
-        EngineData, FileDataReadResultIterator, IntoEngineData, JsonHandler, JsonWriteResult,
-        PredicateRef, SchemaRef,
-    };
-
-    struct SizeOmittingJsonHandler {
-        inner: Arc<dyn JsonHandler>,
-    }
-
-    impl JsonHandler for SizeOmittingJsonHandler {
-        fn parse_json(
-            &self,
-            json_strings: Box<dyn EngineData>,
-            output_schema: SchemaRef,
-        ) -> DeltaResult<Box<dyn EngineData>> {
-            self.inner.parse_json(json_strings, output_schema)
-        }
-
-        fn read_json_files(
-            &self,
-            files: &[FileMeta],
-            physical_schema: SchemaRef,
-            predicate: Option<PredicateRef>,
-        ) -> DeltaResult<FileDataReadResultIterator> {
-            self.inner
-                .read_json_files(files, physical_schema, predicate)
-        }
-
-        fn write_json_file(
-            &self,
-            path: &Url,
-            data: DeltaResultIterator<'_, FilteredEngineData>,
-            overwrite: bool,
-        ) -> DeltaResult<JsonWriteResult> {
-            self.inner.write_json_file(path, data, overwrite)?;
-            Ok(JsonWriteResult::without_size())
-        }
-    }
+    use crate::IntoEngineData;
 
     #[tokio::test]
     async fn disallow_filesystem_committer_for_catalog_managed_tables() {
@@ -220,39 +175,6 @@ mod tests {
                     .as_str()
                     .ends_with("00000000000000000001.json"));
             }
-            CommitResponse::Conflict { .. } => panic!("Expected Committed, got Conflict"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_filesystem_committer_succeeds_without_reported_file_size() {
-        let storage = Arc::new(InMemory::new());
-        let table_root = Url::parse("memory:///").unwrap();
-        let base_engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(storage));
-        let json_handler = Arc::new(SizeOmittingJsonHandler {
-            inner: base_engine.json_handler(),
-        });
-        let engine = DelegatingEngine::new(base_engine).with_json_handler(json_handler);
-
-        let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
-        let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
-        let commit_metadata = CommitMetadata::new(
-            LogRoot::new(table_root).unwrap(),
-            1,
-            CommitType::PathBasedWrite,
-            12345,
-            Some(0),
-            CommitProtocolMetadata::try_new(Some(protocol), Some(metadata), None, None).unwrap(),
-            vec![],
-        );
-
-        let result = FileSystemCommitter::new()
-            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
-            .unwrap();
-
-        match result {
-            CommitResponse::Committed { file_meta } => assert_eq!(file_meta.size, 0),
             CommitResponse::Conflict { .. } => panic!("Expected Committed, got Conflict"),
         }
     }

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -10,7 +10,7 @@ use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator, FileMeta,
-    FilteredEngineData, JsonHandler, PredicateRef,
+    FilteredEngineData, JsonHandler, JsonWriteResult, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
@@ -60,7 +60,7 @@ impl JsonHandler for PlanBasedJsonHandler {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()> {
+    ) -> DeltaResult<JsonWriteResult> {
         debug!(%path, "PlanBasedJsonHandler delegating write_json_file to fallback handler");
         self.fallback.write_json_file(path, data, overwrite)
     }

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -10,7 +10,7 @@ use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    FilteredEngineData, JsonHandler, JsonWriteResult, PredicateRef,
+    FileSize, FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
@@ -64,7 +64,7 @@ impl JsonHandler for PlanBasedJsonHandler {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<JsonWriteResult> {
+    ) -> DeltaResult<FileSize> {
         let Some(fallback) = &self.fallback else {
             return Err(Error::unsupported(
                 "PlanBasedJsonHandler does not support write_json_file yet, and no fallback \
@@ -124,10 +124,11 @@ mod tests {
         let filtered = Ok(FilteredEngineData::with_all_rows_selected(
             single_column_data(vec!["a", "b"]),
         ));
-        make_handler()
+        let written_size = make_handler()
             .write_json_file(&url, Box::new(std::iter::once(filtered)), false)
             .unwrap();
         let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written_size, contents.len() as u64);
         assert_eq!(contents, "{\"x\":\"a\"}\n{\"x\":\"b\"}\n");
     }
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -76,10 +76,7 @@ impl JsonHandler for SyncJsonHandler {
         overwrite: bool,
     ) -> DeltaResult<FileSize> {
         let buf = to_json_bytes(data)?;
-        let size = buf
-            .len()
-            .try_into()
-            .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
+        let size = buf.len() as FileSize;
         put_bytes(self.store.as_ref(), path, buf.into(), overwrite)?;
         Ok(size)
     }
@@ -142,9 +139,9 @@ mod tests {
         let result =
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        let written_size = result?;
+        let written_size = result.unwrap();
         assert_eq!(written_size, 32);
-        assert_eq!(written_size, std::fs::metadata(&path)?.len());
+        assert_eq!(written_size, std::fs::metadata(&path).unwrap().len());
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -155,9 +152,9 @@ mod tests {
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            let written_size = result?;
+            let written_size = result.unwrap();
             assert_eq!(written_size, 28);
-            assert_eq!(written_size, std::fs::metadata(&path)?.len());
+            assert_eq!(written_size, std::fs::metadata(&path).unwrap().len());
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
@@ -175,10 +172,12 @@ mod tests {
         let handler = SyncJsonHandler::new(None);
         let url = Url::from_file_path(&path).unwrap();
 
-        let written_size = handler.write_json_file(&url, Box::new(std::iter::empty()), false)?;
+        let written_size = handler
+            .write_json_file(&url, Box::new(std::iter::empty()), false)
+            .unwrap();
 
         assert_eq!(written_size, 0);
-        assert_eq!(std::fs::metadata(&path)?.len(), 0);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 0);
         Ok(())
     }
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -16,7 +16,7 @@ use crate::object_store::DynObjectStore;
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    JsonHandler, PredicateRef,
+    JsonHandler, JsonWriteResult, PredicateRef,
 };
 
 pub(crate) struct SyncJsonHandler {
@@ -74,9 +74,14 @@ impl JsonHandler for SyncJsonHandler {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()> {
+    ) -> DeltaResult<JsonWriteResult> {
         let buf = to_json_bytes(data)?;
-        put_bytes(self.store.as_ref(), path, buf.into(), overwrite)
+        let size = buf
+            .len()
+            .try_into()
+            .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
+        put_bytes(self.store.as_ref(), path, buf.into(), overwrite)?;
+        Ok(JsonWriteResult::new(size))
     }
 }
 
@@ -137,8 +142,9 @@ mod tests {
         let result =
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful
-        assert!(result.is_ok());
+        // Verify the first write is successful and reports the stored size.
+        let write_result = result?;
+        assert_eq!(write_result.size, Some(std::fs::metadata(&path)?.len()));
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -149,8 +155,9 @@ mod tests {
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful
-            assert!(result.is_ok());
+            // Verify the second write is successful and reports the replaced size.
+            let write_result = result?;
+            assert_eq!(write_result.size, Some(std::fs::metadata(&path)?.len()));
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -147,6 +147,7 @@ mod tests {
         // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
         // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
+        assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -162,6 +163,7 @@ mod tests {
             // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
             // 28 = 2 * (10 + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
+            assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -142,9 +142,9 @@ mod tests {
         let result =
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful and reports the stored size.
+        // Verify the first write is successful and reports the expected size.
         let write_result = result?;
-        assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
+        assert_eq!(write_result.size, 32);
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -155,9 +155,9 @@ mod tests {
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful and reports the replaced size.
+            // Verify the second write is successful and reports the expected size.
             let write_result = result?;
-            assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
+            assert_eq!(write_result.size, 28);
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -144,7 +144,7 @@ mod tests {
 
         // Verify the first write is successful and reports the stored size.
         let write_result = result?;
-        assert_eq!(write_result.size, Some(std::fs::metadata(&path)?.len()));
+        assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -157,7 +157,7 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the replaced size.
             let write_result = result?;
-            assert_eq!(write_result.size, Some(std::fs::metadata(&path)?.len()));
+            assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -144,6 +144,7 @@ mod tests {
 
         // Verify the first write is successful and reports the expected size.
         let write_result = result?;
+        // 32 = (10 JSON + 4 "remi" + 1 newline) + (10 JSON + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
@@ -157,6 +158,7 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the expected size.
             let write_result = result?;
+            // 28 = 2 * (10 JSON + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -16,7 +16,7 @@ use crate::object_store::DynObjectStore;
 use crate::schema::SchemaRef;
 use crate::{
     DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
-    JsonHandler, JsonWriteResult, PredicateRef,
+    FileSize, JsonHandler, PredicateRef,
 };
 
 pub(crate) struct SyncJsonHandler {
@@ -74,14 +74,14 @@ impl JsonHandler for SyncJsonHandler {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<JsonWriteResult> {
+    ) -> DeltaResult<FileSize> {
         let buf = to_json_bytes(data)?;
         let size = buf
             .len()
             .try_into()
             .map_err(|_| Error::generic("JSON file size exceeds u64::MAX"))?;
         put_bytes(self.store.as_ref(), path, buf.into(), overwrite)?;
-        Ok(JsonWriteResult::new(size))
+        Ok(size)
     }
 }
 
@@ -142,12 +142,9 @@ mod tests {
         let result =
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
-        // Verify the first write is successful and reports the expected size.
-        let write_result = result?;
-        // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
-        // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
-        assert_eq!(write_result.size, 32);
-        assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
+        let written_size = result?;
+        assert_eq!(written_size, 32);
+        assert_eq!(written_size, std::fs::metadata(&path)?.len());
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
 
@@ -158,12 +155,9 @@ mod tests {
             handler.write_json_file(&url, Box::new(std::iter::once(filtered_data)), overwrite);
 
         if overwrite {
-            // Verify the second write is successful and reports the expected size.
-            let write_result = result?;
-            // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
-            // 28 = 2 * (10 + 3 value + 1 newline).
-            assert_eq!(write_result.size, 28);
-            assert_eq!(write_result.size, std::fs::metadata(&path)?.len());
+            let written_size = result?;
+            assert_eq!(written_size, 28);
+            assert_eq!(written_size, std::fs::metadata(&path)?.len());
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);
         } else {
@@ -171,6 +165,20 @@ mod tests {
             assert!(matches!(result, Err(Error::FileAlreadyExists(_))));
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_empty_json_file_reports_zero_size() -> DeltaResult<()> {
+        let test_dir = TempDir::new().unwrap();
+        let path = test_dir.path().join("empty.json");
+        let handler = SyncJsonHandler::new(None);
+        let url = Url::from_file_path(&path).unwrap();
+
+        let written_size = handler.write_json_file(&url, Box::new(std::iter::empty()), false)?;
+
+        assert_eq!(written_size, 0);
+        assert_eq!(std::fs::metadata(&path)?.len(), 0);
         Ok(())
     }
 

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -144,7 +144,8 @@ mod tests {
 
         // Verify the first write is successful and reports the expected size.
         let write_result = result?;
-        // 32 = (10 JSON + 4 "remi" + 1 newline) + (10 JSON + 6 "wilson" + 1 newline).
+        // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
+        // 32 = (10 + 4 "remi" + 1 newline) + (10 + 6 "wilson" + 1 newline).
         assert_eq!(write_result.size, 32);
         let json = read_json_file(&path)?;
         assert_eq!(json, vec![json!({"dog": "remi"}), json!({"dog": "wilson"})]);
@@ -158,7 +159,8 @@ mod tests {
         if overwrite {
             // Verify the second write is successful and reports the expected size.
             let write_result = result?;
-            // 28 = 2 * (10 JSON + 3 value + 1 newline).
+            // 10 JSON bytes = 8-byte `{"dog":"` prefix + 2-byte `"}` suffix.
+            // 28 = 2 * (10 + 3 value + 1 newline).
             assert_eq!(write_result.size, 28);
             let json = read_json_file(&path)?;
             assert_eq!(json, vec![json!({"dog": "seb"}), json!({"dog": "tia"})]);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -296,6 +296,39 @@ impl FileMeta {
     }
 }
 
+/// Metadata produced by a successful JSON file write.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct JsonWriteResult {
+    /// The number of bytes written to the JSON file, when known without a separate storage
+    /// metadata request.
+    pub size: Option<FileSize>,
+}
+
+impl JsonWriteResult {
+    /// Create a JSON write result with a known serialized file size.
+    ///
+    /// # Parameters
+    ///
+    /// - `size` - Exact number of bytes written to the JSON file.
+    ///
+    /// # Returns
+    ///
+    /// A write result containing `size`.
+    pub fn new(size: FileSize) -> Self {
+        Self { size: Some(size) }
+    }
+
+    /// Create a JSON write result without a known serialized file size.
+    ///
+    /// # Returns
+    ///
+    /// A write result with no file size.
+    pub fn without_size() -> Self {
+        Self { size: None }
+    }
+}
+
 /// Extension trait that makes it easier to work with traits objects that implement [`Any`],
 /// implemented automatically for any type that satisfies `Any`, `Send`, and `Sync`. In particular,
 /// given some `trait T: Any + Send + Sync`, it allows upcasting `T` to `dyn Any + Send + Sync`,
@@ -751,12 +784,22 @@ pub trait JsonHandler: AsAny {
     /// - `data` - Iterator of [`FilteredEngineData`] to write to the JSON file
     /// - `overwrite` - If true, overwrite the file if it exists. If false, the call must fail if
     ///   the file exists.
+    ///
+    /// # Returns
+    ///
+    /// Metadata about the completed write. Implementations should return the exact serialized file
+    /// size when it is available without a separate storage metadata request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::FileAlreadyExists`] when `overwrite` is false and the destination exists,
+    /// or another error when serialization or storage fails.
     fn write_json_file(
         &self,
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()>;
+    ) -> DeltaResult<JsonWriteResult>;
 }
 
 /// Reserved field IDs for metadata columns in Delta tables.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -296,29 +296,6 @@ impl FileMeta {
     }
 }
 
-/// Metadata produced by a successful JSON file write.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct JsonWriteResult {
-    /// The exact number of bytes written to the JSON file.
-    pub size: FileSize,
-}
-
-impl JsonWriteResult {
-    /// Create a JSON write result with a known serialized file size.
-    ///
-    /// # Parameters
-    ///
-    /// - `size` - Exact number of bytes written to the JSON file.
-    ///
-    /// # Returns
-    ///
-    /// A write result containing `size`.
-    pub fn new(size: FileSize) -> Self {
-        Self { size }
-    }
-}
-
 /// Extension trait that makes it easier to work with traits objects that implement [`Any`],
 /// implemented automatically for any type that satisfies `Any`, `Send`, and `Sync`. In particular,
 /// given some `trait T: Any + Send + Sync`, it allows upcasting `T` to `dyn Any + Send + Sync`,
@@ -777,7 +754,7 @@ pub trait JsonHandler: AsAny {
     ///
     /// # Returns
     ///
-    /// Metadata about the completed write, including the exact serialized file size.
+    /// The exact number of serialized bytes written to the file.
     ///
     /// # Errors
     ///
@@ -788,7 +765,7 @@ pub trait JsonHandler: AsAny {
         path: &Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<JsonWriteResult>;
+    ) -> DeltaResult<FileSize>;
 }
 
 /// Reserved field IDs for metadata columns in Delta tables.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -297,12 +297,11 @@ impl FileMeta {
 }
 
 /// Metadata produced by a successful JSON file write.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct JsonWriteResult {
-    /// The number of bytes written to the JSON file, when known without a separate storage
-    /// metadata request.
-    pub size: Option<FileSize>,
+    /// The exact number of bytes written to the JSON file.
+    pub size: FileSize,
 }
 
 impl JsonWriteResult {
@@ -316,16 +315,7 @@ impl JsonWriteResult {
     ///
     /// A write result containing `size`.
     pub fn new(size: FileSize) -> Self {
-        Self { size: Some(size) }
-    }
-
-    /// Create a JSON write result without a known serialized file size.
-    ///
-    /// # Returns
-    ///
-    /// A write result with no file size.
-    pub fn without_size() -> Self {
-        Self { size: None }
+        Self { size }
     }
 }
 
@@ -787,8 +777,7 @@ pub trait JsonHandler: AsAny {
     ///
     /// # Returns
     ///
-    /// Metadata about the completed write. Implementations should return the exact serialized file
-    /// size when it is available without a separate storage metadata request.
+    /// Metadata about the completed write, including the exact serialized file size.
     ///
     /// # Errors
     ///

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -164,7 +164,9 @@ mod tests {
             _data: DeltaResultIterator<'_, FilteredEngineData>,
             _overwrite: bool,
         ) -> DeltaResult<JsonWriteResult> {
-            Ok(JsonWriteResult::new(0))
+            Err(crate::Error::generic(
+                "StubJsonHandler does not support writes",
+            ))
         }
     }
 

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -10,7 +10,7 @@ use crate::metrics::PrecountedMetricsIterator;
 use crate::schema::SchemaRef;
 use crate::{
     CancellationTokenRef, DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator,
-    FileMeta, FilteredEngineData, JsonHandler, PredicateRef,
+    FileMeta, FilteredEngineData, JsonHandler, JsonWriteResult, PredicateRef,
 };
 
 /// Decorator over an engine-provided `Arc<dyn JsonHandler>` that emits a
@@ -96,7 +96,7 @@ impl JsonHandler for MeteredJsonHandler {
         path: &url::Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<()> {
+    ) -> DeltaResult<JsonWriteResult> {
         self.inner.write_json_file(path, data, overwrite)
     }
 }
@@ -163,8 +163,8 @@ mod tests {
             _path: &Url,
             _data: DeltaResultIterator<'_, FilteredEngineData>,
             _overwrite: bool,
-        ) -> DeltaResult<()> {
-            Ok(())
+        ) -> DeltaResult<JsonWriteResult> {
+            Ok(JsonWriteResult::new(0))
         }
     }
 

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -120,6 +120,7 @@ mod tests {
         /// Set when the cancellation-aware read variant is invoked, so a test can assert the
         /// metered wrapper forwards to it (rather than the plain read).
         cancellation_read_called: std::sync::atomic::AtomicBool,
+        write_result: Option<JsonWriteResult>,
     }
 
     fn empty_batch() -> Box<dyn EngineData> {
@@ -164,9 +165,8 @@ mod tests {
             _data: DeltaResultIterator<'_, FilteredEngineData>,
             _overwrite: bool,
         ) -> DeltaResult<JsonWriteResult> {
-            Err(crate::Error::generic(
-                "StubJsonHandler does not support writes",
-            ))
+            self.write_result
+                .ok_or_else(|| crate::Error::generic("StubJsonHandler does not support writes"))
         }
     }
 
@@ -284,6 +284,24 @@ mod tests {
         };
         assert_eq!(e.num_files, 0);
         assert_eq!(e.bytes_read, 0);
+    }
+
+    #[test]
+    fn write_json_file_forwards_result_without_emitting_metrics() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler {
+            write_result: Some(JsonWriteResult::new(42)),
+            ..Default::default()
+        });
+        let handler = MeteredJsonHandler::new(inner);
+        let path = Url::parse("memory:///_delta_log/0.json").unwrap();
+
+        let result = handler
+            .write_json_file(&path, Box::new(std::iter::empty()), false)
+            .unwrap();
+
+        assert_eq!(result, JsonWriteResult::new(42));
+        assert!(reporter.events().is_empty());
     }
 
     #[test]

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -305,6 +305,19 @@ mod tests {
     }
 
     #[test]
+    fn write_json_file_forwards_errors() {
+        let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler::default());
+        let handler = MeteredJsonHandler::new(inner);
+        let path = Url::parse("memory:///_delta_log/0.json").unwrap();
+
+        let error = handler
+            .write_json_file(&path, Box::new(std::iter::empty()), false)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("does not support writes"));
+    }
+
+    #[test]
     #[should_panic(expected = "wraps another MeteredJsonHandler")]
     fn new_panics_on_double_wrap() {
         let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler::default());

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -10,7 +10,7 @@ use crate::metrics::PrecountedMetricsIterator;
 use crate::schema::SchemaRef;
 use crate::{
     CancellationTokenRef, DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator,
-    FileMeta, FilteredEngineData, JsonHandler, JsonWriteResult, PredicateRef,
+    FileMeta, FileSize, FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// Decorator over an engine-provided `Arc<dyn JsonHandler>` that emits a
@@ -96,7 +96,7 @@ impl JsonHandler for MeteredJsonHandler {
         path: &url::Url,
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
-    ) -> DeltaResult<JsonWriteResult> {
+    ) -> DeltaResult<FileSize> {
         self.inner.write_json_file(path, data, overwrite)
     }
 }
@@ -120,7 +120,7 @@ mod tests {
         /// Set when the cancellation-aware read variant is invoked, so a test can assert the
         /// metered wrapper forwards to it (rather than the plain read).
         cancellation_read_called: std::sync::atomic::AtomicBool,
-        write_result: Option<JsonWriteResult>,
+        write_size: Option<FileSize>,
     }
 
     fn empty_batch() -> Box<dyn EngineData> {
@@ -164,8 +164,8 @@ mod tests {
             _path: &Url,
             _data: DeltaResultIterator<'_, FilteredEngineData>,
             _overwrite: bool,
-        ) -> DeltaResult<JsonWriteResult> {
-            self.write_result
+        ) -> DeltaResult<FileSize> {
+            self.write_size
                 .ok_or_else(|| crate::Error::generic("StubJsonHandler does not support writes"))
         }
     }
@@ -287,20 +287,20 @@ mod tests {
     }
 
     #[test]
-    fn write_json_file_forwards_result_without_emitting_metrics() {
+    fn write_json_file_forwards_size_without_emitting_metrics() {
         let (reporter, _guard) = install_capture();
         let inner: Arc<dyn JsonHandler> = Arc::new(StubJsonHandler {
-            write_result: Some(JsonWriteResult::new(42)),
+            write_size: Some(42),
             ..Default::default()
         });
         let handler = MeteredJsonHandler::new(inner);
         let path = Url::parse("memory:///_delta_log/0.json").unwrap();
 
-        let result = handler
+        let written_size = handler
             .write_json_file(&path, Box::new(std::iter::empty()), false)
             .unwrap();
 
-        assert_eq!(result, JsonWriteResult::new(42));
+        assert_eq!(written_size, 42);
         assert!(reporter.events().is_empty());
     }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1060,11 +1060,16 @@ impl Committer for TestCatalogCommitter {
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         let path = commit_metadata.published_commit_path()?;
-        engine
-            .json_handler()
-            .write_json_file(&path, Box::new(actions), false)?;
+        let write_result =
+            engine
+                .json_handler()
+                .write_json_file(&path, Box::new(actions), false)?;
         Ok(CommitResponse::Committed {
-            file_meta: FileMeta::new(path, commit_metadata.in_commit_timestamp(), 0),
+            file_meta: FileMeta::new(
+                path,
+                commit_metadata.in_commit_timestamp(),
+                write_result.size.unwrap_or_default(),
+            ),
         })
     }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1068,7 +1068,7 @@ impl Committer for TestCatalogCommitter {
             file_meta: FileMeta::new(
                 path,
                 commit_metadata.in_commit_timestamp(),
-                write_result.size.unwrap_or_default(),
+                write_result.size,
             ),
         })
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1072,16 +1072,12 @@ impl Committer for TestCatalogCommitter {
         commit_metadata: CommitMetadata,
     ) -> DeltaResult<CommitResponse> {
         let path = commit_metadata.published_commit_path()?;
-        let write_result =
+        let written_size =
             engine
                 .json_handler()
                 .write_json_file(&path, Box::new(actions), false)?;
         Ok(CommitResponse::Committed {
-            file_meta: FileMeta::new(
-                path,
-                commit_metadata.in_commit_timestamp(),
-                write_result.size,
-            ),
+            file_meta: FileMeta::new(path, commit_metadata.in_commit_timestamp(), written_size),
         })
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

`JsonHandler::write_json_file` returns the exact serialized JSON file size:

```rust
// Before
fn write_json_file(...) -> DeltaResult<()>;

// After
fn write_json_file(...) -> DeltaResult<FileSize>;
```

The default and synchronous engines calculate the size from the serialized JSON buffer. The
filesystem committer and Unity Catalog version-zero commit path use it for `FileMeta.size` instead
of reporting `0`, without adding a fallible metadata request after the commit file is published.

### This PR affects the following public APIs

This is a breaking change to `JsonHandler::write_json_file`. Implementations must return the exact
serialized file size instead of `()`.

## How was this change tested?

- JSON handler tests compare reported sizes with expected serialized lengths and storage metadata
  for normal, empty, and overwrite writes. The empty-file test also verifies an empty payload.
- Filesystem committer and Unity Catalog version-zero tests compare the committed `FileMeta` size
  with the published file.
- Plan-based and metered JSON handler tests verify exact size forwarding.
- `cargo +nightly fmt -- --check` and all Rust and user-guide CI jobs pass.
