### PR TITLE
feat: support nested schema changes in transactions

### DIFF
--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -23,9 +23,12 @@ use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
 /// One segment in a path to a nested schema field.
-#[internal_api]
+/// This kernel also uses ColumnName as a path to a nested field,
+/// however this has the limitation of not concretely identifying
+/// recursion into arrays and maps (MapKey, MapValue).
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[internal_api]
 pub(crate) enum PathSegment {
     Field(String),
     ArrayElement,
@@ -83,8 +86,8 @@ fn to_path_segments(path: &[String]) -> Vec<PathSegment> {
         .collect::<Vec<_>>()
 }
 
-// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
-// case-insensitively; explicit segments select array elements and map keys or values.
+/// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
+/// case-insensitively; can recurse into arrays and maps via explicit `PathSegment`s.
 fn modify_field_at_path(
     data_type: &mut DataType,
     path: &[PathSegment],
@@ -173,8 +176,37 @@ pub(crate) fn apply_schema_operations(
 
     for op in operations {
         let mut root = DataType::from(schema);
-        let add_column = match op {
-            SchemaOperation::AddColumn { path, field } => Some((path, field)),
+        match op {
+            SchemaOperation::AddColumn { path, field } => {
+                if field.is_metadata_column() {
+                    return Err(Error::schema(format!(
+                        "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                        field.name()
+                    )));
+                }
+                if !matches!(field.data_type, DataType::Primitive(_)) {
+                    StructType::ensure_no_metadata_columns_in_field(&field)?;
+                }
+                if !field.is_nullable() {
+                    return Err(Error::schema(format!(
+                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                         because existing data files do not contain this column.",
+                        field.name()
+                    )));
+                }
+                let field = if cm_enabled {
+                    let id = max_id.as_mut().ok_or_else(|| {
+                        Error::invalid_protocol(
+                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                             is not set in table properties",
+                        )
+                    })?;
+                    try_assign_flat_column_mapping_info(&field, id)?
+                } else {
+                    field
+                };
+                modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
+            }
             SchemaOperation::SetNullable { column } => {
                 let (leaf, parent) = column
                     .path()
@@ -187,39 +219,7 @@ pub(crate) fn apply_schema_operations(
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
-                None
             }
-        };
-
-        if let Some((path, field)) = add_column {
-            if field.is_metadata_column() {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': metadata columns are not allowed in a table schema",
-                    field.name()
-                )));
-            }
-            if !matches!(field.data_type, DataType::Primitive(_)) {
-                StructType::ensure_no_metadata_columns_in_field(&field)?;
-            }
-            if !field.is_nullable() {
-                return Err(Error::schema(format!(
-                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                     because existing data files do not contain this column.",
-                    field.name()
-                )));
-            }
-            let field = if cm_enabled {
-                let id = max_id.as_mut().ok_or_else(|| {
-                    Error::invalid_protocol(
-                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                         is not set in table properties",
-                    )
-                })?;
-                try_assign_flat_column_mapping_info(&field, id)?
-            } else {
-                field
-            };
-            modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
         }
 
         let DataType::Struct(updated_schema) = root else {

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -24,8 +24,8 @@ use crate::table_features::{
     StaleAnnotationPolicy,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
-use crate::utils::require;
-use crate::{CollectInto, DeltaResult, Error};
+use crate::utils::{require, CollectInto};
+use crate::{DeltaResult, Error};
 
 pub(crate) mod column_default;
 pub use column_default::ColumnDefault;

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -30,6 +30,7 @@ use crate::{CollectInto, DeltaResult, Error};
 pub(crate) mod column_default;
 pub use column_default::ColumnDefault;
 pub(crate) use column_default::{try_collect_column_defaults, validate_column_defaults_metadata};
+pub(crate) mod changes;
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
+
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::changes::{
@@ -135,7 +136,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         });
         self.transition()
     }
-    
+
     /// Change a column's nullability from NOT NULL to nullable. If the column is already
     /// nullable, the op is a no-op but still generates a commit.
     ///
@@ -145,7 +146,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
-    
+
     /// Add a new column at an explicit schema path.
     ///
     /// `path` identifies the struct that will contain `field`. An empty path targets the table's
@@ -163,7 +164,6 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::AddColumn { path, field });
         self.transition()
     }
-
 }
 
 impl AlterTableTransactionBuilder<Modifying> {

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -134,8 +134,9 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
 
     /// Add a new column at an explicit schema path.
     ///
-    /// The final path segment must be [`PathSegment::Field`] and must match `field.name()`.
-    /// Preceding segments may traverse nested structs, array elements, map keys, and map values.
+    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
+    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
+    /// values.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column_at(

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -39,7 +39,7 @@ use crate::table_features::{
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
-    apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
+    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
 };
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
@@ -129,6 +129,22 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
         self.operations.push(SchemaOperation::AddColumn { field });
+        self.transition()
+    }
+
+    /// Add a new column at an explicit schema path.
+    ///
+    /// The final path segment must be [`PathSegment::Field`] and must match `field.name()`.
+    /// Preceding segments may traverse nested structs, array elements, map keys, and map values.
+    ///
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    pub fn add_column_at(
+        mut self,
+        path: Vec<PathSegment>,
+        field: StructField,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations
+            .push(SchemaOperation::AddColumnAt { path, field });
         self.transition()
     }
 

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -27,8 +27,12 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
+use crate::schema::changes::{
+    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
+};
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
@@ -38,9 +42,6 @@ use crate::table_features::{
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
-use crate::transaction::schema_evolution::{
-    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
-};
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
 
@@ -134,24 +135,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         });
         self.transition()
     }
