### PR TITLE
feat!: lower project operator

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -213,22 +213,37 @@ pub(crate) fn struct_null_when_not(guard: DFExpr, body: DFExpr) -> DFExpr {
 }
 
 /// A struct expression's named values and optional row-level null guard.
-pub(crate) type StructColumns = (Vec<(String, DFExpr)>, Option<DFExpr>);
+pub(crate) struct StructColumns {
+    pairs: Vec<(String, DFExpr)>,
+    null_guard: Option<DFExpr>,
+}
 
-/// Packs a struct's `(name, value)` columns into one `named_struct` value, nulling the whole struct
-/// where `null_guard` is not true.
-fn pack_struct_value((pairs, null_guard): StructColumns) -> DFExpr {
-    // `named_struct` takes one flat arg list of alternating names and values:
-    // `[name1, value1, name2, value2, ...]`, hence two args per field.
-    let mut args = Vec::with_capacity(pairs.len() * 2);
-    for (name, value) in pairs {
-        args.push(lit(name));
-        args.push(value);
+impl StructColumns {
+    /// Packs the columns into one `named_struct` value, preserving the struct's null mask.
+    fn pack(self) -> DFExpr {
+        // `named_struct` takes one flat arg list of alternating names and values:
+        // `[name1, value1, name2, value2, ...]`, hence two args per field.
+        let mut args = Vec::with_capacity(self.pairs.len() * 2);
+        for (name, value) in self.pairs {
+            args.push(lit(name));
+            args.push(value);
+        }
+        let body = named_struct(args);
+        match self.null_guard {
+            Some(guard) => struct_null_when_not(guard, body),
+            None => body,
+        }
     }
-    let body = named_struct(args);
-    match null_guard {
-        Some(guard) => struct_null_when_not(guard, body),
-        None => body,
+
+    /// Returns flat output columns with the struct's null mask applied to each value.
+    pub(crate) fn into_guarded_columns(self) -> Vec<(String, DFExpr)> {
+        let Some(guard) = self.null_guard else {
+            return self.pairs;
+        };
+        self.pairs
+            .into_iter()
+            .map(|(name, value)| (name, struct_null_when_not(guard.clone(), value)))
+            .collect()
     }
 }
 
@@ -243,7 +258,7 @@ fn struct_to_df_expr(
 ) -> DeltaResult<DFExpr> {
     let target = require_struct_output(output_type, "Struct")?;
     let columns = struct_columns_from_fields(fields, nullability, input_schema, target)?;
-    Ok(pack_struct_value(columns))
+    Ok(columns.pack())
 }
 
 /// Builds the `(name, value)` columns of a struct constructor, taking field names and per-child
@@ -266,11 +281,10 @@ fn struct_columns_from_fields(
         let value = to_df_expr(child, input_schema, Some(field.data_type()))?;
         pairs.push((field.name().to_string(), value));
     }
-    let null_guard = match nullability {
-        Some(pred) => Some(to_df_expr(pred, input_schema, None)?),
-        None => None,
-    };
-    Ok((pairs, null_guard))
+    let null_guard = nullability
+        .map(|pred| to_df_expr(pred, input_schema, None))
+        .transpose()?;
+    Ok(StructColumns { pairs, null_guard })
 }
 
 /// Lowers a struct patch (a sparse edit of an input struct) to a `named_struct(..)` value. See
@@ -282,7 +296,7 @@ fn struct_patch_to_df_expr(
 ) -> DeltaResult<DFExpr> {
     let target = require_struct_output(output_type, "StructPatch")?;
     let columns = struct_columns_from_patch(patch, input_schema, target)?;
-    Ok(pack_struct_value(columns))
+    Ok(columns.pack())
 }
 
 /// Builds the `(name, value)` columns of a struct patch. Output field names come positionally from
@@ -315,34 +329,10 @@ fn struct_columns_from_patch(
     let mut output_fields = target.fields();
     let mut pairs: Vec<(String, DFExpr)> = Vec::with_capacity(target.num_fields());
 
-    let append_converted = |pairs: &mut Vec<(String, DFExpr)>,
-                            output_fields: &mut dyn Iterator<Item = &StructField>,
-                            expr: &KernelExpression|
-     -> DeltaResult<()> {
-        let field = output_fields.next().ok_or_else(|| {
-            Error::generic("StructPatch produced more fields than the output schema has")
-        })?;
-        let value = to_df_expr(expr, input_schema, Some(field.data_type()))?;
-        pairs.push((field.name().to_string(), value));
-        Ok(())
-    };
-    let append_existing = |pairs: &mut Vec<(String, DFExpr)>,
-                           output_fields: &mut dyn Iterator<Item = &StructField>,
-                           name: &str|
-     -> DeltaResult<()> {
-        let field = output_fields.next().ok_or_else(|| {
-            Error::generic("StructPatch produced more fields than the output schema has")
-        })?;
-        let value = match &source_expr {
-            Some(base) => get_field(base.clone(), name.to_string()),
-            None => DFExpr::Column(DFColumn::new_unqualified(name)),
-        };
-        pairs.push((field.name().to_string(), value));
-        Ok(())
-    };
-
     for expr in &patch.prepended_fields {
-        append_converted(&mut pairs, &mut output_fields, expr)?;
+        append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
+            to_df_expr(expr, input_schema, Some(field.data_type()))
+        })?;
     }
 
     // Should only count required field patches (excluding optional) for missing input fields
@@ -353,14 +343,21 @@ fn struct_columns_from_patch(
         let field_patch = patch.field_patches.get(name);
 
         if field_patch.is_none_or(|fp| fp.keep_input) {
-            append_existing(&mut pairs, &mut output_fields, name)?;
+            append_struct_patch_field(&mut pairs, &mut output_fields, |_| {
+                Ok(match &source_expr {
+                    Some(base) => get_field(base.clone(), name.to_string()),
+                    None => DFExpr::Column(DFColumn::new_unqualified(name)),
+                })
+            })?;
         }
 
         let Some(field_patch) = field_patch else {
             continue;
         };
         for expr in &field_patch.insertions {
-            append_converted(&mut pairs, &mut output_fields, expr)?;
+            append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
+                to_df_expr(expr, input_schema, Some(field.data_type()))
+            })?;
         }
         if !field_patch.optional {
             used_required_field_patches += 1;
@@ -379,7 +376,9 @@ fn struct_columns_from_patch(
     }
 
     for expr in &patch.appended_fields {
-        append_converted(&mut pairs, &mut output_fields, expr)?;
+        append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
+            to_df_expr(expr, input_schema, Some(field.data_type()))
+        })?;
     }
 
     if output_fields.next().is_some() {
@@ -388,7 +387,20 @@ fn struct_columns_from_patch(
         ));
     }
 
-    Ok((pairs, null_guard))
+    Ok(StructColumns { pairs, null_guard })
+}
+
+fn append_struct_patch_field<'a>(
+    pairs: &mut Vec<(String, DFExpr)>,
+    output_fields: &mut impl Iterator<Item = &'a StructField>,
+    value: impl FnOnce(&StructField) -> DeltaResult<DFExpr>,
+) -> DeltaResult<()> {
+    let field = output_fields.next().ok_or_else(|| {
+        Error::generic("StructPatch produced more fields than the output schema has")
+    })?;
+    let value = value(field)?;
+    pairs.push((field.name().to_string(), value));
+    Ok(())
 }
 
 /// Lowers a `MapToStruct` (reshape a `Map<String, String>` into a struct by parsing each value into

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -89,6 +89,31 @@ pub fn to_df_expr(
     }
 }
 
+/// Lowers [`KernelExpression::Struct`] or [`KernelExpression::StructPatch`] into named child
+/// expressions and an optional row-level null guard. Callers can pack the children into a struct
+/// or use them as individual columns.
+///
+/// # Errors
+/// Returns an error if `expr` has another form, its field count disagrees with `output_type`, or a
+/// field cannot be lowered.
+pub(crate) fn to_df_struct_columns(
+    expr: &KernelExpression,
+    input_schema: &StructType,
+    output_type: &StructType,
+) -> DeltaResult<StructColumns> {
+    match expr {
+        KernelExpression::Struct(fields, nullability) => {
+            struct_columns_from_fields(fields, nullability.as_ref(), input_schema, output_type)
+        }
+        KernelExpression::StructPatch(patch) => {
+            struct_columns_from_patch(patch, input_schema, output_type)
+        }
+        _ => Err(Error::generic(format!(
+            "Expression must be a Struct or StructPatch, got {expr:?}"
+        ))),
+    }
+}
+
 /// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
 /// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
 /// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
@@ -179,7 +204,7 @@ fn require_struct_output<'a>(
 /// `CASE WHEN guard THEN body ELSE NULL END`: nulls the whole struct where `guard` is not true,
 /// matching kernel's row-level struct-null mask. The else is an untyped NULL so CASE coercion
 /// promotes it to `body`'s (all-nullable) struct type rather than forcing a nullability match.
