### PR TITLE
feat: Add catalog managed table support to row tracking change listings.

### DIFF
--- a/kernel/src/commit_range/builder.rs
+++ b/kernel/src/commit_range/builder.rs
@@ -77,6 +77,7 @@ impl CommitRangeBuilder {
                 log_root,
                 start_version,
                 end_version,
+                vec![],
             )?,
         };
 

--- a/kernel/src/commit_range/builder.rs
+++ b/kernel/src/commit_range/builder.rs
@@ -1,7 +1,7 @@
 use url::Url;
 
 use crate::commit_range::CommitRange;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogLoadOptions, LogSegment};
 use crate::path::ParsedLogPath;
 use crate::snapshot::SnapshotRef;
 use crate::{DeltaResult, Engine, Error, Version};
@@ -12,14 +12,13 @@ use crate::{DeltaResult, Engine, Error, Version};
 /// [`CommitRange::builder_from`] (snapshot-based). Supports configuring an end version
 /// and the commit ordering. [`Self::build`] performs delta-log listing and contiguity
 /// validation.
-// TODO(#2781): support UC catalog commit via `with_log_tail(self, Vec<LogPath>)` and
-// `with_max_catalog_version(self, Version)`
 pub struct CommitRangeBuilder {
     table_root: String,
     start_version: Version,
     end_version: Option<Version>,
     snapshot: Option<SnapshotRef>,
     commit_ordering: CommitOrdering,
+    log_load_options: LogLoadOptions,
 }
 
 impl CommitRangeBuilder {
@@ -30,6 +29,7 @@ impl CommitRangeBuilder {
             end_version: None,
             snapshot: None,
             commit_ordering: CommitOrdering::AscendingOrder,
+            log_load_options: LogLoadOptions::default(),
         }
     }
 
@@ -40,6 +40,7 @@ impl CommitRangeBuilder {
             end_version: None,
             snapshot: Some(snapshot.clone()),
             commit_ordering: CommitOrdering::AscendingOrder,
+            log_load_options: LogLoadOptions::default(),
         }
     }
 
