### PR TITLE
fix: truncate timestamp stats to milliseconds in JSON encoding

### DIFF
--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -159,7 +159,9 @@ pub struct EngineExpressionVisitor {
     /// The sub-expression will be in a _one_ item list identified by `child_list_id`
     pub visit_is_null: VisitUnaryFn,
     /// Visits the `ToJson` unary operator belonging to the list identified by `sibling_list_id`.
-    /// The sub-expression will be in a _one_ item list identified by `child_list_id`
+    /// The sub-expression will be in a _one_ item list identified by `child_list_id`.
+    /// See [`UnaryExpressionOp::ToJson`] for the encoding the implementation must produce; in
+    /// particular, timestamps carry exactly three fractional digits, truncated.
     pub visit_to_json: VisitUnaryFn,
     /// Visits the `ParseJson` expression belonging to the list identified by `sibling_list_id`.
     /// The sub-expression (JSON string) will be in a _one_ item list identified by

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -767,6 +767,42 @@ pub fn evaluate_predicate(
     }
 }
 
+/// Timestamp formats used when JSON-encoding, with exactly three fractional digits.
+///
+/// The Delta protocol truncates timestamp statistics down to milliseconds (PROTOCOL.md, Per-file
+/// Statistics), and every `ToJson` caller today encodes Delta statistics: the write path
+/// (`add.stats`), checkpoint stats, and read-side stats synthesis. Commit files are written
+/// separately via `to_json_bytes` and are unaffected.
+///
+/// These mirror Spark's stats encoding, whose pattern is `yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]`
+/// (`FileSourceOptions.commonTimestampFormat`, used for `TimestampType`; the `TimestampNTZType`
+/// write format drops the offset section). Java's `[...]` sections are optional only when *parsing*
+/// -- on format `[.SSS]` always emits three digits -- so Spark renders a whole second as
+/// `...:55.000+00:00`, matching `%.3f`. The three CORRECTED/LEGACY/second-offset variants of
+/// Spark's pattern all agree here, so this holds regardless of `legacyTimeParserPolicy`.
+///
+/// `%:z` writes the array's real UTC offset rather than a literal `Z`. Arrow attaches a timezone
+/// per array and its encoder converts a value into that zone before formatting, so a hardcoded `Z`
+/// would tag a shifted local wall clock as UTC -- a stat off by the zone offset, which is the kind
+/// of skew that makes data skipping drop matching rows. Emitting the true offset keeps the rendered
+/// instant correct for any annotation, and matches Spark, which writes its session zone's offset
+/// (a writer in US Pacific records e.g. `2018-12-31T15:00:00.000-08:00`).
+///
+/// `chrono`'s `%.3f` truncates rather than rounds -- including below the epoch, where it floors, so
+/// `-1500us` renders `...:59.998` exactly as Spark does. That is the direction the protocol
+/// requires: readers compensate for a max stat being up to 999us low (see
+/// `adjust_scalar_for_max_stat_truncation`), but a stat rounded *up* past the true value would let
+/// them prune a file that still holds a matching row.
+///
+/// Emitting sub-millisecond digits is what let a reader using the legacy `SimpleDateFormat` parser
+/// -- where `S` means milliseconds -- read `...:55.298677Z` as `...:00:53.677`, shifting a file's
+/// apparent range ~5 minutes and silently dropping rows from query results.
+///
+/// If a future caller needs to JSON-encode timestamps that are *not* Delta statistics, it must not
+/// reuse this path: sub-millisecond precision is discarded here.
+const STATS_TIMESTAMP_TZ_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f%:z";
+const STATS_TIMESTAMP_NTZ_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f";
+
 /// Converts a StructArray to JSON-encoded strings
 pub fn to_json(input: &dyn Datum) -> Result<ArrayRef, ArrowError> {
     let (array_ref, _is_scalar) = input.get();
@@ -790,7 +826,10 @@ pub fn to_json(input: &dyn Datum) -> Result<ArrayRef, ArrowError> {
                 struct_array.fields().iter().cloned().collect_vec(),
                 true,
             ));
-            let options = EncoderOptions::default().with_struct_mode(StructMode::ObjectOnly);
+            let options = EncoderOptions::default()
+                .with_struct_mode(StructMode::ObjectOnly)
+                .with_timestamp_format(STATS_TIMESTAMP_NTZ_FORMAT.to_string())
+                .with_timestamp_tz_format(STATS_TIMESTAMP_TZ_FORMAT.to_string());
             let mut encoder = make_encoder(&field, struct_array, &options)?;
 
             // Pre-allocate the various buffers
