### PR TITLE
feat!: preserve typed schema-field metadata across FFI

### DIFF
--- a/ffi/examples/read-table/CMakeLists.txt
+++ b/ffi/examples/read-table/CMakeLists.txt
@@ -28,6 +28,10 @@ add_test(NAME read_and_print_with_short_dv COMMAND ${TestRunner} ${KernelTestPat
 # does not call read_parquet_file, so the data section is "[No data]"; this test still
 # requires PRINT_DATA=ON because iterate_scan_metadata_arrow is gated behind it.
 add_test(NAME read_arrow_metadata_basic COMMAND ${TestRunner} ${DatPath}/basic_partitioned/delta/ ${ExpectedPath}/basic-partitioned-arrow-metadata.expected -a)
+# Exercises typed field metadata across the FFI: the column_mapping table's fields carry
+# `delta.columnMapping.id`, which the schema visitor reads back via get_from_metadata_map and
+# prints per field.
+add_test(NAME read_column_mapping_metadata COMMAND ${TestRunner} ${DatPath}/column_mapping/delta/ ${ExpectedPath}/column-mapping-arrow-metadata.expected -a)
 
 if(WIN32)
   set(CMAKE_C_FLAGS_DEBUG "/MT")

--- a/ffi/examples/read-table/schema.h
+++ b/ffi/examples/read-table/schema.h
@@ -37,6 +37,7 @@ typedef struct
   char* type;
   bool is_nullable;
   uintptr_t children;
+  char* column_mapping_id;
 } SchemaItem;
 
 typedef struct SchemaItemList
@@ -66,6 +67,7 @@ SchemaItem* add_to_list(SchemaItemList* list, char* name, char* type, bool is_nu
   list->list[idx].name = name;
   list->list[idx].type = type;
   list->list[idx].is_nullable = is_nullable;
+  list->list[idx].column_mapping_id = NULL;
   list->len++;
   return &list->list[idx];
 }
@@ -87,6 +89,9 @@ void print_list(SchemaBuilder* builder, uintptr_t list_id, int indent, int paren
     SchemaItem* item = &list->list[i];
     char* prefix = is_last ? "└" : "├";
     printf("%s─ %s: %s", prefix, item->name, item->type);
+    if (item->column_mapping_id) {
+      printf(" (column mapping id: %s)", item->column_mapping_id);
+    }
     if (strcmp(item->type, "array") == 0) {
       SchemaItemList child_list = builder->lists[item->children];
       if (child_list.len != 1) {
@@ -110,29 +115,28 @@ void print_list(SchemaBuilder* builder, uintptr_t list_id, int indent, int paren
   }
 }
 
-void print_physical_name(const char *name, const CStringMap* metadata, SharedExternEngine* engine)
+// Read the column-mapping id back out of a field's typed metadata, across the FFI. Returns a
+// freshly-allocated string (owned by the caller) when the field carries `delta.columnMapping.id`,
+// or NULL when it does not. This exercises the typed metadata path end-to-end: the value crosses
+// as a `MetadataNumber`, and we assert that kind before rendering it.
+char* read_column_mapping_id(const CMetadataMap* metadata, SharedExternEngine* engine)
 {
-#ifdef VERBOSE
-  char* key_str = "delta.columnMapping.physicalName";
+  char* key_str = "delta.columnMapping.id";
   KernelStringSlice key = { key_str, strlen(key_str) };
-  ExternResultNullableCvoid res = get_from_string_map(metadata, key, allocate_string, engine);
+  CMetadataValueKind kind;
+  ExternResultNullableCvoid res = get_from_metadata_map(metadata, key, &kind, allocate_string, engine);
   if (res.tag != OkNullableCvoid) {
-    printf("Failed to get physical name\n");
     free_error((Error*)res.err);
-    return;
+    return NULL;
   }
   char* value = res.ok;
-  if (value) {
-    printf("Physical name of %s is %s\n", name, value);
+  if (value && kind != MetadataNumber) {
+    // The kernel types column-mapping ids as numbers; a different kind means the FFI lost the type.
+    printf("Unexpected kind %d for delta.columnMapping.id\n", (int)kind);
     free(value);
-  } else {
-    printf("No physical name\n");
+    return NULL;
   }
-#else
-  (void)name;
-  (void)metadata;
-  (void)engine;
-#endif
+  return value;
 }
 
 // declare all our visitor methods
@@ -159,15 +163,15 @@ void visit_struct(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
   char* name_ptr = allocate_string(name);
   PRINT_CHILD_VISIT("struct", name_ptr, sibling_list_id, "Children", child_list_id);
-  print_physical_name(name_ptr, metadata, builder->engine);
   SchemaItem* struct_item = add_to_list(&builder->lists[sibling_list_id], name_ptr, "struct", is_nullable);
   struct_item->children = child_list_id;
+  struct_item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
 }
 
 void visit_array(
@@ -175,15 +179,15 @@ void visit_array(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
   char* name_ptr = allocate_string(name);
-  print_physical_name(name_ptr, metadata, builder->engine);
   PRINT_CHILD_VISIT("array", name_ptr, sibling_list_id, "Types", child_list_id);
   SchemaItem* array_item = add_to_list(&builder->lists[sibling_list_id], name_ptr, "array", is_nullable);
   array_item->children = child_list_id;
+  array_item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
 }
 
 void visit_map(
@@ -191,15 +195,15 @@ void visit_map(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
   char* name_ptr = allocate_string(name);
-  print_physical_name(name_ptr, metadata, builder->engine);
   PRINT_CHILD_VISIT("map", name_ptr, sibling_list_id, "Types", child_list_id);
   SchemaItem* map_item = add_to_list(&builder->lists[sibling_list_id], name_ptr, "map", is_nullable);
   map_item->children = child_list_id;
+  map_item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
 }
 
 void visit_decimal(
@@ -207,7 +211,7 @@ void visit_decimal(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uint8_t precision,
   uint8_t scale)
 {
@@ -215,9 +219,9 @@ void visit_decimal(
   char* name_ptr = allocate_string(name);
   char* type = malloc(19 * sizeof(char));
   snprintf(type, 19, "decimal(%u)(%d)", precision, scale);
-  print_physical_name(name_ptr, metadata, builder->engine);
   PRINT_NO_CHILD_VISIT(type, name_ptr, sibling_list_id);
-  add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  SchemaItem* item = add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
 }
 
 void visit_simple_type(
@@ -225,18 +229,18 @@ void visit_simple_type(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   char* type)
 {
   SchemaBuilder* builder = data;
   char* name_ptr = allocate_string(name);
-  print_physical_name(name_ptr, metadata, builder->engine);
   PRINT_NO_CHILD_VISIT(type, name_ptr, sibling_list_id);
-  add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  SchemaItem* item = add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
 }
 
 #define DEFINE_VISIT_SIMPLE_TYPE(typename)                                                                                                  \
-  void visit_##typename(void* data, uintptr_t sibling_list_id, struct KernelStringSlice name, bool is_nullable, const CStringMap * metadata)\
+  void visit_##typename(void* data, uintptr_t sibling_list_id, struct KernelStringSlice name, bool is_nullable, const CMetadataMap * metadata)\
   {                                                                                                                                         \
     visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, #typename);                                                       \
   }
@@ -260,7 +264,7 @@ void visit_interval_year_month(void* data,
                                uintptr_t sibling_list_id,
                                struct KernelStringSlice name,
                                bool is_nullable,
-                               const CStringMap * metadata)
+                               const CMetadataMap * metadata)
 {
   visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, "interval year to month");
 }
@@ -269,7 +273,7 @@ void visit_interval_day_time(void* data,
                              uintptr_t sibling_list_id,
                              struct KernelStringSlice name,
                              bool is_nullable,
-                             const CStringMap * metadata)
+                             const CMetadataMap * metadata)
 {
   visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, "interval day to second");
 }
@@ -282,6 +286,7 @@ void free_builder(SchemaBuilder* builder)
     for (uint32_t j = 0; j < list->len; j++) {
       SchemaItem* item = list->list + j;
       free(item->name);
+      free(item->column_mapping_id); // NULL when the field carried no column-mapping id; free(NULL) is a no-op
       // don't free item->type, those are static strings
       if (!strncmp(item->type, "decimal", 7)) {
         // except decimal types, we malloc'd those :)

--- a/ffi/examples/read-table/schema.h
+++ b/ffi/examples/read-table/schema.h
@@ -110,12 +110,13 @@ void print_list(SchemaBuilder* builder, uintptr_t list_id, int indent, int paren
   }
 }
 
-void print_physical_name(const char *name, const CStringMap* metadata, SharedExternEngine* engine)
+void print_physical_name(const char *name, const CMetadataMap* metadata, SharedExternEngine* engine)
 {
 #ifdef VERBOSE
   char* key_str = "delta.columnMapping.physicalName";
   KernelStringSlice key = { key_str, strlen(key_str) };
-  ExternResultNullableCvoid res = get_from_string_map(metadata, key, allocate_string, engine);
+  CMetadataValueKind kind;
+  ExternResultNullableCvoid res = get_from_metadata_map(metadata, key, &kind, allocate_string, engine);
   if (res.tag != OkNullableCvoid) {
     printf("Failed to get physical name\n");
     free_error((Error*)res.err);
@@ -159,7 +160,7 @@ void visit_struct(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
@@ -175,7 +176,7 @@ void visit_array(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
@@ -191,7 +192,7 @@ void visit_map(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uintptr_t child_list_id)
 {
   SchemaBuilder* builder = data;
@@ -207,7 +208,7 @@ void visit_decimal(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   uint8_t precision,
   uint8_t scale)
 {
@@ -225,7 +226,7 @@ void visit_simple_type(
   uintptr_t sibling_list_id,
   struct KernelStringSlice name,
   bool is_nullable,
-  const CStringMap * metadata,
+  const CMetadataMap * metadata,
   char* type)
 {
   SchemaBuilder* builder = data;
@@ -236,7 +237,7 @@ void visit_simple_type(
 }
 
 #define DEFINE_VISIT_SIMPLE_TYPE(typename)                                                                                                  \
-  void visit_##typename(void* data, uintptr_t sibling_list_id, struct KernelStringSlice name, bool is_nullable, const CStringMap * metadata)\
+  void visit_##typename(void* data, uintptr_t sibling_list_id, struct KernelStringSlice name, bool is_nullable, const CMetadataMap * metadata)\
   {                                                                                                                                         \
     visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, #typename);                                                       \
   }

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use delta_kernel::scan::state::{DvInfo, ScanFile};
 use delta_kernel::scan::{PartitionValuesOptions, Scan, ScanBuilder, ScanMetadata, StatsOptions};
+use delta_kernel::schema::MetadataValue;
 use delta_kernel::snapshot::SnapshotRef;
 use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Expression, ExpressionRef};
 use delta_kernel_ffi_macros::handle_descriptor;
@@ -656,6 +657,115 @@ pub unsafe extern "C" fn visit_string_map(
             engine_context,
             kernel_string_slice!(key),
             kernel_string_slice!(val),
+        );
+    }
+}
+
+// === Typed field metadata ===
+
+/// The type of a [`MetadataValue`] carried across the FFI boundary. Each value is delivered as a
+/// string (via `Display`); this tag tells the engine how to interpret it: a signed 64-bit integer,
+/// `true`/`false`, a plain string, or arbitrary JSON text. String-plus-tag is the deliberate wire
+/// form -- `Other` is arbitrary JSON with no fixed C representation, so a tagged union would still
+/// need a string arm.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CMetadataValueKind {
+    MetadataNumber = 0,
+    MetadataString = 1,
+    MetadataBoolean = 2,
+    MetadataOther = 3,
+}
+
+impl From<&MetadataValue> for CMetadataValueKind {
+    fn from(val: &MetadataValue) -> Self {
+        match val {
+            MetadataValue::Number(_) => CMetadataValueKind::MetadataNumber,
+            MetadataValue::String(_) => CMetadataValueKind::MetadataString,
+            MetadataValue::Boolean(_) => CMetadataValueKind::MetadataBoolean,
+            MetadataValue::Other(_) => CMetadataValueKind::MetadataOther,
+        }
+    }
+}
+
+/// A field-metadata map that preserves each value's [`MetadataValue`] type. Used for schema field
+/// metadata, where the kernel knows each value's type; the engine recovers that type via
+/// [`CMetadataValueKind`] rather than inferring it from the key name. (Contrast [`CStringMap`],
+/// whose partition values are strings by definition.)
+#[derive(Default)]
+pub struct CMetadataMap {
+    values: HashMap<String, MetadataValue>,
+}
+
+impl From<HashMap<String, MetadataValue>> for CMetadataMap {
+    fn from(values: HashMap<String, MetadataValue>) -> Self {
+        Self { values }
+    }
+}
+
+/// Probe a [`CMetadataMap`] for a single key. If the key is present, kernel calls `allocate_fn`
+/// with its value rendered to a string, writes the value's [`CMetadataValueKind`] to `kind_out`
+/// (unless `kind_out` is null), and returns the pointer `allocate_fn` produced. If the key is
+/// absent, returns NULL and leaves `kind_out` untouched.
+///
+/// # Safety
+///
+/// The engine is responsible for providing a valid [`CMetadataMap`] pointer, [`KernelStringSlice`],
+/// and (when non-null) a valid `kind_out` pointer.
+#[no_mangle]
+pub unsafe extern "C" fn get_from_metadata_map(
+    map: &CMetadataMap,
+    key: KernelStringSlice,
+    kind_out: *mut CMetadataValueKind,
+    allocate_fn: AllocateStringFn,
+    engine: Handle<SharedExternEngine>,
+) -> ExternResult<NullableCvoid> {
+    let engine = unsafe { engine.as_ref() };
+    get_from_metadata_map_impl(map, key, kind_out, allocate_fn).into_extern_result(&engine)
+}
+fn get_from_metadata_map_impl(
+    map: &CMetadataMap,
+    key: KernelStringSlice,
+    kind_out: *mut CMetadataValueKind,
+    allocate_fn: AllocateStringFn,
+) -> DeltaResult<NullableCvoid> {
+    let string_key = unsafe { TryFromStringSlice::try_from_slice(&key) }?;
+    let Some(val) = map.values.get(string_key) else {
+        return Ok(None);
+    };
+    if !kind_out.is_null() {
+        unsafe { *kind_out = CMetadataValueKind::from(val) };
+    }
+    let value = val.to_string();
+    Ok(allocate_fn(kernel_string_slice!(value)))
+}
+
+/// Visit all entries in a [`CMetadataMap`]. The callback is invoked once per entry with the key,
+/// the value's [`CMetadataValueKind`], and the value rendered to a string. The engine uses the
+/// kind to parse the string back into a typed value.
+///
+/// # Safety
+///
+/// The engine is responsible for providing a valid [`CMetadataMap`] pointer and callback.
+#[no_mangle]
+pub unsafe extern "C" fn visit_metadata_map(
+    map: &CMetadataMap,
+    engine_context: NullableCvoid,
+    visitor: extern "C" fn(
+        engine_context: NullableCvoid,
+        key: KernelStringSlice,
+        kind: CMetadataValueKind,
+        value: KernelStringSlice,
+    ),
+) {
+    for (key, val) in &map.values {
+        let kind = CMetadataValueKind::from(val);
+        let value = val.to_string();
+        visitor(
+            engine_context,
+            kernel_string_slice!(key),
+            kind,
+            kernel_string_slice!(value),
         );
     }
 }
@@ -1673,5 +1783,82 @@ mod tests {
         }
         let final_map: HashMap<String, String> = *unsafe { Box::from_raw(map_ptr) };
         assert_eq!(test_map, final_map);
+    }
+
+    extern "C" fn visit_metadata_entry(
+        engine_context: NullableCvoid,
+        key: KernelStringSlice,
+        kind: super::CMetadataValueKind,
+        value: KernelStringSlice,
+    ) {
+        let map_ptr: *mut HashMap<String, (super::CMetadataValueKind, String)> =
+            engine_context.unwrap().as_ptr().cast();
+        let key = unsafe { String::try_from_slice(&key).unwrap() };
+        let value = unsafe { String::try_from_slice(&value).unwrap() };
+        unsafe {
+            (*map_ptr).insert(key, (kind, value));
+        }
+    }
+
+    #[test]
+    fn visit_metadata_map_maps_kind_and_renders_each_variant() {
+        use delta_kernel::schema::MetadataValue;
+
+        use super::CMetadataValueKind::*;
+
+        // `Number` is i64-only, so a JSON number with a fractional part lands in `Other` -- cover
+        // both so the "parse as i64" contract for `MetadataNumber` stays honest.
+        let test_map = HashMap::from([
+            ("num".to_string(), MetadataValue::Number(-7)),
+            ("str".to_string(), MetadataValue::String("hi".into())),
+            ("bool".to_string(), MetadataValue::Boolean(true)),
+            (
+                "obj".to_string(),
+                MetadataValue::Other(serde_json::json!({"a": 1})),
+            ),
+            (
+                "float".to_string(),
+                MetadataValue::Other(serde_json::json!(1.5)),
+            ),
+        ]);
+        let cmap: super::CMetadataMap = test_map.into();
+
+        let ctx: Box<HashMap<String, (super::CMetadataValueKind, String)>> = Box::default();
+        let ctx_ptr = Box::into_raw(ctx);
+        unsafe {
+            let ptr = NonNull::new_unchecked(ctx_ptr.cast());
+            super::visit_metadata_map(&cmap, Some(ptr), visit_metadata_entry);
+        }
+        let out = *unsafe { Box::from_raw(ctx_ptr) };
+
+        assert_eq!(out["num"], (MetadataNumber, "-7".to_string()));
+        assert_eq!(out["str"], (MetadataString, "hi".to_string()));
+        assert_eq!(out["bool"], (MetadataBoolean, "true".to_string()));
+        assert_eq!(out["obj"], (MetadataOther, "{\"a\":1}".to_string()));
+        assert_eq!(out["float"], (MetadataOther, "1.5".to_string()));
+    }
+
+    #[test]
+    fn visit_metadata_map_empty_never_invokes_callback() {
+        let cmap = super::CMetadataMap::default();
+        let ctx: Box<HashMap<String, (super::CMetadataValueKind, String)>> = Box::default();
+        let ctx_ptr = Box::into_raw(ctx);
+        unsafe {
+            let ptr = NonNull::new_unchecked(ctx_ptr.cast());
+            super::visit_metadata_map(&cmap, Some(ptr), visit_metadata_entry);
+        }
+        let out = *unsafe { Box::from_raw(ctx_ptr) };
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn metadata_value_kind_discriminants_are_stable() {
+        // These integers are the FFI ABI contract -- C consumers switch on them. Reordering the
+        // enum silently renumbers, so pin them here.
+        use super::CMetadataValueKind::*;
+        assert_eq!(MetadataNumber as i32, 0);
+        assert_eq!(MetadataString as i32, 1);
+        assert_eq!(MetadataBoolean as i32, 2);
+        assert_eq!(MetadataOther as i32, 3);
     }
 }

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 
 use delta_kernel::scan::state::{DvInfo, ScanFile};
 use delta_kernel::scan::{PartitionValuesOptions, Scan, ScanBuilder, ScanMetadata, StatsOptions};
+use delta_kernel::schema::MetadataValue;
 use delta_kernel::snapshot::SnapshotRef;
 use delta_kernel::{DeltaResult, DeltaResultIteratorStatic, Error, Expression, ExpressionRef};
 use delta_kernel_ffi_macros::handle_descriptor;
@@ -698,6 +699,112 @@ pub unsafe extern "C" fn visit_string_map(
             engine_context,
             kernel_string_slice!(key),
             kernel_string_slice!(val),
+        );
+    }
+}
+
+// === Typed field metadata ===
+
+/// The type of a [`MetadataValue`] carried across the FFI boundary. Each value is delivered as a
+/// string (via `Display`); this tag tells the engine how to interpret it: a signed 64-bit integer,
+/// a plain string, a boolean value, or arbitrary JSON text.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CMetadataValueKind {
+    MetadataNumber = 0,
+    MetadataString = 1,
+    MetadataBoolean = 2,
+    MetadataJson = 3,
+}
+
+impl From<&MetadataValue> for CMetadataValueKind {
+    fn from(val: &MetadataValue) -> Self {
+        match val {
+            MetadataValue::Number(_) => CMetadataValueKind::MetadataNumber,
+            MetadataValue::String(_) => CMetadataValueKind::MetadataString,
+            MetadataValue::Boolean(_) => CMetadataValueKind::MetadataBoolean,
+            MetadataValue::Other(_) => CMetadataValueKind::MetadataJson,
+        }
+    }
+}
+
+/// A field-metadata map that preserves each value's [`MetadataValue`] type. Used for schema field
+/// metadata, where the kernel knows each value's type; the engine recovers that type via
+/// [`CMetadataValueKind`] rather than inferring it from the key name.
+#[derive(Default)]
+pub struct CMetadataMap {
+    values: HashMap<String, MetadataValue>,
+}
+
+impl From<HashMap<String, MetadataValue>> for CMetadataMap {
+    fn from(values: HashMap<String, MetadataValue>) -> Self {
+        Self { values }
+    }
+}
+
+/// Probe a [`CMetadataMap`] for a single key. If the key is present, kernel calls `allocate_fn`
+/// with its value rendered to a string, writes the value's [`CMetadataValueKind`] to `kind_out`
+/// (unless `kind_out` is null), and returns the pointer `allocate_fn` produced. If the key is
+/// absent, returns NULL and leaves `kind_out` untouched.
+///
+/// # Safety
+///
+/// The engine is responsible for providing a valid [`CMetadataMap`] pointer, [`KernelStringSlice`],
+/// and (when non-null) a valid `kind_out` pointer.
+#[no_mangle]
+pub unsafe extern "C" fn get_from_metadata_map(
+    map: &CMetadataMap,
+    key: KernelStringSlice,
+    kind_out: *mut CMetadataValueKind,
+    allocate_fn: AllocateStringFn,
+    engine: Handle<SharedExternEngine>,
+) -> ExternResult<NullableCvoid> {
+    let engine = unsafe { engine.as_ref() };
+    get_from_metadata_map_impl(map, key, kind_out, allocate_fn).into_extern_result(&engine)
+}
+fn get_from_metadata_map_impl(
+    map: &CMetadataMap,
+    key: KernelStringSlice,
+    kind_out: *mut CMetadataValueKind,
+    allocate_fn: AllocateStringFn,
+) -> DeltaResult<NullableCvoid> {
+    let string_key = unsafe { TryFromStringSlice::try_from_slice(&key) }?;
+    let Some(val) = map.values.get(string_key) else {
+        return Ok(None);
+    };
+    if !kind_out.is_null() {
+        unsafe { *kind_out = CMetadataValueKind::from(val) };
+    }
+    let value = val.to_string();
+    Ok(allocate_fn(kernel_string_slice!(value)))
+}
+
+/// Visit all entries in a [`CMetadataMap`]. The callback is invoked once per entry with the key,
+/// the value's [`CMetadataValueKind`], and the value rendered to a string. The engine uses the
+/// kind to parse the string back into a typed value.
+///
+/// # Safety
+///
+/// The engine is responsible for providing a valid [`CMetadataMap`] pointer and callback.
+#[no_mangle]
+pub unsafe extern "C" fn visit_metadata_map(
+    map: &CMetadataMap,
+    engine_context: NullableCvoid,
+    visitor: extern "C" fn(
+        engine_context: NullableCvoid,
+        key: KernelStringSlice,
+        kind: CMetadataValueKind,
+        value: KernelStringSlice,
+    ),
+) {
+    for (key, val) in &map.values {
+        let kind = CMetadataValueKind::from(val);
+        let value = val.to_string();
+        visitor(
+            engine_context,
+            kernel_string_slice!(key),
+            kind,
+            kernel_string_slice!(value),
         );
     }
 }
@@ -1841,5 +1948,82 @@ mod tests {
             unsafe { free_engine(plan_engine) };
             unsafe { free_engine(engine) };
         }
+    }
+
+    extern "C" fn visit_metadata_entry(
+        engine_context: NullableCvoid,
+        key: KernelStringSlice,
+        kind: super::CMetadataValueKind,
+        value: KernelStringSlice,
+    ) {
+        let map_ptr: *mut HashMap<String, (super::CMetadataValueKind, String)> =
+            engine_context.unwrap().as_ptr().cast();
+        let key = unsafe { String::try_from_slice(&key).unwrap() };
+        let value = unsafe { String::try_from_slice(&value).unwrap() };
+        unsafe {
+            (*map_ptr).insert(key, (kind, value));
+        }
+    }
+
+    #[test]
+    fn visit_metadata_map_maps_kind_and_renders_each_variant() {
+        use delta_kernel::schema::MetadataValue;
+
+        use super::CMetadataValueKind::*;
+
+        // `Number` is i64-only, so a JSON number with a fractional part lands in `Other` -- cover
+        // both so the "parse as i64" contract for `MetadataNumber` stays honest.
+        let test_map = HashMap::from([
+            ("num".to_string(), MetadataValue::Number(-7)),
+            ("str".to_string(), MetadataValue::String("hi".into())),
+            ("bool".to_string(), MetadataValue::Boolean(true)),
+            (
+                "obj".to_string(),
+                MetadataValue::Other(serde_json::json!({"a": 1})),
+            ),
+            (
+                "float".to_string(),
+                MetadataValue::Other(serde_json::json!(1.5)),
+            ),
+        ]);
+        let cmap: super::CMetadataMap = test_map.into();
+
+        let ctx: Box<HashMap<String, (super::CMetadataValueKind, String)>> = Box::default();
+        let ctx_ptr = Box::into_raw(ctx);
+        unsafe {
+            let ptr = NonNull::new_unchecked(ctx_ptr.cast());
+            super::visit_metadata_map(&cmap, Some(ptr), visit_metadata_entry);
+        }
+        let out = *unsafe { Box::from_raw(ctx_ptr) };
+
+        assert_eq!(out["num"], (MetadataNumber, "-7".to_string()));
+        assert_eq!(out["str"], (MetadataString, "hi".to_string()));
+        assert_eq!(out["bool"], (MetadataBoolean, "true".to_string()));
+        assert_eq!(out["obj"], (MetadataJson, "{\"a\":1}".to_string()));
+        assert_eq!(out["float"], (MetadataJson, "1.5".to_string()));
+    }
+
+    #[test]
+    fn visit_metadata_map_empty_never_invokes_callback() {
+        let cmap = super::CMetadataMap::default();
+        let ctx: Box<HashMap<String, (super::CMetadataValueKind, String)>> = Box::default();
+        let ctx_ptr = Box::into_raw(ctx);
+        unsafe {
+            let ptr = NonNull::new_unchecked(ctx_ptr.cast());
+            super::visit_metadata_map(&cmap, Some(ptr), visit_metadata_entry);
+        }
+        let out = *unsafe { Box::from_raw(ctx_ptr) };
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn metadata_value_kind_discriminants_are_stable() {
+        // These integers are the FFI ABI contract -- C consumers switch on them. Reordering the
+        // enum silently renumbers, so pin them here.
+        use super::CMetadataValueKind::*;
+        assert_eq!(MetadataNumber as i32, 0);
+        assert_eq!(MetadataString as i32, 1);
+        assert_eq!(MetadataBoolean as i32, 2);
+        assert_eq!(MetadataJson as i32, 3);
     }
 }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_void;
 use delta_kernel::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 
 use crate::handle::Handle;
-use crate::scan::CStringMap;
+use crate::scan::CMetadataMap;
 use crate::{kernel_string_slice, KernelStringSlice, SharedSchema};
 
 /// The `EngineSchemaVisitor` defines a visitor system to allow engines to build their own
@@ -48,7 +48,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -59,7 +59,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -71,7 +71,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -81,7 +81,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         precision: u8,
         scale: u8,
     ),
@@ -92,7 +92,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `long` belonging to the list identified by `sibling_list_id`.
@@ -101,7 +101,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit an `integer` belonging to the list identified by `sibling_list_id`.
@@ -110,7 +110,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `short` belonging to the list identified by `sibling_list_id`.
@@ -119,7 +119,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `byte` belonging to the list identified by `sibling_list_id`.
@@ -128,7 +128,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `float` belonging to the list identified by `sibling_list_id`.
@@ -137,7 +137,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `double` belonging to the list identified by `sibling_list_id`.
@@ -146,7 +146,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `boolean` belonging to the list identified by `sibling_list_id`.
@@ -155,7 +155,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit `binary` belonging to the list identified by `sibling_list_id`.
@@ -164,7 +164,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `date` belonging to the list identified by `sibling_list_id`.
@@ -173,7 +173,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `timestamp` belonging to the list identified by `sibling_list_id`.
@@ -182,7 +182,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `timestamp` with no timezone belonging to the list identified by `sibling_list_id`.
@@ -191,7 +191,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit an `interval year to month` belonging to the list identified by `sibling_list_id`.
@@ -200,7 +200,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit an `interval day to second` belonging to the list identified by `sibling_list_id`.
@@ -209,7 +209,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `void` belonging to the list identified by `sibling_list_id`.
@@ -218,7 +218,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `variant` belonging to the list identified by `sibling_list_id`.
@@ -227,7 +227,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 }
 
@@ -257,7 +257,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
                 field.name(),
                 field.data_type(),
                 field.is_nullable(),
-                &field.metadata_with_string_values().into(),
+                &field.metadata().clone().into(),
                 visitor,
                 child_list_id,
             );
@@ -271,7 +271,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         contains_null: bool,
     ) -> usize {
         let child_list_id = (visitor.make_field_list)(visitor.data, 1);
-        let metadata = CStringMap::default();
+        let metadata = CMetadataMap::default();
         visit_schema_item(
             "array_element",
             &at.element_type,
@@ -289,7 +289,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         value_contains_null: bool,
     ) -> usize {
         let child_list_id = (visitor.make_field_list)(visitor.data, 2);
-        let metadata = CStringMap::default();
+        let metadata = CMetadataMap::default();
         visit_schema_item(
             "map_key",
             &mt.key_type,
@@ -314,7 +314,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         name: &str,
         data_type: &DataType,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         visitor: &EngineSchemaVisitor,
         sibling_list_id: usize,
     ) {
@@ -426,7 +426,7 @@ mod tests {
                 sibling_list_id: usize,
                 name: KernelStringSlice,
                 is_nullable: bool,
-                _metadata: &CStringMap,
+                _metadata: &CMetadataMap,
                 child_list_id: usize,
             ) {
                 add_field(
@@ -450,7 +450,7 @@ mod tests {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        _metadata: &CStringMap,
+        _metadata: &CMetadataMap,
         _precision: u8,
         _scale: u8,
     ) {
@@ -464,7 +464,7 @@ mod tests {
                 sibling_list_id: usize,
                 name: KernelStringSlice,
                 is_nullable: bool,
-                _metadata: &CStringMap,
+                _metadata: &CMetadataMap,
             ) {
                 add_field(data, sibling_list_id, name, is_nullable, $type_name, None);
             }

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_void;
 use delta_kernel::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 
 use crate::handle::Handle;
-use crate::scan::CStringMap;
+use crate::scan::CMetadataMap;
 use crate::{kernel_string_slice, KernelStringSlice, SharedSchema};
 
 /// The `EngineSchemaVisitor` defines a visitor system to allow engines to build their own
@@ -48,7 +48,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -59,7 +59,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -71,7 +71,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         child_list_id: usize,
     ),
 
@@ -81,7 +81,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         precision: u8,
         scale: u8,
     ),
@@ -92,7 +92,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `long` belonging to the list identified by `sibling_list_id`.
@@ -101,7 +101,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit an `integer` belonging to the list identified by `sibling_list_id`.
@@ -110,7 +110,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `short` belonging to the list identified by `sibling_list_id`.
@@ -119,7 +119,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `byte` belonging to the list identified by `sibling_list_id`.
@@ -128,7 +128,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `float` belonging to the list identified by `sibling_list_id`.
@@ -137,7 +137,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `double` belonging to the list identified by `sibling_list_id`.
@@ -146,7 +146,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `boolean` belonging to the list identified by `sibling_list_id`.
@@ -155,7 +155,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit `binary` belonging to the list identified by `sibling_list_id`.
@@ -164,7 +164,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `date` belonging to the list identified by `sibling_list_id`.
@@ -173,7 +173,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `timestamp` belonging to the list identified by `sibling_list_id`.
@@ -182,7 +182,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `timestamp` with no timezone belonging to the list identified by `sibling_list_id`.
@@ -191,7 +191,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `void` belonging to the list identified by `sibling_list_id`.
@@ -200,7 +200,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 
     /// Visit a `variant` belonging to the list identified by `sibling_list_id`.
@@ -209,7 +209,7 @@ pub struct EngineSchemaVisitor {
         sibling_list_id: usize,
         name: KernelStringSlice,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
     ),
 }
 
@@ -239,7 +239,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
                 field.name(),
                 field.data_type(),
                 field.is_nullable(),
-                &field.metadata_with_string_values().into(),
+                &field.metadata().clone().into(),
                 visitor,
                 child_list_id,
             );
@@ -253,7 +253,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         contains_null: bool,
     ) -> usize {
         let child_list_id = (visitor.make_field_list)(visitor.data, 1);
-        let metadata = CStringMap::default();
+        let metadata = CMetadataMap::default();
         visit_schema_item(
             "array_element",
             &at.element_type,
@@ -271,7 +271,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         value_contains_null: bool,
     ) -> usize {
         let child_list_id = (visitor.make_field_list)(visitor.data, 2);
-        let metadata = CStringMap::default();
+        let metadata = CMetadataMap::default();
         visit_schema_item(
             "map_key",
             &mt.key_type,
@@ -296,7 +296,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
         name: &str,
         data_type: &DataType,
         is_nullable: bool,
-        metadata: &CStringMap,
+        metadata: &CMetadataMap,
         visitor: &EngineSchemaVisitor,
         sibling_list_id: usize,
     ) {

--- a/ffi/tests/read-table-testing/expected-data/column-mapping-arrow-metadata.expected
+++ b/ffi/tests/read-table-testing/expected-data/column-mapping-arrow-metadata.expected
@@ -1,0 +1,9 @@
+Reading table at ../../../../acceptance/tests/dat/out/reader_tests/generated/column_mapping/delta/
+version: 3
+
+Schema:
+├─ letter: string (column mapping id: 1)
+├─ new_int: long (column mapping id: 2)
+└─ date: date (column mapping id: 3)
+
+[No data]

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -716,15 +716,6 @@ impl StructField {
         &self.metadata
     }
 
-    /// Convert our metadata into a HashMap<String, String>. Note this copies all the data so can be
-    /// expensive for large metadata
-    pub fn metadata_with_string_values(&self) -> HashMap<String, String> {
-        self.metadata
-            .iter()
-            .map(|(key, val)| (key.clone(), val.to_string()))
-            .collect()
-    }
-
     /// Applies physical name and field ID mappings to this field.
     ///
     /// This function sets the field ID for the physical [`StructField`] only if the


### PR DESCRIPTION
## What changes are proposed in this pull request?

The FFI schema visitor flattened all field metadata to strings via `StructField::metadata_with_string_values()`, so engines had to recover each value's real type from a hand-maintained allow-list of key names. Any metadata key whose value should be typed (e.g. a `Long`) silently came back as a string unless it was added to that allow-list.

This threads the kernel's own type information across the boundary instead. A new `CMetadataMap` carries `MetadataValue`s (not strings), and the schema visitor callbacks receive `&CMetadataMap` in place of `&CStringMap`. Consumers read each value's type from a `CMetadataValueKind` tag rather than inferring it from the key. The value itself still crosses as a string (via `Display`) -- `MetadataValue::Other` is arbitrary JSON with no fixed C representation, so the string is the only universal form -- and the tag says how to interpret it.

Two access patterns mirror `CStringMap`: `visit_metadata_map` (iterate all entries) and `get_from_metadata_map` (probe one key, with the kind returned via an out-parameter). Partition values keep `CStringMap`, since those are protocol-serialized strings by definition.

The now-unused `StructField::metadata_with_string_values()` is removed. The in-tree `read-table` C example is updated to the new types.

The C/JNR bridge and Java consumer that drop their `LONG_PROMOTED_KEYS` allow-list are a follow-up in the runtime repo.

### This PR affects the following public APIs

Breaking FFI change: `EngineSchemaVisitor`'s `visit_*` callbacks now take `&CMetadataMap` instead of `&CStringMap`. Adds `CMetadataMap`, `CMetadataValueKind`, `visit_metadata_map`, and `get_from_metadata_map`. Removes `StructField::metadata_with_string_values()`.

## How was this change tested?

Unit tests for `visit_metadata_map` (each `MetadataValue` variant round-trips to the expected kind tag and rendered string, including the empty-map case) and a discriminant-stability test pinning the `CMetadataValueKind` ABI values. The `read-table` C example compiles clean under the existing `-Werror` build against the regenerated header.

