### PR TITLE
feat!: add operationParameters/operationMetrics setters in transaction builders

### DIFF
--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -96,6 +96,7 @@ The builder methods:
 
 | Method | Purpose |
 |--------|---------|
+| `with_commit_info_options(CommitInfoClientOptions)` | Client-owned commit-info fields (operation parameters, metrics, engine info) |
 | `with_operation(String)` | Operation name stored in the commit log (e.g. `"INSERT"`, `"MERGE"`) |
 | `with_engine_info(impl Into<String>)` | Identifies your application in the commit log |
 | `with_data_change(bool)` | Whether this commit materially changes data (`true`) or just reorganizes it (`false`, e.g. OPTIMIZE) |
@@ -240,39 +241,69 @@ returns an error:
 > the table first. This gives the committer the information it needs to resolve conflicts
 > safely in multi-writer scenarios.
 
-## Custom commit info
+## Commit info options
 
-Kernel always writes a `commitInfo` action for every commit. To include your own fields in
-that action, call `with_commit_info()` with your custom data and its schema:
+Kernel writes a `commitInfo` action for every commit. You set some fields. Kernel sets the rest.
+Set your fields with `with_operation()` and `CommitInfoClientOptions`:
 
 ```rust,ignore
 let txn = snapshot
     .transaction(Box::new(FileSystemCommitter::new()), &engine)?
     .with_operation("INSERT".to_string())
-    .with_commit_info(engine_commit_info, commit_info_schema);
+    .with_commit_info_options(
+        CommitInfoClientOptions::new()
+            .with_engine_info("my-engine/1.0")
+            .with_operation_parameters([("mode", "Append")])
+            .with_operation_metrics([("numFiles", "1")]),
+    );
 ```
 
-The `engine_commit_info` argument is a `Box<dyn EngineData>` containing the fields you want
-to add, and `commit_info_schema` is the corresponding `SchemaRef`. Kernel merges your fields
-into the final `commitInfo` action.
+### Fields you set
 
-Kernel reserves certain fields and overrides them regardless of what you provide. Do not set
-these fields in your custom commit info:
+| Setter | `commitInfo` field | Notes |
+|--------|--------------------|-------|
+| `with_operation(String)` | `operation` | A transaction setting, not an option. Call order does not matter. |
+| `CommitInfoClientOptions::with_operation_parameters` | `operationParameters` | Kernel always writes this field. An unset value becomes `{}`. |
+| `CommitInfoClientOptions::with_operation_metrics` | `operationMetrics` | Kernel writes this field only when you set it. An empty map becomes `{}`. |
+| `CommitInfoClientOptions::with_engine_info` | `engineInfo` | `Transaction::with_engine_info()` is a shortcut for this option. |
 
-| Field | Set by Kernel to |
-|-------|------------------|
-| `timestamp` | The transaction's commit timestamp |
-| `inCommitTimestamp` | The in-commit timestamp (if ICT is enabled on the table) |
-| `operation` | The value from `with_operation()` |
-| `operationParameters` | Operation parameters (if any) |
+`with_commit_info_options()` replaces all options. To keep the engine info, call
+`with_engine_info()` after it.
+
+### Fields kernel sets
+
+Kernel always sets these fields. You cannot override them.
+
+| Field | Kernel sets it to |
+|-------|-------------------|
+| `timestamp` | The commit timestamp |
+| `inCommitTimestamp` | The in-commit timestamp, if the table uses in-commit timestamps |
 | `kernelVersion` | The Kernel library version |
-| `isBlindAppend` | `true` if `with_blind_append()` was called, omitted otherwise |
-| `engineInfo` | The value from `with_engine_info()` |
+| `isBlindAppend` | `true` if you called `with_blind_append()`. Omitted otherwise. |
 | `txnId` | A unique transaction identifier |
 
-Any field in your custom data that shares a name with a Kernel-reserved field is replaced
-with Kernel's value. Fields with names that do not collide are preserved as-is in the final
-`commitInfo`.
+### Additional fields
+
+For fields the typed setters do not cover, use
+`CommitInfoClientOptions::with_additional_commit_info()`. You pass an `EngineData` batch plus its
+`SchemaRef`. Kernel merges your fields into the `commitInfo` action. Your fields can be any Delta
+type, including nested structs and arrays:
+
+```rust,ignore
+// `engine_commit_info: Box<dyn EngineData>` holds your fields (for example a "notebook" struct and
+// a "clusterId" string); `commit_info_schema: SchemaRef` is its schema.
+let txn = snapshot
+    .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+    .with_operation("INSERT".to_string())
+    .with_commit_info_options(
+        CommitInfoClientOptions::new().with_additional_commit_info(engine_commit_info, commit_info_schema),
+    );
+```
+
+`Transaction::with_additional_commit_info()` is a shortcut that sets the same payload on the options.
+
+Kernel-managed fields always win. Do not set a field with a reserved name (any field in the two
+tables above); kernel overrides it. Prefer the typed setters for the fields they cover.
 
 ## After committing
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -850,13 +850,11 @@ pub(crate) struct CommitInfo {
     /// - The `inCommitTimestamp` field must always be present in CommitInfo.
     /// - The CommitInfo action must always be the first one in a commit.
     pub(crate) in_commit_timestamp: Option<i64>,
-    /// An arbitrary string that identifies the operation associated with this commit. This is
-    /// specified by the engine. Read: optional, write: required (that is, kernel always writes).
+    /// Operation for this commit, set by the engine. Read: optional; write: required (kernel
+    /// always writes).
     pub(crate) operation: Option<String>,
-    /// Map of arbitrary string key-value pairs that provide additional information about the
-    /// operation. This is specified by the engine via
-    /// [`Transaction::with_operation_parameters`](crate::transaction::Transaction::with_operation_parameters)
-    /// or the equivalent create-table / alter-table builder method.
+    /// Operation parameters set by the engine via
+    /// [`CommitInfoClientOptions::with_operation_parameters`](crate::transaction::CommitInfoClientOptions::with_operation_parameters).
     /// Defaults to an empty map when unset.
     pub(crate) operation_parameters: Option<HashMap<String, String>>,
     /// The version of the delta_kernel crate used to write this commit. The kernel will always
@@ -865,11 +863,9 @@ pub(crate) struct CommitInfo {
     pub(crate) kernel_version: Option<String>,
     /// Whether this commit is a blind append.
     pub(crate) is_blind_append: Option<bool>,
-    /// Optional map of stringified operation metrics (e.g. `numFiles`, `numOutputRows`). Specified
-    /// by the engine via
-    /// [`Transaction::with_operation_metrics`](crate::transaction::Transaction::with_operation_metrics)
-    /// or the equivalent create-table / alter-table builder method.
-    /// When unset, this field is written as null.
+    /// Operation metrics (e.g. `numFiles`, `numOutputRows`) set by the engine via
+    /// [`CommitInfoClientOptions::with_operation_metrics`](crate::transaction::CommitInfoClientOptions::with_operation_metrics).
+    /// Omitted from the commit when unset.
     pub(crate) operation_metrics: Option<HashMap<String, String>>,
     /// A place for the engine to store additional metadata associated with this commit
     pub(crate) engine_info: Option<String>,

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -851,10 +851,13 @@ pub(crate) struct CommitInfo {
     /// - The CommitInfo action must always be the first one in a commit.
     pub(crate) in_commit_timestamp: Option<i64>,
     /// An arbitrary string that identifies the operation associated with this commit. This is
-    /// specified by the engine. Read: optional, write: required (that is, kernel alwarys writes).
+    /// specified by the engine. Read: optional, write: required (that is, kernel always writes).
     pub(crate) operation: Option<String>,
     /// Map of arbitrary string key-value pairs that provide additional information about the
-    /// operation. This is specified by the engine. For now this is always empty on write.
+    /// operation. This is specified by the engine via
+    /// [`Transaction::with_operation_parameters`](crate::transaction::Transaction::with_operation_parameters)
+    /// or the equivalent create-table / alter-table builder method.
+    /// Defaults to an empty map when unset.
     pub(crate) operation_parameters: Option<HashMap<String, String>>,
     /// The version of the delta_kernel crate used to write this commit. The kernel will always
     /// write this field, but it is optional since many tables will not have this field (i.e. any
@@ -862,6 +865,12 @@ pub(crate) struct CommitInfo {
     pub(crate) kernel_version: Option<String>,
     /// Whether this commit is a blind append.
     pub(crate) is_blind_append: Option<bool>,
+    /// Optional map of stringified operation metrics (e.g. `numFiles`, `numOutputRows`). Specified
+    /// by the engine via
+    /// [`Transaction::with_operation_metrics`](crate::transaction::Transaction::with_operation_metrics)
+    /// or the equivalent create-table / alter-table builder method.
+    /// When unset, this field is written as null.
+    pub(crate) operation_metrics: Option<HashMap<String, String>>,
     /// A place for the engine to store additional metadata associated with this commit
     pub(crate) engine_info: Option<String>,
     /// A unique transaction identifier for this commit.
@@ -883,6 +892,7 @@ impl CommitInfo {
             operation_parameters: Some(HashMap::new()),
             kernel_version: Some(format!("v{KERNEL_VERSION}")),
             is_blind_append: is_blind_append.then_some(true),
+            operation_metrics: None,
             engine_info,
             txn_id: Some(uuid::Uuid::new_v4().to_string()),
         }
@@ -1814,6 +1824,10 @@ mod tests {
                 ),
                 StructField::nullable("kernelVersion", DataType::STRING),
                 StructField::nullable("isBlindAppend", DataType::BOOLEAN),
+                StructField::nullable(
+                    "operationMetrics",
+                    MapType::new(DataType::STRING, DataType::STRING, false),
+                ),
                 StructField::nullable("engineInfo", DataType::STRING),
                 StructField::nullable("txnId", DataType::STRING),
             ]),
@@ -2129,6 +2143,10 @@ mod tests {
         let mut map_builder = create_string_map_builder(false);
         map_builder.append(true).unwrap();
         let operation_parameters = Arc::new(map_builder.finish());
+        // null operationMetrics (append(false)), vs the empty-but-present map above
+        let mut metrics_builder = create_string_map_builder(false);
+        metrics_builder.append(false).unwrap();
+        let operation_metrics = Arc::new(metrics_builder.finish());
 
         let expected = RecordBatch::try_new(
             record_batch.schema(),
@@ -2139,6 +2157,7 @@ mod tests {
                 operation_parameters,
                 Arc::new(StringArray::from(vec![Some(format!("v{KERNEL_VERSION}"))])),
                 Arc::new(BooleanArray::from(vec![None::<bool>])),
+                operation_metrics,
                 Arc::new(StringArray::from(vec![None::<String>])),
                 Arc::new(StringArray::from(vec![commit_info_txn_id])),
             ],

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -6,6 +6,7 @@
 
 #![allow(unreachable_pub)]
 
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -59,6 +60,8 @@ impl AlterTableTransaction {
             committer,
             operation: Some("ALTER TABLE".to_string()),
             engine_info: None,
+            operation_parameters: HashMap::new(),
+            operation_metrics: None,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -49,6 +49,9 @@ impl AlterTableTransaction {
             operation = "ALTER TABLE",
         );
 
+        // ALTER TABLE's operation is kernel-owned: override any caller-supplied value.
+        let mut commit_info_options = commit_info_options;
+        commit_info_options.operation = Some("ALTER TABLE".to_string());
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
@@ -58,7 +61,6 @@ impl AlterTableTransaction {
             should_emit_protocol: false,
             should_emit_metadata: true,
             committer,
-            operation: Some("ALTER TABLE".to_string()),
             commit_info_options,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -6,7 +6,6 @@
 
 #![allow(unreachable_pub)]
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -14,7 +13,7 @@ use crate::committer::Committer;
 use crate::metrics::MetricId;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
-use crate::transaction::{AlterTable, Transaction};
+use crate::transaction::{AlterTable, CommitInfoClientOptions, Transaction};
 use crate::utils::current_time_ms;
 use crate::DeltaResult;
 
@@ -41,6 +40,7 @@ impl AlterTableTransaction {
         effective_table_config: TableConfiguration,
         committer: Box<dyn Committer>,
         correlation_id: Option<Arc<str>>,
+        commit_info_options: CommitInfoClientOptions,
     ) -> DeltaResult<Self> {
         let span = tracing::info_span!(
             "txn",
@@ -59,9 +59,7 @@ impl AlterTableTransaction {
             should_emit_metadata: true,
             committer,
             operation: Some("ALTER TABLE".to_string()),
-            engine_info: None,
-            operation_parameters: HashMap::new(),
-            operation_metrics: None,
+            commit_info_options,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],
@@ -71,7 +69,6 @@ impl AlterTableTransaction {
             user_domain_removals: vec![],
             data_change: false,
             column_defaults_acknowledged: false,
-            engine_commit_info: None,
             // TODO(#2446): match delta-spark's per-op isBlindAppend policy
             // (ADD/DROP/DROP NOT NULL -> true, SET NOT NULL -> false). Hardcoded false for
             // now: safe, but misses the true-case optimization delta-spark applies.

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -109,9 +109,9 @@ impl<S> AlterTableTransactionBuilder<S> {
     }
 
     /// Set the commit-info options for the alter-table commit. The operation is always
-    /// `ALTER TABLE` and is not part of these options.
+    /// `ALTER TABLE`, regardless of these options.
     pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
-        self.commit_info_options = options;
+        self.commit_info_options.merge(options);
         self
     }
 }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -24,7 +24,6 @@
 //! snapshot.alter_table().build(engine, committer)?;  // compile error
 //! ```
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -39,10 +38,10 @@ use crate::table_features::{
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
-use crate::transaction::collect_string_map;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
 };
+use crate::transaction::CommitInfoClientOptions;
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
 
@@ -79,8 +78,7 @@ pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
     operations: Vec<SchemaOperation>,
     correlation_id: Option<Arc<str>>,
-    operation_parameters: HashMap<String, String>,
-    operation_metrics: Option<HashMap<String, String>>,
+    commit_info_options: CommitInfoClientOptions,
     // PhantomData marker for builder state (Ready or Modifying).
     // Zero-sized; only affects which methods are available at compile time.
     _state: PhantomData<S>,
@@ -98,8 +96,7 @@ impl<S> AlterTableTransactionBuilder<S> {
             snapshot: self.snapshot,
             operations: self.operations,
             correlation_id: self.correlation_id,
-            operation_parameters: self.operation_parameters,
-            operation_metrics: self.operation_metrics,
+            commit_info_options: self.commit_info_options,
             _state: PhantomData,
         }
     }
@@ -111,29 +108,10 @@ impl<S> AlterTableTransactionBuilder<S> {
         self
     }
 
-    /// Set `CommitInfo.operationParameters` for the alter-table commit.
-    ///
-    /// See [`crate::transaction::Transaction::with_operation_parameters`].
-    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_parameters = collect_string_map(operation_parameters);
-        self
-    }
-
-    /// Set `CommitInfo.operationMetrics` for the alter-table commit.
-    ///
-    /// See [`crate::transaction::Transaction::with_operation_metrics`].
-    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_metrics = Some(collect_string_map(operation_metrics));
+    /// Set the commit-info options for the alter-table commit. The operation is always
+    /// `ALTER TABLE` and is not part of these options.
+    pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
+        self.commit_info_options = options;
         self
     }
 }
@@ -145,8 +123,7 @@ impl AlterTableTransactionBuilder<Ready> {
             snapshot,
             operations: Vec::new(),
             correlation_id: None,
-            operation_parameters: HashMap::new(),
-            operation_metrics: None,
+            commit_info_options: CommitInfoClientOptions::new(),
             _state: PhantomData,
         }
     }
@@ -270,11 +247,7 @@ impl AlterTableTransactionBuilder<Modifying> {
             evolved_table_config,
             committer,
             self.correlation_id,
+            self.commit_info_options,
         )
-        .map(|mut txn| {
-            txn.operation_parameters = self.operation_parameters;
-            txn.operation_metrics = self.operation_metrics;
-            txn
-        })
     }
 }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -24,6 +24,7 @@
 //! snapshot.alter_table().build(engine, committer)?;  // compile error
 //! ```
 
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -38,6 +39,7 @@ use crate::table_features::{
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
+use crate::transaction::collect_string_map;
 use crate::transaction::schema_evolution::{
     apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
 };
@@ -77,6 +79,8 @@ pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
     operations: Vec<SchemaOperation>,
     correlation_id: Option<Arc<str>>,
+    operation_parameters: HashMap<String, String>,
+    operation_metrics: Option<HashMap<String, String>>,
     // PhantomData marker for builder state (Ready or Modifying).
     // Zero-sized; only affects which methods are available at compile time.
     _state: PhantomData<S>,
@@ -94,6 +98,8 @@ impl<S> AlterTableTransactionBuilder<S> {
             snapshot: self.snapshot,
             operations: self.operations,
             correlation_id: self.correlation_id,
+            operation_parameters: self.operation_parameters,
+            operation_metrics: self.operation_metrics,
             _state: PhantomData,
         }
     }
