### PR TITLE
feat: make the PlanBasedEngine fallback optional

### DIFF
--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -8,7 +8,7 @@ use delta_kernel::{Engine, PlanExecutor};
 
 use crate::handle::Handle;
 use crate::plans::executor::{CExecuteOpFn, FfiPlanExecutor, SharedPlanExecutor};
-use crate::{engine_to_handle, AllocateErrorFn, NullableCvoid, SharedExternEngine};
+use crate::{engine_to_handle, AllocateErrorFn, NullableCvoid, OptionalValue, SharedExternEngine};
 
 pub mod executor;
 pub mod iter;
@@ -42,55 +42,41 @@ pub unsafe extern "C" fn free_plan_executor(executor: Handle<SharedPlanExecutor>
     executor.drop_handle();
 }
 
-/// Construct a [`PlanBasedEngine`] backed by `plan_executor`, delegating operations not yet
-/// implemented on the plan-execution path to `fallback_engine`.
+/// Construct a [`PlanBasedEngine`] backed by `plan_executor`, optionally delegating operations not
+/// yet implemented on the plan-execution path to `fallback_engine`.
 ///
 /// This method consumes the [`SharedPlanExecutor`] handle. It does NOT consume `fallback_engine`:
 /// the caller retains ownership of the fallback engine handle and must free it separately via
 /// `free_engine`. The returned plan-based engine clones the handlers it needs from the fallback,
-/// so it remains valid independently of when the caller frees its fallback handle.
-///
-/// # Safety
-///
-/// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`], a
-/// valid [`SharedExternEngine`] handle, and a valid [`AllocateErrorFn`].
-#[no_mangle]
-pub unsafe extern "C" fn get_plan_based_engine(
-    plan_executor: Handle<SharedPlanExecutor>,
-    fallback_engine: Handle<SharedExternEngine>,
-    allocate_error: AllocateErrorFn,
-) -> Handle<SharedExternEngine> {
-    let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
-    let fallback: Arc<dyn Engine> = unsafe { fallback_engine.as_ref() }.engine();
-    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new(fallback, executor));
-    engine_to_handle(engine, allocate_error)
-}
-
-/// Construct a [`PlanBasedEngine`] backed by `plan_executor` with no fallback engine.
-///
-/// Operations the plan-execution path does not implement return an unsupported error, rather than
-/// being delegated. Use this when a fallback cannot be constructed: an FFI-backed fallback resolves
-/// the table path itself, which fails for a path only the caller's filesystem can resolve -- a log
-/// served from process memory, for instance. Prefer [`get_plan_based_engine`] otherwise.
-///
-/// This method consumes the [`SharedPlanExecutor`] handle.
+/// so it remains valid independently of when the caller frees its fallback handle. When
+/// `fallback_engine` is [`OptionalValue::None`], unimplemented operations return an unsupported
+/// error.
 ///
 /// # Safety
 ///
 /// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`] and a
-/// valid [`AllocateErrorFn`].
+/// valid [`AllocateErrorFn`]. When `fallback_engine` is [`OptionalValue::Some`], it must contain a
+/// valid [`SharedExternEngine`] handle.
 #[no_mangle]
