### PR TITLE
fix: dv resolution when multiple batches are produced

### DIFF
--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -334,10 +334,10 @@ fn read_scan_file(
         // If sv is None here, but we used to have one (is_dv_resolved_pair == true) it means we've
         // split the selection vector beyond the range of the original. split_vector will return
         // None for rest in that case. When we try and extend that None we still get None, but in
-        // the CDF case we actually DO want to filter out those rows because it means nothing has changed.
-        // Hence, in the case that sv==None and is_dv_resolved_pair==true we need a full array of false.
-        // This only applies to remove/add cases where the associated pair may have a selection vector
-        // that crosses batch sizes.
+        // the CDF case we actually DO want to filter out those rows because it means nothing has
+        // changed. Hence, in the case that sv==None and is_dv_resolved_pair==true we need a
+        // full array of false. This only applies to remove/add cases where the associated
+        // pair may have a selection vector that crosses batch sizes.
         let sv = match sv {
             None if is_dv_resolved_pair => Some(vec![false; len]),
             other => other,

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -330,6 +330,10 @@ fn read_scan_file(
         // because the selection vector is `None`.
         let extend = Some(!is_dv_resolved_pair);
         let rest = split_vector(sv.as_mut(), len, extend);
+        let sv = match sv {
+            None if is_dv_resolved_pair => Some(vec![false; len]),
+            other => other,
+        };
         let result = logical.fold_with(sv, |logical, sv| {
             logical.and_then(|data| data.apply_selection_vector(sv))
         });

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -330,6 +330,14 @@ fn read_scan_file(
         // because the selection vector is `None`.
         let extend = Some(!is_dv_resolved_pair);
         let rest = split_vector(sv.as_mut(), len, extend);
+
+        // If sv is None here, but we used to have one (is_dv_resolved_pair == true) it means we've
+        // split the selection vector beyond the range of the original. split_vector will return
+        // None for rest in that case. When we try and extend that None we still get None, but in
+        // the CDF case we actually DO want to filter out those rows because it means nothing has changed.
+        // Hence, in the case that sv==None and is_dv_resolved_pair==true we need a full array of false.
+        // This only applies to remove/add cases where the associated pair may have a selection vector
+        // that crosses batch sizes.
         let sv = match sv {
             None if is_dv_resolved_pair => Some(vec![false; len]),
             other => other,

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::RecordBatch;
 use delta_kernel::arrow::datatypes::Schema as ArrowSchema;
+use delta_kernel::arrow::util::pretty::pretty_format_batches;
 use delta_kernel::engine::arrow_conversion::TryFromKernel as _;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
 use delta_kernel::expressions::{column_expr, Expression as Expr, Predicate as Pred};
@@ -11,7 +12,8 @@ use delta_kernel::table_changes::TableChanges;
 use delta_kernel::{DeltaResult, Error, PredicateRef, Version};
 use itertools::Itertools;
 use test_utils::{
-    add_commit, create_default_engine, create_table, engine_store_setup, load_test_data,
+    add_commit, create_default_engine, create_default_engine_with_batch, create_table,
+    engine_store_setup, load_test_data,
 };
 use url::Url;
 
@@ -21,10 +23,20 @@ fn read_cdf_for_table(
     end_version: impl Into<Option<Version>>,
     predicate: impl Into<Option<PredicateRef>>,
 ) -> DeltaResult<Vec<RecordBatch>> {
+    read_cdf_for_table_with_batch_size(test_name, start_version, end_version, predicate, None)
+}
+
+fn read_cdf_for_table_with_batch_size(
+    test_name: impl AsRef<str>,
+    start_version: Version,
+    end_version: impl Into<Option<Version>>,
+    predicate: impl Into<Option<PredicateRef>>,
+    batch_size: Option<usize>,
+) -> DeltaResult<Vec<RecordBatch>> {
     let test_dir = load_test_data("tests/data", test_name.as_ref()).unwrap();
     let test_path = test_dir.path().join(test_name.as_ref());
     let test_path = delta_kernel::try_parse_uri(test_path.to_str().expect("table path to string"))?;
-    let engine = test_utils::create_default_engine(&test_path)?;
+    let engine = create_default_engine_with_batch(&test_path, batch_size)?;
     let table_changes = TableChanges::try_new(
         test_path,
         engine.as_ref(),
@@ -53,7 +65,7 @@ fn read_cdf_for_table(
         .map(|data| -> DeltaResult<_> {
             let record_batch = data?.try_into_record_batch()?;
             // Verify that the arrow record batches match the expected schema
-            assert!(record_batch.schema().as_ref() == &scan_schema_as_arrow);
+            assert_eq!(record_batch.schema().as_ref(), &scan_schema_as_arrow);
             Ok(record_batch)
         })
         .try_collect()?;
@@ -103,6 +115,31 @@ fn cdf_with_deletion_vector() -> Result<(), Box<dyn error::Error>> {
     ];
     sort_lines!(expected);
     assert_batches_sorted_eq!(expected, &batches);
+    Ok(())
+}
+
+#[test]
+fn cdf_with_deletion_vector_is_batch_size_invariant() -> Result<(), Box<dyn error::Error>> {
+    let expected = read_cdf_for_table("cdf-table-with-dv", 0, None, None)?;
+    for batch_size in [1usize, 2, 3, 4, 7] {
+        let actual = read_cdf_for_table_with_batch_size(
+            "cdf-table-with-dv",
+            0,
+            None,
+            None,
+            Some(batch_size),
+        )?;
+        let expected_rows: usize = expected.iter().map(RecordBatch::num_rows).sum();
+        let actual_rows: usize = actual.iter().map(RecordBatch::num_rows).sum();
+        assert_eq!(
+            actual_rows, expected_rows,
+            "row count changed at batch_size={batch_size}: got {actual_rows}, want {expected_rows}"
+        );
+        let formatted = pretty_format_batches(&expected)?.to_string();
+        let mut expected_lines: Vec<&str> = formatted.trim().lines().collect();
+        sort_lines!(expected_lines);
+        assert_batches_sorted_eq!(expected_lines, &actual);
+    }
     Ok(())
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -161,6 +161,7 @@ define_sweeps! {
     ),
 }
 use std::collections::{HashMap, HashSet};
+use std::num::NonZero;
 use std::sync::{Arc, Mutex};
 
 pub use counting_reporter::{
@@ -590,14 +591,25 @@ pub fn modify_add_file_partition_keys(
         .expect("failed to rebuild add-file batch after modifying a partition key")
 }
 
-/// Helper to create a DefaultEngine with the default executor for tests.
-///
-/// Uses `TokioBackgroundExecutor` as the default executor.
 pub fn create_default_engine(
     table_root: &url::Url,
 ) -> DeltaResult<Arc<DefaultEngine<TokioBackgroundExecutor>>> {
+    create_default_engine_with_batch(table_root, None)
+}
+
+/// Helper to create a DefaultEngine with the default executor for tests.
+///
+/// Uses `TokioBackgroundExecutor` as the default executor.
+pub fn create_default_engine_with_batch(
+    table_root: &url::Url,
+    batch_size: Option<usize>,
+) -> DeltaResult<Arc<DefaultEngine<TokioBackgroundExecutor>>> {
     let store = store_from_url(table_root)?;
-    Ok(Arc::new(DefaultEngineBuilder::new(store).build()))
+    let mut builder = DefaultEngineBuilder::new(store);
+    if let Some(batch_size) = batch_size {
+        builder = builder.with_batch_size(NonZero::new(batch_size).unwrap());
+    }
+    Ok(Arc::new(builder.build()))
 }
 
 /// Helper to create a DefaultEngine with the default executor for tests.


### PR DESCRIPTION
## What changes are proposed in this pull request?
When you have a parquet file that is large and produces multiple record batches the tail end of that selection vector incorrectly returns none and allows the entire tail of the parquet to leak through the selection. Instead when doing a remove/add we skip the tail end for the pair instead of just silently selecting it from the None.


## How was this change tested?
I found this through testing for a delta-rs change for cdf reading and comparing counts. Claude actually located what the issue was, but I went back and tested this against my own changes on delta-rs and all the counts started matching up correctly.

Stealing @OussamaSaoudi's diagram from below
```
 For a same-path remove+add DV pair, CDF computes a selection vector meaning: “emit only these rows because only these changed.”

  For version 6, the correct mask is conceptually:

  row:   0 1 2 3
  emit:  F F F T

  Only row 3 was restored.

  With one large batch, the kernel extends that mask with false through the file, producing the correct result:

  F F F T F F F F F F

  With several batches, after processing row 3, the remaining mask becomes None. The next batch interprets None as “this file has no selection vector,” which
  normally means “emit every row.” Therefore rows 4–9 leak into the CDF output.

  expected: 3
  actual:   3, 4, 5, 6, 7, 8, 9

  The bug is that None represented two different states:

  - Ordinary file with no DV mask → emit all rows.
  - Resolved DV-pair mask is exhausted → emit no rows.

  The fix checks whether the file came from a resolved DV pair. Once its mask is exhausted, later batches receive an all-false mask instead of None. This
  preserves the normal behavior for ordinary add/remove/CDC files.
```

Essentially, when DVs come from resolved pairs and the entire mask is exhausted then the logical should have been to omit later rows instead of including them. Other pairs don't have their functionality altered. 