### PR TITLE
fix: logical comparison for NULL instead of physical comparison

### DIFF
--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-08-10"
+}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,3 +1,0 @@
-{
-  "sync_reminder_last_shown": "2026-08-10"
-}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,3 +1,0 @@
-{
-  "sync_reminder_last_shown": "2026-08-07"
-}

--- a/.isaac/config.json
+++ b/.isaac/config.json
@@ -1,0 +1,3 @@
+{
+  "sync_reminder_last_shown": "2026-08-07"
+}

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1921,106 +1921,74 @@ mod tests {
         assert_eq!(result.value(0), expected);
     }
 
-    /// `{ n: 1 }` plus a `list` column holding `[1, 2]`, covering both element sources `IN`
-    /// accepts.
-    fn in_batch() -> RecordBatch {
+    /// The two element sources `IN` accepts, both holding `elements`: a literal `Array` scalar
+    /// and a single-row `list` column. The batch also carries an `n` column (always `1`) so the
+    /// needle can be a column in the operand-shape rejection test.
+    fn in_sources(elements: &[Option<i32>]) -> (Expr, Expr, RecordBatch) {
+        let scalars = elements
+            .iter()
+            .map(|e| e.map_or(Scalar::Null(DataType::INTEGER), Scalar::Integer));
+        let literal = Expr::Literal(Scalar::Array(
+            ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), scalars).unwrap(),
+        ));
+
         let item = Arc::new(ArrowField::new("item", ArrowDataType::Int32, true));
         let list = ListArray::new(
             Arc::clone(&item),
-            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, 2])),
-            Arc::new(Int32Array::from(vec![1, 2])),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, elements.len() as i32])),
+            Arc::new(Int32Array::from(elements.to_vec())),
             None,
         );
         let schema = ArrowSchema::new(vec![
             ArrowField::new("n", ArrowDataType::Int32, true),
             ArrowField::new("list", ArrowDataType::List(item), true),
         ]);
-        RecordBatch::try_new(
+        let batch = RecordBatch::try_new(
             Arc::new(schema),
             vec![Arc::new(Int32Array::from(vec![1])), Arc::new(list)],
         )
-        .unwrap()
+        .unwrap();
+        (literal, column_expr!("list"), batch)
     }
 
-    fn int_array_literal() -> Expr {
-        let elements =
-            ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), vec![1, 2]).unwrap();
-        Expr::Literal(Scalar::Array(elements))
-    }
-
-    /// A NULL needle is not null-propagating: it answers `false` rather than NULL.
+    /// `IN` reports membership as a plain boolean and never yields NULL, identically across both
+    /// element sources (a literal array and a list column). Because membership uses logical (SQL)
+    /// equality -- under which NULL is incomparable to everything, including itself -- a NULL
+    /// needle matches nothing (answering `false`, not NULL), and a NULL element matches nothing,
+    /// not even a NULL needle.
     #[rstest]
-    #[case::present_in_literal_array(Some(2), true, true)]
-    #[case::absent_from_literal_array(Some(9), false, true)]
-    #[case::null_needle_in_literal_array(None, false, true)]
-    #[case::present_in_list_column(Some(2), true, false)]
-    #[case::absent_from_list_column(Some(9), false, false)]
-    #[case::null_needle_in_list_column(None, false, false)]
-    fn test_in_matches_membership_and_never_nulls(
-        #[case] needle: Option<i32>,
-        #[case] expected: bool,
-        #[case] literal_elements: bool,
-    ) {
-        let batch = in_batch();
-        let needle = match needle {
-            Some(n) => lit(n),
-            None => Expr::null_literal(DataType::INTEGER),
-        };
-        let elements = if literal_elements {
-            int_array_literal()
-        } else {
-            column_expr!("list")
-        };
-
-        let pred = Pred::binary(BinaryPredicateOp::In, needle, elements);
-        let result = evaluate_predicate(&pred, &batch, false).unwrap();
-        assert_eq!(result.null_count(), 0);
-        assert_eq!(result.value(0), expected);
-    }
-
-    /// A NULL element matches nothing, not even a NULL needle: membership uses logical (SQL)
-    /// equality, where NULL is incomparable to everything including itself.
-    #[rstest]
-    #[case::null_needle_and_null_element(None, &[Some(1), None], false)]
-    #[case::null_needle_and_only_null_element(None, &[None], false)]
+    #[case::present(Some(2), &[Some(1), Some(2)], true)]
+    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
+    #[case::null_needle(None, &[Some(1), Some(2)], false)]
+    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
+    #[case::null_needle_with_only_null_element(None, &[None], false)]
     #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
     #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