@@ -2128,6 +2167,95 @@ mod tests {
         let result = evaluate_expression(&expr, &batch, Some(&output_type)).unwrap();
         let result = result.as_any().downcast_ref::<StructArray>().unwrap();
         assert_eq!(result.is_null(0), expect_null_struct);
+    }
+
+    /// Delta truncates timestamp stats down to milliseconds, so `ToJson` must emit exactly three
+    /// fractional digits for both `Timestamp` (offset-suffixed) and `TimestampNtz` (no offset).
+    /// Truncation must floor, never round up: a max stat above the true value lets readers prune a
+    /// file that still holds a matching row.
+    ///
+    /// The expected strings are byte-for-byte what Spark's stats encoder produces for the same
+    /// microsecond values (pattern `yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]`), so a drift in either
+    /// direction fails here.
+    #[rstest]
+    // Sub-millisecond digits are dropped, not rounded (.298677 -> .298).
+    #[case::micros_dropped(
+        1_783_007_755_298_677,
+        "2026-07-02T15:55:55.298+00:00",
+        "2026-07-02T15:55:55.298"
+    )]
+    // A value that would carry to the next second if the formatter rounded instead of truncating.
+    #[case::no_round_up(
+        1_783_007_755_999_900,
+        "2026-07-02T15:55:55.999+00:00",
+        "2026-07-02T15:55:55.999"
+    )]
+    // Pre-epoch: -1500us must floor to -2ms (.998), not truncate toward zero to -1ms (.999).
+    #[case::pre_epoch_floors(-1_500, "1969-12-31T23:59:59.998+00:00", "1969-12-31T23:59:59.998")]
+    // Whole milliseconds keep their trailing zeros rather than collapsing to fewer digits.
+    #[case::exact_millis(
+        1_783_007_755_000_000,
+        "2026-07-02T15:55:55.000+00:00",
+        "2026-07-02T15:55:55.000"
+    )]
+    fn test_to_json_truncates_timestamps_to_milliseconds(
+        #[case] micros: i64,
+        #[case] expected_tz: &str,
+        #[case] expected_ntz: &str,
+    ) {
+        let tz_array = Arc::new(TimestampMicrosecondArray::from(vec![micros]).with_timezone("UTC"))
+            as ArrayRef;
+        let ntz_array = Arc::new(TimestampMicrosecondArray::from(vec![micros])) as ArrayRef;
+
+        for (array, expected) in [(tz_array, expected_tz), (ntz_array, expected_ntz)] {
+            let field = ArrowField::new("ts", array.data_type().clone(), true);
+            let value = StructArray::from(vec![(Arc::new(field), array)]);
+            let schema =
+                ArrowSchema::new(vec![ArrowField::new("s", value.data_type().clone(), true)]);
+            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
+
+            let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
+            let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
+            let result = result.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(result.value(0), format!(r#"{{"ts":"{expected}"}}"#));
+        }
+    }
+
+    /// Arrow attaches a timezone per array and renders a value *in that zone*, so the format writes
+    /// the array's real offset (`%:z`) rather than a literal `Z` -- otherwise a shifted local wall
+    /// clock would be tagged UTC, a stat off by the zone offset. Each rendering below denotes the
+    /// same instant as the input, `1_783_007_755_298_677us`. `Etc/UTC` is a spelling engines emit
+    /// for UTC; the offset zones are the ones a hardcoded `Z` would have mislabeled. Checked nested
+    /// too, since arrow applies the format per array at any depth.
+    #[rstest]
+    #[case::etc_utc("Etc/UTC", "2026-07-02T15:55:55.298+00:00")]
+    #[case::named_zone("America/New_York", "2026-07-02T11:55:55.298-04:00")]
+    #[case::positive_offset("+05:30", "2026-07-02T21:25:55.298+05:30")]
+    fn test_to_json_renders_the_arrays_real_offset(#[case] timezone: &str, #[case] expected: &str) {
+        let ts = Arc::new(
+            TimestampMicrosecondArray::from(vec![1_783_007_755_298_677i64]).with_timezone(timezone),
+        ) as ArrayRef;
+        let leaf = ArrowField::new("ts", ts.data_type().clone(), true);
+        let inner = StructArray::from(vec![(Arc::new(leaf), ts)]);
+
+        let nested_field = ArrowField::new("minValues", inner.data_type().clone(), true);
+        let outer = StructArray::from(vec![(
+            Arc::new(nested_field),
+            Arc::new(inner.clone()) as ArrayRef,
+        )]);
+
+        for (value, expected) in [
+            (inner, format!(r#"{{"ts":"{expected}"}}"#)),
+            (outer, format!(r#"{{"minValues":{{"ts":"{expected}"}}}}"#)),
+        ] {
+            let schema =
+                ArrowSchema::new(vec![ArrowField::new("s", value.data_type().clone(), true)]);
+            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
+            let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
+            let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
+            let result = result.as_any().downcast_ref::<StringArray>().unwrap();
+            assert_eq!(result.value(0), expected, "timezone {timezone}");
+        }
     }
 
     /// Base64 would render `0xABCD` as `q80=`.

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -767,40 +767,17 @@ pub fn evaluate_predicate(
     }
 }
 
-/// Timestamp formats used when JSON-encoding, with exactly three fractional digits.
+/// `chrono` formats implementing the timestamp encoding [`UnaryExpressionOp::ToJson`] requires.
 ///
-/// The Delta protocol truncates timestamp statistics down to milliseconds (PROTOCOL.md, Per-file
-/// Statistics), and every `ToJson` caller today encodes Delta statistics: the write path
-/// (`add.stats`), checkpoint stats, and read-side stats synthesis. Commit files are written
-/// separately via `to_json_bytes` and are unaffected.
+/// `%.3f` truncates rather than rounds, and floors below the epoch because arrow normalizes the
+/// subsecond field before formatting, so `-1500us` renders `...:59.998`.
 ///
-/// These mirror Spark's stats encoding, whose pattern is `yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]`
-/// (`FileSourceOptions.commonTimestampFormat`, used for `TimestampType`; the `TimestampNTZType`
-/// write format drops the offset section). Java's `[...]` sections are optional only when *parsing*
-/// -- on format `[.SSS]` always emits three digits -- so Spark renders a whole second as
-/// `...:55.000+00:00`, matching `%.3f`. The three CORRECTED/LEGACY/second-offset variants of
-/// Spark's pattern all agree here, so this holds regardless of `legacyTimeParserPolicy`.
-///
-/// `%:z` writes the array's real UTC offset rather than a literal `Z`. Arrow attaches a timezone
-/// per array and its encoder converts a value into that zone before formatting, so a hardcoded `Z`
-/// would tag a shifted local wall clock as UTC -- a stat off by the zone offset, which is the kind
-/// of skew that makes data skipping drop matching rows. Emitting the true offset keeps the rendered
-/// instant correct for any annotation, and matches Spark, which writes its session zone's offset
-/// (a writer in US Pacific records e.g. `2018-12-31T15:00:00.000-08:00`).
-///
-/// `chrono`'s `%.3f` truncates rather than rounds -- including below the epoch, where it floors, so
-/// `-1500us` renders `...:59.998` exactly as Spark does. That is the direction the protocol
-/// requires: readers compensate for a max stat being up to 999us low (see
-/// `adjust_scalar_for_max_stat_truncation`), but a stat rounded *up* past the true value would let
-/// them prune a file that still holds a matching row.
-///
-/// Emitting sub-millisecond digits is what let a reader using the legacy `SimpleDateFormat` parser
-/// -- where `S` means milliseconds -- read `...:55.298677Z` as `...:00:53.677`, shifting a file's
-/// apparent range ~5 minutes and silently dropping rows from query results.
-///
-/// If a future caller needs to JSON-encode timestamps that are *not* Delta statistics, it must not
-/// reuse this path: sub-millisecond precision is discarded here.
-const STATS_TIMESTAMP_TZ_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f%:z";
+/// The `Z` is literal rather than `%:z`, which spells a zero offset `+00:00`. Both are valid ISO
+/// 8601, but every Delta writer emits `Z` (including this crate's own partition-value
+/// serialization), so matching it keeps stats parseable by readers that accept only that form.
+/// Hardcoding it is safe because a Delta `TIMESTAMP` stat is always UTC: `arrow_conversion` accepts
+/// a timezone-annotated array only when the annotation is UTC.
+const STATS_TIMESTAMP_TZ_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
 const STATS_TIMESTAMP_NTZ_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f";
 
 /// Converts a StructArray to JSON-encoded strings
@@ -2170,68 +2147,46 @@ mod tests {
     }
 
     /// Delta truncates timestamp stats down to milliseconds, so `ToJson` must emit exactly three
-    /// fractional digits for both `Timestamp` (offset-suffixed) and `TimestampNtz` (no offset).
-    /// Truncation must floor, never round up: a max stat above the true value lets readers prune a
-    /// file that still holds a matching row.
-    ///
-    /// The expected strings are byte-for-byte what Spark's stats encoder produces for the same
-    /// microsecond values (pattern `yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]`), so a drift in either
-    /// direction fails here.
+    /// fractional digits, floored: a max stat above the true value lets readers prune a file that
+    /// still holds a matching row. `Timestamp` carries a `Z` suffix, `TimestampNtz` none.
     #[rstest]
     // Sub-millisecond digits are dropped, not rounded (.298677 -> .298).
-    #[case::micros_dropped(
-        1_783_007_755_298_677,
-        "2026-07-02T15:55:55.298+00:00",
-        "2026-07-02T15:55:55.298"
-    )]
+    #[case::micros_dropped(1_783_007_755_298_677, "2026-07-02T15:55:55.298")]
     // A value that would carry to the next second if the formatter rounded instead of truncating.
-    #[case::no_round_up(
-        1_783_007_755_999_900,
-        "2026-07-02T15:55:55.999+00:00",
-        "2026-07-02T15:55:55.999"
-    )]
+    #[case::no_round_up(1_783_007_755_999_900, "2026-07-02T15:55:55.999")]
     // Pre-epoch: -1500us must floor to -2ms (.998), not truncate toward zero to -1ms (.999).
-    #[case::pre_epoch_floors(-1_500, "1969-12-31T23:59:59.998+00:00", "1969-12-31T23:59:59.998")]
+    #[case::pre_epoch_floors(-1_500, "1969-12-31T23:59:59.998")]
     // Whole milliseconds keep their trailing zeros rather than collapsing to fewer digits.
-    #[case::exact_millis(
-        1_783_007_755_000_000,
-        "2026-07-02T15:55:55.000+00:00",
-        "2026-07-02T15:55:55.000"
-    )]
+    #[case::exact_millis(1_783_007_755_000_000, "2026-07-02T15:55:55.000")]
     fn test_to_json_truncates_timestamps_to_milliseconds(
         #[case] micros: i64,
-        #[case] expected_tz: &str,
-        #[case] expected_ntz: &str,
+        #[case] expected: &str,
+        #[values(None, Some("UTC"))] timezone: Option<&str>,
     ) {
-        let tz_array = Arc::new(TimestampMicrosecondArray::from(vec![micros]).with_timezone("UTC"))
-            as ArrayRef;
-        let ntz_array = Arc::new(TimestampMicrosecondArray::from(vec![micros])) as ArrayRef;
+        let array = TimestampMicrosecondArray::from(vec![micros]);
+        let array: ArrayRef = match timezone {
+            Some(tz) => Arc::new(array.with_timezone(tz)),
+            None => Arc::new(array),
+        };
+        let field = ArrowField::new("ts", array.data_type().clone(), true);
+        let value = StructArray::from(vec![(Arc::new(field), array)]);
 
-        for (array, expected) in [(tz_array, expected_tz), (ntz_array, expected_ntz)] {
-            let field = ArrowField::new("ts", array.data_type().clone(), true);
-            let value = StructArray::from(vec![(Arc::new(field), array)]);
-            let schema =
-                ArrowSchema::new(vec![ArrowField::new("s", value.data_type().clone(), true)]);
-            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
-
-            let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
-            let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
-            let result = result.as_any().downcast_ref::<StringArray>().unwrap();
-            assert_eq!(result.value(0), format!(r#"{{"ts":"{expected}"}}"#));
-        }
+        // A UTC-annotated array renders the protocol's `Z` suffix; NTZ has no offset at all.
+        let suffix = if timezone.is_some() { "Z" } else { "" };
+        assert_eq!(
+            to_json_string(value),
+            format!(r#"{{"ts":"{expected}{suffix}"}}"#)
+        );
     }
 
-    /// Arrow attaches a timezone per array and renders a value *in that zone*, so the format writes
-    /// the array's real offset (`%:z`) rather than a literal `Z` -- otherwise a shifted local wall
-    /// clock would be tagged UTC, a stat off by the zone offset. Each rendering below denotes the
-    /// same instant as the input, `1_783_007_755_298_677us`. `Etc/UTC` is a spelling engines emit
-    /// for UTC; the offset zones are the ones a hardcoded `Z` would have mislabeled. Checked nested
+    /// A Delta `TIMESTAMP` stat is always UTC, so every spelling of the UTC annotation must render
+    /// the same literal `Z` form rather than a numeric offset a strict reader would reject. Nested
     /// too, since arrow applies the format per array at any depth.
     #[rstest]
-    #[case::etc_utc("Etc/UTC", "2026-07-02T15:55:55.298+00:00")]
-    #[case::named_zone("America/New_York", "2026-07-02T11:55:55.298-04:00")]
-    #[case::positive_offset("+05:30", "2026-07-02T21:25:55.298+05:30")]
-    fn test_to_json_renders_the_arrays_real_offset(#[case] timezone: &str, #[case] expected: &str) {
+    fn test_to_json_renders_utc_timestamps_with_a_z_suffix(
+        #[values("UTC", "Etc/UTC", "+00:00")] timezone: &str,
+    ) {
+        let expected = "2026-07-02T15:55:55.298Z";
         let ts = Arc::new(
             TimestampMicrosecondArray::from(vec![1_783_007_755_298_677i64]).with_timezone(timezone),
         ) as ArrayRef;
@@ -2248,14 +2203,18 @@ mod tests {
             (inner, format!(r#"{{"ts":"{expected}"}}"#)),
             (outer, format!(r#"{{"minValues":{{"ts":"{expected}"}}}}"#)),
         ] {
-            let schema =
-                ArrowSchema::new(vec![ArrowField::new("s", value.data_type().clone(), true)]);
-            let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
-            let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
-            let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
-            let result = result.as_any().downcast_ref::<StringArray>().unwrap();
-            assert_eq!(result.value(0), expected, "timezone {timezone}");
+            assert_eq!(to_json_string(value), expected, "timezone {timezone}");
         }
+    }
+
+    /// Evaluates `ToJson` over a one-column batch wrapping `value` and returns the encoded row.
+    fn to_json_string(value: StructArray) -> String {
+        let schema = ArrowSchema::new(vec![ArrowField::new("s", value.data_type().clone(), true)]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(value)]).unwrap();
+        let expr = Expr::unary(UnaryExpressionOp::ToJson, column_expr!("s"));
+        let result = evaluate_expression(&expr, &batch, Some(&DataType::STRING)).unwrap();
+        let result = result.as_any().downcast_ref::<StringArray>().unwrap();
+        result.value(0).to_string()
     }
 
     /// Base64 would render `0xABCD` as `q80=`.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -103,7 +103,8 @@ pub enum BinaryPredicateOp {
 pub enum UnaryExpressionOp {
     /// SQL `to_json(expr)`: encode a struct as a JSON object string, one string per row. The input
     /// must be a struct and the output is STRING. A NULL input row produces a NULL string rather
-    /// than `"null"`. This is the inverse of [`ParseJsonExpression`].
+    /// than `"null"`. This is the inverse of [`ParseJsonExpression`] for every type except
+    /// timestamps, whose sub-millisecond precision this operator discards (see below).
     ///
     /// Nested structs and arrays encode as JSON objects and arrays. Binary encodes as lowercase
     /// hex rather than base64, two digits per byte in the order the bytes appear, so
@@ -112,6 +113,15 @@ pub enum UnaryExpressionOp {
     /// ```text
     /// {"b":"abcd","l":[1,2],"n":{"z":7}}
     /// ```
+    ///
+    /// Timestamps must encode with exactly three fractional digits, truncated toward negative
+    /// infinity, because kernel writes `add.stats` with this operator and [Per-file Statistics]
+    /// truncates timestamp statistics down to milliseconds. TIMESTAMP takes a literal `Z` suffix
+    /// and TIMESTAMP_NTZ takes no offset, so `{ ts: 2026-07-02T15:55:55.298677Z }` becomes
+    /// `{"ts":"2026-07-02T15:55:55.298Z"}`. Emitting more digits, or rounding up, makes readers
+    /// prune files that hold matching rows.
+    ///
+    /// [Per-file Statistics]: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#per-file-statistics
     ToJson,
 }
 
@@ -319,7 +329,8 @@ pub struct VariadicExpression {
 }
 
 /// An expression that parses a JSON string column into a struct column of `output_schema`, the
-/// inverse of [`UnaryExpressionOp::ToJson`].
+/// inverse of [`UnaryExpressionOp::ToJson`] except for the sub-millisecond timestamp precision
+/// that operator discards.
 ///
 /// Unparseable input must degrade to NULL rather than fail the query, because kernel parses
 /// `add.stats` with this operator and data skipping reads null stats as "include the file". The
@@ -837,7 +848,9 @@ impl Expression {
     }
 
     /// Creates a new ParseJson expression that parses a JSON string column into a struct.
-    /// This is the inverse of `ToJson` - it converts a JSON-encoded string into a struct.
+    /// This is the inverse of [`UnaryExpressionOp::ToJson`] - it converts a JSON-encoded string
+    /// into a struct. Sub-millisecond timestamp precision does not survive the round trip, since
+    /// `ToJson` truncates it.
     pub fn parse_json(json_expr: impl Into<Expression>, output_schema: SchemaRef) -> Self {
         Self::ParseJson(ParseJsonExpression::new(json_expr, output_schema))
     }

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -592,6 +592,93 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     Ok(())
 }
 
+/// Which side of the file's timestamp range a test predicate bounds.
+#[derive(Debug, Clone, Copy)]
+enum Bound {
+    Upper,
+    Lower,
+}
+
+/// Millisecond-truncated timestamp stats must not over-prune files whose real values live in the
+/// dropped sub-millisecond tail. This is the read-side half of the write-side truncation the
+/// protocol mandates (PROTOCOL.md, Per-file Statistics: timestamps are truncated down to
+/// milliseconds); `adjust_scalar_for_max_stat_truncation` is what makes it safe.
+///
+/// The file holds timestamps in [.298677, .307735], so its truncated stats are [.298, .307]. Every
+/// predicate below selects a real row in the file, so pruning it would drop committed data.
+///
+/// The lower-bound cases are the ones that exercise `adjust_scalar_for_max_stat_truncation`: a
+/// `>=` bound between the stored (truncated) max `.307000` and the real max `.307735` compares
+/// against the max stat, and without the 999us widening the file is wrongly pruned.
+#[rstest]
+// Upper bound inside the truncated range.
+#[case::upper_bound_within_range(Bound::Upper, 1_783_007_755_299_000, 1)]
+// Upper bound in the tail below the real max but above the truncated min.
+#[case::upper_bound_in_truncated_tail(Bound::Upper, 1_783_007_755_298_900, 1)]
+// Upper bound below the file's truncated min: nothing in the file can match, prune is correct.
+#[case::upper_bound_below_min(Bound::Upper, 1_783_007_754_000_000, 0)]
+// Lower bound inside the sub-millisecond tail dropped from the max stat. The file really does
+// hold `.307735`, so it must survive despite the stat claiming `.307000`.
+#[case::lower_bound_in_truncated_tail(Bound::Lower, 1_783_007_755_307_500, 1)]
+// Lower bound at the real max: still inside the tail, still must survive.
+#[case::lower_bound_at_real_max(Bound::Lower, 1_783_007_755_307_735, 1)]
+// Lower bound far past the tail (beyond stored max + 999us): pruning is correct here.
+#[case::lower_bound_past_tail(Bound::Lower, 1_783_007_755_400_000, 0)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn millisecond_truncated_timestamp_stats_dont_overprune(
+    #[case] bound: Bound,
+    #[case] bound_us: i64,
+    #[case] expected_survivors: usize,
+    #[values(false, true)] use_parallel: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    let _ = create_table_and_load_snapshot(
+        &table_path,
+        timestamp_stats_schema(),
+        engine.as_ref(),
+        &[],
+    )?;
+
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+
+    // Real values span [.298677, .307735]; a protocol-conforming writer floors the stats to
+    // [.298, .307].
+    add_commit(
+        &table_url.to_string(),
+        store.as_ref(),
+        1,
+        commit_with_adds(
+            1,
+            &[(
+                "file_streaming.parquet",
+                stats_json(
+                    10,
+                    "2026-07-02T15:55:55.298Z",
+                    "2026-07-02T15:55:55.307Z",
+                    1,
+                    100,
+                ),
+            )],
+        ),
+    )
+    .await?;
+
+    let column = column_expr!("EventTime");
+    let literal = Expr::literal(Scalar::Timestamp(bound_us));
+    let predicate = Arc::new(match bound {
+        Bound::Upper => Pred::le(column, literal),
+        Bound::Lower => Pred::ge(column, literal),
+    });
+
+    assert_eq!(
+        surviving_files(&table_path, engine, predicate, use_parallel)?,
+        expected_survivors,
+    );
+    Ok(())
+}
+
 /// Replace table may change partition and data column types. A scan after replacement should
 /// remain compatible with the old addFiles.
 #[rstest]

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -293,6 +293,42 @@ fn timestamp_stats_schema() -> SchemaRef {
     )
 }
 
+/// Creates a `timestamp_stats_schema` table and returns the pieces needed to inject raw commits:
+/// `(tmp_dir, table_path, engine, table_url, store)`.
+#[allow(clippy::type_complexity)]
+fn timestamp_stats_table_setup(
+    properties: &[(&str, &str)],
+) -> Result<
+    (
+        tempfile::TempDir,
+        String,
+        Arc<DefaultEngine<TokioMultiThreadExecutor>>,
+        Url,
+        Arc<delta_kernel::object_store::DynObjectStore>,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let (tmp_dir, table_path, engine) = test_table_setup_mt()?;
+    create_table_and_load_snapshot(
+        &table_path,
+        timestamp_stats_schema(),
+        engine.as_ref(),
+        properties,
+    )?;
+    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| "table_path should be a valid file URL")?;
+    Ok((tmp_dir, table_path, engine, table_url, store))
+}
+
+/// An `EventTime` predicate against a microsecond bound, e.g. `timestamp_pred(Pred::le, micros)`.
+fn timestamp_pred(op: fn(Expr, Expr) -> Pred, micros: i64) -> PredicateRef {
+    Arc::new(op(
+        column_expr!("EventTime"),
+        Expr::literal(Scalar::Timestamp(micros)),
+    ))
+}
+
 /// Builds a stringified Delta `stats` JSON given EventTime/UserId min/max bounds.
 fn stats_json(
     num_records: i64,
@@ -336,20 +372,7 @@ fn commit_with_remove(version: u64, path: &str, deletion_timestamp: i64) -> Stri
 async fn extended_year_timestamp_stats_dont_collapse_skipping(
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let _ = create_table_and_load_snapshot(
-        &table_path,
-        timestamp_stats_schema(),
-        engine.as_ref(),
-        &[],
-    )?;
-
-    // Inject Adds via raw JSON commits using a separate `LocalFileSystem` instance pointing
-    // at the same on-disk root the kernel-managed engine uses. The kernel only reads commit
-    // files during scan_metadata, so a fake Add (no backing parquet) is fine for this test.
-    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
-    let table_url = Url::from_directory_path(&table_path)
-        .map_err(|_| "table_path should be a valid file URL")?;
+    let (_tmp_dir, table_path, engine, table_url, store) = timestamp_stats_table_setup(&[])?;
     let table_url_string = table_url.to_string();
 
     // Co-locate the malformed `file_B` with a valid `file_D` (Sep 2024, out of predicate
@@ -480,20 +503,11 @@ async fn extended_year_timestamp_stats_dont_collapse_skipping(
 async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let table_url = Url::from_directory_path(&table_path)
-        .map_err(|_| "table_path should be a valid file URL")?;
+    // writeStatsAsStruct makes the checkpoint materialize stats_parsed, the column where the
+    // safe-cast result lands.
+    let (_tmp_dir, table_path, engine, table_url, store) =
+        timestamp_stats_table_setup(&[("delta.checkpoint.writeStatsAsStruct", "true")])?;
     let table_url_string = table_url.to_string();
-    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
-
-    // v0: create table with writeStatsAsStruct enabled so the checkpoint materializes
-    // stats_parsed (the column where the safe-cast result lands).
-    let _v0 = create_table_and_load_snapshot(
-        &table_path,
-        timestamp_stats_schema(),
-        engine.as_ref(),
-        &[("delta.checkpoint.writeStatsAsStruct", "true")],
-    )?;
 
     // v1: file_A + file_B + file_E in one commit. The shared batch is what makes the
     // per-cell NULL property observable during checkpoint write.
@@ -592,17 +606,8 @@ async fn extended_year_timestamp_round_trip_via_checkpoint_and_remove(
     Ok(())
 }
 
-/// Which side of the file's timestamp range a test predicate bounds.
-#[derive(Debug, Clone, Copy)]
-enum Bound {
-    Upper,
-    Lower,
-}
-
 /// Millisecond-truncated timestamp stats must not over-prune files whose real values live in the
-/// dropped sub-millisecond tail. This is the read-side half of the write-side truncation the
-/// protocol mandates (PROTOCOL.md, Per-file Statistics: timestamps are truncated down to
-/// milliseconds); `adjust_scalar_for_max_stat_truncation` is what makes it safe.
+/// dropped sub-millisecond tail. `adjust_scalar_for_max_stat_truncation` is what makes it safe.
 ///
 /// The file holds timestamps in [.298677, .307735], so its truncated stats are [.298, .307]. Every
 /// predicate below selects a real row in the file, so pruning it would drop committed data.
@@ -612,41 +617,30 @@ enum Bound {
 /// against the max stat, and without the 999us widening the file is wrongly pruned.
 #[rstest]
 // Upper bound inside the truncated range.
-#[case::upper_bound_within_range(Bound::Upper, 1_783_007_755_299_000, 1)]
+#[case::upper_bound_within_range(timestamp_pred(Pred::le, 1_783_007_755_299_000), 1)]
 // Upper bound in the tail below the real max but above the truncated min.
-#[case::upper_bound_in_truncated_tail(Bound::Upper, 1_783_007_755_298_900, 1)]
+#[case::upper_bound_in_truncated_tail(timestamp_pred(Pred::le, 1_783_007_755_298_900), 1)]
 // Upper bound below the file's truncated min: nothing in the file can match, prune is correct.
-#[case::upper_bound_below_min(Bound::Upper, 1_783_007_754_000_000, 0)]
+#[case::upper_bound_below_min(timestamp_pred(Pred::le, 1_783_007_754_000_000), 0)]
 // Lower bound inside the sub-millisecond tail dropped from the max stat. The file really does
 // hold `.307735`, so it must survive despite the stat claiming `.307000`.
-#[case::lower_bound_in_truncated_tail(Bound::Lower, 1_783_007_755_307_500, 1)]
+#[case::lower_bound_in_truncated_tail(timestamp_pred(Pred::ge, 1_783_007_755_307_500), 1)]
 // Lower bound at the real max: still inside the tail, still must survive.
-#[case::lower_bound_at_real_max(Bound::Lower, 1_783_007_755_307_735, 1)]
+#[case::lower_bound_at_real_max(timestamp_pred(Pred::ge, 1_783_007_755_307_735), 1)]
 // Lower bound far past the tail (beyond stored max + 999us): pruning is correct here.
-#[case::lower_bound_past_tail(Bound::Lower, 1_783_007_755_400_000, 0)]
+#[case::lower_bound_past_tail(timestamp_pred(Pred::ge, 1_783_007_755_400_000), 0)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn millisecond_truncated_timestamp_stats_dont_overprune(
-    #[case] bound: Bound,
-    #[case] bound_us: i64,
+    #[case] predicate: PredicateRef,
     #[case] expected_survivors: usize,
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let _ = create_table_and_load_snapshot(
-        &table_path,
-        timestamp_stats_schema(),
-        engine.as_ref(),
-        &[],
-    )?;
-
-    let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
-    let table_url = Url::from_directory_path(&table_path)
-        .map_err(|_| "table_path should be a valid file URL")?;
+    let (_tmp_dir, table_path, engine, table_url, store) = timestamp_stats_table_setup(&[])?;
 
     // Real values span [.298677, .307735]; a protocol-conforming writer floors the stats to
     // [.298, .307].
     add_commit(
-        &table_url.to_string(),
+        table_url.as_str(),
         store.as_ref(),
         1,
         commit_with_adds(
@@ -664,13 +658,6 @@ async fn millisecond_truncated_timestamp_stats_dont_overprune(
         ),
     )
     .await?;
-
-    let column = column_expr!("EventTime");
-    let literal = Expr::literal(Scalar::Timestamp(bound_us));
-    let predicate = Arc::new(match bound {
-        Bound::Upper => Pred::le(column, literal),
-        Bound::Lower => Pred::ge(column, literal),
-    });
 
     assert_eq!(
         surviving_files(&table_path, engine, predicate, use_parallel)?,

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -91,14 +91,10 @@ fn assert_stats_struct_matches_json(
                 }
             }
             serde_json::Value::String(s) => {
-                // JSON stats render timestamps with exactly three fractional digits, since Delta
-                // truncates timestamp stats down to milliseconds. Format the parsed side the same
-                // way so the two are directly comparable -- the default formatter would elide an
-                // all-zero fraction and spuriously differ on whole-second values.
                 let format_options = FormatOptions::default()
                     .with_display_error(true)
                     .with_timestamp_format(Some("%Y-%m-%dT%H:%M:%S%.3f"))
-                    .with_timestamp_tz_format(Some("%Y-%m-%dT%H:%M:%S%.3f%:z"));
+                    .with_timestamp_tz_format(Some("%Y-%m-%dT%H:%M:%S%.3fZ"));
                 let formatter = ArrayFormatter::try_new(col.as_ref(), &format_options)
                     .unwrap_or_else(|e| panic!("{path}: cannot build formatter: {e}"));
                 let actual = formatter.value(row_idx).to_string();
@@ -228,4 +224,54 @@ fn scan_metadata_with_stats_columns_kernel_written(
     // file with the default 10 rows.
     assert_eq!(file_count, 1, "Should have processed exactly one file");
     assert_eq!(total_num_records, 10, "Should have exactly 10 numRecords");
+}
+
+#[test]
+fn json_stats_truncate_timestamps_to_milliseconds() {
+    let (engine, snapshot, _table) = test_context!(
+        LogState::with_latest_version(1).with_checkpoint_at([1]),
+        FeatureSet::empty(),
+        unpartitioned(),
+        TableConfig::new().write_stats_as_struct(true),
+        version_latest(),
+    );
+
+    let scan = snapshot
+        .scan_builder()
+        .with_stats(StatsOptions::all())
+        .build()
+        .unwrap();
+
+    let mut checked = 0;
+    for scan_metadata in scan.scan_metadata(&engine).unwrap() {
+        let (underlying_data, selection_vector) = scan_metadata.unwrap().scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(underlying_data)
+            .unwrap()
+            .into();
+        let filtered_batch =
+            filter_record_batch(&batch, &BooleanArray::from(selection_vector)).unwrap();
+        let stats_json = get_column!(filtered_batch, "stats", StringArray);
+
+        for i in 0..filtered_batch.num_rows() {
+            let json: serde_json::Value = serde_json::from_str(stats_json.value(i)).unwrap();
+            for bound in [MIN_VALUES, MAX_VALUES] {
+                for (col, rendered) in json[bound].as_object().unwrap() {
+                    let Some(ts) = rendered.as_str().filter(|s| s.contains('T')) else {
+                        continue; // not a timestamp column
+                    };
+                    let fraction = ts
+                        .trim_end_matches('Z')
+                        .rsplit_once('.')
+                        .unwrap_or_else(|| panic!("{bound}.{col} = {ts:?} has no fraction"))
+                        .1;
+                    assert_eq!(fraction.len(), 3, "{bound}.{col} = {ts:?}");
+                    // The builder's values end in .298677, which floors to .298 rather than
+                    // rounding to .299.
+                    assert!(ts.ends_with(".298Z") || ts.ends_with(".298"), "{ts:?}");
+                    checked += 1;
+                }
+            }
+        }
+    }
+    assert!(checked > 0, "no timestamp stats were checked");
 }

--- a/kernel/tests/integration/parsed_stats.rs
+++ b/kernel/tests/integration/parsed_stats.rs
@@ -7,7 +7,7 @@ use delta_kernel::arrow::array::{
 };
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
-use delta_kernel::arrow::util::display::array_value_to_string;
+use delta_kernel::arrow::util::display::{ArrayFormatter, FormatOptions};
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::scan::StatsOptions;
 use delta_kernel::table_features::ColumnMappingMode;
@@ -91,8 +91,17 @@ fn assert_stats_struct_matches_json(
                 }
             }
             serde_json::Value::String(s) => {
-                let actual = array_value_to_string(col.as_ref(), row_idx)
-                    .unwrap_or_else(|e| panic!("{path}: cannot format parsed value: {e}"));
+                // JSON stats render timestamps with exactly three fractional digits, since Delta
+                // truncates timestamp stats down to milliseconds. Format the parsed side the same
+                // way so the two are directly comparable -- the default formatter would elide an
+                // all-zero fraction and spuriously differ on whole-second values.
+                let format_options = FormatOptions::default()
+                    .with_display_error(true)
+                    .with_timestamp_format(Some("%Y-%m-%dT%H:%M:%S%.3f"))
+                    .with_timestamp_tz_format(Some("%Y-%m-%dT%H:%M:%S%.3f%:z"));
+                let formatter = ArrayFormatter::try_new(col.as_ref(), &format_options)
+                    .unwrap_or_else(|e| panic!("{path}: cannot build formatter: {e}"));
+                let actual = formatter.value(row_idx).to_string();
                 assert_eq!(&actual, s, "{path} mismatch at row {row_idx}");
             }
             serde_json::Value::Object(sub_obj) => {

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -108,7 +108,74 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
         .as_bool()
         .unwrap());
 
+    let stats: serde_json::Value =
+        serde_json::from_str(parsed_commits[1]["add"]["stats"].as_str().unwrap())?;
+    assert_eq!(stats["minValues"]["ts_ntz"], "0001-01-01T00:00:00.000");
+    assert_eq!(stats["maxValues"]["ts_ntz"], "9999-12-31T23:59:59.999");
+
     // Verify the data can be read back correctly
+    test_read(&ArrowEngineData::new(data), &table_url, engine)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_append_timestamp_stats_are_millisecond_truncated(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "ts",
+        DataType::TIMESTAMP,
+    )])?);
+
+    let (store, engine, table_location) = engine_store_setup("test_table_timestamp_stats", None);
+    let table_url = create_table(
+        store.clone(),
+        table_location,
+        schema.clone(),
+        &[],
+        true,
+        vec![],
+        vec![],
+    )
+    .await?;
+
+    let mut txn = test_utils::load_and_begin_transaction(table_url.clone(), &engine)?
+        .with_engine_info("default engine");
+
+    // Spans [.298677, .307735]; a conforming writer floors the stats to [.298, .307].
+    let timestamp_values = vec![1_783_007_755_298_677i64, 1_783_007_755_307_735i64];
+    let data = RecordBatch::try_new(
+        Arc::new(schema.as_ref().try_into_arrow()?),
+        vec![Arc::new(
+            TimestampMicrosecondArray::from(timestamp_values).with_timezone("UTC"),
+        )],
+    )?;
+
+    let engine = Arc::new(engine);
+    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let add_files_metadata = engine
+        .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
+        .await?;
+    txn.add_files(add_files_metadata);
+    assert!(txn.commit(engine.as_ref())?.is_committed());
+
+    let commit1 = store
+        .get(&Path::from(
+            "/test_table_timestamp_stats/_delta_log/00000000000000000001.json",
+        ))
+        .await?;
+    let parsed_commits: Vec<_> = Deserializer::from_slice(&commit1.bytes().await?)
+        .into_iter::<serde_json::Value>()
+        .try_collect()?;
+
+    let stats: serde_json::Value =
+        serde_json::from_str(parsed_commits[1]["add"]["stats"].as_str().unwrap())?;
+    assert_eq!(stats["minValues"]["ts"], "2026-07-02T15:55:55.298Z");
+    assert_eq!(stats["maxValues"]["ts"], "2026-07-02T15:55:55.307Z");
+
+    // Kernel must be able to parse the stats it just wrote.
     test_read(&ArrowEngineData::new(data), &table_url, engine)?;
 
     Ok(())

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1553,8 +1553,10 @@ fn generate_column(arrow_type: &ArrowDataType, rows: usize, base: i32) -> ArrayR
             Arc::new(Date32Array::from(values))
         }
         ArrowDataType::Timestamp(TimeUnit::Microsecond, tz) => {
+            // The sub-millisecond component keeps stats-formatting tests honest: a whole-second
+            // value cannot distinguish a three-digit fraction from an elided one.
             let values: Vec<i64> = (0..rows)
-                .map(|i| (18000 + base + i as i32) as i64 * 86_400_000_000)
+                .map(|i| (18000 + base + i as i32) as i64 * 86_400_000_000 + 298_677)
                 .collect();
             let array = TimestampMicrosecondArray::from(values);
             match tz {


### PR DESCRIPTION
## What changes are proposed in this pull request?

`to_json` serialized timestamps at full microsecond precision, but the Delta protocol requires per-file timestamp statistics truncated down to milliseconds. Sub-millisecond digits break readers on a millisecond-only timestamp grammar: `...55.298677Z` parses as `...00:53.677`, shifting a file's apparent range by ~5 minutes. `to_json` now pins both the tz and NTZ timestamp formats to exactly three fractional digits. 

## How was this change tested?
Added new integration tests.