@@ -102,6 +108,32 @@ impl<S> AlterTableTransactionBuilder<S> {
     /// events to the caller's own request or operation id. An empty id is treated as unset.
     pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
+    }
+
+    /// Set `CommitInfo.operationParameters` for the alter-table commit.
+    ///
+    /// See [`crate::transaction::Transaction::with_operation_parameters`].
+    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_parameters = collect_string_map(operation_parameters);
+        self
+    }
+
+    /// Set `CommitInfo.operationMetrics` for the alter-table commit.
+    ///
+    /// See [`crate::transaction::Transaction::with_operation_metrics`].
+    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_metrics = Some(collect_string_map(operation_metrics));
         self
     }
 }
@@ -113,6 +145,8 @@ impl AlterTableTransactionBuilder<Ready> {
             snapshot,
             operations: Vec::new(),
             correlation_id: None,
+            operation_parameters: HashMap::new(),
+            operation_metrics: None,
             _state: PhantomData,
         }
     }
@@ -237,5 +271,10 @@ impl AlterTableTransactionBuilder<Modifying> {
             committer,
             self.correlation_id,
         )
+        .map(|mut txn| {
+            txn.operation_parameters = self.operation_parameters;
+            txn.operation_metrics = self.operation_metrics;
+            txn
+        })
     }
 }

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -44,7 +44,7 @@ use crate::table_properties::{
 };
 use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
-use crate::transaction::{collect_string_map, Transaction};
+use crate::transaction::{CommitInfoClientOptions, Transaction};
 use crate::utils::{current_time_ms, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, StorageHandler};
 
@@ -726,8 +726,7 @@ pub struct CreateTableTransactionBuilder {
     table_properties: HashMap<String, String>,
     data_layout: DataLayout,
     correlation_id: Option<Arc<str>>,
-    operation_parameters: HashMap<String, String>,
-    operation_metrics: Option<HashMap<String, String>>,
+    commit_info_options: CommitInfoClientOptions,
 }
 
 impl CreateTableTransactionBuilder {
@@ -743,8 +742,7 @@ impl CreateTableTransactionBuilder {
             table_properties: HashMap::new(),
             data_layout: DataLayout::None,
             correlation_id: None,
-            operation_parameters: HashMap::new(),
-            operation_metrics: None,
+            commit_info_options: CommitInfoClientOptions::new(),
         }
     }
 
@@ -839,29 +837,13 @@ impl CreateTableTransactionBuilder {
         self
     }
 
-    /// Set `CommitInfo.operationParameters` for the create-table commit.
+    /// Set the commit-info options for the create-table commit.
     ///
-    /// See [`Transaction::with_operation_parameters`].
-    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_parameters = collect_string_map(operation_parameters);
-        self
-    }
-
-    /// Set `CommitInfo.operationMetrics` for the create-table commit.
-    ///
-    /// See [`Transaction::with_operation_metrics`].
-    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_metrics = Some(collect_string_map(operation_metrics));
+    /// The operation is always `CREATE TABLE` and is not part of these options. When the options
+    /// omit engine info, the [`create_table`](super::super::create_table::create_table) value is
+    /// kept.
+    pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
+        self.commit_info_options = options;
         self
     }
 
@@ -987,18 +969,19 @@ impl CreateTableTransactionBuilder {
         // Build TableConfiguration directly for the new table
         let table_configuration = TableConfiguration::try_new(metadata, protocol, table_url, 0)?;
 
-        // Create Transaction<CreateTable> with the effective table configuration
-        let mut txn = Transaction::try_new_create_table(
+        // Fall back to the builder's engine info when the options omit it.
+        let mut commit_info_options = self.commit_info_options;
+        commit_info_options
+            .engine_info
+            .get_or_insert(self.engine_info);
+        Transaction::try_new_create_table(
             table_configuration,
-            self.engine_info,
+            commit_info_options,
             committer,
             data_layout_result.system_domain_metadata,
             data_layout_result.clustering_columns,
             self.correlation_id,
-        )?;
-        txn.operation_parameters = self.operation_parameters;
-        txn.operation_metrics = self.operation_metrics;
-        Ok(txn)
+        )
     }
 }
 

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -44,7 +44,7 @@ use crate::table_properties::{
 };
 use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
-use crate::transaction::Transaction;
+use crate::transaction::{collect_string_map, Transaction};
 use crate::utils::{current_time_ms, try_parse_uri};
 use crate::{DeltaResult, Engine, Error, StorageHandler};
 
@@ -726,6 +726,8 @@ pub struct CreateTableTransactionBuilder {
     table_properties: HashMap<String, String>,
     data_layout: DataLayout,
     correlation_id: Option<Arc<str>>,
+    operation_parameters: HashMap<String, String>,
+    operation_metrics: Option<HashMap<String, String>>,
 }
 
 impl CreateTableTransactionBuilder {
@@ -741,6 +743,8 @@ impl CreateTableTransactionBuilder {
             table_properties: HashMap::new(),
             data_layout: DataLayout::None,
             correlation_id: None,
+            operation_parameters: HashMap::new(),
+            operation_metrics: None,
         }
     }
 
@@ -832,6 +836,32 @@ impl CreateTableTransactionBuilder {
     /// metric events to the caller's own request or operation id. An empty id is treated as unset.
     pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
+        self
+    }
+
+    /// Set `CommitInfo.operationParameters` for the create-table commit.
+    ///
+    /// See [`Transaction::with_operation_parameters`].
+    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_parameters = collect_string_map(operation_parameters);
+        self
+    }
+
+    /// Set `CommitInfo.operationMetrics` for the create-table commit.
+    ///
+    /// See [`Transaction::with_operation_metrics`].
+    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_metrics = Some(collect_string_map(operation_metrics));
         self
     }
 
