### PR TITLE
feat!: Define and implement PrefixSum operator

### DIFF
--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -133,6 +133,12 @@ message SemiJoinNode {
   repeated delta.kernel.expressions.ColumnName build_keys = 3;
 }
 
+message PrefixSumNode {
+  delta.kernel.expressions.ColumnName input = 1;
+  string output = 2;
+  delta.kernel.schema.StructType schema = 3;
+}
+
 // ============================================================================
 // Operator
 // ============================================================================
@@ -150,6 +156,7 @@ message Operator {
     DynamicScanNode dynamic_scan = 7;
     AggregateNode aggregate = 8;
     SemiJoinNode semi_join = 9;
+    PrefixSumNode prefix_sum = 10;
   }
 }
 

--- a/kernel/src/engine/sync/aggs.rs
+++ b/kernel/src/engine/sync/aggs.rs
@@ -178,7 +178,7 @@ impl BoundAggregate for LongAccumulatorAgg {
 
     fn prepare<'a>(&'a self, batch: &'a RecordBatch) -> DeltaResult<Box<dyn AggUpdater + 'a>> {
         Ok(Box::new(LongAccumulatorUpdater {
-            values: extract_long_column(batch, &self.value)?,
+            values: super::extract_long_column(batch, &self.value)?,
             op: self.op,
         }))
     }
@@ -310,7 +310,7 @@ impl BoundAggregate for NonNullByAgg {
     fn prepare<'a>(&'a self, batch: &'a RecordBatch) -> DeltaResult<Box<dyn AggUpdater + 'a>> {
         Ok(Box::new(NonNullByUpdater {
             null_sentinels: extract_column_ref(batch, &self.null_sentinel)?,
-            keys: extract_long_column(batch, &self.key)?,
+            keys: super::extract_long_column(batch, &self.key)?,
             comparison: self.comparison,
         }))
     }
@@ -351,18 +351,6 @@ impl AggUpdater for NonNullByUpdater<'_> {
         }
         Ok(())
     }
-}
-
-fn extract_long_column<'a>(
-    batch: &'a RecordBatch,
-    name: &ColumnName,
-) -> DeltaResult<&'a Int64Array> {
-    let array = extract_column_ref(batch, name)?;
-    array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
-        Error::unsupported(format!(
-            "SyncPlanExecutor aggregate operand `{name}` has non-LONG type"
-        ))
-    })
 }
 
 fn downcast_state<T: 'static>(state: &dyn Any) -> DeltaResult<&T> {

--- a/kernel/src/engine/sync/mod.rs
+++ b/kernel/src/engine/sync/mod.rs
@@ -38,10 +38,38 @@ mod storage;
 mod aggs;
 
 #[cfg(feature = "declarative-plans")]
+mod prefix_sum;
+
+#[cfg(feature = "declarative-plans")]
 pub(crate) mod plan;
 
 #[cfg(feature = "declarative-plans")]
 use plan::SyncPlanExecutor;
