### PR TITLE
feat: current timestamp support for column defaults

### DIFF
--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -191,7 +191,7 @@ pub enum JunctionPredicateOp {
 /// `Scalar::Null` if the output was NULL).
 pub type ScalarExpressionEvaluator<'a> = dyn Fn(&Expression) -> Option<Scalar> + 'a;
 
-/// An opaque expression operation (ie defined and implemented by the engine).
+/// An opaque expression operation whose semantics are supplied by its implementor.
 pub trait OpaqueExpressionOp: DynPartialEq + std::fmt::Debug {
     /// Succinctly identifies this op
     fn name(&self) -> &str;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -8,12 +8,13 @@
 //! grammar rather than defining a kernel-specific dialect, so the forms it accepts match what
 //! Spark reads and writes.
 //!
-//! This is an intentionally light start: a small internal parser covering only the literal forms
-//! Delta metadata contains today. If the supported SQL surface grows, options include moving
-//! parsing behind the [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
+//! This is an intentionally limited internal parser covering literal forms and selected functions.
+//! If the supported SQL surface grows, options include moving parsing behind the
+//! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 
-use crate::expressions::{Expression, Scalar};
+use crate::expressions::{Expression, OpaqueExpressionOp, Scalar, ScalarExpressionEvaluator};
 use crate::schema::{DataType, PrimitiveType};
+use crate::utils::current_time_micros;
 use crate::{DeltaResult, Error};
 
 #[cfg(feature = "check-constraints-in-dev")]
@@ -25,8 +26,9 @@ mod token;
 /// (e.g. the type of the column whose default is being parsed).
 ///
 /// Leading and trailing whitespace are ignored. `NULL` (case-insensitive) is accepted for any
-/// data type. All other input is parsed as a typed literal, which is supported only for primitive
-/// types.
+/// data type. `CURRENT_TIMESTAMP` and `CURRENT_TIMESTAMP()` (case-insensitive) are accepted for
+/// [`DataType::TIMESTAMP`]. All other input is parsed as a typed literal, which is supported only
+/// for primitive types.
 ///
 /// # Examples
 ///
@@ -48,9 +50,43 @@ pub(crate) fn parse_sql(sql: &str, data_type: &DataType) -> DeltaResult<Expressi
     if trimmed.eq_ignore_ascii_case("null") {
         return Ok(Expression::literal(Scalar::Null(data_type.clone())));
     }
-    // TODO(#2630): support SQL function calls (e.g. `current_date()`) when column defaults
-    // need them.
+    if is_current_timestamp(trimmed) {
+        if data_type != &DataType::TIMESTAMP {
+            return Err(Error::generic(format!(
+                "CURRENT_TIMESTAMP requires TIMESTAMP, got {data_type:?}"
+            )));
+        }
+        return Ok(Expression::opaque(CurrentTimestampOp, []));
+    }
     parse_literal(trimmed, data_type, sql)
+}
+
+/// Whether `sql` is one of the supported zero-argument `CURRENT_TIMESTAMP` spellings.
+fn is_current_timestamp(sql: &str) -> bool {
+    sql.eq_ignore_ascii_case("CURRENT_TIMESTAMP") || sql.eq_ignore_ascii_case("CURRENT_TIMESTAMP()")
+}
+
+/// Kernel-owned scalar operation for evaluating `CURRENT_TIMESTAMP` lazily.
+#[derive(Debug, PartialEq)]
+struct CurrentTimestampOp;
+
+impl OpaqueExpressionOp for CurrentTimestampOp {
+    fn name(&self) -> &str {
+        "current_timestamp"
+    }
+
+    fn eval_expr_scalar(
+        &self,
+        _eval_expr: &ScalarExpressionEvaluator<'_>,
+        exprs: &[Expression],
+    ) -> DeltaResult<Scalar> {
+        if !exprs.is_empty() {
+            return Err(Error::generic(
+                "CURRENT_TIMESTAMP does not accept arguments",
+            ));
+        }
+        Ok(Scalar::Timestamp(current_time_micros()?))
+    }
 }
 
 /// Dispatch a SQL literal to the per-type parser for its primitive `data_type`, then wrap the
@@ -374,6 +410,55 @@ mod tests {
     }
 
     #[rstest]
+    #[case("CURRENT_TIMESTAMP")]
+    #[case("CURRENT_TIMESTAMP()")]
+    #[case("current_timestamp")]
+    #[case("CuRrEnT_TiMeStAmP()")]
+    #[case("  CURRENT_TIMESTAMP  ")]
+    #[case("\ncurrent_timestamp()\t")]
+    fn parses_current_timestamp_as_lazy_opaque_expression(#[case] sql: &str) {
+        let before = current_time_micros().unwrap();
+        let Expression::Opaque(opaque) = parse_sql(sql, &DataType::TIMESTAMP).unwrap() else {
+            panic!("expected an opaque expression for {sql:?}");
+        };
+
+        assert_eq!(opaque.op.name(), "current_timestamp");
+        assert!(opaque.exprs.is_empty());
+        let Scalar::Timestamp(timestamp) = opaque
+            .op
+            .eval_expr_scalar(&|_| None, &opaque.exprs)
+            .unwrap()
+        else {
+            panic!("expected a TIMESTAMP scalar for {sql:?}");
+        };
+        let after = current_time_micros().unwrap();
+        assert!(before <= timestamp && timestamp <= after);
+    }
+
+    #[rstest]
+    #[case("CURRENT_TIMESTAMP ()", DataType::TIMESTAMP)]
+    #[case("CURRENT_TIMESTAMP( )", DataType::TIMESTAMP)]
+    #[case("CURRENT_TIMESTAMP(1)", DataType::TIMESTAMP)]
+    #[case("CURRENT_TIMESTAMPS", DataType::TIMESTAMP)]
+    #[case("NOW()", DataType::TIMESTAMP)]
+    #[case("CURRENT_TIMESTAMP", DataType::TIMESTAMP_NTZ)]
+    #[case("CURRENT_TIMESTAMP()", DataType::STRING)]
+    fn rejects_unsupported_current_timestamp_forms_and_types(
+        #[case] sql: &str,
+        #[case] data_type: DataType,
+    ) {
+        assert!(parse_sql(sql, &data_type).is_err());
+    }
+
+    #[test]
+    fn current_timestamp_opaque_op_rejects_children() {
+        let err = CurrentTimestampOp
+            .eval_expr_scalar(&|_| None, &[Expression::literal(1)])
+            .unwrap_err();
+        assert!(err.to_string().contains("does not accept arguments"));
+    }
+
+    #[rstest]
     #[case("42", DataType::INTEGER, Scalar::Integer(42))]
     #[case(" -7 ", DataType::INTEGER, Scalar::Integer(-7))]
     #[case("+5", DataType::INTEGER, Scalar::Integer(5))]
@@ -554,7 +639,6 @@ mod tests {
     #[case("CAST('2024-01-01' AS DATE)", DataType::DATE)]
     #[case("CAST(NULL AS INT)", DataType::INTEGER)]
     #[case("current_date()", DataType::DATE)]
-    #[case("current_timestamp()", DataType::TIMESTAMP)]
     #[case("now()", DataType::TIMESTAMP)]
     #[case("1 + 1", DataType::INTEGER)]
     #[case("concat('a', 'b')", DataType::STRING)]

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -8,9 +8,7 @@
 //! grammar rather than defining a kernel-specific dialect, so the forms it accepts match what
 //! Spark reads and writes.
 //!
-//! This is an intentionally limited internal parser covering literal forms and selected functions.
-//! If the supported SQL surface grows, options include moving parsing behind the
-//! [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
+//! This internal parser supports literals and the zero-argument `CURRENT_TIMESTAMP` function.
 
 use crate::expressions::{Expression, OpaqueExpressionOp, Scalar, ScalarExpressionEvaluator};
 use crate::schema::{DataType, PrimitiveType};
@@ -66,7 +64,6 @@ fn is_current_timestamp(sql: &str) -> bool {
     sql.eq_ignore_ascii_case("CURRENT_TIMESTAMP") || sql.eq_ignore_ascii_case("CURRENT_TIMESTAMP()")
 }
 
-/// Kernel-owned scalar operation for evaluating `CURRENT_TIMESTAMP` lazily.
 #[derive(Debug, PartialEq)]
 struct CurrentTimestampOp;
 
@@ -80,13 +77,20 @@ impl OpaqueExpressionOp for CurrentTimestampOp {
         _eval_expr: &ScalarExpressionEvaluator<'_>,
         exprs: &[Expression],
     ) -> DeltaResult<Scalar> {
-        if !exprs.is_empty() {
-            return Err(Error::generic(
-                "CURRENT_TIMESTAMP does not accept arguments",
-            ));
-        }
-        Ok(Scalar::Timestamp(current_time_micros()?))
+        evaluate_current_timestamp(exprs, current_time_micros)
     }
+}
+
+fn evaluate_current_timestamp(
+    exprs: &[Expression],
+    current_time: impl FnOnce() -> DeltaResult<i64>,
+) -> DeltaResult<Scalar> {
+    if !exprs.is_empty() {
+        return Err(Error::generic(
+            "CURRENT_TIMESTAMP does not accept arguments",
+        ));
+    }
+    Ok(Scalar::Timestamp(current_time()?))
 }
 
 /// Dispatch a SQL literal to the per-type parser for its primitive `data_type`, then wrap the
@@ -378,6 +382,8 @@ fn decode_binary_literal(input: &str) -> DeltaResult<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+
     use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
     use rstest::rstest;
 
@@ -416,23 +422,33 @@ mod tests {
     #[case("CuRrEnT_TiMeStAmP()")]
     #[case("  CURRENT_TIMESTAMP  ")]
     #[case("\ncurrent_timestamp()\t")]
-    fn parses_current_timestamp_as_lazy_opaque_expression(#[case] sql: &str) {
-        let before = current_time_micros().unwrap();
+    fn parses_current_timestamp_as_opaque_expression(#[case] sql: &str) {
         let Expression::Opaque(opaque) = parse_sql(sql, &DataType::TIMESTAMP).unwrap() else {
             panic!("expected an opaque expression for {sql:?}");
         };
 
         assert_eq!(opaque.op.name(), "current_timestamp");
         assert!(opaque.exprs.is_empty());
-        let Scalar::Timestamp(timestamp) = opaque
-            .op
-            .eval_expr_scalar(&|_| None, &opaque.exprs)
-            .unwrap()
+    }
+
+    #[test]
+    fn current_timestamp_reads_clock_only_when_evaluated() {
+        let reads = Cell::new(0);
+        let Expression::Opaque(opaque) =
+            parse_sql("CURRENT_TIMESTAMP", &DataType::TIMESTAMP).unwrap()
         else {
-            panic!("expected a TIMESTAMP scalar for {sql:?}");
+            panic!("expected an opaque expression");
         };
-        let after = current_time_micros().unwrap();
-        assert!(before <= timestamp && timestamp <= after);
+
+        assert_eq!(reads.get(), 0);
+        let scalar = evaluate_current_timestamp(&opaque.exprs, || {
+            reads.set(reads.get() + 1);
+            Ok(123_456)
+        })
+        .unwrap();
+
+        assert_eq!(scalar, Scalar::Timestamp(123_456));
+        assert_eq!(reads.get(), 1);
     }
 
     #[rstest]

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -3,8 +3,8 @@
 //! # Invariants
 //!
 //! The rules Kernel applies to column defaults, and where each comes from. This applies to
-//! [`ColumnDefault::new`], [`validate_column_defaults_metadata`], and the IcebergCompatV3 warnings
-//! in [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
+//! [`ColumnDefault::new`], [`validate_column_defaults_metadata`], and IcebergCompatV3 validation in
+//! [`crate::table_features`]. Rules that follow the protocol are stated plainly; only kernel
 //! divergences are called out as such.
 //!
 //! - `CURRENT_DEFAULT` metadata must be a string.
@@ -14,10 +14,10 @@
 //! - Defaults may appear on nested struct fields, not just top-level columns, so validation
 //!   descends into nested fields. Kernel only *writes* top-level defaults (a kernel limitation),
 //!   but *loads* a snapshot of a table authored elsewhere that carries nested defaults.
-//! - Parsing is best-effort: unparseable SQL (e.g. `current_timestamp()`) is not an error; the
-//!   connector falls back to the raw SQL.
-//! - On an IcebergCompatV3 table, kernel warns when its parser cannot verify that a default is a
-//!   literal.
+//! - Parsing is best-effort: unparseable SQL (e.g. an unsupported function call) is not an error;
+//!   the connector falls back to the raw SQL.
+//! - On an IcebergCompatV3 table, kernel rejects defaults it recognizes as non-literal and warns
+//!   when its parser cannot determine whether a default is a literal.
 
 use crate::expressions::{parse_sql, Expression, Scalar};
 use crate::schema::{DataType, StructField, StructType};
@@ -29,9 +29,9 @@ use crate::{DeltaResult, Error};
 ///
 /// Holds the raw SQL and the column's declared type. On construction the kernel parses the SQL
 /// with its built-in parser and caches the result. [`to_scalar`](Self::to_scalar) returns the
-/// parsed [`Scalar`], or `None` when the kernel could not parse the SQL (e.g.
-/// `current_timestamp()`), in which case a connector can evaluate [`raw_sql`](Self::raw_sql)
-/// itself.
+/// parsed [`Scalar`], or `None` when the kernel could not parse the SQL, in which case a connector
+/// can evaluate [`raw_sql`](Self::raw_sql) itself. Dynamic defaults such as `CURRENT_TIMESTAMP`
+/// are evaluated each time [`to_scalar`](Self::to_scalar) is called.
 ///
 /// The declared type is borrowed from the logical schema, which outlives the carrier.
 #[derive(Debug, Clone, PartialEq)]
@@ -83,16 +83,27 @@ impl<'a> ColumnDefault<'a> {
 
     /// The default as a [`Scalar`], or `None` when the kernel could not parse the SQL.
     ///
-    /// On `None` the connector can evaluate [`raw_sql`](Self::raw_sql) with its own SQL engine.
+    /// Dynamic defaults such as `CURRENT_TIMESTAMP` are evaluated when this method is called. On
+    /// `None` the connector can evaluate [`raw_sql`](Self::raw_sql) with its own SQL engine.
     ///
     /// # Errors
     ///
-    /// Returns an error if the parsed default is not a literal. The parser only emits literals, so
-    /// this is defensive.
+    /// Returns an error if a parsed expression is neither a literal nor a kernel-supported dynamic
+    /// default, or if evaluation of a supported dynamic default fails.
     pub fn to_scalar(&self) -> DeltaResult<Option<Scalar>> {
         match &self.parsed_sql {
             None => Ok(None),
             Some(Expression::Literal(scalar)) => Ok(Some(scalar.clone())),
+            Some(Expression::Opaque(opaque)) => opaque
+                .op
+                .eval_expr_scalar(
+                    &|expr| match expr {
+                        Expression::Literal(scalar) => Some(scalar.clone()),
+                        _ => None,
+                    },
+                    &opaque.exprs,
+                )
+                .map(Some),
             Some(other) => Err(Error::generic(format!(
                 "kernel cannot evaluate non-literal column default expression: {other:?}"
             ))),
@@ -101,11 +112,21 @@ impl<'a> ColumnDefault<'a> {
 
     /// Returns `true` iff the default parsed to a literal expression.
     ///
-    /// Returns `false` for SQL the kernel could not parse (e.g. arithmetic or function calls). Note
-    /// that NULL parses to a literal, so this is `true` for a NULL default regardless of the
-    /// column type.
+    /// Returns `false` for both recognized non-literals such as `CURRENT_TIMESTAMP` and SQL the
+    /// kernel could not parse, such as arithmetic or unsupported function calls. Note that NULL
+    /// parses to a literal, so this is `true` for a NULL default regardless of the column type.
     pub(crate) fn is_kernel_parsable_literal(&self) -> bool {
         matches!(self.parsed_sql, Some(Expression::Literal(_)))
+    }
+
+    /// Returns `true` iff the kernel parsed the default as a non-literal expression.
+    ///
+    /// Unlike [`is_kernel_parsable_literal`](Self::is_kernel_parsable_literal), this distinguishes
+    /// recognized dynamic defaults from SQL the kernel could not parse. IcebergCompatV3 validation
+    /// uses that distinction to reject known non-literals while retaining raw-SQL fallback for
+    /// expressions whose literal status is unknown.
+    pub(crate) fn is_kernel_parsable_non_literal(&self) -> bool {
+        matches!(self.parsed_sql, Some(ref expr) if !matches!(expr, Expression::Literal(_)))
     }
 }
 
@@ -262,6 +283,8 @@ mod tests {
         ParsedNull,
         /// `to_scalar` yields `None`.
         Unparsable,
+        /// `to_scalar` yields the current UTC timestamp.
+        CurrentTimestamp,
         /// `new` fails with an error containing this substring.
         NewErr(&'static str),
     }
@@ -288,7 +311,12 @@ mod tests {
     )]
     #[case::null_struct("NULL", struct_ty(), Expect::ParsedNull)]
     #[case::null_variant("NULL", DataType::unshredded_variant(), Expect::ParsedNull)]
-    #[case::function_call("current_timestamp()", DataType::TIMESTAMP, Expect::Unparsable)]
+    #[case::current_timestamp(
+        "  CuRrEnT_TiMeStAmP()  ",
+        DataType::TIMESTAMP,
+        Expect::CurrentTimestamp
+    )]
+    #[case::unsupported_function("NOW()", DataType::TIMESTAMP, Expect::Unparsable)]
     #[case::type_mismatch("'not an int'", DataType::INTEGER, Expect::Unparsable)]
     #[case::arithmetic("1 + 1", DataType::INTEGER, Expect::Unparsable)]
     #[case::non_primitive_array(
@@ -324,6 +352,21 @@ mod tests {
                 assert_eq!(d.to_scalar().unwrap(), None);
                 // A parse failure must not drop the raw SQL; connectors fall back to it.
                 assert_eq!(d.raw_sql(), raw_sql);
+            }
+            (Ok(d), Expect::CurrentTimestamp) => {
+                assert_eq!(d.raw_sql(), raw_sql);
+                for _ in 0..2 {
+                    let before = Utc::now().timestamp_micros();
+                    let scalar = d.to_scalar().unwrap();
+                    let after = Utc::now().timestamp_micros();
+                    let Some(Scalar::Timestamp(actual)) = scalar else {
+                        panic!("expected a timestamp scalar, got {scalar:?}");
+                    };
+                    assert!(
+                        (before..=after).contains(&actual),
+                        "timestamp {actual} was not sampled between {before} and {after}"
+                    );
+                }
             }
             (Err(e), Expect::NewErr(needle)) => {
                 assert!(e.to_string().contains(needle), "got: {e}");
@@ -408,8 +451,7 @@ mod tests {
 
     #[test]
     fn to_scalar_errors_on_non_literal_parsed_expression() {
-        // The parser only emits literals, so construct a non-literal directly to reach the
-        // defensive error arm.
+        // Construct an unsupported parsed expression directly to reach the defensive error arm.
         let int_ty = DataType::INTEGER;
         let d = ColumnDefault {
             raw_sql: "x".into(),
@@ -421,5 +463,20 @@ mod tests {
             .expect_err("non-literal parsed expression must error")
             .to_string();
         assert!(err.contains("non-literal"), "got: {err}");
+    }
+
+    #[rstest]
+    #[case::literal("42", DataType::INTEGER, true, false)]
+    #[case::dynamic("CURRENT_TIMESTAMP", DataType::TIMESTAMP, false, true)]
+    #[case::unparsed("NOW()", DataType::TIMESTAMP, false, false)]
+    fn classifies_parsed_defaults(
+        #[case] raw_sql: &str,
+        #[case] data_type: DataType,
+        #[case] is_literal: bool,
+        #[case] is_non_literal: bool,
+    ) {
+        let default = ColumnDefault::new(raw_sql.to_string(), &data_type).unwrap();
+        assert_eq!(default.is_kernel_parsable_literal(), is_literal);
+        assert_eq!(default.is_kernel_parsable_non_literal(), is_non_literal);
     }
 }

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -43,6 +43,17 @@ pub struct ColumnDefault<'a> {
     parsed_sql: Option<Expression>,
 }
 
+/// Kernel's classification of a parsed column-default expression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParseStatus {
+    /// The SQL parsed to a literal expression.
+    Literal,
+    /// The SQL parsed to a non-literal expression.
+    NonLiteral,
+    /// Kernel could not parse the SQL expression.
+    Unparsed,
+}
+
 impl<'a> ColumnDefault<'a> {
     /// Build a `ColumnDefault` from a raw SQL string and the column's declared type.
     ///
@@ -110,23 +121,15 @@ impl<'a> ColumnDefault<'a> {
         }
     }
 
-    /// Returns `true` iff the default parsed to a literal expression.
+    /// Classifies the default according to kernel's SQL parser coverage.
     ///
-    /// Returns `false` for both recognized non-literals such as `CURRENT_TIMESTAMP` and SQL the
-    /// kernel could not parse, such as arithmetic or unsupported function calls. Note that NULL
-    /// parses to a literal, so this is `true` for a NULL default regardless of the column type.
-    pub(crate) fn is_kernel_parsable_literal(&self) -> bool {
-        matches!(self.parsed_sql, Some(Expression::Literal(_)))
-    }
-
-    /// Returns `true` iff the kernel parsed the default as a non-literal expression.
-    ///
-    /// Unlike [`is_kernel_parsable_literal`](Self::is_kernel_parsable_literal), this distinguishes
-    /// recognized dynamic defaults from SQL the kernel could not parse. IcebergCompatV3 validation
-    /// uses that distinction to reject known non-literals while retaining raw-SQL fallback for
-    /// expressions whose literal status is unknown.
-    pub(crate) fn is_kernel_parsable_non_literal(&self) -> bool {
-        matches!(self.parsed_sql, Some(ref expr) if !matches!(expr, Expression::Literal(_)))
+    /// NULL is classified as [`ParseStatus::Literal`] regardless of the column type.
+    pub(crate) fn parse_status(&self) -> ParseStatus {
+        match &self.parsed_sql {
+            Some(Expression::Literal(_)) => ParseStatus::Literal,
+            Some(_) => ParseStatus::NonLiteral,
+            None => ParseStatus::Unparsed,
+        }
     }
 }
 
@@ -466,17 +469,15 @@ mod tests {
     }
 
     #[rstest]
-    #[case::literal("42", DataType::INTEGER, true, false)]
-    #[case::dynamic("CURRENT_TIMESTAMP", DataType::TIMESTAMP, false, true)]
-    #[case::unparsed("NOW()", DataType::TIMESTAMP, false, false)]
+    #[case::literal("42", DataType::INTEGER, ParseStatus::Literal)]
+    #[case::dynamic("CURRENT_TIMESTAMP", DataType::TIMESTAMP, ParseStatus::NonLiteral)]
+    #[case::unparsed("NOW()", DataType::TIMESTAMP, ParseStatus::Unparsed)]
     fn classifies_parsed_defaults(
         #[case] raw_sql: &str,
         #[case] data_type: DataType,
-        #[case] is_literal: bool,
-        #[case] is_non_literal: bool,
+        #[case] expected: ParseStatus,
     ) {
         let default = ColumnDefault::new(raw_sql.to_string(), &data_type).unwrap();
-        assert_eq!(default.is_kernel_parsable_literal(), is_literal);
-        assert_eq!(default.is_kernel_parsable_non_literal(), is_non_literal);
+        assert_eq!(default.parse_status(), expected);
     }
 }

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -46,11 +46,8 @@ pub struct ColumnDefault<'a> {
 /// Kernel's classification of a parsed column-default expression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ParseStatus {
-    /// The SQL parsed to a literal expression.
     Literal,
-    /// The SQL parsed to a non-literal expression.
     NonLiteral,
-    /// Kernel could not parse the SQL expression.
     Unparsed,
 }
 

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -30,8 +30,8 @@ use crate::{DeltaResult, Error};
 /// Holds the raw SQL and the column's declared type. On construction the kernel parses the SQL
 /// with its built-in parser and caches the result. [`to_scalar`](Self::to_scalar) returns the
 /// parsed [`Scalar`], or `None` when the kernel could not parse the SQL, in which case a connector
-/// can evaluate [`raw_sql`](Self::raw_sql) itself. Dynamic defaults such as `CURRENT_TIMESTAMP`
-/// are evaluated each time [`to_scalar`](Self::to_scalar) is called.
+/// can evaluate [`raw_sql`](Self::raw_sql) itself. Kernel-supported non-literal defaults such as
+/// `CURRENT_TIMESTAMP` are evaluated each time [`to_scalar`](Self::to_scalar) is called.
 ///
 /// The declared type is borrowed from the logical schema, which outlives the carrier.
 #[derive(Debug, Clone, PartialEq)]
@@ -91,13 +91,14 @@ impl<'a> ColumnDefault<'a> {
 
     /// The default as a [`Scalar`], or `None` when the kernel could not parse the SQL.
     ///
-    /// Dynamic defaults such as `CURRENT_TIMESTAMP` are evaluated when this method is called. On
-    /// `None` the connector can evaluate [`raw_sql`](Self::raw_sql) with its own SQL engine.
+    /// Kernel-supported non-literal defaults such as `CURRENT_TIMESTAMP` are evaluated when this
+    /// method is called. On `None` the connector can evaluate [`raw_sql`](Self::raw_sql) with its
+    /// own SQL engine.
     ///
     /// # Errors
     ///
-    /// Returns an error if a parsed expression is neither a literal nor a kernel-supported dynamic
-    /// default, or if evaluation of a supported dynamic default fails.
+    /// Returns an error if a parsed expression is neither a literal nor a kernel-supported
+    /// non-literal default, or if evaluation of a supported non-literal default fails.
     pub fn to_scalar(&self) -> DeltaResult<Option<Scalar>> {
         match &self.parsed_sql {
             None => Ok(None),
@@ -467,7 +468,7 @@ mod tests {
 
     #[rstest]
     #[case::literal("42", DataType::INTEGER, ParseStatus::Literal)]
-    #[case::dynamic("CURRENT_TIMESTAMP", DataType::TIMESTAMP, ParseStatus::NonLiteral)]
+    #[case::non_literal("CURRENT_TIMESTAMP", DataType::TIMESTAMP, ParseStatus::NonLiteral)]
     #[case::unparsed("NOW()", DataType::TIMESTAMP, ParseStatus::Unparsed)]
     fn classifies_parsed_defaults(
         #[case] raw_sql: &str,

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -4655,7 +4655,7 @@ mod tests {
         #[rstest]
         #[case::parsable_literal(DataType::INTEGER, "42", true)]
         #[case::null_primitive(DataType::INTEGER, "NULL", true)]
-        #[case::unparsable_function_call(DataType::TIMESTAMP, "current_timestamp()", false)]
+        #[case::current_timestamp(DataType::TIMESTAMP, "current_timestamp()", true)]
         #[case::unparsable_type_mismatch(DataType::TIMESTAMP, "0.18", false)]
         fn exposes_default_for_primitive(
             #[case] data_type: DataType,

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -189,16 +189,23 @@ mod column_default_tests {
         )])
     }
 
+    #[derive(Clone, Copy, Debug)]
+    enum ExpectedValidation {
+        Valid,
+        Warning(&'static str),
+        Unsupported(&'static str),
+    }
+
     #[rstest]
     #[case::primitive_literal(
         StructType::try_new([field_with_default("a", DataType::INTEGER, "42")]).unwrap(),
         "a",
-        None
+        ExpectedValidation::Valid
     )]
     #[case::primitive_null(
         StructType::try_new([field_with_default("a", DataType::INTEGER, "NULL")]).unwrap(),
         "a",
-        None
+        ExpectedValidation::Valid
     )]
     #[case::null_on_non_primitive(
         StructType::try_new([field_with_default(
@@ -207,7 +214,7 @@ mod column_default_tests {
             "NULL"
         )]).unwrap(),
         "a",
-        None
+        ExpectedValidation::Valid
     )]
     #[case::non_null_on_non_primitive(
         StructType::try_new([field_with_default(
@@ -216,40 +223,18 @@ mod column_default_tests {
             "ARRAY(1)"
         )]).unwrap(),
         "a",
-        Some("could not verify")
+        ExpectedValidation::Warning("could not verify")
     )]
-    fn v3_column_default_validation(
-        #[case] schema: StructType,
-        #[case] expected_path: &str,
-        #[case] expected_warning: Option<&str>,
-    ) {
-        let table_configuration = table_config_with_schema(schema);
-        let logging = LoggingTest::new();
-        iceberg_compat_v3_column_defaults_validation(&table_configuration).unwrap();
-        let logs = logging.logs();
-
-        match expected_warning {
-            None => assert!(
-                !logs.contains("icebergCompatV3 column default"),
-                "logs: {logs}"
-            ),
-            Some(needle) => {
-                assert!(logs.contains(expected_path), "logs: {logs}");
-                assert!(logs.contains(needle), "logs: {logs}");
-            }
-        }
-    }
-
-    #[rstest]
-    #[case::top_level(
+    #[case::recognized_non_literal_top_level(
         StructType::try_new([field_with_default(
             "a",
             DataType::TIMESTAMP,
             "current_timestamp()"
         )]).unwrap(),
-        "a"
+        "a",
+        ExpectedValidation::Unsupported("current_timestamp()")
     )]
-    #[case::nested(
+    #[case::recognized_non_literal_nested(
         StructType::try_new([StructField::nullable(
             "s",
             DataType::try_struct_type([field_with_default(
@@ -258,23 +243,45 @@ mod column_default_tests {
                 "current_timestamp()"
             )]).unwrap(),
         )]).unwrap(),
-        "s.inner"
+        "s.inner",
+        ExpectedValidation::Unsupported("current_timestamp()")
     )]