@@ -958,14 +988,17 @@ impl CreateTableTransactionBuilder {
         let table_configuration = TableConfiguration::try_new(metadata, protocol, table_url, 0)?;
 
         // Create Transaction<CreateTable> with the effective table configuration
-        Transaction::try_new_create_table(
+        let mut txn = Transaction::try_new_create_table(
             table_configuration,
             self.engine_info,
             committer,
             data_layout_result.system_domain_metadata,
             data_layout_result.clustering_columns,
             self.correlation_id,
-        )
+        )?;
+        txn.operation_parameters = self.operation_parameters;
+        txn.operation_metrics = self.operation_metrics;
+        Ok(txn)
     }
 }
 

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -839,11 +839,10 @@ impl CreateTableTransactionBuilder {
 
     /// Set the commit-info options for the create-table commit.
     ///
-    /// The operation is always `CREATE TABLE` and is not part of these options. When the options
-    /// omit engine info, the [`create_table`](super::super::create_table::create_table) value is
-    /// kept.
+    /// Merges into the current options (fields set in `options` override; unset fields are kept).
+    /// The operation is always `CREATE TABLE`, regardless of these options.
     pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
-        self.commit_info_options = options;
+        self.commit_info_options.merge(options);
         self
     }
 

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -6,27 +6,31 @@ use crate::actions::{CommitInfo, COMMIT_INFO_NAME, LOG_COMMIT_INFO_SCHEMA};
 use crate::expressions::{MapData, Scalar};
 use crate::schema::{schema_ref, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
-use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
+use crate::{
+    DataType, DeltaResult, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData,
+};
 
-/// Builds a list of `(field_name, literal_expression)` pairs covering every [`CommitInfo`]
-/// field. Field names match the camelCase schema names produced by the `ToSchema` derive macro.
-/// The returned vec preserves CommitInfo schema field order, which callers rely on when
-/// inserting kernel-only fields after the last engine field.
+/// Builds a `(field_name, literal_expression)` pair for every [`CommitInfo`] field. Field names
+/// match the camelCase `ToSchema` names. The pairs keep CommitInfo schema order, which the merge
+/// relies on to append kernel-only fields after the engine fields.
 fn commit_info_literal_exprs(
     commit_info: CommitInfo,
-) -> Result<Vec<(&'static str, ExpressionRef)>, Error> {
-    let string_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
-    let map_literal =
-        |map: Option<HashMap<String, String>>, map_type: MapType| -> Result<ExpressionRef, Error> {
-            Ok(Arc::new(Expression::literal(match map {
-                Some(map) => Scalar::Map(MapData::try_new(
-                    map_type,
-                    map.into_iter()
-                        .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
-                )?),
-                None => Scalar::null(map_type),
-            })))
+) -> DeltaResult<Vec<(&'static str, ExpressionRef)>> {
+    // operationParameters and operationMetrics are `map<string, string>` with non-nullable values.
+    // The type must match `LOG_COMMIT_INFO_SCHEMA`, or the evaluator rejects the literal.
+    let map_type = MapType::new(DataType::STRING, DataType::STRING, false);
+    let map_literal = |map: Option<HashMap<String, String>>| -> DeltaResult<Expression> {
+        let scalar = match map {
+            Some(map) => Scalar::Map(MapData::try_new(
+                map_type.clone(),
+                map.into_iter()
+                    .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
+            )?),
+            None => Scalar::null(map_type.clone()),
         };
+        Ok(Expression::literal(scalar))
+    };
+
     let literal_exprs = vec![
         (
             "timestamp",
@@ -42,7 +46,7 @@ fn commit_info_literal_exprs(
         ),
         (
             "operationParameters",
-            map_literal(commit_info.operation_parameters, string_map_type.clone())?,
+            Arc::new(map_literal(commit_info.operation_parameters)?),
         ),
         (
             "kernelVersion",
@@ -54,7 +58,7 @@ fn commit_info_literal_exprs(
         ),
         (
             "operationMetrics",
-            map_literal(commit_info.operation_metrics, string_map_type)?,
+            Arc::new(map_literal(commit_info.operation_metrics)?),
         ),
         (
             "engineInfo",
@@ -64,77 +68,77 @@ fn commit_info_literal_exprs(
     ];
     let expected_expr_len = CommitInfo::to_schema().fields().len();
     if literal_exprs.len() != expected_expr_len {
-        return Err(Error::Generic(format!("expect the commit_info_literal_exprs return {expected_expr_len} expressions, but only get {} expressions. \
-            If CommitInfo field was added/removed, please update Expression::Literal in this function and update the with_commit_info doc comment", literal_exprs.len())));
+        return Err(Error::internal_error(format!(
+            "commit_info_literal_exprs produced {} expressions but CommitInfo has \
+             {expected_expr_len} fields; update this function when CommitInfo fields change",
+            literal_exprs.len()
+        )));
     }
     Ok(literal_exprs)
 }
 
 impl<S> Transaction<S> {
-    pub(super) fn generate_commit_info(
+    /// Builds the `commitInfo` action for this transaction.
+    ///
+    /// The kernel-managed fields come from `commit_info`. If the caller added fields through
+    /// [`with_additional_commit_info`](Transaction::with_additional_commit_info), kernel merges
+    /// them: engine fields stay, a field that collides with a kernel field takes kernel's value,
+    /// and kernel-only fields are appended in schema order.
+    pub(super) fn build_commit_info_action(
         &self,
         engine: &dyn Engine,
-        kernel_commit_info: CommitInfo,
-    ) -> Result<Box<dyn EngineData>, Error> {
-        match &self.engine_commit_info {
-            Some((engine_commit_info, engine_commit_info_schema)) => {
-                let kernel_schema = CommitInfo::to_schema();
+        commit_info: CommitInfo,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        let Some((engine_commit_info, engine_commit_info_schema)) =
+            &self.commit_info_options.additional_commit_info
+        else {
+            return commit_info.into_engine_data(LOG_COMMIT_INFO_SCHEMA.clone(), engine);
+        };
 
-                // Step 1: Build literal expressions for each CommitInfo field.
-                let literal_exprs = commit_info_literal_exprs(kernel_commit_info)?;
+        let kernel_schema = CommitInfo::to_schema();
+        let literal_exprs = commit_info_literal_exprs(commit_info)?;
 
-                // Step 2: Build the output schema and expression patch together. Engine fields
-                // pass through first, overlapping kernel fields are replaced in place, and
-                // kernel-only fields are appended after the last engine field.
-                let mut patch = ProjectionStructPatchBuilder::new(engine_commit_info_schema);
-                for (field_name, expr_ref) in &literal_exprs {
-                    let field = kernel_schema.field(*field_name).ok_or_else(|| {
-                        Error::internal_error(format!(
-                            "CommitInfo schema is missing field '{field_name}'"
-                        ))
-                    })?;
-                    if engine_commit_info_schema.contains(*field_name) {
-                        patch = patch.replace(*field_name, field.clone(), expr_ref.clone());
-                    }
-                }
-                for (field_name, expr_ref) in &literal_exprs {
-                    let field = kernel_schema.field(*field_name).ok_or_else(|| {
-                        Error::internal_error(format!(
-                            "CommitInfo schema is missing field '{field_name}'"
-                        ))
-                    })?;
-                    if !engine_commit_info_schema.contains(*field_name) {
-                        patch = patch.append(field.clone(), expr_ref.clone());
-                    }
-                }
-                let (output_schema, patch) = patch.build()?;
-
-                // Step 3: Wrap the patch in a struct expression so the output matches the
-                // Delta log action format `{ "commitInfo": { merged fields... } }`, consistent
-                // with the None branch which uses `LOG_COMMIT_INFO_SCHEMA`.
-                let wrapped_expr = Expression::struct_from([patch]);
-                let wrapped_schema = schema_ref! { nullable (COMMIT_INFO_NAME): (output_schema) };
-                let evaluator = engine.evaluation_handler().new_expression_evaluator(
-                    engine_commit_info_schema.clone(),
-                    Arc::new(wrapped_expr),
-                    wrapped_schema.into(),
-                )?;
-                evaluator.evaluate(engine_commit_info.as_ref())
+        // A kernel field that collides with an engine field replaces it in place. Kernel-only
+        // fields are appended after, in CommitInfo schema order.
+        let mut patch = ProjectionStructPatchBuilder::new(engine_commit_info_schema);
+        for (field_name, expr_ref) in &literal_exprs {
+            let field = kernel_schema.field(*field_name).cloned().ok_or_else(|| {
+                Error::internal_error(format!("CommitInfo schema is missing field '{field_name}'"))
+            })?;
+            if engine_commit_info_schema.contains(*field_name) {
+                patch = patch.replace(*field_name, field, expr_ref.clone());
             }
-            None => kernel_commit_info.into_engine_data(LOG_COMMIT_INFO_SCHEMA.clone(), engine),
         }
+        for (field_name, expr_ref) in &literal_exprs {
+            let field = kernel_schema.field(*field_name).cloned().ok_or_else(|| {
+                Error::internal_error(format!("CommitInfo schema is missing field '{field_name}'"))
+            })?;
+            if !engine_commit_info_schema.contains(*field_name) {
+                patch = patch.append(field, expr_ref.clone());
+            }
+        }
+        let (output_schema, patch) = patch.build()?;
+
+        // Wrap in `{ "commitInfo": { ... } }`, like the no-extras branch via
+        // `LOG_COMMIT_INFO_SCHEMA`.
+        let wrapped_expr = Expression::struct_from([patch]);
+        let wrapped_schema = schema_ref! { nullable (COMMIT_INFO_NAME): (output_schema) };
+        let evaluator = engine.evaluation_handler().new_expression_evaluator(
+            engine_commit_info_schema.clone(),
+            Arc::new(wrapped_expr),
+            wrapped_schema.into(),
+        )?;
+        evaluator.evaluate(engine_commit_info.as_ref())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::actions::CommitInfo;
     use crate::arrow::array::{
-        Array, ArrayRef, BooleanArray, Int64Array, MapArray, MapBuilder, StringArray,
-        StringBuilder, StructArray,
+        Array, ArrayRef, BooleanArray, Int64Array, MapArray, StringArray, StructArray,
     };
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
@@ -143,15 +147,13 @@ mod tests {
     use crate::committer::FileSystemCommitter;
     use crate::engine::arrow_conversion::TryIntoKernel;
     use crate::engine::arrow_data::ArrowEngineData;
-    use crate::schema::{Schema, SchemaRef, StructField, StructType, ToSchema};
-    use crate::transaction::Transaction;
+    use crate::schema::{Schema, SchemaRef, ToSchema};
+    use crate::transaction::{CommitInfoClientOptions, Transaction};
     use crate::unit_test_utils::load_test_table;
     use crate::utils::FoldWithOption as _;
     use crate::{DeltaResult, Engine, EngineData};
 
-    // ── build_commit_info tests ────────────────────────────────────────────────
-
-    /// Helper: create a kernel `CommitInfo` that mirrors what `Transaction::commit` produces.
+    /// Kernel `CommitInfo` mirroring what `Transaction::commit` produces.
     fn make_kernel_commit_info() -> CommitInfo {
         CommitInfo::new(
             1_700_000_000_000i64,
@@ -162,7 +164,7 @@ mod tests {
         )
     }
 
-    /// Helper: build an Arrow RecordBatch + kernel SchemaRef for use as engine_commit_info.
+    /// Build an Arrow `RecordBatch` + kernel `SchemaRef` for use as engine commit info.
     fn make_engine_commit_info(
         arrow_fields: Vec<ArrowField>,
         columns: Vec<ArrayRef>,
@@ -177,8 +179,7 @@ mod tests {
         )
     }
 
-    /// Helper: extract the inner "commitInfo" StructArray from a top-level RecordBatch.
-    /// Both branches of `build_commit_info` produce `{ "commitInfo": { ... } }`.
+    /// Extract the inner "commitInfo" StructArray. Both branches produce `{ "commitInfo": {...} }`.
     fn commit_info_struct(result: &ArrowEngineData) -> &StructArray {
         let batch = result.record_batch();
         assert_eq!(
@@ -194,7 +195,6 @@ mod tests {
             .expect("commitInfo column should be a StructArray")
     }
 
-    /// Helper: pull a non-null string value from a named column in a StructArray.
     fn get_str<'a>(s: &'a StructArray, col: &str) -> &'a str {
         s.column_by_name(col)
             .unwrap_or_else(|| panic!("field '{col}' not found"))
@@ -204,7 +204,6 @@ mod tests {
             .value(0)
     }
 
-    /// Helper: pull a non-null i64 value from a named column in a StructArray.
     fn get_i64(s: &StructArray, col: &str) -> i64 {
         s.column_by_name(col)
             .unwrap_or_else(|| panic!("field '{col}' not found"))
@@ -214,8 +213,6 @@ mod tests {
             .value(0)
     }
 
-    /// Helper: pull the map value at row 0 from a named MapArray column in a StructArray.
-    /// Returns the key-value pairs as a StructArray.
     fn get_map(s: &StructArray, col: &str) -> StructArray {
         s.column_by_name(col)
             .unwrap_or_else(|| panic!("field '{col}' not found"))
@@ -225,35 +222,17 @@ mod tests {
             .value(0)
     }
 
-    /// Helper: pull a named string->string map column into a `HashMap` for content assertions.
-    fn get_map_entries(s: &StructArray, col: &str) -> HashMap<String, String> {
-        let entries = get_map(s, col);
-        let keys = entries
-            .column(0)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("map keys are strings");
-        let values = entries
-            .column(1)
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("map values are strings");
-        (0..entries.len())
-            .map(|i| (keys.value(i).to_string(), values.value(i).to_string()))
-            .collect()
-    }
-
-    /// Helper: pull a non-null boolean value from a named column in a StructArray.
     fn get_bool(s: &StructArray, col: &str) -> bool {
         s.column_by_name(col)
             .unwrap_or_else(|| panic!("field '{col}' not found"))
             .as_any()
             .downcast_ref::<BooleanArray>()
-            .unwrap_or_else(|| panic!("field '{col}' is not an Int64Array"))
+            .unwrap_or_else(|| panic!("field '{col}' is not a BooleanArray"))
             .value(0)
     }
 
-    /// Create a transaction with the given engine_commit_info, using the shared test table.
+    /// Transaction over the shared test table, setting any extra fields through
+    /// `CommitInfoClientOptions::with_additional_commit_info`.
     fn make_txn(
         engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
     ) -> DeltaResult<(Arc<dyn Engine>, Transaction)> {
@@ -262,89 +241,31 @@ mod tests {
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_operation("WRITE".to_string())
             .fold_with(engine_commit_info, |txn, (data, schema)| {
-                txn.with_commit_info(data, schema)
+                txn.with_commit_info_options(
+                    CommitInfoClientOptions::new().with_additional_commit_info(data, schema),
+                )
             });
         Ok((engine, txn))
     }
 
-    /// no engine_commit_info -- output is the kernel CommitInfo wrapped in a "commitInfo"
-    /// outer struct, matching the Delta log action format produced by `LOG_COMMIT_INFO_SCHEMA`.
+    /// No engine commit info: output is the kernel `CommitInfo` wrapped in a `commitInfo` struct.
     #[test]
     fn test_build_commit_info_none_branch() -> DeltaResult<()> {
         let (engine, txn) = make_txn(None)?;
         let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
+            txn.build_commit_info_action(engine.as_ref(), make_kernel_commit_info())?,
         )?;
         let ci = commit_info_struct(&result);
 
-        let kernel_schema = CommitInfo::to_schema();
-        assert_eq!(ci.num_columns(), kernel_schema.fields().count());
+        assert_eq!(ci.num_columns(), CommitInfo::to_schema().fields().count());
         assert_eq!(get_str(ci, "operation"), "WRITE");
         assert!(!get_str(ci, "kernelVersion").is_empty());
         assert!(!get_str(ci, "txnId").is_empty());
-        assert!(
-            ci.column_by_name("operationMetrics")
-                .expect("operationMetrics field")
-                .is_null(0),
-            "operationMetrics should be null when unset"
-        );
         Ok(())
     }
 
-    /// Kernel CommitInfo carries engine-provided operationParameters / operationMetrics.
-    #[test]
-    fn test_build_commit_info_with_operation_maps() -> DeltaResult<()> {
-        let (engine, txn) = make_txn(None)?;
-        let mut commit_info = make_kernel_commit_info();
-        commit_info.operation_parameters = Some(HashMap::from([
-            ("mode".to_string(), "Append".to_string()),
-            ("partitionBy".to_string(), "[]".to_string()),
-        ]));
-        commit_info.operation_metrics = Some(HashMap::from([
-            ("numFiles".to_string(), "1".to_string()),
-            ("numOutputRows".to_string(), "10".to_string()),
-        ]));
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), commit_info)?,
-        )?;
-        let ci = commit_info_struct(&result);
-
-        // Assert exact entries so a crossed or swapped map is caught.
-        let params = get_map_entries(ci, "operationParameters");
-        assert_eq!(params.get("mode").map(String::as_str), Some("Append"));
-        assert_eq!(params.get("partitionBy").map(String::as_str), Some("[]"));
-        let metrics = get_map_entries(ci, "operationMetrics");
-        assert_eq!(metrics.get("numFiles").map(String::as_str), Some("1"));
-        assert_eq!(metrics.get("numOutputRows").map(String::as_str), Some("10"));
-        Ok(())
-    }
-
-    /// An explicitly empty operationMetrics map is written as `{}` (present, empty), distinct from
-    /// the null written when the map is left unset.
-    #[test]
-    fn test_build_commit_info_empty_metrics_is_empty_map_not_null() -> DeltaResult<()> {
-        let (engine, txn) = make_txn(None)?;
-        let mut commit_info = make_kernel_commit_info();
-        commit_info.operation_metrics = Some(HashMap::new());
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), commit_info)?,
-        )?;
-        let ci = commit_info_struct(&result);
-
-        assert!(
-            !ci.column_by_name("operationMetrics")
-                .expect("operationMetrics field")
-                .is_null(0),
-            "an explicit empty map must be written as a non-null map"
-        );
-        assert_eq!(get_map(ci, "operationMetrics").len(), 0);
-        Ok(())
-    }
-
-    /// engine schema has fields that are fully disjoint from CommitInfo -- all CommitInfo
-    /// fields are appended after the engine-only fields, in CommitInfo schema order.
+    /// Engine fields disjoint from CommitInfo: kernel fields are appended after the engine fields,
+    /// in schema order, and the engine values are unchanged.
     #[test]
     fn test_build_commit_info_disjoint_schemas() -> DeltaResult<()> {
         let (data, schema) = make_engine_commit_info(
@@ -358,293 +279,62 @@ mod tests {
             ],
         );
         let (engine, txn) = make_txn(Some((data, schema)))?;
-
         let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
-        )?;
-        let commit_info = commit_info_struct(&result);
-
-        // All CommitInfo fields are appended -- total = 2 engine + kernel CommitInfo fields.
-        assert_eq!(
-            commit_info.num_columns(),
-            2 + CommitInfo::to_schema().fields().count()
-        );
-
-        // Engine fields are first and their values pass through unchanged.
-        assert_eq!(commit_info.fields()[0].name(), "customApp");
-        assert_eq!(commit_info.fields()[1].name(), "customVersion");
-        assert_eq!(get_str(commit_info, "customApp"), "myApp");
-        assert_eq!(get_i64(commit_info, "customVersion"), 42);
-
-        assert_eq!(get_str(commit_info, "operation"), "WRITE");
-        assert!(!get_str(commit_info, "kernelVersion").is_empty());
-        assert!(get_map(commit_info, "operationParameters").len() == 0);
-        assert!(uuid::Uuid::parse_str(get_str(commit_info, "txnId")).is_ok());
-        assert!(get_i64(commit_info, "timestamp") > 0);
-        assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
-        assert_eq!(get_str(commit_info, "engineInfo"), "test_engine/1.0");
-        assert!(!get_bool(commit_info, "isBlindAppend"));
-
-        Ok(())
-    }
-
-    /// engine schema contains every kernel's CommitInfo field.
-    /// All overlapping fields must be replaced by kernel values, no new fields added.
-    #[test]
-    fn test_build_commit_info_full_overlap() -> DeltaResult<()> {
-        let mut map_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        map_builder.keys().append_value("stale_key");
-        map_builder.values().append_value("stale_value");
-        map_builder.append(true).unwrap();
-        let stale_op_params = Arc::new(map_builder.finish()) as ArrayRef;
-
-        let mut metrics_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        metrics_builder.keys().append_value("stale_metric");
-        metrics_builder.values().append_value("0");
-        metrics_builder.append(true).unwrap();
-        let stale_op_metrics = Arc::new(metrics_builder.finish()) as ArrayRef;
-
-        let (data, schema) = make_engine_commit_info(
-            vec![
-                ArrowField::new("timestamp", ArrowDataType::Int64, true),
-                ArrowField::new("inCommitTimestamp", ArrowDataType::Int64, true),
-                ArrowField::new("operation", ArrowDataType::Utf8, true),
-                ArrowField::new(
-                    "operationParameters",
-                    stale_op_params.data_type().clone(),
-                    true,
-                ),
-                ArrowField::new("kernelVersion", ArrowDataType::Utf8, true),
-                ArrowField::new("isBlindAppend", ArrowDataType::Boolean, true),
-                ArrowField::new(
-                    "operationMetrics",
-                    stale_op_metrics.data_type().clone(),
-                    true,
-                ),
-                ArrowField::new("engineInfo", ArrowDataType::Utf8, true),
-                ArrowField::new("txnId", ArrowDataType::Utf8, true),
-            ],
-            vec![
-                Arc::new(Int64Array::from(vec![Some(0i64)])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![None::<i64>])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
-                stale_op_params,
-                Arc::new(StringArray::from(vec!["v0.0.0"])) as ArrayRef,
-                Arc::new(BooleanArray::from(vec![None::<bool>])) as ArrayRef,
-                stale_op_metrics,
-                Arc::new(StringArray::from(vec!["stale_engine"])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["stale_txn"])) as ArrayRef,
-            ],
-        );
-        let (engine, txn) = make_txn(Some((data, schema)))?;
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
-        )?;
-        let commit_info = commit_info_struct(&result);
-
-        // All CommitInfo fields are present in the engine schema -- no fields appended.
-        assert_eq!(
-            commit_info.num_columns(),
-            CommitInfo::to_schema().fields().count()
-        );
-
-        assert_eq!(get_str(commit_info, "operation"), "WRITE");
-        assert!(!get_str(commit_info, "kernelVersion").is_empty());
-        assert_eq!(get_map(commit_info, "operationParameters").len(), 0);
-        assert!(
-            commit_info
-                .column_by_name("operationMetrics")
-                .expect("operationMetrics field")
-                .is_null(0),
-            "stale engine operationMetrics must be overridden by kernel's null"
-        );
-        assert!(uuid::Uuid::parse_str(get_str(commit_info, "txnId")).is_ok());
-        assert!(get_i64(commit_info, "timestamp") > 0);
-        assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
-        assert_eq!(get_str(commit_info, "engineInfo"), "test_engine/1.0");
-        assert!(!get_bool(commit_info, "isBlindAppend"));
-
-        Ok(())
-    }
-
-    /// Non-empty kernel operationParameters/operationMetrics replace stale engine-supplied values
-    /// in the engine_commit_info branch -- exercises content fidelity of the replace path, not just
-    /// the empty/null override covered by `test_build_commit_info_full_overlap`.
-    #[test]
-    fn test_build_commit_info_nonempty_maps_override_stale_engine() -> DeltaResult<()> {
-        let mut params_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        params_builder.keys().append_value("stale_key");
-        params_builder.values().append_value("stale_value");
-        params_builder.append(true).unwrap();
-        let stale_op_params = Arc::new(params_builder.finish()) as ArrayRef;
-
-        let mut metrics_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
-        metrics_builder.keys().append_value("stale_metric");
-        metrics_builder.values().append_value("0");
-        metrics_builder.append(true).unwrap();
-        let stale_op_metrics = Arc::new(metrics_builder.finish()) as ArrayRef;
-
-        let (data, schema) = make_engine_commit_info(
-            vec![
-                ArrowField::new(
-                    "operationParameters",
-                    stale_op_params.data_type().clone(),
-                    true,
-                ),
-                ArrowField::new(
-                    "operationMetrics",
-                    stale_op_metrics.data_type().clone(),
-                    true,
-                ),
-            ],
-            vec![stale_op_params, stale_op_metrics],
-        );
-        let (engine, txn) = make_txn(Some((data, schema)))?;
-
-        let mut commit_info = make_kernel_commit_info();
-        commit_info.operation_parameters =
-            Some(HashMap::from([("mode".to_string(), "Append".to_string())]));
-        commit_info.operation_metrics =
-            Some(HashMap::from([("numFiles".to_string(), "3".to_string())]));
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), commit_info)?,
+            txn.build_commit_info_action(engine.as_ref(), make_kernel_commit_info())?,
         )?;
         let ci = commit_info_struct(&result);
 
-        let params = get_map_entries(ci, "operationParameters");
-        assert_eq!(params.get("mode").map(String::as_str), Some("Append"));
-        assert!(
-            !params.contains_key("stale_key"),
-            "kernel value must replace the stale engine operationParameters"
-        );
-        let metrics = get_map_entries(ci, "operationMetrics");
-        assert_eq!(metrics.get("numFiles").map(String::as_str), Some("3"));
-        assert!(
-            !metrics.contains_key("stale_metric"),
-            "kernel value must replace the stale engine operationMetrics"
-        );
-        Ok(())
-    }
-
-    /// engine schema has partial overlap -- overlapping fields are replaced, engine-only
-    /// fields pass through, and remaining CommitInfo fields are appended after the last engine
-    /// field.
-    #[test]
-    fn test_build_commit_info_partial_overlap() -> DeltaResult<()> {
-        let (data, schema) = make_engine_commit_info(
-            vec![
-                ArrowField::new("timestamp", ArrowDataType::Int64, true),
-                ArrowField::new("operation", ArrowDataType::Utf8, true),
-                ArrowField::new("myCustomField", ArrowDataType::Utf8, false),
-            ],
-            vec![
-                Arc::new(Int64Array::from(vec![Some(0i64)])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["keep_me"])) as ArrayRef,
-            ],
-        );
-        let (engine, txn) = make_txn(Some((data, schema)))?;
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
-        )?;
-        let ci = commit_info_struct(&result);
-
-        // Engine-only field passes through unchanged.
-        assert_eq!(get_str(ci, "myCustomField"), "keep_me");
-
-        // Overlapping fields are replaced with kernel values.
-        assert_ne!(get_str(ci, "operation"), "STALE_OP");
-        assert_eq!(get_str(ci, "operation"), "WRITE");
-
-        // Engine fields keep their original schema positions (first 3 columns).
-        assert_eq!(ci.fields()[0].name(), "timestamp");
-        assert_eq!(ci.fields()[1].name(), "operation");
-        assert_eq!(ci.fields()[2].name(), "myCustomField");
-
-        // Remaining CommitInfo fields (6 not in engine schema) are appended after myCustomField.
-        // Total = 3 engine fields + 6 kernel-only fields.
         assert_eq!(
             ci.num_columns(),
-            3 + CommitInfo::to_schema().fields().count() - 2
+            2 + CommitInfo::to_schema().fields().count()
         );
+        assert_eq!(ci.fields()[0].name(), "customApp");
+        assert_eq!(ci.fields()[1].name(), "customVersion");
+        assert_eq!(get_str(ci, "customApp"), "myApp");
+        assert_eq!(get_i64(ci, "customVersion"), 42);
+
+        assert_eq!(get_str(ci, "operation"), "WRITE");
+        assert!(!get_str(ci, "kernelVersion").is_empty());
+        assert_eq!(get_map(ci, "operationParameters").len(), 0);
+        assert!(uuid::Uuid::parse_str(get_str(ci, "txnId")).is_ok());
+        assert!(get_i64(ci, "timestamp") > 0);
+        assert_eq!(get_i64(ci, "inCommitTimestamp"), 134_000_000);
+        assert_eq!(get_str(ci, "engineInfo"), "test_engine/1.0");
+        assert!(!get_bool(ci, "isBlindAppend"));
         Ok(())
     }
 
-    /// engine schema has overlapping fields with different DataTypes than kernel expects.
-    /// Kernel replacement must win, so each output field has the kernel's type.
+    /// Overlap: a colliding field takes kernel's value; engine-only fields stay; kernel-only fields
+    /// are appended after.
     #[test]
-    fn test_build_commit_info_type_conflict_replaced_by_kernel() -> DeltaResult<()> {
+    fn test_build_commit_info_overlap_replaced_by_kernel() -> DeltaResult<()> {
         let (data, schema) = make_engine_commit_info(
             vec![
-                ArrowField::new("timestamp", ArrowDataType::Utf8, true),
-                ArrowField::new("inCommitTimestamp", ArrowDataType::Utf8, true),
-                ArrowField::new("operation", ArrowDataType::Int64, true),
-                ArrowField::new("isBlindAppend", ArrowDataType::Utf8, true),
+                ArrowField::new("operation", ArrowDataType::Utf8, true),
                 ArrowField::new("myCustomField", ArrowDataType::Utf8, false),
             ],
             vec![
-                Arc::new(StringArray::from(vec!["not-a-timestamp"])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["not-a-timestamp"])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![0i64])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["not-a-bool"])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["keep_me"])) as ArrayRef,
             ],
         );
         let (engine, txn) = make_txn(Some((data, schema)))?;