-
-    /// Add a new column at an explicit schema path.
-    ///
-    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
-    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
-    /// values.
-    ///
-    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
-    pub fn add_column_at(
-        mut self,
-        path: Vec<PathSegment>,
-        field: StructField,
-    ) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations
-            .push(SchemaOperation::AddColumn { path, field });
-        self.transition()
-    }
-
+    
     /// Change a column's nullability from NOT NULL to nullable. If the column is already
     /// nullable, the op is a no-op but still generates a commit.
     ///
@@ -161,6 +145,25 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
+    
+    /// Add a new column at an explicit schema path.
+    ///
+    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
+    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
+    /// values.
+    ///
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    #[internal_api]
+    pub(crate) fn add_column_at(
+        mut self,
+        path: Vec<PathSegment>,
+        field: StructField,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations
+            .push(SchemaOperation::AddColumn { path, field });
+        self.transition()
+    }
+
 }
 
 impl AlterTableTransactionBuilder<Modifying> {

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -128,7 +128,10 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations.push(SchemaOperation::AddColumn { field });
+        self.operations.push(SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        });
         self.transition()
     }
 
@@ -145,7 +148,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         field: StructField,
     ) -> AlterTableTransactionBuilder<Modifying> {
         self.operations
-            .push(SchemaOperation::AddColumnAt { path, field });
+            .push(SchemaOperation::AddColumn { path, field });
         self.transition()
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -71,8 +71,7 @@ pub(crate) mod alter_table;
 pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
-pub(crate) mod schema_evolution;
-pub use schema_evolution::{PathSegment, SchemaOperation};
+pub use crate::schema::changes::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2149,6 +2149,7 @@ mod tests {
             .contains("fresh_column"));
 
         let txn = txn.with_schema_changes(vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("fresh_column", DataType::INTEGER),
         }])?;
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -71,7 +71,8 @@ pub(crate) mod alter_table;
 pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
-pub use crate::schema::changes::{PathSegment, SchemaOperation};
+#[internal_api]
+pub(crate) use crate::schema::changes::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -72,6 +72,7 @@ pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
 pub(crate) mod schema_evolution;