+
+#[cfg(feature = "declarative-plans")]
+use crate::arrow::array::{Array as _, Int64Array, RecordBatch};
+#[cfg(feature = "declarative-plans")]
+use crate::engine::arrow_expression::evaluate_expression::extract_column_ref;
+#[cfg(feature = "declarative-plans")]
+use crate::expressions::ColumnName;
+
+/// Extracts `name` from `batch` as a LONG column.
+///
+/// # Errors
+///
+/// Returns an error if the column is missing or is not LONG.
+#[cfg(feature = "declarative-plans")]
+fn extract_long_column<'a>(
+    batch: &'a RecordBatch,
+    name: &ColumnName,
+) -> DeltaResult<&'a Int64Array> {
+    let array = extract_column_ref(batch, name)?;
+    array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+        Error::unsupported(format!(
+            "SyncPlanExecutor operand `{name}` has non-LONG type"
+        ))
+    })
+}
 
 /// A simple (test-only) implementation of [`Engine`]. See module docs for supported stores.
 pub(crate) struct SyncEngine {

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use super::aggs::eval_aggregate;
 use super::json::try_create_from_json;
 use super::parquet::{parquet_footer, try_create_from_parquet};
+use super::prefix_sum::eval_prefix_sum;
 use super::read_files_arrow;
 use super::storage::SyncStorageHandler;
 use crate::arrow::array::{
@@ -173,6 +174,7 @@ impl SyncPlanExecutor {
                 self.eval_dynamic_scan(dynamic_scan, &results[inputs[0]])
             }
             Operator::Aggregate(aggregate) => eval_aggregate(&aggregate, &results[inputs[0]]),
+            Operator::PrefixSum(prefix_sum) => eval_prefix_sum(&prefix_sum, &results[inputs[0]]),
             Operator::SemiJoin(join) => {
                 eval_semi_join(join, &results[inputs[0]], &results[inputs[1]])
             }

--- a/kernel/src/engine/sync/prefix_sum.rs
+++ b/kernel/src/engine/sync/prefix_sum.rs
@@ -1,0 +1,133 @@
+//! Prefix-sum evaluation for the synchronous plan executor.
+
+use std::sync::Arc;
+
+use crate::arrow::array::{Array as _, ArrayRef, Int64Array, RecordBatch};
+use crate::arrow::datatypes::Schema as ArrowSchema;
+use crate::engine::arrow_conversion::TryFromKernel as _;
+use crate::plans::ir::nodes::PrefixSum;
+use crate::{DeltaResult, Error};
+
+/// Evaluates a [`PrefixSum`].
+///
+/// Computes an exclusive prefix sum over rows of `input` batches. The first output value is 0;
+/// NULL inputs do not contribute and emit NULL; zero values contribute 0 to the running total.
+pub(super) fn eval_prefix_sum(
+    prefix_sum: &PrefixSum,
+    input: &[RecordBatch],
+) -> DeltaResult<Vec<RecordBatch>> {
+    let output_schema = Arc::new(ArrowSchema::try_from_kernel(&prefix_sum.schema)?);
+    let mut running_total = 0i64;
+    let mut output = Vec::with_capacity(input.len());
+    for batch in input {
+        let values = super::extract_long_column(batch, &prefix_sum.input)?;
+        let mut offsets = Vec::with_capacity(batch.num_rows());
+        for row_idx in 0..batch.num_rows() {
+            if values.is_valid(row_idx) {
+                offsets.push(Some(running_total));
+                running_total = i64::checked_add(running_total, values.value(row_idx))
+                    .ok_or_else(|| Error::generic("SyncPlanExecutor PrefixSum overflowed i64"))?;
+            } else {
+                offsets.push(None);
+            }
+        }
+        let mut columns = batch.columns().to_vec();
+        columns.push(Arc::new(Int64Array::from(offsets)));
+        output.push(RecordBatch::try_new(output_schema.clone(), columns)?);
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arrow::array::StringArray;
+    use crate::arrow::util::pretty::pretty_format_batches;
+    use crate::expressions::column_name;
+    use crate::schema::schema_ref;
+
+    /// Asserts `batches` pretty-print equal to `expected` (row order must match).
+    fn assert_batches_eq(batches: &[RecordBatch], expected: &str) {
+        let formatted = pretty_format_batches(batches).unwrap().to_string();
+        assert_eq!(formatted.trim(), expected.trim());
+    }
+
+    /// Prefix-sums `numRecords` of the fixture schema into an appended `offset` column.
+    fn test_eval_prefix_sum(input: &[RecordBatch]) -> DeltaResult<Vec<RecordBatch>> {
+        let schema = schema_ref! {
+            not_null "path": STRING,
+            nullable "numRecords": LONG,
+        };
+        let prefix_sum = PrefixSum::try_new(&schema, column_name!("numRecords"), "offset")?;
+        eval_prefix_sum(&prefix_sum, input)
+    }
+
+    fn batch(paths: &[&str], sizes: Vec<Option<i64>>) -> RecordBatch {
+        let paths = Arc::new(StringArray::from(paths.to_vec())) as ArrayRef;
+        let sizes = Arc::new(Int64Array::from(sizes));
+        RecordBatch::try_from_iter([("path", paths), ("numRecords", sizes)]).unwrap()
+    }
+
+    #[rstest::rstest]
+    #[case::encounter_order(
+        vec![batch(&["a", "b", "c"], vec![Some(10), Some(5), Some(20)])],
+        "\
++------+------------+--------+
+| path | numRecords | offset |
++------+------------+--------+
+| a    | 10         | 0      |
+| b    | 5          | 10     |
+| c    | 20         | 15     |
++------+------------+--------+"
+    )]
+    #[case::nulls_and_zeros(
+        vec![batch(
+            &["a", "b", "c", "d"],
+            vec![Some(10), None, Some(0), Some(5)],
+        )],
+        "\
++------+------------+--------+
+| path | numRecords | offset |
++------+------------+--------+
+| a    | 10         | 0      |
+| b    |            |        |
+| c    | 0          | 10     |
+| d    | 5          | 10     |
++------+------------+--------+"
+    )]
+    // pretty_format_batches concatenates rows from every batch into one table.
+    #[case::across_batches(
+        vec![
+            batch(&["a"], vec![Some(10)]),
+            batch(&["b", "c"], vec![Some(5), Some(20)]),
+        ],
+        "\
++------+------------+--------+
+| path | numRecords | offset |
++------+------------+--------+
+| a    | 10         | 0      |
+| b    | 5          | 10     |
+| c    | 20         | 15     |
++------+------------+--------+"
+    )]
+    fn exclusive_prefix_sum(
+        #[case] input: Vec<RecordBatch>,
+        #[case] expected: &str,
+    ) -> DeltaResult<()> {
+        assert_batches_eq(&test_eval_prefix_sum(&input)?, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() -> DeltaResult<()> {
+        assert!(test_eval_prefix_sum(&[])?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn overflow_is_an_error() {
+        let input = batch(&["a", "b"], vec![Some(i64::MAX), Some(1)]);
+        let err = test_eval_prefix_sum(&[input]).unwrap_err();
+        assert!(err.to_string().contains("overflowed i64"), "{err}");
+    }
+}

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -40,8 +40,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::ir::nodes::{
-    Aggregate, AggregateBuilder, DynamicScan, FileType, Filter, Operator, Project, ScanFile,
-    ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
+    Aggregate, AggregateBuilder, DynamicScan, FileType, Filter, Operator, PrefixSum, Project,
+    ScanFile, ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
 };
 use super::ir::plan::{Plan, PlanNode};
 use crate::expressions::{ColumnName, ExpressionRef, PredicateRef, Scalar};
@@ -384,6 +384,42 @@ impl PlanBuilder {
     ) -> DeltaResult<Self> {
         let builder = Aggregate::ungrouped(Arc::clone(self.schema()));
         self.aggregate(aggs(builder))
+    }
+
+    /// Append exclusive prefixes of `input` as a new LONG column named `output`. See [`PrefixSum`].
+    ///
+    /// Over an absent input the result stays absent (with the prefix-sum output schema).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error under the same conditions as [`PrefixSum::try_new`].
+    ///
+    /// # Example
+    /// ```
+    /// # use std::sync::Arc;
+    /// # use delta_kernel::PlanBuilder;
+    /// # use delta_kernel::expressions::column_name;
+    /// # use delta_kernel::schema::{DataType, StructField, StructType};
+    /// let schema = Arc::new(StructType::try_new([
+    ///     StructField::not_null("path", DataType::STRING),
+    ///     StructField::not_null("numRecords", DataType::LONG),
+    /// ])?);
+    /// let plan = PlanBuilder::values(
+    ///     schema,
+    ///     vec![vec!["a".into(), 10i64.into()], vec!["b".into(), 5i64.into()]],
+    /// )?
+    /// .prefix_sum(column_name!("numRecords"), "offset")?
+    /// .build()?;
+    /// # Ok::<(), delta_kernel::Error>(())
+    /// ```
+    pub fn prefix_sum(
+        self,
+        input: impl Into<ColumnName>,
+        output: impl Into<String>,
+    ) -> DeltaResult<Self> {
+        let prefix_sum = PrefixSum::try_new(self.schema(), input, output)?;
+        let schema = Arc::clone(&prefix_sum.schema);
+        Ok(self.unary_op_or_absent(schema, prefix_sum))
     }
 
     /// Semi join: emit the `self` (probe) rows that have a match in `build` on the join keys.
@@ -840,6 +876,7 @@ mod tests {
     })]
     #[case::grouped_aggregate(absent_src().aggregate(
         Aggregate::group_by(part_schema(), [column_name!("id")]).max(column_name!("part"))))]