-
         let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
+            txn.build_commit_info_action(engine.as_ref(), make_kernel_commit_info())?,
         )?;
         let ci = commit_info_struct(&result);
 
-        // Each kernel-owned field has the kernel's type, not the engine's.
-        let field_type = |name: &str| {
-            ci.fields()
-                .iter()
-                .find(|f| f.name() == name)
-                .unwrap_or_else(|| panic!("field '{name}' must be present"))
-                .data_type()
-                .clone()
-        };
-        assert_eq!(field_type("timestamp"), ArrowDataType::Int64);
-        assert_eq!(field_type("inCommitTimestamp"), ArrowDataType::Int64);
-        assert_eq!(field_type("operation"), ArrowDataType::Utf8);
-        assert_eq!(field_type("isBlindAppend"), ArrowDataType::Boolean);
-
-        // Engine-only field passes through with its original type and value unchanged.
-        assert_eq!(field_type("myCustomField"), ArrowDataType::Utf8);
+        // Engine-only field passes through; the colliding field takes kernel's value.
         assert_eq!(get_str(ci, "myCustomField"), "keep_me");
-        Ok(())
-    }
-
-    /// engine schema is empty -- all CommitInfo fields are prepended (which, with no engine
-    /// fields preceding them, is equivalent to producing the full CommitInfo schema).
-    #[test]
-    fn test_build_commit_info_empty_engine_schema() -> DeltaResult<()> {
-        // A 0-row, 0-column RecordBatch with an empty kernel schema.
-        let empty_batch = RecordBatch::new_empty(Arc::new(ArrowSchema::empty()));
-        let empty_schema = Arc::new(StructType::new_unchecked(Vec::<StructField>::new()));
-        let (engine, txn) = make_txn(Some((
-            Box::new(ArrowEngineData::new(empty_batch)),
-            empty_schema,
-        )))?;
-
-        let result = ArrowEngineData::try_from_engine_data(
-            txn.generate_commit_info(engine.as_ref(), make_kernel_commit_info())?,
-        )?;
-        let ci = commit_info_struct(&result);
-
-        // With no engine fields, the inner schema matches CommitInfo::to_schema().
-        let kernel_schema = CommitInfo::to_schema();
-        assert_eq!(ci.num_columns(), kernel_schema.fields().count());
-
-        // Column order matches CommitInfo schema field order.
-        for (i, field) in kernel_schema.fields().enumerate() {
-            assert_eq!(ci.fields()[i].name(), field.name());
-        }
+        assert_eq!(get_str(ci, "operation"), "WRITE");
+        // Engine fields keep their positions; kernel-only fields are appended after.
+        assert_eq!(ci.fields()[0].name(), "operation");
+        assert_eq!(ci.fields()[1].name(), "myCustomField");
+        // 2 engine fields + (kernel fields - 1 overlap) appended.
+        assert_eq!(
+            ci.num_columns(),
+            2 + CommitInfo::to_schema().fields().count() - 1
+        );
         Ok(())
     }
 }

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -134,6 +134,7 @@ impl<S> Transaction<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::actions::CommitInfo;
@@ -335,6 +336,31 @@ mod tests {
             ci.num_columns(),
             2 + CommitInfo::to_schema().fields().count() - 1
         );