+pub use schema_evolution::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]
@@ -2135,7 +2136,7 @@ mod tests {
     fn write_context_reflects_updated_effective_table_config(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, snapshot) = setup_non_dv_table();
-        let mut txn = snapshot
+        let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
@@ -2147,24 +2148,9 @@ mod tests {
             .logical_schema()
             .contains("fresh_column"));
 
-        let mut evolved_fields: Vec<StructField> = txn
-            .effective_table_config
-            .logical_schema()
-            .fields()
-            .cloned()
-            .collect();
-        evolved_fields.push(StructField::nullable("fresh_column", DataType::INTEGER));
-        let evolved_schema = Arc::new(StructType::new_unchecked(evolved_fields));
-        let evolved_metadata = txn
-            .effective_table_config
-            .metadata()
-            .clone()
-            .with_schema(evolved_schema.clone())?;
-        txn.effective_table_config = TableConfiguration::try_new_with_schema(
-            &txn.effective_table_config,
-            evolved_metadata,
-            evolved_schema,
-        )?;
+        let txn = txn.with_schema_changes(vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("fresh_column", DataType::INTEGER),
+        }])?;
 
         let updated_write_context = txn.unpartitioned_write_context()?;
         assert!(updated_write_context

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -6,6 +6,8 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
+
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
@@ -21,9 +23,10 @@ use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
 /// One segment in a path to a nested schema field.
+#[internal_api]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PathSegment {
+pub(crate) enum PathSegment {
     Field(String),
     ArrayElement,
     MapKey,
@@ -33,15 +36,13 @@ pub enum PathSegment {
 /// A schema evolution operation to be applied to a table.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
-pub enum SchemaOperation {
-    /// Add a top-level column.
-    AddColumn { field: StructField },
-
+#[internal_api]
+pub(crate) enum SchemaOperation {
     /// Add a column at an explicit schema path.
     ///
     /// The path identifies the struct that will contain `field`. An empty path adds `field` to the
     /// table's root schema.
-    AddColumnAt {
+    AddColumn {
         path: Vec<PathSegment>,
         field: StructField,
     },
@@ -173,8 +174,7 @@ pub(crate) fn apply_schema_operations(
     for op in operations {
         let mut root = DataType::from(schema);
         let add_column = match op {
-            SchemaOperation::AddColumn { field } => Some((Vec::new(), field)),
-            SchemaOperation::AddColumnAt { path, field } => Some((path, field)),
+            SchemaOperation::AddColumn { path, field } => Some((path, field)),
             SchemaOperation::SetNullable { column } => {
                 let (leaf, parent) = column
                     .path()
@@ -316,7 +316,10 @@ mod tests {
         } else {
             StructField::not_null(name, DataType::STRING)
         };
-        SchemaOperation::AddColumn { field }
+        SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }
     }
 
     // Builds a struct column whose nested leaf field has the given name. Used to prove that
@@ -326,6 +329,7 @@ mod tests {
         let inner =
             StructType::try_new(vec![StructField::nullable(leaf_name, DataType::STRING)]).unwrap();
         SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable(name, inner),
         }
     }
@@ -447,12 +451,13 @@ mod tests {
     )]
     #[case::metadata_column(
         vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::create_metadata_column("row_idx", MetadataColumnSpec::RowIndex),
         }],
         "metadata columns are not allowed"
     )]
     #[case::missing_add_parent(
-        vec![SchemaOperation::AddColumnAt {
+        vec![SchemaOperation::AddColumn {
             path: vec![PathSegment::Field("missing".to_string())],
             field: StructField::nullable("added", DataType::STRING),
         }],
@@ -470,7 +475,7 @@ mod tests {
     #[rstest]
     #[case::single(vec![add_col("email", true)], &["id", "name", "email"])]
     #[case::at_root(
-        vec![SchemaOperation::AddColumnAt {
+        vec![SchemaOperation::AddColumn {
             path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }],
@@ -544,7 +549,7 @@ mod tests {
             StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
         let mut path = vec![PathSegment::Field("container".to_string())];
         path.extend(container_path.iter().cloned());
-        let operation = SchemaOperation::AddColumnAt {
+        let operation = SchemaOperation::AddColumn {
             path,
             field: StructField::nullable("added", DataType::INTEGER),
         };
@@ -631,6 +636,7 @@ mod tests {
     fn chain_add_and_set_nullable_applies_both() {
         let ops = vec![
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("email", DataType::STRING),
             },
             SchemaOperation::SetNullable {
@@ -693,6 +699,7 @@ mod tests {
         #[case] expected_id: i64,
     ) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }];
         let result =
@@ -707,6 +714,7 @@ mod tests {
     #[test]
     fn add_column_without_max_column_id_fails_when_mapping_enabled() {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }];
         let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, None)
@@ -722,12 +730,15 @@ mod tests {
     fn add_multiple_columns_with_column_mapping_assigns_unique_ids() {
         let ops = vec![
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("a", DataType::STRING),
             },
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("b", DataType::STRING),
             },
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("c", DataType::STRING),
             },
         ];
@@ -786,6 +797,7 @@ mod tests {
         #[case] expected_id_count: usize,
     ) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("col", data_type),
         }];
         let result =
@@ -828,7 +840,10 @@ mod tests {
         StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
     ))]
     fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let result = apply_schema_operations(
             simple_schema(),
             ops,
@@ -854,7 +869,10 @@ mod tests {
                 .to_string(),
             MetadataValue::String("user-supplied-name".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(7))
                 .unwrap();
@@ -877,6 +895,7 @@ mod tests {
     #[case::negative(-1)]
     fn alter_with_out_of_range_persisted_max_column_id_is_rejected(#[case] seed: i64) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("anything", DataType::INTEGER),
         }];
         let err =
@@ -900,7 +919,10 @@ mod tests {
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
             MetadataValue::String("not-a-number".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let err = apply_schema_operations(
             simple_schema(),
             ops,
@@ -927,6 +949,7 @@ mod tests {
         );
         let schema = StructType::try_new(vec![existing]).unwrap();
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("new", DataType::STRING),
         }];
         // Persisted maxColumnId is stale at 5, but the schema actually contains id=42.

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -32,10 +32,7 @@ pub enum PathSegment {
     MapValue,
 }
 
-/// A schema evolution operation to apply to a table.
-///
-/// Operations are validated and applied in order. Each operation sees the schema state after all
-/// prior operations have been applied.
+/// A schema evolution operation to be applied to a table.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum SchemaOperation {
@@ -119,26 +116,10 @@ fn add_column_at_path(
     match (segment, data_type) {
         // Adding the field to the current struct.
         (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
+            // The path leaf is supposed to be the field we are trying to add.
             if !name.eq_ignore_ascii_case(field.name()) {
                 return Err(Error::schema(format!(
                     "Cannot add column '{}': path leaf '{name}' does not match field name",
-                    field.name()
-                )));
-            }
-            if field.is_metadata_column() {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': metadata columns are not allowed in \
-                     a table schema",
-                    field.name()
-                )));
-            }
-            if !matches!(field.data_type, DataType::Primitive(_)) {
-                StructType::ensure_no_metadata_columns_in_field(&field)?;
-            }
-            if !field.is_nullable() {
-                return Err(Error::schema(format!(
-                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                     because existing data files do not contain this column.",
                     field.name()
                 )));
             }
@@ -263,8 +244,23 @@ pub(crate) fn apply_schema_operations(
             }
         };
 
-        // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
-        // later when the caller builds a new TableConfiguration from the evolved schema.
+        if field.is_metadata_column() {
+            return Err(Error::schema(format!(
+                "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                field.name()
+            )));
+        }
+        if !matches!(field.data_type, DataType::Primitive(_)) {
+            StructType::ensure_no_metadata_columns_in_field(&field)?;
+        }
+        if !field.is_nullable() {
+            return Err(Error::schema(format!(
+                "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                 because existing data files do not contain this column.",
+                field.name()
+            )));
+        }
+
         let mut root = DataType::from(schema);
         add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
         let DataType::Struct(updated_schema) = root else {

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -4,6 +4,7 @@
 //! that validates and applies schema changes to produce an evolved schema.
 
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 
@@ -11,21 +12,43 @@ use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    find_max_column_id_in_schema, try_assign_flat_column_mapping_info, validate_column_mapping_id,
-    ColumnMappingMode,
+    find_max_column_id_in_schema, schema_has_column_mapping_metadata,
+    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
+    validate_column_mapping_id, ColumnMappingMode,
 };
+use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
+use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
-/// A schema evolution operation to be applied during ALTER TABLE.
+/// One segment in a path to a nested schema field.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSegment {
+    Field(String),
+    ArrayElement,
+    MapKey,
+    MapValue,
+}
+
+/// A schema evolution operation to apply to a table.
 ///
-/// Operations are validated and applied in order during
-/// [`apply_schema_operations`]. Each operation sees the schema state after all prior operations
-/// have been applied.
+/// Operations are validated and applied in order. Each operation sees the schema state after all
+/// prior operations have been applied.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
-pub(crate) enum SchemaOperation {
+pub enum SchemaOperation {
     /// Add a top-level column.
     AddColumn { field: StructField },
+
+    /// Add a column at an explicit schema path.
+    ///
+    /// The final segment must be [`PathSegment::Field`] and must match `field.name()`.
+    AddColumnAt {
+        path: Vec<PathSegment>,
+        field: StructField,
+    },
 
     /// Change a column's nullability from NOT NULL to nullable.
     SetNullable { column: ColumnName },
@@ -82,6 +105,97 @@ fn modify_field_at_path(
     modifier(field)
 }
 
+fn add_column_at_path(
+    data_type: &mut DataType,
+    path: &[PathSegment],
+    field: StructField,
+    cm_enabled: bool,
+    max_id: &mut Option<i64>,
+) -> DeltaResult<()> {
+    let (segment, rest) = path
+        .split_first()
+        .ok_or_else(|| Error::schema("Cannot add column: empty column path"))?;
+
+    match (segment, data_type) {
+        // Adding the field to the current struct.
+        (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
+            if !name.eq_ignore_ascii_case(field.name()) {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': path leaf '{name}' does not match field name",
+                    field.name()
+                )));
+            }
+            if field.is_metadata_column() {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': metadata columns are not allowed in \
+                     a table schema",
+                    field.name()
+                )));
+            }
+            if !matches!(field.data_type, DataType::Primitive(_)) {
+                StructType::ensure_no_metadata_columns_in_field(&field)?;
+            }
+            if !field.is_nullable() {
+                return Err(Error::schema(format!(
+                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                     because existing data files do not contain this column.",
+                    field.name()
+                )));
+            }
+            let lowered = field.name().to_lowercase();
+            if parent
+                .fields()
+                .any(|existing| existing.name().to_lowercase() == lowered)
+            {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': a column with that name already exists",
+                    field.name()
+                )));
+            }
+            let field = if cm_enabled {
+                let id = max_id.as_mut().ok_or_else(|| {
+                    Error::invalid_protocol(
+                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                         is not set in table properties",
+                    )
+                })?;
+                try_assign_flat_column_mapping_info(&field, id)?
+            } else {
+                field
+            };
+            parent.field_map_mut().insert(field.name().clone(), field);
+            Ok(())
+        }
+        (PathSegment::Field(name), DataType::Struct(parent)) => {
+            let lowered = name.to_lowercase();
+            let index = parent
+                .fields()
+                .position(|existing| existing.name().to_lowercase() == lowered)
+                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
+            let nested = &mut parent
+                .field_map_mut()
+                .get_index_mut(index)
+                .ok_or_else(|| Error::internal_error("field index became invalid"))?
+                .1
+                .data_type;
+            add_column_at_path(nested, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::ArrayElement, DataType::Array(array)) => {
+            add_column_at_path(&mut array.element_type, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::MapKey, DataType::Map(map)) => {
+            add_column_at_path(&mut map.key_type, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::MapValue, DataType::Map(map)) => {
+            add_column_at_path(&mut map.value_type, rest, field, cm_enabled, max_id)
+        }
+        (segment, data_type) => Err(Error::schema(format!(
+            "Cannot add column '{}': path segment {segment:?} does not match {data_type}",
+            field.name()
+        ))),
+    }
+}
+
 /// The result of applying schema operations.
 #[derive(Debug)]
 pub(crate) struct SchemaEvolutionResult {
@@ -132,61 +246,11 @@ pub(crate) fn apply_schema_operations(
     };
 
     for op in operations {
-        match op {
-            // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
-            // later when the caller builds a new TableConfiguration from the evolved schema --
-            // the alter is rejected if the table doesn't already have the required feature
-            // enabled. This matches Spark, which also rejects with
-            // `DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT` and requires the user to enable the
-            // feature explicitly before adding such a column.
+        let (path, field) = match op {
             SchemaOperation::AddColumn { field } => {
-                if field.is_metadata_column() {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': metadata columns are not allowed in \
-                         a table schema",
-                        field.name()
-                    )));
-                }
-                if !matches!(field.data_type, DataType::Primitive(_)) {
-                    StructType::ensure_no_metadata_columns_in_field(&field)?;
-                }
-                // Case-insensitive sibling-conflict check (O(N) per AddColumn).
-                let lowered = field.name().to_lowercase();
-                if schema.fields().any(|f| f.name().to_lowercase() == lowered) {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': a column with that name already exists",
-                        field.name()
-                    )));
-                }
-                // Validate field is nullable (Delta protocol requires added columns to be
-                // nullable so existing data files can return NULL for the new column)
-                // NOTE: non-nullable columns depend on invariants feature
-                if !field.is_nullable() {
-                    return Err(Error::schema(format!(
-                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                         because existing data files do not contain this column.",
-                        field.name()
-                    )));
-                }
-                let field = if cm_enabled {
-                    let id = max_id.as_mut().ok_or_else(|| {
-                        Error::invalid_protocol(
-                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                             is not set in table properties",
-                        )
-                    })?;
-                    // ALTER TABLE doesn't support icebergCompatV3 yet, so the new field never
-                    // gets `delta.columnMapping.nested.ids` here. Tracking issue:
-                    // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
-                    try_assign_flat_column_mapping_info(&field, id)?
-                } else {
-                    // Stray CM metadata on a mapping-disabled table is handled by the AlterTable
-                    // builder, which strips annotations this ALTER newly introduces from the
-                    // evolved schema.
-                    field
-                };
-                schema.field_map_mut().insert(field.name().clone(), field);
+                (vec![PathSegment::Field(field.name().clone())], field)
             }
