### PR TITLE
feat: support nested column adds and transactional schema changes

### DIFF
--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -129,7 +129,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// The final path component must match `field.name()`. Traversal through arrays uses their
     /// element type, and traversal through maps uses their value type. Map keys cannot be evolved.
-    /// The field must be nullable and must not conflict with an existing sibling field.
+    /// The field must be nullable and must not have a name conflict with an existing sibling field.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column_at_path(
@@ -163,8 +163,7 @@ impl AlterTableTransactionBuilder<Modifying> {
     ///
     /// # Errors
     ///
-    /// - The table enables `icebergCompatV3` or `allowColumnDefaults`, which schema evolution does
-    ///   not yet support
+    /// - The table enables `icebergCompatV3` or `allowColumnDefaults`, which don't support schema changes
     /// - Any individual operation fails validation (see per-method errors above)
     /// - Table does not support writes (unsupported features)
     /// - The evolved schema requires protocol features not enabled on the table (e.g. adding a
@@ -189,18 +188,5 @@ impl AlterTableTransactionBuilder<Modifying> {
             committer,
             self.correlation_id,
         )
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn assert_send_sync<T: Send + Sync>() {}
-
-    #[test]
-    fn builder_states_are_send_and_sync() {
-        assert_send_sync::<AlterTableTransactionBuilder<Ready>>();
-        assert_send_sync::<AlterTableTransactionBuilder<Modifying>>();
     }
 }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -33,9 +33,7 @@ use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
 use crate::transaction::alter_table::AlterTableTransaction;
-use crate::transaction::schema_evolution::{
-    evolve_table_config, AddField, SchemaChange, SetNullable,
-};
+use crate::transaction::schema_evolution::{evolve_table_config, SchemaChange};
 use crate::{DeltaResult, Engine};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
@@ -123,7 +121,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
         let column = ColumnName::new([field.name().clone()]);
-        self.operations.push(AddField::new(column, field).into());
+        self.operations.push(SchemaChange::add_field(column, field));
         self.transition()
     }
 
@@ -139,7 +137,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         column: ColumnName,
         field: StructField,
     ) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations.push(AddField::new(column, field).into());
+        self.operations.push(SchemaChange::add_field(column, field));
         self.transition()
     }
 
@@ -148,7 +146,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// Note: this matches Spark's behavior.
     pub fn set_nullable(mut self, column: ColumnName) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations.push(SetNullable::new(column).into());
+        self.operations.push(SchemaChange::set_nullable(column));
         self.transition()
     }
 }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -31,18 +31,12 @@ use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
-use crate::table_configuration::TableConfiguration;
-use crate::table_features::{
-    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata, ColumnMappingMode,
-    Operation, TableFeature,
-};
-use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
+use crate::table_features::Operation;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
-    apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
+    evolve_table_config, AddField, SchemaChange, SetNullable,
 };
-use crate::utils::FoldWithOption as _;
-use crate::{DeltaResult, Engine, Error};
+use crate::{DeltaResult, Engine};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
 /// See [`Chainable`] for the operations available on this state.
@@ -75,7 +69,7 @@ mod sealed {
 ///   chaining.
 pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
-    operations: Vec<SchemaOperation>,
+    operations: Vec<SchemaChange>,
     correlation_id: Option<Arc<str>>,
     // PhantomData marker for builder state (Ready or Modifying).
     // Zero-sized; only affects which methods are available at compile time.
@@ -128,7 +122,24 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations.push(SchemaOperation::AddColumn { field });
+        let column = ColumnName::new([field.name().clone()]);
+        self.operations.push(AddField::new(column, field).into());
+        self.transition()
+    }
+
+    /// Add a new column at `column` in the table schema.
+    ///
+    /// The final path component must match `field.name()`. Traversal through arrays uses their
+    /// element type, and traversal through maps uses their value type. Map keys cannot be evolved.
+    /// The field must be nullable and must not conflict with an existing sibling field.
+    ///
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    pub fn add_column_at_path(
+        mut self,
+        column: ColumnName,
+        field: StructField,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations.push(AddField::new(column, field).into());
         self.transition()
     }
 
@@ -137,8 +148,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// Note: this matches Spark's behavior.
     pub fn set_nullable(mut self, column: ColumnName) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations
-            .push(SchemaOperation::SetNullable { column });
+        self.operations.push(SetNullable::new(column).into());
         self.transition()
     }
 }
@@ -155,8 +165,8 @@ impl AlterTableTransactionBuilder<Modifying> {
     ///
     /// # Errors
     ///
-    /// - The table enables `icebergCompatV3` or `allowColumnDefaults`, which ALTER TABLE does not
-    ///   yet support
+    /// - The table enables `icebergCompatV3` or `allowColumnDefaults`, which schema evolution does
+    ///   not yet support
     /// - Any individual operation fails validation (see per-method errors above)
     /// - Table does not support writes (unsupported features)
     /// - The evolved schema requires protocol features not enabled on the table (e.g. adding a
@@ -167,69 +177,13 @@ impl AlterTableTransactionBuilder<Modifying> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
-        // We don't support ALTER TABLE on tables with icebergCompatV3 enabled yet. See
-        // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
-        if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            return Err(Error::unsupported(
-                "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
-            ));
-        }
-        // TODO(#2630): Support ALTER TABLE on tables with column defaults.
-        if table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults) {
-            return Err(Error::unsupported(
-                "ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled",
-            ));
-        }
         // Rejects writes to tables kernel can't safely commit to: writer version out of
         // kernel's supported range, unsupported writer features, or schemas with SQL-expression
         // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the
         // protocol must also re-check this on the evolved `TableConfiguration`.
         table_config.ensure_operation_supported(Operation::Write)?;
 
-        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
-        let column_mapping_mode = table_config.column_mapping_mode();
-        let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
-        // Whether the pre-alter schema already carried column-mapping metadata -- the only fact the
-        // strip below needs from it. Captured as a bool (not a clone) before
-        // `apply_schema_operations` consumes `schema` by value. Short-circuits outside
-        // `None` mode, where no strip fires.
-        let current_has_cm = column_mapping_mode == ColumnMappingMode::None
-            && schema_has_column_mapping_metadata(&schema);
-        let SchemaEvolutionResult {
-            schema: evolved_schema,
-            new_max_column_id,
-        } = apply_schema_operations(
-            schema,
-            self.operations,
-            column_mapping_mode,
-            current_max_column_id,
-        )?;
-
-        // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
-        // that was clean before it, strip them; residual annotations already present on the
-        // table are left in place (see `strip_stray_column_mapping_metadata`).
-        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
-            strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
-                .map_or(evolved_schema, Arc::new)
-        } else {
-            evolved_schema
-        };
-
-        let evolved_metadata = table_config
-            .metadata()
-            .clone()
-            .with_schema(evolved_schema.clone())?
-            .fold_with(new_max_column_id, |evolved_metadata, id| {
-                evolved_metadata
-                    .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
-            });
-
-        // Validates the evolved metadata against the protocol.
-        let evolved_table_config = TableConfiguration::try_new_with_schema(
-            table_config,
-            evolved_metadata,
-            evolved_schema,
-        )?;
+        let evolved_table_config = evolve_table_config(table_config, self.operations)?;
 
         AlterTableTransaction::try_new_alter_table(
             self.snapshot,
@@ -237,5 +191,18 @@ impl AlterTableTransactionBuilder<Modifying> {
             committer,
             self.correlation_id,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn builder_states_are_send_and_sync() {
+        assert_send_sync::<AlterTableTransactionBuilder<Ready>>();
+        assert_send_sync::<AlterTableTransactionBuilder<Modifying>>();
     }
 }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -71,7 +71,7 @@ pub(crate) mod alter_table;
 pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
-pub(crate) mod schema_evolution;
+pub mod schema_evolution;
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -68,18 +68,25 @@ impl SchemaChange {
     ) -> DeltaResult<()> {
         match self {
             Self::AddField { column, field } => {
-                apply_traversal(fields, &AddFieldTraversal { column, field }, context)
+                let traversal = AddFieldTraversal { column, field };
+                modify_field_at_path(fields, traversal.path(), &traversal, context)
+                    .map_err(|error| traversal.wrap_error(error))
             }
             Self::SetNullable { column } => {
-                apply_traversal(fields, &SetNullableTraversal { column }, context)
+                let traversal = SetNullableTraversal { column };
+                modify_field_at_path(fields, traversal.path(), &traversal, context)
+                    .map_err(|error| traversal.wrap_error(error))
             }
         }
     }
 }
 