+    #[case::prefix_sum(absent_over(x_schema()).prefix_sum(column_name!("x"), "offset"))]
     #[case::semi_join_absent_build(
         vals(id_schema()).semi_join(absent_src(), [column_name!("id")], [column_name!("id")]))]
     #[case::semi_join_absent_probe(
@@ -962,6 +999,27 @@ mod tests {
             panic!("expected Aggregate");
         };
         assert!(node.group_by.is_empty());
+        Ok(())
+    }
+
+    /// `prefix_sum` appends the exclusive-prefix column and records a unary PrefixSum node.
+    #[test]
+    fn prefix_sum_appends_output_column() -> DeltaResult<()> {
+        let plan = vals(x_schema()).prefix_sum(column_name!("x"), "offset")?;
+        let schema = plan.schema();
+        assert_eq!(
+            schema
+                .fields()
+                .map(|f| f.name().as_str())
+                .collect::<Vec<_>>(),
+            ["x", "offset"]
+        );
+        let built = assert_plan(plan, &[(&[], "values"), (&[0], "prefix_sum")]);
+        let Operator::PrefixSum(node) = &built.nodes[1].op else {
+            panic!("expected PrefixSum");
+        };
+        assert_eq!(node.input, column_name!("x"));
+        assert_eq!(node.output, "offset");
         Ok(())
     }
 