+            SchemaOperation::AddColumnAt { path, field } => (path, field),
             SchemaOperation::SetNullable { column } => {
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
                     f.nullable = true;
@@ -195,8 +259,20 @@ pub(crate) fn apply_schema_operations(
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
+                continue;
             }
-        }
+        };
+
+        // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
+        // later when the caller builds a new TableConfiguration from the evolved schema.
+        let mut root = DataType::from(schema);
+        add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
+        let DataType::Struct(updated_schema) = root else {
+            return Err(Error::internal_error(
+                "schema root changed type while adding a column",
+            ));
+        };
+        schema = *updated_schema;
     }
 
     validate_schema(&schema, column_mapping_mode)?;
@@ -216,6 +292,46 @@ pub(crate) fn apply_schema_operations(
         schema: schema.into(),
         new_max_column_id,
     })
+}
+
+/// Applies schema changes and validates the resulting table configuration.
+///
+/// # Errors
+///
+/// Returns an error when an operation is invalid, the evolved schema violates Delta schema
+/// rules, or the evolved metadata is incompatible with the table protocol.
+pub(crate) fn evolve_table_config(
+    table_config: &TableConfiguration,
+    operations: Vec<SchemaOperation>,
+) -> DeltaResult<TableConfiguration> {
+    let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+    let column_mapping_mode = table_config.column_mapping_mode();
+    let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+    let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+        && schema_has_column_mapping_metadata(&schema);
+    let SchemaEvolutionResult {
+        schema: evolved_schema,
+        new_max_column_id,
+    } = apply_schema_operations(
+        schema,
+        operations,
+        column_mapping_mode,
+        current_max_column_id,
+    )?;
+    let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+        strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+            .map_or(evolved_schema, Arc::new)
+    } else {
+        evolved_schema
+    };
+    let evolved_metadata = table_config
+        .metadata()
+        .clone()
+        .with_schema(evolved_schema.clone())?
+        .fold_with(new_max_column_id, |metadata, id| {
+            metadata.with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+        });
+    TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)
 }
 
 #[cfg(test)]
