### PR TITLE
fix: supurious delta acceptance failure due to network conn issues

### DIFF
--- a/acceptance/build.rs
+++ b/acceptance/build.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use sha2::{Digest, Sha256};
@@ -15,6 +16,7 @@ const DAT_EXISTS_FILE_CHECK: &str = "tests/dat/.done";
 const DAT_OUTPUT_FOLDER: &str = "tests/dat";
 const DAT_VERSION: &str = "0.0.3";
 const ACCEPTANCE_WORKLOADS_VERSION: &str = "0.0.4";
+const DOWNLOAD_ATTEMPTS: usize = 3;
 
 // SHA-256 of the release assets. Each download is otherwise trusted purely on TLS; verifying these
 // digests before extraction stops a tampered or MITM'd tarball from being unpacked to disk. Update
@@ -54,18 +56,34 @@ fn download_dat_files() -> Vec<u8> {
 }
 
 fn download_tarball(url: &str, expected_checksum: &str) -> Vec<u8> {
-    let response = build_agent().get(url).call().unwrap();
+    let agent = build_agent();
+    let mut attempt = 1;
 
+    loop {
+        match download(&agent, url) {
+            Ok(tarball_data) => {
+                verify_checksum(&tarball_data, expected_checksum);
+                return tarball_data;
+            }
+            Err(error) if attempt < DOWNLOAD_ATTEMPTS => {
+                eprintln!("Download attempt {attempt} failed: {error}. Retrying...");
+                std::thread::sleep(Duration::from_secs(1));
+                attempt += 1;
+            }
+            Err(error) => panic!("Failed to download {url}: {error}"),
+        }
+    }
+}
+
+fn download(agent: &Agent, url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let response = agent.get(url).call()?;
     let mut tarball_data: Vec<u8> = Vec::new();
     response
         .into_body()
         .as_reader()
-        .read_to_end(&mut tarball_data)
-        .unwrap();
+        .read_to_end(&mut tarball_data)?;
 
-    verify_checksum(&tarball_data, expected_checksum);
-
-    tarball_data
+    Ok(tarball_data)
 }
 
 /// Panic unless the SHA-256 of `data` equals `expected` (lowercase hex). Called before any

--- a/benchmarks/build.rs
+++ b/benchmarks/build.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use sha2::{Digest, Sha256};
@@ -14,6 +15,7 @@ use ureq::{Agent, Proxy};
 const VERSION: &str = "0.0.5-preview"; // release tag
 const WORKLOADS_VERSION: &str = "0.0.5"; // version in filename
 const WORKLOAD_CHECKSUM: &str = "ddac5359eca42e7ec65b4a7cfc6f4bc1d629d9c204ba714ec15e4ae830c37ba2"; // benchmarks checksum
+const DOWNLOAD_ATTEMPTS: usize = 3;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -39,16 +41,31 @@ fn download_workloads() -> Vec<u8> {
 }
 
 fn download_tarball(url: &str, expected_checksum: &str) -> Vec<u8> {
-    let response = build_agent().get(url).call().unwrap();
+    let agent = build_agent();
+    let mut attempt = 1;
 
+    loop {
+        match download(&agent, url) {
+            Ok(data) => {
+                verify_checksum(&data, expected_checksum);
+                return data;
+            }
+            Err(error) if attempt < DOWNLOAD_ATTEMPTS => {
+                eprintln!("Download attempt {attempt} failed: {error}. Retrying...");
+                std::thread::sleep(Duration::from_secs(1));
+                attempt += 1;
+            }
+            Err(error) => panic!("Failed to download {url}: {error}"),
+        }
+    }
+}
+
+fn download(agent: &Agent, url: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let response = agent.get(url).call()?;
     let mut data: Vec<u8> = Vec::new();
-    response
-        .into_body()
-        .as_reader()
-        .read_to_end(&mut data)
-        .unwrap();
-    verify_checksum(&data, expected_checksum);
-    data
+    response.into_body().as_reader().read_to_end(&mut data)?;
+
+    Ok(data)
 }
 
 /// Panic unless the SHA-256 of `data` equals `expected` (lowercase hex). Called before any


### PR DESCRIPTION
## What changes are proposed in this pull request?

<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

Super quick one. Seems like there are spurious network issues causing `PeerDisconnected` failures on certain CI runs. This seems like Github Runner instability, so applied some simple retries to both fetches. ureq doesn't expose any native primitives to perform automated retries.

Example: https://github.com/delta-io/delta-kernel-rs/actions/runs/31638152264/job/94253598747?pr=3105
Build failures (superset of them): https://github.com/delta-io/delta-kernel-rs/actions?query=is%3Afailure+workflow%3Abuild



## How was this change tested?

Cycled CI 6 times and observed no failures. I was previously observing failures in ~1/3 of the CI runs. 