@@ -1241,6 +1299,12 @@ mod tests {
         || vals(id_schema()).aggregate(Aggregate::group_by(id_schema(), Vec::<ColumnName>::new()).max(column_name!("nope"))))]
     #[case::aggregate_unknown_group_by("not found in schema",
         || vals(id_schema()).aggregate(Aggregate::group_by(id_schema(), [column_name!("nope")]).max(column_name!("id"))))]
+    #[case::prefix_sum_unknown_input("not found in schema",
+        || vals(x_schema()).prefix_sum(column_name!("nope"), "offset"))]
+    #[case::prefix_sum_non_long("must be LONG",
+        || vals(id_schema()).prefix_sum(column_name!("id"), "offset"))]
+    #[case::prefix_sum_duplicate_output("Duplicate field name",
+        || vals(x_schema()).prefix_sum(column_name!("x"), "x"))]
     // union
     #[case::union_schema_disagrees("differing",
         || PlanBuilder::union_all([vals(id_schema()), vals(x_schema())]))]

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -38,6 +38,7 @@ pub enum Operator {
     Filter(Filter),
     DynamicScan(DynamicScan),
     Aggregate(Aggregate),
+    PrefixSum(PrefixSum),
 
     // === Binary operators (2 inputs) =========================================
     SemiJoin(SemiJoin),
@@ -66,6 +67,7 @@ impl_from_payload_for_operator!(
     Filter,
     DynamicScan,
     Aggregate,
+    PrefixSum,
     SemiJoin,
     UnionAll,
 );
@@ -996,6 +998,98 @@ impl TryFrom<AggregateBuilder> for Aggregate {
     }
 }
 
+/// Exclusive prefix sum of one LONG input column, appended as a new output column with the same
+/// nullability as the input. All other input columns pass through unchanged.
+///
+/// # Semantics
+///
+/// The output for row `i` is `SUM(input[0..i])`, or `0` for `i=0`. NULL inputs do not contribute
+/// and produce NULL outputs for their respective rows. Zero-valued inputs are valid but produce
+/// duplicate outputs (because they do not increase the value of the sum). Input rows are consumed
+/// exactly once in any order and output rows can be produced in any order.
+///
+/// # Output schema
+///
+/// `schema` is the input schema with one appended LONG column named `output`. That column's
+/// nullability matches the resolved `input` field (NULL inputs produce NULL outputs).
+///
+/// # Example
+///
+/// ```text
+/// PrefixSum { input: numRecords, output: offset, schema: { path, numRecords, offset } }
+/// ```
+///
+/// One valid output (encounter order):
+///
+/// ```text
+/// path | numRecords | offset
+/// -----+------------+-------
+///  a   |         10 |      0
+///  b   |       NULL |   NULL
+///  c   |          0 |     10
+///  d   |          0 |     10
+///  e   |          5 |     10
+///  f   |         20 |     15
+/// ```
+/// This produces the ranges `[0..10, 10..10, 10..10, 10..15, 15..35]`.
+///
+/// Another valid output (input and output rows both permuted):
+///
+/// ```text
+/// path | numRecords | offset
+/// -----+------------+-------
+///  b   |       NULL |   NULL
+///  f   |         20 |     0
+///  a   |         10 |     25
+///  d   |          0 |     20
+///  c   |          0 |     25
+///  e   |          5 |     20
+/// ```
+/// This produces the ranges `[0..20, 20..20, 20..25, 25..25, 25..35]`.
+#[derive(Debug, Clone)]
+pub struct PrefixSum {
+    /// LONG column to accumulate. May be nested (e.g. `stats.numRecords`).
+    pub input: ColumnName,
+    /// Name of the new top-level LONG column holding exclusive prefixes.
+    pub output: String,
+    /// Input schema with [`Self::output`] appended.
+    pub schema: SchemaRef,
+}
+
+impl PrefixSum {
+    /// Builds a [`PrefixSum`] that appends exclusive prefixes of `input` as `output`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `input` is absent from `input_schema`, is not LONG, or if appending
+    /// `output` would duplicate a top-level field name (case-insensitive).
+    pub fn try_new(
+        input_schema: &StructType,
+        input: impl Into<ColumnName>,
+        output: impl Into<String>,
+    ) -> DeltaResult<Self> {
+        let input = input.into();
+        let output = output.into();
+        let field = input_schema.field_at(&input)?;
+        if field.data_type() != &DataType::LONG {
+            return Err(Error::generic(format!(
+                "prefix sum: input `{input}` must be LONG, got {}",
+                field.data_type()
+            )));
+        }
+        let schema = Arc::new(input_schema.add([StructField::new(
+            output.clone(),
+            DataType::LONG,
+            field.nullable,
+        )])?);
+        Ok(Self {
+            input,
+            output,
+            schema,
+        })
+    }
+}
+
 /// Performs a semi join between two inputs, `inputs.len() == 2`, the child
 /// nodes are `[probe, build]` in this order. It emits a subset of probe rows;
 /// the build side acts as a filter and never contributes columns. This is