@@ -379,6 +495,20 @@ mod tests {
         }],
         "metadata columns are not allowed"
     )]
+    #[case::empty_add_path(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![],
+            field: StructField::nullable("added", DataType::STRING),
+        }],
+        "empty column path"
+    )]
+    #[case::add_path_leaf_mismatch(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![PathSegment::Field("other".to_string())],
+            field: StructField::nullable("added", DataType::STRING),
+        }],
+        "does not match field name"
+    )]
     fn apply_schema_operations_rejects(
         #[case] ops: Vec<SchemaOperation>,
         #[case] error_contains: &str,
@@ -402,6 +532,79 @@ mod tests {
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
+    }
+
+    fn struct_with_existing_field() -> StructType {
+        StructType::try_new([StructField::nullable("existing", DataType::STRING)]).unwrap()
+    }
+
+    fn nested_struct_at<'a>(mut data_type: &'a DataType, path: &[PathSegment]) -> &'a StructType {
+        for segment in path {
+            data_type = match (segment, data_type) {
+                (PathSegment::ArrayElement, DataType::Array(array)) => array.element_type(),
+                (PathSegment::MapKey, DataType::Map(map)) => map.key_type(),
+                (PathSegment::MapValue, DataType::Map(map)) => map.value_type(),
+                (segment, data_type) => {
+                    panic!("path segment {segment:?} does not match {data_type}")
+                }
+            };
+        }
+        let DataType::Struct(parent) = data_type else {
+            panic!("path does not resolve to a struct");
+        };
+        parent
+    }
+
+    #[rstest]
+    #[case::struct_parent(
+        DataType::from(struct_with_existing_field()),
+        vec![],
+    )]
+    #[case::array_element(
+        DataType::from(ArrayType::new(struct_with_existing_field(), true)),
+        vec![PathSegment::ArrayElement],
+    )]
+    #[case::map_key(
+        DataType::from(MapType::new(
+            struct_with_existing_field(),
+            DataType::INTEGER,
+            true,
+        )),
+        vec![PathSegment::MapKey],
+    )]
+    #[case::map_value(
+        DataType::from(MapType::new(
+            DataType::INTEGER,
+            struct_with_existing_field(),
+            true,
+        )),
+        vec![PathSegment::MapValue],
+    )]
+    fn add_column_at_traverses_nested_types(
+        #[case] parent_type: DataType,
+        #[case] container_path: Vec<PathSegment>,
+    ) {
+        let schema =
+            StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
+        let mut path = vec![PathSegment::Field("container".to_string())];
+        path.extend(container_path.iter().cloned());
+        path.push(PathSegment::Field("added".to_string()));
+        let operation = SchemaOperation::AddColumnAt {
+            path,
+            field: StructField::nullable("added", DataType::INTEGER),
+        };
+
+        let result =
+            apply_schema_operations(schema, vec![operation], ColumnMappingMode::None, None)
+                .unwrap();
+        let container = result.schema.field("container").unwrap();
+        let parent = nested_struct_at(container.data_type(), &container_path);
+
+        assert!(parent.field("existing").is_some());
+        assert_eq!(
+            parent.field("added"),
+            Some(&StructField::nullable("added", DataType::INTEGER))
+        );
     }
 
     // === apply_schema_operations: SetNullable tests ===

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -6,8 +6,6 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use indexmap::IndexMap;
-
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
@@ -41,7 +39,8 @@ pub enum SchemaOperation {
 
     /// Add a column at an explicit schema path.
     ///
-    /// The final segment must be [`PathSegment::Field`] and must match `field.name()`.
+    /// The path identifies the struct that will contain `field`. An empty path adds `field` to the
+    /// table's root schema.
     AddColumnAt {
         path: Vec<PathSegment>,
         field: StructField,
@@ -51,128 +50,73 @@ pub enum SchemaOperation {
     SetNullable { column: ColumnName },
 }
 
-// Helper to modify a nested column. For each component in `path`, locates the matching field
-// (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
-// to mutate the field in place.
-//
-// `modifier` is expected to mutate the field's nullability, metadata, or `data_type` -- but
-// not its name. Renames need additional handling (IndexMap re-keying + sibling-conflict check)
-// that downstream PRs will introduce alongside the rename caller.
-//
-// Returns an error if a field in the path does not exist or an intermediate field is not a struct.
-//
-// Example:
-//   fields   = [ id: int not null, address: struct { city: string not null, zip: string } ]
-//   path     = ["address", "city"]
-//   modifier = |f| { f.nullable = true; Ok(()) }
-// yields:
-//   [ id: int not null, address: struct { city: string, zip: string } ]
-fn modify_field_at_path(
-    fields: &mut IndexMap<String, StructField>,
-    path: &[String],
-    modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
-) -> DeltaResult<()> {
-    let (first, rest) = path
-        .split_first()
-        .ok_or_else(|| Error::generic("empty column path"))?;
-
-    // Delta column names are case-insensitive.
-    let lowered = first.to_lowercase();
-    let idx = fields
-        .iter()
-        .position(|(_, f)| f.name().to_lowercase() == lowered)
-        .ok_or_else(|| Error::generic(format!("field '{first}' does not exist")))?;
-
-    if !rest.is_empty() {
-        let (_, field) = fields
-            .get_index_mut(idx)
-            .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-        let DataType::Struct(inner) = &mut field.data_type else {
-            return Err(Error::generic(format!(
-                "intermediate field '{first}' is not a struct"
-            )));
-        };
-        return modify_field_at_path(inner.field_map_mut(), rest, modifier);
+fn add_field(parent: &mut StructType, field: StructField) -> DeltaResult<()> {
+    let lowered = field.name().to_lowercase();
+    if parent
+        .fields()
+        .any(|existing| existing.name().to_lowercase() == lowered)
+    {
+        return Err(Error::schema(format!(
+            "Cannot add column '{}': a column with that name already exists",
+            field.name()
+        )));
     }
-
-    // === Leaf handling ===
-    let (_, field) = fields
-        .get_index_mut(idx)
-        .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    modifier(field)
+    parent.field_map_mut().insert(field.name().clone(), field);
+    Ok(())
 }
 
-fn add_column_at_path(
+fn set_field_nullable(field: &mut StructType, name: &str) -> DeltaResult<()> {
+    let field = field
+        .field_map_mut()
+        .values_mut()
+        .find(|field| field.name().to_lowercase() == name.to_lowercase())
+        .ok_or_else(|| Error::generic(format!("field '{}' does not exist", name)))?;
+    field.nullable = true;
+    Ok(())
+}
+
+fn to_path_segments(path: &[String]) -> Vec<PathSegment> {
+    path.iter()
+        .cloned()
+        .map(PathSegment::Field)
+        .collect::<Vec<_>>()
+}
+
+// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
+// case-insensitively; explicit segments select array elements and map keys or values.
+fn modify_field_at_path(
     data_type: &mut DataType,
     path: &[PathSegment],
-    field: StructField,
-    cm_enabled: bool,
-    max_id: &mut Option<i64>,
+    modifier: impl FnOnce(&mut StructType) -> DeltaResult<()>,
 ) -> DeltaResult<()> {
-    let (segment, rest) = path
-        .split_first()
-        .ok_or_else(|| Error::schema("Cannot add column: empty column path"))?;
+    let Some((segment, rest)) = path.split_first() else {
+        let DataType::Struct(parent) = data_type else {
+            return Err(Error::generic("path target is not a struct"));
+        };
+        return modifier(parent);
+    };
 
     match (segment, data_type) {
-        // Adding the field to the current struct.
-        (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
-            // The path leaf is supposed to be the field we are trying to add.
-            if !name.eq_ignore_ascii_case(field.name()) {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': path leaf '{name}' does not match field name",
-                    field.name()
-                )));
-            }
-            let lowered = field.name().to_lowercase();
-            if parent
-                .fields()
-                .any(|existing| existing.name().to_lowercase() == lowered)
-            {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': a column with that name already exists",
-                    field.name()
-                )));
-            }
-            let field = if cm_enabled {
-                let id = max_id.as_mut().ok_or_else(|| {
-                    Error::invalid_protocol(
-                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                         is not set in table properties",
-                    )
-                })?;
-                try_assign_flat_column_mapping_info(&field, id)?
-            } else {
-                field
-            };
-            parent.field_map_mut().insert(field.name().clone(), field);
-            Ok(())
-        }
         (PathSegment::Field(name), DataType::Struct(parent)) => {
             let lowered = name.to_lowercase();
-            let index = parent
-                .fields()
-                .position(|existing| existing.name().to_lowercase() == lowered)
-                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
-            let nested = &mut parent
+            let field = parent
                 .field_map_mut()
-                .get_index_mut(index)
-                .ok_or_else(|| Error::internal_error("field index became invalid"))?
-                .1
-                .data_type;
-            add_column_at_path(nested, rest, field, cm_enabled, max_id)
+                .values_mut()
+                .find(|field| field.name().to_lowercase() == lowered)
+                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
+            modify_field_at_path(&mut field.data_type, rest, modifier)
         }
         (PathSegment::ArrayElement, DataType::Array(array)) => {
-            add_column_at_path(&mut array.element_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut array.element_type, rest, modifier)
         }
         (PathSegment::MapKey, DataType::Map(map)) => {
-            add_column_at_path(&mut map.key_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut map.key_type, rest, modifier)
         }
         (PathSegment::MapValue, DataType::Map(map)) => {
-            add_column_at_path(&mut map.value_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut map.value_type, rest, modifier)
         }
         (segment, data_type) => Err(Error::schema(format!(
-            "Cannot add column '{}': path segment {segment:?} does not match {data_type}",
-            field.name()
+            "path segment {segment:?} does not match {data_type}"
         ))),
     }
 }