+/// Trait for traversal policies that can be used to apply schema changes to a schema.
 trait TraversalPolicy {
+    /// Returns the path to the field to be modified.
     fn path(&self) -> &[String];
 
+    /// Applies the schema change to the leaf field at the given index.
     fn apply_at_leaf(
         &self,
         fields: &mut IndexMap<String, StructField>,
@@ -103,15 +110,6 @@ struct AddFieldTraversal<'a> {
 
 struct SetNullableTraversal<'a> {
     column: &'a ColumnName,
-}
-
-fn apply_traversal(
-    fields: &mut IndexMap<String, StructField>,
-    traversal: &impl TraversalPolicy,
-    context: &mut SchemaEvolutionContext,
-) -> DeltaResult<()> {
-    modify_field_at_path(fields, traversal.path(), traversal, context)
-        .map_err(|error| traversal.wrap_error(error))
 }
 
 fn modify_field_at_path(
@@ -334,7 +332,7 @@ pub(crate) fn apply_schema_operations(
         Ordering::Equal => None,
         Ordering::Less => {
             return Err(Error::internal_error(
-                "max column ID went backwards during schema evolution",
+                "max column ID decreased during schema evolution",
             ))
         }
     };
@@ -386,9 +384,8 @@ pub(crate) fn evolve_table_config(
     TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)
 }
 
-// Rejects tables whose enabled features kernel cannot evolve the schema of yet. Lives on the one
-// path every caller funnels through so the ALTER TABLE builder and
-// `Transaction::with_schema_changes` cannot drift apart on which tables they accept.
+/// Rejects tables whose enabled features don't yet support schema evolution.
+/// Should be called before committing any schema changes (schema evolution, ALTER TABLE).
 fn ensure_schema_evolution_supported(table_config: &TableConfiguration) -> DeltaResult<()> {
     // Added columns would not receive the required column-mapping nested ids. See
     // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
@@ -398,7 +395,7 @@ fn ensure_schema_evolution_supported(table_config: &TableConfiguration) -> Delta
             "Schema changes are not yet supported on tables with icebergCompatV3 enabled"
         )
     );