-pub unsafe extern "C" fn get_plan_based_engine_without_fallback(
+pub unsafe extern "C" fn get_plan_based_engine(
     plan_executor: Handle<SharedPlanExecutor>,
+    fallback_engine: OptionalValue<Handle<SharedExternEngine>>,
     allocate_error: AllocateErrorFn,
 ) -> Handle<SharedExternEngine> {
     let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
-    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new_without_fallback(executor));
+    let fallback = match fallback_engine {
+        OptionalValue::Some(engine) => Some(unsafe { engine.as_ref() }.engine()),
+        OptionalValue::None => None,
+    };
+    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new(fallback, executor));
     engine_to_handle(engine, allocate_error)
 }
 
 #[cfg(test)]
 mod tests {
+    use delta_kernel::arrow::array::{Array, RecordBatch, StringArray};
+    use delta_kernel::engine::arrow_data::ArrowEngineData;
+    use delta_kernel::engine_data::FilteredEngineData;
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel_default_engine::DefaultEngineBuilder;
     use url::Url;
@@ -120,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn get_plan_based_engine_returns_plan_based_engine() {
+    fn plan_based_engine_works_after_fallback_handle_is_freed() {
         let executor = unsafe { get_plan_executor(None, unreachable_callback) };
 
         // The caller retains ownership of the fallback engine handle. `shallow_copy` mimics C
@@ -129,14 +115,37 @@ mod tests {
         let fallback_handle = engine_to_handle(Arc::new(fallback), allocate_err);
 
         let engine_handle = unsafe {
-            get_plan_based_engine(executor, fallback_handle.shallow_copy(), allocate_err)
+            get_plan_based_engine(
+                executor,
+                OptionalValue::Some(fallback_handle.shallow_copy()),
+                allocate_err,
+            )
         };
 
         assert_is_plan_based_engine(&engine_handle);
 
-        // The plan-based engine and the fallback are freed independently.
-        unsafe { free_engine(engine_handle) };
         unsafe { free_engine(fallback_handle) };
+
+        let batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(StringArray::from(vec!["one"])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let data = Box::new(ArrowEngineData::new(batch));
+        let location = Url::parse("memory:///table/_delta_log/00000000000000000001.json").unwrap();
+        unsafe { engine_handle.as_ref() }
+            .engine()
+            .json_handler()
+            .write_json_file(
+                &location,
+                Box::new(std::iter::once(Ok(
+                    FilteredEngineData::with_all_rows_selected(data),
+                ))),
+                false,
+            )
+            .expect("plan-based engine retains its fallback json handler");
+
+        unsafe { free_engine(engine_handle) };
     }
 
     #[test]
@@ -144,7 +153,7 @@ mod tests {
         let executor = unsafe { get_plan_executor(None, unreachable_callback) };
 
         let engine_handle =
-            unsafe { get_plan_based_engine_without_fallback(executor, allocate_err) };
+            unsafe { get_plan_based_engine(executor, OptionalValue::None, allocate_err) };
 
         assert_is_plan_based_engine(&engine_handle);
 
@@ -157,7 +166,7 @@ mod tests {
     fn without_fallback_unimplemented_operations_are_unsupported() {
         let executor = unsafe { get_plan_executor(None, unreachable_callback) };
         let engine_handle =
-            unsafe { get_plan_based_engine_without_fallback(executor, allocate_err) };
+            unsafe { get_plan_based_engine(executor, OptionalValue::None, allocate_err) };
 
         let engine = unsafe { engine_handle.as_ref() }.engine();
         let location = Url::parse("memory:///table/_delta_log/00000000000000000001.json").unwrap();

--- a/ffi/src/plans/mod.rs
+++ b/ffi/src/plans/mod.rs
@@ -66,10 +66,34 @@ pub unsafe extern "C" fn get_plan_based_engine(
     engine_to_handle(engine, allocate_error)
 }
 
+/// Construct a [`PlanBasedEngine`] backed by `plan_executor` with no fallback engine.
+///
+/// Operations the plan-execution path does not implement return an unsupported error, rather than
+/// being delegated. Use this when a fallback cannot be constructed: an FFI-backed fallback resolves
+/// the table path itself, which fails for a path only the caller's filesystem can resolve -- a log
+/// served from process memory, for instance. Prefer [`get_plan_based_engine`] otherwise.
+///
+/// This method consumes the [`SharedPlanExecutor`] handle.
+///
+/// # Safety
+///
+/// Caller must pass a valid [`SharedPlanExecutor`] handle obtained from [`get_plan_executor`] and a
+/// valid [`AllocateErrorFn`].
+#[no_mangle]
+pub unsafe extern "C" fn get_plan_based_engine_without_fallback(
+    plan_executor: Handle<SharedPlanExecutor>,
+    allocate_error: AllocateErrorFn,
+) -> Handle<SharedExternEngine> {
+    let executor: Arc<dyn PlanExecutor> = unsafe { plan_executor.into_inner() };
+    let engine: Arc<dyn Engine> = Arc::new(PlanBasedEngine::new_without_fallback(executor));
+    engine_to_handle(engine, allocate_error)
+}
+
 #[cfg(test)]
 mod tests {
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel_default_engine::DefaultEngineBuilder;
+    use url::Url;
 
     use super::*;
     use crate::error::EngineExecResult;
@@ -113,5 +137,39 @@ mod tests {
         // The plan-based engine and the fallback are freed independently.
         unsafe { free_engine(engine_handle) };
         unsafe { free_engine(fallback_handle) };
+    }
+
+    #[test]
+    fn get_plan_based_engine_without_fallback_returns_plan_based_engine() {
+        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
+
+        let engine_handle =
+            unsafe { get_plan_based_engine_without_fallback(executor, allocate_err) };
+
+        assert_is_plan_based_engine(&engine_handle);
+
+        unsafe { free_engine(engine_handle) };
+    }
+
+    /// Without a fallback, an operation the plan-execution path does not implement reports that
+    /// rather than delegating.
+    #[test]
+    fn without_fallback_unimplemented_operations_are_unsupported() {
+        let executor = unsafe { get_plan_executor(None, unreachable_callback) };
+        let engine_handle =
+            unsafe { get_plan_based_engine_without_fallback(executor, allocate_err) };
+
+        let engine = unsafe { engine_handle.as_ref() }.engine();
+        let location = Url::parse("memory:///table/_delta_log/00000000000000000001.json").unwrap();
+        let err = engine
+            .json_handler()
+            .write_json_file(&location, Box::new(std::iter::empty()), false)
+            .expect_err("write_json_file has no plan-execution path and no fallback");
+        assert!(
+            matches!(err, delta_kernel::Error::Unsupported(_)),
+            "expected an unsupported error, got: {err:?}",
+        );
+
+        unsafe { free_engine(engine_handle) };
     }
 }

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -1762,7 +1762,13 @@ mod tests {
             fallback: &Handle<SharedExternEngine>,
         ) -> Handle<SharedExternEngine> {
             let executor = unsafe { get_plan_executor(None, unreachable_executor) };
-            unsafe { get_plan_based_engine(executor, fallback.shallow_copy(), allocate_err) }
+            unsafe {
+                get_plan_based_engine(
+                    executor,
+                    OptionalValue::Some(fallback.shallow_copy()),
+                    allocate_err,
+                )
+            }
         }
 
         #[tokio::test]

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -9,22 +9,26 @@ use crate::engine::arrow_utils;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, DeltaResultIterator, EngineData, FileDataReadResultIterator, FileMeta,
+    DeltaResult, DeltaResultIterator, EngineData, Error, FileDataReadResultIterator, FileMeta,
     FilteredEngineData, JsonHandler, PredicateRef,
 };
 
 /// A [`JsonHandler`] that delegates to a [`PlanExecutor`].
 ///
-/// Operations not yet implemented on the plan-execution path delegate to the required `fallback`
-/// handler.
+/// Operations not yet implemented on the plan-execution path delegate to `fallback` when one is
+/// configured, and otherwise return an unsupported error.
 pub struct PlanBasedJsonHandler {
     executor: Arc<dyn PlanExecutor>,
-    fallback: Arc<dyn JsonHandler>,
+    fallback: Option<Arc<dyn JsonHandler>>,
 }
 
 impl PlanBasedJsonHandler {
-    /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
-    pub fn new(plan_executor: Arc<dyn PlanExecutor>, fallback: Arc<dyn JsonHandler>) -> Self {
+    /// Construct a handler that delegates not-yet-implemented operations to `fallback`, or returns
+    /// an unsupported error for them when `fallback` is `None`.
+    pub fn new(
+        plan_executor: Arc<dyn PlanExecutor>,
+        fallback: Option<Arc<dyn JsonHandler>>,
+    ) -> Self {
         Self {
             executor: plan_executor,
             fallback,
@@ -61,8 +65,14 @@ impl JsonHandler for PlanBasedJsonHandler {
         data: DeltaResultIterator<'_, FilteredEngineData>,
         overwrite: bool,
     ) -> DeltaResult<()> {
+        let Some(fallback) = &self.fallback else {
+            return Err(Error::unsupported(
+                "PlanBasedJsonHandler does not support write_json_file yet, and no fallback \
+                 handler is configured",
+            ));
+        };
         debug!(%path, "PlanBasedJsonHandler delegating write_json_file to fallback handler");
-        self.fallback.write_json_file(path, data, overwrite)
+        fallback.write_json_file(path, data, overwrite)
     }
 }
 
@@ -93,7 +103,7 @@ mod tests {
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(
             Arc::new(SyncPlanExecutor::default()),
-            SyncEngine::new().json_handler(),
+            Some(SyncEngine::new().json_handler()),
         )
     }
 
@@ -124,7 +134,7 @@ mod tests {
     fn make_parquet_handler() -> PlanBasedParquetHandler {
         PlanBasedParquetHandler::new(
             Arc::new(SyncPlanExecutor::default()),
-            SyncEngine::new().parquet_handler(),
+            Some(SyncEngine::new().parquet_handler()),
         )
     }
 

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -20,6 +20,7 @@ use json::PlanBasedJsonHandler;
 use parquet::PlanBasedParquetHandler;
 use storage::PlanBasedStorageHandler;
 
+use crate::engine::arrow_expression::ArrowEvaluationHandler;
 use crate::plans::PlanExecutor;
 use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandler};
 
@@ -29,7 +30,10 @@ use crate::{Engine, EvaluationHandler, JsonHandler, ParquetHandler, StorageHandl
 /// [`Operation`](crate::plans::Operation)s and delegated to the plan executor.
 ///
 /// Operations not yet implemented on the plan-execution path (e.g. `write_json_file`,
-/// `write_parquet_file`) and evaluation are delegated to the required `fallback` [`Engine`].
+/// `write_parquet_file`) are delegated to `fallback` when one is configured, and otherwise return
+/// an unsupported error. A fallback is optional because a connector may be unable to construct one:
+/// an FFI-backed engine resolves table paths itself, which fails for a path only the connector can
+/// resolve.
 pub struct PlanBasedEngine {
     executor: Arc<dyn PlanExecutor>,
     evaluation: Arc<dyn EvaluationHandler>,
@@ -51,12 +55,29 @@ impl PlanBasedEngine {
             storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
             json: Arc::new(PlanBasedJsonHandler::new(
                 plan_executor.clone(),
-                fallback.json_handler(),
+                Some(fallback.json_handler()),
             )),
             parquet: Arc::new(PlanBasedParquetHandler::new(
                 plan_executor.clone(),
-                fallback.parquet_handler(),
+                Some(fallback.parquet_handler()),
             )),
+            executor: plan_executor,
+        }
+    }
+
+    /// Construct a `PlanBasedEngine` with no fallback [`Engine`], for a caller that cannot build
+    /// one -- an FFI-backed fallback resolves table paths itself, which fails for a path only the
+    /// connector's filesystem can resolve.
+    ///
+    /// Operations the plan-execution path does not implement return an unsupported error rather
+    /// than being delegated. Evaluation, which needs no path resolution, uses the Arrow
+    /// implementation.
+    pub fn new_without_fallback(plan_executor: Arc<dyn PlanExecutor>) -> Self {
+        Self {
+            evaluation: Arc::new(ArrowEvaluationHandler),
+            storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
+            json: Arc::new(PlanBasedJsonHandler::new(plan_executor.clone(), None)),
+            parquet: Arc::new(PlanBasedParquetHandler::new(plan_executor.clone(), None)),
             executor: plan_executor,
         }
     }

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -44,40 +44,27 @@ pub struct PlanBasedEngine {
 
 impl PlanBasedEngine {
     /// Construct a `PlanBasedEngine` backed by `plan_executor`, delegating operations not yet
-    /// implemented on the plan-execution path to `fallback`.
+    /// implemented on the plan-execution path to `fallback` when it is provided.
     ///
-    /// The fallback's [`EvaluationHandler`] is used for evaluation, and each plan-based handler
-    /// falls back to the fallback's corresponding handler for operations the plan-execution path
-    /// does not yet implement.
-    pub fn new(fallback: Arc<dyn Engine>, plan_executor: Arc<dyn PlanExecutor>) -> Self {
+    /// When `fallback` is `None`, those operations return an unsupported error. Evaluation uses the
+    /// fallback's [`EvaluationHandler`] when one is available and otherwise uses the Arrow
+    /// implementation.
+    pub fn new(fallback: Option<Arc<dyn Engine>>, plan_executor: Arc<dyn PlanExecutor>) -> Self {
+        let evaluation: Arc<dyn EvaluationHandler> = fallback.as_ref().map_or_else(
+            || Arc::new(ArrowEvaluationHandler) as Arc<dyn EvaluationHandler>,
+            |engine| engine.evaluation_handler(),
+        );
         Self {
-            evaluation: fallback.evaluation_handler(),
+            evaluation,
             storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
             json: Arc::new(PlanBasedJsonHandler::new(
                 plan_executor.clone(),
-                Some(fallback.json_handler()),
+                fallback.as_ref().map(|engine| engine.json_handler()),
             )),
             parquet: Arc::new(PlanBasedParquetHandler::new(
                 plan_executor.clone(),
-                Some(fallback.parquet_handler()),
+                fallback.as_ref().map(|engine| engine.parquet_handler()),
             )),
-            executor: plan_executor,
-        }
-    }
-
-    /// Construct a `PlanBasedEngine` with no fallback [`Engine`], for a caller that cannot build
-    /// one -- an FFI-backed fallback resolves table paths itself, which fails for a path only the
-    /// connector's filesystem can resolve.
-    ///
-    /// Operations the plan-execution path does not implement return an unsupported error rather
-    /// than being delegated. Evaluation, which needs no path resolution, uses the Arrow
-    /// implementation.
-    pub fn new_without_fallback(plan_executor: Arc<dyn PlanExecutor>) -> Self {
-        Self {
-            evaluation: Arc::new(ArrowEvaluationHandler),
-            storage: Arc::new(PlanBasedStorageHandler::new(plan_executor.clone())),
-            json: Arc::new(PlanBasedJsonHandler::new(plan_executor.clone(), None)),
-            parquet: Arc::new(PlanBasedParquetHandler::new(plan_executor.clone(), None)),
             executor: plan_executor,
         }
     }
@@ -102,5 +89,117 @@ impl Engine for PlanBasedEngine {
 
     fn plan_executor(&self) -> Option<Arc<dyn PlanExecutor>> {
         Some(self.executor.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tempfile::tempdir;
+    use url::Url;
+
+    use super::PlanBasedEngine;
+    use crate::arrow::array::{Array, Int64Array, RecordBatch, StringArray};
+    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::engine::arrow_expression::ArrowEvaluationHandler;
+    use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::engine::sync::SyncEngine;
+    use crate::engine_data::FilteredEngineData;
+    use crate::{Engine as _, EngineData, Error};
+
+    fn plan_engine(fallback: Option<Arc<dyn crate::Engine>>) -> PlanBasedEngine {
+        PlanBasedEngine::new(fallback, Arc::new(SyncPlanExecutor::default()))
+    }
+
+    #[test]
+    fn uses_fallback_evaluation_handler_when_available() {
+        let fallback: Arc<dyn crate::Engine> = Arc::new(SyncEngine::new());
+        let expected_evaluation_handler = fallback.evaluation_handler();
+        let engine = plan_engine(Some(fallback));
+
+        assert!(Arc::ptr_eq(
+            &engine.evaluation_handler(),
+            &expected_evaluation_handler
+        ));
+    }
+
+    #[test]
+    fn uses_arrow_evaluation_handler_without_fallback() {
+        let engine = plan_engine(None);
+
+        assert!(engine
+            .evaluation_handler()
+            .as_ref()
+            .any_ref()
+            .is::<ArrowEvaluationHandler>());
+    }
+
+    #[test]
+    fn unimplemented_writes_delegate_to_fallback() {
+        let dir = tempdir().unwrap();
+        let engine = plan_engine(Some(Arc::new(SyncEngine::new())));
+        let json_location = Url::from_file_path(dir.path().join("out.json")).unwrap();
+        let json_batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(StringArray::from(vec!["one"])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let json_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(json_batch));
+
+        engine
+            .json_handler()
+            .write_json_file(
+                &json_location,
+                Box::new(std::iter::once(Ok(
+                    FilteredEngineData::with_all_rows_selected(json_data),
+                ))),
+                false,
+            )
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(json_location.to_file_path().unwrap()).unwrap(),
+            "{\"value\":\"one\"}\n"
+        );
+
+        let parquet_location = Url::from_file_path(dir.path().join("out.parquet")).unwrap();
+        let parquet_batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![1])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let parquet_data: Box<dyn EngineData> = Box::new(ArrowEngineData::new(parquet_batch));
+
+        engine
+            .parquet_handler()
+            .write_parquet_file(
+                parquet_location.clone(),
+                Box::new(std::iter::once(Ok(parquet_data))),
+            )
+            .unwrap();
+        assert!(
+            std::fs::metadata(parquet_location.to_file_path().unwrap())
+                .unwrap()
+                .len()
+                > 0
+        );
+    }
+
+    #[test]
+    fn unimplemented_writes_are_unsupported_without_fallback() {
+        let engine = plan_engine(None);
+        let location = Url::parse("memory:///table/out").unwrap();
+
+        let json_err = engine
+            .json_handler()
+            .write_json_file(&location, Box::new(std::iter::empty()), false)
+            .expect_err("no fallback is configured");
+        assert!(matches!(json_err, Error::Unsupported(_)));
+
+        let parquet_err = engine
+            .parquet_handler()
+            .write_parquet_file(location, Box::new(std::iter::empty()))
+            .expect_err("no fallback is configured");
+        assert!(matches!(parquet_err, Error::Unsupported(_)));
     }
 }

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -16,7 +16,6 @@ use crate::{
 ///
 /// Operations not yet implemented on the plan-execution path delegate to `fallback` when one is
 /// configured, and otherwise return an unsupported error.
-/// handler.
 pub struct PlanBasedParquetHandler {
     executor: Arc<dyn PlanExecutor>,
     fallback: Option<Arc<dyn ParquetHandler>>,

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -8,22 +8,27 @@ use url::Url;
 use crate::plans::{IoOperation, Operation, PlanBuilder, PlanExecutor};
 use crate::schema::SchemaRef;
 use crate::{
-    DeltaResult, DeltaResultIteratorStatic, EngineData, FileDataReadResultIterator, FileMeta,
-    ParquetFooter, ParquetHandler, PredicateRef,
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileDataReadResultIterator,
+    FileMeta, ParquetFooter, ParquetHandler, PredicateRef,
 };
 
 /// A [`ParquetHandler`] that delegates to a [`PlanExecutor`].
 ///
-/// Operations not yet implemented on the plan-execution path delegate to the required `fallback`
+/// Operations not yet implemented on the plan-execution path delegate to `fallback` when one is
+/// configured, and otherwise return an unsupported error.
 /// handler.
 pub struct PlanBasedParquetHandler {
     executor: Arc<dyn PlanExecutor>,
-    fallback: Arc<dyn ParquetHandler>,
+    fallback: Option<Arc<dyn ParquetHandler>>,
 }
 
 impl PlanBasedParquetHandler {
-    /// Construct a handler that delegates not-yet-implemented operations to `fallback`.
-    pub fn new(plan_executor: Arc<dyn PlanExecutor>, fallback: Arc<dyn ParquetHandler>) -> Self {
+    /// Construct a handler that delegates not-yet-implemented operations to `fallback`, or returns
+    /// an unsupported error for them when `fallback` is `None`.
+    pub fn new(
+        plan_executor: Arc<dyn PlanExecutor>,
+        fallback: Option<Arc<dyn ParquetHandler>>,
+    ) -> Self {
         Self {
             executor: plan_executor,
             fallback,
@@ -51,8 +56,14 @@ impl ParquetHandler for PlanBasedParquetHandler {
         location: Url,
         data: DeltaResultIteratorStatic<Box<dyn EngineData>>,
     ) -> DeltaResult<()> {
+        let Some(fallback) = &self.fallback else {
+            return Err(Error::unsupported(
+                "PlanBasedParquetHandler does not support write_parquet_file yet, and no fallback \
+                 handler is configured",
+            ));
+        };
         debug!(%location, "PlanBasedParquetHandler delegating write_parquet_file to fallback handler");
-        self.fallback.write_parquet_file(location, data)
+        fallback.write_parquet_file(location, data)
     }
 
     fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
@@ -86,7 +97,7 @@ mod tests {
     fn make_handler() -> PlanBasedParquetHandler {
         PlanBasedParquetHandler::new(
             Arc::new(SyncPlanExecutor::default()),
-            SyncEngine::new().parquet_handler(),
+            Some(SyncEngine::new().parquet_handler()),
         )
     }
 


### PR DESCRIPTION
This PR adds no fallback option for PlanBasedEngine.
The fallback is an FFI-backed engine that resolves the table path itself when it is constructed. That fails today for a path only the connector can resolve -- a log served out of the connector's own filesystem rather than object storage. Requiring a fallback therefore rules out exactly the case where routing I/O through the executor is the point.

Add PlanBasedEngine::new_without_fallback plus a
get_plan_based_engine_without_fallback FFI entry point. Evaluation, which needs no path resolution, uses ArrowEvaluationHandler rather than borrowing the fallback's.

get_plan_based_engine keeps its signature and behavior; callers that can build a fallback are unaffected.

## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