@@ -227,45 +171,60 @@ pub(crate) fn apply_schema_operations(
     };
 
     for op in operations {
-        let (path, field) = match op {
-            SchemaOperation::AddColumn { field } => {
-                (vec![PathSegment::Field(field.name().clone())], field)
-            }
-            SchemaOperation::AddColumnAt { path, field } => (path, field),
+        let mut root = DataType::from(schema);
+        let add_column = match op {
+            SchemaOperation::AddColumn { field } => Some((Vec::new(), field)),
+            SchemaOperation::AddColumnAt { path, field } => Some((path, field)),
             SchemaOperation::SetNullable { column } => {
-                modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
-                    f.nullable = true;
-                    Ok(())
+                let (leaf, parent) = column
+                    .path()
+                    .split_last()
+                    .ok_or_else(|| Error::generic("empty column path"))?;
+                let parent = to_path_segments(parent);
+                modify_field_at_path(&mut root, &parent, |parent| {
+                    set_field_nullable(parent, leaf)
                 })
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
-                continue;
+                None
             }
         };
 
-        if field.is_metadata_column() {
-            return Err(Error::schema(format!(
-                "Cannot add column '{}': metadata columns are not allowed in a table schema",
-                field.name()
-            )));
-        }
-        if !matches!(field.data_type, DataType::Primitive(_)) {
-            StructType::ensure_no_metadata_columns_in_field(&field)?;
-        }
-        if !field.is_nullable() {
-            return Err(Error::schema(format!(
-                "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                 because existing data files do not contain this column.",
-                field.name()
-            )));
+        if let Some((path, field)) = add_column {
+            if field.is_metadata_column() {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                    field.name()
+                )));
+            }
+            if !matches!(field.data_type, DataType::Primitive(_)) {
+                StructType::ensure_no_metadata_columns_in_field(&field)?;
+            }
+            if !field.is_nullable() {
+                return Err(Error::schema(format!(
+                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                     because existing data files do not contain this column.",
+                    field.name()
+                )));
+            }
+            let field = if cm_enabled {
+                let id = max_id.as_mut().ok_or_else(|| {
+                    Error::invalid_protocol(
+                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                         is not set in table properties",
+                    )
+                })?;
+                try_assign_flat_column_mapping_info(&field, id)?
+            } else {
+                field
+            };
+            modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
         }
 