-fn struct_null_when_not(guard: DFExpr, body: DFExpr) -> DFExpr {
+pub(crate) fn struct_null_when_not(guard: DFExpr, body: DFExpr) -> DFExpr {
     DFExpr::Case(Case::new(
         None,
         vec![(Box::new(guard), Box::new(body))],
@@ -187,9 +212,29 @@ fn struct_null_when_not(guard: DFExpr, body: DFExpr) -> DFExpr {
     ))
 }
 
-/// Lowers a struct constructor to `named_struct(..)`, taking field names and per-child target types
-/// from `output_type`. An optional nullability predicate nulls the whole struct where it is not
-/// true.
+/// A struct expression's named values and optional row-level null guard.
+pub(crate) type StructColumns = (Vec<(String, DFExpr)>, Option<DFExpr>);
+
+/// Packs a struct's `(name, value)` columns into one `named_struct` value, nulling the whole struct
+/// where `null_guard` is not true.
+fn pack_struct_value((pairs, null_guard): StructColumns) -> DFExpr {
+    // `named_struct` takes one flat arg list of alternating names and values:
+    // `[name1, value1, name2, value2, ...]`, hence two args per field.
+    let mut args = Vec::with_capacity(pairs.len() * 2);
+    for (name, value) in pairs {
+        args.push(lit(name));
+        args.push(value);
+    }
+    let body = named_struct(args);
+    match null_guard {
+        Some(guard) => struct_null_when_not(guard, body),
+        None => body,
+    }
+}
+
+/// Lowers a struct constructor to a `named_struct(..)` value, taking field names and per-child
+/// target types from `output_type`. An optional nullability predicate nulls the whole struct where
+/// it is not true.
 fn struct_to_df_expr(
     fields: &[ExpressionRef],
     nullability: Option<&ExpressionRef>,
@@ -197,6 +242,18 @@ fn struct_to_df_expr(
     output_type: Option<&KernelDataType>,
 ) -> DeltaResult<DFExpr> {
     let target = require_struct_output(output_type, "Struct")?;
+    let columns = struct_columns_from_fields(fields, nullability, input_schema, target)?;
+    Ok(pack_struct_value(columns))
+}
+
+/// Builds the `(name, value)` columns of a struct constructor, taking field names and per-child
+/// target types from `target`, plus the lowered nullability guard when present.
+fn struct_columns_from_fields(
+    fields: &[ExpressionRef],
+    nullability: Option<&ExpressionRef>,
+    input_schema: &StructType,
+    target: &StructType,
+) -> DeltaResult<StructColumns> {
     if fields.len() != target.num_fields() {
         return Err(Error::generic(format!(
             "Struct expression field count mismatch: {} fields in expression but {} in schema",
@@ -204,34 +261,40 @@ fn struct_to_df_expr(
             target.num_fields()
         )));
     }
-    // `named_struct` takes one flat arg list of alternating names and values:
-    // `[name1, value1, name2, value2, ...]`, hence two args per field.
-    let mut args = Vec::with_capacity(fields.len() * 2);
+    let mut pairs = Vec::with_capacity(fields.len());
     for (child, field) in fields.iter().zip(target.fields()) {
-        args.push(lit(field.name().to_string()));
-        args.push(to_df_expr(child, input_schema, Some(field.data_type()))?);
+        let value = to_df_expr(child, input_schema, Some(field.data_type()))?;
+        pairs.push((field.name().to_string(), value));
     }
-    let body = named_struct(args);
-    let Some(pred) = nullability else {
-        return Ok(body);
+    let null_guard = match nullability {
+        Some(pred) => Some(to_df_expr(pred, input_schema, None)?),
+        None => None,
     };
-    let guard = to_df_expr(pred, input_schema, None)?;
-    Ok(struct_null_when_not(guard, body))
+    Ok((pairs, null_guard))
 }
 
-/// Lowers a struct patch (a sparse edit of an input struct) to a `named_struct(..)` rebuild. Output
-/// field names come positionally from `output_type`, whose corresponding field types are forwarded
-/// when lowering computed values. Walks the evaluator's emission order: prepends, each input field
-/// (passed through unless dropped/replaced, then its insertions), and appends. A nested patch
-/// (`input_path` set) nulls the output where the source struct row is null, matching the
-/// evaluator's preservation of the source struct's null buffer.
+/// Lowers a struct patch (a sparse edit of an input struct) to a `named_struct(..)` value. See
+/// [`struct_columns_from_patch`] for the emission order and the nested-patch null semantics.
 fn struct_patch_to_df_expr(
     patch: &ExpressionStructPatch,
     input_schema: &StructType,
     output_type: Option<&KernelDataType>,
 ) -> DeltaResult<DFExpr> {
     let target = require_struct_output(output_type, "StructPatch")?;
+    let columns = struct_columns_from_patch(patch, input_schema, target)?;
+    Ok(pack_struct_value(columns))
+}
 
+/// Builds the `(name, value)` columns of a struct patch. Output field names come positionally from
+/// `target`, whose corresponding field types are forwarded when lowering computed values. Walks the
+/// evaluator's emission order: prepends, each input field (passed through unless dropped/replaced,
+/// then its insertions), and appends. A nested patch (`input_path` set) reports a null guard on the
+/// source struct row, matching the evaluator's preservation of the source struct's null buffer.
+fn struct_columns_from_patch(
+    patch: &ExpressionStructPatch,
+    input_schema: &StructType,
+    target: &StructType,
+) -> DeltaResult<StructColumns> {
     // A patch targets either the whole input struct (`input_path` is `None`), whose fields are the
     // top-level columns, or the nested struct at that path, whose fields are reached through it.
     let (mut source_struct, mut source_expr) = (input_schema, None);
@@ -244,30 +307,28 @@ fn struct_patch_to_df_expr(
         let source = column_to_df_expr(path, input_schema)?;
         (source_struct, source_expr) = (nested.as_ref(), Some(source));
     }
+    // A nested patch must preserve its source struct's null bitmap. This predicate lets the caller
+    // null every flattened output column wherever the source struct is null.
+    let null_guard = source_expr.as_ref().map(|base| base.clone().is_not_null());
 
-    // Append `[name, value]` pairs in the evaluator's emission order, consuming one output field
-    // per appended value so each value is lowered against the type it lands in.
+    // Append `(name, value)` pairs in the evaluator's emission order
     let mut output_fields = target.fields();
-    let mut args = Vec::with_capacity(target.num_fields() * 2);
+    let mut pairs: Vec<(String, DFExpr)> = Vec::with_capacity(target.num_fields());
 
-    // Both closures need the shared `output_fields` cursor, so it is threaded as a parameter rather
-    // than captured.
-    let append_field_with_converted_expr =
-        |args: &mut Vec<DFExpr>,
-         output_fields: &mut dyn Iterator<Item = &StructField>,
-         expr: &KernelExpression|
-         -> DeltaResult<()> {
-            let field = output_fields.next().ok_or_else(|| {
-                Error::generic("StructPatch produced more fields than the output schema has")
-            })?;
-            let value = to_df_expr(expr, input_schema, Some(field.data_type()))?;
-            args.push(lit(field.name().to_string()));
-            args.push(value);
-            Ok(())
-        };
-    let append_field_with_existing_col = |args: &mut Vec<DFExpr>,
-                                          output_fields: &mut dyn Iterator<Item = &StructField>,
-                                          name: &str|
+    let append_converted = |pairs: &mut Vec<(String, DFExpr)>,
+                            output_fields: &mut dyn Iterator<Item = &StructField>,
+                            expr: &KernelExpression|
+     -> DeltaResult<()> {
+        let field = output_fields.next().ok_or_else(|| {
+            Error::generic("StructPatch produced more fields than the output schema has")
+        })?;
+        let value = to_df_expr(expr, input_schema, Some(field.data_type()))?;
+        pairs.push((field.name().to_string(), value));
+        Ok(())
+    };
+    let append_existing = |pairs: &mut Vec<(String, DFExpr)>,
+                           output_fields: &mut dyn Iterator<Item = &StructField>,
+                           name: &str|
      -> DeltaResult<()> {
         let field = output_fields.next().ok_or_else(|| {
             Error::generic("StructPatch produced more fields than the output schema has")
@@ -276,13 +337,12 @@ fn struct_patch_to_df_expr(
             Some(base) => get_field(base.clone(), name.to_string()),
             None => DFExpr::Column(DFColumn::new_unqualified(name)),
         };
-        args.push(lit(field.name().to_string()));
-        args.push(value);
+        pairs.push((field.name().to_string(), value));
         Ok(())
     };
 
     for expr in &patch.prepended_fields {
-        append_field_with_converted_expr(&mut args, &mut output_fields, expr)?;
+        append_converted(&mut pairs, &mut output_fields, expr)?;
     }
 
     // Should only count required field patches (excluding optional) for missing input fields
@@ -293,14 +353,14 @@ fn struct_patch_to_df_expr(
         let field_patch = patch.field_patches.get(name);
 
         if field_patch.is_none_or(|fp| fp.keep_input) {
-            append_field_with_existing_col(&mut args, &mut output_fields, name)?;
+            append_existing(&mut pairs, &mut output_fields, name)?;
         }
 
         let Some(field_patch) = field_patch else {
             continue;
         };
         for expr in &field_patch.insertions {
-            append_field_with_converted_expr(&mut args, &mut output_fields, expr)?;
+            append_converted(&mut pairs, &mut output_fields, expr)?;
         }
         if !field_patch.optional {
             used_required_field_patches += 1;
@@ -319,7 +379,7 @@ fn struct_patch_to_df_expr(
     }
 
     for expr in &patch.appended_fields {
-        append_field_with_converted_expr(&mut args, &mut output_fields, expr)?;
+        append_converted(&mut pairs, &mut output_fields, expr)?;
     }
 
     if output_fields.next().is_some() {
@@ -328,11 +388,7 @@ fn struct_patch_to_df_expr(
         ));
     }
 
-    let body = named_struct(args);
-    let Some(base) = source_expr else {
-        return Ok(body);
-    };
-    Ok(struct_null_when_not(base.is_not_null(), body))
+    Ok((pairs, null_guard))
 }
 
 /// Lowers a `MapToStruct` (reshape a `Map<String, String>` into a struct by parsing each value into

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -329,10 +329,34 @@ fn struct_columns_from_patch(
     let mut output_fields = target.fields();
     let mut pairs: Vec<(String, DFExpr)> = Vec::with_capacity(target.num_fields());
 
-    for expr in &patch.prepended_fields {
-        append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
-            to_df_expr(expr, input_schema, Some(field.data_type()))
+    let append_converted = |pairs: &mut Vec<(String, DFExpr)>,
+                            output_fields: &mut dyn Iterator<Item = &StructField>,
+                            expr: &KernelExpression|
+     -> DeltaResult<()> {
+        let field = output_fields.next().ok_or_else(|| {
+            Error::generic("StructPatch produced more fields than the output schema has")
         })?;
+        let value = to_df_expr(expr, input_schema, Some(field.data_type()))?;
+        pairs.push((field.name().to_string(), value));
+        Ok(())
+    };
+    let append_existing = |pairs: &mut Vec<(String, DFExpr)>,
+                           output_fields: &mut dyn Iterator<Item = &StructField>,
+                           name: &str|
+     -> DeltaResult<()> {
+        let field = output_fields.next().ok_or_else(|| {
+            Error::generic("StructPatch produced more fields than the output schema has")
+        })?;
+        let value = match &source_expr {
+            Some(base) => get_field(base.clone(), name.to_string()),
+            None => DFExpr::Column(DFColumn::new_unqualified(name)),
+        };
+        pairs.push((field.name().to_string(), value));
+        Ok(())
+    };
+
+    for expr in &patch.prepended_fields {
+        append_converted(&mut pairs, &mut output_fields, expr)?;
     }
 
     // Should only count required field patches (excluding optional) for missing input fields
@@ -343,21 +367,14 @@ fn struct_columns_from_patch(
         let field_patch = patch.field_patches.get(name);
 
         if field_patch.is_none_or(|fp| fp.keep_input) {
-            append_struct_patch_field(&mut pairs, &mut output_fields, |_| {
-                Ok(match &source_expr {
-                    Some(base) => get_field(base.clone(), name.to_string()),
-                    None => DFExpr::Column(DFColumn::new_unqualified(name)),
-                })
-            })?;
+            append_existing(&mut pairs, &mut output_fields, name)?;
         }
 
         let Some(field_patch) = field_patch else {
             continue;
         };
         for expr in &field_patch.insertions {
-            append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
-                to_df_expr(expr, input_schema, Some(field.data_type()))
-            })?;
+            append_converted(&mut pairs, &mut output_fields, expr)?;
         }
         if !field_patch.optional {
             used_required_field_patches += 1;
@@ -376,9 +393,7 @@ fn struct_columns_from_patch(
     }
 
     for expr in &patch.appended_fields {
-        append_struct_patch_field(&mut pairs, &mut output_fields, |field| {
-            to_df_expr(expr, input_schema, Some(field.data_type()))
-        })?;
+        append_converted(&mut pairs, &mut output_fields, expr)?;
     }
 
     if output_fields.next().is_some() {
@@ -388,19 +403,6 @@ fn struct_columns_from_patch(
     }
 
     Ok(StructColumns { pairs, null_guard })
-}
-
-fn append_struct_patch_field<'a>(
-    pairs: &mut Vec<(String, DFExpr)>,
-    output_fields: &mut impl Iterator<Item = &'a StructField>,
-    value: impl FnOnce(&StructField) -> DeltaResult<DFExpr>,
-) -> DeltaResult<()> {
-    let field = output_fields.next().ok_or_else(|| {
-        Error::generic("StructPatch produced more fields than the output schema has")
-    })?;
-    let value = value(field)?;
-    pairs.push((field.name().to_string(), value));
-    Ok(())
 }
 
 /// Lowers a `MapToStruct` (reshape a `Map<String, String>` into a struct by parsing each value into

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -15,20 +15,18 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
 use datafusion::common::{DFSchema, DataFusionError};
 use datafusion::logical_expr::{
-    col as df_col, lit as df_lit, EmptyRelation, Expr as DFExpr, ExprSchemable,
-    Filter as DFFilter,
+    col as df_col, lit as df_lit, EmptyRelation, Expr as DFExpr, ExprSchemable, Filter as DFFilter,
     LogicalPlan as DFLogicalPlan, LogicalPlanBuilder, Projection as DFProjection,
 };
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
-use delta_kernel::expressions::{Expression as KernelExpression, Scalar as KernelScalar};
+use delta_kernel::expressions::Scalar as KernelScalar;
 use delta_kernel::plans::ir::nodes::{
     Filter as KernelFilter, Operator as KernelOperator, Project as KernelProject,
     Values as KernelValues,
 };
 use delta_kernel::schema::StructType;
-use delta_kernel::DeltaResult;
 
-use crate::expression::{struct_null_when_not, to_df_struct_columns};
+use crate::expression::to_df_struct_columns;
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
 
@@ -91,8 +89,9 @@ fn lower_project(
     let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
     let arrow_schema: ArrowSchema = project.schema.as_ref().try_into_arrow()?;
     let df_schema = Arc::new(DFSchema::try_from(arrow_schema)?);
-    let columns = project_output_columns(&project.expr, &input_schema, project.schema.as_ref())
-        .map_err(|error| DataFusionError::External(Box::new(error)))?;
+    let columns = to_df_struct_columns(&project.expr, &input_schema, project.schema.as_ref())
+        .map_err(|error| DataFusionError::External(Box::new(error)))?
+        .into_guarded_columns();
     let exprs: Result<Vec<DFExpr>, DataFusionError> = columns
         .into_iter()
         .zip(project.schema.fields())
@@ -165,24 +164,6 @@ fn lower_row(row: &[KernelScalar]) -> Result<Vec<DFExpr>, DataFusionError> {
     row.iter().map(lower_literal).collect()
 }
 
-/// Flattens a [`KernelProject`]'s struct output and applies its row-level null guard to every
-/// output column.
-fn project_output_columns(
-    expr: &KernelExpression,
-    input_schema: &StructType,
-    output_type: &StructType,
-) -> DeltaResult<Vec<(String, DFExpr)>> {
-    let (columns, null_guard) = to_df_struct_columns(expr, input_schema, output_type)?;
-    let Some(guard) = null_guard else {
-        return Ok(columns);
-    };
-    let guarded = columns
-        .into_iter()
-        .map(|(name, value)| (name, struct_null_when_not(guard.clone(), value)))
-        .collect();
-    Ok(guarded)
-}
-
 #[cfg(test)]
 mod tests {
     use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
@@ -192,12 +173,15 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
     use delta_kernel::expressions::{
-        col, lit, ArrayData as KernelArrayData, BinaryPredicateOp as KernelBinaryPredicateOp,
-        Expression as KernelExpr, ExpressionStructPatch, ExpressionStructPatchBuilder,
-        JunctionPredicateOp as KernelJunctionPredicateOp, MapData as KernelMapData,
-        Predicate as KernelPredicate, StructData as KernelStructData,
+        col, lit as kernel_lit, null_lit, ArrayData as KernelArrayData,
+        BinaryPredicateOp as KernelBinaryPredicateOp, Expression as KernelExpr, ExpressionRef,
+        ExpressionStructPatchBuilder, JunctionPredicateOp as KernelJunctionPredicateOp,
+        MapData as KernelMapData, Predicate as KernelPredicate, StructData as KernelStructData,
     };
-    use delta_kernel::schema::{schema, ArrayType, DataType, MapType, StructField, StructType};
+    use delta_kernel::schema::{
+        schema, ArrayType, DataType, MapType, SchemaRef, StructField, StructType,
+    };
+    use delta_kernel::struct_patch::ProjectionStructPatchBuilder;
     use rstest::rstest;
 
     use super::*;
@@ -518,27 +502,39 @@ mod tests {
     #[rstest]
     #[case::is_null(KernelPredicate::is_null(col!("a")), NULL_ROW)]
     #[case::equal(
-        KernelPredicate::binary(KernelBinaryPredicateOp::Equal, col!("a"), lit(5i64)),
+        KernelPredicate::binary(KernelBinaryPredicateOp::Equal, col!("a"), kernel_lit(5i64)),
         Y_ROW
     )]
     #[case::less_than(
-        KernelPredicate::binary(KernelBinaryPredicateOp::LessThan, col!("a"), lit(5i64)),
+        KernelPredicate::binary(
+            KernelBinaryPredicateOp::LessThan,
+            col!("a"),
+            kernel_lit(5i64),
+        ),
         X_ROW
     )]
     #[case::greater_than(
-        KernelPredicate::binary(KernelBinaryPredicateOp::GreaterThan, col!("a"), lit(5i64)),
+        KernelPredicate::binary(
+            KernelBinaryPredicateOp::GreaterThan,
+            col!("a"),
+            kernel_lit(5i64),
+        ),
         Z_ROW
     )]
     #[case::distinct(
-        KernelPredicate::binary(KernelBinaryPredicateOp::Distinct, col!("a"), lit(5i64)),
+        KernelPredicate::binary(
+            KernelBinaryPredicateOp::Distinct,
+            col!("a"),
+            kernel_lit(5i64),
+        ),
         NULL_X_AND_Z_ROWS
     )]
     #[case::and(
         KernelPredicate::junction(
             KernelJunctionPredicateOp::And,
             [
-                KernelPredicate::gt(col!("a"), lit(1i64)),
-                KernelPredicate::lt(col!("a"), lit(9i64)),
+                KernelPredicate::gt(col!("a"), kernel_lit(1i64)),
+                KernelPredicate::lt(col!("a"), kernel_lit(9i64)),
             ],
         ),
         Y_ROW
@@ -547,8 +543,8 @@ mod tests {
         KernelPredicate::junction(
             KernelJunctionPredicateOp::Or,
             [
-                KernelPredicate::lt(col!("a"), lit(5i64)),
-                KernelPredicate::gt(col!("a"), lit(5i64)),
+                KernelPredicate::lt(col!("a"), kernel_lit(5i64)),
+                KernelPredicate::gt(col!("a"), kernel_lit(5i64)),
             ],
         ),
         X_AND_Z_ROWS
@@ -604,17 +600,114 @@ mod tests {
 
     /// Lowers a Project over `parent`.
     fn lower_project_expr(
-        expr: KernelExpr,
-        schema: StructType,
+        expr: impl Into<ExpressionRef>,
+        schema: impl Into<SchemaRef>,
         parent: &Arc<DFLogicalPlan>,
     ) -> Result<DFLogicalPlan, DataFusionError> {
         lower_operator(
             &KernelOperator::Project(KernelProject {
                 expr: expr.into(),
-                schema: Arc::new(schema),
+                schema: schema.into(),
             }),
             std::slice::from_ref(parent),
         )
+    }
+
+    fn project_nested_schema() -> StructType {
+        StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap()
+    }
+
+    fn project_input_schema() -> StructType {
+        StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::LONG),
+            StructField::nullable("flag", DataType::BOOLEAN),
+            StructField::nullable("small", DataType::INTEGER),
+            StructField::nullable("nested", project_nested_schema()),
+        ])
+        .unwrap()
+    }
+
+    fn project_nested_value(value: i32) -> KernelScalar {
+        let schema = project_nested_schema();
+        KernelScalar::Struct(
+            KernelStructData::try_new(
+                schema.fields().cloned().collect(),
+                vec![KernelScalar::Integer(value)],
+            )
+            .unwrap(),
+        )
+    }
+
+    fn project_input() -> Arc<DFLogicalPlan> {
+        let rows = vec![
+            vec![
+                10i64.into(),
+                2i64.into(),
+                true.into(),
+                1i32.into(),
+                project_nested_value(7),
+            ],
+            vec![
+                20i64.into(),
+                KernelScalar::null(DataType::LONG),
+                false.into(),
+                2i32.into(),
+                project_nested_value(8),
+            ],
+            vec![
+                KernelScalar::null(DataType::LONG),
+                4i64.into(),
+                KernelScalar::null(DataType::BOOLEAN),
+                3i32.into(),
+                KernelScalar::null(project_nested_schema()),
+            ],
+        ];
+        Arc::new(lower_values_node(project_input_schema(), rows).unwrap())
+    }
+
+    fn struct_project(
+        fields: impl IntoIterator<Item = (StructField, KernelExpr)>,
+    ) -> (SchemaRef, ExpressionRef) {
+        let (fields, exprs): (Vec<_>, Vec<_>) = fields.into_iter().unzip();
+        (
+            Arc::new(StructType::try_new(fields).unwrap()),
+            KernelExpr::struct_from(exprs).into(),
+        )
+    }
+
+    fn guarded_struct_project(
+        fields: impl IntoIterator<Item = (StructField, KernelExpr)>,
+        guard: KernelExpr,
+    ) -> (SchemaRef, ExpressionRef) {
+        let (fields, exprs): (Vec<_>, Vec<_>) = fields.into_iter().unzip();
+        (
+            Arc::new(StructType::try_new(fields).unwrap()),
+            KernelExpr::struct_with_nullability_from(exprs, guard).into(),
+        )
+    }
+
+    fn struct_patch_project() -> (SchemaRef, ExpressionRef) {
+        let input = project_input_schema();
+        ProjectionStructPatchBuilder::new(&input)
+            .replace_expr("b", KernelExpr::coalesce([col!("b"), kernel_lit(99i64)]))
+            .drop("flag")
+            .drop("small")
+            .drop("nested")
+            .append(
+                StructField::nullable("sum", DataType::LONG),
+                col!("a") + KernelExpr::coalesce([col!("b"), kernel_lit(99i64)]),
+            )
+            .build()
+            .unwrap()
+    }
+
+    fn nested_struct_patch_project() -> (SchemaRef, ExpressionRef) {
+        let input = project_input_schema();
+        ProjectionStructPatchBuilder::new_nested(&input, ["nested"])
+            .replace_expr("value", col!("nested.value") + kernel_lit(1i32))
+            .build()
+            .unwrap()
     }
 
     #[rstest]
@@ -684,43 +777,33 @@ mod tests {
 
     #[rstest]
     #[case::replace(
-        ExpressionStructPatchBuilder::new()
-            .replace("a", KernelExpr::literal(7i64))
+        ProjectionStructPatchBuilder::new(&test_schema())
+            .replace_expr("a", KernelExpr::literal(7i64))
             .build()
             .unwrap(),
-        StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::STRING),
-        ]).unwrap(),
         vec!["a", "b"]
     )]
     #[case::drop(
