### PR TITLE
feat!: implement aggregator operator

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -117,7 +117,10 @@ pub(crate) fn to_df_struct_columns(
 /// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
 /// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
 /// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
-fn column_to_df_expr(name: &KernelColumnName, input_schema: &StructType) -> DeltaResult<DFExpr> {
+pub(crate) fn column_to_df_expr(
+    name: &KernelColumnName,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
     let _ = input_schema.field_at(name)?;
     let mut path = name.iter();
     let Some(root) = path.next() else {

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -6,9 +6,7 @@ use datafusion::arrow::array::{new_null_array, ArrayRef, RecordBatch, StructArra
 use datafusion::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
 use datafusion::common::utils::take_function_args;
 use datafusion::common::{Column as DFColumn, DataFusionError, ScalarValue as DFScalarValue};
-use datafusion::functions::core::expr_fn::{
-    coalesce, get_field, get_field_path, named_struct, nullif,
-};
+use datafusion::functions::core::expr_fn::{coalesce, get_field, named_struct, nullif};
 use datafusion::functions_nested::expr_fn::make_array;
 use datafusion::logical_expr::{
     binary_expr, cast, lit, Case, ColumnarValue, Expr as DFExpr, Operator, ScalarFunctionArgs,
@@ -18,9 +16,9 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::parse_json;
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
-    Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
-    ParseJsonExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
+    BinaryExpression, BinaryExpressionOp, Expression as KernelExpression, ExpressionRef,
+    ExpressionStructPatch, MapToStructExpression, ParseJsonExpression, UnaryExpressionOp,
+    VariadicExpression, VariadicExpressionOp,
 };
 use delta_kernel::schema::{
     DataType as KernelDataType, PrimitiveType, SchemaRef as KernelSchemaRef, StructField,
@@ -30,6 +28,7 @@ use delta_kernel::{DeltaResult, EngineData, Error};
 
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
+use crate::utils::column_to_df_expr;
 
 /// Converts `expr` into the equivalent DataFusion [`Expr`](DFExpr), resolving column references
 /// against `input_schema`.
@@ -111,28 +110,6 @@ pub(crate) fn to_df_struct_columns(
         _ => Err(Error::generic(format!(
             "Expression must be a Struct or StructPatch, got {expr:?}"
         ))),
-    }
-}
-
-/// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
-/// `get_field(col("a"), "b", "c")` call. The path is resolved against `input_schema` (via
-/// [`StructType::field_at`]) to fail fast, but the resolved field is otherwise unused.
-pub(crate) fn column_to_df_expr(
-    name: &KernelColumnName,
-    input_schema: &StructType,
-) -> DeltaResult<DFExpr> {
-    let _ = input_schema.field_at(name)?;
-    let mut path = name.iter();
-    let Some(root) = path.next() else {
-        return Err(Error::generic("cannot convert an empty column reference"));
-    };
-    let root = DFExpr::Column(DFColumn::new_unqualified(root));
-    let field_names = Vec::from_iter(path.map(lit));
-    // A bare column stays a bare column; only nested access wraps it in a `get_field` call.
-    if field_names.is_empty() {
-        Ok(root)
-    } else {
-        Ok(get_field_path(root, field_names))
     }
 }
 
@@ -568,8 +545,8 @@ mod tests {
     use datafusion::physical_expr::create_physical_expr;
     use datafusion::physical_expr::execution_props::ExecutionProps;
     use delta_kernel::expressions::{
-        col, lit, null_lit, Expression as KernelExpr, ExpressionStructPatch,
-        ExpressionStructPatchBuilder,
+        col, lit, null_lit, ColumnName as KernelColumnName, Expression as KernelExpr,
+        ExpressionStructPatch, ExpressionStructPatchBuilder,
     };
     use delta_kernel::schema::{schema, schema_ref, ArrayType, DataType, MapType, StructType};
     use rstest::rstest;

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -18,6 +18,7 @@ mod operator;
 mod plan;
 mod predicate;
 mod scalar;
+mod utils;
 
 pub use expression::to_df_expr;
 pub use predicate::to_df_predicate_expr;

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -116,9 +116,10 @@ fn lower_project(
 
 /// Lowers an [`Aggregate`](KernelAggregate) to a DataFusion aggregate over its input.
 ///
-/// Aggregate operands retain their types from the input because the kernel IR does not declare
-/// separate operand types. DataFusion applies any function-specific input coercion; the explicit
-/// casts here make group keys and aggregate results match the aggregate's declared output schema.
+/// This lowering does not cast aggregate operands. It passes them using their input-schema types,
+/// and DataFusion's type-coercion analyzer inserts any casts required by each aggregate function's
+/// signature. The explicit casts here only make group keys and final aggregate results match the
+/// aggregate's declared output schema.
 fn lower_aggregate(
     aggregate: &KernelAggregate,
     input: &Arc<DFLogicalPlan>,

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -14,19 +14,24 @@ use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Schema as ArrowSchema;
 use datafusion::common::{DFSchema, DataFusionError};
+use datafusion::functions_aggregate::expr_fn::{count, max, min, sum};
+use datafusion::functions_aggregate::first_last::first_value_udaf;
 use datafusion::logical_expr::{
-    col as df_col, lit as df_lit, EmptyRelation, Expr as DFExpr, ExprSchemable, Filter as DFFilter,
-    LogicalPlan as DFLogicalPlan, LogicalPlanBuilder, Projection as DFProjection,
+    col as df_col, lit as df_lit, Aggregate as DFAggregate, EmptyRelation, Expr as DFExpr,
+    ExprFunctionExt, ExprSchemable, Filter as DFFilter, LogicalPlan as DFLogicalPlan,
+    LogicalPlanBuilder, Projection as DFProjection,
 };
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
-use delta_kernel::expressions::Scalar as KernelScalar;
+use delta_kernel::expressions::{
+    ColumnName as KernelColumnName, Expression as KernelExpression, Scalar as KernelScalar,
+};
 use delta_kernel::plans::ir::nodes::{
-    Filter as KernelFilter, Operator as KernelOperator, Project as KernelProject,
-    Values as KernelValues,
+    Agg as KernelAgg, Aggregate as KernelAggregate, Filter as KernelFilter,
+    Operator as KernelOperator, Project as KernelProject, Values as KernelValues,
 };
 use delta_kernel::schema::StructType;
 
-use crate::expression::to_df_struct_columns;
+use crate::expression::{to_df_expr, to_df_struct_columns};
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
 
@@ -64,8 +69,14 @@ pub(crate) fn lower_operator(
             };
             lower_filter(filter, input)
         }
-        // TODO: lower the remaining operators (scans, Load/Aggregate, SemiJoin, UnionAll), each
-        // in its own change.
+        KernelOperator::Aggregate(aggregate) => {
+            let [input] = inputs else {
+                return Err(input_count_error(1));
+            };
+            lower_aggregate(aggregate, input)
+        }
+        // TODO: lower the remaining operators (scans, Load, SemiJoin, UnionAll), each in its own
+        // change.
         _ => Err(DataFusionError::NotImplemented(format!(
             "lowering operator {op} to a DataFusion LogicalPlan"
         ))),
@@ -103,6 +114,123 @@ fn lower_project(
         .collect();
     let projection = DFProjection::try_new_with_schema(exprs?, Arc::clone(input), df_schema)?;
     Ok(DFLogicalPlan::Projection(projection))
+}
+
+/// Lowers an [`Aggregate`](KernelAggregate) to a DataFusion aggregate over its parent.
+fn lower_aggregate(
+    aggregate: &KernelAggregate,
+    input: &Arc<DFLogicalPlan>,
+) -> Result<DFLogicalPlan, DataFusionError> {
+    let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
+    let output_fields: Vec<_> = aggregate.schema.fields().collect();
+    let expected_field_count = aggregate.group_by.len() + aggregate.aggs.len();
+    if output_fields.len() != expected_field_count {
+        return Err(DataFusionError::Plan(format!(
+            "Aggregate declares {} group key(s) and {} aggregate expression(s), but its output \
+             schema has {} fields",
+            aggregate.group_by.len(),
+            aggregate.aggs.len(),
+            output_fields.len()
+        )));
+    }
+
+    if expected_field_count == 0 {
+        let arrow_schema: ArrowSchema = aggregate.schema.as_ref().try_into_arrow()?;
+        let empty = EmptyRelation {
+            produce_one_row: true,
+            schema: Arc::new(arrow_schema.try_into()?),
+        };
+        return Ok(DFLogicalPlan::EmptyRelation(empty));
+    }
+
+    let (group_fields, aggregate_fields) = output_fields.split_at(aggregate.group_by.len());
+    let group_exprs: Result<Vec<_>, DataFusionError> = aggregate
+        .group_by
+        .iter()
+        .zip(group_fields)
+        .map(|(column, field)| {
+            let expr = column_to_df_expr(column, &input_schema)?;
+            let target = field.data_type().try_into_arrow()?;
+            let expr = expr
+                .cast_to(&target, input.schema())?
+                .alias(field.name().clone());
+            Ok(expr)
+        })
+        .collect();
+    let aggregate_exprs: Result<Vec<_>, DataFusionError> = aggregate
+        .aggs
+        .iter()
+        .zip(aggregate_fields)
+        .map(|(agg, field)| {
+            let expr = lower_agg(agg, &input_schema)?;
+            let target = field.data_type().try_into_arrow()?;
+            let expr = expr
+                .cast_to(&target, input.schema())?
+                .alias(field.name().clone());
+            Ok(expr)
+        })
+        .collect();
+
+    let arrow_schema: ArrowSchema = aggregate.schema.as_ref().try_into_arrow()?;
+    let df_schema = Arc::new(DFSchema::try_from(arrow_schema)?);
+    let df_aggregate = DFAggregate::try_new_with_schema(
+        Arc::clone(input),
+        group_exprs?,
+        aggregate_exprs?,
+        df_schema,
+    )?;
+    Ok(DFLogicalPlan::Aggregate(df_aggregate))
+}
+
+fn lower_agg(agg: &KernelAgg, input_schema: &StructType) -> Result<DFExpr, DataFusionError> {
+    match agg {
+        KernelAgg::Min(value) => Ok(min(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Max(value) => Ok(max(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Sum(value) => Ok(sum(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Count(value) => Ok(count(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::CountStar => Ok(count(df_lit(1))),
+        KernelAgg::MinNonNullBy(operands) => lower_non_null_by(
+            &operands.value,
+            &operands.null_sentinel,
+            &operands.key,
+            input_schema,
+            true,
+        ),
+        KernelAgg::MaxNonNullBy(operands) => lower_non_null_by(
+            &operands.value,
+            &operands.null_sentinel,
+            &operands.key,
+            input_schema,
+            false,
+        ),
+    }
+}
+
+fn lower_non_null_by(
+    value: &KernelColumnName,
+    null_sentinel: &KernelColumnName,
+    key: &KernelColumnName,
+    input_schema: &StructType,
+    ascending: bool,
+) -> Result<DFExpr, DataFusionError> {
+    let value = column_to_df_expr(value, input_schema)?;
+    let null_sentinel = column_to_df_expr(null_sentinel, input_schema)?;
+    let key = column_to_df_expr(key, input_schema)?;
+    let filter = null_sentinel.is_not_null().and(key.clone().is_not_null());
+    let first_value = first_value_udaf().call(vec![value]);
+    first_value
+        .order_by(vec![key.sort(ascending, false)])
+        .filter(filter)
+        .build()
+}
+
+fn column_to_df_expr(
+    column: &KernelColumnName,
+    input_schema: &StructType,
+) -> Result<DFExpr, DataFusionError> {
+    let column = KernelExpression::Column(column.clone());
+    to_df_expr(&column, input_schema, None)
+        .map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
 /// Lowers a [`Filter`](KernelFilter) node into a DataFusion [`Filter`](DFFilter) logical plan over
@@ -166,6 +294,7 @@ fn lower_row(row: &[KernelScalar]) -> Result<Vec<DFExpr>, DataFusionError> {
 
 #[cfg(test)]
 mod tests {
+    use datafusion::arrow::array::Array;
     use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::ScalarValue as DFScalarValue;
@@ -173,7 +302,7 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use datafusion::{assert_batches_eq, assert_batches_sorted_eq};
     use delta_kernel::expressions::{
-        col, lit as kernel_lit, null_lit, ArrayData as KernelArrayData,
+        col, column_name, lit as kernel_lit, null_lit, ArrayData as KernelArrayData,
         BinaryPredicateOp as KernelBinaryPredicateOp, Expression as KernelExpr, ExpressionRef,
         ExpressionStructPatchBuilder, JunctionPredicateOp as KernelJunctionPredicateOp,
         MapData as KernelMapData, Predicate as KernelPredicate, StructData as KernelStructData,
@@ -215,6 +344,27 @@ mod tests {
     /// An empty input relation with `schema`.
     fn input_with_schema(schema: StructType) -> Arc<DFLogicalPlan> {
         Arc::new(lower_values_node(schema, vec![]).unwrap())
+    }
+
+    fn empty_schema() -> StructType {
+        let fields: Vec<StructField> = Vec::new();
+        StructType::try_new(fields).unwrap()
+    }
+
+    fn output_names(plan: &DFLogicalPlan) -> Vec<&String> {
+        plan.schema()
+            .fields()
+            .iter()
+            .map(|field| field.name())
+            .collect()
+    }
+
+    fn output_types(plan: &DFLogicalPlan) -> Vec<ArrowDataType> {
+        plan.schema()
+            .fields()
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect()
     }
 
     // === Values ===
@@ -581,22 +731,6 @@ mod tests {
     }
 
     // === Project ===
-
-    fn empty_schema() -> StructType {
-        let fields: Vec<StructField> = Vec::new();
-        StructType::try_new(fields).unwrap()
-    }
-
-    /// The field names DataFusion reports for `plan`'s output columns.
-    fn output_names(plan: &DFLogicalPlan) -> Vec<&String> {
-        plan.schema().fields().iter().map(|f| f.name()).collect()
-    }
-
-    /// The Arrow types DataFusion reports for `plan`'s output columns.
-    fn output_types(plan: &DFLogicalPlan) -> Vec<ArrowDataType> {
-        let fields = plan.schema().fields();
-        fields.iter().map(|f| f.data_type().clone()).collect()
-    }
 
     /// Lowers a Project over `parent`.
     fn lower_project_expr(
@@ -1277,6 +1411,352 @@ mod tests {
         assert!(
             message.contains(r#"cannot convert Unknown expression "engine_expr""#),
             "{message}"
+        );
+    }
+
+    // === Aggregate ===
+
+    fn aggregate_input_schema() -> StructType {
+        StructType::try_new([
+            StructField::nullable("group", DataType::STRING),
+            StructField::nullable("value", DataType::STRING),
+            StructField::nullable("key", DataType::LONG),
+        ])
+        .unwrap()
+    }
+
+    fn test_aggregate() -> KernelAggregate {
+        KernelAggregate::ungrouped(Arc::new(aggregate_input_schema()))
+            .max(column_name!("value"))
+            .build()
+            .unwrap()
+    }
+
+    #[rstest]
+    #[case::missing(0)]
+    #[case::extra(2)]
+    fn aggregate_rejects_wrong_input_count(#[case] actual: usize) {
+        let input = input_with_schema(aggregate_input_schema());
+        let inputs = vec![input; actual];
+        let op = KernelOperator::Aggregate(test_aggregate());
+        let err = lower_operator(&op, &inputs).unwrap_err();
+        assert!(
+            err.to_string().contains(&format!(
+                "aggregate expects 1 input(s), but received {actual}"
+            )),
+            "{err}"
+        );
+    }
+
+    #[rstest]
+    #[case::min(KernelAgg::min(column_name!("value")), "min", None)]
+    #[case::max(KernelAgg::max(column_name!("value")), "max", None)]
+    #[case::min_non_null_by(
+        KernelAgg::min_non_null_by(
+            column_name!("value"),
+            column_name!("value"),
+            column_name!("key")
+        ),
+        "first_value",
+        Some(true)
+    )]
+    #[case::max_non_null_by(
+        KernelAgg::max_non_null_by(
+            column_name!("value"),
+            column_name!("value"),
+            column_name!("key")
+        ),
+        "first_value",
+        Some(false)
+    )]
+    fn aggregate_lowers_function_with_declared_schema(
+        #[case] agg: KernelAgg,
+        #[case] expected_function: &str,
+        #[case] expected_ascending: Option<bool>,
+        #[values(false, true)] grouped: bool,
+    ) {
+        let parent = input_with_schema(aggregate_input_schema());
+        let group_by = grouped.then(|| column_name!("group"));
+        let aggregate = KernelAggregate::group_by(Arc::new(aggregate_input_schema()), group_by)
+            .aggregate_as(agg, "result")
+            .build()
+            .unwrap();
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+
+        let expected_names = if grouped {
+            vec!["group", "result"]
+        } else {
+            vec!["result"]
+        };
+        assert_eq!(output_names(&lowered), expected_names);
+        let DFLogicalPlan::Aggregate(aggregate) = &lowered else {
+            panic!("expected Aggregate, got {lowered:?}");
+        };
+        assert!(Arc::ptr_eq(&aggregate.input, &parent));
+        let expected_group: Vec<_> = grouped
+            .then(|| df_col("group").alias("group"))
+            .into_iter()
+            .collect();
+        assert_eq!(aggregate.group_expr, expected_group);
+
+        let [DFExpr::Alias(alias)] = aggregate.aggr_expr.as_slice() else {
+            panic!("expected one aliased aggregate expression");
+        };
+        assert_eq!(alias.name, "result");
+        let DFExpr::AggregateFunction(function) = alias.expr.as_ref() else {
+            panic!("expected aggregate function, got {:?}", alias.expr);
+        };
+        assert_eq!(function.func.name(), expected_function);
+        assert_eq!(function.params.args, [df_col("value")]);
+
+        let Some(ascending) = expected_ascending else {
+            assert!(function.params.order_by.is_empty());
+            assert!(function.params.filter.is_none());
+            return;
+        };
+        assert_eq!(
+            function.params.order_by,
+            [df_col("key").sort(ascending, false)]
+        );
+        let expected_filter = df_col("value")
+            .is_not_null()
+            .and(df_col("key").is_not_null());
+        assert_eq!(function.params.filter.as_deref(), Some(&expected_filter));
+    }
+
+    #[tokio::test]
+    async fn aggregate_casts_output_to_declared_type() {
+        let input =
+            StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap();
+        let parent =
+            Arc::new(lower_values_node(input, vec![vec![KernelScalar::Integer(7)]]).unwrap());
+        let aggregate = KernelAggregate {
+            group_by: vec![],
+            aggs: vec![KernelAgg::max(column_name!("value"))],
+            schema: Arc::new(
+                StructType::try_new([StructField::nullable("result", DataType::LONG)]).unwrap(),
+            ),
+        };
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        assert_eq!(output_types(&lowered), [ArrowDataType::Int64]);
+        let batches = execute(lowered).await.unwrap();
+        assert_batches_eq!(
+            &[
+                "+--------+",
+                "| result |",
+                "+--------+",
+                "| 7      |",
+                "+--------+"
+            ],
+            &batches
+        );
+    }
+
+    #[test]
+    fn empty_global_aggregate_lowers_to_one_row_relation() {
+        let parent = input_with_schema(test_schema());
+        let aggregate = KernelAggregate {
+            group_by: vec![],
+            aggs: vec![],
+            schema: Arc::new(empty_schema()),
+        };
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+
+        let DFLogicalPlan::EmptyRelation(empty) = &lowered else {
+            panic!("expected EmptyRelation, got {lowered:?}");
+        };
+        assert!(empty.produce_one_row);
+        assert!(empty.schema.fields().is_empty());
+    }
+
+    #[test]
+    fn aggregate_rejects_output_schema_with_wrong_field_count() {
+        let parent = input_with_schema(aggregate_input_schema());
+        let aggregate = KernelAggregate {
+            group_by: vec![column_name!("group")],
+            aggs: vec![KernelAgg::max(column_name!("value"))],
+            schema: Arc::new(
+                StructType::try_new([StructField::nullable("group", DataType::STRING)]).unwrap(),
+            ),
+        };
+        let err = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("output schema has 1 fields"),
+            "{err}"
+        );
+    }
+
+    /// Mixed-value input; the other cases contain only NULLs or no rows:
+    ///
+    /// ```text
+    /// value
+    /// ------
+    /// banana
+    /// cherry
+    /// NULL
+    /// apple
+    /// ```
+    #[rstest]
+    #[case::mixed_values(
+        vec![
+            vec!["banana".into()],
+            vec!["cherry".into()],
+            vec![KernelScalar::Null(DataType::STRING)],
+            vec!["apple".into()],
+        ],
+        Some("apple"),
+        Some("cherry")
+    )]
+    #[case::all_null(
+        vec![
+            vec![KernelScalar::Null(DataType::STRING)],
+            vec![KernelScalar::Null(DataType::STRING)],
+        ],
+        None,
+        None
+    )]
+    #[case::no_rows(vec![], None, None)]
+    #[tokio::test]
+    async fn aggregate_executes_min_and_max_over_nullable_or_empty_values(
+        #[case] rows: Vec<Vec<KernelScalar>>,
+        #[case] expected_min: Option<&str>,
+        #[case] expected_max: Option<&str>,
+    ) {
+        let input_schema = Arc::new(
+            StructType::try_new([StructField::nullable("value", DataType::STRING)]).unwrap(),
+        );
+        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
+        let aggregate = KernelAggregate::ungrouped(input_schema)
+            .aggregate_as(KernelAgg::min(column_name!("value")), "min_value")
+            .aggregate_as(KernelAgg::max(column_name!("value")), "max_value")
+            .build()
+            .unwrap();
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        let batches = execute(lowered).await.unwrap();
+        let expected_row = format!(
+            "| {:<9} | {:<9} |",
+            expected_min.unwrap_or_default(),
+            expected_max.unwrap_or_default()
+        );
+        assert_batches_eq!(
+            &[
+                "+-----------+-----------+",
+                "| min_value | max_value |",
+                "+-----------+-----------+",
+                expected_row.as_str(),
+                "+-----------+-----------+",
+            ],
+            &batches
+        );
+        assert_eq!(batches[0].column(0).is_null(0), expected_min.is_none());
+        assert_eq!(batches[0].column(1).is_null(0), expected_max.is_none());
+    }
+
+    /// Input:
+    ///
+    /// ```text
+    /// group   | value  | key
+    /// --------+--------+-----
+    /// valid   | NULL   | 0
+    /// valid   | min    | 1
+    /// valid   | max    | 3
+    /// valid   | NULL   | 4
+    /// valid   | no-key | NULL
+    /// invalid | NULL   | 1
+    /// invalid | no-key | NULL
+    /// ```
+    #[tokio::test]
+    async fn aggregate_non_null_by_ignores_rows_unless_value_and_key_are_both_non_null() {
+        let rows = vec![
+            vec![
+                "valid".into(),
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(0),
+            ],
+            vec!["valid".into(), "min".into(), KernelScalar::Long(1)],
+            vec!["valid".into(), "max".into(), KernelScalar::Long(3)],
+            vec![
+                "valid".into(),
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(4),
+            ],
+            vec![
+                "valid".into(),
+                "no-key".into(),
+                KernelScalar::Null(DataType::LONG),
+            ],
+            vec![
+                "invalid".into(),
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(1),
+            ],
+            vec![
+                "invalid".into(),
+                "no-key".into(),
+                KernelScalar::Null(DataType::LONG),
+            ],
+        ];
+        let input_schema = Arc::new(aggregate_input_schema());
+        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
+        let aggregate =
+            KernelAggregate::group_by(Arc::clone(&input_schema), [column_name!("group")])
+                .aggregate_as(
+                    KernelAgg::min_non_null_by(
+                        column_name!("value"),
+                        column_name!("value"),
+                        column_name!("key"),
+                    ),
+                    "min_value",
+                )
+                .aggregate_as(
+                    KernelAgg::max_non_null_by(
+                        column_name!("value"),
+                        column_name!("value"),
+                        column_name!("key"),
+                    ),
+                    "max_value",
+                )
+                .build()
+                .unwrap();
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        let batches = execute(lowered).await.unwrap();
+        assert_batches_sorted_eq!(
+            &[
+                "+---------+-----------+-----------+",
+                "| group   | min_value | max_value |",
+                "+---------+-----------+-----------+",
+                "| invalid |           |           |",
+                "| valid   | min       | max       |",
+                "+---------+-----------+-----------+",
+            ],
+            &batches
         );
     }
 }

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -3,9 +3,9 @@
 //!
 //! DataFusion has no single "operator" type: each relational operator is its own `LogicalPlan`
 //! variant holding its inputs, so lowering an operator *is* building the plan node that wraps its
-//! already-lowered inputs. Most nodes are built through `LogicalPlanBuilder`, which validates as it
-//! goes (a filter predicate must be boolean, a projection's expression count must match its
-//! schema).
+//! already-lowered inputs. Each node uses its validating constructor: filters use
+//! [`DFFilter::try_new`], aggregates use [`DFAggregate::try_new_with_schema`], and values use
+//! [`LogicalPlanBuilder`].
 //!
 //! This module lowers one operator at a time; the walk that feeds it each node's inputs is
 //! [`crate::plan`].
@@ -22,16 +22,14 @@ use datafusion::logical_expr::{
     LogicalPlanBuilder, Projection as DFProjection,
 };
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
-use delta_kernel::expressions::{
-    ColumnName as KernelColumnName, Expression as KernelExpression, Scalar as KernelScalar,
-};
+use delta_kernel::expressions::{ColumnName as KernelColumnName, Scalar as KernelScalar};
 use delta_kernel::plans::ir::nodes::{
     Agg as KernelAgg, Aggregate as KernelAggregate, Filter as KernelFilter,
     Operator as KernelOperator, Project as KernelProject, Values as KernelValues,
 };
 use delta_kernel::schema::StructType;
 
-use crate::expression::{to_df_expr, to_df_struct_columns};
+use crate::expression::{column_to_df_expr, to_df_struct_columns};
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
 
@@ -116,7 +114,11 @@ fn lower_project(
     Ok(DFLogicalPlan::Projection(projection))
 }
 
-/// Lowers an [`Aggregate`](KernelAggregate) to a DataFusion aggregate over its parent.
+/// Lowers an [`Aggregate`](KernelAggregate) to a DataFusion aggregate over its input.
+///
+/// Aggregate operands retain their types from the input because the kernel IR does not declare
+/// separate operand types. DataFusion applies any function-specific input coercion; the explicit
+/// casts here make group keys and aggregate results match the aggregate's declared output schema.
 fn lower_aggregate(
     aggregate: &KernelAggregate,
     input: &Arc<DFLogicalPlan>,
@@ -149,7 +151,7 @@ fn lower_aggregate(
         .iter()
         .zip(group_fields)
         .map(|(column, field)| {
-            let expr = column_to_df_expr(column, &input_schema)?;
+            let expr = lower_column(column, &input_schema)?;
             let target = field.data_type().try_into_arrow()?;
             let expr = expr
                 .cast_to(&target, input.schema())?
@@ -184,10 +186,10 @@ fn lower_aggregate(
 
 fn lower_agg(agg: &KernelAgg, input_schema: &StructType) -> Result<DFExpr, DataFusionError> {
     match agg {
-        KernelAgg::Min(value) => Ok(min(column_to_df_expr(value, input_schema)?)),
-        KernelAgg::Max(value) => Ok(max(column_to_df_expr(value, input_schema)?)),
-        KernelAgg::Sum(value) => Ok(sum(column_to_df_expr(value, input_schema)?)),
-        KernelAgg::Count(value) => Ok(count(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Min(value) => Ok(min(lower_column(value, input_schema)?)),
+        KernelAgg::Max(value) => Ok(max(lower_column(value, input_schema)?)),
+        KernelAgg::Sum(value) => Ok(sum(lower_column(value, input_schema)?)),
+        KernelAgg::Count(value) => Ok(count(lower_column(value, input_schema)?)),
         KernelAgg::CountStar => Ok(count(df_lit(1))),
         KernelAgg::MinNonNullBy(operands) => lower_non_null_by(
             &operands.value,
@@ -213,9 +215,9 @@ fn lower_non_null_by(
     input_schema: &StructType,
     ascending: bool,
 ) -> Result<DFExpr, DataFusionError> {
-    let value = column_to_df_expr(value, input_schema)?;
-    let null_sentinel = column_to_df_expr(null_sentinel, input_schema)?;
-    let key = column_to_df_expr(key, input_schema)?;
+    let value = lower_column(value, input_schema)?;
+    let null_sentinel = lower_column(null_sentinel, input_schema)?;
+    let key = lower_column(key, input_schema)?;
     let filter = null_sentinel.is_not_null().and(key.clone().is_not_null());
     let first_value = first_value_udaf().call(vec![value]);
     first_value
@@ -224,12 +226,11 @@ fn lower_non_null_by(
         .build()
 }
 
-fn column_to_df_expr(
+fn lower_column(
     column: &KernelColumnName,
     input_schema: &StructType,
 ) -> Result<DFExpr, DataFusionError> {
-    let column = KernelExpression::Column(column.clone());
-    to_df_expr(&column, input_schema, None)
+    column_to_df_expr(column, input_schema)
         .map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
@@ -1454,7 +1455,7 @@ mod tests {
     #[case::max(KernelAgg::max(column_name!("value")), "max", df_col("value"), None)]
     #[case::sum(KernelAgg::sum(column_name!("key")), "sum", df_col("key"), None)]
     #[case::count(KernelAgg::count(column_name!("value")), "count", df_col("value"), None)]
-    #[case::count_star(KernelAgg::count_star(), "count", lit(1), None)]
+    #[case::count_star(KernelAgg::count_star(), "count", df_lit(1), None)]
     #[case::min_non_null_by(
         KernelAgg::min_non_null_by(
             column_name!("value"),
@@ -1536,7 +1537,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aggregate_casts_output_to_declared_type() {
+    async fn aggregate_casts_result_not_operand_to_declared_type() {
         let input =
             StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap();
         let parent =
@@ -1555,6 +1556,23 @@ mod tests {
         )
         .unwrap();
         assert_eq!(output_types(&lowered), [ArrowDataType::Int64]);
+        let DFLogicalPlan::Aggregate(aggregate) = &lowered else {
+            panic!("expected Aggregate, got {lowered:?}");
+        };
+        let [DFExpr::Alias(alias)] = aggregate.aggr_expr.as_slice() else {
+            panic!("expected one aliased aggregate expression");
+        };
+        let DFExpr::Cast(cast) = alias.expr.as_ref() else {
+            panic!(
+                "expected cast around aggregate result, got {:?}",
+                alias.expr
+            );
+        };
+        let DFExpr::AggregateFunction(function) = cast.expr.as_ref() else {
+            panic!("expected aggregate inside cast, got {:?}", cast.expr);
+        };
+        assert_eq!(function.params.args, [df_col("value")]);
+
         let batches = execute(lowered).await.unwrap();
         assert_batches_eq!(
             &[
@@ -1783,6 +1801,51 @@ mod tests {
         assert_eq!(batches[0].column(0).is_null(0), expected_sum.is_none());
         assert!(!batches[0].column(1).is_null(0));
         assert!(!batches[0].column(2).is_null(0));
+    }
+
+    #[tokio::test]
+    async fn aggregate_ungrouped_non_null_by_emits_nulls_for_empty_input() {
+        let input_schema = Arc::new(aggregate_input_schema());
+        let parent =
+            Arc::new(lower_values_node(input_schema.as_ref().clone(), Vec::new()).unwrap());
+        let aggregate = KernelAggregate::ungrouped(input_schema)
+            .aggregate_as(
+                KernelAgg::min_non_null_by(
+                    column_name!("value"),
+                    column_name!("sentinel"),
+                    column_name!("key"),
+                ),
+                "min_value",
+            )
+            .aggregate_as(
+                KernelAgg::max_non_null_by(
+                    column_name!("value"),
+                    column_name!("sentinel"),
+                    column_name!("key"),
+                ),
+                "max_value",
+            )
+            .build()
+            .unwrap();
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        let batches = execute(lowered).await.unwrap();
+        assert_batches_eq!(
+            &[
+                "+-----------+-----------+",
+                "| min_value | max_value |",
+                "+-----------+-----------+",
+                "|           |           |",
+                "+-----------+-----------+",
+            ],
+            &batches
+        );
+        assert!(batches[0].column(0).is_null(0));
+        assert!(batches[0].column(1).is_null(0));
     }
 
     /// Input:

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -27,11 +27,12 @@ use delta_kernel::plans::ir::nodes::{
     Agg as KernelAgg, Aggregate as KernelAggregate, Filter as KernelFilter,
     Operator as KernelOperator, Project as KernelProject, Values as KernelValues,
 };
-use delta_kernel::schema::StructType;
+use delta_kernel::schema::{StructField, StructType};
 
-use crate::expression::{column_to_df_expr, to_df_struct_columns};
+use crate::expression::to_df_struct_columns;
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
+use crate::utils::column_to_df_expr;
 
 /// Lowers one kernel [`Operator`](KernelOperator) over its already-lowered inputs.
 ///
@@ -124,20 +125,9 @@ fn lower_aggregate(
     aggregate: &KernelAggregate,
     input: &Arc<DFLogicalPlan>,
 ) -> Result<DFLogicalPlan, DataFusionError> {
-    let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
+    let input_schema = input.schema().as_ref();
     let output_fields: Vec<_> = aggregate.schema.fields().collect();
-    let expected_field_count = aggregate.group_by.len() + aggregate.aggs.len();
-    if output_fields.len() != expected_field_count {
-        return Err(DataFusionError::Plan(format!(
-            "Aggregate declares {} group key(s) and {} aggregate expression(s), but its output \
-             schema has {} fields",
-            aggregate.group_by.len(),
-            aggregate.aggs.len(),
-            output_fields.len()
-        )));
-    }
-
-    if expected_field_count == 0 {
+    if aggregate.group_by.is_empty() && aggregate.aggs.is_empty() {
         let arrow_schema: ArrowSchema = aggregate.schema.as_ref().try_into_arrow()?;
         let empty = EmptyRelation {
             produce_one_row: true,
@@ -146,31 +136,23 @@ fn lower_aggregate(
         return Ok(DFLogicalPlan::EmptyRelation(empty));
     }
 
-    let (group_fields, aggregate_fields) = output_fields.split_at(aggregate.group_by.len());
     let group_exprs: Result<Vec<_>, DataFusionError> = aggregate
         .group_by
         .iter()
-        .zip(group_fields)
-        .map(|(column, field)| {
-            let expr = lower_column(column, &input_schema)?;
-            let target = field.data_type().try_into_arrow()?;
-            let expr = expr
-                .cast_to(&target, input.schema())?
-                .alias(field.name().clone());
-            Ok(expr)
+        .enumerate()
+        .map(|(index, column)| {
+            let expr = column_to_df_expr(column, input_schema)?;
+            cast_aggregate_output(expr, output_fields.get(index).copied(), input_schema)
         })
         .collect();
     let aggregate_exprs: Result<Vec<_>, DataFusionError> = aggregate
         .aggs
         .iter()
-        .zip(aggregate_fields)
-        .map(|(agg, field)| {
-            let expr = lower_agg(agg, &input_schema)?;
-            let target = field.data_type().try_into_arrow()?;
-            let expr = expr
-                .cast_to(&target, input.schema())?
-                .alias(field.name().clone());
-            Ok(expr)
+        .enumerate()
+        .map(|(index, agg)| {
+            let expr = lower_aggregate_function(agg, input_schema)?;
+            let field_index = aggregate.group_by.len() + index;
+            cast_aggregate_output(expr, output_fields.get(field_index).copied(), input_schema)
         })
         .collect();
 
@@ -185,12 +167,30 @@ fn lower_aggregate(
     Ok(DFLogicalPlan::Aggregate(df_aggregate))
 }
 
-fn lower_agg(agg: &KernelAgg, input_schema: &StructType) -> Result<DFExpr, DataFusionError> {
+fn cast_aggregate_output(
+    expr: DFExpr,
+    field: Option<&StructField>,
+    input_schema: &DFSchema,
+) -> Result<DFExpr, DataFusionError> {
+    let Some(field) = field else {
+        // No output field matches this expression; keep it for DataFusion's arity check.
+        return Ok(expr);
+    };
+    let target = field.data_type().try_into_arrow()?;
+    let expr = expr.cast_to(&target, input_schema)?;
+    Ok(expr.alias(field.name().clone()))
+}
+
+fn lower_aggregate_function(
+    agg: &KernelAgg,
+    input_schema: &DFSchema,
+) -> Result<DFExpr, DataFusionError> {
     match agg {
-        KernelAgg::Min(value) => Ok(min(lower_column(value, input_schema)?)),
-        KernelAgg::Max(value) => Ok(max(lower_column(value, input_schema)?)),
-        KernelAgg::Sum(value) => Ok(sum(lower_column(value, input_schema)?)),
-        KernelAgg::Count(value) => Ok(count(lower_column(value, input_schema)?)),
+        KernelAgg::Min(value) => Ok(min(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Max(value) => Ok(max(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Sum(value) => Ok(sum(column_to_df_expr(value, input_schema)?)),
+        KernelAgg::Count(value) => Ok(count(column_to_df_expr(value, input_schema)?)),
+        // DataFusion produces 1 for every input row, so counting it implements COUNT(*).
         KernelAgg::CountStar => Ok(count(df_lit(1))),
         KernelAgg::MinNonNullBy(operands) => lower_non_null_by(
             &operands.value,
@@ -213,26 +213,18 @@ fn lower_non_null_by(
     value: &KernelColumnName,
     null_sentinel: &KernelColumnName,
     key: &KernelColumnName,
-    input_schema: &StructType,
+    input_schema: &DFSchema,
     ascending: bool,
 ) -> Result<DFExpr, DataFusionError> {
-    let value = lower_column(value, input_schema)?;
-    let null_sentinel = lower_column(null_sentinel, input_schema)?;
-    let key = lower_column(key, input_schema)?;
+    let value = column_to_df_expr(value, input_schema)?;
+    let null_sentinel = column_to_df_expr(null_sentinel, input_schema)?;
+    let key = column_to_df_expr(key, input_schema)?;
     let filter = null_sentinel.is_not_null().and(key.clone().is_not_null());
     let first_value = first_value_udaf().call(vec![value]);
     first_value
         .order_by(vec![key.sort(ascending, false)])
         .filter(filter)
         .build()
-}
-
-fn lower_column(
-    column: &KernelColumnName,
-    input_schema: &StructType,
-) -> Result<DFExpr, DataFusionError> {
-    column_to_df_expr(column, input_schema)
-        .map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
 /// Lowers a [`Filter`](KernelFilter) node into a DataFusion [`Filter`](DFFilter) logical plan over
@@ -1536,6 +1528,72 @@ mod tests {
         assert_eq!(function.params.filter.as_deref(), Some(&expected_filter));
     }
 
+    #[test]
+    fn aggregate_resolves_columns_without_converting_input_schema_to_kernel() {
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "value",
+            ArrowDataType::Duration(datafusion::arrow::datatypes::TimeUnit::Second),
+            true,
+        )]);
+        let df_schema = Arc::new(DFSchema::try_from(arrow_schema).unwrap());
+        let kernel_schema: Result<StructType, _> = df_schema.as_arrow().try_into_kernel();
+        assert!(kernel_schema.is_err());
+        let parent = Arc::new(DFLogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: false,
+            schema: df_schema,
+        }));
+        let aggregate = KernelAggregate {
+            group_by: vec![],
+            aggs: vec![KernelAgg::count(column_name!("value"))],
+            schema: Arc::new(
+                StructType::try_new([StructField::not_null("count", DataType::LONG)]).unwrap(),
+            ),
+        };
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        assert_eq!(output_names(&lowered), ["count"]);
+        assert_eq!(output_types(&lowered), [ArrowDataType::Int64]);
+    }
+
+    #[tokio::test]
+    async fn datafusion_rejects_unresolved_aggregate_columns() {
+        let parent = Arc::new(
+            lower_values_node(
+                aggregate_input_schema(),
+                vec![vec![
+                    "group".into(),
+                    "value".into(),
+                    "sentinel".into(),
+                    1i64.into(),
+                ]],
+            )
+            .unwrap(),
+        );
+        let aggregate = KernelAggregate {
+            group_by: vec![],
+            aggs: vec![KernelAgg::min_non_null_by(
+                column_name!("value"),
+                column_name!("sentinel.missing"),
+                column_name!("key"),
+            )],
+            schema: Arc::new(
+                StructType::try_new([StructField::nullable("result", DataType::STRING)]).unwrap(),
+            ),
+        };
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        let err = execute(lowered).await.unwrap_err();
+        assert!(err.to_string().contains("Cannot access field"), "{err}");
+    }
+
     #[tokio::test]
     async fn aggregate_casts_result_not_operand_to_declared_type() {
         let input =
@@ -1623,7 +1681,8 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            err.to_string().contains("output schema has 1 fields"),
+            err.to_string()
+                .contains("Aggregate schema has wrong number of fields. Expected 2 got 1"),
             "{err}"
         );
     }

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -1620,6 +1620,18 @@ mod tests {
     /// NULL
     /// apple
     /// ```
+    ///
+    /// ```sql
+    /// SELECT min(value) AS min_value, max(value) AS max_value FROM input
+    /// ```
+    ///
+    /// ```text
+    /// case         | min_value | max_value
+    /// -------------+-----------+----------
+    /// mixed_values | apple     | cherry
+    /// all_null     | NULL      | NULL
+    /// no_rows      | NULL      | NULL
+    /// ```
     #[rstest]
     #[case::mixed_values(
         vec![
@@ -1690,6 +1702,21 @@ mod tests {
     /// NULL
     /// 5
     /// 1
+    /// ```
+    ///
+    /// ```sql
+    /// SELECT sum(value) AS sum_value,
+    ///        count(value) AS count_value,
+    ///        count(*) AS row_count
+    /// FROM input
+    /// ```
+    ///
+    /// ```text
+    /// case         | sum_value | count_value | row_count
+    /// -------------+-----------+-------------+----------
+    /// mixed_values | 9         | 3           | 4
+    /// all_null     | NULL      | 0           | 2
+    /// no_rows      | NULL      | 0           | 0
     /// ```
     #[rstest]
     #[case::mixed_values(
@@ -1771,6 +1798,21 @@ mod tests {
     /// valid   | no-key        | present  | NULL
     /// invalid | no-sentinel   | NULL     | 1
     /// invalid | no-key        | present  | NULL
+    /// ```
+    ///
+    /// ```sql
+    /// SELECT group,
+    ///        min_non_null_by(value, sentinel, key) AS min_value,
+    ///        max_non_null_by(value, sentinel, key) AS max_value
+    /// FROM input
+    /// GROUP BY group
+    /// ```
+    ///
+    /// ```text
+    /// group   | min_value | max_value
+    /// --------+-----------+----------
+    /// invalid | NULL      | NULL
+    /// valid   | min       | NULL
     /// ```
     #[tokio::test]
     async fn aggregate_non_null_by_filters_on_sentinel_and_key_but_retains_null_value() {

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -295,7 +295,6 @@ fn lower_row(row: &[KernelScalar]) -> Result<Vec<DFExpr>, DataFusionError> {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::array::Array;
     use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::common::ScalarValue as DFScalarValue;
@@ -1628,194 +1627,121 @@ mod tests {
         );
     }
 
-    /// Mixed-value input; the other cases contain only NULLs or no rows:
+    /// Exercises ungrouped aggregate NULL handling over mixed, all-NULL, and empty input.
+    ///
+    /// The mixed case gives the greatest qualifying key a NULL value, so `max_non_null_by` must
+    /// retain that NULL rather than skip it.
     ///
     /// ```text
-    /// value
-    /// ------
-    /// banana
-    /// cherry
-    /// NULL
-    /// apple
-    /// ```
-    ///
-    /// ```sql
-    /// SELECT min(value) AS min_value, max(value) AS max_value FROM input
-    /// ```
-    ///
-    /// ```text
-    /// case         | min_value | max_value
-    /// -------------+-----------+----------
-    /// mixed_values | apple     | cherry
-    /// all_null     | NULL      | NULL
-    /// no_rows      | NULL      | NULL
+    /// case         | min   | max    | sum  | count | count(*) | min_by | max_by
+    /// -------------+-------+--------+------+-------+----------+--------+-------
+    /// mixed_values | apple | cherry | 9    | 3     | 4        | apple  | NULL
+    /// all_null     | NULL  | NULL   | NULL | 0     | 2        | NULL   | NULL
+    /// no_rows      | NULL  | NULL   | NULL | 0     | 0        | NULL   | NULL
     /// ```
     #[rstest]
     #[case::mixed_values(
         vec![
-            vec!["banana".into()],
-            vec!["cherry".into()],
-            vec![KernelScalar::Null(DataType::STRING)],
-            vec!["apple".into()],
+            vec![
+                "banana".into(),
+                KernelScalar::Long(3),
+                "present".into(),
+                KernelScalar::Long(2),
+            ],
+            vec![
+                "cherry".into(),
+                KernelScalar::Null(DataType::LONG),
+                "present".into(),
+                KernelScalar::Long(3),
+            ],
+            vec![
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(5),
+                "present".into(),
+                KernelScalar::Long(4),
+            ],
+            vec![
+                "apple".into(),
+                KernelScalar::Long(1),
+                "present".into(),
+                KernelScalar::Long(1),
+            ],
         ],
-        Some("apple"),
-        Some("cherry")
+        vec![
+            DFScalarValue::Utf8(Some("apple".into())),
+            DFScalarValue::Utf8(Some("cherry".into())),
+            DFScalarValue::Int64(Some(9)),
+            DFScalarValue::Int64(Some(3)),
+            DFScalarValue::Int64(Some(4)),
+            DFScalarValue::Utf8(Some("apple".into())),
+            DFScalarValue::Utf8(None),
+        ]
     )]
     #[case::all_null(
         vec![
-            vec![KernelScalar::Null(DataType::STRING)],
-            vec![KernelScalar::Null(DataType::STRING)],
+            vec![
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Null(DataType::LONG),
+                "present".into(),
+                KernelScalar::Long(1),
+            ],
+            vec![
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Null(DataType::LONG),
+                "present".into(),
+                KernelScalar::Long(2),
+            ],
         ],
-        None,
-        None
+        vec![
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Int64(None),
+            DFScalarValue::Int64(Some(0)),
+            DFScalarValue::Int64(Some(2)),
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Utf8(None),
+        ]
     )]
-    #[case::no_rows(vec![], None, None)]
+    #[case::no_rows(
+        vec![],
+        vec![
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Int64(None),
+            DFScalarValue::Int64(Some(0)),
+            DFScalarValue::Int64(Some(0)),
+            DFScalarValue::Utf8(None),
+            DFScalarValue::Utf8(None),
+        ]
+    )]
     #[tokio::test]
-    async fn aggregate_executes_min_and_max_over_nullable_or_empty_values(
+    async fn aggregate_executes_ungrouped_functions(
         #[case] rows: Vec<Vec<KernelScalar>>,
-        #[case] expected_min: Option<&str>,
-        #[case] expected_max: Option<&str>,
+        #[case] expected: Vec<DFScalarValue>,
     ) {
         let input_schema = Arc::new(
-            StructType::try_new([StructField::nullable("value", DataType::STRING)]).unwrap(),
+            StructType::try_new([
+                StructField::nullable("value", DataType::STRING),
+                StructField::nullable("number", DataType::LONG),
+                StructField::nullable("sentinel", DataType::STRING),
+                StructField::nullable("key", DataType::LONG),
+            ])
+            .unwrap(),
         );
         let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
         let aggregate = KernelAggregate::ungrouped(input_schema)
             .aggregate_as(KernelAgg::min(column_name!("value")), "min_value")
             .aggregate_as(KernelAgg::max(column_name!("value")), "max_value")
-            .build()
-            .unwrap();
-
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
-        )
-        .unwrap();
-        let batches = execute(lowered).await.unwrap();
-        let expected_row = format!(
-            "| {:<9} | {:<9} |",
-            expected_min.unwrap_or_default(),
-            expected_max.unwrap_or_default()
-        );
-        assert_batches_eq!(
-            &[
-                "+-----------+-----------+",
-                "| min_value | max_value |",
-                "+-----------+-----------+",
-                expected_row.as_str(),
-                "+-----------+-----------+",
-            ],
-            &batches
-        );
-        assert_eq!(batches[0].column(0).is_null(0), expected_min.is_none());
-        assert_eq!(batches[0].column(1).is_null(0), expected_max.is_none());
-    }
-
-    /// Mixed-value input; the other cases contain only NULLs or no rows:
-    ///
-    /// ```text
-    /// value
-    /// -----
-    /// 3
-    /// NULL
-    /// 5
-    /// 1
-    /// ```
-    ///
-    /// ```sql
-    /// SELECT sum(value) AS sum_value,
-    ///        count(value) AS count_value,
-    ///        count(*) AS row_count
-    /// FROM input
-    /// ```
-    ///
-    /// ```text
-    /// case         | sum_value | count_value | row_count
-    /// -------------+-----------+-------------+----------
-    /// mixed_values | 9         | 3           | 4
-    /// all_null     | NULL      | 0           | 2
-    /// no_rows      | NULL      | 0           | 0
-    /// ```
-    #[rstest]
-    #[case::mixed_values(
-        vec![
-            vec![KernelScalar::Long(3)],
-            vec![KernelScalar::Null(DataType::LONG)],
-            vec![KernelScalar::Long(5)],
-            vec![KernelScalar::Long(1)],
-        ],
-        Some(9),
-        3,
-        4
-    )]
-    #[case::all_null(
-        vec![
-            vec![KernelScalar::Null(DataType::LONG)],
-            vec![KernelScalar::Null(DataType::LONG)],
-        ],
-        None,
-        0,
-        2
-    )]
-    #[case::no_rows(vec![], None, 0, 0)]
-    #[tokio::test]
-    async fn aggregate_executes_sum_count_and_count_star(
-        #[case] rows: Vec<Vec<KernelScalar>>,
-        #[case] expected_sum: Option<i64>,
-        #[case] expected_count: i64,
-        #[case] expected_row_count: i64,
-    ) {
-        let input_schema = Arc::new(
-            StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
-        );
-        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
-        let aggregate = KernelAggregate::ungrouped(input_schema)
-            .aggregate_as(KernelAgg::sum(column_name!("value")), "sum_value")
-            .aggregate_as(KernelAgg::count(column_name!("value")), "count_value")
+            .aggregate_as(KernelAgg::sum(column_name!("number")), "sum_value")
+            .aggregate_as(KernelAgg::count(column_name!("number")), "count_value")
             .aggregate_as(KernelAgg::count_star(), "row_count")
-            .build()
-            .unwrap();
-
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
-        )
-        .unwrap();
-        let batches = execute(lowered).await.unwrap();
-        let expected_row = format!(
-            "| {:<9} | {expected_count:<11} | {expected_row_count:<9} |",
-            expected_sum
-                .map(|value| value.to_string())
-                .unwrap_or_default()
-        );
-        assert_batches_eq!(
-            &[
-                "+-----------+-------------+-----------+",
-                "| sum_value | count_value | row_count |",
-                "+-----------+-------------+-----------+",
-                expected_row.as_str(),
-                "+-----------+-------------+-----------+",
-            ],
-            &batches
-        );
-        assert_eq!(batches[0].column(0).is_null(0), expected_sum.is_none());
-        assert!(!batches[0].column(1).is_null(0));
-        assert!(!batches[0].column(2).is_null(0));
-    }
-
-    #[tokio::test]
-    async fn aggregate_ungrouped_non_null_by_emits_nulls_for_empty_input() {
-        let input_schema = Arc::new(aggregate_input_schema());
-        let parent =
-            Arc::new(lower_values_node(input_schema.as_ref().clone(), Vec::new()).unwrap());
-        let aggregate = KernelAggregate::ungrouped(input_schema)
             .aggregate_as(
                 KernelAgg::min_non_null_by(
                     column_name!("value"),
                     column_name!("sentinel"),
                     column_name!("key"),
                 ),
-                "min_value",
+                "min_by_value",
             )
             .aggregate_as(
                 KernelAgg::max_non_null_by(
@@ -1823,7 +1749,7 @@ mod tests {
                     column_name!("sentinel"),
                     column_name!("key"),
                 ),
-                "max_value",
+                "max_by_value",
             )
             .build()
             .unwrap();
@@ -1833,19 +1759,27 @@ mod tests {
             std::slice::from_ref(&parent),
         )
         .unwrap();
-        let batches = execute(lowered).await.unwrap();
-        assert_batches_eq!(
-            &[
-                "+-----------+-----------+",
-                "| min_value | max_value |",
-                "+-----------+-----------+",
-                "|           |           |",
-                "+-----------+-----------+",
-            ],
-            &batches
+        assert_eq!(
+            output_names(&lowered),
+            vec![
+                "min_value",
+                "max_value",
+                "sum_value",
+                "count_value",
+                "row_count",
+                "min_by_value",
+                "max_by_value",
+            ]
         );
-        assert!(batches[0].column(0).is_null(0));
-        assert!(batches[0].column(1).is_null(0));
+        let batches = execute(lowered).await.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 1);
+        let actual = batches[0]
+            .columns()
+            .iter()
+            .map(|column| DFScalarValue::try_from_array(column.as_ref(), 0).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
     }
 
     /// Input:

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -1420,6 +1420,7 @@ mod tests {
         StructType::try_new([
             StructField::nullable("group", DataType::STRING),
             StructField::nullable("value", DataType::STRING),
+            StructField::nullable("sentinel", DataType::STRING),
             StructField::nullable("key", DataType::LONG),
         ])
         .unwrap()
@@ -1449,29 +1450,35 @@ mod tests {
     }
 
     #[rstest]
-    #[case::min(KernelAgg::min(column_name!("value")), "min", None)]
-    #[case::max(KernelAgg::max(column_name!("value")), "max", None)]
+    #[case::min(KernelAgg::min(column_name!("value")), "min", df_col("value"), None)]
+    #[case::max(KernelAgg::max(column_name!("value")), "max", df_col("value"), None)]
+    #[case::sum(KernelAgg::sum(column_name!("key")), "sum", df_col("key"), None)]
+    #[case::count(KernelAgg::count(column_name!("value")), "count", df_col("value"), None)]
+    #[case::count_star(KernelAgg::count_star(), "count", lit(1), None)]
     #[case::min_non_null_by(
         KernelAgg::min_non_null_by(
             column_name!("value"),
-            column_name!("value"),
+            column_name!("sentinel"),
             column_name!("key")
         ),
         "first_value",
+        df_col("value"),
         Some(true)
     )]
     #[case::max_non_null_by(
         KernelAgg::max_non_null_by(
             column_name!("value"),
-            column_name!("value"),
+            column_name!("sentinel"),
             column_name!("key")
         ),
         "first_value",
+        df_col("value"),
         Some(false)
     )]
     fn aggregate_lowers_function_with_declared_schema(
         #[case] agg: KernelAgg,
         #[case] expected_function: &str,
+        #[case] expected_arg: DFExpr,
         #[case] expected_ascending: Option<bool>,
         #[values(false, true)] grouped: bool,
     ) {
@@ -1511,7 +1518,7 @@ mod tests {
             panic!("expected aggregate function, got {:?}", alias.expr);
         };
         assert_eq!(function.func.name(), expected_function);
-        assert_eq!(function.params.args, [df_col("value")]);
+        assert_eq!(function.params.args, [expected_arg]);
 
         let Some(ascending) = expected_ascending else {
             assert!(function.params.order_by.is_empty());
@@ -1522,7 +1529,7 @@ mod tests {
             function.params.order_by,
             [df_col("key").sort(ascending, false)]
         );
-        let expected_filter = df_col("value")
+        let expected_filter = df_col("sentinel")
             .is_not_null()
             .and(df_col("key").is_not_null());
         assert_eq!(function.params.filter.as_deref(), Some(&expected_filter));
@@ -1674,47 +1681,146 @@ mod tests {
         assert_eq!(batches[0].column(1).is_null(0), expected_max.is_none());
     }
 
+    /// Mixed-value input; the other cases contain only NULLs or no rows:
+    ///
+    /// ```text
+    /// value
+    /// -----
+    /// 3
+    /// NULL
+    /// 5
+    /// 1
+    /// ```
+    #[rstest]
+    #[case::mixed_values(
+        vec![
+            vec![KernelScalar::Long(3)],
+            vec![KernelScalar::Null(DataType::LONG)],
+            vec![KernelScalar::Long(5)],
+            vec![KernelScalar::Long(1)],
+        ],
+        Some(9),
+        3,
+        4
+    )]
+    #[case::all_null(
+        vec![
+            vec![KernelScalar::Null(DataType::LONG)],
+            vec![KernelScalar::Null(DataType::LONG)],
+        ],
+        None,
+        0,
+        2
+    )]
+    #[case::no_rows(vec![], None, 0, 0)]
+    #[tokio::test]
+    async fn aggregate_executes_sum_count_and_count_star(
+        #[case] rows: Vec<Vec<KernelScalar>>,
+        #[case] expected_sum: Option<i64>,
+        #[case] expected_count: i64,
+        #[case] expected_row_count: i64,
+    ) {
+        let input_schema = Arc::new(
+            StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
+        );
+        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
+        let aggregate = KernelAggregate::ungrouped(input_schema)
+            .aggregate_as(KernelAgg::sum(column_name!("value")), "sum_value")
+            .aggregate_as(KernelAgg::count(column_name!("value")), "count_value")
+            .aggregate_as(KernelAgg::count_star(), "row_count")
+            .build()
+            .unwrap();
+
+        let lowered = lower_operator(
+            &KernelOperator::Aggregate(aggregate),
+            std::slice::from_ref(&parent),
+        )
+        .unwrap();
+        let batches = execute(lowered).await.unwrap();
+        let expected_row = format!(
+            "| {:<9} | {expected_count:<11} | {expected_row_count:<9} |",
+            expected_sum
+                .map(|value| value.to_string())
+                .unwrap_or_default()
+        );
+        assert_batches_eq!(
+            &[
+                "+-----------+-------------+-----------+",
+                "| sum_value | count_value | row_count |",
+                "+-----------+-------------+-----------+",
+                expected_row.as_str(),
+                "+-----------+-------------+-----------+",
+            ],
+            &batches
+        );
+        assert_eq!(batches[0].column(0).is_null(0), expected_sum.is_none());
+        assert!(!batches[0].column(1).is_null(0));
+        assert!(!batches[0].column(2).is_null(0));
+    }
+
     /// Input:
     ///
     /// ```text
-    /// group   | value  | key
-    /// --------+--------+-----
-    /// valid   | NULL   | 0
-    /// valid   | min    | 1
-    /// valid   | max    | 3
-    /// valid   | NULL   | 4
-    /// valid   | no-key | NULL
-    /// invalid | NULL   | 1
-    /// invalid | no-key | NULL
+    /// group   | value         | sentinel | key
+    /// --------+---------------+----------+-----
+    /// valid   | ignored-low   | NULL     | 0
+    /// valid   | min           | present  | 1
+    /// valid   | max           | present  | 3
+    /// valid   | NULL          | present  | 4
+    /// valid   | ignored-high  | NULL     | 5
+    /// valid   | no-key        | present  | NULL
+    /// invalid | no-sentinel   | NULL     | 1
+    /// invalid | no-key        | present  | NULL
     /// ```
     #[tokio::test]
-    async fn aggregate_non_null_by_ignores_rows_unless_value_and_key_are_both_non_null() {
+    async fn aggregate_non_null_by_filters_on_sentinel_and_key_but_retains_null_value() {
         let rows = vec![
             vec![
                 "valid".into(),
+                "ignored-low".into(),
                 KernelScalar::Null(DataType::STRING),
                 KernelScalar::Long(0),
             ],
-            vec!["valid".into(), "min".into(), KernelScalar::Long(1)],
-            vec!["valid".into(), "max".into(), KernelScalar::Long(3)],
+            vec![
+                "valid".into(),
+                "min".into(),
+                "present".into(),
+                KernelScalar::Long(1),
+            ],
+            vec![
+                "valid".into(),
+                "max".into(),
+                "present".into(),
+                KernelScalar::Long(3),
+            ],
             vec![
                 "valid".into(),
                 KernelScalar::Null(DataType::STRING),
+                "present".into(),
                 KernelScalar::Long(4),
             ],
             vec![
                 "valid".into(),
+                "ignored-high".into(),
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(5),
+            ],
+            vec![
+                "valid".into(),
                 "no-key".into(),
+                "present".into(),
                 KernelScalar::Null(DataType::LONG),
             ],
             vec![
                 "invalid".into(),
+                "no-sentinel".into(),
                 KernelScalar::Null(DataType::STRING),
                 KernelScalar::Long(1),
             ],
             vec![
                 "invalid".into(),
                 "no-key".into(),
+                "present".into(),
                 KernelScalar::Null(DataType::LONG),
             ],
         ];
@@ -1725,7 +1831,7 @@ mod tests {
                 .aggregate_as(
                     KernelAgg::min_non_null_by(
                         column_name!("value"),
-                        column_name!("value"),
+                        column_name!("sentinel"),
                         column_name!("key"),
                     ),
                     "min_value",
@@ -1733,7 +1839,7 @@ mod tests {
                 .aggregate_as(
                     KernelAgg::max_non_null_by(
                         column_name!("value"),
-                        column_name!("value"),
+                        column_name!("sentinel"),
                         column_name!("key"),
                     ),
                     "max_value",
@@ -1753,7 +1859,7 @@ mod tests {
                 "| group   | min_value | max_value |",
                 "+---------+-----------+-----------+",
                 "| invalid |           |           |",
-                "| valid   | min       | max       |",
+                "| valid   | min       |           |",
                 "+---------+-----------+-----------+",
             ],
             &batches

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -1788,16 +1788,18 @@ mod tests {
     /// Input:
     ///
     /// ```text
-    /// group   | value         | sentinel | key
-    /// --------+---------------+----------+-----
-    /// valid   | ignored-low   | NULL     | 0
-    /// valid   | min           | present  | 1
-    /// valid   | max           | present  | 3
-    /// valid   | NULL          | present  | 4
-    /// valid   | ignored-high  | NULL     | 5
-    /// valid   | no-key        | present  | NULL
-    /// invalid | no-sentinel   | NULL     | 1
-    /// invalid | no-key        | present  | NULL
+    /// group      | value        | sentinel | key
+    /// -----------+--------------+----------+-----
+    /// values     | min          | present  | 1
+    /// values     | max          | present  | 3
+    /// null-value | ignored-low  | NULL     | 0
+    /// null-value | min          | present  | 1
+    /// null-value | max          | present  | 3
+    /// null-value | NULL         | present  | 4
+    /// null-value | ignored-high | NULL     | 5
+    /// null-value | no-key       | present  | NULL
+    /// invalid    | no-sentinel  | NULL     | 1
+    /// invalid    | no-key       | present  | NULL
     /// ```
     ///
     /// ```sql
@@ -1809,46 +1811,59 @@ mod tests {
     /// ```
     ///
     /// ```text
-    /// group   | min_value | max_value
-    /// --------+-----------+----------
-    /// invalid | NULL      | NULL
-    /// valid   | min       | NULL
+    /// group      | min_value | max_value
+    /// -----------+-----------+----------
+    /// invalid    | NULL      | NULL
+    /// null-value | min       | NULL
+    /// values     | min       | max
     /// ```
     #[tokio::test]
     async fn aggregate_non_null_by_filters_on_sentinel_and_key_but_retains_null_value() {
         let rows = vec![
             vec![
-                "valid".into(),
-                "ignored-low".into(),
-                KernelScalar::Null(DataType::STRING),
-                KernelScalar::Long(0),
-            ],
-            vec![
-                "valid".into(),
+                "values".into(),
                 "min".into(),
                 "present".into(),
                 KernelScalar::Long(1),
             ],
             vec![
-                "valid".into(),
+                "values".into(),
                 "max".into(),
                 "present".into(),
                 KernelScalar::Long(3),
             ],
             vec![
-                "valid".into(),
+                "null-value".into(),
+                "ignored-low".into(),
+                KernelScalar::Null(DataType::STRING),
+                KernelScalar::Long(0),
+            ],
+            vec![
+                "null-value".into(),
+                "min".into(),
+                "present".into(),
+                KernelScalar::Long(1),
+            ],
+            vec![
+                "null-value".into(),
+                "max".into(),
+                "present".into(),
+                KernelScalar::Long(3),
+            ],
+            vec![
+                "null-value".into(),
                 KernelScalar::Null(DataType::STRING),
                 "present".into(),
                 KernelScalar::Long(4),
             ],
             vec![
-                "valid".into(),
+                "null-value".into(),
                 "ignored-high".into(),
                 KernelScalar::Null(DataType::STRING),
                 KernelScalar::Long(5),
             ],
             vec![
-                "valid".into(),
+                "null-value".into(),
                 "no-key".into(),
                 "present".into(),
                 KernelScalar::Null(DataType::LONG),
@@ -1897,12 +1912,13 @@ mod tests {
         let batches = execute(lowered).await.unwrap();
         assert_batches_sorted_eq!(
             &[
-                "+---------+-----------+-----------+",
-                "| group   | min_value | max_value |",
-                "+---------+-----------+-----------+",
-                "| invalid |           |           |",
-                "| valid   | min       |           |",
-                "+---------+-----------+-----------+",
+                "+------------+-----------+-----------+",
+                "| group      | min_value | max_value |",
+                "+------------+-----------+-----------+",
+                "| invalid    |           |           |",
+                "| null-value | min       |           |",
+                "| values     | min       | max       |",
+                "+------------+-----------+-----------+",
             ],
             &batches
         );

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -126,7 +126,7 @@ fn lower_aggregate(
     input: &Arc<DFLogicalPlan>,
 ) -> Result<DFLogicalPlan, DataFusionError> {
     let input_schema = input.schema().as_ref();
-    let output_fields: Vec<_> = aggregate.schema.fields().collect();
+    let output_fields = Vec::from_iter(aggregate.schema.fields());
     if aggregate.group_by.is_empty() && aggregate.aggs.is_empty() {
         let arrow_schema: ArrowSchema = aggregate.schema.as_ref().try_into_arrow()?;
         let empty = EmptyRelation {
@@ -304,6 +304,7 @@ mod tests {
         schema, ArrayType, DataType, MapType, SchemaRef, StructField, StructType,
     };
     use delta_kernel::struct_patch::ProjectionStructPatchBuilder;
+    use delta_kernel::PlanBuilder;
     use rstest::rstest;
 
     use super::*;
@@ -337,11 +338,6 @@ mod tests {
     /// An empty input relation with `schema`.
     fn input_with_schema(schema: StructType) -> Arc<DFLogicalPlan> {
         Arc::new(lower_values_node(schema, vec![]).unwrap())
-    }
-
-    fn empty_schema() -> StructType {
-        let fields: Vec<StructField> = Vec::new();
-        StructType::try_new(fields).unwrap()
     }
 
     fn output_names(plan: &DFLogicalPlan) -> Vec<&String> {
@@ -724,6 +720,11 @@ mod tests {
     }
 
     // === Project ===
+
+    fn empty_schema() -> StructType {
+        let fields: Vec<StructField> = Vec::new();
+        StructType::try_new(fields).unwrap()
+    }
 
     /// Lowers a Project over `parent`.
     fn lower_project_expr(
@@ -1419,6 +1420,10 @@ mod tests {
         .unwrap()
     }
 
+    fn lower(builder: PlanBuilder) -> DFLogicalPlan {
+        crate::plan::to_df_plan(&builder.build().unwrap()).unwrap()
+    }
+
     fn test_aggregate() -> KernelAggregate {
         KernelAggregate::ungrouped(Arc::new(aggregate_input_schema()))
             .max(column_name!("value"))
@@ -1475,17 +1480,24 @@ mod tests {
         #[case] expected_ascending: Option<bool>,
         #[values(false, true)] grouped: bool,
     ) {
-        let parent = input_with_schema(aggregate_input_schema());
-        let group_by = grouped.then(|| column_name!("group"));
-        let aggregate = KernelAggregate::group_by(Arc::new(aggregate_input_schema()), group_by)
-            .aggregate_as(agg, "result")
-            .build()
-            .unwrap();
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
+        let parent = PlanBuilder::values(
+            Arc::new(aggregate_input_schema()),
+            vec![vec![
+                "group".into(),
+                "value".into(),
+                "sentinel".into(),
+                1i64.into(),
+            ]],
         )
         .unwrap();
+        let builder = if grouped {
+            parent.aggregate_by([column_name!("group")], |aggregate| {
+                aggregate.aggregate_as(agg, "result")
+            })
+        } else {
+            parent.aggregate_ungrouped(|aggregate| aggregate.aggregate_as(agg, "result"))
+        };
+        let lowered = lower(builder.unwrap());
 
         let expected_names = if grouped {
             vec!["group", "result"]
@@ -1496,7 +1508,6 @@ mod tests {
         let DFLogicalPlan::Aggregate(aggregate) = &lowered else {
             panic!("expected Aggregate, got {lowered:?}");
         };
-        assert!(Arc::ptr_eq(&aggregate.input, &parent));
         let expected_group: Vec<_> = grouped
             .then(|| df_col("group").alias("group"))
             .into_iter()
@@ -1646,17 +1657,9 @@ mod tests {
 
     #[test]
     fn empty_global_aggregate_lowers_to_one_row_relation() {
-        let parent = input_with_schema(test_schema());
-        let aggregate = KernelAggregate {
-            group_by: vec![],
-            aggs: vec![],
-            schema: Arc::new(empty_schema()),
-        };
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
-        )
-        .unwrap();
+        let parent = PlanBuilder::values(Arc::new(test_schema()), vec![]).unwrap();
+        let builder = parent.aggregate_ungrouped(|aggregate| aggregate);
+        let lowered = lower(builder.unwrap());
 
         let DFLogicalPlan::EmptyRelation(empty) = &lowered else {
             panic!("expected EmptyRelation, got {lowered:?}");
@@ -1788,37 +1791,32 @@ mod tests {
             ])
             .unwrap(),
         );
-        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
-        let aggregate = KernelAggregate::ungrouped(input_schema)
-            .aggregate_as(KernelAgg::min(column_name!("value")), "min_value")
-            .aggregate_as(KernelAgg::max(column_name!("value")), "max_value")
-            .aggregate_as(KernelAgg::sum(column_name!("number")), "sum_value")
-            .aggregate_as(KernelAgg::count(column_name!("number")), "count_value")
-            .aggregate_as(KernelAgg::count_star(), "row_count")
-            .aggregate_as(
-                KernelAgg::min_non_null_by(
-                    column_name!("value"),
-                    column_name!("sentinel"),
-                    column_name!("key"),
-                ),
-                "min_by_value",
-            )
-            .aggregate_as(
-                KernelAgg::max_non_null_by(
-                    column_name!("value"),
-                    column_name!("sentinel"),
-                    column_name!("key"),
-                ),
-                "max_by_value",
-            )
-            .build()
-            .unwrap();
-
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
-        )
-        .unwrap();
+        let parent = PlanBuilder::values(input_schema, rows).unwrap();
+        let builder = parent.aggregate_ungrouped(|aggregate| {
+            aggregate
+                .aggregate_as(KernelAgg::min(column_name!("value")), "min_value")
+                .aggregate_as(KernelAgg::max(column_name!("value")), "max_value")
+                .aggregate_as(KernelAgg::sum(column_name!("number")), "sum_value")
+                .aggregate_as(KernelAgg::count(column_name!("number")), "count_value")
+                .aggregate_as(KernelAgg::count_star(), "row_count")
+                .aggregate_as(
+                    KernelAgg::min_non_null_by(
+                        column_name!("value"),
+                        column_name!("sentinel"),
+                        column_name!("key"),
+                    ),
+                    "min_by_value",
+                )
+                .aggregate_as(
+                    KernelAgg::max_non_null_by(
+                        column_name!("value"),
+                        column_name!("sentinel"),
+                        column_name!("key"),
+                    ),
+                    "max_by_value",
+                )
+        });
+        let lowered = lower(builder.unwrap());
         assert_eq!(
             output_names(&lowered),
             vec![
@@ -1938,10 +1936,9 @@ mod tests {
                 KernelScalar::Null(DataType::LONG),
             ],
         ];
-        let input_schema = Arc::new(aggregate_input_schema());
-        let parent = Arc::new(lower_values_node(input_schema.as_ref().clone(), rows).unwrap());
-        let aggregate =
-            KernelAggregate::group_by(Arc::clone(&input_schema), [column_name!("group")])
+        let parent = PlanBuilder::values(Arc::new(aggregate_input_schema()), rows).unwrap();
+        let builder = parent.aggregate_by([column_name!("group")], |aggregate| {
+            aggregate
                 .aggregate_as(
                     KernelAgg::min_non_null_by(
                         column_name!("value"),
@@ -1958,14 +1955,8 @@ mod tests {
                     ),
                     "max_value",
                 )
-                .build()
-                .unwrap();
-
-        let lowered = lower_operator(
-            &KernelOperator::Aggregate(aggregate),
-            std::slice::from_ref(&parent),
-        )
-        .unwrap();
+        });
+        let lowered = lower(builder.unwrap());
         let batches = execute(lowered).await.unwrap();
         assert_batches_sorted_eq!(
             &[

--- a/datafusion-executor/src/utils.rs
+++ b/datafusion-executor/src/utils.rs
@@ -1,0 +1,62 @@
+//! Shared helpers for lowering kernel plans to DataFusion.
+
+use datafusion::common::{Column as DFColumn, DFSchema, DataFusionError};
+use datafusion::functions::core::expr_fn::get_field_path;
+use datafusion::logical_expr::{lit, Expr as DFExpr};
+use delta_kernel::expressions::ColumnName as KernelColumnName;
+use delta_kernel::schema::StructType;
+use delta_kernel::{DeltaResult, Error};
+
+/// A schema that can resolve the root of a kernel column path to a DataFusion column.
+pub(crate) trait ColumnResolver {
+    /// Error returned when the column cannot be resolved.
+    type Error;
+
+    /// Validates and returns the root DataFusion column.
+    fn resolve_column(&self, name: &KernelColumnName) -> Result<DFColumn, Self::Error>;
+}
+
+/// Lowers a column reference to a nested field access, e.g. `a.b.c` becomes a single
+/// `get_field(col("a"), "b", "c")` call.
+///
+/// # Errors
+/// Returns an error when the path is empty or the schema's resolver rejects it.
+pub(crate) fn column_to_df_expr<E>(
+    name: &KernelColumnName,
+    input_schema: &impl ColumnResolver<Error = E>,
+) -> Result<DFExpr, E> {
+    let root = DFExpr::Column(input_schema.resolve_column(name)?);
+    let field_names = Vec::from_iter(name.iter().skip(1).map(lit));
+    // A bare column stays a bare column; only nested access wraps it in a `get_field` call.
+    if field_names.is_empty() {
+        Ok(root)
+    } else {
+        Ok(get_field_path(root, field_names))
+    }
+}
+
+impl ColumnResolver for StructType {
+    type Error = Error;
+
+    fn resolve_column(&self, name: &KernelColumnName) -> DeltaResult<DFColumn> {
+        let Some(root) = name.first() else {
+            return Err(Error::generic("cannot convert an empty column reference"));
+        };
+        let _ = self.field_at(name)?;
+        Ok(DFColumn::new_unqualified(root.as_str()))
+    }
+}
+
+impl ColumnResolver for DFSchema {
+    type Error = DataFusionError;
+
+    fn resolve_column(&self, name: &KernelColumnName) -> Result<DFColumn, DataFusionError> {
+        let Some(root) = name.first() else {
+            return Err(DataFusionError::Plan(
+                "cannot convert an empty column reference".to_string(),
+            ));
+        };
+        let _ = self.field_with_unqualified_name(root)?;
+        Ok(DFColumn::new_unqualified(root.as_str()))
+    }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Lowers the Kernel Aggregate operator to DataFusion while preserving its declared schema.

- Min/Max ignore NULLs and return NULL for all-NULL or empty input, matching Kernel.
- MinNonNullBy/MaxNonNullBy filter NULL sentinel/key rows, order by key, and retain a selected NULL value.
- Empty global aggregates produce one row.

## How was this change tested?
Unit and execution tests cover grouped and ungrouped aggregates, NULLs, empty input, casts, and schema validation.