-    // TODO(#2630): Support schema evolution on tables with column defaults.
+
     require!(
         !table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
         Error::unsupported(

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -86,7 +86,6 @@ trait TraversalPolicy {
     /// Returns the path to the field to be modified.
     fn path(&self) -> &[String];
 
-    /// Applies the schema change to the leaf field at the given index.
     fn apply_at_leaf(
         &self,
         fields: &mut IndexMap<String, StructField>,
@@ -395,7 +394,7 @@ fn ensure_schema_evolution_supported(table_config: &TableConfiguration) -> Delta
             "Schema changes are not yet supported on tables with icebergCompatV3 enabled"
         )
     );
-
+    // TODO(#2630): Support schema evolution on tables with column defaults.
     require!(
         !table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
         Error::unsupported(

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -1,9 +1,9 @@
 //! Schema evolution operations for ALTER TABLE.
 //!
-//! This module defines the [`SchemaOperation`] enum and the [`apply_schema_operations`] function
-//! that validates and applies schema changes to produce an evolved schema.
+//! This module defines operations for validating and applying schema changes.
 
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 
@@ -11,46 +11,107 @@ use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    find_max_column_id_in_schema, try_assign_flat_column_mapping_info, validate_column_mapping_id,
-    ColumnMappingMode,
+    find_max_column_id_in_schema, schema_has_column_mapping_metadata,
+    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
+    validate_column_mapping_id, ColumnMappingMode, TableFeature,
 };
+use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
+use crate::utils::{require, FoldWithOption as _};
 use crate::DeltaResult;
 
-/// A schema evolution operation to be applied during ALTER TABLE.
-///
-/// Operations are validated and applied in order during
-/// [`apply_schema_operations`]. Each operation sees the schema state after all prior operations
-/// have been applied.
-#[derive(Debug, Clone)]
-pub(crate) enum SchemaOperation {
-    /// Add a top-level column.
-    AddColumn { field: StructField },
-
-    /// Change a column's nullability from NOT NULL to nullable.
-    SetNullable { column: ColumnName },
+/// Context shared by schema operations while they are applied.
+pub(crate) struct SchemaOperationContext {
+    column_mapping_enabled: bool,
+    max_column_id: Option<i64>,
 }
 
-// Helper to modify a nested column. For each component in `path`, locates the matching field
-// (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
-// to mutate the field in place.
-//
-// `modifier` is expected to mutate the field's nullability, metadata, or `data_type` -- but
-// not its name. Renames need additional handling (IndexMap re-keying + sibling-conflict check)
-// that downstream PRs will introduce alongside the rename caller.
-//
-// Returns an error if a field in the path does not exist or an intermediate field is not a struct.
-//
-// Example:
-//   fields   = [ id: int not null, address: struct { city: string not null, zip: string } ]
-//   path     = ["address", "city"]
-//   modifier = |f| { f.nullable = true; Ok(()) }
-// yields:
-//   [ id: int not null, address: struct { city: string, zip: string } ]
+/// Internal behavior shared by schema evolution operations.
+pub(crate) trait SchemaOperation: Send + Sync + std::fmt::Debug {
+    /// Returns the path to the field affected by this operation.
+    fn path(&self) -> &[String];
+
+    /// Applies the operation at the final path component.
+    fn apply_at_leaf(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        field_index: Option<usize>,
+        context: &mut SchemaOperationContext,
+    ) -> DeltaResult<()>;
+
+    /// Descends through the data type according to this operation's recursion policy.
+    fn descend<'a>(
+        &self,
+        data_type: &'a mut DataType,
+        path_component: &str,
+    ) -> DeltaResult<&'a mut StructType>;
+
+    /// Adds operation-specific context to an error returned by the shared traversal.
+    fn wrap_error(&self, error: Error) -> Error;
+}
+
+#[derive(Debug, Clone)]
+/// Adds a field at a column path.
+pub struct AddField {
+    column: ColumnName,
+    field: StructField,
+}
+
+impl AddField {
+    /// Creates an operation that adds `field` at `column`.
+    pub fn new(column: ColumnName, field: StructField) -> Self {
+        Self { column, field }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Makes an existing field nullable.
+pub struct SetNullable {
+    column: ColumnName,
+}
+
+impl SetNullable {
+    /// Creates an operation that makes `column` nullable.
+    pub fn new(column: ColumnName) -> Self {
+        Self { column }
+    }
+}
+
+/// A schema change that can be applied to a transaction.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum SchemaChange {
+    /// Adds a field at a column path.
+    AddField(AddField),
+    /// Makes an existing field nullable.
+    SetNullable(SetNullable),
+}
+
+impl From<AddField> for SchemaChange {
+    fn from(operation: AddField) -> Self {
+        Self::AddField(operation)
+    }
+}
+
+impl From<SetNullable> for SchemaChange {
+    fn from(operation: SetNullable) -> Self {
+        Self::SetNullable(operation)
+    }
+}
+
+/// Helper to modify a nested column. For each component in `path`, locates the matching field
+/// (case-insensitive), then delegates container traversal and leaf behavior to `operation`.
+///
+/// # Example
+///
+/// For the path `address.city`, the walker locates `address`, asks the operation how to enter its
+/// data type, and then applies the operation to `city` in the returned struct.
 fn modify_field_at_path(
     fields: &mut IndexMap<String, StructField>,
     path: &[String],
-    modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
+    operation: &dyn SchemaOperation,
+    context: &mut SchemaOperationContext,
 ) -> DeltaResult<()> {
     let (first, rest) = path
         .split_first()
@@ -58,28 +119,187 @@ fn modify_field_at_path(
 
     // Delta column names are case-insensitive.
     let lowered = first.to_lowercase();
-    let idx = fields
+    let field_index = fields
         .iter()
-        .position(|(_, f)| f.name().to_lowercase() == lowered)
-        .ok_or_else(|| Error::generic(format!("field '{first}' does not exist")))?;
+        .position(|(_, field)| field.name().to_lowercase() == lowered);
 
-    if !rest.is_empty() {
-        let (_, field) = fields
-            .get_index_mut(idx)
-            .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-        let DataType::Struct(inner) = &mut field.data_type else {
-            return Err(Error::generic(format!(
-                "intermediate field '{first}' is not a struct"
-            )));
-        };
-        return modify_field_at_path(inner.field_map_mut(), rest, modifier);
+    if rest.is_empty() {
+        return operation.apply_at_leaf(fields, field_index, context);
     }
 
-    // === Leaf handling ===
+    let field_index =
+        field_index.ok_or_else(|| Error::generic(format!("field '{first}' does not exist")))?;
     let (_, field) = fields
-        .get_index_mut(idx)
+        .get_index_mut(field_index)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    modifier(field)
+    let inner = operation.descend(&mut field.data_type, first)?;
+    modify_field_at_path(inner.field_map_mut(), rest, operation, context)
+}
+
+/// Apply rules for additive change to schema.
+/// Can add a field as a top-level column or inside
+///  a nested struct, array, or map value.
+impl SchemaOperation for AddField {
+    fn path(&self) -> &[String] {
+        self.column.path()
+    }
+
+    fn apply_at_leaf(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        field_index: Option<usize>,
+        context: &mut SchemaOperationContext,
+    ) -> DeltaResult<()> {
+        let leaf = self
+            .column
+            .path()
+            .last()
+            .ok_or_else(|| Error::generic("empty column path"))?;
+        if !leaf.eq_ignore_ascii_case(self.field.name()) {
+            return Err(Error::schema(format!(
+                "path leaf '{leaf}' does not match field name '{}'",
+                self.field.name()
+            )));
+        }
+        if field_index.is_some() {
+            return Err(Error::schema("a column with that name already exists"));
+        }
+        if self.field.is_metadata_column() {
+            return Err(Error::schema(
+                "metadata columns are not allowed in a table schema",
+            ));
+        }
+        if !matches!(self.field.data_type, DataType::Primitive(_)) {
+            StructType::ensure_no_metadata_columns_in_field(&self.field)?;
+        }
+        if !self.field.is_nullable() {
+            return Err(Error::schema(
+                "Added columns cannot be non-nullable because existing data files do not contain \
+                 this column",
+            ));
+        }
+
+        let field = if context.column_mapping_enabled {
+            let id = context.max_column_id.as_mut().ok_or_else(|| {
+                Error::invalid_protocol(
+                    "Column mapping is enabled but delta.columnMapping.maxColumnId is not set in \
+                     table properties",
+                )
+            })?;
+            try_assign_flat_column_mapping_info(&self.field, id)?
+        } else {
+            self.field.clone()
+        };
+        fields.insert(field.name().clone(), field);
+        Ok(())
+    }
+
+    fn descend<'a>(
+        &self,
+        data_type: &'a mut DataType,
+        path_component: &str,
+    ) -> DeltaResult<&'a mut StructType> {
+        match data_type {
+            DataType::Struct(inner) => Ok(inner),
+            DataType::Array(array) => self.descend(&mut array.element_type, path_component),
+            DataType::Map(map) => self.descend(&mut map.value_type, path_component),
+            _ => Err(Error::generic(format!(
+                "intermediate field '{path_component}' is not a struct and does not contain one"
+            ))),
+        }
+    }
+
+    fn wrap_error(&self, error: Error) -> Error {
+        if matches!(error, Error::InvalidProtocol(_)) {
+            return error;
+        }
+        Error::schema(format!(
+            "Cannot add column '{}': {error}",
+            self.field.name()
+        ))
+    }
+}
+
+impl SchemaOperation for SetNullable {
+    fn path(&self) -> &[String] {
+        self.column.path()
+    }
+
+    fn apply_at_leaf(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        field_index: Option<usize>,
+        _context: &mut SchemaOperationContext,
+    ) -> DeltaResult<()> {
+        let field_index = field_index.ok_or_else(|| {
+            let leaf = self.column.path().last().map_or("", String::as_str);
+            Error::generic(format!("field '{leaf}' does not exist"))
+        })?;
+        let (_, field) = fields
+            .get_index_mut(field_index)
+            .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
+        field.nullable = true;
+        Ok(())
+    }
+
+    fn descend<'a>(
+        &self,
+        data_type: &'a mut DataType,
+        path_component: &str,
+    ) -> DeltaResult<&'a mut StructType> {
+        let DataType::Struct(inner) = data_type else {
+            return Err(Error::generic(format!(
+                "intermediate field '{path_component}' is not a struct"
+            )));
+        };
+        Ok(inner)
+    }
+
+    fn wrap_error(&self, error: Error) -> Error {
+        Error::generic(format!(
+            "Cannot set nullable on column '{}': {error}",
+            self.column
+        ))
+    }
+}
+
+impl SchemaOperation for SchemaChange {
+    fn path(&self) -> &[String] {
+        match self {
+            Self::AddField(operation) => operation.path(),
+            Self::SetNullable(operation) => operation.path(),
+        }
+    }
+
+    fn apply_at_leaf(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        field_index: Option<usize>,
+        context: &mut SchemaOperationContext,
+    ) -> DeltaResult<()> {
+        match self {
+            Self::AddField(operation) => operation.apply_at_leaf(fields, field_index, context),
+            Self::SetNullable(operation) => operation.apply_at_leaf(fields, field_index, context),
+        }
+    }
+
+    fn descend<'a>(
+        &self,
+        data_type: &'a mut DataType,
+        path_component: &str,
+    ) -> DeltaResult<&'a mut StructType> {
+        match self {
+            Self::AddField(operation) => operation.descend(data_type, path_component),
+            Self::SetNullable(operation) => operation.descend(data_type, path_component),
+        }
+    }
+
+    fn wrap_error(&self, error: Error) -> Error {
+        match self {
+            Self::AddField(operation) => operation.wrap_error(error),
+            Self::SetNullable(operation) => operation.wrap_error(error),
+        }
+    }
 }
 
 /// The result of applying schema operations.
@@ -104,7 +324,7 @@ pub(crate) struct SchemaEvolutionResult {
 /// operation failed and why.
 pub(crate) fn apply_schema_operations(
     mut schema: StructType,
-    operations: Vec<SchemaOperation>,
+    operations: Vec<SchemaChange>,
     column_mapping_mode: ColumnMappingMode,
     current_max_column_id: Option<i64>,
 ) -> DeltaResult<SchemaEvolutionResult> {
@@ -125,86 +345,32 @@ pub(crate) fn apply_schema_operations(
 
     // When column mapping is enabled and the property is set, defensively take the max with
     // the schema's actual max in case a non-conforming writer left the property stale.
-    let mut max_id = if cm_enabled {
+    let max_id = if cm_enabled {
         current_max_column_id.map(|cfg| cfg.max(find_max_column_id_in_schema(&schema).unwrap_or(0)))
     } else {
         current_max_column_id
     };
 
-    for op in operations {
-        match op {
-            // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
-            // later when the caller builds a new TableConfiguration from the evolved schema --
-            // the alter is rejected if the table doesn't already have the required feature
-            // enabled. This matches Spark, which also rejects with
-            // `DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT` and requires the user to enable the
-            // feature explicitly before adding such a column.
-            SchemaOperation::AddColumn { field } => {
-                if field.is_metadata_column() {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': metadata columns are not allowed in \
-                         a table schema",
-                        field.name()
-                    )));
-                }
-                if !matches!(field.data_type, DataType::Primitive(_)) {
-                    StructType::ensure_no_metadata_columns_in_field(&field)?;
-                }
-                // Case-insensitive sibling-conflict check (O(N) per AddColumn).
-                let lowered = field.name().to_lowercase();
-                if schema.fields().any(|f| f.name().to_lowercase() == lowered) {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': a column with that name already exists",
-                        field.name()
-                    )));
-                }
-                // Validate field is nullable (Delta protocol requires added columns to be
-                // nullable so existing data files can return NULL for the new column)
-                // NOTE: non-nullable columns depend on invariants feature
-                if !field.is_nullable() {
-                    return Err(Error::schema(format!(
-                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                         because existing data files do not contain this column.",
-                        field.name()
-                    )));
-                }
-                let field = if cm_enabled {
-                    let id = max_id.as_mut().ok_or_else(|| {
-                        Error::invalid_protocol(
-                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                             is not set in table properties",
-                        )
-                    })?;
-                    // ALTER TABLE doesn't support icebergCompatV3 yet, so the new field never
-                    // gets `delta.columnMapping.nested.ids` here. Tracking issue:
-                    // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
-                    try_assign_flat_column_mapping_info(&field, id)?
-                } else {
-                    // Stray CM metadata on a mapping-disabled table is handled by the AlterTable
-                    // builder, which strips annotations this ALTER newly introduces from the
-                    // evolved schema.
-                    field
-                };
-                schema.field_map_mut().insert(field.name().clone(), field);
-            }
-            SchemaOperation::SetNullable { column } => {
-                modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
-                    f.nullable = true;
-                    Ok(())
-                })
-                .map_err(|e| {
-                    Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
-                })?;
-            }
-        }
+    let mut context = SchemaOperationContext {
+        column_mapping_enabled: cm_enabled,
+        max_column_id: max_id,
+    };
+    for operation in operations {
+        modify_field_at_path(
+            schema.field_map_mut(),
+            operation.path(),
+            &operation,
+            &mut context,
+        )
+        .map_err(|error| operation.wrap_error(error))?;
     }
 
     validate_schema(&schema, column_mapping_mode)?;
 
     // `max_id` is only ever incremented by `try_assign_flat_column_mapping_info`. If it grew,
     // the new value must be persisted; if it went backwards, that's a bug.