-    fn test_in_null_element_matches_nothing(
+    fn test_in_membership_never_nulls(
         #[case] needle: Option<i32>,
         #[case] elements: &[Option<i32>],
         #[case] expected: bool,
     ) {
-        let elements: Vec<Scalar> = elements
-            .iter()
-            .map(|e| match e {
-                Some(n) => Scalar::Integer(*n),
-                None => Scalar::Null(DataType::INTEGER),
-            })
-            .collect();
-        let elements =
-            ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), elements).unwrap();
+        let (literal_source, column_source, batch) = in_sources(elements);
         let needle = match needle {
             Some(n) => lit(n),
             None => Expr::null_literal(DataType::INTEGER),
         };
+        for elements in [literal_source, column_source] {
+            let pred = Pred::binary(BinaryPredicateOp::In, needle.clone(), elements);
+            let result = evaluate_predicate(&pred, &batch, false).unwrap();
+            assert_eq!(result.null_count(), 0);
+            assert_eq!(result.value(0), expected);
 
-        let pred = Pred::binary(
-            BinaryPredicateOp::In,
-            needle,
-            Expr::Literal(Scalar::Array(elements)),
-        );
-        let result = evaluate_predicate(&pred, &in_batch(), false).unwrap();
-        assert_eq!(result.null_count(), 0);
-        assert_eq!(result.value(0), expected);
-
-        // `IN` never produces NULL, so `NOT IN` is always its exact complement.
-        let result = evaluate_predicate(&Pred::not(pred), &in_batch(), false).unwrap();
-        assert_eq!(result.null_count(), 0);
-        assert_eq!(result.value(0), !expected);
+            // `IN` never produces NULL, so `NOT IN` is always its exact complement.
+            let result = evaluate_predicate(&Pred::not(pred), &batch, false).unwrap();
+            assert_eq!(result.null_count(), 0);
+            assert_eq!(result.value(0), !expected);
+        }
     }
 
