### PR TITLE
feat: add ordered scan execution to declarative plans

### DIFF
--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -34,12 +34,14 @@ message ScanParquetNode {
   repeated ScanFile files = 1;
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
+  bool ordered_scan = 4;
 }
 
 message ScanJsonNode {
   repeated ScanFile files = 1;
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
+  bool ordered_scan = 4;
 }
 
 message ValuesRow {

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -35,8 +35,7 @@ message ScanParquetNode {
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
   // True preserves input-file and per-file row order, with each batch containing rows from at
-  // most one file. False, including the proto3 default, provides no order or file-boundary
-  // guarantee.
+  // most one file.
   bool ordered_scan = 4;
 }
 
@@ -45,8 +44,7 @@ message ScanJsonNode {
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
   // True preserves input-file and per-file row order, with each batch containing rows from at
-  // most one file. False, including the proto3 default, provides no order or file-boundary
-  // guarantee.
+  // most one file.
   bool ordered_scan = 4;
 }
 

--- a/kernel/proto/plan.proto
+++ b/kernel/proto/plan.proto
@@ -34,6 +34,9 @@ message ScanParquetNode {
   repeated ScanFile files = 1;
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
+  // True preserves input-file and per-file row order, with each batch containing rows from at
+  // most one file. False, including the proto3 default, provides no order or file-boundary
+  // guarantee.
   bool ordered_scan = 4;
 }
 
@@ -41,6 +44,9 @@ message ScanJsonNode {
   repeated ScanFile files = 1;
   repeated string file_constant_columns = 2;
   delta.kernel.schema.StructType schema = 3;
+  // True preserves input-file and per-file row order, with each batch containing rows from at
+  // most one file. False, including the proto3 default, provides no order or file-boundary
+  // guarantee.
   bool ordered_scan = 4;
 }
 

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -82,13 +82,12 @@ mod tests {
     // TODO(#2618): Refactor and share a test suite with sync engine tests.
 
     use std::io::Write as _;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use rstest::rstest;
     use tempfile::{tempdir, NamedTempFile};
     use url::Url;
 
-    use super::super::assert_batches_sorted_eq;
     use super::PlanBasedJsonHandler;
     use crate::arrow::array::{Array, Int32Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
@@ -96,11 +95,33 @@ mod tests {
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::FilteredEngineData;
+    use crate::plans::ir::nodes::Operator;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
     use crate::{
         DeltaResult, Engine as _, EngineData, FileDataReadResultIterator, FileMeta,
-        JsonHandler as _, ParquetHandler as _,
+        JsonHandler as _, Operation, ParquetHandler as _, PlanExecutor, PlanResult,
     };
+
+    #[derive(Default)]
+    struct RecordingPlanExecutor {
+        scans: Mutex<Vec<(&'static str, bool)>>,
+    }
+
+    impl PlanExecutor for RecordingPlanExecutor {
+        fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
+            let Operation::QueryPlan(plan) = op else {
+                panic!("expected query plan");
+            };
+            assert_eq!(plan.nodes.len(), 1);
+            let scan = match &plan.nodes[0].op {
+                Operator::ScanJson(scan) => ("json", scan.ordered_scan),
+                Operator::ScanParquet(scan) => ("parquet", scan.ordered_scan),
+                op => panic!("expected scan, got {op}"),
+            };
+            self.scans.lock().unwrap().push(scan);
+            Ok(PlanResult::Data(Box::new(std::iter::empty())))
+        }
+    }
 
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(
@@ -197,11 +218,54 @@ mod tests {
                     .into()
             })
             .collect();
-        assert_batches_sorted_eq(
-            &[
-                "+---+", "| x |", "+---+", "| 1 |", "| 2 |", "| 3 |", "| 4 |", "+---+",
-            ],
-            &batches,
+        let batch_values: Vec<Vec<i32>> = batches
+            .iter()
+            .map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert!(batch_values.iter().all(|values| {
+            !values.is_empty()
+                && (values.iter().all(|value| *value <= 2)
+                    || values.iter().all(|value| *value >= 3))
+        }));
+        assert_eq!(
+            batch_values.into_iter().flatten().collect::<Vec<_>>(),
+            vec![3, 4, 1, 2]
+        );
+    }
+
+    #[test]
+    fn plan_based_handlers_request_ordered_scans() {
+        let executor = Arc::new(RecordingPlanExecutor::default());
+        let fallback = SyncEngine::new();
+        let json = PlanBasedJsonHandler::new(executor.clone(), fallback.json_handler());
+        let parquet = PlanBasedParquetHandler::new(executor.clone(), fallback.parquet_handler());
+        let file = FileMeta {
+            location: Url::parse("file:///data").unwrap(),
+            last_modified: 0,
+            size: 0,
+        };
+
+        drop(
+            json.read_json_files(std::slice::from_ref(&file), test_schema(), None)
+                .unwrap(),
+        );
+        drop(
+            parquet
+                .read_parquet_files(&[file], test_schema(), None)
+                .unwrap(),
+        );
+
+        assert_eq!(
+            *executor.scans.lock().unwrap(),
+            vec![("json", true), ("parquet", true)]
         );
     }
 

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -53,7 +53,8 @@ impl JsonHandler for PlanBasedJsonHandler {
     ) -> DeltaResult<FileDataReadResultIterator> {
         // TODO: `_predicate` is dropped. Re-apply it as a Filter node over the scan; the
         // single-node executor can then match the filter -> scan shape.
-        let query = PlanBuilder::scan_json(files.to_vec(), &[], physical_schema)?.build()?;
+        let query =
+            PlanBuilder::scan_json_ordered(files.to_vec(), &[], physical_schema)?.build()?;
         self.executor
             .execute_op(Operation::QueryPlan(query))?
             .into_data()

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -82,46 +82,25 @@ mod tests {
     // TODO(#2618): Refactor and share a test suite with sync engine tests.
 
     use std::io::Write as _;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use rstest::rstest;
     use tempfile::{tempdir, NamedTempFile};
     use url::Url;
 
+    use super::super::assert_ordered_file_batches;
     use super::PlanBasedJsonHandler;
-    use crate::arrow::array::{Array, Int32Array, RecordBatch, StringArray};
+    use crate::arrow::array::{Array, Int32Array, Int64Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::plans::parquet::PlanBasedParquetHandler;
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::FilteredEngineData;
-    use crate::plans::ir::nodes::Operator;
     use crate::schema::{DataType, SchemaRef, StructField, StructType};
     use crate::{
         DeltaResult, Engine as _, EngineData, FileDataReadResultIterator, FileMeta,
-        JsonHandler as _, Operation, ParquetHandler as _, PlanExecutor, PlanResult,
+        JsonHandler as _, ParquetHandler as _,
     };
-
-    #[derive(Default)]
-    struct RecordingPlanExecutor {
-        scans: Mutex<Vec<(&'static str, bool)>>,
-    }
-
-    impl PlanExecutor for RecordingPlanExecutor {
-        fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
-            let Operation::QueryPlan(plan) = op else {
-                panic!("expected query plan");
-            };
-            assert_eq!(plan.nodes.len(), 1);
-            let scan = match &plan.nodes[0].op {
-                Operator::ScanJson(scan) => ("json", scan.ordered_scan),
-                Operator::ScanParquet(scan) => ("parquet", scan.ordered_scan),
-                op => panic!("expected scan, got {op}"),
-            };
-            self.scans.lock().unwrap().push(scan);
-            Ok(PlanResult::Data(Box::new(std::iter::empty())))
-        }
-    }
 
     fn make_handler() -> PlanBasedJsonHandler {
         PlanBasedJsonHandler::new(
@@ -208,7 +187,7 @@ mod tests {
     fn test_read_json_files_preserves_input_file_order() {
         let (_first, first) = temp_json_file(&[r#"{"x": 1}"#, r#"{"x": 2}"#]);
         let (_second, second) = temp_json_file(&[r#"{"x": 3}"#, r#"{"x": 4}"#]);
-        let schema = test_schema();
+        let schema = ordered_test_schema();
         let batches: Vec<RecordBatch> = make_handler()
             .read_json_files(&[second, first], schema, None)
             .unwrap()
@@ -218,59 +197,27 @@ mod tests {
                     .into()
             })
             .collect();
-        let batch_values: Vec<Vec<i32>> = batches
+        let batch_values: Vec<Vec<i64>> = batches
             .iter()
             .map(|batch| {
                 batch
                     .column(0)
                     .as_any()
-                    .downcast_ref::<Int32Array>()
+                    .downcast_ref::<Int64Array>()
                     .unwrap()
                     .values()
                     .to_vec()
             })
             .collect();
-        assert!(batch_values.iter().all(|values| {
-            !values.is_empty()
-                && (values.iter().all(|value| *value <= 2)
-                    || values.iter().all(|value| *value >= 3))
-        }));
-        assert_eq!(
-            batch_values.into_iter().flatten().collect::<Vec<_>>(),
-            vec![3, 4, 1, 2]
-        );
-    }
-
-    #[test]
-    fn plan_based_handlers_request_ordered_scans() {
-        let executor = Arc::new(RecordingPlanExecutor::default());
-        let fallback = SyncEngine::new();
-        let json = PlanBasedJsonHandler::new(executor.clone(), fallback.json_handler());
-        let parquet = PlanBasedParquetHandler::new(executor.clone(), fallback.parquet_handler());
-        let file = FileMeta {
-            location: Url::parse("file:///data").unwrap(),
-            last_modified: 0,
-            size: 0,
-        };
-
-        drop(
-            json.read_json_files(std::slice::from_ref(&file), test_schema(), None)
-                .unwrap(),
-        );
-        drop(
-            parquet
-                .read_parquet_files(&[file], test_schema(), None)
-                .unwrap(),
-        );
-
-        assert_eq!(
-            *executor.scans.lock().unwrap(),
-            vec![("json", true), ("parquet", true)]
-        );
+        assert_ordered_file_batches(batch_values);
     }
 
     fn test_schema() -> SchemaRef {
         Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap())
+    }
+
+    fn ordered_test_schema() -> SchemaRef {
+        Arc::new(StructType::try_new([StructField::not_null("x", DataType::LONG)]).unwrap())
     }
 
     /// No files -> an absent plan -> a zero-row result (no rows, no error), for either handler.

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -88,6 +88,7 @@ mod tests {
     use tempfile::{tempdir, NamedTempFile};
     use url::Url;
 
+    use super::super::assert_batches_sorted_eq;
     use super::PlanBasedJsonHandler;
     use crate::arrow::array::{Array, Int32Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
@@ -180,6 +181,28 @@ mod tests {
             &[1, 2, 3]
         );
         assert!(iter.next().is_none(), "expected exactly one batch");
+    }
+
+    #[test]
+    fn test_read_json_files_preserves_input_file_order() {
+        let (_first, first) = temp_json_file(&[r#"{"x": 1}"#, r#"{"x": 2}"#]);
+        let (_second, second) = temp_json_file(&[r#"{"x": 3}"#, r#"{"x": 4}"#]);
+        let schema = test_schema();
+        let batches: Vec<RecordBatch> = make_handler()
+            .read_json_files(&[second, first], schema, None)
+            .unwrap()
+            .map(|result| {
+                ArrowEngineData::try_from_engine_data(result.unwrap())
+                    .unwrap()
+                    .into()
+            })
+            .collect();
+        assert_batches_sorted_eq(
+            &[
+                "+---+", "| x |", "+---+", "| 1 |", "| 2 |", "| 3 |", "| 4 |", "+---+",
+            ],
+            &batches,
+        );
     }
 
     fn test_schema() -> SchemaRef {

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -107,19 +107,45 @@ impl Engine for PlanBasedEngine {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     use tempfile::tempdir;
     use url::Url;
 
-    use super::PlanBasedEngine;
+    use super::{PlanBasedEngine, PlanBasedJsonHandler, PlanBasedParquetHandler};
     use crate::arrow::array::{Array, Int64Array, RecordBatch, StringArray};
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::FilteredEngineData;
-    use crate::{Engine as _, EngineData, Error};
+    use crate::plans::ir::nodes::Operator;
+    use crate::schema::{DataType, StructField, StructType};
+    use crate::{
+        DeltaResult, Engine as _, EngineData, Error, FileMeta, JsonHandler as _, Operation,
+        ParquetHandler as _, PlanExecutor, PlanResult,
+    };
+
+    #[derive(Default)]
+    struct RecordingPlanExecutor {
+        scans: Mutex<Vec<(&'static str, bool)>>,
+    }
+
+    impl PlanExecutor for RecordingPlanExecutor {
+        fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
+            let Operation::QueryPlan(plan) = op else {
+                panic!("expected query plan");
+            };
+            assert_eq!(plan.nodes.len(), 1);
+            let scan = match &plan.nodes[0].op {
+                Operator::ScanJson(scan) => ("json", scan.ordered_scan),
+                Operator::ScanParquet(scan) => ("parquet", scan.ordered_scan),
+                op => panic!("expected scan, got {op}"),
+            };
+            self.scans.lock().unwrap().push(scan);
+            Ok(PlanResult::Data(Box::new(std::iter::empty())))
+        }
+    }
 
     fn plan_engine(fallback: Option<Arc<dyn crate::Engine>>) -> PlanBasedEngine {
         PlanBasedEngine::new(fallback, Arc::new(SyncPlanExecutor::default()))
@@ -215,50 +241,14 @@ mod tests {
             .expect_err("no fallback is configured");
         assert!(matches!(parquet_err, Error::Unsupported(_)));
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use url::Url;
-
-    use super::{PlanBasedJsonHandler, PlanBasedParquetHandler};
-    use crate::engine::sync::SyncEngine;
-    use crate::plans::ir::nodes::Operator;
-    use crate::schema::{DataType, StructField, StructType};
-    use crate::{
-        DeltaResult, Engine as _, FileMeta, JsonHandler as _, Operation, ParquetHandler as _,
-        PlanExecutor, PlanResult,
-    };
-
-    #[derive(Default)]
-    struct RecordingPlanExecutor {
-        scans: Mutex<Vec<(&'static str, bool)>>,
-    }
-
-    impl PlanExecutor for RecordingPlanExecutor {
-        fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
-            let Operation::QueryPlan(plan) = op else {
-                panic!("expected query plan");
-            };
-            assert_eq!(plan.nodes.len(), 1);
-            let scan = match &plan.nodes[0].op {
-                Operator::ScanJson(scan) => ("json", scan.ordered_scan),
-                Operator::ScanParquet(scan) => ("parquet", scan.ordered_scan),
-                op => panic!("expected scan, got {op}"),
-            };
-            self.scans.lock().unwrap().push(scan);
-            Ok(PlanResult::Data(Box::new(std::iter::empty())))
-        }
-    }
 
     #[test]
     fn plan_based_handlers_request_ordered_scans() {
         let executor = Arc::new(RecordingPlanExecutor::default());
         let fallback = SyncEngine::new();
-        let json = PlanBasedJsonHandler::new(executor.clone(), fallback.json_handler());
-        let parquet = PlanBasedParquetHandler::new(executor.clone(), fallback.parquet_handler());
+        let json = PlanBasedJsonHandler::new(executor.clone(), Some(fallback.json_handler()));
+        let parquet =
+            PlanBasedParquetHandler::new(executor.clone(), Some(fallback.parquet_handler()));
         let file = FileMeta {
             location: Url::parse("file:///data").unwrap(),
             last_modified: 0,

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -16,27 +16,6 @@ pub mod json;
 pub mod parquet;
 pub mod storage;
 
-#[cfg(test)]
-use crate::arrow::array::RecordBatch;
-
-#[cfg(test)]
-pub(crate) fn assert_batches_sorted_eq(expected: &[&str], actual: &[RecordBatch]) {
-    fn sorted_lines(mut lines: Vec<String>) -> Vec<String> {
-        if lines.len() > 3 {
-            let end = lines.len() - 1;
-            lines[2..end].sort_unstable();
-        }
-        lines
-    }
-
-    let actual = crate::arrow::util::pretty::pretty_format_batches(actual)
-        .unwrap()
-        .to_string();
-    let expected = expected.iter().map(|line| (*line).to_owned()).collect();
-    let actual = actual.trim().lines().map(str::to_owned).collect();
-    assert_eq!(sorted_lines(expected), sorted_lines(actual));
-}
-
 use json::PlanBasedJsonHandler;
 use parquet::PlanBasedParquetHandler;
 use storage::PlanBasedStorageHandler;

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -16,6 +16,19 @@ pub mod json;
 pub mod parquet;
 pub mod storage;
 
+#[cfg(test)]
+fn assert_ordered_file_batches(batch_values: Vec<Vec<i64>>) {
+    assert!(batch_values.iter().all(|values| {
+        values.is_empty()
+            || values.iter().all(|value| *value <= 2)
+            || values.iter().all(|value| *value >= 3)
+    }));
+    assert_eq!(
+        batch_values.into_iter().flatten().collect::<Vec<_>>(),
+        vec![3, 4, 1, 2]
+    );
+}
+
 use json::PlanBasedJsonHandler;
 use parquet::PlanBasedParquetHandler;
 use storage::PlanBasedStorageHandler;
@@ -201,5 +214,70 @@ mod tests {
             .write_parquet_file(location, Box::new(std::iter::empty()))
             .expect_err("no fallback is configured");
         assert!(matches!(parquet_err, Error::Unsupported(_)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use url::Url;
+
+    use super::{PlanBasedJsonHandler, PlanBasedParquetHandler};
+    use crate::engine::sync::SyncEngine;
+    use crate::plans::ir::nodes::Operator;
+    use crate::schema::{DataType, StructField, StructType};
+    use crate::{
+        DeltaResult, Engine as _, FileMeta, JsonHandler as _, Operation, ParquetHandler as _,
+        PlanExecutor, PlanResult,
+    };
+
+    #[derive(Default)]
+    struct RecordingPlanExecutor {
+        scans: Mutex<Vec<(&'static str, bool)>>,
+    }
+
+    impl PlanExecutor for RecordingPlanExecutor {
+        fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
+            let Operation::QueryPlan(plan) = op else {
+                panic!("expected query plan");
+            };
+            assert_eq!(plan.nodes.len(), 1);
+            let scan = match &plan.nodes[0].op {
+                Operator::ScanJson(scan) => ("json", scan.ordered_scan),
+                Operator::ScanParquet(scan) => ("parquet", scan.ordered_scan),
+                op => panic!("expected scan, got {op}"),
+            };
+            self.scans.lock().unwrap().push(scan);
+            Ok(PlanResult::Data(Box::new(std::iter::empty())))
+        }
+    }
+
+    #[test]
+    fn plan_based_handlers_request_ordered_scans() {
+        let executor = Arc::new(RecordingPlanExecutor::default());
+        let fallback = SyncEngine::new();
+        let json = PlanBasedJsonHandler::new(executor.clone(), fallback.json_handler());
+        let parquet = PlanBasedParquetHandler::new(executor.clone(), fallback.parquet_handler());
+        let file = FileMeta {
+            location: Url::parse("file:///data").unwrap(),
+            last_modified: 0,
+            size: 0,
+        };
+        let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
+            "x",
+            DataType::INTEGER,
+        )]));
+
+        drop(
+            json.read_json_files(std::slice::from_ref(&file), schema.clone(), None)
+                .unwrap(),
+        );
+        drop(parquet.read_parquet_files(&[file], schema, None).unwrap());
+
+        assert_eq!(
+            *executor.scans.lock().unwrap(),
+            vec![("json", true), ("parquet", true)]
+        );
     }
 }

--- a/kernel/src/engine/plans/mod.rs
+++ b/kernel/src/engine/plans/mod.rs
@@ -16,6 +16,27 @@ pub mod json;
 pub mod parquet;
 pub mod storage;
 
+#[cfg(test)]
+use crate::arrow::array::RecordBatch;
+
+#[cfg(test)]
+pub(crate) fn assert_batches_sorted_eq(expected: &[&str], actual: &[RecordBatch]) {
+    fn sorted_lines(mut lines: Vec<String>) -> Vec<String> {
+        if lines.len() > 3 {
+            let end = lines.len() - 1;
+            lines[2..end].sort_unstable();
+        }
+        lines
+    }
+
+    let actual = crate::arrow::util::pretty::pretty_format_batches(actual)
+        .unwrap()
+        .to_string();
+    let expected = expected.iter().map(|line| (*line).to_owned()).collect();
+    let actual = actual.trim().lines().map(str::to_owned).collect();
+    assert_eq!(sorted_lines(expected), sorted_lines(actual));
+}
+
 use json::PlanBasedJsonHandler;
 use parquet::PlanBasedParquetHandler;
 use storage::PlanBasedStorageHandler;

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -84,7 +84,6 @@ mod tests {
     use tempfile::tempdir;
     use url::Url;
 
-    use super::super::assert_batches_sorted_eq;
     use super::PlanBasedParquetHandler;
     use crate::arrow::array::{Array, Int64Array, RecordBatch};
     use crate::engine::arrow_conversion::TryIntoKernel as _;
@@ -220,18 +219,26 @@ mod tests {
                     .into()
             })
             .collect();
-        assert_batches_sorted_eq(
-            &[
-                "+-------+",
-                "| value |",
-                "+-------+",
-                "| 1     |",
-                "| 2     |",
-                "| 3     |",
-                "| 4     |",
-                "+-------+",
-            ],
-            &batches,
+        let batch_values: Vec<Vec<i64>> = batches
+            .iter()
+            .map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert!(batch_values.iter().all(|values| {
+            !values.is_empty()
+                && (values.iter().all(|value| *value <= 2)
+                    || values.iter().all(|value| *value >= 3))
+        }));
+        assert_eq!(
+            batch_values.into_iter().flatten().collect::<Vec<_>>(),
+            vec![3, 4, 1, 2]
         );
     }
 

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -84,6 +84,7 @@ mod tests {
     use tempfile::tempdir;
     use url::Url;
 
+    use super::super::assert_ordered_file_batches;
     use super::PlanBasedParquetHandler;
     use crate::arrow::array::{Array, Int64Array, RecordBatch};
     use crate::engine::arrow_conversion::TryIntoKernel as _;
@@ -231,15 +232,7 @@ mod tests {
                     .to_vec()
             })
             .collect();
-        assert!(batch_values.iter().all(|values| {
-            !values.is_empty()
-                && (values.iter().all(|value| *value <= 2)
-                    || values.iter().all(|value| *value >= 3))
-        }));
-        assert_eq!(
-            batch_values.into_iter().flatten().collect::<Vec<_>>(),
-            vec![3, 4, 1, 2]
-        );
+        assert_ordered_file_batches(batch_values);
     }
 
     /// No files -> an absent plan -> a zero-row result (no rows, no error).

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -84,6 +84,7 @@ mod tests {
     use tempfile::tempdir;
     use url::Url;
 
+    use super::super::assert_batches_sorted_eq;
     use super::PlanBasedParquetHandler;
     use crate::arrow::array::{Array, Int64Array, RecordBatch};
     use crate::engine::arrow_conversion::TryIntoKernel as _;
@@ -189,6 +190,48 @@ mod tests {
                 .unwrap()
                 .values(),
             &[10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn test_read_parquet_files_preserves_input_file_order() {
+        let temp_dir = tempdir().unwrap();
+        let first_batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![1, 2])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let second_batch = RecordBatch::try_from_iter(vec![(
+            "value",
+            Arc::new(Int64Array::from(vec![3, 4])) as Arc<dyn Array>,
+        )])
+        .unwrap();
+        let (first, schema) =
+            make_test_parquet_file(&temp_dir.path().join("first.parquet"), &first_batch);
+        let (second, _) =
+            make_test_parquet_file(&temp_dir.path().join("second.parquet"), &second_batch);
+
+        let batches: Vec<RecordBatch> = make_handler()
+            .read_parquet_files(&[second, first], schema, None)
+            .unwrap()
+            .map(|result| {
+                ArrowEngineData::try_from_engine_data(result.unwrap())
+                    .unwrap()
+                    .into()
+            })
+            .collect();
+        assert_batches_sorted_eq(
+            &[
+                "+-------+",
+                "| value |",
+                "+-------+",
+                "| 1     |",
+                "| 2     |",
+                "| 3     |",
+                "| 4     |",
+                "+-------+",
+            ],
+            &batches,
         );
     }
 

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -44,7 +44,8 @@ impl ParquetHandler for PlanBasedParquetHandler {
     ) -> DeltaResult<FileDataReadResultIterator> {
         // TODO: `_predicate` is dropped. Re-apply it as a Filter node over the scan; the
         // single-node executor can then match the filter -> scan shape.
-        let query = PlanBuilder::scan_parquet(files.to_vec(), &[], physical_schema)?.build()?;
+        let query =
+            PlanBuilder::scan_parquet_ordered(files.to_vec(), &[], physical_schema)?.build()?;
         self.executor
             .execute_op(Operation::QueryPlan(query))?
             .into_data()

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -152,6 +152,7 @@ impl SyncPlanExecutor {
         results: &[Vec<RecordBatch>],
     ) -> DeltaResult<Vec<RecordBatch>> {
         let PlanNode { op, inputs } = node;
+        // `eval_scan` preserves scan order by default, so `ordered_scan` is intentionally ignored.
         match op {
             Operator::ScanJson(ScanJson {
                 files,

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -157,11 +157,13 @@ impl SyncPlanExecutor {
                 files,
                 file_constant_columns,
                 schema,
+                ordered_scan: _,
             }) => self.eval_scan(FileType::Json, files, file_constant_columns, schema),
             Operator::ScanParquet(ScanParquet {
                 files,
                 file_constant_columns,
                 schema,
+                ordered_scan: _,
             }) => self.eval_scan(FileType::Parquet, files, file_constant_columns, schema),
             Operator::Values(values) => Ok(vec![values_to_record_batch(values)?]),
             Operator::UnionAll(_) => Ok(Vec::from_iter(

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -118,7 +118,31 @@ impl PlanBuilder {
         file_constant_columns: &[&str],
         schema: impl Into<SchemaRef>,
     ) -> DeltaResult<Self> {
-        Self::scan_source(FileType::Parquet, files, file_constant_columns, schema)
+        Self::scan_source(
+            FileType::Parquet,
+            files,
+            file_constant_columns,
+            schema,
+            false,
+        )
+    }
+
+    /// An ordered Parquet scan source over `files` producing rows matching `schema`.
+    ///
+    /// The resulting scan preserves the input file order, row order within each file, and file
+    /// boundaries in its output batches.
+    pub fn scan_parquet_ordered(
+        files: impl IntoIterator<Item = impl Into<ScanFile>>,
+        file_constant_columns: &[&str],
+        schema: impl Into<SchemaRef>,
+    ) -> DeltaResult<Self> {
+        Self::scan_source(
+            FileType::Parquet,
+            files,
+            file_constant_columns,
+            schema,
+            true,
+        )
     }
 
     /// A newline-delimited JSON scan source over `files` producing rows matching `schema`. See
@@ -128,7 +152,20 @@ impl PlanBuilder {
         file_constant_columns: &[&str],
         schema: impl Into<SchemaRef>,
     ) -> DeltaResult<Self> {
-        Self::scan_source(FileType::Json, files, file_constant_columns, schema)
+        Self::scan_source(FileType::Json, files, file_constant_columns, schema, false)
+    }
+
+    /// An ordered newline-delimited JSON scan source over `files` producing rows matching
+    /// `schema`.
+    ///
+    /// The resulting scan preserves the input file order, row order within each file, and file
+    /// boundaries in its output batches.
+    pub fn scan_json_ordered(
+        files: impl IntoIterator<Item = impl Into<ScanFile>>,
+        file_constant_columns: &[&str],
+        schema: impl Into<SchemaRef>,
+    ) -> DeltaResult<Self> {
+        Self::scan_source(FileType::Json, files, file_constant_columns, schema, true)
     }
 
     /// Shared body of [`Self::scan_parquet`] / [`Self::scan_json`]. Normalizes and validates the
@@ -139,6 +176,7 @@ impl PlanBuilder {
         files: impl IntoIterator<Item = impl Into<ScanFile>>,
         file_constant_columns: &[&str],
         schema: impl Into<SchemaRef>,
+        ordered_scan: bool,
     ) -> DeltaResult<Self> {
         let schema = schema.into();
         let files = Vec::from_iter(files.into_iter().map(Into::into));
@@ -164,11 +202,13 @@ impl PlanBuilder {
                 files,
                 file_constant_columns,
                 schema: Arc::clone(&schema),
+                ordered_scan,
             }),
             FileType::Json => Operator::from(ScanJson {
                 files,
                 file_constant_columns,
                 schema: Arc::clone(&schema),
+                ordered_scan,
             }),
         };
         Ok(Self::present(schema, op, vec![]))

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -715,6 +715,25 @@ mod tests {
         assert_plan(src, &[(&[], "scan_parquet")]);
     }
 
+    #[test]
+    fn ordered_scan_sources_set_ordered_flag() -> DeltaResult<()> {
+        let parquet =
+            PlanBuilder::scan_parquet_ordered([test_file("file:///a.parquet")], &[], id_schema())?
+                .build()?;
+        let json = PlanBuilder::scan_json_ordered([test_file("file:///a.json")], &[], id_schema())?
+            .build()?;
+
+        let Operator::ScanParquet(parquet) = &parquet.nodes[0].op else {
+            panic!("expected ScanParquet");
+        };
+        let Operator::ScanJson(json) = &json.nodes[0].op else {
+            panic!("expected ScanJson");
+        };
+        assert!(parquet.ordered_scan);
+        assert!(json.ordered_scan);
+        Ok(())
+    }
+
     /// `{ id, part }`, with `part` used as a file-constant column.
     fn part_schema() -> SchemaRef {
         Arc::new(StructType::new_unchecked([

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -716,21 +716,39 @@ mod tests {
     }
 
     #[test]
-    fn ordered_scan_sources_set_ordered_flag() -> DeltaResult<()> {
-        let parquet =
-            PlanBuilder::scan_parquet_ordered([test_file("file:///a.parquet")], &[], id_schema())?
-                .build()?;
-        let json = PlanBuilder::scan_json_ordered([test_file("file:///a.json")], &[], id_schema())?
-            .build()?;
+    fn scan_sources_set_ordered_flag() -> DeltaResult<()> {
+        let scans = [
+            (
+                PlanBuilder::scan_parquet([test_file("file:///a.parquet")], &[], id_schema())?,
+                false,
+            ),
+            (
+                PlanBuilder::scan_json([test_file("file:///a.json")], &[], id_schema())?,
+                false,
+            ),
+            (
+                PlanBuilder::scan_parquet_ordered(
+                    [test_file("file:///a.parquet")],
+                    &[],
+                    id_schema(),
+                )?,
+                true,
+            ),
+            (
+                PlanBuilder::scan_json_ordered([test_file("file:///a.json")], &[], id_schema())?,
+                true,
+            ),
+        ];
 
-        let Operator::ScanParquet(parquet) = &parquet.nodes[0].op else {
-            panic!("expected ScanParquet");
-        };
-        let Operator::ScanJson(json) = &json.nodes[0].op else {
-            panic!("expected ScanJson");
-        };
-        assert!(parquet.ordered_scan);
-        assert!(json.ordered_scan);
+        for (scan, expected) in scans {
+            let plan = scan.build()?;
+            let actual = match &plan.nodes[0].op {
+                Operator::ScanParquet(scan) => scan.ordered_scan,
+                Operator::ScanJson(scan) => scan.ordered_scan,
+                op => panic!("expected scan, got {op}"),
+            };
+            assert_eq!(actual, expected);
+        }
         Ok(())
     }
 

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -106,13 +106,14 @@ impl PlanBuilder {
         }
     }
 
-    /// A Parquet scan source over `files` producing rows matching `schema`.
+    /// An unordered Parquet scan source over `files` producing rows matching `schema`.
     ///
     /// `file_constant_columns` names the per-file-constant output columns (see [`ScanParquet`]);
     /// pass `&[]` when there are none. An empty `files` yields the absent relation.
     ///
     /// Produces an error when any file's constant count differs from `file_constant_columns`'s
     /// length, or a `file_constant_columns` entry is absent from `schema`.
+    /// Use [`Self::scan_parquet_ordered`] when ordering and file boundaries are required.
     pub fn scan_parquet(
         files: impl IntoIterator<Item = impl Into<ScanFile>>,
         file_constant_columns: &[&str],
@@ -130,7 +131,8 @@ impl PlanBuilder {
     /// An ordered Parquet scan source over `files` producing rows matching `schema`.
     ///
     /// The resulting scan preserves the input file order, row order within each file, and file
-    /// boundaries in its output batches.
+    /// boundaries in its output batches. Empty-input behavior and validation errors match
+    /// [`Self::scan_parquet`].
     pub fn scan_parquet_ordered(
         files: impl IntoIterator<Item = impl Into<ScanFile>>,
         file_constant_columns: &[&str],
@@ -145,8 +147,9 @@ impl PlanBuilder {
         )
     }
 
-    /// A newline-delimited JSON scan source over `files` producing rows matching `schema`. See
-    /// [`ScanJson`]. Exhibits same behaviour as [`Self::scan_parquet`].
+    /// An unordered newline-delimited JSON scan source over `files` producing rows matching
+    /// `schema`. See [`ScanJson`]. Exhibits the same behavior as [`Self::scan_parquet`]. Use
+    /// [`Self::scan_json_ordered`] when ordering and file boundaries are required.
     pub fn scan_json(
         files: impl IntoIterator<Item = impl Into<ScanFile>>,
         file_constant_columns: &[&str],
@@ -159,7 +162,8 @@ impl PlanBuilder {
     /// `schema`.
     ///
     /// The resulting scan preserves the input file order, row order within each file, and file
-    /// boundaries in its output batches.
+    /// boundaries in its output batches. Empty-input behavior and validation errors match
+    /// [`Self::scan_json`].
     pub fn scan_json_ordered(
         files: impl IntoIterator<Item = impl Into<ScanFile>>,
         file_constant_columns: &[&str],

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -25,6 +25,10 @@ use crate::{DeltaResult, Error, FileMeta};
 /// An operator that reshapes its rows (a source, projection, aggregation, or file scan) carries a
 /// caller-declared `schema` field holding its output schema. The rest emit rows they were given, so
 /// they inherit an input's schema; each payload's docs name which input.
+///
+/// Operators downstream of an ordered scan must preserve its row-order and file-boundary
+/// guarantees through the plan result. Errors are outside the ordering guarantee and may be
+/// returned eagerly.
 #[derive(Debug, Clone, Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum Operator {
@@ -103,8 +107,9 @@ impl From<FileMeta> for ScanFile {
 ///
 /// When `ordered_scan` is false, output row order is unspecified: the engine is free to read
 /// `files` in any order, in parallel, and to interleave rows from different files. When it is true,
-/// output follows the input file order, preserves row order within each file, and does not merge
-/// batches across file boundaries.
+/// output follows the input file order and preserves row order within each file. A file may produce
+/// zero, one, or multiple batches, and each batch contains rows from at most one file. Downstream
+/// operators must preserve these guarantees. Errors may be returned eagerly.
 ///
 /// # Column resolution
 ///
@@ -199,8 +204,9 @@ pub struct ScanParquet {
 /// non-nullable fields.
 ///
 /// When `ordered_scan` is false, output row order is unspecified. When it is true, output follows
-/// the input file order, preserves row order within each file, and does not merge batches across
-/// file boundaries.
+/// the input file order and preserves row order within each file. A file may produce zero, one, or
+/// multiple batches, and each batch contains rows from at most one file. Downstream operators must
+/// preserve these guarantees. Errors may be returned eagerly.
 ///
 /// # File-constant columns
 ///

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -101,8 +101,10 @@ impl From<FileMeta> for ScanFile {
 /// Reads Parquet `files` into row batches matching `schema`. The engine returns exactly the
 /// columns named by `schema`, in schema order.
 ///
-/// Output row order is unspecified: the engine is free to read `files` in any order, in
-/// parallel, and to interleave rows from different files.
+/// When `ordered_scan` is false, output row order is unspecified: the engine is free to read
+/// `files` in any order, in parallel, and to interleave rows from different files. When it is true,
+/// output follows the input file order, preserves row order within each file, and does not merge
+/// batches across file boundaries.
 ///
 /// # Column resolution
 ///
@@ -184,6 +186,8 @@ pub struct ScanParquet {
     pub files: Vec<ScanFile>,
     pub file_constant_columns: Vec<String>,
     pub schema: SchemaRef,
+    /// Whether output must preserve input file order and row order within each file.
+    pub ordered_scan: bool,
 }
 
 /// Reads newline-delimited JSON `files` (one JSON object per line) into row batches matching
@@ -194,8 +198,9 @@ pub struct ScanParquet {
 /// each JSON line. Missing JSON fields produce NULL for nullable `schema` fields and an error for
 /// non-nullable fields.
 ///
-/// Output row order is unspecified: the engine is free to read `files` in any order, in
-/// parallel, and to interleave rows from different files.
+/// When `ordered_scan` is false, output row order is unspecified. When it is true, output follows
+/// the input file order, preserves row order within each file, and does not merge batches across
+/// file boundaries.
 ///
 /// # File-constant columns
 ///
@@ -209,6 +214,8 @@ pub struct ScanJson {
     pub files: Vec<ScanFile>,
     pub file_constant_columns: Vec<String>,
     pub schema: SchemaRef,
+    /// Whether output must preserve input file order and row order within each file.
+    pub ordered_scan: bool,
 }
 
 /// Inline literal rows. Each `rows[i]` carries one [`Scalar`] per **top-level** field

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -171,6 +171,7 @@ impl From<&ScanParquet> for proto_plan::ScanParquetNode {
             files: convert_vec(&node.files),
             file_constant_columns: node.file_constant_columns.clone(),
             schema: Some(node.schema.as_ref().into()),
+            ordered_scan: node.ordered_scan,
         }
     }
 }
@@ -181,6 +182,7 @@ impl From<&ScanJson> for proto_plan::ScanJsonNode {
             files: convert_vec(&node.files),
             file_constant_columns: node.file_constant_columns.clone(),
             schema: Some(node.schema.as_ref().into()),
+            ordered_scan: node.ordered_scan,
         }
     }
 }
@@ -1232,6 +1234,7 @@ mod tests {
                         files: vec![ScanFile::new(sample_file_meta())],
                         file_constant_columns: vec![],
                         schema: schema.clone(),
+                        ordered_scan: false,
                     }),
                     inputs: vec![],
                 },
@@ -1288,6 +1291,7 @@ mod tests {
             files: vec![],
             file_constant_columns: vec![],
             schema: sample_schema(),
+            ordered_scan: false,
         }),
         "scan_parquet"
     )]
@@ -1296,6 +1300,7 @@ mod tests {
             files: vec![],
             file_constant_columns: vec![],
             schema: sample_schema(),
+            ordered_scan: false,
         }),
         "scan_json"
     )]
@@ -1367,6 +1372,7 @@ mod tests {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
+            ordered_scan: false,
         };
         let proto = proto_plan::ScanParquetNode::from(&node);
         assert_eq!(proto.files.len(), 1);
@@ -1380,6 +1386,7 @@ mod tests {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
+            ordered_scan: false,
         };
         let proto = proto_plan::ScanJsonNode::from(&node);
         assert_eq!(proto.files.len(), 1);

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -1372,12 +1372,13 @@ mod tests {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
-            ordered_scan: false,
+            ordered_scan: true,
         };
         let proto = proto_plan::ScanParquetNode::from(&node);
         assert_eq!(proto.files.len(), 1);
         assert_eq!(proto.file_constant_columns.len(), 1);
         assert!(proto.schema.is_some());
+        assert!(proto.ordered_scan);
     }
 
     #[test]
@@ -1386,12 +1387,13 @@ mod tests {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
-            ordered_scan: false,
+            ordered_scan: true,
         };
         let proto = proto_plan::ScanJsonNode::from(&node);
         assert_eq!(proto.files.len(), 1);
         assert_eq!(proto.file_constant_columns.len(), 1);
         assert!(proto.schema.is_some());
+        assert!(proto.ordered_scan);
     }
 
     #[test]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -1366,34 +1366,38 @@ mod tests {
         assert_eq!(proto.file_constants.len(), 2);
     }
 
-    #[test]
-    fn from_scan_parquet() {
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn from_scan_parquet(#[case] ordered_scan: bool) {
         let node = ScanParquet {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
-            ordered_scan: true,
+            ordered_scan,
         };
         let proto = proto_plan::ScanParquetNode::from(&node);
         assert_eq!(proto.files.len(), 1);
         assert_eq!(proto.file_constant_columns.len(), 1);
         assert!(proto.schema.is_some());
-        assert!(proto.ordered_scan);
+        assert_eq!(proto.ordered_scan, ordered_scan);
     }
 
-    #[test]
-    fn from_scan_json() {
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn from_scan_json(#[case] ordered_scan: bool) {
         let node = ScanJson {
             files: vec![ScanFile::new(sample_file_meta())],
             file_constant_columns: vec!["c".to_string()],
             schema: sample_schema(),
-            ordered_scan: true,
+            ordered_scan,
         };
         let proto = proto_plan::ScanJsonNode::from(&node);
         assert_eq!(proto.files.len(), 1);
         assert_eq!(proto.file_constant_columns.len(), 1);
         assert!(proto.schema.is_some());
-        assert!(proto.ordered_scan);
+        assert_eq!(proto.ordered_scan, ordered_scan);
     }
 
     #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds an ordered-scan option to declarative Parquet and JSON scan nodes while keeping existing scan builders unordered by default. Ordered scans preserve input-file order, row order within each file, and file boundaries through downstream operators.

Plan-based JSON and Parquet handlers now request ordered execution to preserve their existing output contract. The protobuf representation, synchronous executor, builder APIs, documentation, and ordering tests are updated accordingly.

### This PR affects the following public APIs

Adds ordered Parquet and JSON builder methods and exposes the ordering choice on their declarative scan nodes.

## How was this change tested?

- Targeted Delta Kernel unit tests for ordered builders, handlers, execution, and protobuf conversion
- `cargo clippy -p delta_kernel --lib --all-features -- -D warnings`
- `cargo doc -p delta_kernel --all-features --no-deps`
- `cargo +nightly fmt --check`