@@ -1228,5 +1322,50 @@ mod tests {
             )
             .build();
         assert_result_error_with_message(result, "missing");
+    }
+
+    #[test]
+    fn prefix_sum_appends_long_output_matching_input_nullability() {
+        let input = schema(&[("path", false), ("numRecords", true)]);
+        let prefix =
+            PrefixSum::try_new(input.as_ref(), column_name!("numRecords"), "offset").unwrap();
+        let names: Vec<&str> = prefix.schema.fields().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, ["path", "numRecords", "offset"]);
+        let offset = prefix.schema.field("offset").unwrap();
+        assert_eq!(offset.data_type(), &DataType::LONG);
+        assert!(offset.nullable);
+        assert_eq!(prefix.output, "offset");
+        assert_eq!(prefix.input, column_name!("numRecords"));
+    }
+
+    #[test]
+    fn prefix_sum_non_nullable_input_yields_non_nullable_output() {
+        let input = schema(&[("n", false)]);
+        let prefix = PrefixSum::try_new(input.as_ref(), column_name!("n"), "off").unwrap();
+        assert!(!prefix.schema.field("off").unwrap().nullable);
+    }
+
+    #[test]
+    fn prefix_sum_rejects_non_long_input() {
+        let input = Arc::new(StructType::new_unchecked([StructField::not_null(
+            "s",
+            DataType::STRING,
+        )]));
+        let result = PrefixSum::try_new(input.as_ref(), column_name!("s"), "off");
+        assert_result_error_with_message(result, "must be LONG");
+    }
+
+    #[test]
+    fn prefix_sum_rejects_missing_input_column() {
+        let input = schema(&[("n", true)]);
+        let result = PrefixSum::try_new(input.as_ref(), column_name!("missing"), "off");
+        assert_result_error_with_message(result, "missing");
+    }
+
+    #[test]
+    fn prefix_sum_rejects_duplicate_output_name() {
+        let input = schema(&[("n", true)]);
+        let result = PrefixSum::try_new(input.as_ref(), column_name!("n"), "n");
+        assert_result_error_with_message(result, "Duplicate field name");
     }
 }

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -18,8 +18,8 @@ use crate::expressions::{
     UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::plans::ir::nodes::{
-    Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
-    ScanParquet, SemiJoin, Values,
+    Agg, Aggregate, DynamicScan, FileType, Filter, Operator, PrefixSum, Project, ScanFile,
+    ScanJson, ScanParquet, SemiJoin, Values,
 };
 use crate::plans::ir::plan::{Plan, PlanNode};
 use crate::plans::{IoOperation, Operation};
@@ -149,6 +149,7 @@ impl From<&Operator> for proto_plan::Operator {
             Operator::Filter(n) => Op::Filter(n.into()),
             Operator::DynamicScan(n) => Op::DynamicScan(n.into()),
             Operator::Aggregate(n) => Op::Aggregate(n.into()),
+            Operator::PrefixSum(n) => Op::PrefixSum(n.into()),
             Operator::SemiJoin(n) => Op::SemiJoin(n.into()),
             Operator::UnionAll(_) => Op::UnionAll(proto_plan::UnionAllNode {}),
         };
@@ -284,6 +285,16 @@ impl From<&SemiJoin> for proto_plan::SemiJoinNode {
             inverted: node.inverted,
             probe_keys: convert_vec(&node.probe_keys),
             build_keys: convert_vec(&node.build_keys),
+        }
+    }
+}
+
+impl From<&PrefixSum> for proto_plan::PrefixSumNode {
+    fn from(node: &PrefixSum) -> Self {
+        proto_plan::PrefixSumNode {
+            input: Some((&node.input).into()),
+            output: node.output.clone(),
+            schema: Some(node.schema.as_ref().into()),
         }
     }
 }