-        let mut root = DataType::from(schema);
-        add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
         let DataType::Struct(updated_schema) = root else {
             return Err(Error::internal_error(
-                "schema root changed type while adding a column",
+                "schema root changed type during schema evolution",
             ));
         };
         schema = *updated_schema;
@@ -388,34 +347,35 @@ mod tests {
 
     // === modify_field_at_path tests ===
 
-    // Convert a StructType into the IndexMap<String, StructField> shape that
-    // `modify_field_at_path` operates on.
-    fn into_field_map(schema: StructType) -> IndexMap<String, StructField> {
-        schema
-            .into_fields()
-            .map(|f| (f.name().clone(), f))
-            .collect()
-    }
-
-    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<()> {
-        f.nullable = true;
-        Ok(())
-    }
-
     fn modify_field_at_path_test_helper(
         schema: StructType,
         path: &[String],
-    ) -> DeltaResult<IndexMap<String, StructField>> {
-        let mut fields = into_field_map(schema);
-        modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
-        Ok(fields)
+    ) -> DeltaResult<StructType> {
+        let (leaf, parent) = path
+            .split_last()
+            .ok_or_else(|| Error::generic("empty column path"))?;
+        let parent = parent
+            .iter()
+            .cloned()
+            .map(PathSegment::Field)
+            .collect::<Vec<_>>();
+        let mut root = DataType::from(schema);
+        modify_field_at_path(&mut root, &parent, |parent| {
+            set_field_nullable(parent, leaf)
+        })?;
+        let DataType::Struct(schema) = root else {
+            return Err(Error::internal_error(
+                "schema root changed type while testing path modification",
+            ));
+        };
+        Ok(*schema)
     }
 
     #[test]
     fn modify_top_level_field_sets_nullable() {
         let path = vec!["id".to_string()];
         let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(id.is_nullable());
     }
 
@@ -423,7 +383,7 @@ mod tests {
     fn modify_nested_field_modifies_only_leaf() {
         let path = vec!["address".to_string(), "city".to_string()];
         let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
-        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let addr = result.fields().find(|f| f.name() == "address").unwrap();
         match addr.data_type() {
             DataType::Struct(s) => assert!(s.field("city").unwrap().is_nullable()),
             other => panic!("Expected Struct, got: {other:?}"),
@@ -437,9 +397,9 @@ mod tests {
     fn modify_nested_leaf_preserves_other_fields() {
         let path = vec!["address".to_string(), "city".to_string()];
         let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(!id.is_nullable());
-        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let addr = result.fields().find(|f| f.name() == "address").unwrap();
         match addr.data_type() {
             DataType::Struct(s) => assert!(s.field("zip").unwrap().is_nullable()),
             other => panic!("Expected Struct, got: {other:?}"),
@@ -466,7 +426,7 @@ mod tests {
     fn modify_case_insensitive_lookup_finds_field() {
         let path = vec!["ID".to_string()];
         let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(id.is_nullable());
     }
 
@@ -491,19 +451,12 @@ mod tests {
         }],
         "metadata columns are not allowed"
     )]
-    #[case::empty_add_path(
+    #[case::missing_add_parent(
         vec![SchemaOperation::AddColumnAt {
-            path: vec![],
+            path: vec![PathSegment::Field("missing".to_string())],
             field: StructField::nullable("added", DataType::STRING),
         }],
-        "empty column path"
-    )]
-    #[case::add_path_leaf_mismatch(
-        vec![SchemaOperation::AddColumnAt {
-            path: vec![PathSegment::Field("other".to_string())],
-            field: StructField::nullable("added", DataType::STRING),
-        }],
-        "does not match field name"
+        "does not exist"
     )]
     fn apply_schema_operations_rejects(
         #[case] ops: Vec<SchemaOperation>,
@@ -516,6 +469,13 @@ mod tests {
 
     #[rstest]
     #[case::single(vec![add_col("email", true)], &["id", "name", "email"])]
+    #[case::at_root(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![],
+            field: StructField::nullable("email", DataType::STRING),
+        }],
+        &["id", "name", "email"],
+    )]
     #[case::multiple(
         vec![add_col("email", true), add_col("age", true)],
         &["id", "name", "email", "age"]