+        Ok(())
+    }
+
+    /// Non-empty `operationParameters` and `operationMetrics` maps are written through the merge
+    /// branch with their entries.
+    #[test]
+    fn test_build_commit_info_merges_non_empty_maps() -> DeltaResult<()> {
+        let (data, schema) = make_engine_commit_info(
+            vec![ArrowField::new("customApp", ArrowDataType::Utf8, false)],
+            vec![Arc::new(StringArray::from(vec!["myApp"])) as ArrayRef],
+        );
+        let (engine, txn) = make_txn(Some((data, schema)))?;
+
+        let mut commit_info = make_kernel_commit_info();
+        commit_info.operation_parameters =
+            Some(HashMap::from([("mode".to_string(), "Append".to_string())]));
+        commit_info.operation_metrics =
+            Some(HashMap::from([("numFiles".to_string(), "2".to_string())]));
+
+        let result = ArrowEngineData::try_from_engine_data(
+            txn.build_commit_info_action(engine.as_ref(), commit_info)?,
+        )?;
+        let ci = commit_info_struct(&result);
+        assert_eq!(get_map(ci, "operationParameters").len(), 1);
+        assert_eq!(get_map(ci, "operationMetrics").len(), 1);
         Ok(())
     }
 }

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::Transaction;
@@ -14,7 +15,18 @@ use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, Into
 fn commit_info_literal_exprs(
     commit_info: CommitInfo,
 ) -> Result<Vec<(&'static str, ExpressionRef)>, Error> {
-    let op_params_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
+    let string_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
+    let map_literal =
+        |map: Option<HashMap<String, String>>, map_type: MapType| -> Result<ExpressionRef, Error> {
+            Ok(Arc::new(Expression::literal(match map {
+                Some(map) => Scalar::Map(MapData::try_new(
+                    map_type,
+                    map.into_iter()
+                        .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
+                )?),
+                None => Scalar::null(map_type),
+            })))
+        };
     let literal_exprs = vec![
         (
             "timestamp",
@@ -30,16 +42,7 @@ fn commit_info_literal_exprs(
         ),
         (
             "operationParameters",
-            Arc::new(Expression::literal(
-                match commit_info.operation_parameters {
-                    Some(map) => Scalar::Map(MapData::try_new(
-                        op_params_map_type,
-                        map.into_iter()
-                            .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
-                    )?),
-                    None => Scalar::null(op_params_map_type),
-                },
-            )),
+            map_literal(commit_info.operation_parameters, string_map_type.clone())?,
         ),
         (
             "kernelVersion",
@@ -48,6 +51,10 @@ fn commit_info_literal_exprs(
         (
             "isBlindAppend",
             Arc::new(Expression::literal(commit_info.is_blind_append)),
+        ),
+        (
+            "operationMetrics",
+            map_literal(commit_info.operation_metrics, string_map_type)?,
         ),
         (
             "engineInfo",
@@ -121,6 +128,7 @@ impl<S> Transaction<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use crate::actions::CommitInfo;
@@ -217,6 +225,24 @@ mod tests {
             .value(0)
     }
 
+    /// Helper: pull a named string->string map column into a `HashMap` for content assertions.
+    fn get_map_entries(s: &StructArray, col: &str) -> HashMap<String, String> {
+        let entries = get_map(s, col);
+        let keys = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("map keys are strings");
+        let values = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("map values are strings");
+        (0..entries.len())
+            .map(|i| (keys.value(i).to_string(), values.value(i).to_string()))
+            .collect()
+    }
+
     /// Helper: pull a non-null boolean value from a named column in a StructArray.
     fn get_bool(s: &StructArray, col: &str) -> bool {
         s.column_by_name(col)
@@ -256,6 +282,64 @@ mod tests {
         assert_eq!(get_str(ci, "operation"), "WRITE");
         assert!(!get_str(ci, "kernelVersion").is_empty());
         assert!(!get_str(ci, "txnId").is_empty());
+        assert!(
+            ci.column_by_name("operationMetrics")
+                .expect("operationMetrics field")
+                .is_null(0),
+            "operationMetrics should be null when unset"
+        );
+        Ok(())
+    }
+
+    /// Kernel CommitInfo carries engine-provided operationParameters / operationMetrics.
+    #[test]
+    fn test_build_commit_info_with_operation_maps() -> DeltaResult<()> {
+        let (engine, txn) = make_txn(None)?;
+        let mut commit_info = make_kernel_commit_info();
+        commit_info.operation_parameters = Some(HashMap::from([
+            ("mode".to_string(), "Append".to_string()),
+            ("partitionBy".to_string(), "[]".to_string()),
+        ]));
+        commit_info.operation_metrics = Some(HashMap::from([
+            ("numFiles".to_string(), "1".to_string()),
+            ("numOutputRows".to_string(), "10".to_string()),
+        ]));
+
+        let result = ArrowEngineData::try_from_engine_data(
+            txn.generate_commit_info(engine.as_ref(), commit_info)?,
+        )?;
+        let ci = commit_info_struct(&result);
+
+        // Assert exact entries so a crossed or swapped map is caught.
+        let params = get_map_entries(ci, "operationParameters");
+        assert_eq!(params.get("mode").map(String::as_str), Some("Append"));
+        assert_eq!(params.get("partitionBy").map(String::as_str), Some("[]"));
+        let metrics = get_map_entries(ci, "operationMetrics");
+        assert_eq!(metrics.get("numFiles").map(String::as_str), Some("1"));
+        assert_eq!(metrics.get("numOutputRows").map(String::as_str), Some("10"));
+        Ok(())
+    }
+
+    /// An explicitly empty operationMetrics map is written as `{}` (present, empty), distinct from
+    /// the null written when the map is left unset.
+    #[test]
+    fn test_build_commit_info_empty_metrics_is_empty_map_not_null() -> DeltaResult<()> {
+        let (engine, txn) = make_txn(None)?;
+        let mut commit_info = make_kernel_commit_info();
+        commit_info.operation_metrics = Some(HashMap::new());
+
+        let result = ArrowEngineData::try_from_engine_data(
+            txn.generate_commit_info(engine.as_ref(), commit_info)?,
+        )?;
+        let ci = commit_info_struct(&result);
+
+        assert!(
+            !ci.column_by_name("operationMetrics")
+                .expect("operationMetrics field")
+                .is_null(0),
+            "an explicit empty map must be written as a non-null map"
+        );
+        assert_eq!(get_map(ci, "operationMetrics").len(), 0);
         Ok(())
     }
 
@@ -280,7 +364,7 @@ mod tests {
         )?;
         let commit_info = commit_info_struct(&result);
 
-        // All CommitInfo fields are appended -- total = 2 engine + 8 CommitInfo.
+        // All CommitInfo fields are appended -- total = 2 engine + kernel CommitInfo fields.
         assert_eq!(
             commit_info.num_columns(),
             2 + CommitInfo::to_schema().fields().count()
@@ -314,6 +398,12 @@ mod tests {
         map_builder.append(true).unwrap();
         let stale_op_params = Arc::new(map_builder.finish()) as ArrayRef;
 
+        let mut metrics_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        metrics_builder.keys().append_value("stale_metric");
+        metrics_builder.values().append_value("0");
+        metrics_builder.append(true).unwrap();
+        let stale_op_metrics = Arc::new(metrics_builder.finish()) as ArrayRef;
+
         let (data, schema) = make_engine_commit_info(
             vec![
                 ArrowField::new("timestamp", ArrowDataType::Int64, true),
@@ -326,6 +416,11 @@ mod tests {
                 ),
                 ArrowField::new("kernelVersion", ArrowDataType::Utf8, true),
                 ArrowField::new("isBlindAppend", ArrowDataType::Boolean, true),
+                ArrowField::new(
+                    "operationMetrics",
+                    stale_op_metrics.data_type().clone(),
+                    true,
+                ),
                 ArrowField::new("engineInfo", ArrowDataType::Utf8, true),
                 ArrowField::new("txnId", ArrowDataType::Utf8, true),
             ],
@@ -336,6 +431,7 @@ mod tests {
                 stale_op_params,
                 Arc::new(StringArray::from(vec!["v0.0.0"])) as ArrayRef,
                 Arc::new(BooleanArray::from(vec![None::<bool>])) as ArrayRef,
+                stale_op_metrics,
                 Arc::new(StringArray::from(vec!["stale_engine"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["stale_txn"])) as ArrayRef,
             ],
@@ -347,18 +443,88 @@ mod tests {
         )?;
         let commit_info = commit_info_struct(&result);
 
-        // All 8 CommitInfo fields are present in the engine schema -- no fields appended.
-        assert_eq!(commit_info.num_columns(), 8);
+        // All CommitInfo fields are present in the engine schema -- no fields appended.
+        assert_eq!(
+            commit_info.num_columns(),
+            CommitInfo::to_schema().fields().count()
+        );
 
         assert_eq!(get_str(commit_info, "operation"), "WRITE");
         assert!(!get_str(commit_info, "kernelVersion").is_empty());
         assert_eq!(get_map(commit_info, "operationParameters").len(), 0);
+        assert!(
+            commit_info
+                .column_by_name("operationMetrics")
+                .expect("operationMetrics field")
+                .is_null(0),
+            "stale engine operationMetrics must be overridden by kernel's null"
+        );
         assert!(uuid::Uuid::parse_str(get_str(commit_info, "txnId")).is_ok());
         assert!(get_i64(commit_info, "timestamp") > 0);
         assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
         assert_eq!(get_str(commit_info, "engineInfo"), "test_engine/1.0");
         assert!(!get_bool(commit_info, "isBlindAppend"));
 
+        Ok(())
+    }
+
+    /// Non-empty kernel operationParameters/operationMetrics replace stale engine-supplied values
+    /// in the engine_commit_info branch -- exercises content fidelity of the replace path, not just
+    /// the empty/null override covered by `test_build_commit_info_full_overlap`.
+    #[test]
+    fn test_build_commit_info_nonempty_maps_override_stale_engine() -> DeltaResult<()> {
+        let mut params_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        params_builder.keys().append_value("stale_key");
+        params_builder.values().append_value("stale_value");
+        params_builder.append(true).unwrap();
+        let stale_op_params = Arc::new(params_builder.finish()) as ArrayRef;
+
+        let mut metrics_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        metrics_builder.keys().append_value("stale_metric");
+        metrics_builder.values().append_value("0");
+        metrics_builder.append(true).unwrap();
+        let stale_op_metrics = Arc::new(metrics_builder.finish()) as ArrayRef;
+
+        let (data, schema) = make_engine_commit_info(
+            vec![
+                ArrowField::new(
+                    "operationParameters",
+                    stale_op_params.data_type().clone(),
+                    true,
+                ),
+                ArrowField::new(
+                    "operationMetrics",
+                    stale_op_metrics.data_type().clone(),
+                    true,
+                ),
+            ],
+            vec![stale_op_params, stale_op_metrics],
+        );
+        let (engine, txn) = make_txn(Some((data, schema)))?;
+
+        let mut commit_info = make_kernel_commit_info();
+        commit_info.operation_parameters =
+            Some(HashMap::from([("mode".to_string(), "Append".to_string())]));
+        commit_info.operation_metrics =
+            Some(HashMap::from([("numFiles".to_string(), "3".to_string())]));
+
+        let result = ArrowEngineData::try_from_engine_data(
+            txn.generate_commit_info(engine.as_ref(), commit_info)?,
+        )?;
+        let ci = commit_info_struct(&result);
+
+        let params = get_map_entries(ci, "operationParameters");
+        assert_eq!(params.get("mode").map(String::as_str), Some("Append"));
+        assert!(
+            !params.contains_key("stale_key"),
+            "kernel value must replace the stale engine operationParameters"
+        );
+        let metrics = get_map_entries(ci, "operationMetrics");
+        assert_eq!(metrics.get("numFiles").map(String::as_str), Some("3"));
+        assert!(
+            !metrics.contains_key("stale_metric"),
+            "kernel value must replace the stale engine operationMetrics"
+        );
         Ok(())
     }
 

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -31,7 +31,6 @@
 // and for tests. Also allow dead_code since these are used by integration tests.
 #![allow(unreachable_pub, dead_code)]
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -43,7 +42,7 @@ use crate::expressions::ColumnName;
 use crate::metrics::MetricId;
 use crate::schema::SchemaRef;
 use crate::table_configuration::TableConfiguration;
-use crate::transaction::{CreateTable, Transaction};
+use crate::transaction::{CommitInfoClientOptions, CreateTable, Transaction};
 use crate::utils::current_time_ms;
 use crate::DeltaResult;
 
@@ -141,7 +140,7 @@ impl CreateTableTransaction {
     /// This is typically called via `CreateTableTransactionBuilder::build()` rather than directly.
     pub(crate) fn try_new_create_table(
         effective_table_config: TableConfiguration,
-        engine_info: String,
+        commit_info_options: CommitInfoClientOptions,
         committer: Box<dyn Committer>,
         system_domain_metadata: Vec<DomainMetadata>,
         clustering_columns: Option<Vec<ColumnName>>,
@@ -162,9 +161,7 @@ impl CreateTableTransaction {
             should_emit_metadata: true,
             committer,
             operation: Some("CREATE TABLE".to_string()),
-            engine_info: Some(engine_info),
-            operation_parameters: HashMap::new(),
-            operation_metrics: None,
+            commit_info_options,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],
@@ -174,7 +171,6 @@ impl CreateTableTransaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
-            engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
             num_dv_updates: 0,

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -31,6 +31,7 @@
 // and for tests. Also allow dead_code since these are used by integration tests.
 #![allow(unreachable_pub, dead_code)]
 
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -162,6 +163,8 @@ impl CreateTableTransaction {
             committer,
             operation: Some("CREATE TABLE".to_string()),
             engine_info: Some(engine_info),
+            operation_parameters: HashMap::new(),
+            operation_metrics: None,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -151,6 +151,9 @@ impl CreateTableTransaction {
             path = %effective_table_config.table_root(),
             operation = "CREATE",
         );
+        // CREATE TABLE's operation is kernel-owned: override any caller-supplied value.
+        let mut commit_info_options = commit_info_options;
+        commit_info_options.operation = Some("CREATE TABLE".to_string());
         Ok(Transaction {
             span,
             operation_id: MetricId::new(),
@@ -160,7 +163,6 @@ impl CreateTableTransaction {
             should_emit_protocol: true,
             should_emit_metadata: true,
             committer,
-            operation: Some("CREATE TABLE".to_string()),
             commit_info_options,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -88,18 +88,22 @@ pub use write_context::WriteContext;
 /// Client-supplied fields for a transaction's `CommitInfo` action, and the structured entry point
 /// for populating it.
 ///
-/// The typed setters cover the common provenance fields.
+/// The typed setters cover the common fields.
 /// [`with_additional_commit_info`](Self::with_additional_commit_info) adds arbitrary extra fields
 /// (including nested or non-string values) as [`EngineData`].
 ///
-/// Fields that drive kernel behavior are not here. Kernel interprets `operation` (CRC
-/// incremental-safety) and blind-append status, so they are [`Transaction`] settings
-/// (`with_operation`, `with_blind_append`). Kernel-owned fields (timestamp, kernel version,
-/// transaction id) are set at commit time.
+/// Kernel reads `operation` at commit time to classify CRC incremental-safety, and sets the
+/// kernel-owned fields (timestamp, kernel version, transaction id) itself. Blind-append status is
+/// a separate [`Transaction`] setting (`with_blind_append`) because it is a write-behavior mode,
+/// not just commit metadata.
 ///
 /// Not `Clone`/`PartialEq`: `additional_commit_info` holds opaque [`EngineData`].
 #[derive(Default)]
 pub struct CommitInfoClientOptions {
+    /// Operation recorded in the commit (e.g. "WRITE", "CREATE TABLE"). Kernel also reads it to
+    /// classify CRC incremental-safety. Set via `Transaction::with_operation`; fixed by kernel for
+    /// create-table and alter-table.
+    pub(crate) operation: Option<String>,
     /// Always written; an unset value serializes as an empty map (`{}`).
     pub(crate) operation_parameters: Option<HashMap<String, String>>,
     /// Written only when set; an unset value is omitted from the commit.
@@ -114,6 +118,7 @@ pub struct CommitInfoClientOptions {
 impl std::fmt::Debug for CommitInfoClientOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommitInfoClientOptions")
+            .field("operation", &self.operation)
             .field("operation_parameters", &self.operation_parameters)
             .field("operation_metrics", &self.operation_metrics)
             .field("engine_info", &self.engine_info)
@@ -179,6 +184,27 @@ impl CommitInfoClientOptions {
     ) -> Self {
         self.additional_commit_info = Some((additional_commit_info, commit_info_schema));
         self
+    }
+
+    /// Merge `other` into these options: each field set in `other` overrides ours; a field left
+    /// unset in `other` keeps its current value. `operation` has no public setter here, so it is
+    /// never overridden by a merge (it comes from `Transaction::with_operation` or kernel).
+    pub(crate) fn merge(&mut self, other: CommitInfoClientOptions) {
+        if other.operation.is_some() {
+            self.operation = other.operation;
+        }
+        if other.operation_parameters.is_some() {
+            self.operation_parameters = other.operation_parameters;
+        }
+        if other.operation_metrics.is_some() {
+            self.operation_metrics = other.operation_metrics;
+        }
+        if other.engine_info.is_some() {
+            self.engine_info = other.engine_info;
+        }
+        if other.additional_commit_info.is_some() {
+            self.additional_commit_info = other.additional_commit_info;
+        }
     }
 }
 
@@ -316,10 +342,6 @@ pub struct Transaction<S = ExistingTable> {
     // Whether to emit a Metadata action. True for CREATE TABLE and ALTER TABLE, false otherwise.
     should_emit_metadata: bool,
     committer: Box<dyn Committer>,
-    // Operation recorded in the commitInfo action (e.g. "WRITE", "CREATE TABLE"). Kernel
-    // interprets it for CRC incremental-safety, so it is a transaction field, not a
-    // commit-info option.
-    operation: Option<String>,
     commit_info_options: CommitInfoClientOptions,
     add_files_metadata: Vec<Box<dyn EngineData>>,
     remove_files_metadata: Vec<FilteredEngineData>,
@@ -548,7 +570,7 @@ impl<S> Transaction<S> {
         let mut kernel_commit_info = CommitInfo::new(
             self.commit_timestamp,
             in_commit_timestamp,
-            self.operation.clone(),
+            self.commit_info_options.operation.clone(),
             self.commit_info_options.engine_info.clone(),
             self.is_blind_append,
         );
@@ -688,7 +710,7 @@ impl<S> Transaction<S> {
         span.record("remove_files_bytes", file_stats.gross_remove_bytes);
         span.record("is_blind_append", self.is_blind_append);
         span.record("data_change", self.data_change);
-        if let Some(operation) = self.operation.as_deref() {
+        if let Some(operation) = self.commit_info_options.operation.as_deref() {
             span.record("operation", operation);
         }
         span.record("prepare_duration_ns", prepare_duration.as_nanos() as u64);
@@ -727,12 +749,22 @@ impl<S> Transaction<S> {
         self
     }
 
+    /// Set the client-supplied commit-info options for this transaction.
+    ///
+    /// Merges into the current options: each field set in `options` overrides its current value;
+    /// fields left unset keep their current value (so a prior `with_engine_info` or the operation
+    /// are not cleared). A later convenience setter (e.g.
+    /// [`with_engine_info`](Self::with_engine_info)) overrides its field again.
+    pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
+        self.commit_info_options.merge(options);
+        self
+    }
+
     /// Add arbitrary caller-supplied fields to this transaction's `commitInfo` action.
     ///
     /// Convenience shortcut for [`CommitInfoClientOptions::with_additional_commit_info`]; see it
     /// for the merge and kernel-override rules. Sets the same payload on this transaction's
-    /// options, so a later [`with_commit_info_options`](Self::with_commit_info_options) replaces
-    /// it.
+    /// options.
     pub fn with_additional_commit_info(
         mut self,
         additional_commit_info: Box<dyn EngineData>,
@@ -967,7 +999,8 @@ impl<S> Transaction<S> {
     /// A create-table transaction has no read snapshot (no pre-existing table).
     fn is_create_table(&self) -> bool {
         debug_assert!(
-            self.operation.as_deref() != Some("CREATE TABLE") || self.read_snapshot_opt.is_none(),
+            self.commit_info_options.operation.as_deref() != Some("CREATE TABLE")
+                || self.read_snapshot_opt.is_none(),
             "CREATE TABLE operation should not have a read snapshot"
         );
         self.read_snapshot_opt.is_none()
@@ -1604,6 +1637,7 @@ impl<S> Transaction<S> {
         // `kernel/src/crc/file_stats.rs`). So at this point every size is known to be
         // present, and only operation classification can flip `is_incremental_safe`.
         let is_incremental_safe = self
+            .commit_info_options
             .operation
             .as_deref()
             .is_some_and(is_incremental_safe_operation);
@@ -3255,24 +3289,26 @@ mod tests {
         );
     }
 
-    /// `operation` is a first-class transaction setting, so it survives a later
-    /// `with_commit_info_options` (which replaces only the payload). `engine_info` lives in the
-    /// payload, so the same replace clears it unless a convenience setter follows.
+    /// `with_commit_info_options` merges: fields unset in the new options keep their current value,
+    /// so a prior `operation` and `engine_info` both survive an empty-options call.
     #[test]
-    fn test_operation_survives_options_replace_but_engine_info_does_not() -> DeltaResult<()> {
+    fn test_options_merge_keeps_prior_operation_and_engine_info() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
 
-        // Replace the options after setting both: operation survives, engine_info is cleared.
+        // Merge empty options: operation and engine_info both survive.
         let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_operation("WRITE".to_string())
             .with_engine_info("from-setter")
             .with_commit_info_options(CommitInfoClientOptions::new());
-        assert_eq!(txn.operation.as_deref(), Some("WRITE"));
-        assert_eq!(txn.commit_info_options.engine_info, None);
+        assert_eq!(txn.commit_info_options.operation.as_deref(), Some("WRITE"));
+        assert_eq!(
+            txn.commit_info_options.engine_info.as_deref(),
+            Some("from-setter")
+        );
 
-        // A convenience setter after the options override wins for engine_info.
+        // A field set in the new options overrides the prior value; a later setter wins again.
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_commit_info_options(

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -85,6 +85,103 @@ use stats_verifier::StatsColumnVerifier;
 use write_context::SharedWriteState;
 pub use write_context::WriteContext;
 
+/// Client-supplied fields for a transaction's `CommitInfo` action, and the structured entry point
+/// for populating it.
+///
+/// The typed setters cover the common provenance fields.
+/// [`with_additional_commit_info`](Self::with_additional_commit_info) adds arbitrary extra fields
+/// (including nested or non-string values) as [`EngineData`].
+///
+/// Fields that drive kernel behavior are not here. Kernel interprets `operation` (CRC
+/// incremental-safety) and blind-append status, so they are [`Transaction`] settings
+/// (`with_operation`, `with_blind_append`). Kernel-owned fields (timestamp, kernel version,
+/// transaction id) are set at commit time.
+///
+/// Not `Clone`/`PartialEq`: `additional_commit_info` holds opaque [`EngineData`].
+#[derive(Default)]
+pub struct CommitInfoClientOptions {
+    /// Always written; an unset value serializes as an empty map (`{}`).
+    pub(crate) operation_parameters: Option<HashMap<String, String>>,
+    /// Written only when set; an unset value is omitted from the commit.
+    pub(crate) operation_metrics: Option<HashMap<String, String>>,
+    pub(crate) engine_info: Option<String>,
+    /// Arbitrary extra `commitInfo` fields plus their schema, merged into the action at commit
+    /// time. Kernel-managed fields always win over a colliding engine field. See
+    /// [`with_additional_commit_info`](Self::with_additional_commit_info).
+    pub(crate) additional_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
+}
+
+impl std::fmt::Debug for CommitInfoClientOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommitInfoClientOptions")
+            .field("operation_parameters", &self.operation_parameters)
+            .field("operation_metrics", &self.operation_metrics)
+            .field("engine_info", &self.engine_info)
+            .field(
+                "additional_commit_info",
+                &self.additional_commit_info.is_some(),
+            )
+            .finish()
+    }
+}
+
+impl CommitInfoClientOptions {
+    /// Create empty commit-info options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the operation parameters recorded in table history.
+    ///
+    /// Values must already be stringified. A later call replaces the complete map.
+    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_parameters = Some(collect_string_map(operation_parameters));
+        self
+    }
+
+    /// Set the operation metrics recorded in table history.
+    ///
+    /// Values must already be stringified. A later call replaces the complete map. An explicitly
+    /// empty map is written as `{}`.
+    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_metrics = Some(collect_string_map(operation_metrics));
+        self
+    }
+
+    /// Set the engine information recorded in table history.
+    pub fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
+        self.engine_info = Some(engine_info.into());
+        self
+    }
+
+    /// Add arbitrary extra fields to the `commitInfo` action, beyond the typed setters above.
+    ///
+    /// `additional_commit_info` holds the fields; `commit_info_schema` is their schema. Fields may
+    /// be nested structs, arrays, or non-string scalars. Kernel merges them, but kernel-managed
+    /// fields always win. Do not set `timestamp`, `inCommitTimestamp`, `operation`,
+    /// `operationParameters`, `operationMetrics`, `kernelVersion`, `isBlindAppend`, `engineInfo`,
+    /// or `txnId`; kernel overrides them. Prefer the typed setters where they apply. A later call
+    /// replaces the whole payload.
+    pub fn with_additional_commit_info(
+        mut self,
+        additional_commit_info: Box<dyn EngineData>,
+        commit_info_schema: SchemaRef,
+    ) -> Self {
+        self.additional_commit_info = Some((additional_commit_info, commit_info_schema));
+        self
+    }
+}
+
 /// Type alias for an iterator of [`EngineData`] results.
 pub(crate) type EngineDataResultIterator<'a> =
     Box<dyn Iterator<Item = DeltaResult<Box<dyn EngineData>>> + Send + 'a>;
@@ -190,10 +287,13 @@ impl SupportsDataFiles for CreateTable {}
 /// # Examples
 ///
 /// ```rust,ignore
-/// // create a transaction
-/// let mut txn = table.new_transaction(&engine)?;
-/// // stage table changes (right now only commit info)
-/// txn.commit_info(Box::new(ArrowEngineData::new(engine_commit_info)));
+/// // create a transaction, set its operation and the client commit-info payload
+/// let txn = snapshot
+///     .transaction(Box::new(FileSystemCommitter::new()), &engine)?
+///     .with_operation("WRITE".to_string())
+///     .with_commit_info_options(
+///         CommitInfoClientOptions::new().with_operation_metrics([("numFiles", "1")]),
+///     );
 /// // commit! (consume the transaction)
 /// txn.commit(&engine)?;
 /// ```
@@ -216,13 +316,11 @@ pub struct Transaction<S = ExistingTable> {
     // Whether to emit a Metadata action. True for CREATE TABLE and ALTER TABLE, false otherwise.
     should_emit_metadata: bool,
     committer: Box<dyn Committer>,
+    // Operation recorded in the commitInfo action (e.g. "WRITE", "CREATE TABLE"). Kernel
+    // interprets it for CRC incremental-safety, so it is a transaction field, not a
+    // commit-info option.
     operation: Option<String>,
-    engine_info: Option<String>,
-    // Engine-provided CommitInfo.operationParameters. Always written (empty map when unset)
-    operation_parameters: HashMap<String, String>,
-    // Engine-provided CommitInfo.operationMetrics. Written as null when unset, hence Option.
-    operation_metrics: Option<HashMap<String, String>>,
-    engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
+    commit_info_options: CommitInfoClientOptions,
     add_files_metadata: Vec<Box<dyn EngineData>>,
     remove_files_metadata: Vec<FilteredEngineData>,
     // NB: hashmap would require either duplicating the appid or splitting SetTransaction
@@ -275,7 +373,7 @@ impl<S> std::fmt::Debug for Transaction<S> {
         f.write_str(&format!(
             "Transaction {{ read_snapshot version: {}, engine_info: {} }}",
             version_info,
-            self.engine_info.is_some()
+            self.commit_info_options.engine_info.is_some()
         ))
     }
 }
@@ -451,12 +549,19 @@ impl<S> Transaction<S> {
             self.commit_timestamp,
             in_commit_timestamp,
             self.operation.clone(),
-            self.engine_info.clone(),
+            self.commit_info_options.engine_info.clone(),
             self.is_blind_append,
         );
-        kernel_commit_info.operation_parameters = Some(self.operation_parameters.clone());
-        kernel_commit_info.operation_metrics = self.operation_metrics.clone();
-        let commit_info_action = self.generate_commit_info(engine, kernel_commit_info);
+        // operationParameters: always written (unset becomes `{}`). operationMetrics: written only
+        // when set.
+        kernel_commit_info.operation_parameters = Some(
+            self.commit_info_options
+                .operation_parameters
+                .clone()
+                .unwrap_or_default(),
+        );
+        kernel_commit_info.operation_metrics = self.commit_info_options.operation_metrics.clone();
+        let commit_info_action = self.build_commit_info_action(engine, kernel_commit_info);
 
         // Step 3: Generate Protocol and Metadata actions based on emit flags
         let (protocol_action, protocol) = if self.should_emit_protocol {
@@ -618,37 +723,23 @@ impl<S> Transaction<S> {
 
     /// Set the engine info field of this transaction's commit info action. This field is optional.
     pub fn with_engine_info(mut self, engine_info: impl Into<String>) -> Self {
-        self.engine_info = Some(engine_info.into());
+        self.commit_info_options.engine_info = Some(engine_info.into());
         self
     }
 
-    /// Set `CommitInfo.operationParameters` for this transaction.
+    /// Add arbitrary caller-supplied fields to this transaction's `commitInfo` action.
     ///
-    /// Values should already be stringified the way table history expects (for example
-    /// `mode` -> `"Append"`, `partitionBy` -> `"[\"date\"]"`). Kernel writes this map as-is and
-    /// does not interpret or validate keys.
-    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_parameters = collect_string_map(operation_parameters);
-        self
-    }
-
-    /// Set `CommitInfo.operationMetrics` for this transaction.
-    ///
-    /// Values should already be stringified (for example `numFiles` -> `"1"`). Kernel writes this
-    /// map as-is and does not interpret or validate keys. When unset, `operationMetrics` is written
-    /// as null; an explicitly empty map is written as `{}`.
-    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
-    where
-        I: IntoIterator<Item = (K, V)>,
-        K: Into<String>,
-        V: Into<String>,
-    {
-        self.operation_metrics = Some(collect_string_map(operation_metrics));
+    /// Convenience shortcut for [`CommitInfoClientOptions::with_additional_commit_info`]; see it
+    /// for the merge and kernel-override rules. Sets the same payload on this transaction's
+    /// options, so a later [`with_commit_info_options`](Self::with_commit_info_options) replaces
+    /// it.
+    pub fn with_additional_commit_info(
+        mut self,
+        additional_commit_info: Box<dyn EngineData>,
+        commit_info_schema: SchemaRef,
+    ) -> Self {
+        self.commit_info_options.additional_commit_info =
+            Some((additional_commit_info, commit_info_schema));
         self
     }
 
@@ -657,28 +748,6 @@ impl<S> Transaction<S> {
     /// When unset, behavior is unchanged.
     pub fn with_correlation_id(mut self, correlation_id: impl Into<Arc<str>>) -> Self {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
-        self
-    }
-
-    /// Set the content of the commitInfo action for this transaction. Note that kernel will
-    /// _always_ write a commitInfo, this function simply allows engines to add their own data
-    /// into that action if they wish. Note that the following fields in `engine_commit_info`
-    /// will be overridden by kernel if they are set (meaning you should not set them):
-    /// - timestamp
-    /// - inCommitTimestamp
-    /// - operation
-    /// - operationParameters
-    /// - kernelVersion
-    /// - isBlindAppend
-    /// - operationMetrics
-    /// - engineInfo
-    /// - txnId
-    pub fn with_commit_info(
-        mut self,
-        engine_commit_info: Box<dyn EngineData>,
-        commit_info_schema: SchemaRef,
-    ) -> Self {
-        self.engine_commit_info = Some((engine_commit_info, commit_info_schema));
         self
     }
 
@@ -1852,10 +1921,11 @@ pub struct RetryableTransaction<S = ExistingTable> {
     pub error: Error,
 }
 
-/// Collect stringifiable key/value pairs into a `CommitInfo` string map. Shared by the
-/// `with_operation_parameters`/`with_operation_metrics` setters on `Transaction` and its builders.
-pub(crate) fn collect_string_map<I, K, V>(pairs: I) -> HashMap<String, String>
+/// Collect stringifiable key/value pairs into a string map. Shared by the
+/// `CommitInfoClientOptions` setters.
+pub(crate) fn collect_string_map<C, I, K, V>(pairs: I) -> C
 where
+    C: FromIterator<(String, String)>,
     I: IntoIterator<Item = (K, V)>,
     K: Into<String>,
     V: Into<String>,
@@ -3146,8 +3216,11 @@ mod tests {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let mut txn = snapshot
             .transaction(Box::new(IoErrorCommitter), engine.as_ref())?
-            .with_operation_parameters([("mode", "Append")])
-            .with_operation_metrics([("numFiles", "1")]);
+            .with_commit_info_options(
+                CommitInfoClientOptions::new()
+                    .with_operation_parameters([("mode", "Append")])
+                    .with_operation_metrics([("numFiles", "1")]),
+            );
         add_dummy_file(&mut txn);
 
         let CommitResult::RetryableTransaction(retryable) = txn.commit(engine.as_ref())? else {
@@ -3155,30 +3228,60 @@ mod tests {
         };
 
         assert_eq!(
-            retryable.transaction.operation_parameters,
-            HashMap::from([("mode".to_string(), "Append".to_string())]),
+            retryable
+                .transaction
+                .commit_info_options
+                .operation_parameters,
+            Some(HashMap::from([("mode".to_string(), "Append".to_string())])),
             "operationParameters must survive a retryable commit failure"
         );
         assert_eq!(
-            retryable.transaction.operation_metrics,
+            retryable.transaction.commit_info_options.operation_metrics,
             Some(HashMap::from([("numFiles".to_string(), "1".to_string())])),
             "operationMetrics must survive a retryable commit failure"
         );
         Ok(())
     }
 
-    /// The with_operation_* setters replace the whole map (last call wins) and dedup duplicate
-    /// input keys (last value wins) via the shared collect_string_map helper.
+    /// A later setter call replaces the whole map; duplicate input keys keep the last value.
     #[test]
-    fn test_with_operation_parameters_replaces_and_dedups() -> DeltaResult<()> {
+    fn test_commit_info_options_replaces_and_dedups_operation_parameters() {
+        let options = CommitInfoClientOptions::new()
+            .with_operation_parameters([("a", "1"), ("a", "2")])
+            .with_operation_parameters([("b", "3")]);
+        assert_eq!(
+            options.operation_parameters,
+            Some(HashMap::from([("b".to_string(), "3".to_string())]))
+        );
+    }
+
+    /// `operation` is a first-class transaction setting, so it survives a later
+    /// `with_commit_info_options` (which replaces only the payload). `engine_info` lives in the
+    /// payload, so the same replace clears it unless a convenience setter follows.
+    #[test]
+    fn test_operation_survives_options_replace_but_engine_info_does_not() -> DeltaResult<()> {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
+
+        // Replace the options after setting both: operation survives, engine_info is cleared.
+        let txn = snapshot
+            .clone()
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation("WRITE".to_string())
+            .with_engine_info("from-setter")
+            .with_commit_info_options(CommitInfoClientOptions::new());
+        assert_eq!(txn.operation.as_deref(), Some("WRITE"));
+        assert_eq!(txn.commit_info_options.engine_info, None);
+
+        // A convenience setter after the options override wins for engine_info.
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
-            .with_operation_parameters([("a", "1"), ("a", "2")]) // duplicate key -> last wins
-            .with_operation_parameters([("b", "3")]); // second call -> replaces
+            .with_commit_info_options(
+                CommitInfoClientOptions::new().with_engine_info("from-options"),
+            )
+            .with_engine_info("from-setter");
         assert_eq!(
-            txn.operation_parameters,
-            HashMap::from([("b".to_string(), "3".to_string())])
+            txn.commit_info_options.engine_info.as_deref(),
+            Some("from-setter")
         );
         Ok(())
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -218,6 +218,10 @@ pub struct Transaction<S = ExistingTable> {
     committer: Box<dyn Committer>,
     operation: Option<String>,
     engine_info: Option<String>,
+    // Engine-provided CommitInfo.operationParameters. Always written (empty map when unset)
+    operation_parameters: HashMap<String, String>,
+    // Engine-provided CommitInfo.operationMetrics. Written as null when unset, hence Option.
+    operation_metrics: Option<HashMap<String, String>>,
     engine_commit_info: Option<(Box<dyn EngineData>, SchemaRef)>,
     add_files_metadata: Vec<Box<dyn EngineData>>,
     remove_files_metadata: Vec<FilteredEngineData>,
@@ -443,13 +447,15 @@ impl<S> Transaction<S> {
 
         // Step 2: Construct commit info with ICT if enabled
         let in_commit_timestamp = self.get_in_commit_timestamp(engine)?;
-        let kernel_commit_info = CommitInfo::new(
+        let mut kernel_commit_info = CommitInfo::new(
             self.commit_timestamp,
             in_commit_timestamp,
             self.operation.clone(),
             self.engine_info.clone(),
             self.is_blind_append,
         );
+        kernel_commit_info.operation_parameters = Some(self.operation_parameters.clone());
+        kernel_commit_info.operation_metrics = self.operation_metrics.clone();
         let commit_info_action = self.generate_commit_info(engine, kernel_commit_info);
 
         // Step 3: Generate Protocol and Metadata actions based on emit flags
@@ -616,6 +622,36 @@ impl<S> Transaction<S> {
         self
     }
 
+    /// Set `CommitInfo.operationParameters` for this transaction.
+    ///
+    /// Values should already be stringified the way table history expects (for example
+    /// `mode` -> `"Append"`, `partitionBy` -> `"[\"date\"]"`). Kernel writes this map as-is and
+    /// does not interpret or validate keys.
+    pub fn with_operation_parameters<I, K, V>(mut self, operation_parameters: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_parameters = collect_string_map(operation_parameters);
+        self
+    }
+
+    /// Set `CommitInfo.operationMetrics` for this transaction.
+    ///
+    /// Values should already be stringified (for example `numFiles` -> `"1"`). Kernel writes this
+    /// map as-is and does not interpret or validate keys. When unset, `operationMetrics` is written
+    /// as null; an explicitly empty map is written as `{}`.
+    pub fn with_operation_metrics<I, K, V>(mut self, operation_metrics: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.operation_metrics = Some(collect_string_map(operation_metrics));
+        self
+    }
+
     /// Attach an opaque, caller-supplied correlation id for joining this transaction's commit
     /// metric events to the caller's own request or operation id. An empty id is treated as unset.
     /// When unset, behavior is unchanged.
@@ -634,6 +670,7 @@ impl<S> Transaction<S> {
     /// - operationParameters
     /// - kernelVersion
     /// - isBlindAppend
+    /// - operationMetrics
     /// - engineInfo
     /// - txnId
     pub fn with_commit_info(
@@ -1813,6 +1850,20 @@ pub struct RetryableTransaction<S = ExistingTable> {
     pub transaction: Transaction<S>,
     /// Transient error that caused the commit to fail.
     pub error: Error,
+}
+
+/// Collect stringifiable key/value pairs into a `CommitInfo` string map. Shared by the
+/// `with_operation_parameters`/`with_operation_metrics` setters on `Transaction` and its builders.
+pub(crate) fn collect_string_map<I, K, V>(pairs: I) -> HashMap<String, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    pairs
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect()
 }
 
 #[cfg(test)]
@@ -3087,6 +3138,48 @@ mod tests {
                 retryable.error
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_retryable_transaction_preserves_operation_maps() -> DeltaResult<()> {
+        let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
+        let mut txn = snapshot
+            .transaction(Box::new(IoErrorCommitter), engine.as_ref())?
+            .with_operation_parameters([("mode", "Append")])
+            .with_operation_metrics([("numFiles", "1")]);
+        add_dummy_file(&mut txn);
+
+        let CommitResult::RetryableTransaction(retryable) = txn.commit(engine.as_ref())? else {
+            panic!("expected RetryableTransaction from IoErrorCommitter");
+        };
+
+        assert_eq!(
+            retryable.transaction.operation_parameters,
+            HashMap::from([("mode".to_string(), "Append".to_string())]),
+            "operationParameters must survive a retryable commit failure"
+        );
+        assert_eq!(
+            retryable.transaction.operation_metrics,
+            Some(HashMap::from([("numFiles".to_string(), "1".to_string())])),
+            "operationMetrics must survive a retryable commit failure"
+        );
+        Ok(())
+    }
+
+    /// The with_operation_* setters replace the whole map (last call wins) and dedup duplicate
+    /// input keys (last value wins) via the shared collect_string_map helper.
+    #[test]
+    fn test_with_operation_parameters_replaces_and_dedups() -> DeltaResult<()> {
+        let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
+        let txn = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_operation_parameters([("a", "1"), ("a", "2")]) // duplicate key -> last wins
+            .with_operation_parameters([("b", "3")]); // second call -> replaces
+        assert_eq!(
+            txn.operation_parameters,
+            HashMap::from([("b".to_string(), "3".to_string())])
+        );
         Ok(())
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 use tracing::instrument;
 
-use super::Transaction;
+use super::{CommitInfoClientOptions, Transaction};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
 use crate::committer::Committer;
@@ -94,9 +94,7 @@ impl Transaction {
             should_emit_metadata: false,
             committer,
             operation: None,
-            engine_info: None,
-            operation_parameters: HashMap::new(),
-            operation_metrics: None,
+            commit_info_options: CommitInfoClientOptions::new(),
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],
@@ -106,7 +104,6 @@ impl Transaction {
             user_domain_removals: vec![],
             data_change: true,
             column_defaults_acknowledged: false,
-            engine_commit_info: None,
             is_blind_append: false,
             dv_matched_files: vec![],
             num_dv_updates: 0,
@@ -118,6 +115,17 @@ impl Transaction {
     // -------------------------------------------------------------------------
     // Public API
     // -------------------------------------------------------------------------
+
+    /// Replace this transaction's commit-info options wholesale.
+    ///
+    /// Convenience setters (e.g. [`with_engine_info`]) called after this method override their
+    /// corresponding option.
+    ///
+    /// [`with_engine_info`]: Transaction::with_engine_info
+    pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
+        self.commit_info_options = options;
+        self
+    }
 
     /// Mark this transaction as a blind append.
     ///

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -93,7 +93,6 @@ impl Transaction {
             should_emit_protocol: false,
             should_emit_metadata: false,
             committer,
-            operation: None,
             commit_info_options: CommitInfoClientOptions::new(),
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
@@ -116,17 +115,6 @@ impl Transaction {
     // Public API
     // -------------------------------------------------------------------------
 
-    /// Replace this transaction's commit-info options wholesale.
-    ///
-    /// Convenience setters (e.g. [`with_engine_info`]) called after this method override their
-    /// corresponding option.
-    ///
-    /// [`with_engine_info`]: Transaction::with_engine_info
-    pub fn with_commit_info_options(mut self, options: CommitInfoClientOptions) -> Self {
-        self.commit_info_options = options;
-        self
-    }
-
     /// Mark this transaction as a blind append.
     ///
     /// Blind append transactions should only add new files and avoid write operations that
@@ -139,7 +127,7 @@ impl Transaction {
     /// Set the operation that this transaction is performing. This string will be persisted in the
     /// commit and visible to anyone who describes the table history.
     pub fn with_operation(mut self, operation: String) -> Self {
-        self.operation = Some(operation);
+        self.commit_info_options.operation = Some(operation);
         self
     }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -95,6 +95,8 @@ impl Transaction {
             committer,
             operation: None,
             engine_info: None,
+            operation_parameters: HashMap::new(),
+            operation_metrics: None,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],
             set_transactions: vec![],

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -22,6 +22,7 @@ use delta_kernel::table_features::{
 use delta_kernel::table_properties::TableProperties;
 use delta_kernel::transaction::create_table::{create_table, CreateTableTransaction};
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::CommitInfoClientOptions;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use serde_json::Value;
@@ -49,16 +50,20 @@ pub(crate) fn partition_test_schema() -> DeltaResult<Arc<StructType>> {
     ])?))
 }
 
-/// Engine-supplied operationParameters/operationMetrics set on the create-table builder are
-/// written to the version-0 commit's CommitInfo.
+/// operationParameters/operationMetrics set on the create-table builder reach the version-0
+/// CommitInfo. The operation stays `CREATE TABLE`, and engine info falls back to the `create_table`
+/// argument when the options omit it.
 #[tokio::test]
 async fn test_create_table_writes_operation_parameters_and_metrics() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let schema = simple_schema()?;
 
     let _ = create_table(&table_path, schema, "Test/1.0")
-        .with_operation_parameters([("mode", "Create"), ("description", "events")])
-        .with_operation_metrics([("numFiles", "0")])
+        .with_commit_info_options(
+            CommitInfoClientOptions::new()
+                .with_operation_parameters([("mode", "Create"), ("description", "events")])
+                .with_operation_metrics([("numFiles", "0")]),
+        )
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
@@ -66,11 +71,34 @@ async fn test_create_table_writes_operation_parameters_and_metrics() -> DeltaRes
     let commit_infos =
         read_actions_from_commit(&table_url, 0, "commitInfo").expect("failed to read commit");
     let ci = &commit_infos[0];
+    assert_eq!(ci["operation"], "CREATE TABLE");
+    // engine info omitted from the options -> the create_table value is retained.
+    assert_eq!(ci["engineInfo"], "Test/1.0");
     assert_eq!(
         ci["operationParameters"],
         serde_json::json!({"mode": "Create", "description": "events"})
     );
     assert_eq!(ci["operationMetrics"], serde_json::json!({"numFiles": "0"}));
+    Ok(())
+}
+
+/// Engine info supplied through the commit-info options overrides the `create_table` argument.
+#[tokio::test]
+async fn test_create_table_options_engine_info_overrides_arg() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let _ = create_table(&table_path, simple_schema()?, "arg-engine/1.0")
+        .with_commit_info_options(
+            CommitInfoClientOptions::new().with_engine_info("options-engine/2.0"),
+        )
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let commit_infos =
+        read_actions_from_commit(&table_url, 0, "commitInfo").expect("failed to read commit");
+    // The options value wins over the create_table argument.
+    assert_eq!(commit_infos[0]["engineInfo"], "options-engine/2.0");
     Ok(())
 }
 

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -25,7 +25,10 @@ use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use serde_json::Value;
-use test_utils::{assert_result_error_with_message, test_table_setup, test_table_setup_mt};
+use test_utils::{
+    assert_result_error_with_message, read_actions_from_commit, test_table_setup,
+    test_table_setup_mt,
+};
 
 /// Helper to create a simple two-column schema for tests.
 /// Shared with sub-modules.
@@ -44,6 +47,31 @@ pub(crate) fn partition_test_schema() -> DeltaResult<Arc<StructType>> {
         StructField::nullable("date", DataType::DATE),
         StructField::nullable("value", DataType::STRING),
     ])?))
+}
+
+/// Engine-supplied operationParameters/operationMetrics set on the create-table builder are
+/// written to the version-0 commit's CommitInfo.
+#[tokio::test]
+async fn test_create_table_writes_operation_parameters_and_metrics() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = simple_schema()?;
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_operation_parameters([("mode", "Create"), ("description", "events")])
+        .with_operation_metrics([("numFiles", "0")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let commit_infos =
+        read_actions_from_commit(&table_url, 0, "commitInfo").expect("failed to read commit");
+    let ci = &commit_infos[0];
+    assert_eq!(
+        ci["operationParameters"],
+        serde_json::json!({"mode": "Create", "description": "events"})
+    );
+    assert_eq!(ci["operationMetrics"], serde_json::json!({"numFiles": "0"}));
+    Ok(())
 }
 
 #[tokio::test]

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -16,6 +16,7 @@ use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::CommitInfoClientOptions;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
@@ -54,8 +55,8 @@ fn max_column_id(snap: &Snapshot) -> Option<i64> {
 // Add column tests
 // ============================================================================
 
-/// Engine-supplied operationParameters/operationMetrics set on the alter-table builder are
-/// written to the alter commit's CommitInfo.
+/// operationParameters/operationMetrics set on the alter-table builder reach the alter commit's
+/// CommitInfo. The operation stays `ALTER TABLE`.
 #[tokio::test]
 async fn alter_table_writes_operation_parameters_and_metrics(
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -65,8 +66,11 @@ async fn alter_table_writes_operation_parameters_and_metrics(
 
     snapshot
         .alter_table()
-        .with_operation_parameters([("columnsAdded", "1")])
-        .with_operation_metrics([("numAddedColumns", "1")])
+        .with_commit_info_options(
+            CommitInfoClientOptions::new()
+                .with_operation_parameters([("columnsAdded", "1")])
+                .with_operation_metrics([("numAddedColumns", "1")]),
+        )
         .add_column(StructField::nullable("added", DataType::STRING))
         .build(engine.as_ref(), committer())?
         .commit(engine.as_ref())?
@@ -76,6 +80,7 @@ async fn alter_table_writes_operation_parameters_and_metrics(
     let commit_infos =
         read_actions_from_commit(&table_url, 1, "commitInfo").expect("failed to read commit");
     let ci = &commit_infos[0];
+    assert_eq!(ci["operation"], "ALTER TABLE");
     assert_eq!(
         ci["operationParameters"],
         serde_json::json!({"columnsAdded": "1"})

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -20,8 +20,8 @@ use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
     add_commit, column_mapping_fixtures as fixtures, create_table as create_test_table,
-    create_table_and_load_snapshot, engine_store_setup, test_table_setup, test_table_setup_mt,
-    write_batch_to_table,
+    create_table_and_load_snapshot, engine_store_setup, read_actions_from_commit, test_table_setup,
+    test_table_setup_mt, write_batch_to_table,
 };
 
 fn simple_schema() -> SchemaRef {
@@ -53,6 +53,39 @@ fn max_column_id(snap: &Snapshot) -> Option<i64> {
 // ============================================================================
 // Add column tests
 // ============================================================================
+
+/// Engine-supplied operationParameters/operationMetrics set on the alter-table builder are
+/// written to the alter commit's CommitInfo.
+#[tokio::test]
+async fn alter_table_writes_operation_parameters_and_metrics(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    snapshot
+        .alter_table()
+        .with_operation_parameters([("columnsAdded", "1")])
+        .with_operation_metrics([("numAddedColumns", "1")])
+        .add_column(StructField::nullable("added", DataType::STRING))
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let table_url = delta_kernel::try_parse_uri(&table_path)?;
+    let commit_infos =
+        read_actions_from_commit(&table_url, 1, "commitInfo").expect("failed to read commit");
+    let ci = &commit_infos[0];
+    assert_eq!(
+        ci["operationParameters"],
+        serde_json::json!({"columnsAdded": "1"})
+    );
+    assert_eq!(
+        ci["operationMetrics"],
+        serde_json::json!({"numAddedColumns": "1"})
+    );
+    Ok(())
+}
 
 /// End-to-end lifecycle: write, ALTER to add columns, scan, write populated rows, scan again.
 /// Each column is added in its own alter commit with a checkpoint after, exercising

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -2,19 +2,21 @@
 
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{ArrayRef, RecordBatch, StringArray};
-use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
+use delta_kernel::arrow::array::{ArrayRef, RecordBatch, StringArray, StructArray};
+use delta_kernel::arrow::datatypes::{
+    DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema,
+};
+use delta_kernel::engine::arrow_conversion::TryIntoKernel;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::Schema;
+use delta_kernel::transaction::CommitInfoClientOptions;
 use itertools::Itertools;
 use serde_json::{json, Deserializer};
 use test_utils::{load_and_begin_transaction, set_json_value, setup_test_tables};
 
-use crate::common::write_utils::{
-    get_simple_int_schema, validate_timestamp, validate_txn_id, ZERO_UUID,
-};
+use crate::common::write_utils::{get_simple_int_schema, validate_txn_id, ZERO_UUID};
 
 #[tokio::test]
 async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
@@ -111,8 +113,8 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Engine-supplied `operationParameters` and `operationMetrics`, set through the public transaction
-/// builder methods, are written to the commit's CommitInfo with their exact key/value entries.
+/// Engine-set `operationParameters` and `operationMetrics` are written to the commit's CommitInfo
+/// with their exact entries.
 #[tokio::test]
 async fn test_commit_info_with_operation_metrics() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
@@ -123,8 +125,11 @@ async fn test_commit_info_with_operation_metrics() -> Result<(), Box<dyn std::er
     {
         let txn = load_and_begin_transaction(table_url.clone(), &engine)?
             .with_operation("WRITE".to_string())
-            .with_operation_parameters([("mode", "Append"), ("partitionBy", "[]")])
-            .with_operation_metrics([("numFiles", "1"), ("numOutputRows", "10")]);
+            .with_commit_info_options(
+                CommitInfoClientOptions::new()
+                    .with_operation_parameters([("mode", "Append"), ("partitionBy", "[]")])
+                    .with_operation_metrics([("numFiles", "1"), ("numOutputRows", "10")]),
+            );
 
         let _ = txn.commit(&engine)?;
 
@@ -137,6 +142,7 @@ async fn test_commit_info_with_operation_metrics() -> Result<(), Box<dyn std::er
         let parsed: serde_json::Value = serde_json::from_slice(&commit.bytes().await?)?;
         let ci = &parsed["commitInfo"];
 
+        assert_eq!(ci["operation"], "WRITE");
         assert_eq!(
             ci["operationParameters"],
             json!({"mode": "Append", "partitionBy": "[]"})
@@ -149,12 +155,42 @@ async fn test_commit_info_with_operation_metrics() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-/// Verifies that when `engine_commit_info` is provided (the `Some` branch of `build_commit_info`):
-/// - The written JSON is correctly wrapped in a top-level `"commitInfo"` key.
-/// - Engine-only fields (not in `CommitInfo::to_schema()`) pass through to the log unchanged.
-/// - Fields that overlap with kernel-managed CommitInfo fields are overridden by kernel values,
-/// - All kernel-managed fields (`timestamp`, `kernelVersion`, `txnId`, `operationParameters`,
-///   `operationMetrics`) are present with correct values.
+/// An empty `operationMetrics` map is written as `{}`, unlike the unset case, which is omitted
+/// (see `test_commit_info`).
+#[tokio::test]
+async fn test_commit_info_empty_operation_metrics_written_as_empty_map(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let schema = get_simple_int_schema();
+
+    for (table_url, engine, store, table_name) in
+        setup_test_tables(schema, &[], None, "test_table").await?
+    {
+        let txn = load_and_begin_transaction(table_url.clone(), &engine)?
+            .with_operation("WRITE".to_string())
+            .with_commit_info_options(
+                CommitInfoClientOptions::new().with_operation_metrics(Vec::<(&str, &str)>::new()),
+            );
+        let _ = txn.commit(&engine)?;
+
+        let commit = store
+            .get(&Path::from(format!(
+                "/{table_name}/_delta_log/00000000000000000001.json"
+            )))
+            .await?;
+        let parsed: serde_json::Value = serde_json::from_slice(&commit.bytes().await?)?;
+        let ci = &parsed["commitInfo"];
+
+        assert_eq!(ci["operationMetrics"], json!({}));
+        // operationParameters is always present; unset serializes as an empty map too.
+        assert_eq!(ci["operationParameters"], json!({}));
+    }
+    Ok(())
+}
+
+/// `with_additional_commit_info` merges caller fields into the on-disk `commitInfo`: engine-only
+/// fields stay (a nested struct stays a nested object), a colliding field takes kernel's value,
+/// and kernel-managed fields are present.
 #[tokio::test]
 async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
@@ -163,33 +199,41 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema, &[], None, "test_table").await?
     {
-        // Build engine_commit_info with:
-        //   - "myApp"    : engine-only field, must pass through unchanged.
-        //   - "myVersion": engine-only field, must pass through unchanged.
-        //   - "operation": overlapping with CommitInfo; kernel must override with "WRITE".
+        // A nested "notebook" struct, a flat "clusterId", and an "operation" field that collides
+        // with the kernel-managed one (kernel must win).
+        let notebook_fields = Fields::from(vec![
+            Field::new("notebookId", ArrowDataType::Utf8, false),
+            Field::new("notebookPath", ArrowDataType::Utf8, false),
+        ]);
+        let notebook = StructArray::new(
+            notebook_fields.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["4443029"])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["/Users/me/nb"])) as ArrayRef,
+            ],
+            None,
+        );
         let arrow_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("myApp", ArrowDataType::Utf8, false),
-            Field::new("myVersion", ArrowDataType::Utf8, false),
-            Field::new("operation", ArrowDataType::Utf8, false),
+            Field::new("clusterId", ArrowDataType::Utf8, false),
+            Field::new("operation", ArrowDataType::Utf8, true),
+            Field::new("notebook", ArrowDataType::Struct(notebook_fields), false),
         ]));
         let batch = RecordBatch::try_new(
-            arrow_schema,
+            arrow_schema.clone(),
             vec![
-                Arc::new(StringArray::from(vec!["spark"])) as ArrayRef,
-                Arc::new(StringArray::from(vec!["3.5.0"])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["1027-202406-pooh991"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
+                Arc::new(notebook) as ArrayRef,
             ],
         )?;
-        let engine_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::not_null("myApp", DataType::STRING),
-            StructField::not_null("myVersion", DataType::STRING),
-            StructField::nullable("operation", DataType::STRING),
-        ]));
+        let kernel_schema: Schema = arrow_schema.as_ref().try_into_kernel()?;
 
         let txn = load_and_begin_transaction(table_url.clone(), &engine)?
-            .with_operation("WRITE".to_string())
-            .with_commit_info(Box::new(ArrowEngineData::new(batch)), engine_schema);
-
+            .with_operation("INSERT".to_string())
+            .with_additional_commit_info(
+                Box::new(ArrowEngineData::new(batch)),
+                Arc::new(kernel_schema),
+            );
         let _ = txn.commit(&engine)?;
 
         let commit = store
@@ -197,36 +241,19 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
                 "/{table_name}/_delta_log/00000000000000000001.json"
             )))
             .await?;
+        let parsed: serde_json::Value = serde_json::from_slice(&commit.bytes().await?)?;
+        let ci = &parsed["commitInfo"];
 
-        let mut parsed_commits: Vec<_> = Deserializer::from_slice(&commit.bytes().await?)
-            .into_iter::<serde_json::Value>()
-            .try_collect()?;
-
-        validate_txn_id(&parsed_commits[0]["commitInfo"]);
-        validate_timestamp(&parsed_commits[0]["commitInfo"]);
-
-        // Zero out non-deterministic fields for stable comparison.
-        set_json_value(&mut parsed_commits[0], "commitInfo.timestamp", json!(0))?;
-        set_json_value(&mut parsed_commits[0], "commitInfo.txnId", json!(ZERO_UUID))?;
-
-        // Null-valued CommitInfo fields (inCommitTimestamp, isBlindAppend, engineInfo) are
-        // omitted from the JSON -- consistent with how the Delta log serializes optional fields.
-        let expected_commits = vec![json!({
-            "commitInfo": {
-                // Engine-only fields pass through unchanged.
-                "myApp": "spark",
-                "myVersion": "3.5.0",
-                // Kernel overrides the engine's stale "STALE_OP" with the real operation.
-                "operation": "WRITE",
-                // Remaining kernel-managed non-null fields are appended.
-                "operationParameters": {},
-                "kernelVersion": format!("v{}", env!("CARGO_PKG_VERSION")),
-                "txnId": ZERO_UUID,
-                "timestamp": 0,
-            }
-        })];
-
-        assert_eq!(parsed_commits, expected_commits);
+        // Kernel wins on the colliding field; engine-only fields pass through.
+        assert_eq!(ci["operation"], "INSERT");
+        assert_eq!(ci["clusterId"], "1027-202406-pooh991");
+        // The nested struct round-trips as a nested object, not a stringified blob.
+        assert_eq!(
+            ci["notebook"],
+            json!({"notebookId": "4443029", "notebookPath": "/Users/me/nb"})
+        );
+        // A kernel-managed field is present.
+        assert_eq!(ci["operationParameters"], json!({}));
     }
     Ok(())
 }

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -111,12 +111,50 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Engine-supplied `operationParameters` and `operationMetrics`, set through the public transaction
+/// builder methods, are written to the commit's CommitInfo with their exact key/value entries.
+#[tokio::test]
+async fn test_commit_info_with_operation_metrics() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let schema = get_simple_int_schema();
+
+    for (table_url, engine, store, table_name) in
+        setup_test_tables(schema, &[], None, "test_table").await?
+    {
+        let txn = load_and_begin_transaction(table_url.clone(), &engine)?
+            .with_operation("WRITE".to_string())
+            .with_operation_parameters([("mode", "Append"), ("partitionBy", "[]")])
+            .with_operation_metrics([("numFiles", "1"), ("numOutputRows", "10")]);
+
+        let _ = txn.commit(&engine)?;
+
+        let commit = store
+            .get(&Path::from(format!(
+                "/{table_name}/_delta_log/00000000000000000001.json"
+            )))
+            .await?;
+
+        let parsed: serde_json::Value = serde_json::from_slice(&commit.bytes().await?)?;
+        let ci = &parsed["commitInfo"];
+
+        assert_eq!(
+            ci["operationParameters"],
+            json!({"mode": "Append", "partitionBy": "[]"})
+        );
+        assert_eq!(
+            ci["operationMetrics"],
+            json!({"numFiles": "1", "numOutputRows": "10"})
+        );
+    }
+    Ok(())
+}
+
 /// Verifies that when `engine_commit_info` is provided (the `Some` branch of `build_commit_info`):
 /// - The written JSON is correctly wrapped in a top-level `"commitInfo"` key.
 /// - Engine-only fields (not in `CommitInfo::to_schema()`) pass through to the log unchanged.
 /// - Fields that overlap with kernel-managed CommitInfo fields are overridden by kernel values,
-/// - All kernel-managed fields (`timestamp`, `kernelVersion`, `txnId`, `operationParameters`) are
-///   present with correct values.
+/// - All kernel-managed fields (`timestamp`, `kernelVersion`, `txnId`, `operationParameters`,
+///   `operationMetrics`) are present with correct values.
 #[tokio::test]
 async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds `CommitInfoClientOptions`, a structured builder for the client-set `CommitInfo` fields, plus a
new `operationMetrics` field inside `CommitInfo`. Can attach it with `with_commit_info_options(...)` on a write transaction or the create/alter-table builders.

```rs
// write
snapshot.transaction(committer, engine)?
    .with_operation("WRITE".to_string())
    .with_commit_info_options(
        CommitInfoClientOptions::new()
            .with_operation_parameters([("mode", "Append"), ("partitionBy", "[]")])
            .with_operation_metrics([("numFiles", "1"), ("numOutputRows", "10")]),
    )
    .commit(engine)?;
```

Writes:

```json
"operationParameters": { "mode": "Append", "partitionBy": "[]" },
"operationMetrics":    { "numFiles": "1", "numOutputRows": "10" }
```

```rs
// create table
create_table(path, schema, "MyEngine/1.0")
    .with_commit_info_options(CommitInfoClientOptions::new().with_operation_parameters([("mode", "Create")]))
    .build(engine, committer)?.commit(engine)?;

// alter table
snapshot.alter_table()
    .with_commit_info_options(CommitInfoClientOptions::new().with_operation_metrics([("numAddedColumns", "1")]))
    .add_column(StructField::nullable("added", DataType::STRING))
    .build(engine, committer)?.commit(engine)?;
```

Rules:
- `operationParameters`: always written; unset -> `{}`.
- `operationMetrics`: written only when set; empty -> `{}`.
- `with_commit_info_options` merges: fields set override, unset keep. A prior `with_operation`/
  `with_engine_info` is not cleared.

`CommitInfoClientOptions` holds every client-controlled `commitInfo` field: `operation`,
`isBlindAppend`, `operationParameters`, `operationMetrics`, `engineInfo`, and arbitrary extras.
Kernel reads `operation` (CRC incremental-safety) and `isBlindAppend` (blind-append rules) from it.
`with_operation`/`with_engine_info`/`with_blind_append` stay as top-level setters (backwards compat;
`with_operation`/`with_engine_info` are also FFI-exported).

### Arbitrary fields

For fields the typed setters don't cover (nested structs, non-string), pass `EngineData` + schema:

```rs
// `extra` holds e.g. a "clusterId" and a nested "notebook" struct
CommitInfoClientOptions::new().with_additional_commit_info(extra, schema)
```
Post merge, a kernel-managed field wins on a name collision.

Another follow-up: a later PR will update the engine info to potentially always suffix the kernel version.

### This PR affects the following public APIs

New:
- `CommitInfoClientOptions` (`with_operation_parameters`, `with_operation_metrics`,
  `with_engine_info`, `with_additional_commit_info`).
- `with_commit_info_options(...)` on `Transaction` (all states) and both builders; merges.
- `operationMetrics` field on `commitInfo`.

Breaking:
- `Transaction::with_commit_info(...)` renamed to `with_additional_commit_info(...)`.
- `CommitInfoClientOptions` is not `Clone`/`PartialEq` (holds `EngineData`).

## How was this change tested?

UT + integration: write/create/alter paths; unset/empty/`{}` map cases; merge keeps a prior
`operation`/`engine_info`; nested-struct extra field; kernel wins on a name collision.