-        ExpressionStructPatchBuilder::new().drop("a").build().unwrap(),
-        StructType::try_new([
-            StructField::nullable("b", DataType::STRING),
-        ]).unwrap(),
+        ProjectionStructPatchBuilder::new(&test_schema()).drop("a").build().unwrap(),
         vec!["b"]
     )]
     #[case::inject(
-        ExpressionStructPatchBuilder::new()
-            .append(KernelExpr::literal(7i64))
+        ProjectionStructPatchBuilder::new(&test_schema())
+            .append(
+                StructField::nullable("injected", DataType::LONG),
+                KernelExpr::literal(7i64),
+            )
             .build()
             .unwrap(),
-        StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::STRING),
-            StructField::nullable("injected", DataType::LONG),
-        ]).unwrap(),
         vec!["a", "b", "injected"]
     )]
     fn project_lowers_struct_patch(
-        #[case] patch: ExpressionStructPatch,
-        #[case] output: StructType,
+        #[case] project: (SchemaRef, ExpressionRef),
         #[case] expected_names: Vec<&str>,
     ) {
-        let parent = input_with_schema(test_schema());
-        let expr = KernelExpr::struct_patch(patch).unwrap();
-        let lowered = lower_project_expr(expr, output, &parent).unwrap();
+        let input = input_with_schema(test_schema());
+        let (output, expr) = project;
+        let lowered = lower_project_expr(expr, output, &input).unwrap();
         assert_eq!(output_names(&lowered), expected_names);
     }
 
