### PR TITLE
feat!: pass column field parts as a structured array over the FFI

### DIFF
--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -114,7 +114,7 @@ uintptr_t convert_engine_to_kernel_binop(
       state, binop->exprs.list[0]);
   uintptr_t right = convert_engine_to_kernel_expression_item(
       state, binop->exprs.list[1]);
-  
+
   switch (binop->op) {
     case Add:
       return visit_expression_plus(state, left, right);
@@ -154,10 +154,10 @@ const void* convert_engine_to_kernel_next_fn(void* data) {
     // Return NULL to signal end of iteration
     return NULL;
   }
-  
+
   ExpressionItem item = iter_state->list->list[iter_state->current_index];
   iter_state->current_index++;
-  
+
   uintptr_t result = convert_engine_to_kernel_expression_item(iter_state->state, item);
   // Return the result as a pointer (cast uintptr_t to void*)
   return (const void*)result;
@@ -171,12 +171,12 @@ uintptr_t convert_engine_to_kernel_variadic(
     .current_index = 0,
     .state = state
   };
-  
+
   EngineIterator iterator = {
     .data = &iter_state,
     .get_next = convert_engine_to_kernel_next_fn
   };
-  
+
   switch (variadic->op) {
     case And:
       return visit_predicate_and(state, &iterator);
@@ -198,7 +198,7 @@ uintptr_t convert_engine_to_kernel_unary(
   assert(unary->sub_expr.len == 1);
   uintptr_t inner = convert_engine_to_kernel_expression_item(
       state, unary->sub_expr.list[0]);
-  
+
   switch (unary->type) {
     case Not:
       return visit_predicate_not(state, inner);
@@ -225,8 +225,6 @@ uintptr_t convert_engine_to_kernel_expression_item(
       return convert_engine_to_kernel_unary(state, (struct Unary*)item.ref);
     case Column: {
       struct Column* column = (struct Column*)item.ref;
-      // The kernel copies the parts out before visit_expression_column returns, so this
-      // array only needs to outlive the call.
       KernelStringSlice* parts = malloc(sizeof(KernelStringSlice) * column->len);
       for (size_t i = 0; i < column->len; i++) {
         parts[i].ptr = column->parts[i];
@@ -288,7 +286,7 @@ static inline uintptr_t expression_item_list_visitor(
  * Convert an engine expression to a kernel expression using the visitor
  * pattern. Returns a SharedExpression handle that must be freed with
  * free_kernel_expression.
- * 
+ *
  * This function uses the EngineExpression visitor pattern, completely
  * hiding KernelExpressionVisitorState management from the caller.
  */
@@ -298,10 +296,10 @@ SharedExpression* convert_engine_to_kernel_expression(
     .expression = (void*)&expr_list,
     .visitor = expression_item_list_visitor
   };
-  
+
   ExternResultHandleSharedExpression result = visit_engine_expression(
       &engine_expr, allocate_error);
-  
+
   if (result.tag == OkHandleSharedExpression) {
     return result.ok;
   } else {
@@ -325,7 +323,7 @@ static inline uintptr_t predicate_item_list_visitor(
  * Convert an engine predicate to a kernel predicate using the visitor
  * pattern. Returns a SharedPredicate handle that must be freed with
  * free_kernel_predicate.
- * 
+ *
  * This function uses the EnginePredicate visitor pattern, completely
  * hiding KernelExpressionVisitorState management from the caller.
  */
@@ -335,10 +333,10 @@ SharedPredicate* convert_engine_to_kernel_predicate(
     .predicate = (void*)&pred_list,
     .visitor = predicate_item_list_visitor
   };
-  
+
   ExternResultHandleSharedPredicate result = visit_engine_predicate(
       &engine_pred, allocate_error);
-  
+
   if (result.tag == OkHandleSharedPredicate) {
     return result.ok;
   } else {
@@ -348,4 +346,3 @@ SharedPredicate* convert_engine_to_kernel_predicate(
     abort();
   }
 }
-

--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -227,8 +227,8 @@ uintptr_t convert_engine_to_kernel_expression_item(
       struct Column* column = (struct Column*)item.ref;
       KernelStringSlice* parts = malloc(sizeof(KernelStringSlice) * column->len);
       for (size_t i = 0; i < column->len; i++) {
-        parts[i].ptr = column->parts[i];
-        parts[i].len = strlen(column->parts[i]);
+        parts[i].ptr = column->parts[i].ptr;
+        parts[i].len = column->parts[i].len;
       }
       ExternResultusize result = visit_expression_column(
           state, parts, column->len, allocate_error);

--- a/ffi/examples/visit-expression/engine_to_kernel_expression.h
+++ b/ffi/examples/visit-expression/engine_to_kernel_expression.h
@@ -224,13 +224,17 @@ uintptr_t convert_engine_to_kernel_expression_item(
     case Unary:
       return convert_engine_to_kernel_unary(state, (struct Unary*)item.ref);
     case Column: {
-      char* column_name = (char*)item.ref;
-      KernelStringSlice str_slice = {
-        .ptr = column_name,
-        .len = strlen(column_name)
-      };
+      struct Column* column = (struct Column*)item.ref;
+      // The kernel copies the parts out before visit_expression_column returns, so this
+      // array only needs to outlive the call.
+      KernelStringSlice* parts = malloc(sizeof(KernelStringSlice) * column->len);
+      for (size_t i = 0; i < column->len; i++) {
+        parts[i].ptr = column->parts[i];
+        parts[i].len = strlen(column->parts[i]);
+      }
       ExternResultusize result = visit_expression_column(
-          state, str_slice, allocate_error);
+          state, parts, column->len, allocate_error);
+      free(parts);
       if (result.tag == Errusize) {
         print_error("visit_expression_column failed", (Error*)result.err);
         free_error((Error*)result.err);

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -119,6 +119,12 @@ struct OpaquePredicate {
 struct Unknown {
   char* name;
 };
+// A column is a list of field-name parts. Keeping the parts structured (rather than a single
+// dotted string) lets a field name that itself contains a period survive the FFI round-trip.
+struct Column {
+  char** parts;
+  size_t len;
+};
 struct MapToStructExpr {
   ExpressionItemList child_expr;
 };
@@ -469,8 +475,26 @@ DEFINE_UNARY(visit_expr_not, Not)
  * Column Expression
  ************************************************************/
 void visit_expr_column(void* data, uintptr_t sibling_id_list, KernelStringSlice col_name) {
-  char* column_name = allocate_string(col_name);
-  put_expr_item(data, sibling_id_list, column_name, Column);
+  // The outbound (kernel -> engine) callback delivers the column as a single dotted string, so
+  // the example stores it as a one-part column.
+  struct Column* column = malloc(sizeof(struct Column));
+  column->len = 1;
+  column->parts = malloc(sizeof(char*));
+  column->parts[0] = allocate_string(col_name);
+  put_expr_item(data, sibling_id_list, column, Column);
+}
+
+struct Column* make_column(const char* const* parts, size_t len) {
+  struct Column* column = malloc(sizeof(struct Column));
+  column->len = len;
+  column->parts = malloc(sizeof(char*) * len);
+  for (size_t i = 0; i < len; i++) {
+    size_t part_len = strlen(parts[i]);
+    char* copy = malloc(part_len + 1);
+    memcpy(copy, parts[i], part_len + 1);
+    column->parts[i] = copy;
+  }
+  return column;
 }
 
 /*************************************************************
@@ -699,7 +723,12 @@ void free_expression_item(ExpressionItem ref) {
       break;
     }
     case Column: {
-      free(ref.ref);
+      struct Column* column = ref.ref;
+      for (size_t i = 0; i < column->len; i++) {
+        free(column->parts[i]);
+      }
+      free(column->parts);
+      free(column);
       break;
     }
     case MapToStruct: {

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -121,8 +121,12 @@ struct Unknown {
 };
 // A column is a list of field-name parts. Keeping the parts structured (rather than a single
 // dotted string) lets a field name that itself contains a period survive the FFI round-trip.
+struct ColumnPart {
+  char* ptr;
+  size_t len;
+};
 struct Column {
-  char** parts;
+  struct ColumnPart* parts;
   size_t len;
 };
 struct MapToStructExpr {
@@ -474,25 +478,29 @@ DEFINE_UNARY(visit_expr_not, Not)
 /*************************************************************
  * Column Expression
  ************************************************************/
-void visit_expr_column(void* data, uintptr_t sibling_id_list, KernelStringSlice col_name) {
-  // The outbound (kernel -> engine) callback delivers the column as a single dotted string, so
-  // the example stores it as a one-part column.
+void visit_expr_column(void* data,
+                       uintptr_t sibling_id_list,
+                       const KernelStringSlice* parts,
+                       uintptr_t parts_len) {
   struct Column* column = malloc(sizeof(struct Column));
-  column->len = 1;
-  column->parts = malloc(sizeof(char*));
-  column->parts[0] = allocate_string(col_name);
+  column->len = parts_len;
+  column->parts = malloc(sizeof(struct ColumnPart) * parts_len);
+  for (size_t i = 0; i < parts_len; i++) {
+    column->parts[i].ptr = allocate_string(parts[i]);
+    column->parts[i].len = parts[i].len;
+  }
   put_expr_item(data, sibling_id_list, column, Column);
 }
 
 struct Column* make_column(const char* const* parts, size_t len) {
   struct Column* column = malloc(sizeof(struct Column));
   column->len = len;
-  column->parts = malloc(sizeof(char*) * len);
+  column->parts = malloc(sizeof(struct ColumnPart) * len);
   for (size_t i = 0; i < len; i++) {
     size_t part_len = strlen(parts[i]);
     char* copy = malloc(part_len + 1);
     memcpy(copy, parts[i], part_len + 1);
-    column->parts[i] = copy;
+    column->parts[i] = (struct ColumnPart){ .ptr = copy, .len = part_len };
   }
   return column;
 }
@@ -725,7 +733,7 @@ void free_expression_item(ExpressionItem ref) {
     case Column: {
       struct Column* column = ref.ref;
       for (size_t i = 0; i < column->len; i++) {
-        free(column->parts[i]);
+        free(column->parts[i].ptr);
       }
       free(column->parts);
       free(column);

--- a/ffi/examples/visit-expression/expression.h
+++ b/ffi/examples/visit-expression/expression.h
@@ -492,19 +492,6 @@ void visit_expr_column(void* data,
   put_expr_item(data, sibling_id_list, column, Column);
 }
 
-struct Column* make_column(const char* const* parts, size_t len) {
-  struct Column* column = malloc(sizeof(struct Column));
-  column->len = len;
-  column->parts = malloc(sizeof(struct ColumnPart) * len);
-  for (size_t i = 0; i < len; i++) {
-    size_t part_len = strlen(parts[i]);
-    char* copy = malloc(part_len + 1);
-    memcpy(copy, parts[i], part_len + 1);
-    column->parts[i] = (struct ColumnPart){ .ptr = copy, .len = part_len };
-  }
-  return column;
-}
-
 /*************************************************************
  * EngineExpressionVisitor Implementation
  ************************************************************/

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -284,8 +284,12 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       break;
     }
     case Column: {
-      char* column_name = ref.ref;
-      printf("Column(%s)\n", column_name);
+      struct Column* column = ref.ref;
+      printf("Column(");
+      for (size_t i = 0; i < column->len; i++) {
+        printf("%s%s", i > 0 ? ", " : "", column->parts[i]);
+      }
+      printf(")\n");
       break;
     }
     case MapToStruct: {

--- a/ffi/examples/visit-expression/expression_print.h
+++ b/ffi/examples/visit-expression/expression_print.h
@@ -287,7 +287,8 @@ void print_tree_helper(ExpressionItem ref, int depth) {
       struct Column* column = ref.ref;
       printf("Column(");
       for (size_t i = 0; i < column->len; i++) {
-        printf("%s%s", i > 0 ? ", " : "", column->parts[i]);
+        printf("%s", i > 0 ? ", " : "");
+        fwrite(column->parts[i].ptr, sizeof(char), column->parts[i].len, stdout);
       }
       printf(")\n");
       break;

--- a/ffi/examples/visit-expression/visit_expression.c
+++ b/ffi/examples/visit-expression/visit_expression.c
@@ -77,6 +77,38 @@ bool run_test_case(const TestCase* test) {
   return all_passed;
 }
 
+// Round-trips a multi-part column whose middle field ("b.c") contains a period, checking the
+// period is preserved as a single part. The reconstructed kernel column must match the reference
+// column built directly in Rust.
+bool run_dotted_column_roundtrip_test() {
+  printf("=== Dotted-field Column Round-trip Test ===\n");
+  printf("Builds column [\"a\", \"b.c\", \"d\"] from structured parts and checks the field\n"
+         "containing a period survives as a single part.\n\n");
+
+  const char* parts[] = { "a", "b.c", "d" };
+  struct Column* column = make_column(parts, 3);
+  ExpressionItemList expr_list = { .len = 1, .list = malloc(sizeof(ExpressionItem)) };
+  expr_list.list[0] = (ExpressionItem){ .ref = column, .type = Column };
+
+  print_expression(expr_list);
+
+  SharedExpression* reconstructed = convert_engine_to_kernel_expression(expr_list);
+  SharedExpression* reference = get_testing_dotted_field_column();
+  bool equal = expressions_are_equal(&reconstructed, &reference);
+
+  printf("\n=== Dotted-field Column Round-trip Result ===\n");
+  if (equal) {
+    printf("SUCCESS: dotted field \"b.c\" survived as a single column part!\n");
+  } else {
+    printf("FAILURE: reconstructed column does NOT match [\"a\", \"b.c\", \"d\"]!\n");
+  }
+
+  free_kernel_expression(reconstructed);
+  free_kernel_expression(reference);
+  free_expression_list(expr_list);
+  return equal;
+}
+
 int main() {
   // Define test cases
   // We use an iterator pattern to add tests
@@ -121,6 +153,11 @@ int main() {
       printf("\n");  // Separator between test cases
     }
   }
-  
+
+  printf("\n");
+  if (!run_dotted_column_roundtrip_test()) {
+    all_tests_passed = false;
+  }
+
   return all_tests_passed ? 0 : 1;
 }

--- a/ffi/examples/visit-expression/visit_expression.c
+++ b/ffi/examples/visit-expression/visit_expression.c
@@ -77,18 +77,13 @@ bool run_test_case(const TestCase* test) {
   return all_passed;
 }
 
-// Round-trips a multi-part column whose middle field ("b.c") contains a period, checking the
-// period is preserved as a single part. The reconstructed kernel column must match the reference
-// column built directly in Rust.
+// Round-trips a kernel multi-part column whose middle field ("b.c") contains a period, checking
+// the outbound and inbound visitors both preserve it as a single part.
 bool run_dotted_column_roundtrip_test() {
-  const char* parts[] = { "a", "b.c", "d" };
-  struct Column* column = make_column(parts, 3);
-  ExpressionItemList expr_list = { .len = 1, .list = malloc(sizeof(ExpressionItem)) };
-  expr_list.list[0] = (ExpressionItem){ .ref = column, .type = Column };
-
+  SharedExpression* original = get_testing_dotted_field_column();
+  ExpressionItemList expr_list = construct_expression(original);
   SharedExpression* reconstructed = convert_engine_to_kernel_expression(expr_list);
-  SharedExpression* reference = get_testing_dotted_field_column();
-  bool equal = expressions_are_equal(&reconstructed, &reference);
+  bool equal = expressions_are_equal(&reconstructed, &original);
 
   printf("=== Dotted-field Column Round-trip Test ===\n");
   if (equal) {
@@ -97,8 +92,8 @@ bool run_dotted_column_roundtrip_test() {
     printf("FAILURE: reconstructed column does NOT match [\"a\", \"b.c\", \"d\"]!\n");
   }
 
+  free_kernel_expression(original);
   free_kernel_expression(reconstructed);
-  free_kernel_expression(reference);
   free_expression_list(expr_list);
   return equal;
 }

--- a/ffi/examples/visit-expression/visit_expression.c
+++ b/ffi/examples/visit-expression/visit_expression.c
@@ -81,22 +81,16 @@ bool run_test_case(const TestCase* test) {
 // period is preserved as a single part. The reconstructed kernel column must match the reference
 // column built directly in Rust.
 bool run_dotted_column_roundtrip_test() {
-  printf("=== Dotted-field Column Round-trip Test ===\n");
-  printf("Builds column [\"a\", \"b.c\", \"d\"] from structured parts and checks the field\n"
-         "containing a period survives as a single part.\n\n");
-
   const char* parts[] = { "a", "b.c", "d" };
   struct Column* column = make_column(parts, 3);
   ExpressionItemList expr_list = { .len = 1, .list = malloc(sizeof(ExpressionItem)) };
   expr_list.list[0] = (ExpressionItem){ .ref = column, .type = Column };
 
-  print_expression(expr_list);
-
   SharedExpression* reconstructed = convert_engine_to_kernel_expression(expr_list);
   SharedExpression* reference = get_testing_dotted_field_column();
   bool equal = expressions_are_equal(&reconstructed, &reference);
 
-  printf("\n=== Dotted-field Column Round-trip Result ===\n");
+  printf("=== Dotted-field Column Round-trip Test ===\n");
   if (equal) {
     printf("SUCCESS: dotted field \"b.c\" survived as a single column part!\n");
   } else {

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -31,6 +31,12 @@ type VisitParseJsonFn = extern "C" fn(
     child_list_id: usize,
     output_schema: Handle<SharedSchema>,
 );
+type VisitColumnFn = extern "C" fn(
+    data: *mut c_void,
+    sibling_list_id: usize,
+    parts: *const KernelStringSlice,
+    parts_len: usize,
+);
 
 /// The [`EngineExpressionVisitor`] defines a visitor system to allow engines to build their own
 /// representation of a kernel expression or predicate.
@@ -210,9 +216,11 @@ pub struct EngineExpressionVisitor {
     /// `sibling_list_id`. The element expressions will be in a list identified by
     /// `child_list_id`.
     pub visit_array: VisitVariadicFn,
-    /// Visits the `column` belonging to the list identified by `sibling_list_id`.
-    pub visit_column:
-        extern "C" fn(data: *mut c_void, sibling_list_id: usize, name: KernelStringSlice),
+    /// Visits a `column` belonging to the list identified by `sibling_list_id`.
+    ///
+    /// `parts` contains the ordered field-name parts of the column. Each part is valid only for
+    /// the duration of this callback.
+    pub visit_column: VisitColumnFn,
     /// Visits a `Struct` expression belonging to the list identified by `sibling_list_id`.
     /// The sub-expressions (fields) of the struct are in a list identified by `child_list_id`
     pub visit_struct_expr:
@@ -406,9 +414,18 @@ fn visit_expression_column(
     name: &ColumnName,
     sibling_list_id: usize,
 ) {
-    let name = name.to_string();
-    let name = kernel_string_slice!(name);
-    call!(visitor, visit_column, sibling_list_id, name);
+    let parts: Vec<_> = name
+        .path()
+        .iter()
+        .map(|part| kernel_string_slice!(part))
+        .collect();
+    call!(
+        visitor,
+        visit_column,
+        sibling_list_id,
+        parts.as_ptr(),
+        parts.len()
+    );
 }
 
 fn visit_expression_struct(
@@ -758,11 +775,22 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::TryFromStringSlice;
 
     #[derive(Debug, PartialEq, Eq)]
     enum LiteralEvent {
-        IntervalYearMonth { sibling_list_id: usize, value: i32 },
-        IntervalDayTime { sibling_list_id: usize, value: i64 },
+        IntervalYearMonth {
+            sibling_list_id: usize,
+            value: i32,
+        },
+        IntervalDayTime {
+            sibling_list_id: usize,
+            value: i64,
+        },
+        Column {
+            sibling_list_id: usize,
+            parts: Vec<String>,
+        },
     }
 
     #[derive(Default)]
@@ -802,6 +830,23 @@ mod tests {
         });
     }
 
+    extern "C" fn visit_column(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        parts: *const KernelStringSlice,
+        parts_len: usize,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        let parts = unsafe { std::slice::from_raw_parts(parts, parts_len) }
+            .iter()
+            .map(|part| unsafe { String::try_from_slice(part).unwrap() })
+            .collect();
+        builder.events.push(LiteralEvent::Column {
+            sibling_list_id,
+            parts,
+        });
+    }
+
     macro_rules! ignore_fn {
         ($fn_name:ident $(, $arg_type:ty)*) => {
             extern "C" fn $fn_name(
@@ -828,7 +873,6 @@ mod tests {
     ignore_fn!(ignore_map_literal, usize, usize);
     ignore_fn!(ignore_null, u8, u8, u8);
     ignore_fn!(ignore_parse_json, usize, Handle<SharedSchema>);
-    ignore_fn!(ignore_column, KernelStringSlice);
     ignore_fn!(ignore_struct_patch, usize, usize, usize, usize);
     ignore_fn!(ignore_field_patch, KernelStringSlice, usize, bool, bool);
     ignore_fn!(ignore_opaque_expr, Handle<SharedOpaqueExpressionOp>, usize);
@@ -875,14 +919,32 @@ mod tests {
             visit_divide: ignore_child_list,
             visit_coalesce: ignore_child_list,
             visit_array: ignore_child_list,
-            visit_column: ignore_column,
+            visit_column,
             visit_struct_expr: ignore_child_list,
             visit_struct_patch_expr: ignore_struct_patch,
             visit_field_patch: ignore_field_patch,
             visit_opaque_expr: ignore_opaque_expr,
             visit_opaque_pred: ignore_opaque_pred,
-            visit_unknown: ignore_column,
+            visit_unknown: ignore_string_slice,
         }
+    }
+
+    #[test]
+    fn visit_expression_column_uses_structured_parts() {
+        let mut builder = TestExpressionBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+
+        let top_level_id =
+            visit_expression_internal(&Expression::column(["a", "b.c", "d"]), &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(
+            builder.events,
+            vec![LiteralEvent::Column {
+                sibling_list_id: 0,
+                parts: vec!["a".to_string(), "b.c".to_string(), "d".to_string()],
+            }]
+        );
     }
 
     #[rstest]

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -223,9 +223,13 @@ pub extern "C" fn visit_expression_unknown(
     name.map_or(0, |name| wrap_expression(state, Expression::Unknown(name)))
 }
 
+/// Builds a column from ordered field-name parts. Periods inside a part are preserved.
+///
+/// Returns an error for zero parts, empty parts, or invalid UTF-8.
+///
 /// # Safety
-/// `parts` must point to `parts_len` valid [`KernelStringSlice`], each valid for the
-/// duration of this call. The field parts are copied out before this function returns.
+/// If `parts_len > 0`, `parts` must point to `parts_len` valid [`KernelStringSlice`] values.
+/// Every slice must remain valid for this call. The field parts are copied before returning.
 #[no_mangle]
 pub unsafe extern "C" fn visit_expression_column(
     state: &mut KernelExpressionVisitorState,
@@ -1120,23 +1124,25 @@ mod tests {
         };
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
         assert_eq!(expr, Expression::column(["a", "b.c", "d"]));
-        let Expression::Column(name) = expr else {
-            panic!("expected a column expression, got {expr:?}");
-        };
-        let fields: Vec<&str> = name.path().iter().map(String::as_str).collect();
-        assert_eq!(fields, vec!["a", "b.c", "d"]);
     }
 
-    /// Invalid part lists are rejected at the boundary. Parts are raw bytes so the
-    /// invalid-UTF-8 case can share the same shape as the empty-string and no-parts cases:
-    /// - `no_parts`: a column must have at least one field part.
-    /// - `empty_part`: an empty field name is a caller bug (symmetric with `parts_len == 0`).
-    /// - `invalid_utf8`: a field name must be valid UTF-8, so `try_from_slice` fails.
     #[rstest]
-    #[case::no_parts(&[])]
-    #[case::empty_part(&[&b"a"[..], &b""[..], &b"d"[..]])]
-    #[case::invalid_utf8(&[&[0xFF, 0xFE][..]])]
-    fn invalid_column_parts_are_rejected(#[case] raw_parts: &[&[u8]]) {
+    #[case::no_parts(
+        &[],
+        KernelError::GenericError,
+        Some("Generic delta kernel error: column must have at least one field part")
+    )]
+    #[case::empty_part(
+        &[&b"a"[..], &b""[..], &b"d"[..]],
+        KernelError::GenericError,
+        Some("Generic delta kernel error: column field part must not be empty")
+    )]
+    #[case::invalid_utf8(&[&[0xFF, 0xFE][..]], KernelError::Utf8Error, None)]
+    fn invalid_column_parts_are_rejected(
+        #[case] raw_parts: &[&[u8]],
+        #[case] expected_error: KernelError,
+        #[case] expected_message: Option<&str>,
+    ) {
         let mut state = KernelExpressionVisitorState::default();
         let slices: Vec<KernelStringSlice> = raw_parts
             .iter()
@@ -1145,9 +1151,10 @@ mod tests {
                 len: bytes.len(),
             })
             .collect();
-        let result =
-            unsafe { visit_expression_column_impl(&mut state, slices.as_ptr(), slices.len()) };
-        assert!(result.is_err());
+        let result = unsafe {
+            visit_expression_column(&mut state, slices.as_ptr(), slices.len(), allocate_err)
+        };
+        assert_extern_result_error_with_message(result, expected_error, expected_message);
     }
 
     // ============================================================================
@@ -1236,7 +1243,10 @@ mod tests {
     // miri can validate the unsafe boundary, not just the `_impl` helpers above.
     // ============================================================================
 
-    use crate::ffi_test_utils::{allocate_err, ok_or_panic};
+    use crate::error::KernelError;
+    use crate::ffi_test_utils::{
+        allocate_err, assert_extern_result_error_with_message, ok_or_panic,
+    };
     use crate::kernel_string_slice;
 
     #[test]

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -248,14 +248,12 @@ unsafe fn visit_expression_column_impl(
             "column must have at least one field part",
         ));
     }
-    // Each part is one column field name, used verbatim; a field name may therefore contain any
-    // character, including a period. Empty parts are rejected: an empty field name is a caller
-    // bug, kept symmetric with the parts_len == 0 guard.
+
     let slices = unsafe { std::slice::from_raw_parts(parts, parts_len) };
     let fields = slices
         .iter()
-        .map(|slice| unsafe { <&str>::try_from_slice(slice) })
-        .collect::<DeltaResult<Vec<&str>>>()?;
+        .map(|slice| unsafe { String::try_from_slice(slice) })
+        .collect::<DeltaResult<Vec<String>>>()?;
     if fields.iter().any(|field| field.is_empty()) {
         return Err(delta_kernel::Error::generic(
             "column field part must not be empty",
@@ -1106,10 +1104,6 @@ mod tests {
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
         assert_eq!(expr, lit(expected));
     }
-
-    // ============================================================================
-    // visit_expression_column_impl (structured field parts)
-    // ============================================================================
 
     /// A field name containing a literal period must survive as a single field part.
     #[test]

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -224,22 +224,44 @@ pub extern "C" fn visit_expression_unknown(
 }
 
 /// # Safety
-/// The string slice must be valid
+/// `parts` must point to `parts_len` valid [`KernelStringSlice`], each valid for the
+/// duration of this call. The field parts are copied out before this function returns.
 #[no_mangle]
 pub unsafe extern "C" fn visit_expression_column(
     state: &mut KernelExpressionVisitorState,
-    name: KernelStringSlice,
+    parts: *const KernelStringSlice,
+    parts_len: usize,
     allocate_error: AllocateErrorFn,
 ) -> ExternResult<usize> {
-    let name = unsafe { TryFromStringSlice::try_from_slice(&name) };
-    visit_expression_column_impl(state, name).into_extern_result(&allocate_error)
+    visit_expression_column_impl(state, parts, parts_len).into_extern_result(&allocate_error)
 }
-fn visit_expression_column_impl(
+/// # Safety
+/// `parts` must point to `parts_len` valid [`KernelStringSlice`], each valid for the
+/// duration of this call.
+unsafe fn visit_expression_column_impl(
     state: &mut KernelExpressionVisitorState,
-    name: DeltaResult<&str>,
+    parts: *const KernelStringSlice,
+    parts_len: usize,
 ) -> DeltaResult<usize> {
-    // TODO: FIXME: This is incorrect if any field name in the column path contains a period.
-    let name = ColumnName::from_naive_str_split(name?);
+    if parts_len == 0 {
+        return Err(delta_kernel::Error::generic(
+            "column must have at least one field part",
+        ));
+    }
+    // Each part is one column field name, used verbatim; a field name may therefore contain any
+    // character, including a period. Empty parts are rejected: an empty field name is a caller
+    // bug, kept symmetric with the parts_len == 0 guard.
+    let slices = unsafe { std::slice::from_raw_parts(parts, parts_len) };
+    let fields = slices
+        .iter()
+        .map(|slice| unsafe { <&str>::try_from_slice(slice) })
+        .collect::<DeltaResult<Vec<&str>>>()?;
+    if fields.iter().any(|field| field.is_empty()) {
+        return Err(delta_kernel::Error::generic(
+            "column field part must not be empty",
+        ));
+    }
+    let name = ColumnName::new(fields);
     Ok(wrap_expression(state, name))
 }
 
@@ -1083,6 +1105,55 @@ mod tests {
         };
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
         assert_eq!(expr, lit(expected));
+    }
+
+    // ============================================================================
+    // visit_expression_column_impl (structured field parts)
+    // ============================================================================
+
+    /// A field name containing a literal period must survive as a single field part.
+    #[test]
+    fn column_with_dotted_field_round_trips_to_three_parts() {
+        let mut state = KernelExpressionVisitorState::default();
+        let (a, b, d) = ("a", "b.c", "d");
+        let parts = [
+            kernel_string_slice!(a),
+            kernel_string_slice!(b),
+            kernel_string_slice!(d),
+        ];
+        let id = unsafe {
+            visit_expression_column_impl(&mut state, parts.as_ptr(), parts.len()).unwrap()
+        };
+        let expr = unwrap_kernel_expression(&mut state, id).unwrap();
+        assert_eq!(expr, Expression::column(["a", "b.c", "d"]));
+        let Expression::Column(name) = expr else {
+            panic!("expected a column expression, got {expr:?}");
+        };
+        let fields: Vec<&str> = name.path().iter().map(String::as_str).collect();
+        assert_eq!(fields, vec!["a", "b.c", "d"]);
+    }
+
+    /// Invalid part lists are rejected at the boundary. Parts are raw bytes so the
+    /// invalid-UTF-8 case can share the same shape as the empty-string and no-parts cases:
+    /// - `no_parts`: a column must have at least one field part.
+    /// - `empty_part`: an empty field name is a caller bug (symmetric with `parts_len == 0`).
+    /// - `invalid_utf8`: a field name must be valid UTF-8, so `try_from_slice` fails.
+    #[rstest]
+    #[case::no_parts(&[])]
+    #[case::empty_part(&[&b"a"[..], &b""[..], &b"d"[..]])]
+    #[case::invalid_utf8(&[&[0xFF, 0xFE][..]])]
+    fn invalid_column_parts_are_rejected(#[case] raw_parts: &[&[u8]]) {
+        let mut state = KernelExpressionVisitorState::default();
+        let slices: Vec<KernelStringSlice> = raw_parts
+            .iter()
+            .map(|bytes| KernelStringSlice {
+                ptr: bytes.as_ptr().cast(),
+                len: bytes.len(),
+            })
+            .collect();
+        let result =
+            unsafe { visit_expression_column_impl(&mut state, slices.as_ptr(), slices.len()) };
+        assert!(result.is_err());
     }
 
     // ============================================================================

--- a/ffi/src/incremental_scan.rs
+++ b/ffi/src/incremental_scan.rs
@@ -838,10 +838,12 @@ mod tests {
         state: &mut KernelExpressionVisitorState,
     ) -> usize {
         let id = "id";
+        let parts = [kernel_string_slice!(id)];
         let col = unsafe {
             ok_or_panic(visit_expression_column(
                 state,
-                kernel_string_slice!(id),
+                parts.as_ptr(),
+                parts.len(),
                 allocate_err,
             ))
         };
@@ -932,10 +934,12 @@ mod tests {
         state: &mut KernelExpressionVisitorState,
     ) -> usize {
         let missing = "nonexistent";
+        let parts = [kernel_string_slice!(missing)];
         let col = unsafe {
             ok_or_panic(visit_expression_column(
                 state,
-                kernel_string_slice!(missing),
+                parts.as_ptr(),
+                parts.len(),
                 allocate_err,
             ))
         };

--- a/ffi/src/scan.rs
+++ b/ffi/src/scan.rs
@@ -1131,10 +1131,12 @@ mod scan_builder_tests {
         state: &mut KernelExpressionVisitorState,
     ) -> usize {
         let id = "id";
+        let parts = [kernel_string_slice!(id)];
         let col = unsafe {
             ok_or_panic(visit_expression_column(
                 state,
-                kernel_string_slice!(id),
+                parts.as_ptr(),
+                parts.len(),
                 allocate_err,
             ))
         };

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -264,7 +264,8 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
 /// checks it round-trips to this reference.
 ///
 /// # Safety
-/// The caller is responsible for freeing the returned memory.
+/// The caller must free the returned handle with
+/// [`crate::expressions::free_kernel_expression`].
 #[no_mangle]
 pub unsafe extern "C" fn get_testing_dotted_field_column() -> Handle<SharedExpression> {
     Arc::new(Expr::column(["a", "b.c", "d"])).into()

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -259,6 +259,17 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
     Arc::new(Expr::struct_from(sub_exprs)).into()
 }
 
+/// Constructs a reference column expression whose middle field name contains a literal period
+/// (`a`, `b.c`, `d`). The C example builds the same column from a structured parts array and
+/// checks it round-trips to this reference.
+///
+/// # Safety
+/// The caller is responsible for freeing the returned memory.
+#[no_mangle]
+pub unsafe extern "C" fn get_testing_dotted_field_column() -> Handle<SharedExpression> {
+    Arc::new(Expr::column(["a", "b.c", "d"])).into()
+}
+
 /// Constructs a simple kernel predicate using only primitive types for round-trip testing.
 /// This predicate only uses types that have full visitor support.
 ///

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -37,7 +37,7 @@ StructExpression
             Short(0)
   StructPatch
     input_path
-      Column(foo.bar.baz)
+      Column(foo, bar, baz)
     prepended_fields
       String(prepended)
     field_patches
@@ -87,7 +87,7 @@ StructExpression
   StructPatch
   StructPatch
     input_path
-      Column(empty.nested)
+      Column(empty, nested)
   Array
     Short(5)
     Short(0)

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -266,10 +266,4 @@ And
 SUCCESS: Round-trip predicate matches original!
 
 === Dotted-field Column Round-trip Test ===
-Builds column ["a", "b.c", "d"] from structured parts and checks the field
-containing a period survives as a single part.
-
-Column(a, b.c, d)
-
-=== Dotted-field Column Round-trip Result ===
 SUCCESS: dotted field "b.c" survived as a single column part!

--- a/ffi/tests/test-expression-visitor/expected.txt
+++ b/ffi/tests/test-expression-visitor/expected.txt
@@ -264,3 +264,12 @@ And
 
 === Predicate Round-trip Test ===
 SUCCESS: Round-trip predicate matches original!
+
+=== Dotted-field Column Round-trip Test ===
+Builds column ["a", "b.c", "d"] from structured parts and checks the field
+containing a period survives as a single part.
+
+Column(a, b.c, d)
+
+=== Dotted-field Column Round-trip Result ===
+SUCCESS: dotted field "b.c" survived as a single column part!


### PR DESCRIPTION
## What changes are proposed in this pull request?

`visit_expression_column` (engine -> kernel) took a single dot-joined column string and re-split it with `ColumnName::from_naive_str_split`, which mis-parses a field name containing a literal period (e.g. a column
`["a", "b.c", "d"]` round-tripped to a 4-part name instead of 3). This replaces the lossy dotted-string wire format with a structured parts array:

```
visit_expression_column(state, parts: *const KernelStringSlice,
                        parts_len: usize, allocate_error)
```

The visitor callback that carries a column the other way takes the same shape, so a field name survives in both directions:

```
visit_column(data, sibling_list_id, parts: *const KernelStringSlice,
             parts_len: usize)
```

### This PR affects the following public APIs

Two breaking FFI changes, each replacing a single dot-joined `KernelStringSlice` column name with a `(parts, parts_len)` array of per-field slices (the C header is regenerated accordingly):

- `visit_expression_column` -- the entry point an engine calls to build a column.
- `EngineExpressionVisitor::visit_column` -- the callback kernel calls to hand a column to an engine. Every engine implementing this visitor must be updated.

This is required to fix the mis-parsing above: the old single-string contract cannot represent a field name that itself contains a period.

### Connector migration

C-based connectors and language bindings generated from the C header must update both directions of the column visitor ABI:

- When calling `visit_expression_column`, construct one `KernelStringSlice` per column path component and pass the array with its length. Do not join the components with `.`.
- Update `EngineExpressionVisitor::visit_column` callbacks to accept `(parts, parts_len)` instead of one `KernelStringSlice`.
- Preserve each part's explicit byte length. Both the parts array and its slices are borrowed only for the duration of the callback, so copy any data retained afterward.
- Do not pass a zero-length parts array or an empty field part; both are rejected by the engine-to-kernel entry point.
- Regenerate or update connector bindings from the new C header before upgrading to this version.

## How was this change tested?

Unit tests on both directions of the boundary -- a multi-part column whose middle field contains a period, and rejection of zero parts, an empty part, and invalid UTF-8 -- plus a dotted-field round-trip in the `visit-expression` C example asserted against its golden output.