-    fn v3_column_default_validation_rejects_recognized_non_literal(
+    fn v3_column_default_validation(
         #[case] schema: StructType,
         #[case] expected_path: &str,
+        #[case] expected: ExpectedValidation,
     ) {
         let table_configuration = table_config_with_schema(schema);
-        let error = iceberg_compat_v3_column_defaults_validation(&table_configuration)
-            .expect_err("icebergCompatV3 must reject a recognized non-literal default");
+        let logging = LoggingTest::new();
+        let result = iceberg_compat_v3_column_defaults_validation(&table_configuration);
 
-        assert!(matches!(&error, crate::Error::Unsupported(_)));
-        let message = error.to_string();
-        assert!(message.contains(expected_path), "got: {message}");
-        assert!(message.contains("current_timestamp()"), "got: {message}");
-        assert!(
-            message.contains("requires column defaults to be literals"),
-            "got: {message}"
-        );
+        match expected {
+            ExpectedValidation::Valid => {
+                result.unwrap();
+                let logs = logging.logs();
+                assert!(
+                    !logs.contains("icebergCompatV3 column default"),
+                    "logs: {logs}"
+                );
+            }
+            ExpectedValidation::Warning(needle) => {
+                result.unwrap();
+                let logs = logging.logs();
+                assert!(logs.contains(expected_path), "logs: {logs}");
+                assert!(logs.contains(needle), "logs: {logs}");
+            }
+            ExpectedValidation::Unsupported(default_sql) => {
+                let error = result
+                    .expect_err("icebergCompatV3 must reject a recognized non-literal default");
+                assert!(matches!(&error, crate::Error::Unsupported(_)));
+                let message = error.to_string();
+                assert!(message.contains(expected_path), "got: {message}");
+                assert!(message.contains(default_sql), "got: {message}");
+                assert!(
+                    message.contains("requires column defaults to be literals"),
+                    "got: {message}"
+                );
+            }
+        }
     }
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -7,7 +7,7 @@ use super::{
     IcebergCompatValidator, IcebergCompatVersion,
 };
 use crate::schema::PrimitiveType::*;
-use crate::schema::{try_collect_column_defaults, DataType};
+use crate::schema::{column_default, try_collect_column_defaults, DataType};
 use crate::table_configuration::TableConfiguration;
 use crate::{DeltaResult, Error};
 
@@ -68,18 +68,22 @@ pub(crate) fn iceberg_compat_v3_column_defaults_validation(
     for (path, column_default) in
         try_collect_column_defaults(table_configuration.logical_schema_ref())?
     {
-        if column_default.is_kernel_parsable_non_literal() {
-            return Err(Error::unsupported(format!(
-                "icebergCompatV3 requires column defaults to be literals, but the default for \
-                 '{path}' is a non-literal expression: {}",
-                column_default.raw_sql()
-            )));
-        } else if !column_default.is_kernel_parsable_literal() {
-            warn!(
-                "kernel could not verify that the icebergCompatV3 column default for '{path}' is a \
-                 literal, got: {}",
-                column_default.raw_sql()
-            );
+        match column_default.parse_status() {
+            column_default::ParseStatus::Literal => {}
+            column_default::ParseStatus::NonLiteral => {
+                return Err(Error::unsupported(format!(
+                    "icebergCompatV3 requires column defaults to be literals, but the default for \
+                     '{path}' is a non-literal expression: {}",
+                    column_default.raw_sql()
+                )));
+            }
+            column_default::ParseStatus::Unparsed => {
+                warn!(
+                    "kernel could not verify that the icebergCompatV3 column default for '{path}' \
+                     is a literal, got: {}",
+                    column_default.raw_sql()
+                );
+            }
         }
     }
     Ok(())

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::schema::PrimitiveType::*;
 use crate::schema::{try_collect_column_defaults, DataType};
 use crate::table_configuration::TableConfiguration;
-use crate::DeltaResult;
+use crate::{DeltaResult, Error};
 
 /// V3 invariants paired with the version constant. Fed to
 /// [`super::validate_iceberg_compat_if_needed`].
@@ -51,27 +51,30 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
     )
 }
 
-/// Validates IcebergCompatV3 column defaults and logs warnings kernel cannot verify.
+/// Validates that IcebergCompatV3 column defaults are literals.
 ///
-/// The IcebergCompatV3 spec requires column defaults to be literals. Kernel warns when its parser
-/// cannot verify that requirement. This warning can be a false positive when the expression is a
-/// literal that kernel's parser cannot parse.
-///
-/// This condition remains a warning because the table has already passed metadata validation and
-/// rejecting a DML transaction could block valid tables based on kernel parser limitations. The
-/// check provides defense in depth without treating an interoperability risk as definite
-/// corruption.
+/// The IcebergCompatV3 spec requires column defaults to be literals. Kernel rejects defaults its
+/// parser recognizes as non-literal expressions and warns when its parser cannot determine whether
+/// the SQL is a literal. The latter warning can be a false positive for a literal outside kernel's
+/// parser coverage.
 ///
 /// # Errors
 ///
-/// Propagates malformed column-default metadata errors from [`try_collect_column_defaults`].
+/// Returns [`Error::Unsupported`] when kernel recognizes a non-literal default. Propagates
+/// malformed column-default metadata errors from [`try_collect_column_defaults`].
 pub(crate) fn iceberg_compat_v3_column_defaults_validation(
     table_configuration: &TableConfiguration,
 ) -> DeltaResult<()> {
     for (path, column_default) in
         try_collect_column_defaults(table_configuration.logical_schema_ref())?
     {
-        if !column_default.is_kernel_parsable_literal() {
+        if column_default.is_kernel_parsable_non_literal() {
+            return Err(Error::unsupported(format!(
+                "icebergCompatV3 requires column defaults to be literals, but the default for \
+                 '{path}' is a non-literal expression: {}",
+                column_default.raw_sql()
+            )));
+        } else if !column_default.is_kernel_parsable_literal() {
             warn!(
                 "kernel could not verify that the icebergCompatV3 column default for '{path}' is a \
                  literal, got: {}",
@@ -193,15 +196,6 @@ mod column_default_tests {
         "a",
         None
     )]
-    #[case::non_literal_primitive(
-        StructType::try_new([field_with_default(
-            "a",
-            DataType::TIMESTAMP,
-            "current_timestamp()"
-        )]).unwrap(),
-        "a",
-        Some("could not verify")
-    )]
     #[case::null_on_non_primitive(
         StructType::try_new([field_with_default(
             "a",
@@ -218,18 +212,6 @@ mod column_default_tests {
             "ARRAY(1)"
         )]).unwrap(),
         "a",
-        Some("could not verify")
-    )]
-    #[case::nested_non_literal(
-        StructType::try_new([StructField::nullable(
-            "s",
-            DataType::try_struct_type([field_with_default(
-                "inner",
-                DataType::TIMESTAMP,
-                "current_timestamp()"
-            )]).unwrap(),
-        )]).unwrap(),
-        "s.inner",
         Some("could not verify")
     )]
     fn v3_column_default_validation(
@@ -252,5 +234,43 @@ mod column_default_tests {
                 assert!(logs.contains(needle), "logs: {logs}");
             }
         }