@@ -876,21 +959,208 @@ mod tests {
         assert_eq!(output_types(&lowered), expected_types);
     }
 
+    #[rstest]
+    #[case::literal_column_and_cast(
+        struct_project([
+            (StructField::nullable("selected", DataType::LONG), col!("a")),
+            (StructField::nullable("literal", DataType::STRING), kernel_lit("constant")),
+            (
+                StructField::nullable("null_value", DataType::LONG),
+                null_lit(DataType::LONG),
+            ),
+            (StructField::nullable("widened", DataType::LONG), col!("small")),
+        ]),
+        &[
+            "+----------+----------+------------+---------+",
+            "| selected | literal  | null_value | widened |",
+            "+----------+----------+------------+---------+",
+            "| 10       | constant |            | 1       |",
+            "| 20       | constant |            | 2       |",
+            "|          | constant |            | 3       |",
+            "+----------+----------+------------+---------+",
+        ]
+    )]
+    #[case::arithmetic(
+        struct_project([
+            (StructField::nullable("sum", DataType::LONG), col!("a") + col!("b")),
+            (
+                StructField::nullable("difference", DataType::LONG),
+                col!("a") - col!("b"),
+            ),
+            (
+                StructField::nullable("product", DataType::LONG),
+                col!("a") * col!("b"),
+            ),
+            (
+                StructField::nullable("quotient", DataType::LONG),
+                col!("a") / col!("b"),
+            ),
+        ]),
+        &[
+            "+-----+------------+---------+----------+",
+            "| sum | difference | product | quotient |",
+            "+-----+------------+---------+----------+",
+            "| 12  | 8          | 20      | 5        |",
+            "|     |            |         |          |",
+            "|     |            |         |          |",
+            "+-----+------------+---------+----------+",
+        ]
+    )]
+    #[case::variadic(
+        struct_project([
+            (
+                StructField::nullable("coalesced", DataType::LONG),
+                KernelExpr::coalesce([col!("b"), col!("a"), kernel_lit(99i64)]),
+            ),
+            (
+                StructField::nullable(
+                    "array",
+                    ArrayType::new(DataType::LONG, true),
+                ),
+                KernelExpr::array([col!("a"), col!("b"), kernel_lit(5i64)]),
+            ),
+        ]),
+        &[
+            "+-----------+------------+",
+            "| coalesced | array      |",
+            "+-----------+------------+",
+            "| 2         | [10, 2, 5] |",
+            "| 20        | [20, , 5]  |",
+            "| 4         | [, 4, 5]   |",
+            "+-----------+------------+",
+        ]
+    )]
+    #[case::predicate(
+        struct_project([
+            (
+                StructField::nullable("is_null", DataType::BOOLEAN),
+                KernelExpr::from_pred(col!("b").is_null()),
+            ),
+            (
+                StructField::nullable("greater", DataType::BOOLEAN),
+                KernelExpr::from_pred(col!("a").gt(kernel_lit(15i64))),
+            ),
+            (
+                StructField::nullable("conjunction", DataType::BOOLEAN),
+                KernelExpr::from_pred(KernelPredicate::and(
+                    col!("a").is_not_null(),
+                    col!("b").lt(kernel_lit(3i64)),
+                )),
+            ),
+            (
+                StructField::nullable("distinct", DataType::BOOLEAN),
+                KernelExpr::from_pred(col!("a").distinct(col!("b"))),
+            ),
+        ]),
+        &[
+            "+---------+---------+-------------+----------+",
+            "| is_null | greater | conjunction | distinct |",
+            "+---------+---------+-------------+----------+",
+            "| false   | false   | true        | true     |",
+            "| true    | true    |             | true     |",
+            "| false   |         | false       | true     |",
+            "+---------+---------+-------------+----------+",
+        ]
+    )]
+    #[case::nested_struct(
+        struct_project([(
+            StructField::nullable(
+                "record",
+                StructType::try_new([
+                    StructField::nullable("value", DataType::LONG),
+                    StructField::nullable("label", DataType::STRING),
+                ]).unwrap(),
+            ),
+            KernelExpr::struct_with_nullability_from(
+                [col!("nested.value"), kernel_lit("seen")],
+                KernelExpr::from_pred(col!("nested").is_not_null()),
+            ),
+        )]),
+        &[
+            "+-------------------------+",
+            "| record                  |",
+            "+-------------------------+",
+            "| {value: 7, label: seen} |",
+            "| {value: 8, label: seen} |",
+            "|                         |",
+            "+-------------------------+",
+        ]
+    )]
+    #[case::array_of_structs(
+        struct_project([(
+            StructField::nullable(
+                "records",
+                ArrayType::new(
+                    StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
+                    true,
+                ),
+            ),
+            KernelExpr::array([
+                KernelExpr::struct_from([col!("a")]),
+                KernelExpr::struct_from([col!("b")]),
+            ]),
+        )]),
+        &[
+            "+---------------------------+",
+            "| records                   |",
+            "+---------------------------+",
+            "| [{value: 10}, {value: 2}] |",
+            "| [{value: 20}, {value: }]  |",
+            "| [{value: }, {value: 4}]   |",
+            "+---------------------------+",
+        ]
+    )]
+    #[case::top_level_nullability(
+        guarded_struct_project(
+            [
+                (StructField::nullable("a", DataType::LONG), col!("a")),
+                (StructField::nullable("b", DataType::LONG), col!("b")),
+            ],
+            col!("flag"),
+        ),
+        &[
+            "+----+---+",
+            "| a  | b |",
+            "+----+---+",
+            "| 10 | 2 |",
+            "|    |   |",
+            "|    |   |",
+            "+----+---+",
+        ]
+    )]
+    #[case::struct_patch(
+        struct_patch_project(),
+        &[
+            "+----+----+-----+",
+            "| a  | b  | sum |",
+            "+----+----+-----+",
+            "| 10 | 2  | 12  |",
+            "| 20 | 99 | 119 |",
+            "|    | 4  |     |",
+            "+----+----+-----+",
+        ]
+    )]
+    #[case::nested_struct_patch(
+        nested_struct_patch_project(),
+        &[
+            "+-------+",
+            "| value |",
+            "+-------+",
+            "| 8     |",
+            "| 9     |",
+            "|       |",
+            "+-------+",
+        ]
+    )]
     #[tokio::test]