-    /// Struct/array/map elements have no logical comparison, so they never match. See
-    /// [`Scalar::logical_partial_cmp`].
+    /// Struct/array/map elements have no logical comparison, so they never match -- not even a
+    /// structurally identical needle. See [`Scalar::logical_partial_cmp`].
     #[test]
     fn test_in_nested_element_never_matches() {
         let make_struct = |v| {
@@ -2042,12 +2010,13 @@ mod tests {
         )
         .unwrap();
 
+        let (_, _, batch) = in_sources(&[Some(1)]);
         let pred = Pred::binary(
             BinaryPredicateOp::In,
             Expr::literal(make_struct(1)),
             Expr::Literal(Scalar::Array(elements)),
         );
-        let result = evaluate_predicate(&pred, &in_batch(), false).unwrap();
+        let result = evaluate_predicate(&pred, &batch, false).unwrap();
         assert_eq!(result.null_count(), 0);
         assert!(!result.value(0));
     }
@@ -2055,13 +2024,14 @@ mod tests {
     /// Only a literal left operand is supported, so a column needle is rejected regardless of where
     /// the elements come from, as is a right operand that holds no elements at all.
     #[rstest]
-    #[case::column_in_literal_array(int_array_literal())]
-    #[case::column_in_column(column_expr!("list"))]
+    #[case::column_in_literal_array(in_sources(&[Some(1), Some(2)]).0)]
+    #[case::column_in_column(in_sources(&[Some(1), Some(2)]).1)]
     #[case::non_array_right_operand(lit(1))]
-    fn test_in_rejects_unsupported_operand_shapes(#[case] elements: Expr) {
-        let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), elements);
+    fn test_in_rejects_unsupported_operand_shapes(#[case] right: Expr) {
+        let (.., batch) = in_sources(&[Some(1), Some(2)]);
+        let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), right);
         assert_result_error_with_message(
-            evaluate_predicate(&pred, &in_batch(), false),
+            evaluate_predicate(&pred, &batch, false),
             "Invalid right value for (NOT) IN comparison",
         );
     }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -699,8 +699,7 @@ pub fn evaluate_predicate(
                     }
                 }
                 (Expression::Literal(lit), Expression::Literal(Scalar::Array(ad))) => {
-                    // Logical (SQL) equality, so a NULL never matches -- not even another NULL.
-                    // `Scalar`'s `PartialEq` is physical and would match them structurally.
+                    // Logical equality, so a NULL never matches another NULL.
                     let exists = ad.array_elements().iter().any(|e| lit.logical_eq(e));
                     Ok(BooleanArray::from(vec![exists]))
                 }

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -699,7 +699,9 @@ pub fn evaluate_predicate(
                     }
                 }
                 (Expression::Literal(lit), Expression::Literal(Scalar::Array(ad))) => {
-                    let exists = ad.array_elements().contains(lit);
+                    // Logical (SQL) equality, so a NULL never matches -- not even another NULL.
+                    // `Scalar`'s `PartialEq` is physical and would match them structurally.
+                    let exists = ad.array_elements().iter().any(|e| lit.logical_eq(e));
                     Ok(BooleanArray::from(vec![exists]))
                 }
                 (l, r) => Err(Error::invalid_expression(format!(
@@ -1118,6 +1120,7 @@ mod tests {
     use crate::expressions::{
         col, column_expr, column_expr_ref, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
         Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, Predicate as Pred,
+        StructData,
     };
     use crate::schema::{schema, schema_ref, ArrayType, DataType, StructField, StructType};
     use crate::unit_test_utils::assert_result_error_with_message;
@@ -1973,6 +1976,80 @@ mod tests {
         let result = evaluate_predicate(&pred, &batch, false).unwrap();
         assert_eq!(result.null_count(), 0);
         assert_eq!(result.value(0), expected);
+    }
+
+    /// A NULL element matches nothing, not even a NULL needle: membership uses logical (SQL)
+    /// equality, where NULL is incomparable to everything including itself.
+    #[rstest]
+    #[case::null_needle_and_null_element(None, &[Some(1), None], false)]
+    #[case::null_needle_and_only_null_element(None, &[None], false)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
+    fn test_in_null_element_matches_nothing(
+        #[case] needle: Option<i32>,
+        #[case] elements: &[Option<i32>],
+        #[case] expected: bool,
+    ) {
+        let elements: Vec<Scalar> = elements
+            .iter()
+            .map(|e| match e {
+                Some(n) => Scalar::Integer(*n),
+                None => Scalar::Null(DataType::INTEGER),
+            })
+            .collect();
+        let elements =
+            ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), elements).unwrap();
+        let needle = match needle {
+            Some(n) => lit(n),
+            None => Expr::null_literal(DataType::INTEGER),
+        };
+
+        let pred = Pred::binary(
+            BinaryPredicateOp::In,
+            needle,
+            Expr::Literal(Scalar::Array(elements)),
+        );
+        let result = evaluate_predicate(&pred, &in_batch(), false).unwrap();
+        assert_eq!(result.null_count(), 0);
+        assert_eq!(result.value(0), expected);
+
+        // `IN` never produces NULL, so `NOT IN` is always its exact complement.
+        let result = evaluate_predicate(&Pred::not(pred), &in_batch(), false).unwrap();
+        assert_eq!(result.null_count(), 0);
+        assert_eq!(result.value(0), !expected);
+    }
+
+    /// Struct/array/map elements have no logical comparison, so they never match. See
+    /// [`Scalar::logical_partial_cmp`].
+    #[test]
+    fn test_in_nested_element_never_matches() {
+        let make_struct = |v| {
+            Scalar::Struct(
+                StructData::try_new(
+                    vec![StructField::nullable("a", DataType::INTEGER)],
+                    vec![Scalar::Integer(v)],
+                )
+                .unwrap(),
+            )
+        };
+        let element_type: DataType =
+            StructType::try_new([StructField::nullable("a", DataType::INTEGER)])
+                .unwrap()
+                .into();
+        let elements = ArrayData::try_new(
+            ArrayType::new(element_type, true),
+            vec![make_struct(1), make_struct(2)],
+        )
+        .unwrap();
+
+        let pred = Pred::binary(
+            BinaryPredicateOp::In,
+            Expr::literal(make_struct(1)),
+            Expr::Literal(Scalar::Array(elements)),
+        );
+        let result = evaluate_predicate(&pred, &in_batch(), false).unwrap();
+        assert_eq!(result.null_count(), 0);
+        assert!(!result.value(0));
     }
 
     /// Only a literal left operand is supported, so a column needle is rejected regardless of where

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -699,7 +699,9 @@ pub fn evaluate_predicate(
                     }
                 }
                 (Expression::Literal(lit), Expression::Literal(Scalar::Array(ad))) => {
-                    // Logical equality, so a NULL never matches another NULL.
+                    // Logical (SQL) equality, so a NULL never matches another NULL. Struct, array,
+                    // and map elements/needles are unsupported: `logical_eq` returns `false` for
+                    // them, so they never match, not even a structurally identical value.
                     let exists = ad.array_elements().iter().any(|e| lit.logical_eq(e));
                     Ok(BooleanArray::from(vec![exists]))
                 }
@@ -1923,7 +1925,7 @@ mod tests {
     /// The two element sources `IN` accepts, both holding `elements`: a literal `Array` scalar
     /// and a single-row `list` column. The batch also carries an `n` column (always `1`) so the
     /// needle can be a column in the operand-shape rejection test.
-    fn in_sources(elements: &[Option<i32>]) -> (Expr, Expr, RecordBatch) {
+    fn in_element_sources(elements: &[Option<i32>]) -> (Expr, Expr, RecordBatch) {
         let scalars = elements
             .iter()
             .map(|e| e.map_or(Scalar::Null(DataType::INTEGER), Scalar::Integer));
@@ -1968,7 +1970,7 @@ mod tests {
         #[case] elements: &[Option<i32>],
         #[case] expected: bool,
     ) {
-        let (literal_source, column_source, batch) = in_sources(elements);
+        let (literal_source, column_source, batch) = in_element_sources(elements);
         let needle = match needle {
             Some(n) => lit(n),
             None => Expr::null_literal(DataType::INTEGER),
@@ -2009,10 +2011,10 @@ mod tests {
         )
         .unwrap();
 
-        let (_, _, batch) = in_sources(&[Some(1)]);
+        let (_, _, batch) = in_element_sources(&[Some(1)]);
         let pred = Pred::binary(
             BinaryPredicateOp::In,
-            Expr::literal(make_struct(1)),
+            Expr::Literal(make_struct(1)),
             Expr::Literal(Scalar::Array(elements)),
         );
         let result = evaluate_predicate(&pred, &batch, false).unwrap();
@@ -2023,11 +2025,11 @@ mod tests {
     /// Only a literal left operand is supported, so a column needle is rejected regardless of where
     /// the elements come from, as is a right operand that holds no elements at all.
     #[rstest]
-    #[case::column_in_literal_array(in_sources(&[Some(1), Some(2)]).0)]
-    #[case::column_in_column(in_sources(&[Some(1), Some(2)]).1)]
+    #[case::column_in_literal_array(in_element_sources(&[Some(1), Some(2)]).0)]
+    #[case::column_in_column(in_element_sources(&[Some(1), Some(2)]).1)]
     #[case::non_array_right_operand(lit(1))]
     fn test_in_rejects_unsupported_operand_shapes(#[case] right: Expr) {
-        let (.., batch) = in_sources(&[Some(1), Some(2)]);
+        let (.., batch) = in_element_sources(&[Some(1), Some(2)]);
         let pred = Pred::binary(BinaryPredicateOp::In, column_expr!("n"), right);
         assert_result_error_with_message(
             evaluate_predicate(&pred, &batch, false),

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1120,10 +1120,12 @@ mod tests {
     };
     use crate::expressions::{
         col, column_expr, column_expr_ref, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
-        Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, Predicate as Pred,
-        StructData,
+        Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData,
+        Predicate as Pred, StructData,
     };
-    use crate::schema::{schema, schema_ref, ArrayType, DataType, StructField, StructType};
+    use crate::schema::{
+        schema, schema_ref, ArrayType, DataType, MapType, StructField, StructType,
+    };
     use crate::unit_test_utils::assert_result_error_with_message;
 
     fn create_test_batch() -> RecordBatch {
@@ -1988,33 +1990,38 @@ mod tests {
         }
     }
 
-    /// Struct/array/map elements have no logical comparison, so they never match -- not even a
-    /// structurally identical needle. See [`Scalar::logical_partial_cmp`].
-    #[test]
-    fn test_in_nested_element_never_matches() {
-        let make_struct = |v| {
-            Scalar::Struct(
-                StructData::try_new(
-                    vec![StructField::nullable("a", DataType::INTEGER)],
-                    vec![Scalar::Integer(v)],
-                )
-                .unwrap(),
-            )
-        };
-        let element_type: DataType =
-            StructType::try_new([StructField::nullable("a", DataType::INTEGER)])
-                .unwrap()
-                .into();
+    /// Nested elements (struct, array, map) have no logical comparison, See
+    /// [`Scalar::logical_partial_cmp`].
+    #[rstest]
+    #[case::struct_element(Scalar::Struct(
+        StructData::try_new(
+            vec![StructField::nullable("a", DataType::INTEGER)],
+            vec![Scalar::Integer(1)],
+        )
+        .unwrap(),
+    ))]
+    #[case::array_element(Scalar::Array(
+        ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), vec![1, 2]).unwrap(),
+    ))]
+    #[case::map_element(Scalar::Map(
+        MapData::try_new(
+            MapType::new(DataType::STRING, DataType::INTEGER, false),
+            vec![("k", 1)],
+        )
+        .unwrap(),
+    ))]
+    fn test_in_nested_element_never_matches(#[case] needle: Scalar) {
+        // A single-element literal array holding a structurally identical copy of the needle.
         let elements = ArrayData::try_new(
-            ArrayType::new(element_type, true),
-            vec![make_struct(1), make_struct(2)],
+            ArrayType::new(needle.data_type(), true),
+            vec![needle.clone()],
         )
         .unwrap();
 
         let (_, _, batch) = in_element_sources(&[Some(1)]);
         let pred = Pred::binary(
             BinaryPredicateOp::In,
-            Expr::Literal(make_struct(1)),
+            Expr::Literal(needle),
             Expr::Literal(Scalar::Array(elements)),
         );
         let result = evaluate_predicate(&pred, &batch, false).unwrap();

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1954,11 +1954,7 @@ mod tests {
         (literal, column_expr!("list"), batch)
     }
 
-    /// `IN` reports membership as a plain boolean and never yields NULL, identically across both
-    /// element sources (a literal array and a list column). Because membership uses logical (SQL)
-    /// equality -- under which NULL is incomparable to everything, including itself -- a NULL
-    /// needle matches nothing (answering `false`, not NULL), and a NULL element matches nothing,
-    /// not even a NULL needle.
+    /// NULL never matches because logical equality treats it as incomparable, including to itself.
     #[rstest]
     #[case::present(Some(2), &[Some(1), Some(2)], true)]
     #[case::absent(Some(9), &[Some(1), Some(2)], false)]

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -95,6 +95,10 @@ pub enum BinaryPredicateOp {
     /// Testing a literal against a list column is the shape data skipping uses, and it is the
     /// reason the operands sit this way around rather than the more familiar
     /// column-on-the-left form.
+    ///
+    /// Membership uses logical (SQL) equality, so a NULL matches nothing -- not even another NULL.
+    /// Struct, array, and map elements have no logical comparison and therefore never match, even
+    /// when structurally identical. See [`Scalar::logical_partial_cmp`].
     In,
 }
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -81,10 +81,11 @@ pub enum BinaryPredicateOp {
     /// value. `DISTINCT(1, 1)` and `DISTINCT(NULL, NULL)` are `false`; `DISTINCT(NULL, 1)` is
     /// `true`.
     Distinct,
-    /// SQL `left IN (elements)`: `true` when `left` equals one of the elements, and `false`
-    /// otherwise, including when `left` is NULL. `left` must be a literal, and the elements are
-    /// either a list-typed column or an [`Expression::Literal`] holding a [`Scalar::Array`], never
-    /// a list of expressions or a subquery:
+    /// SQL `left IN (elements)`: returns `false` when `left` is NULL. Otherwise, it returns `true`
+    /// when `left` equals any element and `false` when none match. NULL elements never match.
+    /// `left` must be a literal, and the elements are either a list-typed column or an
+    /// [`Expression::Literal`] holding a [`Scalar::Array`], never a list of expressions or a
+    /// subquery:
     ///
     /// ```sql
     /// 2 IN (1, 2, 3)         -- literal elements

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -95,10 +95,6 @@ pub enum BinaryPredicateOp {
     /// Testing a literal against a list column is the shape data skipping uses, and it is the
     /// reason the operands sit this way around rather than the more familiar
     /// column-on-the-left form.
-    ///
-    /// Membership uses logical (SQL) equality, so a NULL matches nothing -- not even another NULL.
-    /// Struct, array, and map elements have no logical comparison and therefore never match, even
-    /// when structurally identical. See [`Scalar::logical_partial_cmp`].
     In,
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

### What was the problem?

Previously, `IN` membership against a literal array used physical equality. Physical equality
treats two NULL scalar values as identical, so kernel returned `true` for
`NULL IN [NULL, 2]`.

That does not match logical SQL equality, where NULL is incomparable to every value, including
itself. SQL represents the result as NULL (unknown). Kernel's `IN` predicate instead follows the
convention of always returning a boolean, with an incomparable NULL producing `false`.

The physical comparison appears to have been introduced in #1554.

### What is the solution?

Use logical equality for membership against literal arrays. This prevents a NULL needle from
matching a NULL element and makes literal-array behavior consistent with kernel's boolean
convention:

| Expression | SQL result | Kernel before | Kernel after |
|---|---:|---:|---:|
| `NULL IN [NULL, 2]` | NULL | `true` | `false` |
| `NULL IN [2, 3]` | NULL | `false` | `false` |

Logical comparison is not defined for struct, array, or map scalars. Those nested values therefore
do not match, even when they are structurally identical. Removing the `IN` operator entirely can
be considered separately.

## How was this change tested?

Added unit coverage for literal-array and list-column membership, including present and absent
values, NULL needles and elements, `NOT IN`, unsupported operand shapes, and nested scalar values.