-    let new_max_column_id = match max_id.cmp(&current_max_column_id) {
-        Ordering::Greater => max_id,
+    let new_max_column_id = match context.max_column_id.cmp(&current_max_column_id) {
+        Ordering::Greater => context.max_column_id,
         Ordering::Equal => None,
         Ordering::Less => {
             return Err(Error::internal_error(
@@ -216,6 +382,70 @@ pub(crate) fn apply_schema_operations(
         schema: schema.into(),
         new_max_column_id,
     })
+}
+
+/// Applies schema operations and rebuilds the table configuration around the evolved schema.
+///
+/// # Errors
+///
+/// Returns an error if the table enables a feature that schema evolution does not support yet, an
+/// operation is invalid, the evolved schema violates Delta schema rules, or the evolved metadata is
+/// incompatible with the table protocol.
+pub(crate) fn evolve_table_config(
+    table_config: &TableConfiguration,
+    operations: Vec<SchemaChange>,
+) -> DeltaResult<TableConfiguration> {
+    ensure_schema_evolution_supported(table_config)?;
+    let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+    let column_mapping_mode = table_config.column_mapping_mode();
+    let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+    let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+        && schema_has_column_mapping_metadata(&schema);
+    let SchemaEvolutionResult {
+        schema: evolved_schema,
+        new_max_column_id,
+    } = apply_schema_operations(
+        schema,
+        operations,
+        column_mapping_mode,
+        current_max_column_id,
+    )?;
+    let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+        strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+            .map_or(evolved_schema, Arc::new)
+    } else {
+        evolved_schema
+    };
+    let evolved_metadata = table_config
+        .metadata()
+        .clone()
+        .with_schema(evolved_schema.clone())?
+        .fold_with(new_max_column_id, |metadata, id| {
+            metadata.with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+        });
+    TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)
+}
+
+// Rejects tables whose enabled features kernel cannot evolve the schema of yet. Lives on the one
+// path every caller funnels through so the ALTER TABLE builder and
+// `Transaction::with_schema_changes` cannot drift apart on which tables they accept.
+fn ensure_schema_evolution_supported(table_config: &TableConfiguration) -> DeltaResult<()> {
+    // Added columns would not receive the required column-mapping nested ids. See
+    // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
+    require!(
+        !table_config.is_feature_enabled(&TableFeature::IcebergCompatV3),
+        Error::unsupported(
+            "Schema evolution is not yet supported on tables with icebergCompatV3 enabled"
+        )
+    );
+    // TODO(#2630): Support schema evolution on tables with column defaults.
+    require!(
+        !table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults),
+        Error::unsupported(
+            "Schema changes are not yet supported on tables with allowColumnDefaults enabled"
+        )
+    );
+    Ok(())
 }
 
 #[cfg(test)]
@@ -239,24 +469,37 @@ mod tests {
         .unwrap()
     }
 
-    fn add_col(name: &str, nullable: bool) -> SchemaOperation {
+    type Operation = SchemaChange;
+
+    fn add_field_at(column: ColumnName, field: StructField) -> Operation {
+        AddField::new(column, field).into()
+    }
+
+    fn add_field(field: StructField) -> Operation {
+        let column = ColumnName::new([field.name().clone()]);
+        add_field_at(column, field)
+    }
+
+    fn set_nullable(column: ColumnName) -> Operation {
+        SetNullable::new(column).into()
+    }
+
+    fn add_col(name: &str, nullable: bool) -> Operation {
         let field = if nullable {
             StructField::nullable(name, DataType::STRING)
         } else {
             StructField::not_null(name, DataType::STRING)
         };
-        SchemaOperation::AddColumn { field }
+        add_field(field)
     }
 
     // Builds a struct column whose nested leaf field has the given name. Used to prove that
     // `validate_schema` (not just the top-level dup check or `StructType::try_new`) is
     // reached from `apply_schema_operations`.
-    fn add_struct_with_nested_leaf(name: &str, leaf_name: &str) -> SchemaOperation {
+    fn add_struct_with_nested_leaf(name: &str, leaf_name: &str) -> Operation {
         let inner =
             StructType::try_new(vec![StructField::nullable(leaf_name, DataType::STRING)]).unwrap();
-        SchemaOperation::AddColumn {
-            field: StructField::nullable(name, inner),
-        }
+        add_field(StructField::nullable(name, inner))
     }
 
     fn nested_schema() -> StructType {
@@ -285,17 +528,17 @@ mod tests {
             .collect()
     }
 
-    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<()> {
-        f.nullable = true;
-        Ok(())
-    }
-
     fn modify_field_at_path_test_helper(
         schema: StructType,
         path: &[String],
     ) -> DeltaResult<IndexMap<String, StructField>> {
         let mut fields = into_field_map(schema);
-        modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
+        let operation = SetNullable::new(ColumnName::new(path.to_vec()));
+        let mut context = SchemaOperationContext {
+            column_mapping_enabled: false,
+            max_column_id: None,
+        };
+        modify_field_at_path(&mut fields, path, &operation, &mut context)?;
         Ok(fields)
     }
 
@@ -374,15 +617,13 @@ mod tests {
         "invalid character"
     )]
     #[case::metadata_column(
-        vec![SchemaOperation::AddColumn {
-            field: StructField::create_metadata_column("row_idx", MetadataColumnSpec::RowIndex),
-        }],
+        vec![add_field(StructField::create_metadata_column(
+            "row_idx",
+            MetadataColumnSpec::RowIndex,
+        ))],
         "metadata columns are not allowed"
     )]