-    async fn project_executes_integer_to_long_cast() {
-        let input = StructType::try_new([StructField::nullable("a", DataType::INTEGER)]).unwrap();
-        let parent =
-            Arc::new(lower_values_node(input, vec![vec![KernelScalar::Integer(7)]]).unwrap());
-        let output = StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap();
-        let lowered =
-            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap();
-
+    async fn project_executes_expression(
+        #[case] project: (SchemaRef, ExpressionRef),
+        #[case] expected: &[&str],
+    ) {
+        let (output, expr) = project;
+        let lowered = lower_project_expr(expr, output, &project_input()).unwrap();
         let batches = execute(lowered).await.unwrap();
-        assert_batches_eq!(&["+---+", "| a |", "+---+", "| 7 |", "+---+",], &batches);
-        assert_eq!(
-            batches[0].schema().field(0).data_type(),
-            &ArrowDataType::Int64
-        );
+        assert_batches_eq!(expected, &batches);
     }
 
     #[tokio::test]
@@ -909,44 +1179,6 @@ mod tests {
                 .contains("Cannot cast string 'abc' to value of Int32 type"),
             "{err}"
         );
-    }
-
-    #[tokio::test]
-    async fn project_executes_nested_integer_to_long_cast() {
-        let input_nested =
-            StructType::try_new([StructField::nullable("leaf", DataType::INTEGER)]).unwrap();
-        let input =
-            StructType::try_new([StructField::nullable("nested", input_nested.clone())]).unwrap();
-        let nested = KernelScalar::Struct(
-            KernelStructData::try_new(
-                input_nested.fields().cloned().collect(),
-                vec![KernelScalar::Integer(7)],
-            )
-            .unwrap(),
-        );
-        let parent = Arc::new(lower_values_node(input, vec![vec![nested]]).unwrap());
-        let output_nested =
-            StructType::try_new([StructField::nullable("leaf", DataType::LONG)]).unwrap();
-        let output = StructType::try_new([StructField::nullable("nested", output_nested)]).unwrap();
-        let lowered =
-            lower_project_expr(KernelExpr::struct_from([col!("nested")]), output, &parent).unwrap();
-
-        let batches = execute(lowered).await.unwrap();
-        assert_batches_eq!(
-            &[
-                "+-----------+",
-                "| nested    |",
-                "+-----------+",
-                "| {leaf: 7} |",
-                "+-----------+",
-            ],
-            &batches
-        );
-        let schema = batches[0].schema();
-        let ArrowDataType::Struct(fields) = schema.field(0).data_type() else {
-            panic!("expected nested struct");
-        };
-        assert_eq!(fields[0].data_type(), &ArrowDataType::Int64);
     }
 
     #[test]

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -13,18 +13,22 @@
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
-use datafusion::common::DataFusionError;
+use datafusion::common::{DFSchema, DataFusionError};
 use datafusion::logical_expr::{
-    col as df_col, lit as df_lit, EmptyRelation, Expr as DFExpr, Filter as DFFilter,
-    LogicalPlan as DFLogicalPlan, LogicalPlanBuilder,
+    col as df_col, lit as df_lit, EmptyRelation, Expr as DFExpr, ExprSchemable,
+    Filter as DFFilter,
+    LogicalPlan as DFLogicalPlan, LogicalPlanBuilder, Projection as DFProjection,
 };
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
-use delta_kernel::expressions::Scalar as KernelScalar;
+use delta_kernel::expressions::{Expression as KernelExpression, Scalar as KernelScalar};
 use delta_kernel::plans::ir::nodes::{
-    Filter as KernelFilter, Operator as KernelOperator, Values as KernelValues,
+    Filter as KernelFilter, Operator as KernelOperator, Project as KernelProject,
+    Values as KernelValues,
 };
 use delta_kernel::schema::StructType;