@@ -584,7 +544,6 @@ mod tests {
             StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
         let mut path = vec![PathSegment::Field("container".to_string())];
         path.extend(container_path.iter().cloned());
-        path.push(PathSegment::Field("added".to_string()));
         let operation = SchemaOperation::AddColumnAt {
             path,
             field: StructField::nullable("added", DataType::INTEGER),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 use tracing::instrument;
 
-use super::schema_evolution::{evolve_table_config, SchemaOperation};
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
@@ -32,6 +31,7 @@ use crate::metrics::MetricId;
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
+use crate::schema::changes::{evolve_table_config, SchemaOperation};
 use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
@@ -144,7 +144,8 @@ impl Transaction {
     /// Returns an error if the table enables an unsupported schema-evolution feature, `changes` is
     /// empty, data files have already been staged, or an operation produces a schema that is
     /// invalid for the table protocol.
-    pub fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+    #[internal_api]
+    pub(crate) fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
         if self
             .effective_table_config
             .is_feature_enabled(&TableFeature::IcebergCompatV3)

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 use tracing::instrument;
 
+use super::schema_evolution::{evolve_table_config, SchemaOperation};
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
@@ -36,7 +37,7 @@ use crate::snapshot::SnapshotRef;
 use crate::table_features::{
     iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
 };
-use crate::utils::current_time_ms;
+use crate::utils::{current_time_ms, require};
 use crate::{DataType, DeltaResult, Engine, Expression};
 
 // =============================================================================
@@ -131,6 +132,48 @@ impl Transaction {
     pub fn with_operation(mut self, operation: String) -> Self {
         self.operation = Some(operation);
         self
+    }
+
+    /// Applies schema changes before data files are staged in this transaction.
+    ///
+    /// Changes are applied sequentially and the resulting table configuration is validated before
+    /// this method returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table enables an unsupported schema-evolution feature, `changes` is
+    /// empty, data files have already been staged, or an operation produces a schema that is
+    /// invalid for the table protocol.
+    pub fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::IcebergCompatV3)
+        {
+            return Err(Error::unsupported(
+                "Schema changes are not yet supported on tables with icebergCompatV3 enabled",
+            ));
+        }
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::AllowColumnDefaults)
+        {
+            return Err(Error::unsupported(
+                "Schema changes are not yet supported on tables with allowColumnDefaults enabled",
+            ));
+        }
+        require!(
+            !changes.is_empty(),
+            Error::generic("with_schema_changes requires at least one schema operation")
+        );
+        require!(
+            !self.has_data_file_actions(),
+            Error::invalid_transaction_state(
+                "with_schema_changes must be called before staging data files"
+            )
+        );
+        self.effective_table_config = evolve_table_config(&self.effective_table_config, changes)?;
+        self.should_emit_metadata = true;
+        Ok(self)
     }
 
     /// Remove domain metadata from the Delta log.

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -145,7 +145,10 @@ impl Transaction {
     /// empty, data files have already been staged, or an operation produces a schema that is
     /// invalid for the table protocol.
     #[internal_api]
-    pub(crate) fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+    pub(crate) fn with_schema_changes(
+        mut self,
+        changes: Vec<SchemaOperation>,
+    ) -> DeltaResult<Self> {
         if self
             .effective_table_config
             .is_feature_enabled(&TableFeature::IcebergCompatV3)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose schema operations through `Transaction::with_schema_changes` and add explicit typed paths for adding columns inside nested structs, array elements, map keys, and map values. The existing `SetNullable` path is also modified to recurse into arrays and maps.
Small refactoring: moved `schema_evolution.rs` under the `schema` directory, as `changes.rs`

### This PR affects the following public APIs

- Adds `Transaction::with_schema_changes` as an internal API.
- Exposes `SchemaOperation` and `PathSegment` as internal APIs.
- Adds `AlterTableTransactionBuilder::add_column_at` as an alternative to `add_column`, for additive nested changes, simply to preserve the existing public API.

## How was this change tested?

- Tested against the schema evolution and alter table suites: All previous tests pass.
- Added unit tests for 'add_column_at_path`: adding nested columns