-    fn apply_schema_operations_rejects(
-        #[case] ops: Vec<SchemaOperation>,
-        #[case] error_contains: &str,
-    ) {
+    fn apply_schema_operations_rejects(#[case] ops: Vec<Operation>, #[case] error_contains: &str) {
         let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
             .unwrap_err();
         assert!(err.to_string().contains(error_contains));
@@ -395,13 +636,104 @@ mod tests {
         &["id", "name", "email", "age"]
     )]
     fn apply_schema_operations_succeeds(
-        #[case] ops: Vec<SchemaOperation>,
+        #[case] ops: Vec<Operation>,
         #[case] expected_names: &[&str],
     ) {
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
+    }
+
+    #[derive(Clone, Copy)]
+    enum NestedContainer {
+        Struct,
+        Array,
+        Map,
+    }
+
+    fn schema_with_nested_container(container: NestedContainer) -> StructType {
+        let value = schema! { nullable "existing": STRING };
+        let data_type = match container {
+            NestedContainer::Struct => DataType::from(value),
+            NestedContainer::Array => DataType::from(ArrayType::new(value, true)),
+            NestedContainer::Map => DataType::from(MapType::new(
+                schema! { nullable "key_field": STRING },
+                value,
+                true,
+            )),
+        };
+        StructType::try_new([StructField::nullable("container", data_type)]).unwrap()
+    }
+
+    fn nested_value_struct(field: &StructField, container: NestedContainer) -> &StructType {
+        match (field.data_type(), container) {
+            (DataType::Struct(inner), NestedContainer::Struct) => inner,
+            (DataType::Array(array), NestedContainer::Array) => match &array.element_type {
+                DataType::Struct(inner) => inner,
+                other => panic!("Expected struct array element, got: {other:?}"),
+            },
+            (DataType::Map(map), NestedContainer::Map) => match &map.value_type {
+                DataType::Struct(inner) => inner,
+                other => panic!("Expected struct map value, got: {other:?}"),
+            },
+            (other, _) => panic!("Unexpected nested container: {other:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case::nested_struct(NestedContainer::Struct)]
+    #[case::array_element_struct(NestedContainer::Array)]
+    #[case::map_value_struct(NestedContainer::Map)]
+    fn add_field_recurses_through_additive_containers(#[case] container: NestedContainer) {
+        let schema = schema_with_nested_container(container);
+        let ops = vec![add_field_at(
+            column_name!("CONTAINER.added"),
+            StructField::nullable("added", DataType::INTEGER),
+        )];
+
+        let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
+        let nested = nested_value_struct(result.schema.field("container").unwrap(), container);
+        assert!(nested.field("existing").is_some());
+        assert!(nested.field("added").is_some());
+
+        if let NestedContainer::Map = container {
+            let DataType::Map(map) = result.schema.field("container").unwrap().data_type() else {
+                panic!("Expected map");
+            };
+            let DataType::Struct(key) = &map.key_type else {
+                panic!("Expected struct map key");
+            };
+            assert!(key.field("key_field").is_some());
+            assert!(key.field("added").is_none());
+        }
+    }
+
+    #[rstest]
+    #[case::duplicate(
+        column_name!("container.existing"),
+        StructField::nullable("existing", DataType::INTEGER),
+        "already exists"
+    )]
+    #[case::path_leaf_mismatch(
+        column_name!("container.other"),
+        StructField::nullable("added", DataType::INTEGER),
+        "does not match field name"
+    )]
+    fn add_nested_field_rejects_invalid_leaf(
+        #[case] column: ColumnName,
+        #[case] field: StructField,
+        #[case] error_contains: &str,
+    ) {
+        let ops = vec![add_field_at(column, field)];
+        let err = apply_schema_operations(
+            schema_with_nested_container(NestedContainer::Struct),
+            ops,
+            ColumnMappingMode::None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains(error_contains));
     }
 
     // === apply_schema_operations: SetNullable tests ===
@@ -422,11 +754,12 @@ mod tests {
     #[case::already_nullable_is_noop(simple_schema(), column_name!("name"))]
     #[case::case_insensitive(simple_schema(), column_name!("ID"))]
     #[case::nested_field(nested_schema(), column_name!("address.city"))]
-    #[case::deeply_nested_field(deeply_nested_required_schema(), column_name!("address.location.zipcode"))]
+    #[case::deeply_nested_field(
+        deeply_nested_required_schema(),
+        column_name!("address.location.zipcode")
+    )]
     fn set_nullable_succeeds(#[case] schema: StructType, #[case] column: ColumnName) {
-        let ops = vec![SchemaOperation::SetNullable {
-            column: column.clone(),
-        }];
+        let ops = vec![set_nullable(column.clone())];
         let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         assert!(result.schema.field_at_path(column.path()).is_nullable());
     }
@@ -436,7 +769,7 @@ mod tests {
     #[case::through_non_struct(column_name!("name.inner"), "not a struct")]
     #[case::empty_path(ColumnName::new(Vec::<String>::new()), "empty column path")]
     fn set_nullable_fails(#[case] column: ColumnName, #[case] error_contains: &str) {
-        let ops = vec![SchemaOperation::SetNullable { column }];
+        let ops = vec![set_nullable(column)];
         let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None)
             .unwrap_err();
         assert!(
@@ -454,9 +787,7 @@ mod tests {
             StructType::try_new(vec![StructField::not_null("city", DataType::STRING)]).unwrap(),
         )])
         .unwrap();
-        let ops = vec![SchemaOperation::SetNullable {
-            column: column_name!("address"),
-        }];
+        let ops = vec![set_nullable(column_name!("address"))];
         let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         let addr = result.schema.field("address").unwrap();
         assert!(addr.is_nullable(), "struct itself must be nullable");