+use delta_kernel::DeltaResult;
 
+use crate::expression::{struct_null_when_not, to_df_struct_columns};
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
 
@@ -50,18 +54,56 @@ pub(crate) fn lower_operator(
             };
             lower_values(values)
         }
+        KernelOperator::Project(project) => {
+            let [input] = inputs else {
+                return Err(input_count_error(1));
+            };
+            lower_project(project, input)
+        }
         KernelOperator::Filter(filter) => {
             let [input] = inputs else {
                 return Err(input_count_error(1));
             };
             lower_filter(filter, input)
         }
-        // TODO: lower the remaining operators (scans, Project/Load/Aggregate, SemiJoin, UnionAll),
-        // each in its own change.
+        // TODO: lower the remaining operators (scans, Load/Aggregate, SemiJoin, UnionAll), each
+        // in its own change.
         _ => Err(DataFusionError::NotImplemented(format!(
             "lowering operator {op} to a DataFusion LogicalPlan"
         ))),
     }
+}
+
+/// Lowers a [`Project`](KernelProject) to a single DataFusion projection.
+///
+/// A kernel Project holds a struct expression and its declared output schema, while DataFusion
+/// expects a flat expression list. Each struct field is therefore lowered, cast to its declared
+/// type, and aliased with its declared name before the declared output schema is attached to the
+/// DataFusion projection.
+///
+/// # Errors
+/// Returns an error if the Project expression is not a `Struct`/`StructPatch`, lowering a field or
+/// its nullability guard fails, or DataFusion cannot cast a field to its declared type.
+fn lower_project(
+    project: &KernelProject,
+    input: &Arc<DFLogicalPlan>,
+) -> Result<DFLogicalPlan, DataFusionError> {
+    let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
+    let arrow_schema: ArrowSchema = project.schema.as_ref().try_into_arrow()?;
+    let df_schema = Arc::new(DFSchema::try_from(arrow_schema)?);
+    let columns = project_output_columns(&project.expr, &input_schema, project.schema.as_ref())
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
+    let exprs: Result<Vec<DFExpr>, DataFusionError> = columns
+        .into_iter()
+        .zip(project.schema.fields())
+        .map(|((name, expr), field)| {
+            let target = field.data_type().try_into_arrow()?;
+            let expr = expr.cast_to(&target, input.schema())?.alias(name);
+            Ok(expr)
+        })
+        .collect();
+    let projection = DFProjection::try_new_with_schema(exprs?, Arc::clone(input), df_schema)?;
+    Ok(DFLogicalPlan::Projection(projection))
 }
 
 /// Lowers a [`Filter`](KernelFilter) node into a DataFusion [`Filter`](DFFilter) logical plan over
@@ -123,13 +165,35 @@ fn lower_row(row: &[KernelScalar]) -> Result<Vec<DFExpr>, DataFusionError> {
     row.iter().map(lower_literal).collect()
 }
 
