### PR TITLE
fix: block dv + addFile + dataChange txn when cdf enabled

### DIFF
--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -390,13 +390,12 @@ impl<S> Transaction<S> {
         }
 
         // CDF check only applies to existing tables (not create table)
-        // If there are add and remove files with data change in the same transaction, we block it.
-        // This is because kernel does not yet have a way to discern DML operations. For DML
-        // operations that perform updates on rows, ChangeDataFeed requires that a `cdc` file be
-        // written to the delta log.
+        // When a data changing transaction adds files and also stages removes or DV updates, Kernel cannot tell
+        // whether it represents an UPDATE that requires CDC files(which kernel doesn't support yet).
+        // We block that as a conservative choice.
         if !self.is_create_table()
             && !self.add_files_metadata.is_empty()
-            && !self.remove_files_metadata.is_empty()
+            && (!self.remove_files_metadata.is_empty() || self.num_dv_updates > 0)
             && self.data_change
         {
             let cdf_enabled = self

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -391,7 +391,8 @@ impl<S> Transaction<S> {
 
         // If a data-changing transaction has add files together with remove files or DV updates,
         // block it when CDF is enabled. Kernel cannot discern DML operations. DML operations that
-        // update rows require a `cdc` file, but Kernel does not support writing CDC files.
+        // update rows require a `cdc` file, but Kernel does not currently support writing CDC
+        // files.
         if !self.is_create_table()
             && !self.add_files_metadata.is_empty()
             && (!self.remove_files_metadata.is_empty() || self.num_dv_updates > 0)

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -400,15 +400,13 @@ impl<S> Transaction<S> {
         {
             let cdf_enabled = self
                 .effective_table_config
-                .table_properties()
-                .enable_change_data_feed
-                .unwrap_or(false);
+                .is_feature_enabled(&TableFeature::ChangeDataFeed);
             require!(
                 !cdf_enabled,
                 Error::generic(
                     "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
                      This would require writing CDC files for DML operations, which is not yet supported. \
-                     Consider using separate transactions: one to add files, another to remove files."
+                     Only use separate transactions when doing so preserves the required atomicity and CDF semantics: one to add files and another to remove files or update deletion vectors."
                 )
             );
         }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -406,7 +406,7 @@ impl<S> Transaction<S> {
                 Error::generic(
                     "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
                      This would require writing CDC files for DML operations, which is not yet supported. \
-                     Only use separate transactions when doing so preserves the required atomicity and CDF semantics: one to add files and another to remove files or update deletion vectors."
+                     Consider using separate transactions: one to add files, another to remove files or update deletion vectors."
                 )
             );
         }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -389,10 +389,9 @@ impl<S> Transaction<S> {
             validate_schema_for_write(&self.effective_table_config.logical_schema())?;
         }
 
-        // CDF check only applies to existing tables (not create table)
-        // When a data changing transaction adds files and also stages removes or DV updates, Kernel cannot tell
-        // whether it represents an UPDATE that requires CDC files(which kernel doesn't support yet).
-        // We block that as a conservative choice.
+        // If a data-changing transaction has add files together with remove files or DV updates,
+        // block it when CDF is enabled. Kernel cannot discern DML operations. DML operations that
+        // update rows require a `cdc` file, but Kernel does not support writing CDC files.
         if !self.is_create_table()
             && !self.add_files_metadata.is_empty()
             && (!self.remove_files_metadata.is_empty() || self.num_dv_updates > 0)

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
-use delta_kernel::arrow::array::Int32Array;
+use delta_kernel::arrow::array::{Int32Array, Int64Array, StringArray, StructArray};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -18,11 +18,11 @@ use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExe
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
     assert_result_error_with_message, begin_transaction, create_add_files_metadata, create_table,
-    engine_store_setup, load_and_begin_transaction,
+    engine_store_setup, into_record_batch, load_and_begin_transaction,
 };
 use url::Url;
 
-use crate::common::write_utils::{get_scan_files, get_simple_int_schema};
+use crate::common::write_utils::{get_scan_files, get_simple_int_schema, resolve_struct_field};
 
 // Helper function to create a table with CDF enabled
 async fn create_cdf_table(
@@ -212,12 +212,11 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
     let (data, selection_vector) = scan_metadata.scan_files.into_parts();
     txn.remove_files(FilteredEngineData::try_new(data, selection_vector)?);
 
-    // This should fail with our new error message
     assert_result_error_with_message(
         txn.commit(engine.as_ref()),
         "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
          This would require writing CDC files for DML operations, which is not yet supported. \
-         Consider using separate transactions: one to add files, another to remove files."
+         Only use separate transactions when doing so preserves the required atomicity and CDF semantics: one to add files and another to remove files or update deletion vectors.",
     );
 
     Ok(())
@@ -245,7 +244,7 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
     Some("Cannot add and remove data in the same transaction")
 )]
 #[tokio::test]