@@ -988,8 +999,8 @@ mod tests {
         IndirectDataSkippingPredicateEvaluator,
     };
     use crate::plans::ir::nodes::{
-        Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
-        ScanParquet, SemiJoin, UnionAll, Values,
+        Agg, Aggregate, DynamicScan, FileType, Filter, Operator, PrefixSum, Project, ScanFile,
+        ScanJson, ScanParquet, SemiJoin, UnionAll, Values,
     };
     use crate::plans::ir::plan::{Plan, PlanNode};
     use crate::plans::proto::{
@@ -1333,6 +1344,14 @@ mod tests {
         Operator::SemiJoin(SemiJoin { inverted: false, probe_keys: vec![], build_keys: vec![] }),
         "semi_join"
     )]
+    #[case(
+        Operator::PrefixSum(PrefixSum {
+            input: ColumnName::new(["n"]),
+            output: "offset".to_string(),
+            schema: sample_schema(),
+        }),
+        "prefix_sum"
+    )]
     #[case(Operator::UnionAll(UnionAll), "union_all")]
     fn from_operator(#[case] op: Operator, #[case] expected: &str) {
         use proto_plan::operator::Op;
@@ -1345,6 +1364,7 @@ mod tests {
             Op::DynamicScan(_) => "dynamic_scan",
             Op::Aggregate(_) => "aggregate",
             Op::SemiJoin(_) => "semi_join",
+            Op::PrefixSum(_) => "prefix_sum",
             Op::UnionAll(_) => "union_all",
         };
         assert_eq!(kind, expected);
@@ -1505,6 +1525,19 @@ mod tests {
         assert_eq!(proto.group_by.len(), 1);
         assert_eq!(proto.aggs.len(), 1);
         assert!(proto.aggs[0].func.is_some());
+        assert!(proto.schema.is_some());
+    }
+
+    #[test]
+    fn from_prefix_sum() {
+        let node = PrefixSum {
+            input: ColumnName::new(["n"]),
+            output: "offset".to_string(),
+            schema: sample_schema(),
+        };
+        let proto = proto_plan::PrefixSumNode::from(&node);
+        assert_eq!(proto.input.expect("input").path, ["n"]);
+        assert_eq!(proto.output, "offset");
         assert!(proto.schema.is_some());
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Define a new `Operator::PrefixSum` that computes an exclusive prefix sum over a single column, appending the resulting output column to the otherwise unchanged input:
|input|output|comment|
|-|-|:-|
|1|0|Initial value is always zero
|3|1|
|NULL|NULL|NULL values do not contribute
|5|4|
|0|9|`0` is treated normally but the next row will repeat the value
|1|9|The final `1` is ignored

The result can be interpreted as the starting offset for a series of non-overlapping half-open intervals that exactly partitions the SUM over the input. For the above example, that would produce:
```
0..0+1, 1..1+3, NULL, 4..4+5, 9..9+0, 9..9+1
= 0..1,   1..4, NULL,   4..9,   9..9,  9..10
```
This primitive will eventually be used to compute row id base values for newly added `add` actions when row tracking is enabled. 

It is defined as a new top-level operator because:
* Unlike a normal `Aggregate` it does not reduce rows
* It is stateful, unlike the simple expressions `Project` allows
* Its presence in a query materially changes planning and execution (like an `Agg` or a `Join`)

A single-threaded implementation is provided for the sync engine; engines can efficiently distribute the execution of a large prefix sum by a standard two-phase algorithm:
1. [distributed] Partition the input and compute the SUM of each partition
2. [local] Compute the prefix sum over the partition sums
3. [distributed] Compute a prefix sum over each partition, using its prefix sum value as input

Because the operator is unordered, the engine can choose whatever partitioning it wants, as long as each row is processed exactly once.

### This PR affects the following public APIs

New plan operator.

## How was this change tested?

New unit tests.