### PR TITLE
fix: remove version from kernel in datafusion executor

### DIFF
--- a/datafusion-executor/Cargo.toml
+++ b/datafusion-executor/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.88"
 [workspace]
 
 [dependencies]
-delta_kernel = { path = "../kernel", version = "0.26.0", default-features = false, features = [
+delta_kernel = { path = "../kernel", default-features = false, features = [
   "declarative-plans",
   "arrow-58",
   "default-engine-base",


### PR DESCRIPTION
## What changes are proposed in this pull request?
Removes version in kernel from datafusion executor to avoid having to bump version every new kernel vendor.

## How was this change tested?
CI passes