+    }
+
+    #[rstest]
+    #[case::top_level(
+        StructType::try_new([field_with_default(
+            "a",
+            DataType::TIMESTAMP,
+            "current_timestamp()"
+        )]).unwrap(),
+        "a"
+    )]
+    #[case::nested(
+        StructType::try_new([StructField::nullable(
+            "s",
+            DataType::try_struct_type([field_with_default(
+                "inner",
+                DataType::TIMESTAMP,
+                "current_timestamp()"
+            )]).unwrap(),
+        )]).unwrap(),
+        "s.inner"
+    )]
+    fn v3_column_default_validation_rejects_recognized_non_literal(
+        #[case] schema: StructType,
+        #[case] expected_path: &str,
+    ) {
+        let table_configuration = table_config_with_schema(schema);
+        let error = iceberg_compat_v3_column_defaults_validation(&table_configuration)
+            .expect_err("icebergCompatV3 must reject a recognized non-literal default");
+
+        assert!(matches!(&error, crate::Error::Unsupported(_)));
+        let message = error.to_string();
+        assert!(message.contains(expected_path), "got: {message}");
+        assert!(message.contains("current_timestamp()"), "got: {message}");
+        assert!(
+            message.contains("requires column defaults to be literals"),
+            "got: {message}"
+        );
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2249,7 +2249,12 @@ mod tests {
         fn collects_present_defaults_and_skips_columns_without_one() {
             let schema = StructType::try_new(vec![
                 field_with_default("parsable", DataType::INTEGER, "42"),
-                field_with_default("unparsable", DataType::TIMESTAMP, "current_timestamp()"),
+                field_with_default(
+                    "current_timestamp",
+                    DataType::TIMESTAMP,
+                    "CURRENT_TIMESTAMP",
+                ),
+                field_with_default("unparsable", DataType::TIMESTAMP, "NOW()"),
                 StructField::nullable("no_default", DataType::STRING),
             ])
             .unwrap();
@@ -2258,7 +2263,7 @@ mod tests {
             let defaults = txn.top_level_column_defaults().unwrap();
             assert_eq!(
                 defaults.len(),
-                2,
+                3,
                 "only columns with a default are returned"
             );
             assert!(!defaults.contains_key("no_default"));
@@ -2267,8 +2272,15 @@ mod tests {
             assert_eq!(parsable.raw_sql(), "42");
             assert!(parsable.to_scalar().unwrap().is_some());
 
+            let current_timestamp = &defaults["current_timestamp"];
+            assert_eq!(current_timestamp.raw_sql(), "CURRENT_TIMESTAMP");
+            assert!(matches!(
+                current_timestamp.to_scalar().unwrap(),
+                Some(Scalar::Timestamp(_))
+            ));
+
             let unparsable = &defaults["unparsable"];
-            assert_eq!(unparsable.raw_sql(), "current_timestamp()");
+            assert_eq!(unparsable.raw_sql(), "NOW()");
             assert!(unparsable.to_scalar().unwrap().is_none());
         }
 

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -144,6 +144,13 @@ pub(crate) fn current_time_ms() -> DeltaResult<i64> {
         .map_err(|_| Error::generic("Current timestamp exceeds i64 millisecond range"))
 }
 
+/// Returns the current time in microseconds since Unix epoch.
+pub(crate) fn current_time_micros() -> DeltaResult<i64> {
+    let duration = current_time_duration()?;
+    i64::try_from(duration.as_micros())
+        .map_err(|_| Error::generic("Current timestamp exceeds i64 microsecond range"))
+}
+
 /// Extension trait for folding zero or one value from an [`Option`] into a base value.
 #[internal_api]
 pub(crate) trait FoldWithOption: Sized {
@@ -235,6 +242,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn current_time_micros_is_within_system_time_bounds() {
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_micros();
+        let current = u128::try_from(current_time_micros().unwrap()).unwrap();
+        let after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_micros();
+
+        assert!(before <= current && current <= after);
+    }
 
     #[test]
     fn test_path_parsing() {

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -152,7 +152,7 @@ pub(crate) fn current_time_micros() -> DeltaResult<i64> {
 
 fn duration_to_micros(duration: Duration) -> DeltaResult<i64> {
     i64::try_from(duration.as_micros())
-        .map_err(|_| Error::generic("Current timestamp exceeds i64 microsecond range"))
+        .map_err(|_| Error::generic("Duration exceeds i64 microsecond range"))
 }
 
 /// Extension trait for folding zero or one value from an [`Option`] into a base value.

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -147,6 +147,10 @@ pub(crate) fn current_time_ms() -> DeltaResult<i64> {
 /// Returns the current time in microseconds since Unix epoch.
 pub(crate) fn current_time_micros() -> DeltaResult<i64> {
     let duration = current_time_duration()?;
+    duration_to_micros(duration)
+}
+
+fn duration_to_micros(duration: Duration) -> DeltaResult<i64> {
     i64::try_from(duration.as_micros())
         .map_err(|_| Error::generic("Current timestamp exceeds i64 microsecond range"))
 }
@@ -256,6 +260,18 @@ mod tests {
             .as_micros();
 
         assert!(before <= current && current <= after);
+    }
+
+    #[test]
+    fn duration_to_micros_checks_i64_bounds() {
+        let max = Duration::from_micros(i64::MAX as u64);
+        assert_eq!(duration_to_micros(max).unwrap(), i64::MAX);
+
+        let overflow = Duration::from_micros(i64::MAX as u64 + 1);
+        assert!(duration_to_micros(overflow)
+            .unwrap_err()
+            .to_string()
+            .contains("i64 microsecond range"));
     }
 
     #[test]

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -476,65 +476,62 @@ async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
     Ok(())
 }
 
-/// On an `icebergCompatV3` table, a default whose SQL expression kernel cannot parse produces a
-/// warning rather than an error, so the snapshot loads and a DML transaction constructs.
+#[derive(Clone, Copy, Debug)]
+enum V3ValidationOutcome {
+    Warning(&'static str),
+    Unsupported(&'static str),
+}
+
+#[rstest]
+#[case::unparseable(
+    "test_v3_tolerates_unparseable_default",
+    DataType::from(ArrayType::new(DataType::INTEGER, true)),
+    "ARRAY(1)",
+    V3ValidationOutcome::Warning("could not verify")
+)]
+#[case::recognized_non_literal(
+    "test_v3_rejects_recognized_non_literal_default",
+    DataType::TIMESTAMP,
+    "current_timestamp()",
+    V3ValidationOutcome::Unsupported("requires column defaults to be literals")
+)]
 #[tokio::test]
-async fn test_load_and_write_tolerate_v3_unparseable_default(
+async fn test_v3_column_default_validation_e2e(
+    #[case] table_name: &str,
+    #[case] field_type: DataType,
+    #[case] default_sql: &str,
+    #[case] expected: V3ValidationOutcome,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let field_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
-    let default_sql = "ARRAY(1)";
     let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
     let (engine, table_url) = setup_unpartitioned_table(
-        "test_v3_tolerates_unparseable_default",
+        table_name,
         schema,
         vec!["allowColumnDefaults", "icebergCompatV3"],
     )
     .await?;
 
-    // Read: the snapshot loads despite the unverifiable default.
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-
     let logging = LoggingTest::new();
-    snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-    assert!(
-        logging.logs().contains("could not verify"),
-        "logs: {}",
-        logging.logs()
-    );
 
-    Ok(())
-}
-
-/// A snapshot containing a recognized non-literal default remains readable, but IcebergCompatV3
-/// rejects construction of a DML transaction because the feature requires literal defaults.
-#[tokio::test]
-async fn test_load_allows_but_write_rejects_v3_recognized_non_literal_default(
-) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![StructField::nullable("c", DataType::TIMESTAMP)])?;
-    let schema = schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
-
-    let (engine, table_url) = setup_unpartitioned_table(
-        "test_v3_rejects_recognized_non_literal_default",
-        schema,
-        vec!["allowColumnDefaults", "icebergCompatV3"],
-    )
-    .await?;
-
-    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
-    let error = snapshot
-        .transaction(Box::new(FileSystemCommitter::new()), &engine)
-        .expect_err("icebergCompatV3 must reject a recognized non-literal default");
-
-    assert!(matches!(&error, delta_kernel::Error::Unsupported(_)));
-    let message = error.to_string();
-    assert!(message.contains("icebergCompatV3"), "got: {message}");
-    assert!(message.contains("current_timestamp()"), "got: {message}");
-    assert!(
-        message.contains("requires column defaults to be literals"),
-        "got: {message}"
-    );
+    match expected {
+        V3ValidationOutcome::Warning(needle) => {
+            snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+            let logs = logging.logs();
+            assert!(logs.contains(needle), "logs: {logs}");
+        }
+        V3ValidationOutcome::Unsupported(needle) => {
+            let error = snapshot
+                .transaction(Box::new(FileSystemCommitter::new()), &engine)
+                .expect_err("icebergCompatV3 must reject a recognized non-literal default");
+            assert!(matches!(&error, delta_kernel::Error::Unsupported(_)));
+            let message = error.to_string();
+            assert!(message.contains("icebergCompatV3"), "got: {message}");
+            assert!(message.contains(default_sql), "got: {message}");
+            assert!(message.contains(needle), "got: {message}");
+        }
+    }
 
     Ok(())
 }

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -375,7 +375,7 @@ async fn assert_materialized_column_default_round_trips(
         let defaults = txn.top_level_column_defaults()?;
         defaults["c"]
             .to_scalar()?
-            .expect("a primitive literal default must materialize")
+            .expect("a kernel-supported primitive default must materialize")
     };
     let values = scalar.to_array(1)?;
     insert_data(snapshot, &engine, vec![values.clone()])
@@ -403,6 +403,7 @@ async fn assert_materialized_column_default_round_trips(
 #[case::binary(DataType::BINARY, "X'deadbeef'")]
 #[case::date(DataType::DATE, "DATE '2024-01-01'")]
 #[case::timestamp(DataType::TIMESTAMP, "TIMESTAMP '2024-01-01T12:00:00Z'")]
+#[case::current_timestamp(DataType::TIMESTAMP, "CURRENT_TIMESTAMP")]
 #[case::timestamp_ntz(DataType::TIMESTAMP_NTZ, "TIMESTAMP_NTZ '2024-01-01 12:00:00'")]
 #[case::decimal(DataType::decimal(10, 2).unwrap(), "1.23")]
 #[tokio::test]
@@ -425,7 +426,7 @@ async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
         MetadataValue::String("7".to_string()),
     )]);
 
-    // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default,
+    // `a`: no default, `b`: kernel-parsable literal, `c`: kernel-evaluated non-literal default,
     // `s.inner`: nested default that the top-level API must not return.
     let base = StructType::try_new(vec![
         StructField::nullable("a", DataType::INTEGER),
@@ -467,42 +468,26 @@ async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
 
     let c = &defaults["c"];
     assert_eq!(c.raw_sql(), "current_timestamp()");
-    assert_eq!(
-        c.to_scalar()?,
-        None,
-        "a non-kernel-parsable default is not parsed by the kernel",
+    assert!(
+        matches!(c.to_scalar()?, Some(Scalar::Timestamp(_))),
+        "CURRENT_TIMESTAMP must materialize to a timestamp scalar",
     );
 
     Ok(())
 }
 
-/// On an `icebergCompatV3` table, a default kernel cannot verify as a literal produces a
+/// On an `icebergCompatV3` table, a default whose SQL expression kernel cannot parse produces a
 /// warning rather than an error, so the snapshot loads and a DML transaction constructs.
-#[rstest]
-#[case::non_literal(
-    "non_literal",
-    DataType::TIMESTAMP,
-    "current_timestamp()",
-    "could not verify"
-)]
-#[case::unparsable_non_primitive(
-    "non_primitive",
-    DataType::from(ArrayType::new(DataType::INTEGER, true)),
-    "ARRAY(1)",
-    "could not verify"
-)]
 #[tokio::test]