@@ -472,12 +803,8 @@ mod tests {
     #[test]
     fn chain_add_and_set_nullable_applies_both() {
         let ops = vec![
-            SchemaOperation::AddColumn {
-                field: StructField::nullable("email", DataType::STRING),
-            },
-            SchemaOperation::SetNullable {
-                column: column_name!("id"),
-            },
+            add_field(StructField::nullable("email", DataType::STRING)),
+            set_nullable(column_name!("id")),
         ];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
@@ -500,9 +827,7 @@ mod tests {
             StructField::not_null("gamma", DataType::STRING),
         ])
         .unwrap();
-        let ops = vec![SchemaOperation::SetNullable {
-            column: column_name!("beta.nested"),
-        }];
+        let ops = vec![set_nullable(column_name!("beta.nested"))];
         let result = apply_schema_operations(schema, ops, ColumnMappingMode::None, None).unwrap();
         let names: Vec<&String> = result.schema.fields().map(|f| f.name()).collect();
         assert_eq!(names, vec!["alpha", "beta", "gamma"]);
@@ -534,9 +859,7 @@ mod tests {
         #[case] current_max: i64,
         #[case] expected_id: i64,
     ) {
-        let ops = vec![SchemaOperation::AddColumn {
-            field: StructField::nullable("email", DataType::STRING),
-        }];
+        let ops = vec![add_field(StructField::nullable("email", DataType::STRING))];
         let result =
             apply_schema_operations(simple_schema(), ops, mode, Some(current_max)).unwrap();
         let email_field = result.schema.field("email").unwrap();
@@ -548,9 +871,7 @@ mod tests {
 
     #[test]
     fn add_column_without_max_column_id_fails_when_mapping_enabled() {
-        let ops = vec![SchemaOperation::AddColumn {
-            field: StructField::nullable("email", DataType::STRING),
-        }];
+        let ops = vec![add_field(StructField::nullable("email", DataType::STRING))];
         let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, None)
             .unwrap_err();
         assert!(matches!(err, Error::InvalidProtocol(_)));
@@ -563,15 +884,9 @@ mod tests {
     #[test]
     fn add_multiple_columns_with_column_mapping_assigns_unique_ids() {
         let ops = vec![
-            SchemaOperation::AddColumn {
-                field: StructField::nullable("a", DataType::STRING),
-            },
-            SchemaOperation::AddColumn {
-                field: StructField::nullable("b", DataType::STRING),
-            },
-            SchemaOperation::AddColumn {
-                field: StructField::nullable("c", DataType::STRING),
-            },
+            add_field(StructField::nullable("a", DataType::STRING)),
+            add_field(StructField::nullable("b", DataType::STRING)),
+            add_field(StructField::nullable("c", DataType::STRING)),
         ];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
@@ -627,9 +942,7 @@ mod tests {
         #[case] data_type: DataType,
         #[case] expected_id_count: usize,
     ) {
-        let ops = vec![SchemaOperation::AddColumn {
-            field: StructField::nullable("col", data_type),
-        }];
+        let ops = vec![add_field(StructField::nullable("col", data_type))];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(10))
                 .unwrap();
@@ -670,7 +983,7 @@ mod tests {
         StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
     ))]
     fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![add_field(field)];
         let result = apply_schema_operations(
             simple_schema(),
             ops,
@@ -696,7 +1009,7 @@ mod tests {
                 .to_string(),
             MetadataValue::String("user-supplied-name".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![add_field(field)];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(7))
                 .unwrap();
@@ -718,9 +1031,10 @@ mod tests {
     #[case::i64_max(i64::MAX)]
     #[case::negative(-1)]
     fn alter_with_out_of_range_persisted_max_column_id_is_rejected(#[case] seed: i64) {
-        let ops = vec![SchemaOperation::AddColumn {
-            field: StructField::nullable("anything", DataType::INTEGER),
-        }];
+        let ops = vec![add_field(StructField::nullable(
+            "anything",
+            DataType::INTEGER,
+        ))];
         let err =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(seed))
                 .unwrap_err()
@@ -742,7 +1056,7 @@ mod tests {
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
             MetadataValue::String("not-a-number".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![add_field(field)];
         let err = apply_schema_operations(
             simple_schema(),
             ops,
@@ -768,9 +1082,7 @@ mod tests {
             MetadataValue::Number(42),
         );
         let schema = StructType::try_new(vec![existing]).unwrap();
-        let ops = vec![SchemaOperation::AddColumn {
-            field: StructField::nullable("new", DataType::STRING),
-        }];
+        let ops = vec![add_field(StructField::nullable("new", DataType::STRING))];
         // Persisted maxColumnId is stale at 5, but the schema actually contains id=42.
         let result =
             apply_schema_operations(schema, ops, ColumnMappingMode::Name, Some(5)).unwrap();

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -100,6 +100,15 @@ impl From<SetNullable> for SchemaChange {
     }
 }
 
+impl SchemaChange {
+    fn as_operation(&self) -> &dyn SchemaOperation {
+        match self {
+            Self::AddField(operation) => operation,
+            Self::SetNullable(operation) => operation,
+        }
+    }
+}
+
 /// Helper to modify a nested column. For each component in `path`, locates the matching field
 /// (case-insensitive), then delegates container traversal and leaf behavior to `operation`.
 ///
@@ -263,45 +272,6 @@ impl SchemaOperation for SetNullable {
     }
 }
 
-impl SchemaOperation for SchemaChange {
-    fn path(&self) -> &[String] {
-        match self {
-            Self::AddField(operation) => operation.path(),
-            Self::SetNullable(operation) => operation.path(),
-        }
-    }
-
-    fn apply_at_leaf(
-        &self,
-        fields: &mut IndexMap<String, StructField>,
-        field_index: Option<usize>,
-        context: &mut SchemaOperationContext,
-    ) -> DeltaResult<()> {
-        match self {
-            Self::AddField(operation) => operation.apply_at_leaf(fields, field_index, context),
-            Self::SetNullable(operation) => operation.apply_at_leaf(fields, field_index, context),
-        }
-    }
-
-    fn descend<'a>(
-        &self,
-        data_type: &'a mut DataType,
-        path_component: &str,
-    ) -> DeltaResult<&'a mut StructType> {
-        match self {
-            Self::AddField(operation) => operation.descend(data_type, path_component),
-            Self::SetNullable(operation) => operation.descend(data_type, path_component),
-        }
-    }
-
-    fn wrap_error(&self, error: Error) -> Error {
-        match self {
-            Self::AddField(operation) => operation.wrap_error(error),
-            Self::SetNullable(operation) => operation.wrap_error(error),
-        }
-    }
-}
-
 /// The result of applying schema operations.
 #[derive(Debug)]
 pub(crate) struct SchemaEvolutionResult {
@@ -356,10 +326,11 @@ pub(crate) fn apply_schema_operations(
         max_column_id: max_id,
     };
     for operation in operations {
+        let operation = operation.as_operation();
         modify_field_at_path(
             schema.field_map_mut(),
             operation.path(),
-            &operation,
+            operation,
             &mut context,
         )
         .map_err(|error| operation.wrap_error(error))?;

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -1,4 +1,4 @@
-//! Schema evolution operations for ALTER TABLE.
+//! Schema evolution operations for table and write transactions.
 //!
 //! This module defines operations for validating and applying schema changes.
 
@@ -21,61 +21,10 @@ use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::utils::{require, FoldWithOption as _};
 use crate::DeltaResult;
 
-/// Context shared by schema operations while they are applied.
-pub(crate) struct SchemaOperationContext {
+/// Context shared by schema changes while they are applied.
+struct SchemaEvolutionContext {
     column_mapping_enabled: bool,
     max_column_id: Option<i64>,
-}
-
-/// Internal behavior shared by schema evolution operations.
-pub(crate) trait SchemaOperation: Send + Sync + std::fmt::Debug {
-    /// Returns the path to the field affected by this operation.
-    fn path(&self) -> &[String];
-
-    /// Applies the operation at the final path component.
-    fn apply_at_leaf(
-        &self,
-        fields: &mut IndexMap<String, StructField>,
-        field_index: Option<usize>,
-        context: &mut SchemaOperationContext,
-    ) -> DeltaResult<()>;
-
-    /// Descends through the data type according to this operation's recursion policy.
-    fn descend<'a>(
-        &self,
-        data_type: &'a mut DataType,
-        path_component: &str,
-    ) -> DeltaResult<&'a mut StructType>;
-
-    /// Adds operation-specific context to an error returned by the shared traversal.
-    fn wrap_error(&self, error: Error) -> Error;
-}
-
-#[derive(Debug, Clone)]
-/// Adds a field at a column path.
-pub struct AddField {
-    column: ColumnName,
-    field: StructField,
-}
-
-impl AddField {
-    /// Creates an operation that adds `field` at `column`.
-    pub fn new(column: ColumnName, field: StructField) -> Self {
-        Self { column, field }
-    }
-}
-
-#[derive(Debug, Clone)]
-/// Makes an existing field nullable.
-pub struct SetNullable {
-    column: ColumnName,
-}
-
-impl SetNullable {
-    /// Creates an operation that makes `column` nullable.
-    pub fn new(column: ColumnName) -> Self {
-        Self { column }
-    }
 }
 
 /// A schema change that can be applied to a transaction.
@@ -83,44 +32,93 @@ impl SetNullable {
 #[derive(Debug, Clone)]
 pub enum SchemaChange {
     /// Adds a field at a column path.
-    AddField(AddField),
+    ///
+    /// Traversal through arrays uses their element type and traversal through maps uses their
+    /// value type. Map keys cannot be evolved.
+    AddField {
+        /// Full path to the new field, including its name as the final component.
+        column: ColumnName,
+        /// The nullable field to add.
+        field: StructField,
+    },
     /// Makes an existing field nullable.
-    SetNullable(SetNullable),
-}
-
-impl From<AddField> for SchemaChange {
-    fn from(operation: AddField) -> Self {
-        Self::AddField(operation)
-    }
-}
-
-impl From<SetNullable> for SchemaChange {
-    fn from(operation: SetNullable) -> Self {
-        Self::SetNullable(operation)
-    }
+    ///
+    /// Every intermediate path component must be a struct field.
+    SetNullable {
+        /// Path to the field whose nullability should be relaxed.
+        column: ColumnName,
+    },
 }
 
 impl SchemaChange {
-    fn as_operation(&self) -> &dyn SchemaOperation {
+    /// Creates a change that adds `field` at `column`.
+    pub fn add_field(column: ColumnName, field: StructField) -> Self {
+        Self::AddField { column, field }
+    }
+
+    /// Creates a change that makes `column` nullable.
+    pub fn set_nullable(column: ColumnName) -> Self {
+        Self::SetNullable { column }
+    }
+
+    fn apply(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        context: &mut SchemaEvolutionContext,
+    ) -> DeltaResult<()> {
         match self {
-            Self::AddField(operation) => operation,
-            Self::SetNullable(operation) => operation,
+            Self::AddField { column, field } => {
+                apply_traversal(fields, &AddFieldTraversal { column, field }, context)
+            }
+            Self::SetNullable { column } => {
+                apply_traversal(fields, &SetNullableTraversal { column }, context)
+            }
         }
     }
 }
 
-/// Helper to modify a nested column. For each component in `path`, locates the matching field
-/// (case-insensitive), then delegates container traversal and leaf behavior to `operation`.
-///
-/// # Example
-///
-/// For the path `address.city`, the walker locates `address`, asks the operation how to enter its
-/// data type, and then applies the operation to `city` in the returned struct.
+trait TraversalPolicy {
+    fn path(&self) -> &[String];
+
+    fn apply_at_leaf(
+        &self,
+        fields: &mut IndexMap<String, StructField>,
+        field_index: Option<usize>,
+        context: &mut SchemaEvolutionContext,
+    ) -> DeltaResult<()>;
+
+    fn descend<'a>(
+        &self,
+        data_type: &'a mut DataType,
+        path_component: &str,
+    ) -> DeltaResult<&'a mut StructType>;
+
+    fn wrap_error(&self, error: Error) -> Error;
+}
+
+struct AddFieldTraversal<'a> {
+    column: &'a ColumnName,
+    field: &'a StructField,
+}
+
+struct SetNullableTraversal<'a> {
+    column: &'a ColumnName,
+}
+
+fn apply_traversal(
+    fields: &mut IndexMap<String, StructField>,
+    traversal: &impl TraversalPolicy,
+    context: &mut SchemaEvolutionContext,
+) -> DeltaResult<()> {
+    modify_field_at_path(fields, traversal.path(), traversal, context)
+        .map_err(|error| traversal.wrap_error(error))
+}
+
 fn modify_field_at_path(
     fields: &mut IndexMap<String, StructField>,
     path: &[String],
-    operation: &dyn SchemaOperation,
-    context: &mut SchemaOperationContext,
+    traversal: &impl TraversalPolicy,
+    context: &mut SchemaEvolutionContext,
 ) -> DeltaResult<()> {
     let (first, rest) = path
         .split_first()
@@ -133,7 +131,7 @@ fn modify_field_at_path(
         .position(|(_, field)| field.name().to_lowercase() == lowered);
 
     if rest.is_empty() {
-        return operation.apply_at_leaf(fields, field_index, context);
+        return traversal.apply_at_leaf(fields, field_index, context);
     }
 
     let field_index =
@@ -141,14 +139,11 @@ fn modify_field_at_path(
     let (_, field) = fields
         .get_index_mut(field_index)
         .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    let inner = operation.descend(&mut field.data_type, first)?;
-    modify_field_at_path(inner.field_map_mut(), rest, operation, context)
+    let inner = traversal.descend(&mut field.data_type, first)?;
+    modify_field_at_path(inner.field_map_mut(), rest, traversal, context)
 }
 
-/// Apply rules for additive change to schema.
-/// Can add a field as a top-level column or inside
-///  a nested struct, array, or map value.
-impl SchemaOperation for AddField {
+impl TraversalPolicy for AddFieldTraversal<'_> {
     fn path(&self) -> &[String] {
         self.column.path()
     }
@@ -157,7 +152,7 @@ impl SchemaOperation for AddField {
         &self,
         fields: &mut IndexMap<String, StructField>,
         field_index: Option<usize>,
-        context: &mut SchemaOperationContext,
+        context: &mut SchemaEvolutionContext,
     ) -> DeltaResult<()> {
         let leaf = self
             .column
@@ -179,7 +174,7 @@ impl SchemaOperation for AddField {
             ));
         }
         if !matches!(self.field.data_type, DataType::Primitive(_)) {
-            StructType::ensure_no_metadata_columns_in_field(&self.field)?;
+            StructType::ensure_no_metadata_columns_in_field(self.field)?;
         }
         if !self.field.is_nullable() {
             return Err(Error::schema(
@@ -195,7 +190,7 @@ impl SchemaOperation for AddField {
                      table properties",
                 )
             })?;
-            try_assign_flat_column_mapping_info(&self.field, id)?
+            try_assign_flat_column_mapping_info(self.field, id)?
         } else {
             self.field.clone()
         };
@@ -220,16 +215,17 @@ impl SchemaOperation for AddField {
 
     fn wrap_error(&self, error: Error) -> Error {
         if matches!(error, Error::InvalidProtocol(_)) {
-            return error;
+            error
+        } else {
+            Error::schema(format!(
+                "Cannot add column '{}': {error}",
+                self.field.name()
+            ))
         }
-        Error::schema(format!(
-            "Cannot add column '{}': {error}",
-            self.field.name()
-        ))
     }
 }
 
-impl SchemaOperation for SetNullable {
+impl TraversalPolicy for SetNullableTraversal<'_> {
     fn path(&self) -> &[String] {
         self.column.path()
     }
@@ -238,7 +234,7 @@ impl SchemaOperation for SetNullable {
         &self,
         fields: &mut IndexMap<String, StructField>,
         field_index: Option<usize>,
-        _context: &mut SchemaOperationContext,
+        _context: &mut SchemaEvolutionContext,
     ) -> DeltaResult<()> {
         let field_index = field_index.ok_or_else(|| {
             let leaf = self.column.path().last().map_or("", String::as_str);
@@ -321,19 +317,12 @@ pub(crate) fn apply_schema_operations(
         current_max_column_id
     };
 
-    let mut context = SchemaOperationContext {
+    let mut context = SchemaEvolutionContext {
         column_mapping_enabled: cm_enabled,
         max_column_id: max_id,
     };
     for operation in operations {
-        let operation = operation.as_operation();
-        modify_field_at_path(
-            schema.field_map_mut(),
-            operation.path(),
-            operation,
-            &mut context,
-        )
-        .map_err(|error| operation.wrap_error(error))?;
+        operation.apply(schema.field_map_mut(), &mut context)?;
     }
 
     validate_schema(&schema, column_mapping_mode)?;
@@ -406,7 +395,7 @@ fn ensure_schema_evolution_supported(table_config: &TableConfiguration) -> Delta
     require!(
         !table_config.is_feature_enabled(&TableFeature::IcebergCompatV3),
         Error::unsupported(
-            "Schema evolution is not yet supported on tables with icebergCompatV3 enabled"
+            "Schema changes are not yet supported on tables with icebergCompatV3 enabled"
         )
     );
     // TODO(#2630): Support schema evolution on tables with column defaults.
@@ -443,7 +432,7 @@ mod tests {
     type Operation = SchemaChange;
 
     fn add_field_at(column: ColumnName, field: StructField) -> Operation {
-        AddField::new(column, field).into()
+        SchemaChange::add_field(column, field)
     }
 
     fn add_field(field: StructField) -> Operation {
@@ -452,7 +441,7 @@ mod tests {
     }
 
     fn set_nullable(column: ColumnName) -> Operation {
-        SetNullable::new(column).into()
+        SchemaChange::set_nullable(column)
     }
 
     fn add_col(name: &str, nullable: bool) -> Operation {
@@ -504,12 +493,12 @@ mod tests {
         path: &[String],
     ) -> DeltaResult<IndexMap<String, StructField>> {
         let mut fields = into_field_map(schema);
-        let operation = SetNullable::new(ColumnName::new(path.to_vec()));
-        let mut context = SchemaOperationContext {
+        let mut context = SchemaEvolutionContext {
             column_mapping_enabled: false,
             max_column_id: None,
         };
-        modify_field_at_path(&mut fields, path, &operation, &mut context)?;
+        SchemaChange::set_nullable(ColumnName::new(path.to_vec()))
+            .apply(&mut fields, &mut context)?;
         Ok(fields)
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -141,8 +141,9 @@ impl Transaction {
     ///
     /// # Errors
     ///
-    /// Returns an error if `changes` is empty, an operation is invalid, or the evolved schema is
-    /// incompatible with the table protocol.
+    /// Returns an error if `changes` is empty, data file actions have already been staged, the
+    /// table enables a feature that schema evolution does not support, an operation is invalid, or
+    /// the evolved schema is incompatible with the table protocol.
     pub fn with_schema_changes(mut self, changes: Vec<SchemaChange>) -> DeltaResult<Self> {
         require!(
             !changes.is_empty(),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -36,7 +36,8 @@ use crate::snapshot::SnapshotRef;
 use crate::table_features::{
     iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
 };
-use crate::utils::current_time_ms;
+use crate::transaction::schema_evolution::{evolve_table_config, SchemaChange};
+use crate::utils::{current_time_ms, require};
 use crate::{DataType, DeltaResult, Engine, Expression};
 
 // =============================================================================
@@ -131,6 +132,31 @@ impl Transaction {
     pub fn with_operation(mut self, operation: String) -> Self {
         self.operation = Some(operation);
         self
+    }
+
+    /// Applies schema operations to the transaction's effective table configuration.
+    ///
+    /// Operations are applied in order, with each operation observing changes made by preceding
+    /// operations. A successful call causes the transaction to emit updated table metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `changes` is empty, an operation is invalid, or the evolved schema is
+    /// incompatible with the table protocol.
+    pub fn with_schema_changes(mut self, changes: Vec<SchemaChange>) -> DeltaResult<Self> {
+        require!(
+            !changes.is_empty(),
+            Error::generic("with_schema_changes requires at least one schema operation")
+        );
+        require!(
+            !self.has_data_file_actions(),
+            Error::invalid_transaction_state(
+                "with_schema_changes must be called before staging data files"
+            )
+        );
+        self.effective_table_config = evolve_table_config(&self.effective_table_config, changes)?;
+        self.should_emit_metadata = true;
+        Ok(self)
     }
 
     /// Remove domain metadata from the Delta log.

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -16,7 +16,7 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::transaction::schema_evolution::AddField;
+use delta_kernel::transaction::schema_evolution::SchemaChange;
 use delta_kernel::{DeltaResult, Engine};
 use rstest::rstest;
 use test_utils::{
@@ -31,6 +31,16 @@ fn simple_schema() -> SchemaRef {
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("name", DataType::STRING),
         ])
+        .unwrap(),
+    )
+}
+
+fn nested_schema() -> SchemaRef {
+    Arc::new(
+        StructType::try_new([StructField::nullable(
+            "address",
+            StructType::try_new([StructField::nullable("city", DataType::STRING)]).unwrap(),
+        )])
         .unwrap(),
     )
 }
@@ -78,7 +88,10 @@ fn add_column_error(
             .unwrap_err(),
         EvolutionEntryPoint::WriteTransaction => snapshot
             .transaction(committer(), engine)?
-            .with_schema_changes(vec![AddField::new(column_name!("new_col"), field).into()])
+            .with_schema_changes(vec![SchemaChange::add_field(
+                column_name!("new_col"),
+                field,
+            )])
             .unwrap_err(),
     };
     Ok(error.to_string())
@@ -220,6 +233,43 @@ async fn add_columns_lifecycle(
         assert_eq!(null_count, 2, "column {name} should have 2 NULLs");
     }
 
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn add_nested_column_commits_through_each_entry_point(
+    #[values(EvolutionEntryPoint::AlterTable, EvolutionEntryPoint::WriteTransaction)]
+    entry_point: EvolutionEntryPoint,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, nested_schema(), engine.as_ref(), &[])?;
+    let column = column_name!("address.zip");
+    let field = StructField::nullable("zip", DataType::INTEGER);
+
+    let snapshot = match entry_point {
+        EvolutionEntryPoint::AlterTable => snapshot
+            .alter_table()
+            .add_column_at_path(column, field)
+            .build(engine.as_ref(), committer())?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot(),
+        EvolutionEntryPoint::WriteTransaction => snapshot
+            .transaction(committer(), engine.as_ref())?
+            .with_schema_changes(vec![SchemaChange::add_field(column, field)])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot(),
+    };
+
+    let schema = snapshot.schema();
+    let DataType::Struct(address) = schema.field("address").unwrap().data_type() else {
+        panic!("address must remain a struct");
+    };
+    assert_eq!(
+        address.field("zip"),
+        Some(&StructField::nullable("zip", DataType::INTEGER))
+    );
     Ok(())
 }
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -16,7 +16,8 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::DeltaResult;
+use delta_kernel::transaction::schema_evolution::AddField;
+use delta_kernel::{DeltaResult, Engine};
 use rstest::rstest;
 use test_utils::{
     add_commit, column_mapping_fixtures as fixtures, create_table as create_test_table,
@@ -48,6 +49,39 @@ fn max_column_id(snap: &Snapshot) -> Option<i64> {
         .configuration()
         .get("delta.columnMapping.maxColumnId")
         .and_then(|v| v.parse().ok())
+}
+
+/// The public entry points into schema evolution. Both funnel through the same table-config
+/// evolution, so guards for features kernel cannot evolve yet must reject through either one.
+#[derive(Debug, Clone, Copy)]
+enum EvolutionEntryPoint {
+    AlterTable,
+    WriteTransaction,
+}
+
+fn unsupported_feature_message(feature: &str) -> String {
+    format!("Schema changes are not yet supported on tables with {feature} enabled")
+}
+
+/// Adds a column through `entry_point`, returning the error message it is rejected with.
+fn add_column_error(
+    snapshot: Arc<Snapshot>,
+    entry_point: EvolutionEntryPoint,
+    engine: &dyn Engine,
+) -> DeltaResult<String> {
+    let field = StructField::nullable("new_col", DataType::STRING);
+    let error = match entry_point {
+        EvolutionEntryPoint::AlterTable => snapshot
+            .alter_table()
+            .add_column(field)
+            .build(engine, committer())
+            .unwrap_err(),
+        EvolutionEntryPoint::WriteTransaction => snapshot
+            .transaction(committer(), engine)?
+            .with_schema_changes(vec![AddField::new(column_name!("new_col"), field).into()])
+            .unwrap_err(),
+    };
+    Ok(error.to_string())
 }
 
 // ============================================================================
@@ -909,8 +943,12 @@ async fn add_column_strip_is_none_mode_only(
     Ok(())
 }
 
+#[rstest]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn std::error::Error>> {
+async fn schema_evolution_blocked_when_iceberg_compat_v3_enabled(
+    #[values(EvolutionEntryPoint::AlterTable, EvolutionEntryPoint::WriteTransaction)]
+    entry_point: EvolutionEntryPoint,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     let snapshot = create_table_and_load_snapshot(
         &table_path,
@@ -919,14 +957,9 @@ async fn alter_blocked_when_iceberg_compat_v3_enabled() -> Result<(), Box<dyn st
         &[("delta.enableIcebergCompatV3", "true")],
     )?;
 
-    let msg = snapshot
-        .alter_table()
-        .add_column(StructField::nullable("new_col", DataType::STRING))
-        .build(engine.as_ref(), committer())
-        .unwrap_err()
-        .to_string();
+    let msg = add_column_error(snapshot, entry_point, engine.as_ref())?;
     assert!(
-        msg.contains("ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled"),
+        msg.contains(&unsupported_feature_message("icebergCompatV3")),
         "unexpected error: {msg}",
     );
 
@@ -968,9 +1001,12 @@ async fn add_column_with_orphan_default_metadata_succeeds() -> DeltaResult<()> {
     Ok(())
 }
 
+#[rstest]
 #[tokio::test]
-async fn alter_blocked_when_allow_column_defaults_enabled() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn schema_evolution_blocked_when_allow_column_defaults_enabled(
+    #[values(EvolutionEntryPoint::AlterTable, EvolutionEntryPoint::WriteTransaction)]
+    entry_point: EvolutionEntryPoint,
+) -> Result<(), Box<dyn std::error::Error>> {
     let (store, engine, table_url) = engine_store_setup("alter_column_defaults", None);
     let table_url = create_test_table(
         store,
@@ -984,14 +1020,9 @@ async fn alter_blocked_when_allow_column_defaults_enabled() -> Result<(), Box<dy
     .await?;
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
 
-    let msg = snapshot
-        .alter_table()
-        .add_column(StructField::nullable("new_col", DataType::STRING))
-        .build(&engine, committer())
-        .unwrap_err()
-        .to_string();
+    let msg = add_column_error(snapshot, entry_point, &engine)?;
     assert!(
-        msg.contains("ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled"),
+        msg.contains(&unsupported_feature_message("allowColumnDefaults")),
         "unexpected error: {msg}",
     );
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In order to fully support schema evolution (e.g. metadata changes and table changes in the same commit for `INSERT WITH SCHEMA EVOLUTION`) we add the following API and functionalities:

- Add nested column insertion through structs, array elements, and map values.
- Expose `SchemaChange` and add 'with_schema_changes(changes)' method for update table transaction
- Share schema-evolution validation and table-configuration rebuilding across ALTER TABLE and write transactions.
- Add integration coverage for both schema-evolution entry points.

### This PR affects the following public APIs

Adds `SchemaChange`, `Transaction::with_schema_changes`, and `AlterTableTransactionBuilder::add_column_at_path`.

## How was this change tested?

Unit tests for all added (and affected) functionalities
- all tests in `kernel/src/transaction/schema_evolution.rs` suite pass, including preserved functionality for SetNullable
- all tests in `delta-kernel-rs/kernel/tests/integration/features/alter_table.rs` pass