@@ -54,6 +55,11 @@ impl CommitRangeBuilder {
     /// [`CommitOrdering::AscendingOrder`].
     pub fn with_ordering(mut self, commit_ordering: CommitOrdering) -> Self {
         self.commit_ordering = commit_ordering;
+        self
+    }
+
+    pub(crate) fn with_log_load_options(mut self, log_load_options: LogLoadOptions) -> Self {
+        self.log_load_options = log_load_options;
         self
     }
 
@@ -72,12 +78,12 @@ impl CommitRangeBuilder {
 
         let log_segment = match &self.snapshot {
             Some(snapshot) => snapshot.log_segment().clone(),
-            None => LogSegment::for_table_changes(
+            None => LogSegment::for_commit_range(
                 engine.storage_handler().as_ref(),
                 log_root,
                 start_version,
                 end_version,
-                vec![],
+                self.log_load_options.clone(),
             )?,
         };
 

--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -109,6 +109,10 @@ impl CommitRange {
         &self.table_root
     }
 
+    pub(crate) fn commit_files(&self) -> &[ParsedLogPath] {
+        &self.commit_files
+    }
+
     /// Iterator over the commits in the range, yielding one [`CommitAction`] per commit.
     ///
     /// - `engine`: performs the per-commit JSON reads.

--- a/kernel/src/engine/sync/json.rs
+++ b/kernel/src/engine/sync/json.rs
@@ -21,11 +21,12 @@ use crate::{
 
 pub(crate) struct SyncJsonHandler {
     store: Option<Arc<DynObjectStore>>,
+    batch_size: Option<usize>,
 }
 
 impl SyncJsonHandler {
-    pub(crate) fn new(store: Option<Arc<DynObjectStore>>) -> Self {
-        Self { store }
+    pub(crate) fn new(store: Option<Arc<DynObjectStore>>, batch_size: Option<usize>) -> Self {
+        Self { store, batch_size }
     }
 }
 
@@ -35,10 +36,22 @@ pub(super) fn try_create_from_json(
     _predicate: Option<PredicateRef>,
     file_location: String,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
+    try_create_from_json_with_batch_size(data, schema, file_location, None)
+}
+
+fn try_create_from_json_with_batch_size(
+    data: Bytes,
+    schema: SchemaRef,
+    file_location: String,
+    batch_size: Option<usize>,
+) -> DeltaResult<impl Iterator<Item = DeltaResult<ArrowEngineData>>> {
     let json_schema = Arc::new(json_arrow_schema(&schema)?);
     let reorder_indices = build_json_reorder_indices(&schema)?;
-    let json = ReaderBuilder::new(json_schema)
-        .with_coerce_primitive(true)
+    let mut reader_builder = ReaderBuilder::new(json_schema).with_coerce_primitive(true);
+    if let Some(batch_size) = batch_size {
+        reader_builder = reader_builder.with_batch_size(batch_size);
+    }
+    let json = reader_builder
         .build(BufReader::new(Cursor::new(data)))?
         .map(move |data| fixup_json_read(data?, &reorder_indices, &file_location));
     Ok(json)
@@ -51,13 +64,12 @@ impl JsonHandler for SyncJsonHandler {
         schema: SchemaRef,
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
-        let iter = read_files_arrow(
-            self.store.as_ref(),
-            files,
-            schema,
-            predicate,
-            try_create_from_json,
-        );
+        let iter = read_files_arrow(self.store.as_ref(), files, schema, predicate, {
+            let batch_size = self.batch_size;
+            move |data, schema, _predicate, file_location| {
+                try_create_from_json_with_batch_size(data, schema, file_location, batch_size)
+            }
+        });
         Ok(Box::new(iter.map(|data| Ok(Box::new(data?) as _))))
     }
 
@@ -128,7 +140,7 @@ mod tests {
     fn do_test_write_json_file(overwrite: bool) -> DeltaResult<()> {
         let test_dir = TempDir::new().unwrap();
         let path = test_dir.path().join("00000000000000000001.json");
-        let handler = SyncJsonHandler::new(None);
+        let handler = SyncJsonHandler::new(None, None);
         let url = Url::from_file_path(&path).unwrap();
 
         // First write with no existing file
@@ -166,6 +178,6 @@ mod tests {
     //
     // #[test]
     // fn json_handler_file_path_contract() {
-    //     test_json_handler_file_path_contract(&SyncJsonHandler::new(None));
+    //     test_json_handler_file_path_contract(&SyncJsonHandler::new(None, None));
     // }
 }

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -53,22 +53,26 @@ pub(crate) struct SyncEngine {
 impl SyncEngine {
     /// Create a SyncEngine that reads from the local filesystem via [`LocalFileSystem`].
     pub(crate) fn new() -> Self {
-        Self::new_inner(None)
+        Self::new_inner(None, None)
     }
 
     /// Create a SyncEngine backed by `store`. All I/O is performed synchronously via
     /// [`futures::executor::block_on`]. See module docs for the deadlock caveat on
     /// reactor-dependent stores.
     pub(crate) fn new_with_store(store: Arc<DynObjectStore>) -> Self {
-        Self::new_inner(Some(store))
+        Self::new_inner(Some(store), None)
     }
 
-    fn new_inner(store: Option<Arc<DynObjectStore>>) -> Self {
+    pub(crate) fn new_with_batch_size(batch_size: usize) -> Self {
+        Self::new_inner(None, Some(batch_size))
+    }
+
+    fn new_inner(store: Option<Arc<DynObjectStore>>, batch_size: Option<usize>) -> Self {
         SyncEngine {
             storage_handler: Arc::new(storage::SyncStorageHandler::new(store.clone())),
             #[cfg(feature = "declarative-plans")]
             plan_executor: Arc::new(plan::SyncPlanExecutor::new(store.clone())),
-            json_handler: Arc::new(json::SyncJsonHandler::new(store.clone())),
+            json_handler: Arc::new(json::SyncJsonHandler::new(store.clone(), batch_size)),
             parquet_handler: Arc::new(parquet::SyncParquetHandler::new(store)),
             evaluation_handler: Arc::new(ArrowEvaluationHandler {}),
         }

--- a/kernel/src/log_compaction/writer.rs
+++ b/kernel/src/log_compaction/writer.rs
@@ -115,6 +115,7 @@ impl LogCompactionWriter {
             self.snapshot.log_segment().log_root.clone(),
             self.start_version,
             Some(self.end_version),
+            vec![],
         )?;
 
         // Read actions from the version-filtered log segment

--- a/kernel/src/log_compaction/writer.rs
+++ b/kernel/src/log_compaction/writer.rs
@@ -7,7 +7,7 @@ use super::COMPACTION_ACTIONS_SCHEMA;
 use crate::action_reconciliation::log_replay::ActionReconciliationProcessor;
 use crate::action_reconciliation::{ActionReconciliationIterator, RetentionCalculator};
 use crate::log_replay::LogReplayProcessor;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogLoadOptions, LogSegment};
 use crate::path::ParsedLogPath;
 use crate::table_properties::TableProperties;
 use crate::{DeltaResult, Engine, Error, SnapshotRef, Version};
@@ -110,12 +110,12 @@ impl LogCompactionWriter {
 
         // Create a log segment specifically for the compaction range
         // This ensures we only process commits in [start_version, end_version]
-        let compaction_log_segment = LogSegment::for_table_changes(
+        let compaction_log_segment = LogSegment::for_commit_range(
             engine.storage_handler().as_ref(),
             self.snapshot.log_segment().log_root.clone(),
             self.start_version,
             Some(self.end_version),
-            vec![],
+            LogLoadOptions::default(),
         )?;
 
         // Read actions from the version-filtered log segment

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -16,6 +16,7 @@ use crate::cancellation::{CancellableIterator, CancellationTokenRef};
 use crate::committer::CatalogCommit;
 use crate::expressions::ColumnName;
 use crate::last_checkpoint_hint::LastCheckpointHint;
+use crate::log_path::LogPath;
 use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
 #[internal_api]
@@ -412,12 +413,17 @@ impl LogSegment {
     /// and all commits between versions `start_version` (inclusive) and `end_version`
     /// (inclusive). If no `end_version` is specified it will be the most recent version by
     /// default.
+    ///
+    /// `log_tail` must contain a contiguous ascending sequence of commit paths. It takes
+    /// precedence over numbered commits at overlapping versions, and entries outside the selected
+    /// range are ignored.
     #[internal_api]
     pub(crate) fn for_table_changes(
         storage: &dyn StorageHandler,
         log_root: Url,
         start_version: Version,
         end_version: impl Into<Option<Version>>,
+        log_tail: Vec<LogPath>,
     ) -> DeltaResult<Self> {
         let end_version = end_version.into();
         if let Some(end_version) = end_version {
@@ -429,12 +435,10 @@ impl LogSegment {
         }
 
         // TODO: compactions?
-        // TODO(#2796): table-changes does not supply a log_tail yet. CDF over a catalog-managed
-        // table will need the catalog's commits passed here to see unbackfilled staged commits.
         let listed_files = LogSegmentFiles::list_commits(
             storage,
             &log_root,
-            vec![], // log-tail
+            log_tail.into_iter().map(Into::into).collect(),
             Some(start_version),
             end_version,
         )?;

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -49,6 +49,148 @@ mod crc_tests;
 #[cfg(test)]
 mod tests;
 
+/// Catalog-aware inputs shared by snapshot and commit-range log loading.
+///
+/// A supplied log tail must be a contiguous ascending suffix ending at the caller-visible latest
+/// version. It replaces numbered commits from its first version onward. Staged commits require a
+/// maximum catalog-ratified version.
+#[derive(Debug, Clone, Default)]
+#[internal_api]
+pub(crate) struct LogLoadOptions {
+    max_catalog_version: Option<Version>,
+    log_tail: Vec<LogPath>,
+}
+
+impl LogLoadOptions {
+    pub(crate) fn new(max_catalog_version: Option<Version>, log_tail: Vec<LogPath>) -> Self {
+        Self {
+            max_catalog_version,
+            log_tail,
+        }
+    }
+
+    /// Sets the highest table version ratified by the catalog.
+    ///
+    /// Explicit range or snapshot versions must not exceed this limit.
+    #[internal_api]
+    pub(crate) fn with_max_catalog_version(mut self, max_catalog_version: Version) -> Self {
+        self.max_catalog_version = Some(max_catalog_version);
+        self
+    }
+
+    /// Sets the catalog-provided log tail, including staged commits absent from the numbered log.
+    ///
+    /// Entries must be contiguous ascending commits ending at the caller-visible latest version.
+    /// With a catalog maximum, an unbounded load requires the tail to end exactly there; an
+    /// explicitly bounded load requires the tail to reach the requested version. Staged commits
+    /// require [`Self::with_max_catalog_version`].
+    #[internal_api]
+    pub(crate) fn with_log_tail(mut self, log_tail: Vec<LogPath>) -> Self {
+        self.log_tail = log_tail;
+        self
+    }
+
+    pub(crate) fn max_catalog_version(&self) -> Option<Version> {
+        self.max_catalog_version
+    }
+
+    pub(crate) fn log_tail(&self) -> &[LogPath] {
+        &self.log_tail
+    }
+
+    pub(crate) fn validate(&self, target_version: Option<Version>) -> DeltaResult<()> {
+        let log_tail: Vec<ParsedLogPath> = self.log_tail.iter().cloned().map(Into::into).collect();
+
+        for pair in log_tail.windows(2) {
+            require!(
+                pair[0]
+                    .version
+                    .checked_add(1)
+                    .is_some_and(|next| next == pair[1].version),
+                Error::LogTailVersionsNotContiguous {
+                    first_version: pair[0].version,
+                    second_version: pair[1].version,
+                }
+            );
+        }
+
+        let has_staged_commits = log_tail
+            .iter()
+            .any(|path| path.file_type == LogPathFileType::StagedCommit);
+        require!(
+            !has_staged_commits || self.max_catalog_version.is_some(),
+            Error::MaxCatalogVersion(
+                "Max catalog version is required when providing staged commits in the log tail. \
+                 Use with_max_catalog_version()."
+                    .to_string()
+            )
+        );
+
+        if let Some(target_version) = target_version {
+            self.validate_version(target_version)?;
+            if let Some(last) = log_tail.last() {
+                require!(
+                    last.version >= target_version,
+                    self.log_tail_ends_before_target_error(last.version, target_version)
+                );
+            }
+        } else if let (Some(max_catalog_version), Some(last)) =
+            (self.max_catalog_version, log_tail.last())
+        {
+            require!(
+                last.version == max_catalog_version,
+                Error::MaxCatalogVersion(format!(
+                    "Log tail version {} does not match max catalog version \
+                     {max_catalog_version}",
+                    last.version
+                ))
+            );
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn resolve_end_version(
+        &self,
+        start_version: Version,
+        end_version: Option<Version>,
+    ) -> DeltaResult<Option<Version>> {
+        self.validate_version(start_version)?;
+        self.validate(end_version)?;
+        Ok(end_version.or(self.max_catalog_version))
+    }
+
+    fn validate_version(&self, version: Version) -> DeltaResult<()> {
+        if let Some(max_catalog_version) = self.max_catalog_version {
+            require!(
+                version <= max_catalog_version,
+                Error::MaxCatalogVersion(format!(
+                    "Requested version {version} exceeds max catalog version \
+                     {max_catalog_version}"
+                ))
+            );
+        }
+        Ok(())
+    }
+
+    fn log_tail_ends_before_target_error(
+        &self,
+        log_tail_version: Version,
+        target_version: Version,
+    ) -> Error {
+        match self.max_catalog_version {
+            Some(max_catalog_version) => Error::MaxCatalogVersion(format!(
+                "Log tail version {log_tail_version} is less than requested version \
+                 {target_version} for max catalog version {max_catalog_version}"
+            )),
+            None => Error::generic(format!(
+                "Log tail version {log_tail_version} is less than requested version \
+                 {target_version}"
+            )),
+        }
+    }
+}
+
 /// Information about checkpoint reading for data skipping optimization.
 ///
 /// Returned alongside the actions iterator from checkpoint reading functions.
@@ -105,8 +247,8 @@ pub(crate) struct ActionsWithCheckpointInfo<A: Iterator<Item = DeltaResult<Actio
 ///     3. All checkpoint_parts must belong to the same checkpoint version, and must form a complete
 ///        version. Multi-part checkpoints must have all their parts.
 ///
-/// [`LogSegment`] is used in [`Snapshot`] when built with [`LogSegment::for_snapshot`], and
-/// in `TableChanges` when built with [`LogSegment::for_table_changes`].
+/// [`LogSegment`] is used in [`Snapshot`] when built with [`LogSegment::for_snapshot`] and by
+/// commit-range consumers through [`LogSegment::for_commit_range`].
 ///
 /// [`Snapshot`]: crate::snapshot::Snapshot
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -408,24 +550,21 @@ impl LogSegment {
         LogSegment::try_new(listed_files, log_root, time_travel_version, checkpoint_hint)
     }
 
-    /// Constructs a [`LogSegment`] to be used for `TableChanges`. For a TableChanges between
-    /// versions `start_version` and `end_version`: Its LogSegment is made of zero checkpoints
-    /// and all commits between versions `start_version` (inclusive) and `end_version`
-    /// (inclusive). If no `end_version` is specified it will be the most recent version by
-    /// default.
+    /// Constructs a checkpoint-free [`LogSegment`] over an inclusive commit range.
     ///
-    /// `log_tail` must contain a contiguous ascending sequence of commit paths. It takes
-    /// precedence over numbered commits at overlapping versions, and entries outside the selected
-    /// range are ignored.
+    /// `load_options.log_tail` must be a contiguous ascending suffix ending at the caller-visible
+    /// latest version. It replaces numbered commits from its first version onward; commits outside
+    /// the selected range are then excluded from the returned segment. When no explicit end is
+    /// supplied, the catalog maximum is used when present, otherwise the latest visible version.
     #[internal_api]
-    pub(crate) fn for_table_changes(
+    pub(crate) fn for_commit_range(
         storage: &dyn StorageHandler,
         log_root: Url,
         start_version: Version,
         end_version: impl Into<Option<Version>>,
-        log_tail: Vec<LogPath>,
+        load_options: LogLoadOptions,
     ) -> DeltaResult<Self> {
-        let end_version = end_version.into();
+        let end_version = load_options.resolve_end_version(start_version, end_version.into())?;
         if let Some(end_version) = end_version {
             if start_version > end_version {
                 return Err(Error::generic(
@@ -438,7 +577,7 @@ impl LogSegment {
         let listed_files = LogSegmentFiles::list_commits(
             storage,
             &log_root,
-            log_tail.into_iter().map(Into::into).collect(),
+            load_options.log_tail.into_iter().map(Into::into).collect(),
             Some(start_version),
             end_version,
         )?;

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1043,7 +1043,7 @@ async fn build_table_changes_with_commit_versions() {
     ///////// Specify start version and end version /////////
 
     let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 2, 5).unwrap();
+        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 2, 5, vec![]).unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
@@ -1057,7 +1057,8 @@ async fn build_table_changes_with_commit_versions() {
 
     ///////// Start version and end version are the same /////////
     let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, Some(0)).unwrap();
+        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, Some(0), vec![])
+            .unwrap();
 
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
@@ -1069,7 +1070,8 @@ async fn build_table_changes_with_commit_versions() {
     assert_eq!(commit_files[0].version, 0);
 
     ///////// Specify no start or end version /////////
-    let log_segment = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, None).unwrap();
+    let log_segment =
+        LogSegment::for_table_changes(storage.as_ref(), log_root, 0, None, vec![]).unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
@@ -1095,7 +1097,7 @@ async fn test_non_contiguous_log() {
     .await;
 
     let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None);
+        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None, vec![]);
     // check the error message up to the timestamp
     let expected_error_pattern = "Generic delta kernel error: Expected contiguous commit files, \
         but found gap: ParsedLogPath { location: FileMeta { location: Url { scheme: \"memory\", \
@@ -1104,13 +1106,14 @@ async fn test_non_contiguous_log() {
     assert_result_error_with_message(log_segment_res, expected_error_pattern);
 
     let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None);
+        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None, vec![]);
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: Expected the first commit to have version 1",
     );
 
-    let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1));
+    let log_segment_res =
+        LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1), vec![]);
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: LogSegment end version 0 not the same as the specified end \
@@ -1129,7 +1132,8 @@ async fn table_changes_fails_with_larger_start_version_than_end() {
         None,
     )
     .await;
-    let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 1, Some(0));
+    let log_segment_res =
+        LogSegment::for_table_changes(storage.as_ref(), log_root, 1, Some(0), vec![]);
     assert_result_error_with_message(log_segment_res, "Generic delta kernel error: Failed to build LogSegment: start_version cannot be greater than end_version");
 }
 
@@ -4951,9 +4955,14 @@ async fn read_actions_with_null_map_values(
 
     // Build engine and read actions -- same as DeltaActionExtractor::get_actions.
     let engine = SyncEngine::new_with_store(store);
-    let log_segment =
-        LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, Some(0))
-            .unwrap();
+    let log_segment = LogSegment::for_table_changes(
+        engine.storage_handler().as_ref(),
+        log_root,
+        0,
+        Some(0),
+        vec![],
+    )
+    .unwrap();
 
     // Use all_actions_schema to cover sidecar and checkpointMetadata (checkpoint-only actions).
     let action_schema = get_all_actions_schema().clone();

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1042,8 +1042,14 @@ async fn build_table_changes_with_commit_versions() {
 
     ///////// Specify start version and end version /////////
 
-    let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 2, 5, vec![]).unwrap();
+    let log_segment = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root.clone(),
+        2,
+        5,
+        LogLoadOptions::default(),
+    )
+    .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
@@ -1056,9 +1062,14 @@ async fn build_table_changes_with_commit_versions() {
     assert_eq!(versions, expected_versions);
 
     ///////// Start version and end version are the same /////////
-    let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, Some(0), vec![])
-            .unwrap();
+    let log_segment = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root.clone(),
+        0,
+        Some(0),
+        LogLoadOptions::default(),
+    )
+    .unwrap();
 
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
@@ -1070,8 +1081,14 @@ async fn build_table_changes_with_commit_versions() {
     assert_eq!(commit_files[0].version, 0);
 
     ///////// Specify no start or end version /////////
-    let log_segment =
-        LogSegment::for_table_changes(storage.as_ref(), log_root, 0, None, vec![]).unwrap();
+    let log_segment = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root,
+        0,
+        None,
+        LogLoadOptions::default(),
+    )
+    .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
 
@@ -1082,6 +1099,58 @@ async fn build_table_changes_with_commit_versions() {
     let versions = commit_files.into_iter().map(|x| x.version).collect_vec();
     let expected_versions = (0..=7).collect_vec();
     assert_eq!(versions, expected_versions);
+}
+
+#[rstest]
+#[case::gap_outside_range(
+    &[0, 2],
+    2,
+    Some(2),
+    Some(2),
+    "Log tail versions 0 and 2 are not contiguous",
+)]
+#[case::tail_ends_before_target(
+    &[0, 1],
+    0,
+    Some(2),
+    None,
+    "Log tail version 1 is less than requested version 2",
+)]
+#[test]
+fn commit_range_validates_entire_log_tail_before_listing(
+    #[case] log_tail_versions: &[Version],
+    #[case] start_version: Version,
+    #[case] end_version: Option<Version>,
+    #[case] max_catalog_version: Option<Version>,
+    #[case] expected_error: &str,
+) {
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let log_tail = log_tail_versions
+        .iter()
+        .map(|version| {
+            LogPath::try_new(FileMeta {
+                location: log_root.join(&format!("{version:020}.json")).unwrap(),
+                last_modified: 0,
+                size: 1,
+            })
+            .unwrap()
+        })
+        .collect();
+    let mut load_options = LogLoadOptions::default().with_log_tail(log_tail);
+    if let Some(max_catalog_version) = max_catalog_version {
+        load_options = load_options.with_max_catalog_version(max_catalog_version);
+    }
+    let engine = SyncEngine::new_with_store(Arc::new(InMemory::new()));
+
+    let result = LogSegment::for_commit_range(
+        engine.storage_handler().as_ref(),
+        log_root,
+        start_version,
+        end_version,
+        load_options,
+    );
+
+    assert_result_error_with_message(result, expected_error);
 }
 
 #[tokio::test]
@@ -1096,8 +1165,13 @@ async fn test_non_contiguous_log() {
     )
     .await;
 
-    let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None, vec![]);
+    let log_segment_res = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root.clone(),
+        0,
+        None,
+        LogLoadOptions::default(),
+    );
     // check the error message up to the timestamp
     let expected_error_pattern = "Generic delta kernel error: Expected contiguous commit files, \
         but found gap: ParsedLogPath { location: FileMeta { location: Url { scheme: \"memory\", \
@@ -1105,15 +1179,25 @@ async fn test_non_contiguous_log() {
         \"/_delta_log/00000000000000000000.json\", query: None, fragment: None }, last_modified:";
     assert_result_error_with_message(log_segment_res, expected_error_pattern);
 
-    let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None, vec![]);
+    let log_segment_res = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root.clone(),
+        1,
+        None,
+        LogLoadOptions::default(),
+    );
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: Expected the first commit to have version 1",
     );
 
-    let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1), vec![]);
+    let log_segment_res = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root,
+        0,
+        Some(1),
+        LogLoadOptions::default(),
+    );
     assert_result_error_with_message(
         log_segment_res,
         "Generic delta kernel error: LogSegment end version 0 not the same as the specified end \
@@ -1132,8 +1216,13 @@ async fn table_changes_fails_with_larger_start_version_than_end() {
         None,
     )
     .await;