+/// Flattens a [`KernelProject`]'s struct output and applies its row-level null guard to every
+/// output column.
+fn project_output_columns(
+    expr: &KernelExpression,
+    input_schema: &StructType,
+    output_type: &StructType,
+) -> DeltaResult<Vec<(String, DFExpr)>> {
+    let (columns, null_guard) = to_df_struct_columns(expr, input_schema, output_type)?;
+    let Some(guard) = null_guard else {
+        return Ok(columns);
+    };
+    let guarded = columns
+        .into_iter()
+        .map(|(name, value)| (name, struct_null_when_not(guard.clone(), value)))
+        .collect();
+    Ok(guarded)
+}
+
 #[cfg(test)]
 mod tests {
+    use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
     use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::common::ScalarValue as DFScalarValue;
+    use datafusion::logical_expr::{col as df_col, Case};
     use datafusion::prelude::SessionContext;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
     use delta_kernel::expressions::{
         col, lit, ArrayData as KernelArrayData, BinaryPredicateOp as KernelBinaryPredicateOp,
+        Expression as KernelExpr, ExpressionStructPatch, ExpressionStructPatchBuilder,
         JunctionPredicateOp as KernelJunctionPredicateOp, MapData as KernelMapData,
         Predicate as KernelPredicate, StructData as KernelStructData,
     };
@@ -517,6 +581,454 @@ mod tests {
             err.to_string()
                 .contains(&format!("filter expects 1 input(s), but received {actual}")),
             "{err}"
+        );
+    }
+
+    // === Project ===
+
+    fn empty_schema() -> StructType {
+        let fields: Vec<StructField> = Vec::new();
+        StructType::try_new(fields).unwrap()
+    }
+
+    /// The field names DataFusion reports for `plan`'s output columns.
+    fn output_names(plan: &DFLogicalPlan) -> Vec<&String> {
+        plan.schema().fields().iter().map(|f| f.name()).collect()
+    }
+
+    /// The Arrow types DataFusion reports for `plan`'s output columns.
+    fn output_types(plan: &DFLogicalPlan) -> Vec<ArrowDataType> {
+        let fields = plan.schema().fields();
+        fields.iter().map(|f| f.data_type().clone()).collect()
+    }
+
+    /// Lowers a Project over `parent`.
+    fn lower_project_expr(
+        expr: KernelExpr,
+        schema: StructType,
+        parent: &Arc<DFLogicalPlan>,
+    ) -> Result<DFLogicalPlan, DataFusionError> {
+        lower_operator(
+            &KernelOperator::Project(KernelProject {
+                expr: expr.into(),
+                schema: Arc::new(schema),
+            }),
+            std::slice::from_ref(parent),
+        )
+    }
+
+    #[rstest]
+    #[case::missing(0)]
+    #[case::extra(2)]
+    fn project_rejects_wrong_parent_count(#[case] actual: usize) {
+        let parent = input_with_schema(test_schema());
+        let parents = vec![parent; actual];
+        let op = KernelOperator::Project(KernelProject {
+            expr: KernelExpr::struct_from([col!("a")]).into(),
+            schema: Arc::new(
+                StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap(),
+            ),
+        });
+        let err = lower_operator(&op, &parents).unwrap_err();
+        assert!(
+            err.to_string().contains(&format!(
+                "project expects 1 input(s), but received {actual}"
+            )),
+            "{err}"
+        );
+    }
+
+    #[rstest]
+    #[case::flat(
+        KernelExpr::struct_from([col!("b"), col!("a")]),
+        StructType::try_new([
+            StructField::nullable("renamed_b", DataType::STRING),
+            StructField::nullable("renamed_a", DataType::LONG),
+        ]).unwrap(),
+        vec!["renamed_b", "renamed_a"]
+    )]
+    #[case::nested(
+        KernelExpr::struct_from([KernelExpr::struct_from([col!("a")])]),
+        StructType::try_new([StructField::nullable(
+            "nested",
+            StructType::try_new([StructField::nullable("leaf", DataType::LONG)]).unwrap(),
+        )]).unwrap(),
+        vec!["nested"]
+    )]
+    fn project_lowers_single_projection_with_declared_schema(
+        #[case] expr: KernelExpr,
+        #[case] output: StructType,
+        #[case] expected_names: Vec<&str>,
+    ) {
+        let expected_arrow: ArrowSchema = (&output).try_into_arrow().unwrap();
+        let expected_types: Vec<ArrowDataType> = expected_arrow
+            .fields()
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect();
+        let parent = input_with_schema(test_schema());
+        let lowered = lower_project_expr(expr, output, &parent).unwrap();
+
+        assert_eq!(output_names(&lowered), expected_names);
+        assert_eq!(output_types(&lowered), expected_types);
+        let DFLogicalPlan::Projection(projection) = &lowered else {
+            panic!("expected Projection, got {lowered:?}");
+        };
+        assert!(Arc::ptr_eq(&projection.input, &parent));
+        assert_eq!(projection.expr.len(), expected_names.len());
+        assert!(matches!(
+            projection.input.as_ref(),
+            DFLogicalPlan::EmptyRelation(_)
+        ));
+    }
+
+    #[rstest]
+    #[case::replace(
+        ExpressionStructPatchBuilder::new()
+            .replace("a", KernelExpr::literal(7i64))
+            .build()
+            .unwrap(),
+        StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::STRING),
+        ]).unwrap(),
+        vec!["a", "b"]
+    )]
+    #[case::drop(
+        ExpressionStructPatchBuilder::new().drop("a").build().unwrap(),
+        StructType::try_new([
+            StructField::nullable("b", DataType::STRING),
+        ]).unwrap(),
+        vec!["b"]
+    )]
+    #[case::inject(
+        ExpressionStructPatchBuilder::new()
+            .append(KernelExpr::literal(7i64))
+            .build()
+            .unwrap(),
+        StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("b", DataType::STRING),
+            StructField::nullable("injected", DataType::LONG),
+        ]).unwrap(),
+        vec!["a", "b", "injected"]
+    )]
+    fn project_lowers_struct_patch(
+        #[case] patch: ExpressionStructPatch,
+        #[case] output: StructType,
+        #[case] expected_names: Vec<&str>,
+    ) {
+        let parent = input_with_schema(test_schema());
+        let expr = KernelExpr::struct_patch(patch).unwrap();
+        let lowered = lower_project_expr(expr, output, &parent).unwrap();
+        assert_eq!(output_names(&lowered), expected_names);
+    }
+
+    #[test]
+    fn project_schema_and_predicate_are_available_to_a_downstream_filter() {
+        let parent = input_with_schema(test_schema());
+        let output =
+            StructType::try_new([StructField::nullable("projected", DataType::LONG)]).unwrap();
+        let projected = Arc::new(
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap(),
+        );
+        let filter = KernelFilter {
+            predicate: KernelPredicate::is_null(col!("projected")).into(),
+        };
+        let filtered = lower_operator(
+            &KernelOperator::Filter(filter),
+            std::slice::from_ref(&projected),
+        )
+        .unwrap();
+        let DFLogicalPlan::Filter(filter) = &filtered else {
+            panic!("expected Filter, got {filtered:?}");
+        };
+        assert_eq!(filter.predicate, df_col("projected").is_null());
+        assert!(Arc::ptr_eq(&filter.input, &projected));
+        assert_eq!(filtered.schema(), projected.schema());
+    }
+
+    /// A boolean nullability guard masks each output column individually (`CASE WHEN guard THEN
+    /// value ELSE NULL`), the per-field equivalent of nulling the whole struct.
+    #[test]
+    fn project_with_boolean_nullability_guard_masks_each_column() {
+        let input = StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+            StructField::nullable("flag", DataType::BOOLEAN),
+        ])
+        .unwrap();
+        let parent = input_with_schema(input);
+        let output = StructType::try_new([StructField::nullable("out", DataType::LONG)]).unwrap();
+        let expr = KernelExpr::struct_with_nullability_from([col!("a")], col!("flag"));
+        let lowered = lower_project_expr(expr, output, &parent).unwrap();
+
+        assert_eq!(output_names(&lowered), ["out"]);
+        assert_eq!(output_types(&lowered), [ArrowDataType::Int64]);
+        let DFLogicalPlan::Projection(projection) = &lowered else {
+            panic!("expected Projection, got {lowered:?}");
+        };
+        let expected = DFExpr::Case(Case::new(
+            None,
+            vec![(Box::new(df_col("flag")), Box::new(df_col("a")))],
+            Some(Box::new(df_lit(DFScalarValue::Null))),
+        ))
+        .alias("out");
+        assert_eq!(projection.expr, [expected]);
+    }
+
+    #[test]
+    fn zero_field_project_lowers_to_empty_projection() {
+        let parent = input_with_schema(test_schema());
+        let lowered = lower_project_expr(
+            KernelExpr::struct_from([] as [KernelExpr; 0]),
+            empty_schema(),
+            &parent,
+        )
+        .unwrap();
+        assert!(lowered.schema().fields().is_empty());
+        let DFLogicalPlan::Projection(project) = &lowered else {
+            panic!("expected Projection");
+        };
+        assert!(project.expr.is_empty());
+    }
+
+    #[rstest]
+    #[case::unknown(KernelExpr::unknown("engine_expr"), "must be a Struct or StructPatch")]
+    #[case::non_struct(KernelExpr::literal(1i64), "must be a Struct or StructPatch")]
+    #[case::unresolved_nullability(
+        KernelExpr::struct_with_nullability_from(
+            [] as [KernelExpr; 0],
+            col!("missing")
+        ),
+        "missing"
+    )]
+    #[case::malformed_patch(
+        KernelExpr::struct_patch(ExpressionStructPatchBuilder::new()).unwrap(),
+        "produced more fields"
+    )]
+    fn zero_field_project_rejects_invalid_expression(
+        #[case] expr: KernelExpr,
+        #[case] expected_message: &str,
+    ) {
+        let parent = input_with_schema(test_schema());
+        let err = lower_project_expr(expr, empty_schema(), &parent).unwrap_err();
+        assert!(err.to_string().contains(expected_message), "{err}");
+    }
+
+    #[test]
+    fn project_rejects_uncastable_output_type() {
+        let parent = input_with_schema(test_schema());
+        let output =
+            StructType::try_new([StructField::nullable("a", DataType::unshredded_variant())])
+                .unwrap();
+        let err =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(&err, DataFusionError::Plan(_)), "{message}");
+        assert!(
+            message.contains("Cannot automatically convert"),
+            "{message}"
+        );
+    }
+
+    #[rstest]
+    #[case::primitive(
+        StructType::try_new([
+            StructField::nullable("a", DataType::INTEGER),
+        ]).unwrap(),
+        KernelExpr::struct_from([col!("a")]),
+        StructType::try_new([
+            StructField::nullable("a", DataType::LONG),
+        ]).unwrap()
+    )]
+    #[case::nested(
+        StructType::try_new([
+            StructField::nullable(
+                "nested",
+                StructType::try_new([
+                    StructField::nullable("leaf", DataType::INTEGER),
+                ]).unwrap(),
+            ),
+        ]).unwrap(),
+        KernelExpr::struct_from([col!("nested")]),
+        StructType::try_new([
+            StructField::nullable(
+                "nested",
+                StructType::try_new([
+                    StructField::nullable("leaf", DataType::LONG),
+                ]).unwrap(),
+            ),
+        ]).unwrap()
+    )]
+    fn project_casts_output_to_declared_type(
+        #[case] input: StructType,
+        #[case] expr: KernelExpr,
+        #[case] output: StructType,
+    ) {
+        let expected: ArrowSchema = (&output).try_into_arrow().unwrap();
+        let expected_types: Vec<ArrowDataType> = expected
+            .fields()
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect();
+        let parent = input_with_schema(input);
+        let lowered = lower_project_expr(expr, output, &parent).unwrap();
+        assert_eq!(output_types(&lowered), expected_types);
+    }
+
+    #[tokio::test]
+    async fn project_executes_integer_to_long_cast() {
+        let input = StructType::try_new([StructField::nullable("a", DataType::INTEGER)]).unwrap();
+        let parent =
+            Arc::new(lower_values_node(input, vec![vec![KernelScalar::Integer(7)]]).unwrap());
+        let output = StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap();
+        let lowered =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap();
+
+        let batches = execute(lowered).await.unwrap();
+        assert_batches_eq!(&["+---+", "| a |", "+---+", "| 7 |", "+---+",], &batches);
+        assert_eq!(
+            batches[0].schema().field(0).data_type(),
+            &ArrowDataType::Int64
+        );
+    }
+
+    #[tokio::test]
+    async fn project_rejects_invalid_cast_value_during_execution() {
+        let input = StructType::try_new([StructField::nullable("a", DataType::STRING)]).unwrap();
+        let parent = Arc::new(
+            lower_values_node(input, vec![vec![KernelScalar::String("abc".into())]]).unwrap(),
+        );
+        let output = StructType::try_new([StructField::nullable("a", DataType::INTEGER)]).unwrap();
+        let lowered =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap();
+
+        let err = execute(lowered).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Cannot cast string 'abc' to value of Int32 type"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn project_executes_nested_integer_to_long_cast() {
+        let input_nested =
+            StructType::try_new([StructField::nullable("leaf", DataType::INTEGER)]).unwrap();
+        let input =
+            StructType::try_new([StructField::nullable("nested", input_nested.clone())]).unwrap();
+        let nested = KernelScalar::Struct(
+            KernelStructData::try_new(
+                input_nested.fields().cloned().collect(),
+                vec![KernelScalar::Integer(7)],
+            )
+            .unwrap(),
+        );
+        let parent = Arc::new(lower_values_node(input, vec![vec![nested]]).unwrap());
+        let output_nested =
+            StructType::try_new([StructField::nullable("leaf", DataType::LONG)]).unwrap();
+        let output = StructType::try_new([StructField::nullable("nested", output_nested)]).unwrap();
+        let lowered =
+            lower_project_expr(KernelExpr::struct_from([col!("nested")]), output, &parent).unwrap();
+
+        let batches = execute(lowered).await.unwrap();
+        assert_batches_eq!(
+            &[
+                "+-----------+",
+                "| nested    |",
+                "+-----------+",
+                "| {leaf: 7} |",
+                "+-----------+",
+            ],
+            &batches
+        );
+        let schema = batches[0].schema();
+        let ArrowDataType::Struct(fields) = schema.field(0).data_type() else {
+            panic!("expected nested struct");
+        };
+        assert_eq!(fields[0].data_type(), &ArrowDataType::Int64);
+    }
+
+    #[test]
+    fn project_normalizes_kernel_compatible_arrow_representations() {
+        let expected = StructType::try_new([
+            StructField::nullable("string", DataType::STRING),
+            StructField::nullable("array", ArrayType::new(DataType::LONG, true)),
+            StructField::nullable(
+                "map",
+                MapType::new(DataType::STRING, DataType::STRING, true),
+            ),
+        ])
+        .unwrap();
+        let map_entries = ArrowDataType::Struct(
+            vec![
+                Arc::new(ArrowField::new("key", ArrowDataType::Utf8View, false)),
+                Arc::new(ArrowField::new("value", ArrowDataType::Utf8View, true)),
+            ]
+            .into(),
+        );
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("string", ArrowDataType::Utf8View, true),
+            ArrowField::new(
+                "array",
+                ArrowDataType::LargeList(Arc::new(ArrowField::new(
+                    "element",
+                    ArrowDataType::Int64,
+                    true,
+                ))),
+                true,
+            ),
+            ArrowField::new(
+                "map",
+                ArrowDataType::Map(
+                    Arc::new(ArrowField::new("entries", map_entries, false)),
+                    false,
+                ),
+                true,
+            ),
+        ]);
+        let empty = EmptyRelation {
+            produce_one_row: false,
+            schema: Arc::new(DFSchema::try_from(arrow_schema).unwrap()),
+        };
+        let parent = Arc::new(DFLogicalPlan::EmptyRelation(empty));
+        let output: ArrowSchema = (&expected).try_into_arrow().unwrap();
+        let expected_types: Vec<ArrowDataType> = output
+            .fields()
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect();
+        let expr = KernelExpr::struct_from([col!("string"), col!("array"), col!("map")]);
+
+        let lowered = lower_project_expr(expr, expected, &parent).unwrap();
+        assert_eq!(output_types(&lowered), expected_types);
+    }
+
+    #[rstest]
+    #[case::interval(DataType::INTERVAL_YEAR_MONTH)]
+    #[case::variant(DataType::unshredded_variant())]
+    fn project_preserves_kernel_physical_type(#[case] data_type: DataType) {
+        let schema = StructType::try_new([StructField::nullable("a", data_type)]).unwrap();
+        let expected: ArrowSchema = (&schema).try_into_arrow().unwrap();
+        let expected_type = expected.field(0).data_type().clone();
+        let parent = input_with_schema(schema.clone());
+        let lowered =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), schema, &parent).unwrap();
+        assert_eq!(output_types(&lowered), [expected_type]);
+    }
+
+    /// Errors from converting a Project's child expression propagate to the caller.
+    #[test]
+    fn project_propagates_expression_conversion_error() {
+        let parent = input_with_schema(test_schema());
+        let output = StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap();
+        let expr = KernelExpr::struct_from([KernelExpr::unknown("engine_expr")]);
+        let err = lower_project_expr(expr, output, &parent).unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(&err, DataFusionError::External(_)), "{message}");
+        assert!(
+            message.contains(r#"cannot convert Unknown expression "engine_expr""#),
+            "{message}"
         );
     }
 }

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -775,38 +775,6 @@ mod tests {
         ));
     }
 