-async fn test_add_and_dv_update_respects_cdf_and_data_change(
+async fn test_add_and_dv_update_fails_for_data_changing_cdf_transaction(
     #[case] cdf_enabled: bool,
     #[case] data_change: bool,
     #[case] expected_error: Option<&str>,
@@ -291,7 +290,7 @@ async fn test_add_and_dv_update_respects_cdf_and_data_change(
             "new.parquet",
             100,   /* size */
             2_000, /* modification_time */
-            Some(3),
+            Some(1),
         )],
     )?;
     txn.add_files(new_file);
@@ -314,12 +313,31 @@ async fn test_add_and_dv_update_respects_cdf_and_data_change(
         assert_eq!(snapshot.version(), 1);
     } else {
         let snapshot = commit_result?.unwrap_post_commit_snapshot();
-        let active_files = get_scan_files(snapshot.clone(), &engine)?
-            .into_iter()
-            .map(|files| files.apply_selection_vector().map(|data| data.len()))
-            .sum::<Result<usize, _>>()?;
+        let mut active_files = 0;
+        let mut existing_dv = None;
+        for files in get_scan_files(snapshot.clone(), &engine)? {
+            let batch = into_record_batch(files.apply_selection_vector()?);
+            active_files += batch.num_rows();
+
+            let batch = StructArray::from(batch);
+            let paths: &StringArray = resolve_struct_field(&batch, &["path".into()]);
+            if let Some(row) = paths
+                .iter()
+                .position(|path| path == Some("existing.parquet"))
+            {
+                let dv_paths: &StringArray = resolve_struct_field(
+                    &batch,
+                    &["deletionVector".into(), "pathOrInlineDv".into()],
+                );
+                let cardinalities: &Int64Array =
+                    resolve_struct_field(&batch, &["deletionVector".into(), "cardinality".into()]);
+                existing_dv = Some((dv_paths.value(row).to_string(), cardinalities.value(row)));
+            }
+        }
+
         assert_eq!(snapshot.version(), 2);
         assert_eq!(active_files, 2);
+        assert_eq!(existing_dv, Some(("memory:///dv.bin".to_string(), 1)));
     }
 
     Ok(())

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -224,18 +224,41 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
 }
 
 #[rstest]
-#[case::data_change(true, Some("Cannot add and remove data in the same transaction"))]
-#[case::no_data_change(false, None)]
+#[case::cdf_disabled_no_data_change(
+    false, /* cdf_enabled */
+    false, /* data_change */
+    None
+)]
+#[case::cdf_disabled_data_change(
+    false, /* cdf_enabled */
+    true,  /* data_change */
+    None
+)]
+#[case::cdf_enabled_no_data_change(
+    true,  /* cdf_enabled */
+    false, /* data_change */
+    None
+)]
+#[case::cdf_enabled_data_change(
+    true, /* cdf_enabled */
+    true, /* data_change */
+    Some("Cannot add and remove data in the same transaction")
+)]
 #[tokio::test]