-    let log_segment_res =
-        LogSegment::for_table_changes(storage.as_ref(), log_root, 1, Some(0), vec![]);
+    let log_segment_res = LogSegment::for_commit_range(
+        storage.as_ref(),
+        log_root,
+        1,
+        Some(0),
+        LogLoadOptions::default(),
+    );
     assert_result_error_with_message(log_segment_res, "Generic delta kernel error: Failed to build LogSegment: start_version cannot be greater than end_version");
 }
 
@@ -4074,7 +4163,7 @@ fn test_stats_parsed_mixed_with_one_incompatible_rejects_all() {
 
 /// Creates a checkpoint batch with `add.partitionValues_parsed` in the parquet schema.
 fn add_batch_with_partition_values_parsed(output_schema: SchemaRef) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
+    let handler = SyncJsonHandler::new(None, None);
     let json_strings: StringArray = vec![
         r#"{"add":{"path":"part-00000.parquet","partitionValues":{"id":"1"},"partitionValues_parsed":{"id":1},"size":635,"modificationTime":1677811178336,"dataChange":true}}"#,
         r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["id"],"configuration":{},"createdTime":1677811175819}}"#,
@@ -4955,12 +5044,12 @@ async fn read_actions_with_null_map_values(
 
     // Build engine and read actions -- same as DeltaActionExtractor::get_actions.
     let engine = SyncEngine::new_with_store(store);
-    let log_segment = LogSegment::for_table_changes(
+    let log_segment = LogSegment::for_commit_range(
         engine.storage_handler().as_ref(),
         log_root,
         0,
         Some(0),
-        vec![],
+        LogLoadOptions::default(),
     )
     .unwrap();
 

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -23,7 +23,7 @@ fn parse_batch<S: AsRef<str>>(
     json: impl IntoIterator<Item = S>,
     output_schema: SchemaRef,
 ) -> Box<ArrowEngineData> {
-    let handler = SyncJsonHandler::new(None);
+    let handler = SyncJsonHandler::new(None, None);
     let json_strings = StringArray::from_iter_values(json);
     let parsed = handler
         .parse_json(string_array_to_engine_data(json_strings), output_schema)

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -5,10 +5,9 @@ use std::sync::Arc;
 use tracing::{info, instrument};
 
 use crate::log_path::LogPath;
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogLoadOptions, LogSegment};
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
 use crate::metrics::{LogSegmentLoadType, MetricId, SnapshotLoadMetricContext};
-use crate::path::LogPathFileType;
 use crate::snapshot::SnapshotRef;
 use crate::utils::{require, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, Snapshot, Version};
@@ -172,6 +171,12 @@ impl SnapshotBuilder {
         self
     }
 
+    pub(crate) fn with_log_load_options(mut self, load_options: LogLoadOptions) -> Self {
+        self.max_catalog_version = load_options.max_catalog_version();
+        self.log_tail = load_options.log_tail().to_vec();
+        self
+    }
+
     /// Bound how many commits kernel will replay to advance a stale CRC to the target version.
     /// See [`IncrementalReplay`]. Defaults to [`IncrementalReplay::Disabled`].
     ///
@@ -252,10 +257,14 @@ impl SnapshotBuilder {
             load_type,
         };
 
-        let log_tail: Vec<_> = log_tail.into_iter().map(Into::into).collect();
-
-        // Pre-build validations for catalog-managed tables
-        Self::validate_catalog_managed_build_inputs(version, max_catalog_version, &log_tail)?;
+        let load_options = LogLoadOptions::new(max_catalog_version, log_tail);
+        load_options.validate(version)?;
+        let log_tail: Vec<_> = load_options
+            .log_tail()
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect();
 
         // Use time-travel version if set, otherwise fall back to max_catalog_version. Passing this
         // as the version to LogSegment::for_snapshot does NOT skip the _last_checkpoint hint --
@@ -321,76 +330,6 @@ impl SnapshotBuilder {
     // ============================================================================
 
     // ===== Catalog-managed Validations =====
-
-    /// Pre-build validations for catalog-managed table invariants.
-    fn validate_catalog_managed_build_inputs(
-        version: Option<Version>,
-        max_catalog_version: Option<Version>,
-        log_tail: &[crate::path::ParsedLogPath],
-    ) -> DeltaResult<()> {
-        // Log tail must be sorted ascending and contiguous (no gaps or duplicates)
-        for pair in log_tail.windows(2) {
-            require!(
-                pair[0].version + 1 == pair[1].version,
-                Error::LogTailVersionsNotContiguous {
-                    first_version: pair[0].version,
-                    second_version: pair[1].version,
-                }
-            );
-        }
-
-        // TODO: If inline commits (or any other catalog commits) are ever supported, change this
-        // method to check if there are any catalog commits.
-        let has_catalog_commits = log_tail
-            .iter()
-            .any(|p| p.file_type == LogPathFileType::StagedCommit);
-
-        // Staged commits require max_catalog_version
-        require!(
-            !has_catalog_commits || max_catalog_version.is_some(),
-            Error::MaxCatalogVersion(
-                "Max catalog version is required when providing staged commits in the log tail. \
-                 Use with_max_catalog_version()."
-                    .to_string()
-            )
-        );
-
-        // Time-travel version must not exceed max_catalog_version
-        if let (Some(ver), Some(max_cv)) = (version, max_catalog_version) {
-            require!(
-                ver <= max_cv,
-                Error::MaxCatalogVersion(format!(
-                    "Requested version {ver} exceeds max catalog version {max_cv}"
-                ))
-            );
-        }
-
-        // Log tail end version validation when max_catalog_version is set
-        if let (Some(max_cv), Some(last)) = (max_catalog_version, log_tail.last()) {
-            if let Some(ver) = version {
-                // With time-travel: last log_tail entry must be >= requested version
-                require!(
-                    last.version >= ver,
-                    Error::MaxCatalogVersion(format!(
-                        "Log tail version {} is less than requested version {ver} for max catalog \
-                         version {max_cv}",
-                        last.version
-                    ))
-                );
-            } else {
-                // Without time-travel: last log_tail entry must == max_catalog_version
-                require!(
-                    last.version == max_cv,
-                    Error::MaxCatalogVersion(format!(
-                        "Log tail version {} does not match max catalog version {max_cv}",
-                        last.version
-                    ))
-                );
-            }
-        }
-
-        Ok(())
-    }
 
     /// Post-build validation: catalog-managed tables must have max_catalog_version, and
     /// non-catalog-managed tables must not.
@@ -1041,6 +980,7 @@ mod tests {
         #[case::gap(vec![1, 3], vec![1, 3], 3)]
         #[case::duplicates(vec![1], vec![1, 1], 1)]
         #[case::unsorted(vec![1, 2], vec![2, 1], 2)]
+        #[case::overflow(vec![], vec![u64::MAX, 0], u64::MAX)]
         #[test_log::test(tokio::test)]
         async fn test_non_contiguous_log_tail_errors(
             #[case] commit_versions: Vec<u64>,

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -213,6 +213,8 @@ impl LogReplayScanner {
         let mut remove_dvs = HashMap::default();
         let mut add_paths = HashSet::default();
         let mut has_cdc_action = false;
+        let mut metadata_opt = None;
+        let mut protocol_opt = None;
 
         for actions in action_iter {
             let actions = actions?;
@@ -225,51 +227,53 @@ impl LogReplayScanner {
             };
             visitor.visit_rows_of(actions.as_ref())?;
 
-            let metadata_opt = Metadata::try_new_from_data(actions.as_ref())?;
-            let has_metadata_update = metadata_opt.is_some();
-            let protocol_opt = Protocol::try_new_from_data(actions.as_ref())?;
-            let has_protocol_update = protocol_opt.is_some();
-
-            if let Some(ref metadata) = metadata_opt {
-                let schema = metadata.parse_schema()?;
-                // Compatibility is evaluated against the end version's logical schema.
-                require!(
-                    mode.schemas_compatible(&schema, table_schema.as_ref()),
-                    Error::change_data_feed_incompatible_schema_at_version(
-                        table_schema,
-                        &schema,
-                        commit_file.version
-                    )
-                );
+            if metadata_opt.is_none() {
+                metadata_opt = Metadata::try_new_from_data(actions.as_ref())?;
             }
-
-            // Update table configuration with any new Protocol or Metadata from this commit
-            if has_metadata_update || has_protocol_update {
-                *table_configuration = TableConfiguration::try_new_from(
-                    table_configuration,
-                    metadata_opt,
-                    protocol_opt,
-                    commit_file.version,
-                )?;
-
-                let writer_features_str = table_configuration
-                    .protocol()
-                    .writer_features()
-                    .map(format_features)
-                    .unwrap_or_else(|| "[]".to_string());
-
-                info!(
-                    version = commit_file.version,
-                    id = table_configuration.metadata().id(),
-                    // Writer features are always a superset of reader features, so we log writer features to trace the full set of table features.
-                    writerFeatures = %writer_features_str,
-                    minReaderVersion = table_configuration.protocol().min_reader_version(),
-                    minWriterVersion = table_configuration.protocol().min_writer_version(),
-                    schemaString = %table_configuration.metadata().schema_string(),
-                    configuration = ?table_configuration.metadata().configuration(),
-                    "Table configuration updated during CDF query"
-                );
+            if protocol_opt.is_none() {
+                protocol_opt = Protocol::try_new_from_data(actions.as_ref())?;
             }
+        }
+
+        let has_metadata_update = metadata_opt.is_some();
+        let has_protocol_update = protocol_opt.is_some();
+        if let Some(ref metadata) = metadata_opt {
+            let schema = metadata.parse_schema()?;
+            // Compatibility is evaluated against the end version's logical schema.
+            require!(
+                mode.schemas_compatible(&schema, table_schema.as_ref()),
+                Error::change_data_feed_incompatible_schema_at_version(
+                    table_schema,
+                    &schema,
+                    commit_file.version
+                )
+            );
+        }
+        if has_metadata_update || has_protocol_update {
+            *table_configuration = TableConfiguration::try_new_from(
+                table_configuration,
+                metadata_opt,
+                protocol_opt,
+                commit_file.version,
+            )?;
+
+            let writer_features_str = table_configuration
+                .protocol()
+                .writer_features()
+                .map(format_features)
+                .unwrap_or_else(|| "[]".to_string());
+
+            info!(
+                version = commit_file.version,
+                id = table_configuration.metadata().id(),
+                // Writer features are always a superset of reader features, so we log writer features to trace the full set of table features.
+                writerFeatures = %writer_features_str,
+                minReaderVersion = table_configuration.protocol().min_reader_version(),
+                minWriterVersion = table_configuration.protocol().min_writer_version(),
+                schemaString = %table_configuration.metadata().schema_string(),
+                configuration = ?table_configuration.metadata().configuration(),
+                "Table configuration updated during CDF query"
+            );
 
             if has_metadata_update {
                 require!(
@@ -278,11 +282,9 @@ impl LogReplayScanner {
                 );
             }
 
-            if has_protocol_update {
-                table_configuration
-                    .ensure_operation_supported(mode.read_operation())
-                    .map_err(|e| mode.protocol_support_error(e, commit_file.version))?;
-            }
+            table_configuration
+                .ensure_operation_supported(mode.read_operation())
+                .map_err(|e| mode.protocol_support_error(e, commit_file.version))?;
         }
         // We resolve the remove deletion vector map after visiting the entire commit.
         if has_cdc_action {

--- a/kernel/src/table_changes/log_replay.rs
+++ b/kernel/src/table_changes/log_replay.rs
@@ -22,7 +22,7 @@ use crate::schema::{schema_ref, ColumnNamesAndTypes, DataType, SchemaRef};
 use crate::table_changes::scan_file::{cdf_scan_row_expression, cdf_scan_row_schema};
 use crate::table_changes::CdfMode;
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{format_features, Operation, TableFeature};
+use crate::table_features::{format_features, TableFeature};
 use crate::utils::require;
 use crate::{DeltaResult, Engine, EngineData, Error, PredicateRef, RowVisitor};
 
@@ -280,7 +280,7 @@ impl LogReplayScanner {
 
             if has_protocol_update {
                 table_configuration
-                    .ensure_operation_supported(Operation::Cdf)
+                    .ensure_operation_supported(mode.read_operation())
                     .map_err(|e| mode.protocol_support_error(e, commit_file.version))?;
             }
         }

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -161,6 +161,7 @@ fn get_segment(
         log_root,
         start_version,
         end_version,
+        vec![],
     )?;
     Ok(log_segment.listed.ascending_commit_files)
 }

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::actions::{Add, Cdc, CommitInfo, Metadata, Protocol, Remove};
 use crate::engine::sync::SyncEngine;
 use crate::expressions::{column_expr, BinaryPredicateOp, Scalar};
-use crate::log_segment::LogSegment;
+use crate::log_segment::{LogLoadOptions, LogSegment};
 use crate::path::ParsedLogPath;
 use crate::scan::state::DvInfo;
 use crate::scan::PhysicalPredicate;
@@ -156,12 +156,12 @@ fn get_segment(
 ) -> DeltaResult<Vec<ParsedLogPath>> {
     let table_root = url::Url::from_directory_path(path).unwrap();
     let log_root = table_root.join("_delta_log/")?;
-    let log_segment = LogSegment::for_table_changes(
+    let log_segment = LogSegment::for_commit_range(
         engine.storage_handler().as_ref(),
         log_root,
         start_version,
         end_version,
-        vec![],
+        LogLoadOptions::default(),
     )?;
     Ok(log_segment.listed.ascending_commit_files)
 }
@@ -218,6 +218,48 @@ async fn metadata_protocol() {
     let sv = result_to_sv(scan_batches);
     assert_eq!(sv, &[false, false]);
 }
+
+#[tokio::test]
+async fn metadata_and_protocol_in_separate_batches_are_applied_atomically() {
+    let engine = Arc::new(SyncEngine::new_with_batch_size(1));
+    let mut mock_table = LocalMockTable::new();
+    let end_schema = Arc::new(StructType::new_unchecked([
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable("value", DataType::STRING),
+        StructField::nullable("ts", DataType::TIMESTAMP_NTZ),
+    ]));
+    mock_table
+        .commit([
+            metadata_with_cdf(end_schema.clone()),
+            Action::Protocol(
+                Protocol::try_new_modern(
+                    [TableFeature::TimestampWithoutTimezone],
+                    [
+                        TableFeature::TimestampWithoutTimezone,
+                        TableFeature::ChangeDataFeed,
+                    ],
+                )
+                .unwrap(),
+            ),
+        ])
+        .await;
+
+    let commits = get_segment(engine.as_ref(), mock_table.table_root(), 0, None)
+        .unwrap()
+        .into_iter();
+    let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
+    let table_config = get_default_table_config(&table_root);
+    let result: DeltaResult<Vec<_>> =
+        table_changes_action_iter(engine, &table_config, commits, end_schema, None)
+            .unwrap()
+            .try_collect();
+
+    assert!(
+        result.is_ok(),
+        "metadata and protocol must be applied as one commit"
+    );
+}
+
 #[tokio::test]
 async fn cdf_not_enabled() {
     let engine = Arc::new(SyncEngine::new());

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -44,12 +44,12 @@ use scan::TableChangesScanBuilder;
 use scan_file::scan_metadata_to_scan_file;
 use url::Url;
 
-use crate::log_path::LogPath;
-use crate::log_segment::LogSegment;
+use crate::commit_range::CommitRange;
+use crate::log_segment::LogLoadOptions;
 use crate::path::AsUrl;
 use crate::schema::compare::SchemaComparison as _;
 use crate::schema::{DataType, Schema, StructField, StructType};
-use crate::snapshot::{Snapshot, SnapshotBuilder, SnapshotRef};
+use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{Operation, TableFeature};
 use crate::table_properties::{
@@ -86,51 +86,6 @@ pub(crate) enum TableChangesListingMode {
     /// post-image. Intermediate actions are omitted, but each surviving action still requires
     /// row-level reconciliation. Computing net changes buffers the full range.
     NetChanges,
-}
-
-/// Catalog metadata used while loading a table-changes range.
-#[derive(Debug, Clone, Default)]
-#[internal_api]
-pub(crate) struct TableChangesLoadOptions {
-    max_catalog_version: Option<Version>,
-    log_tail: Vec<LogPath>,
-}
-
-impl TableChangesLoadOptions {
-    /// Sets the highest table version ratified by the catalog.
-    ///
-    /// Range construction rejects this option for non-catalog-managed tables and rejects explicit
-    /// range versions above this limit.
-    #[internal_api]
-    pub(crate) fn with_max_catalog_version(mut self, max_catalog_version: Version) -> Self {
-        self.max_catalog_version = Some(max_catalog_version);
-        self
-    }
-
-    /// Sets the catalog-provided log tail, including staged commits absent from the numbered log.
-    ///
-    /// Entries must form a contiguous ascending sequence. Staged commits require
-    /// [`Self::with_max_catalog_version`], and range construction validates the tail endpoint
-    /// against the requested version.
-    #[internal_api]
-    pub(crate) fn with_log_tail(mut self, log_tail: Vec<LogPath>) -> Self {
-        self.log_tail = log_tail;
-        self
-    }
-
-    fn configure_snapshot_builder(&self, mut builder: SnapshotBuilder) -> SnapshotBuilder {
-        if let Some(max_catalog_version) = self.max_catalog_version {
-            builder = builder.with_max_catalog_version(max_catalog_version);
-        }
-        if !self.log_tail.is_empty() {
-            builder = builder.with_log_tail(self.log_tail.clone());
-        }
-        builder
-    }
-
-    fn effective_end_version(&self, end_version: Option<Version>) -> Option<Version> {
-        end_version.or(self.max_catalog_version)
-    }
 }
 
 /// Identifies the table feature that must remain enabled across the change-feed range.
@@ -272,10 +227,9 @@ static CDF_FIELDS: LazyLock<[StructField; 3]> = LazyLock::new(|| {
 /// - [Change Data Files](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#change-data-files).
 #[derive(Debug)]
 pub struct TableChanges {
-    pub(crate) log_segment: LogSegment,
+    commit_range: CommitRange,
     table_root: Url,
     end_snapshot: SnapshotRef,
-    start_version: Version,
     schema: Schema,
     start_table_config: TableConfiguration,
     // Both feed types share range loading and log replay. The mode is fixed at construction, and
@@ -311,7 +265,7 @@ impl TableChanges {
             start_version,
             end_version,
             CdfMode::ChangeDataFeed,
-            TableChangesLoadOptions::default(),
+            LogLoadOptions::default(),
         )
     }
 
@@ -319,8 +273,7 @@ impl TableChanges {
     ///
     /// This path requires `delta.enableRowTracking` and ignores `_change_data` files.
     /// [`TableChanges::scan_file_listing`] returns the `add` and `remove` actions whose data must
-    /// be reconciled by row ID. Catalog ratification and log-tail metadata from `load_options` are
-    /// applied while loading the range.
+    /// be reconciled by row ID.
     ///
     /// # Parameters
     ///
@@ -329,7 +282,8 @@ impl TableChanges {
     /// - `start_version`: First version in the change feed.
     /// - `end_version`: Optional inclusive end version. When omitted, the catalog maximum is used
     ///   if present; otherwise the newest version is used.
-    /// - `load_options`: Catalog ratification and log-tail metadata used to load the range.
+    /// - `load_options`: Catalog ratification and log-tail metadata used by both snapshots and the
+    ///   commit range.
     ///
     /// # Errors
     ///
@@ -344,7 +298,7 @@ impl TableChanges {
         engine: &dyn Engine,
         start_version: Version,
         end_version: Option<Version>,
-        load_options: TableChangesLoadOptions,
+        load_options: LogLoadOptions,
     ) -> DeltaResult<Self> {
         Self::try_new_internal(
             table_root,
@@ -362,22 +316,19 @@ impl TableChanges {
         start_version: Version,
         end_version: Option<Version>,
         mode: CdfMode,
-        load_options: TableChangesLoadOptions,
+        load_options: LogLoadOptions,
     ) -> DeltaResult<Self> {
-        let log_root = table_root.join("_delta_log/")?;
-        let effective_end_version = load_options.effective_end_version(end_version);
-        let log_segment = LogSegment::for_table_changes(
-            engine.storage_handler().as_ref(),
-            log_root,
-            start_version,
-            effective_end_version,
-            load_options.log_tail.clone(),
-        )?;
+        let commit_range_builder = CommitRange::builder_for(table_root.as_str(), start_version)
+            .with_log_load_options(load_options.clone());
+        let commit_range_builder = match end_version {
+            Some(end_version) => commit_range_builder.with_end_version(end_version),
+            None => commit_range_builder,
+        };
+        let commit_range = commit_range_builder.build(engine)?;
 
-        let start_snapshot = load_options
-            .configure_snapshot_builder(
-                Snapshot::builder_for(table_root.as_url().clone()).at_version(start_version),
-            )
+        let start_snapshot = Snapshot::builder_for(table_root.as_url().clone())
+            .at_version(start_version)
+            .with_log_load_options(load_options.clone())
             .build(engine)?;
         start_snapshot
             .table_configuration()
@@ -387,8 +338,8 @@ impl TableChanges {
             Some(version) => Snapshot::builder_from(start_snapshot.clone()).at_version(version),
             None => Snapshot::builder_from(start_snapshot.clone()),
         };
-        let end_snapshot = load_options
-            .configure_snapshot_builder(end_snapshot_builder)
+        let end_snapshot = end_snapshot_builder
+            .with_log_load_options(load_options)
             .build(engine)?;
         end_snapshot
             .table_configuration()
@@ -454,8 +405,7 @@ impl TableChanges {
         Ok(TableChanges {
             table_root,
             end_snapshot,
-            log_segment,
-            start_version,
+            commit_range,
             schema,
             start_table_config: start_snapshot.table_configuration().clone(),
             mode,
@@ -464,12 +414,12 @@ impl TableChanges {
 
     /// The start version of the `TableChanges`.
     pub fn start_version(&self) -> Version {
-        self.start_version
+        self.commit_range.start_version()
     }
     /// The end version (inclusive) of the [`TableChanges`]. If no `end_version` was specified in
     /// [`TableChanges::try_new`], this returns the newest version as of the call to `try_new`.
     pub fn end_version(&self) -> Version {
-        self.log_segment.end_version
+        self.commit_range.end_version()
     }
     /// The logical schema of the change data feed. For details on the shape of the schema, see
     /// [`TableChanges`].
@@ -583,7 +533,7 @@ impl TableChanges {
             ));
         }
 
-        let commits = self.log_segment.listed.ascending_commit_files.clone();
+        let commits = self.commit_range.commit_files().to_vec();
         let schema = self.end_snapshot.schema();
         let scan_metadata = table_changes_action_iter_with_mode(
             engine,
@@ -634,7 +584,7 @@ mod tests {
         assert_result_error_with_message, test_schema_flat_with_column_mapping, Action,
         LocalMockTable,
     };
-    use crate::{Engine, Error, FileMeta};
+    use crate::{Engine, Error, FileMeta, LogPath};
 
     fn listing_test_schema() -> Arc<StructType> {
         Arc::new(StructType::new_unchecked([
@@ -719,7 +669,7 @@ mod tests {
                 end_version.into(),
             )
             .unwrap();
-            assert_eq!(table_changes.start_version, start_version);
+            assert_eq!(table_changes.start_version(), start_version);
             assert_eq!(table_changes.end_version(), end_version);
         }
 
@@ -814,7 +764,7 @@ mod tests {
                 engine.as_ref(),
                 0,
                 Some(0),
-                TableChangesLoadOptions::default(),
+                LogLoadOptions::default(),
             ),
             missing_property,
         );
@@ -832,7 +782,7 @@ mod tests {
             engine.as_ref(),
             0,
             Some(1),
-            TableChangesLoadOptions::default(),
+            LogLoadOptions::default(),
         );
         assert!(
             matches!(&res, Err(Error::RowTrackingChangeFeedUnsupported(_))),
@@ -886,7 +836,7 @@ mod tests {
             engine.as_ref(),
             1,
             Some(2),
-            TableChangesLoadOptions::default(),
+            LogLoadOptions::default(),
         );
         assert!(
             matches!(&res, Err(Error::ChangeDataFeedIncompatibleSchema(_, _))),
@@ -932,7 +882,7 @@ mod tests {
                 engine.as_ref(),
                 0,
                 Some(1),
-                TableChangesLoadOptions::default(),
+                LogLoadOptions::default(),
             )
             .unwrap(),
         );
@@ -981,7 +931,7 @@ mod tests {
             };
             log_tail.push(LogPath::try_new(file_meta).unwrap());
         }
-        let options = TableChangesLoadOptions::default()
+        let options = LogLoadOptions::default()
             .with_max_catalog_version(2)
             .with_log_tail(log_tail);
 
@@ -1008,12 +958,57 @@ mod tests {
         assert_eq!(paths, HashSet::from(["path_0", "path_1", "path_2"]));
     }
 
+    #[tokio::test]
+    async fn catalog_managed_row_tracking_listing_rejects_metadata_that_disables_ict() {
+        let store = Arc::new(InMemory::new());
+        let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(store.clone()));
+        let table_root = Url::parse("memory:///").unwrap();
+        write_catalog_managed_row_tracking_base(store.as_ref(), &table_root).await;
+
+        for (version, ict_enabled) in [(1, false), (2, true)] {
+            let mut properties = row_tracking_properties();
+            properties.insert(
+                ENABLE_IN_COMMIT_TIMESTAMPS.to_string(),
+                ict_enabled.to_string(),
+            );
+            let metadata =
+                Metadata::try_new(None, None, listing_test_schema(), vec![], 0, properties)
+                    .unwrap();
+            add_commit(
+                &table_root,
+                store.as_ref(),
+                version,
+                serialize_actions([commit_info_action(version), Action::Metadata(metadata)]),
+            )
+            .await
+            .unwrap();
+        }
+
+        let table_changes = TableChanges::try_new_row_tracking_cdf_listing(
+            table_root,
+            engine.as_ref(),
+            0,
+            Some(2),
+            LogLoadOptions::default().with_max_catalog_version(2),
+        )
+        .unwrap();
+        let result = Arc::new(table_changes)
+            .scan_file_listing(engine, TableChangesListingMode::AllChanges)
+            .map(|_| ());
+        assert_result_error_with_message(
+            result,
+            "Feature 'catalogManaged' requires 'inCommitTimestamp' to be enabled",
+        );
+    }
+
     #[rstest::rstest]
-    #[case::catalog_latest(None, Some(2), &["path_0", "path_1", "path_2"])]
-    #[case::explicit_end(Some(1), Some(1), &["path_0", "path_1"])]
-    #[case::explicit_end_above_catalog_maximum(Some(3), None, &[])]
+    #[case::catalog_latest(0, None, Some(2), &["path_0", "path_1", "path_2"])]
+    #[case::explicit_end(0, Some(1), Some(1), &["path_0", "path_1"])]
+    #[case::end_above_catalog_maximum(0, Some(3), None, &[])]
+    #[case::start_above_catalog_maximum(3, Some(3), None, &[])]
     #[tokio::test]
     async fn catalog_managed_row_tracking_listing_respects_version_bounds(
+        #[case] start_version: Version,
         #[case] end_version: Option<Version>,
         #[case] expected_end_version: Option<Version>,
         #[case] expected_paths: &[&str],
@@ -1022,7 +1017,7 @@ mod tests {
         let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(store.clone()));
         let table_root = Url::parse("memory:///").unwrap();
         write_catalog_managed_row_tracking_base(store.as_ref(), &table_root).await;
-        for version in 1..=3 {
+        for version in 1..=2 {
             let body = serialize_actions([
                 commit_info_action(version),
                 row_tracking_add_action(&format!("path_{version}"), version),
@@ -1031,12 +1026,12 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let options = TableChangesLoadOptions::default().with_max_catalog_version(2);
+        let options = LogLoadOptions::default().with_max_catalog_version(2);
 
         let table_changes = TableChanges::try_new_row_tracking_cdf_listing(
             table_root,
             engine.as_ref(),
-            0,
+            start_version,
             end_version,
             options,
         );
@@ -1103,7 +1098,7 @@ mod tests {
                 engine.as_ref(),
                 0,
                 Some(0),
-                TableChangesLoadOptions::default(),
+                LogLoadOptions::default(),
             )
             .unwrap(),
         );
@@ -1221,7 +1216,7 @@ mod tests {
                 engine.as_ref(),
                 1,
                 Some(end_version),
-                TableChangesLoadOptions::default(),
+                LogLoadOptions::default(),
             )
             .unwrap(),
         );
@@ -1285,7 +1280,7 @@ mod tests {
             engine.as_ref(),
             0,
             Some(0),
-            TableChangesLoadOptions::default(),
+            LogLoadOptions::default(),
         )
         .unwrap();
         let res = table_changes.into_scan_builder().build();
@@ -1317,7 +1312,7 @@ mod tests {
                 engine.as_ref(),
                 0,
                 Some(0),
-                TableChangesLoadOptions::default(),
+                LogLoadOptions::default(),
             )
             .unwrap(),
         );

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -44,11 +44,12 @@ use scan::TableChangesScanBuilder;
 use scan_file::scan_metadata_to_scan_file;
 use url::Url;
 
+use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::path::AsUrl;
 use crate::schema::compare::SchemaComparison as _;
 use crate::schema::{DataType, Schema, StructField, StructType};
-use crate::snapshot::{Snapshot, SnapshotRef};
+use crate::snapshot::{Snapshot, SnapshotBuilder, SnapshotRef};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{Operation, TableFeature};
 use crate::table_properties::{
@@ -87,6 +88,51 @@ pub(crate) enum TableChangesListingMode {
     NetChanges,
 }
 
+/// Catalog metadata used while loading a table-changes range.
+#[derive(Debug, Clone, Default)]
+#[internal_api]
+pub(crate) struct TableChangesLoadOptions {
+    max_catalog_version: Option<Version>,
+    log_tail: Vec<LogPath>,
+}
+
+impl TableChangesLoadOptions {
+    /// Sets the highest table version ratified by the catalog.
+    ///
+    /// Range construction rejects this option for non-catalog-managed tables and rejects explicit
+    /// range versions above this limit.
+    #[internal_api]
+    pub(crate) fn with_max_catalog_version(mut self, max_catalog_version: Version) -> Self {
+        self.max_catalog_version = Some(max_catalog_version);
+        self
+    }
+
+    /// Sets the catalog-provided log tail, including staged commits absent from the numbered log.
+    ///
+    /// Entries must form a contiguous ascending sequence. Staged commits require
+    /// [`Self::with_max_catalog_version`], and range construction validates the tail endpoint
+    /// against the requested version.
+    #[internal_api]
+    pub(crate) fn with_log_tail(mut self, log_tail: Vec<LogPath>) -> Self {
+        self.log_tail = log_tail;
+        self
+    }
+
+    fn configure_snapshot_builder(&self, mut builder: SnapshotBuilder) -> SnapshotBuilder {
+        if let Some(max_catalog_version) = self.max_catalog_version {
+            builder = builder.with_max_catalog_version(max_catalog_version);
+        }
+        if !self.log_tail.is_empty() {
+            builder = builder.with_log_tail(self.log_tail.clone());
+        }
+        builder
+    }
+
+    fn effective_end_version(&self, end_version: Option<Version>) -> Option<Version> {
+        end_version.or(self.max_catalog_version)
+    }
+}
+
 /// Identifies the table feature that must remain enabled across the change-feed range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CdfMode {
@@ -117,6 +163,14 @@ impl CdfMode {
         match self {
             CdfMode::ChangeDataFeed => Error::change_data_feed_unsupported(version),
             CdfMode::RowTracking => Error::row_tracking_change_feed_unsupported(version),
+        }
+    }
+
+    /// The read operation whose feature support is required by this mode.
+    pub(crate) fn read_operation(self) -> Operation {
+        match self {
+            CdfMode::ChangeDataFeed => Operation::Cdf,
+            CdfMode::RowTracking => Operation::Scan,
         }
     }
 
@@ -257,6 +311,7 @@ impl TableChanges {
             start_version,
             end_version,
             CdfMode::ChangeDataFeed,
+            TableChangesLoadOptions::default(),
         )
     }
 
@@ -264,26 +319,24 @@ impl TableChanges {
     ///
     /// This path requires `delta.enableRowTracking` and ignores `_change_data` files.
     /// [`TableChanges::scan_file_listing`] returns the `add` and `remove` actions whose data must
-    /// be reconciled by row ID.
-    ///
-    /// Construction validates the range boundaries. [`TableChanges::scan_file_listing`] validates
-    /// intermediate metadata and protocol updates while replaying the range. Every enabled reader
-    /// feature must be supported by Kernel, and each schema must be readable using the end-version
-    /// logical schema without datatype widening.
+    /// be reconciled by row ID. Catalog ratification and log-tail metadata from `load_options` are
+    /// applied while loading the range.
     ///
     /// # Parameters
     ///
     /// - `table_root`: URL of the table root containing `_delta_log`.
     /// - `engine`: Engine used to read the transaction log.
     /// - `start_version`: First version in the change feed.
-    /// - `end_version`: The end version (inclusive) of the change data feed. If this is none, this
-    ///   defaults to the newest table version.
+    /// - `end_version`: Optional inclusive end version. When omitted, the catalog maximum is used
+    ///   if present; otherwise the newest version is used.
+    /// - `load_options`: Catalog ratification and log-tail metadata used to load the range.
     ///
     /// # Errors
     ///
-    /// Returns an error if the range cannot be loaded or a boundary has unavailable row tracking,
-    /// unsupported reader features, or an incompatible schema. Errors from intermediate versions
-    /// are returned by [`TableChanges::scan_file_listing`].
+    /// Returns an error if the range or catalog inputs are invalid, a catalog maximum is supplied
+    /// for a non-catalog-managed table, or a boundary has unavailable row tracking, unsupported
+    /// reader features, or an incompatible schema. Errors from intermediate versions are returned
+    /// by [`TableChanges::scan_file_listing`].
     #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     #[internal_api]
     pub(crate) fn try_new_row_tracking_cdf_listing(
@@ -291,6 +344,7 @@ impl TableChanges {
         engine: &dyn Engine,
         start_version: Version,
         end_version: Option<Version>,
+        load_options: TableChangesLoadOptions,
     ) -> DeltaResult<Self> {
         Self::try_new_internal(
             table_root,
@@ -298,6 +352,7 @@ impl TableChanges {
             start_version,
             end_version,
             CdfMode::RowTracking,
+            load_options,
         )
     }
 
@@ -307,31 +362,37 @@ impl TableChanges {
         start_version: Version,
         end_version: Option<Version>,
         mode: CdfMode,
+        load_options: TableChangesLoadOptions,
     ) -> DeltaResult<Self> {
         let log_root = table_root.join("_delta_log/")?;
+        let effective_end_version = load_options.effective_end_version(end_version);
         let log_segment = LogSegment::for_table_changes(
             engine.storage_handler().as_ref(),
             log_root,
             start_version,
-            end_version,
+            effective_end_version,
+            load_options.log_tail.clone(),
         )?;
 
-        let start_snapshot = Snapshot::builder_for(table_root.as_url().clone())
-            .at_version(start_version)
+        let start_snapshot = load_options
+            .configure_snapshot_builder(
+                Snapshot::builder_for(table_root.as_url().clone()).at_version(start_version),
+            )
             .build(engine)?;
         start_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Cdf)?;
+            .ensure_operation_supported(mode.read_operation())?;
 
-        let end_snapshot = match end_version {
-            Some(version) => Snapshot::builder_from(start_snapshot.clone())
-                .at_version(version)
-                .build(engine)?,
-            None => Snapshot::builder_from(start_snapshot.clone()).build(engine)?,
+        let end_snapshot_builder = match end_version {
+            Some(version) => Snapshot::builder_from(start_snapshot.clone()).at_version(version),
+            None => Snapshot::builder_from(start_snapshot.clone()),
         };
+        let end_snapshot = load_options
+            .configure_snapshot_builder(end_snapshot_builder)
+            .build(engine)?;
         end_snapshot
             .table_configuration()
-            .ensure_operation_supported(Operation::Cdf)?;
+            .ensure_operation_supported(mode.read_operation())?;
 
         // Verify the change feed is enabled at the beginning and end of the interval to fail early.
         // The `ensure_operation_supported` calls above already validate that every enabled reader
@@ -546,15 +607,17 @@ impl TableChanges {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
+    use ::test_utils::{add_commit, add_staged_commit};
     use itertools::{assert_equal, Itertools};
 
     use super::*;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
-    use crate::actions::{Add, Metadata, Protocol, Remove};
+    use crate::actions::{Add, CommitInfo, Metadata, Protocol, Remove};
     use crate::engine::sync::SyncEngine;
+    use crate::object_store::memory::InMemory;
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_changes::test_utils::{
         row_tracking_properties, row_tracking_protocol, row_tracking_setup_actions,
@@ -564,20 +627,80 @@ mod tests {
     use crate::table_changes::CDF_FIELDS;
     use crate::table_features::TableFeature;
     use crate::table_properties::{
-        COLUMN_MAPPING_MODE, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
-        MATERIALIZED_ROW_ID_COLUMN_NAME,
+        COLUMN_MAPPING_MODE, ENABLE_IN_COMMIT_TIMESTAMPS,
+        MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME, MATERIALIZED_ROW_ID_COLUMN_NAME,
     };
     use crate::unit_test_utils::{
         assert_result_error_with_message, test_schema_flat_with_column_mapping, Action,
         LocalMockTable,
     };
-    use crate::{Engine, Error};
+    use crate::{Engine, Error, FileMeta};
 
     fn listing_test_schema() -> Arc<StructType> {
         Arc::new(StructType::new_unchecked([
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),
         ]))
+    }
+
+    fn catalog_managed_row_tracking_setup_actions() -> Vec<Action> {
+        let mut properties = row_tracking_properties();
+        properties.insert(ENABLE_IN_COMMIT_TIMESTAMPS.to_string(), "true".to_string());
+        let metadata =
+            Metadata::try_new(None, None, listing_test_schema(), vec![], 0, properties).unwrap();
+        let protocol = Protocol::try_new_modern(
+            [TableFeature::CatalogManaged],
+            [
+                TableFeature::CatalogManaged,
+                TableFeature::InCommitTimestamp,
+                TableFeature::RowTracking,
+                TableFeature::DomainMetadata,
+            ],
+        )
+        .unwrap();
+        vec![Action::Protocol(protocol), Action::Metadata(metadata)]
+    }
+
+    fn commit_info_action(version: Version) -> Action {
+        let timestamp = 1_000 + version as i64;
+        Action::CommitInfo(CommitInfo::new(
+            timestamp,
+            Some(timestamp),
+            None,
+            None,
+            true,
+        ))
+    }
+
+    fn row_tracking_add_action(path: &str, version: Version) -> Action {
+        Action::Add(Add {
+            path: path.to_string(),
+            data_change: true,
+            size: 100,
+            base_row_id: Some(version as i64 * 10),
+            default_row_commit_version: Some(version as i64),
+            ..Default::default()
+        })
+    }
+
+    fn serialize_actions(actions: impl IntoIterator<Item = Action>) -> String {
+        actions
+            .into_iter()
+            .map(|action| serde_json::to_string(&action).unwrap())
+            .join("\n")
+    }
+
+    async fn write_catalog_managed_row_tracking_base(
+        store: &dyn crate::object_store::ObjectStore,
+        table_root: &Url,
+    ) {
+        let actions = [commit_info_action(0)]
+            .into_iter()
+            .chain(catalog_managed_row_tracking_setup_actions())
+            .chain([row_tracking_add_action("path_0", 0)]);
+        add_commit(table_root, store, 0, serialize_actions(actions))
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -686,7 +809,13 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         assert_result_error_with_message(
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 0, Some(0)),
+            TableChanges::try_new_row_tracking_cdf_listing(
+                table_root,
+                engine.as_ref(),
+                0,
+                Some(0),
+                TableChangesLoadOptions::default(),
+            ),
             missing_property,
         );
     }
@@ -698,7 +827,13 @@ mod tests {
         let path = "./tests/data/table-with-cdf";
         let engine = Box::new(SyncEngine::new());
         let url = delta_kernel::try_parse_uri(path).unwrap();
-        let res = TableChanges::try_new_row_tracking_cdf_listing(url, engine.as_ref(), 0, Some(1));
+        let res = TableChanges::try_new_row_tracking_cdf_listing(
+            url,
+            engine.as_ref(),
+            0,
+            Some(1),
+            TableChangesLoadOptions::default(),
+        );
         assert!(
             matches!(&res, Err(Error::RowTrackingChangeFeedUnsupported(_))),
             "expected a row-tracking-disabled error, got {res:?}"
@@ -746,8 +881,13 @@ mod tests {
             .await;
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
-        let res =
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 1, Some(2));
+        let res = TableChanges::try_new_row_tracking_cdf_listing(
+            table_root,
+            engine.as_ref(),
+            1,
+            Some(2),
+            TableChangesLoadOptions::default(),
+        );
         assert!(
             matches!(&res, Err(Error::ChangeDataFeedIncompatibleSchema(_, _))),
             "expected an incompatible start schema to be rejected, got {res:?}"
@@ -787,8 +927,14 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let table_changes = Arc::new(
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 0, Some(1))
-                .unwrap(),
+            TableChanges::try_new_row_tracking_cdf_listing(
+                table_root,
+                engine.as_ref(),
+                0,
+                Some(1),
+                TableChangesLoadOptions::default(),
+            )
+            .unwrap(),
         );
         let listing: Vec<TableChangesFileAction> = table_changes
             .scan_file_listing(engine, TableChangesListingMode::AllChanges)
@@ -810,6 +956,109 @@ mod tests {
         assert!(listing.iter().all(|fa| fa.remove.is_none()));
         assert_eq!(add_side("path_0").base_row_id, Some(0));
         assert_eq!(add_side("path_1").base_row_id, Some(5));
+    }
+
+    #[tokio::test]
+    async fn catalog_managed_row_tracking_listing_reads_staged_commits() {
+        let store = Arc::new(InMemory::new());
+        let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(store.clone()));
+        let table_root = Url::parse("memory:///").unwrap();
+        write_catalog_managed_row_tracking_base(store.as_ref(), &table_root).await;
+
+        let mut log_tail = Vec::new();
+        for version in 1..=2 {
+            let body = serialize_actions([
+                commit_info_action(version),
+                row_tracking_add_action(&format!("path_{version}"), version),
+            ]);
+            let path = add_staged_commit(&table_root, store.as_ref(), version, body)
+                .await
+                .unwrap();
+            let file_meta = FileMeta {
+                location: table_root.join(path.as_ref()).unwrap(),
+                last_modified: 123,
+                size: 100,
+            };
+            log_tail.push(LogPath::try_new(file_meta).unwrap());
+        }
+        let options = TableChangesLoadOptions::default()
+            .with_max_catalog_version(2)
+            .with_log_tail(log_tail);
+
+        let table_changes = Arc::new(
+            TableChanges::try_new_row_tracking_cdf_listing(
+                table_root,
+                engine.as_ref(),
+                0,
+                None,
+                options,
+            )
+            .unwrap(),
+        );
+        assert_eq!(table_changes.end_version(), 2);
+        let listing: Vec<TableChangesFileAction> = table_changes
+            .scan_file_listing(engine, TableChangesListingMode::AllChanges)
+            .unwrap()
+            .try_collect()
+            .unwrap();
+        let paths = listing
+            .iter()
+            .filter_map(|action| action.add.as_ref().map(|add| add.path.as_str()))
+            .collect::<HashSet<_>>();
+        assert_eq!(paths, HashSet::from(["path_0", "path_1", "path_2"]));
+    }
+
+    #[rstest::rstest]
+    #[case::catalog_latest(None, Some(2), &["path_0", "path_1", "path_2"])]
+    #[case::explicit_end(Some(1), Some(1), &["path_0", "path_1"])]
+    #[case::explicit_end_above_catalog_maximum(Some(3), None, &[])]
+    #[tokio::test]
+    async fn catalog_managed_row_tracking_listing_respects_version_bounds(
+        #[case] end_version: Option<Version>,
+        #[case] expected_end_version: Option<Version>,
+        #[case] expected_paths: &[&str],
+    ) {
+        let store = Arc::new(InMemory::new());
+        let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new_with_store(store.clone()));
+        let table_root = Url::parse("memory:///").unwrap();
+        write_catalog_managed_row_tracking_base(store.as_ref(), &table_root).await;
+        for version in 1..=3 {
+            let body = serialize_actions([
+                commit_info_action(version),
+                row_tracking_add_action(&format!("path_{version}"), version),
+            ]);
+            add_commit(&table_root, store.as_ref(), version, body)
+                .await
+                .unwrap();
+        }
+        let options = TableChangesLoadOptions::default().with_max_catalog_version(2);
+
+        let table_changes = TableChanges::try_new_row_tracking_cdf_listing(
+            table_root,
+            engine.as_ref(),
+            0,
+            end_version,
+            options,
+        );
+        let Some(expected_end_version) = expected_end_version else {
+            assert_result_error_with_message(
+                table_changes,
+                "Requested version 3 exceeds max catalog version 2",
+            );
+            return;
+        };
+        let table_changes = Arc::new(table_changes.unwrap());
+        assert_eq!(table_changes.end_version(), expected_end_version);
+        let listing: Vec<TableChangesFileAction> = table_changes
+            .scan_file_listing(engine, TableChangesListingMode::AllChanges)
+            .unwrap()
+            .try_collect()
+            .unwrap();
+        let paths = listing
+            .iter()
+            .filter_map(|action| action.add.as_ref().map(|add| add.path.as_str()))
+            .collect::<HashSet<_>>();
+        assert_eq!(paths, expected_paths.iter().copied().collect());
     }
 
     #[tokio::test]
@@ -849,8 +1098,14 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let table_changes = Arc::new(
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 0, Some(0))
-                .unwrap(),
+            TableChanges::try_new_row_tracking_cdf_listing(
+                table_root,
+                engine.as_ref(),
+                0,
+                Some(0),
+                TableChangesLoadOptions::default(),
+            )
+            .unwrap(),
         );
         assert_eq!(
             table_changes.materialized_row_id_column_name().unwrap(),
@@ -966,6 +1221,7 @@ mod tests {
                 engine.as_ref(),
                 1,
                 Some(end_version),
+                TableChangesLoadOptions::default(),
             )
             .unwrap(),
         );
@@ -1024,9 +1280,14 @@ mod tests {
             .await;
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
-        let table_changes =
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 0, Some(0))
-                .unwrap();
+        let table_changes = TableChanges::try_new_row_tracking_cdf_listing(
+            table_root,
+            engine.as_ref(),
+            0,
+            Some(0),
+            TableChangesLoadOptions::default(),
+        )
+        .unwrap();
         let res = table_changes.into_scan_builder().build();
         assert_result_error_with_message(
             res,
@@ -1051,8 +1312,14 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let table_changes = Arc::new(
-            TableChanges::try_new_row_tracking_cdf_listing(table_root, engine.as_ref(), 0, Some(0))
-                .unwrap(),
+            TableChanges::try_new_row_tracking_cdf_listing(
+                table_root,
+                engine.as_ref(),
+                0,
+                Some(0),
+                TableChangesLoadOptions::default(),
+            )
+            .unwrap(),
         );
         let listing: Vec<TableChangesFileAction> = table_changes
             .scan_file_listing(engine, mode)

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -154,12 +154,7 @@ impl TableChangesScan {
         &self,
         engine: Arc<dyn Engine>,
     ) -> DeltaResult<impl Iterator<Item = DeltaResult<TableChangesScanMetadata>>> {
-        let commits = self
-            .table_changes
-            .log_segment
-            .listed
-            .ascending_commit_files
-            .clone();
+        let commits = self.table_changes.commit_range.commit_files().to_vec();
         // NOTE: This is a cheap arc clone
         let physical_predicate = match self.state_info.physical_predicate.clone() {
             PhysicalPredicate::StaticSkipAll => return Ok(None.into_iter().flatten()),

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -491,7 +491,7 @@ mod tests {
     use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
     use crate::actions::{Add, Cdc, Metadata, Protocol, Remove};
     use crate::engine::sync::SyncEngine;
-    use crate::log_segment::LogSegment;
+    use crate::log_segment::{LogLoadOptions, LogSegment};
     use crate::scan::state::DvInfo;
     use crate::schema::{DataType, StructField, StructType};
     use crate::table_changes::log_replay::{
@@ -544,12 +544,12 @@ mod tests {
         mock_table: &LocalMockTable,
     ) -> Vec<CdfScanFile> {
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
-        let log_segment = LogSegment::for_table_changes(
+        let log_segment = LogSegment::for_commit_range(
             engine.storage_handler().as_ref(),
             table_root.join("_delta_log/").unwrap(),
             0,
             None,
-            vec![],
+            LogLoadOptions::default(),
         )
         .unwrap();
         let table_schema = Arc::new(StructType::new_unchecked([
@@ -648,12 +648,12 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
-        let log_segment = LogSegment::for_table_changes(
+        let log_segment = LogSegment::for_commit_range(
             engine.storage_handler().as_ref(),
             log_root,
             0,
             None,
-            vec![],
+            LogLoadOptions::default(),
         )
         .unwrap();
         let table_schema = Arc::new(StructType::new_unchecked([

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -549,6 +549,7 @@ mod tests {
             table_root.join("_delta_log/").unwrap(),
             0,
             None,
+            vec![],
         )
         .unwrap();
         let table_schema = Arc::new(StructType::new_unchecked([
@@ -647,9 +648,14 @@ mod tests {
 
         let table_root = url::Url::from_directory_path(mock_table.table_root()).unwrap();
         let log_root = table_root.join("_delta_log/").unwrap();
-        let log_segment =
-            LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, None)
-                .unwrap();
+        let log_segment = LogSegment::for_table_changes(
+            engine.storage_handler().as_ref(),
+            log_root,
+            0,
+            None,
+            vec![],
+        )
+        .unwrap();
         let table_schema = Arc::new(StructType::new_unchecked([
             StructField::nullable("id", DataType::INTEGER),
             StructField::nullable("value", DataType::STRING),


### PR DESCRIPTION
## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->
Add catalog-managed table support to row-tracking change listings.
  - Apply the catalog’s maximum version and log tail when loading the commit range and boundary snapshots.
  - Read staged catalog commits that have not been published to the numbered Delta log.
  - Validate row-tracking listings using normal scan support while preserving CDF-specific validation.
  - Respect catalog version bounds when selecting an implicit or explicit end version.
 
## How was this change tested?
Added unit tests covering staged commits, catalog-latest resolution, explicit end versions, and rejection of versions above the catalog maximum.