-    #[rstest]
-    #[case::replace(
-        ProjectionStructPatchBuilder::new(&test_schema())
-            .replace_expr("a", KernelExpr::literal(7i64))
-            .build()
-            .unwrap(),
-        vec!["a", "b"]
-    )]
-    #[case::drop(
-        ProjectionStructPatchBuilder::new(&test_schema()).drop("a").build().unwrap(),
-        vec!["b"]
-    )]
-    #[case::inject(
-        ProjectionStructPatchBuilder::new(&test_schema())
-            .append(
-                StructField::nullable("injected", DataType::LONG),
-                KernelExpr::literal(7i64),
-            )
-            .build()
-            .unwrap(),
-        vec!["a", "b", "injected"]
-    )]
-    fn project_lowers_struct_patch(
-        #[case] project: (SchemaRef, ExpressionRef),
-        #[case] expected_names: Vec<&str>,
-    ) {
-        let input = input_with_schema(test_schema());
-        let (output, expr) = project;
-        let lowered = lower_project_expr(expr, output, &input).unwrap();
-        assert_eq!(output_names(&lowered), expected_names);
-    }
-
     #[test]
     fn project_schema_and_predicate_are_available_to_a_downstream_filter() {
         let parent = input_with_schema(test_schema());
@@ -1126,6 +1094,54 @@ mod tests {
             "|    |   |",
             "|    |   |",
             "+----+---+",
+        ]
+    )]
+    #[case::struct_patch_replace(
+        ProjectionStructPatchBuilder::new(&project_input_schema())
+            .replace_expr("a", kernel_lit(7i64))
+            .build()
+            .unwrap(),
+        &[
+            "+---+---+-------+-------+------------+",
+            "| a | b | flag  | small | nested     |",
+            "+---+---+-------+-------+------------+",
+            "| 7 | 2 | true  | 1     | {value: 7} |",
+            "| 7 |   | false | 2     | {value: 8} |",
+            "| 7 | 4 |       | 3     |            |",
+            "+---+---+-------+-------+------------+",
+        ]
+    )]
+    #[case::struct_patch_drop(
+        ProjectionStructPatchBuilder::new(&project_input_schema())
+            .drop("a")
+            .build()
+            .unwrap(),
+        &[
+            "+---+-------+-------+------------+",
+            "| b | flag  | small | nested     |",
+            "+---+-------+-------+------------+",
+            "| 2 | true  | 1     | {value: 7} |",
+            "|   | false | 2     | {value: 8} |",
+            "| 4 |       | 3     |            |",
+            "+---+-------+-------+------------+",
+        ]
+    )]
+    #[case::struct_patch_inject(
+        ProjectionStructPatchBuilder::new(&project_input_schema())
+            .append(
+                StructField::nullable("injected", DataType::LONG),
+                kernel_lit(7i64),
+            )
+            .build()
+            .unwrap(),
+        &[
+            "+----+---+-------+-------+------------+----------+",
+            "| a  | b | flag  | small | nested     | injected |",
+            "+----+---+-------+-------+------------+----------+",
+            "| 10 | 2 | true  | 1     | {value: 7} | 7        |",
+            "| 20 |   | false | 2     | {value: 8} | 7        |",
+            "|    | 4 |       | 3     |            | 7        |",
+            "+----+---+-------+-------+------------+----------+",
         ]
     )]
     #[case::struct_patch(

--- a/datafusion-executor/src/plan.rs
+++ b/datafusion-executor/src/plan.rs
@@ -62,13 +62,19 @@ pub(crate) fn to_df_plan(plan: &KernelPlan) -> Result<DFLogicalPlan, DataFusionE
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::assert_batches_eq;
     use datafusion::prelude::SessionContext;
-    use delta_kernel::expressions::{col, Predicate as KernelPredicate, Scalar as KernelScalar};
-    use delta_kernel::plans::ir::nodes::Values as KernelValues;
+    use delta_kernel::expressions::{
+        col, Expression as KernelExpr, Predicate as KernelPredicate, Scalar as KernelScalar,
+    };
+    use delta_kernel::plans::ir::nodes::{
+        Filter as KernelFilter, Project as KernelProject, Values as KernelValues,
+    };
     use delta_kernel::plans::ir::plan::PlanNode as KernelPlanNode;
-    use delta_kernel::schema::{schema, DataType, StructType};
+    use delta_kernel::schema::{schema, DataType, StructField, StructType};
     use delta_kernel::PlanBuilder;
     use rstest::rstest;
 
@@ -147,5 +153,38 @@ mod tests {
         .unwrap();
         let batches = execute(&plan).await.unwrap();
         assert_batches_eq!(&["+---+", "| a |", "+---+", "|   |", "+---+"], &batches);
+    }
+
+    #[tokio::test]
+    async fn values_project_filter_composes_through_declared_project_schema() {
+        let project_schema = Arc::new(
+            StructType::try_new([StructField::nullable("projected", DataType::LONG)]).unwrap(),
+        );
+        let project = KernelProject {
+            expr: KernelExpr::struct_from([col!("a")]).into(),
+            schema: project_schema,
+        };
+        let filter = KernelFilter {
+            predicate: KernelPredicate::is_not_null(col!("projected")).into(),
+        };
+        let plan = KernelPlan {
+            nodes: vec![
+                values_node(vec![vec![1i64.into()]]),
+                KernelPlanNode::new(project, vec![0]),
+                KernelPlanNode::new(filter, vec![1]),
+            ],
+        };
+
+        let batches = execute(&plan).await.unwrap();
+        assert_batches_eq!(
+            &[
+                "+-----------+",
+                "| projected |",
+                "+-----------+",
+                "| 1         |",
+                "+-----------+",
+            ],
+            &batches
+        );
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Lowers Project Operator to DataFusion plan. In the previous `Struct`, `StructPatch` implementation, they directly generate the final `named_struct` value. However, `Project` actually takes a list of `Expr` per column. Thus, I refactored out `Struct`, `StructPatch` column `Expr`s into its own dedicated functions, that are exposed to `LogicalPlan` building.

## How was this change tested?
See PR tests.