-async fn test_cdf_add_and_dv_update_requires_no_data_change(
+async fn test_add_and_dv_update_respects_cdf_and_data_change(
+    #[case] cdf_enabled: bool,
     #[case] data_change: bool,
     #[case] expected_error: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let schema = get_simple_int_schema();
     let (store, engine, table_location) = engine_store_setup(
-        &format!("test_cdf_add_and_dv_update_{data_change}"),
+        &format!("test_add_and_dv_update_{cdf_enabled}_{data_change}"),
         None, /* local_directory */
     );
+    let mut writer_features = vec!["deletionVectors"];
+    if cdf_enabled {
+        writer_features.push("changeDataFeed");
+    }
     let table_url = create_table(
         store,
         table_location,
@@ -243,7 +266,7 @@ async fn test_cdf_add_and_dv_update_requires_no_data_change(
         &[],  /* partition_columns */
         true, /* use_37_protocol */
         vec!["deletionVectors"],
-        vec!["changeDataFeed", "deletionVectors"],
+        writer_features,
     )
     .await?;
 

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -216,7 +216,7 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
         txn.commit(engine.as_ref()),
         "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
          This would require writing CDC files for DML operations, which is not yet supported. \
-         Only use separate transactions when doing so preserves the required atomicity and CDF semantics: one to add files and another to remove files or update deletion vectors.",
+         Consider using separate transactions: one to add files, another to remove files or update deletion vectors.",
     );
 
     Ok(())

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -1,7 +1,9 @@
 //! Integration tests for change-data-feed aware write paths.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use delta_kernel::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
@@ -10,16 +12,17 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::schema::SchemaRef;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{Snapshot, Version};
+use rstest::rstest;
 use tempfile::{tempdir, TempDir};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    assert_result_error_with_message, begin_transaction, create_table, engine_store_setup,
-    load_and_begin_transaction,
+    assert_result_error_with_message, begin_transaction, create_add_files_metadata, create_table,
+    engine_store_setup, load_and_begin_transaction,
 };
 use url::Url;
 
-use crate::common::write_utils::get_simple_int_schema;
+use crate::common::write_utils::{get_scan_files, get_simple_int_schema};
 
 // Helper function to create a table with CDF enabled
 async fn create_cdf_table(
@@ -216,6 +219,85 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
          This would require writing CDC files for DML operations, which is not yet supported. \
          Consider using separate transactions: one to add files, another to remove files."
     );
+
+    Ok(())
+}
+
+#[rstest]
+#[case::data_change(true, Some("Cannot add and remove data in the same transaction"))]
+#[case::no_data_change(false, None)]
+#[tokio::test]
+async fn test_cdf_add_and_dv_update_requires_no_data_change(
+    #[case] data_change: bool,
+    #[case] expected_error: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = get_simple_int_schema();
+    let (store, engine, table_location) = engine_store_setup(
+        &format!("test_cdf_add_and_dv_update_{data_change}"),
+        None, /* local_directory */
+    );
+    let table_url = create_table(
+        store,
+        table_location,
+        schema,
+        &[],  /* partition_columns */
+        true, /* use_37_protocol */
+        vec!["deletionVectors"],
+        vec!["changeDataFeed", "deletionVectors"],
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+    let mut setup_txn = begin_transaction(snapshot, &engine)?;
+    let existing_file = create_add_files_metadata(
+        setup_txn.add_files_schema(),
+        vec![(
+            "existing.parquet",
+            100,   /* size */
+            1_000, /* modification_time */
+            Some(3),
+        )],
+    )?;
+    setup_txn.add_files(existing_file);
+    let snapshot = setup_txn.commit(&engine)?.unwrap_post_commit_snapshot();
+
+    let mut txn = begin_transaction(snapshot.clone(), &engine)?.with_data_change(data_change);
+    let new_file = create_add_files_metadata(
+        txn.add_files_schema(),
+        vec![(
+            "new.parquet",
+            100,   /* size */
+            2_000, /* modification_time */
+            Some(3),
+        )],
+    )?;
+    txn.add_files(new_file);
+    let descriptor = DeletionVectorDescriptor::try_new(
+        DeletionVectorStorageType::PersistedAbsolute,
+        "memory:///dv.bin",
+        Some(0), /* offset */
+        1,       /* size_in_bytes */
+        1,       /* cardinality */
+    )?;
+    txn.update_deletion_vectors(
+        HashMap::from([("existing.parquet".to_string(), descriptor)]),
+        get_scan_files(snapshot, &engine)?.into_iter().map(Ok),
+    )?;
+
+    let commit_result = txn.commit(&engine);
+    if let Some(expected_error) = expected_error {
+        assert_result_error_with_message(commit_result, expected_error);
+        let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+        assert_eq!(snapshot.version(), 1);
+    } else {
+        let snapshot = commit_result?.unwrap_post_commit_snapshot();
+        let active_files = get_scan_files(snapshot.clone(), &engine)?
+            .into_iter()
+            .map(|files| files.apply_selection_vector().map(|data| data.len()))
+            .sum::<Result<usize, _>>()?;
+        assert_eq!(snapshot.version(), 2);
+        assert_eq!(active_files, 2);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
When a dataChange txn on a cdf table contains addFile + dv update, kernel can not tell if it's a DML operations which update rows(it requires writing cdc file which kernel doesn't yet support). 
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
Test txn with addFile + dv update with different dataChange flag/cdf enabled or not