-async fn test_load_and_write_tolerate_v3_unverifiable_default(
-    #[case] label: &str,
-    #[case] field_type: DataType,
-    #[case] default_sql: &str,
-    #[case] warning_text: &str,
+async fn test_load_and_write_tolerate_v3_unparseable_default(
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let field_type = DataType::from(ArrayType::new(DataType::INTEGER, true));
+    let default_sql = "ARRAY(1)";
     let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
     let (engine, table_url) = setup_unpartitioned_table(
-        &format!("test_v3_tolerates_{label}"),
+        "test_v3_tolerates_unparseable_default",
         schema,
         vec!["allowColumnDefaults", "icebergCompatV3"],
     )
@@ -514,9 +499,41 @@ async fn test_load_and_write_tolerate_v3_unverifiable_default(
     let logging = LoggingTest::new();
     snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
     assert!(
-        logging.logs().contains(warning_text),
+        logging.logs().contains("could not verify"),
         "logs: {}",
         logging.logs()
+    );
+
+    Ok(())
+}
+
+/// A snapshot containing a recognized non-literal default remains readable, but IcebergCompatV3
+/// rejects construction of a DML transaction because the feature requires literal defaults.
+#[tokio::test]
+async fn test_load_allows_but_write_rejects_v3_recognized_non_literal_default(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let base = StructType::try_new(vec![StructField::nullable("c", DataType::TIMESTAMP)])?;
+    let schema = schema_with_column_defaults(&base, HashMap::from([("c", "current_timestamp()")]))?;
+
+    let (engine, table_url) = setup_unpartitioned_table(
+        "test_v3_rejects_recognized_non_literal_default",
+        schema,
+        vec!["allowColumnDefaults", "icebergCompatV3"],
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    let error = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), &engine)
+        .expect_err("icebergCompatV3 must reject a recognized non-literal default");
+
+    assert!(matches!(&error, delta_kernel::Error::Unsupported(_)));
+    let message = error.to_string();
+    assert!(message.contains("icebergCompatV3"), "got: {message}");
+    assert!(message.contains("current_timestamp()"), "got: {message}");
+    assert!(
+        message.contains("requires column defaults to be literals"),
+        "got: {message}"
     );
 
     Ok(())


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds kernel support for `CURRENT_TIMESTAMP` column defaults. The internal SQL parser represents it as a private opaque expression, and `ColumnDefault::to_scalar()` evaluates it as the current UTC time in microseconds since the Unix epoch.

Unsupported expressions still fall back to raw SQL. IcebergCompatV3 validation rejects recognized non-literal defaults such as `CURRENT_TIMESTAMP`.

## How was this change tested?

Added unit and integration coverage for parsing, lazy evaluation, UTC timestamps, unsupported forms, and IcebergCompatV3 rejection. Clippy and documentation checks pass.
