### PR TITLE
feat: Define and use Predicate TRUE/FALSE/NULL constants

### DIFF
--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -785,7 +785,7 @@ fn visit_predicate_opaque_impl(
         return Ok(0);
     }
     tracing::info!("opaque predicate `{name}`: no eval callbacks; kernel will not prune on it");
-    Ok(wrap_predicate(state, Predicate::null_literal()))
+    Ok(wrap_predicate(state, Predicate::NULL))
 }
 
 /// Build an opaque predicate over `FfiOpaquePredicateOp(name, callbacks)` and
@@ -1154,7 +1154,7 @@ mod tests {
         assert_ne!(id, 0);
         let pred = unwrap_kernel_predicate(&mut state, id).unwrap();
         // No eval callbacks => NULL boolean literal, which abstains everywhere (even under NOT).
-        assert_eq!(pred, Predicate::null_literal());
+        assert_eq!(pred, Predicate::NULL);
         // Children are drained from the visitor state even though they're discarded.
         assert!(state.inflight_ids.is_empty());
     }
@@ -1194,7 +1194,7 @@ mod tests {
         let id = ok_or_panic(result);
         assert_ne!(id, 0);
         let pred = unwrap_kernel_predicate(&mut state, id).unwrap();
-        assert_eq!(pred, Predicate::null_literal());
+        assert_eq!(pred, Predicate::NULL);
     }
 
     /// Drives `visit_predicate_opaque_with_eval` end to end: pass the callbacks struct by value,

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -196,8 +196,8 @@ pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicat
 
     let mut sub_exprs = vec![
         column_pred!("col"),
-        Pred::literal(true),
-        Pred::literal(false),
+        Pred::TRUE,
+        Pred::FALSE,
         Pred::binary(
             BinaryPredicateOp::In,
             Expr::literal(10),
@@ -297,8 +297,8 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
 pub unsafe extern "C" fn get_simple_testing_kernel_predicate() -> Handle<SharedPredicate> {
     let sub_preds = vec![
         column_pred!("pred_col"),
-        Pred::literal(true),
-        Pred::literal(false),
+        Pred::TRUE,
+        Pred::FALSE,
         Pred::eq(Expr::literal(10), Expr::literal(10)),
         Pred::ne(Expr::literal(5), Expr::literal(10)),
         Pred::lt(Expr::literal(5), Expr::literal(10)),
@@ -308,7 +308,7 @@ pub unsafe extern "C" fn get_simple_testing_kernel_predicate() -> Handle<SharedP
         Pred::distinct(Expr::literal(1), Expr::literal(2)),
         Pred::is_null(column_expr!("nullable_col")),
         Pred::is_not_null(column_expr!("nonnull_col")),
-        Pred::not(Pred::literal(false)),
+        Pred::not(Pred::FALSE),
         Pred::or_from(vec![
             Pred::eq(Expr::literal(1), Expr::literal(1)),
             Pred::eq(Expr::literal(2), Expr::literal(2)),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2012,7 +2012,7 @@ mod tests {
 
         let operand = |v: Option<bool>| match v {
             Some(b) => Pred::literal(b),
-            None => Pred::null_literal(),
+            None => Pred::NULL,
         };
         let pred = Pred::junction(op, [operand(left), operand(right)]);
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -629,7 +629,7 @@ fn test_logical() {
     let expected = BooleanArray::from(vec![t, f, f, f, n, f]);
     assert_eq!(results, expected);
 
-    let pred_and_lit = Pred::and(column_a.clone(), Pred::literal(true));
+    let pred_and_lit = Pred::and(column_a.clone(), Pred::TRUE);
     let results = evaluate_predicate(&pred_and_lit, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![t, t, f, f, t, f]);
     assert_eq!(results, expected);
@@ -639,7 +639,7 @@ fn test_logical() {
     let expected = BooleanArray::from(vec![t, t, t, f, t, n]);
     assert_eq!(results, expected);
 
-    let pred_or_lit = Pred::or(column_a.clone(), Pred::literal(false));
+    let pred_or_lit = Pred::or(column_a.clone(), Pred::FALSE);
     let results = evaluate_predicate(&pred_or_lit, &batch, false).unwrap();
     let expected = BooleanArray::from(vec![t, t, f, f, t, f]);
     assert_eq!(results, expected);

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -858,6 +858,13 @@ impl Expression {
 }
 
 impl Predicate {
+    /// Literal boolean true
+    pub const TRUE: Self = Self::literal(true);
+    /// Literal boolean false
+    pub const FALSE: Self = Self::literal(false);
+    /// NULL boolean literal
+    pub const NULL: Self = Self::null_literal();
+
     /// Returns a set of columns referenced by this predicate.
     pub fn references(&self) -> HashSet<&ColumnName> {
         let mut references = GetColumnReferences::default();
@@ -866,16 +873,16 @@ impl Predicate {
     }
 
     /// Creates a new boolean column reference. See also [`Expression::column`].
-    pub fn column(field_names: impl CollectInto<ColumnName>) -> Predicate {
+    pub fn column(field_names: impl CollectInto<ColumnName>) -> Self {
         Self::from_expr(ColumnName::new(field_names))
     }
 
-    /// Create a new literal boolean value
+    /// Create a new literal boolean value. See also [`Self::TRUE`] and [`Self::FALSE`].
     pub const fn literal(value: bool) -> Self {
         Self::BooleanExpression(Expression::Literal(Scalar::Boolean(value)))
     }
 
-    /// Creates a NULL literal boolean value
+    /// Creates a NULL literal boolean value. Prefer [`Self::NULL`].
     pub const fn null_literal() -> Self {
         Self::BooleanExpression(Expression::Literal(Scalar::Null(DataType::BOOLEAN)))
     }
@@ -894,12 +901,12 @@ impl Predicate {
     }
 
     /// Create a new predicate `self IS NULL`
-    pub fn is_null(expr: impl Into<Expression>) -> Predicate {
+    pub fn is_null(expr: impl Into<Expression>) -> Self {
         Self::unary(UnaryPredicateOp::IsNull, expr)
     }
 
     /// Create a new predicate `self IS NOT NULL`
-    pub fn is_not_null(expr: impl Into<Expression>) -> Predicate {
+    pub fn is_not_null(expr: impl Into<Expression>) -> Self {
         Self::not(Self::is_null(expr))
     }
 
@@ -1596,8 +1603,8 @@ mod tests {
                 // Boolean expression
                 Predicate::from_expr(column_expr!("is_active")),
                 // Literals
-                Predicate::literal(true),
-                Predicate::literal(false),
+                Predicate::TRUE,
+                Predicate::FALSE,
                 // NOT
                 Predicate::not(Predicate::from_expr(column_expr!("x"))),
                 // Nested NOT
@@ -1619,8 +1626,7 @@ mod tests {
 
         #[test]
         fn test_predicate_null_literal_roundtrip() {
-            let pred = Predicate::null_literal();
-            assert_roundtrip(&pred);
+            assert_roundtrip(&Predicate::NULL);
         }
 
         #[test]
@@ -1833,12 +1839,12 @@ mod tests {
     #[test]
     fn empty_and_from_returns_identity_literal() {
         let result = Pred::and_from(std::iter::empty());
-        assert_eq!(result, Pred::literal(true));
+        assert_eq!(result, Pred::TRUE);
     }
 
     #[test]
     fn empty_or_from_returns_identity_literal() {
         let result = Pred::or_from(std::iter::empty());
-        assert_eq!(result, Pred::literal(false));
+        assert_eq!(result, Pred::FALSE);
     }
 }

--- a/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
+++ b/kernel/src/kernel_predicates/parquet_stats_skipping/tests.rs
@@ -105,7 +105,7 @@ fn test_junctions() {
             .iter()
             .map(|val| match val {
                 Some(v) => Pred::literal(*v),
-                None => Pred::null_literal(),
+                None => Pred::NULL,
             })
             .collect();
 

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::*;
 use crate::expressions::{
-    column_expr, column_name, column_pred, ArrayData, Expression as Expr, OpaqueExpressionOp,
+    col, column_expr, column_name, column_pred, ArrayData, Expression as Expr, OpaqueExpressionOp,
     OpaquePredicateOp, Predicate as Pred, ScalarExpressionEvaluator, StructData,
 };
 use crate::kernel_predicates::parquet_stats_skipping::ParquetStatsProvider;
@@ -470,7 +470,7 @@ fn test_eval_junction() {
             .cloned()
             .map(|v| match v {
                 Some(v) => Pred::literal(v),
-                None => Pred::null_literal(),
+                None => Pred::NULL,
             })
             .collect();
         for inverted in [true, false] {
@@ -1046,12 +1046,8 @@ impl ResolveColumnAsScalar for NullColumnResolver {
 
 #[test]
 fn test_sql_where() {
-    let col = &column_expr!("x");
     let col_pred = &column_pred!("x");
     const VAL: Expr = Expr::Literal(Scalar::Integer(1));
-    const NULL: Pred = Pred::null_literal();
-    const FALSE: Pred = Pred::literal(false);
-    const TRUE: Pred = Pred::literal(true);
     let null_filter = DefaultKernelPredicateEvaluator::from(NullColumnResolver);
     let empty_filter = DefaultKernelPredicateEvaluator::from(EmptyColumnResolver);
 
@@ -1079,7 +1075,7 @@ fn test_sql_where() {
     );
 
     // SQL eval does not modify behavior of IS NULL
-    let pred = &Pred::is_null(col.clone());
+    let pred = &col!("x").is_null();
     expect_eq!(null_filter.eval_sql_where(pred), Some(true), "{pred}");
 
     // NOT a gets skipped when NULL but not when missing
@@ -1088,34 +1084,34 @@ fn test_sql_where() {
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
     // Injected NULL checks only short circuit if inputs are NULL
-    let pred = &Pred::lt(FALSE, TRUE);
+    let pred = &Pred::lt(Pred::FALSE, Pred::TRUE);
     expect_eq!(null_filter.eval_sql_where(pred), Some(true), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), Some(true), "{pred}");
 
     // Contrast normal vs SQL WHERE semantics - comparison
-    let pred = &Pred::lt(col.clone(), VAL);
+    let pred = &Pred::lt(col!("x"), VAL);
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     // NULL check produces NULL due to missing column
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
-    let pred = &Pred::lt(VAL, col.clone());
+    let pred = &Pred::lt(VAL, col!("x"));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
-    let pred = &Pred::distinct(VAL, col.clone());
+    let pred = &Pred::distinct(VAL, col!("x"));
     expect_eq!(null_filter.eval(pred), Some(true), "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(true), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
-    let pred = &Pred::distinct(NULL, col.clone());
+    let pred = &Pred::distinct(Pred::NULL, col!("x"));
     expect_eq!(null_filter.eval(pred), Some(false), "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
     // Contrast normal vs SQL WHERE semantics - comparison inside AND
-    let pred = &Pred::and(TRUE, Pred::lt(col.clone(), VAL));
+    let pred = &Pred::and(Pred::TRUE, Pred::lt(col!("x"), VAL));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
@@ -1123,19 +1119,19 @@ fn test_sql_where() {
     // NULL literal is treated as unknown (not false) under eval_sql_where, so it does not
     // force static skipping. This prevents incorrect pruning when indirect data skipping
     // rewriters use NULL as a sentinel for unsupported predicate arms.
-    let pred = &Pred::and(NULL, Pred::lt(col.clone(), VAL));
+    let pred = &Pred::and(Pred::NULL, Pred::lt(col!("x"), VAL));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
     // Contrast normal vs. SQL WHERE semantics - comparison inside AND inside AND
-    let pred = &Pred::and(TRUE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
+    let pred = &Pred::and(Pred::TRUE, Pred::and(Pred::TRUE, Pred::lt(col!("x"), VAL)));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");
 
     // Ditto for comparison inside OR inside AND
-    let pred = &Pred::or(FALSE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
+    let pred = &Pred::or(Pred::FALSE, Pred::and(Pred::TRUE, Pred::lt(col!("x"), VAL)));
     expect_eq!(null_filter.eval(pred), None, "{pred}");
     expect_eq!(null_filter.eval_sql_where(pred), Some(false), "{pred}");
     expect_eq!(empty_filter.eval_sql_where(pred), None, "{pred}");

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -1305,7 +1305,7 @@ mod tests {
         }),
         "project"
     )]
-    #[case(Operator::Filter(Filter { predicate: Arc::new(Predicate::literal(true)) }), "filter")]
+    #[case(Operator::Filter(Filter { predicate: Arc::new(Predicate::TRUE) }), "filter")]
     #[case(
         Operator::Load(Load {
             schema: sample_schema(),
@@ -1409,7 +1409,7 @@ mod tests {
     #[test]
     fn from_filter() {
         let node = Filter {
-            predicate: Arc::new(Predicate::literal(true)),
+            predicate: Arc::new(Predicate::TRUE),
         };
         let proto = proto_plan::FilterNode::from(&node);
         assert!(proto.predicate.is_some());
@@ -1517,7 +1517,7 @@ mod tests {
     #[rstest]
     #[case(lit(1), "literal")]
     #[case(Expression::Column(ColumnName::new(["a"])), "column")]
-    #[case(Expression::Predicate(Box::new(Predicate::literal(true))), "predicate")]
+    #[case(Expression::Predicate(Box::new(Predicate::TRUE)), "predicate")]
     #[case(Expression::struct_from([lit(1)]), "struct_expr")]
     #[case(
         Expression::StructPatch(
@@ -1553,14 +1553,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Predicate::literal(true), "boolean_expression")]
-    #[case(Predicate::not(Predicate::literal(true)), "not")]
+    #[case(Predicate::TRUE, "boolean_expression")]
+    #[case(Predicate::not(Predicate::TRUE), "not")]
     #[case(Predicate::is_null(lit(1)), "unary")]
     #[case(Predicate::gt(lit(1), lit(2)), "binary")]
-    #[case(
-        Predicate::and(Predicate::literal(true), Predicate::literal(false)),
-        "junction"
-    )]
+    #[case(Predicate::and(Predicate::TRUE, Predicate::FALSE), "junction")]
     #[case(Predicate::opaque(TestOpaquePredOp, [lit(1)]), "opaque")]
     #[case(Predicate::Unknown("x".to_string()), "unknown")]
     fn from_predicate(#[case] pred: Predicate, #[case] expected: &str) {
@@ -1695,10 +1692,9 @@ mod tests {
 
     #[test]
     fn from_junction_predicate() {
-        let proto_expr::predicate::Kind::Junction(junction) = pred_kind_of(Predicate::and(
-            Predicate::literal(true),
-            Predicate::literal(false),
-        )) else {
+        let proto_expr::predicate::Kind::Junction(junction) =
+            pred_kind_of(Predicate::and(Predicate::TRUE, Predicate::FALSE))
+        else {
             panic!("expected a junction predicate");
         };
         assert_eq!(junction.op, proto_expr::JunctionPredicateOp::And as i32);

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -484,7 +484,7 @@ fn collect_junction_preds(
             Some(pred) => Some(pred),
             None => keep_null.then(|| {
                 keep_null = false;
-                Pred::null_literal()
+                Pred::NULL
             }),
         })
         .collect();

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rstest::rstest;
 
 use super::*;
-use crate::expressions::{column_expr_ref, column_name};
+use crate::expressions::{col, column_expr_ref, column_name};
 use crate::kernel_predicates::{
     DefaultKernelPredicateEvaluator, EmptyColumnResolver, UnimplementedColumnResolver,
 };
@@ -170,7 +170,7 @@ fn test_eval_junction() {
             .iter()
             .map(|val| match val {
                 Some(v) => Pred::literal(*v),
-                None => Pred::null_literal(),
+                None => Pred::NULL,
             })
             .collect();
 
@@ -265,11 +265,7 @@ fn test_eval_distinct() {
 
 #[test]
 fn test_sql_where() {
-    let col = &column_expr!("x");
     const VAL: Expr = Expr::Literal(Scalar::Integer(10));
-    const NULL: Pred = Pred::null_literal();
-    const FALSE: Pred = Pred::literal(false);
-    const TRUE: Pred = Pred::literal(true);
 
     const ROWCOUNT: i64 = 2;
     const ALL_NULL: i64 = ROWCOUNT;
@@ -321,22 +317,22 @@ fn test_sql_where() {
     // Sanity tests -- only all-null columns should behave differently between normal and SQL WHERE.
     const MISSING: bool = true;
     const PRESENT: bool = false;
-    let pred = &Pred::lt(TRUE, FALSE);
+    let pred = &Pred::lt(Pred::TRUE, Pred::FALSE);
     do_test(ALL_NULL, pred, MISSING, Some(false), Some(false));
 
-    let pred = &Pred::is_not_null(col.clone());
+    let pred = &Pred::is_not_null(col!("x"));
     do_test(ALL_NULL, pred, PRESENT, Some(false), Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
     // SQL WHERE allows a present-but-all-null column to be pruned, but not a missing column.
-    let pred = &Pred::lt(col.clone(), VAL);
+    let pred = &Pred::lt(col!("x"), VAL);
     do_test(NO_NULL, pred, PRESENT, Some(true), Some(true));
     do_test(SOME_NULL, pred, PRESENT, Some(true), Some(true));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
     // Comparison inside AND works
-    let pred = &Pred::and(TRUE, Pred::lt(VAL, col.clone()));
+    let pred = &Pred::and(Pred::TRUE, Pred::lt(VAL, col!("x")));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
@@ -344,22 +340,22 @@ fn test_sql_where() {
     // force static skipping on its own. With present-but-all-null stats, the comparison arm
     // still evaluates to false (null-safe check fails), so AND(unknown, false) = false.
     // With missing stats, both arms are unknown, so AND(unknown, unknown) = unknown.
-    let pred = &Pred::and(NULL, Pred::lt(col.clone(), VAL));
+    let pred = &Pred::and(Pred::NULL, Pred::lt(col!("x"), VAL));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
     // Comparison inside AND inside AND works
-    let pred = &Pred::and(TRUE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
+    let pred = &Pred::and(Pred::TRUE, Pred::and(Pred::TRUE, Pred::lt(col!("x"), VAL)));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
     // Comparison inside OR works
-    let pred = &Pred::or(FALSE, Pred::lt(col.clone(), VAL));
+    let pred = &Pred::or(Pred::FALSE, Pred::lt(col!("x"), VAL));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 
     // Comparison inside AND inside OR works
-    let pred = &Pred::or(FALSE, Pred::and(TRUE, Pred::lt(col.clone(), VAL)));
+    let pred = &Pred::or(Pred::FALSE, Pred::and(Pred::TRUE, Pred::lt(col!("x"), VAL)));
     do_test(ALL_NULL, pred, PRESENT, None, Some(false));
     do_test(ALL_NULL, pred, MISSING, None, None);
 }

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -1007,7 +1007,7 @@ mod tests {
         let state = state(
             data_schema(),
             vec![],
-            Some(Predicate::literal(false)),
+            Some(Predicate::FALSE),
             stats.clone(),
             partition_values.clone(),
         );

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -41,19 +41,18 @@ fn field_names(s: &StructArray) -> Vec<String> {
 
 #[test]
 fn test_static_skipping() {
-    const NULL: Pred = Pred::null_literal();
     let test_cases = [
         (false, column_pred!("a")),
-        (true, Pred::literal(false)),
-        (false, Pred::literal(true)),
-        (false, NULL), // NULL is unknown, not false -- conservative (no skip)
-        (true, Pred::and(column_pred!("a"), Pred::literal(false))),
-        (false, Pred::or(column_pred!("a"), Pred::literal(true))),
-        (false, Pred::or(column_pred!("a"), Pred::literal(false))),
+        (true, Pred::FALSE),
+        (false, Pred::TRUE),
+        (false, Pred::NULL), // NULL is unknown, not false -- conservative (no skip)
+        (true, Pred::and(column_pred!("a"), Pred::FALSE)),
+        (false, Pred::or(column_pred!("a"), Pred::TRUE)),
+        (false, Pred::or(column_pred!("a"), Pred::FALSE)),
         (false, Pred::lt(column_expr!("a"), Expr::literal(10))),
         (false, Pred::lt(Expr::literal(10), Expr::literal(100))),
         (true, Pred::gt(Expr::literal(10), Expr::literal(100))),
-        (false, Pred::and(NULL, column_pred!("a"))), // NULL is unknown, not false
+        (false, Pred::and(Pred::NULL, column_pred!("a"))), // NULL is unknown, not false
     ];
     for (should_skip, predicate) in test_cases {
         assert_eq!(
@@ -103,8 +102,8 @@ fn test_physical_predicate() {
     // NOTE: We break several column mapping rules here because they don't matter for this
     // test. For example, we do not provide field ids, and not all columns have physical names.
     let test_cases = [
-        (Pred::literal(true), Some(PhysicalPredicate::None)),
-        (Pred::literal(false), Some(PhysicalPredicate::StaticSkipAll)),
+        (Pred::TRUE, Some(PhysicalPredicate::None)),
+        (Pred::FALSE, Some(PhysicalPredicate::StaticSkipAll)),
         (column_pred!("x"), None), // no such column
         (
             column_pred!("a"),
@@ -177,9 +176,9 @@ fn test_physical_predicate() {
             )),
         ),
         (
-            Pred::and(column_pred!("mapped.n"), Pred::literal(true)),
+            Pred::and(column_pred!("mapped.n"), Pred::TRUE),
             Some(PhysicalPredicate::Some(
-                Pred::and(column_pred!("phys_mapped.phys_n"), Pred::literal(true)).into(),
+                Pred::and(column_pred!("phys_mapped.phys_n"), Pred::TRUE).into(),
                 StructType::new_unchecked(vec![StructField::nullable(
                     "phys_mapped",
                     StructType::new_unchecked(vec![StructField::nullable(
@@ -199,7 +198,7 @@ fn test_physical_predicate() {
             )),
         ),
         (
-            Pred::and(column_pred!("mapped.n"), Pred::literal(false)),
+            Pred::and(column_pred!("mapped.n"), Pred::FALSE),
             Some(PhysicalPredicate::StaticSkipAll),
         ),
     ];
@@ -1157,7 +1156,7 @@ fn test_build_actions_meta_predicate_static_skip_all() {
 
     // A predicate that statically evaluates to false should produce StaticSkipAll,
     // which means build_actions_meta_predicate returns None.
-    let predicate = Arc::new(Pred::literal(false));
+    let predicate = Arc::new(Pred::FALSE);
     let scan = snapshot
         .scan_builder()
         .with_predicate(predicate)
@@ -2392,7 +2391,7 @@ mod scan_metadata_completed_tests {
     #[case::basic_scan("./tests/data/parsed-stats/", None, 6, 6, 17236, 0, 0)]
     #[case::static_skip_all(
         "./tests/data/parsed-stats/",
-        Some(Arc::new(Pred::literal(false))),
+        Some(Arc::new(Pred::FALSE)),
         0,
         0,
         0,

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -983,8 +983,8 @@ mod tests {
                         Expr::unknown("unknown") - column_expr!("b"),
                     ],
                 ),
-                Pred::literal(true),
-                Pred::not(Pred::literal(true)),
+                Pred::TRUE,
+                Pred::not(Pred::TRUE),
             ]),
             Pred::and_from([
                 Pred::is_null(column_expr!("b")),
@@ -1148,7 +1148,7 @@ mod tests {
             }
         }
 
-        let pred = Pred::and(column_pred!("x"), Pred::literal(true));
+        let pred = Pred::and(column_pred!("x"), Pred::TRUE);
         let mut transform = LiteralRemover;
         let result = transform.transform_pred(&pred);
         let result = result.map(Cow::into_owned);

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -1435,8 +1435,8 @@ async fn removes_are_never_filtered_by_predicate() -> Result<(), Box<dyn std::er
 // stream, but Removes are still reported. A tautology (`id > 25 OR TRUE`) is useless for
 // skipping and behaves like no predicate.
 #[rstest]
-#[case::static_skip_all(Pred::and(column_expr!("id").gt(Expr::literal(25i32)), Pred::literal(false)), 0)]
-#[case::tautology(Pred::or(column_expr!("id").gt(Expr::literal(25i32)), Pred::literal(true)), 2)]
+#[case::static_skip_all(Pred::and(column_expr!("id").gt(Expr::literal(25i32)), Pred::FALSE), 0)]
+#[case::tautology(Pred::or(column_expr!("id").gt(Expr::literal(25i32)), Pred::TRUE), 2)]
 #[tokio::test]
 async fn static_skip_all_and_tautology(
     #[case] predicate: Pred,
@@ -1836,7 +1836,7 @@ async fn column_free_predicate_keeps_all_added_files() -> Result<(), Box<dyn std
         .at_version(1)
         .build(engine.as_ref())?;
 
-    let predicate: PredicateRef = Arc::new(Pred::literal(true));
+    let predicate: PredicateRef = Arc::new(Pred::TRUE);
     let listing = unwrap_listing(
         target
             .incremental_scan_builder(0)

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -1360,13 +1360,13 @@ fn not_and_or_predicates(
 }
 
 #[rstest::rstest]
-#[case::literal_false(Pred::literal(false), table_for_numbers(vec![]))]
+#[case::literal_false(Pred::FALSE, table_for_numbers(vec![]))]
 #[case::and_with_literal_false(
-    Pred::and(column_pred!("number"), Pred::literal(false)),
+    Pred::and(column_pred!("number"), Pred::FALSE),
     table_for_numbers(vec![])
 )]
 #[case::literal_true(
-    Pred::literal(true),
+    Pred::TRUE,
     table_for_numbers(vec![1, 2, 3, 4, 5, 6])
 )]
 #[case::from_literal_expr(

--- a/workloads/src/predicate_parser.rs
+++ b/workloads/src/predicate_parser.rs
@@ -564,8 +564,8 @@ mod tests {
 
     // -- Boolean literals --
     #[rstest]
-    #[case("TRUE", KPred::literal(true))]
-    #[case("FALSE", KPred::literal(false))]
+    #[case("TRUE", KPred::TRUE)]
+    #[case("FALSE", KPred::FALSE)]
     fn boolean_literals(#[case] sql: &str, #[case] expected: KPred) {
         let schema = test_schema();
         assert_eq!(parse_predicate(sql, &schema).unwrap(), expected);


### PR DESCRIPTION
## What changes are proposed in this pull request?

See title.

Most of the changes were done mechanically with the following three regexp search and replace:
* `s/Pred\(icate\)?::literal[(]true[)]/Pred\1::TRUE)/`
* `s/Pred\(icate\)?::literal[(]false[)]/Pred\1::FALSE)/`
* `s/Pred\(icate\)?::null_literal[(][)]/Pred\1::NULL)/`

Manual changes are flagged as PR comments for reviewer convenience.

### This PR affects the following public APIs

The new constants are pub, but `Predicate::literal` and `Predicate::null_literal` are still available and unchanged.

## How was this change tested?

Existing unit tests