### PR TITLE
feat!: emit geometry/geography over the FFI schema visitor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,14 +338,14 @@ jobs:
           cargo build --locked
           popd
           pushd ffi
-          cargo build --locked --features default-engine-rustls,test-ffi,tracing,delta-kernel-unity-catalog
+          cargo build --locked --features default-engine-rustls,test-ffi,tracing,delta-kernel-unity-catalog,geo-type-in-dev
           popd
       - name: build and run read-table test
         run: |
           pushd ffi/examples/read-table
           mkdir build
           pushd build
-          cmake ..
+          cmake .. -DGEO_TYPE_IN_DEV=ON
           make
           make test
       - name: build and run visit-expression test

--- a/ffi/examples/read-table/CMakeLists.txt
+++ b/ffi/examples/read-table/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.12)
 project(read_table)
 option(PRINT_DATA "Print out the table data. Requires arrow-glib" ON)
 option(VERBOSE "Enable for more diagnostics messages." OFF)
+option(
+  GEO_TYPE_IN_DEV
+  "Register the geometry/geography schema test. Requires delta_kernel_ffi built with --features geo-type-in-dev."
+  OFF)
 add_executable(read_table read_table.c arrow.c ../common/kernel_utils.c)
 target_compile_definitions(read_table PUBLIC DEFINE_DEFAULT_ENGINE_BASE)
 target_include_directories(read_table PUBLIC 
@@ -32,6 +36,9 @@ add_test(NAME read_arrow_metadata_basic COMMAND ${TestRunner} ${DatPath}/basic_p
 # `delta.columnMapping.id`, which the schema visitor reads back via get_from_metadata_map and
 # prints per field.
 add_test(NAME read_column_mapping_metadata COMMAND ${TestRunner} ${DatPath}/column_mapping/delta/ ${ExpectedPath}/column-mapping-arrow-metadata.expected -a)
+if(GEO_TYPE_IN_DEV)
+  add_test(NAME read_and_print_geo COMMAND ${TestRunner} ${KernelTestPath}/table-with-geo/ ${ExpectedPath}/table-with-geo.expected)
+endif()
 
 if(WIN32)
   set(CMAKE_C_FLAGS_DEBUG "/MT")

--- a/ffi/examples/read-table/schema.h
+++ b/ffi/examples/read-table/schema.h
@@ -72,6 +72,13 @@ SchemaItem* add_to_list(SchemaItemList* list, char* name, char* type, bool is_nu
   return &list->list[idx];
 }
 
+bool field_type_needs_free(char* type)
+{
+  return !strncmp(type, "decimal", 7) ||
+         !strncmp(type, "geometry", 8) ||
+         !strncmp(type, "geography", 9);
+}
+
 // print out all items in a list, recursing into any children they may have
 void print_list(SchemaBuilder* builder, uintptr_t list_id, int indent, int parents_on_last)
 {
@@ -278,6 +285,48 @@ void visit_interval_day_time(void* data,
   visit_simple_type(data, sibling_list_id, name, is_nullable, metadata, "interval day to second");
 }
 
+void visit_geometry(void* data,
+                    uintptr_t sibling_list_id,
+                    struct KernelStringSlice name,
+                    bool is_nullable,
+                    const CMetadataMap * metadata,
+                    struct KernelStringSlice crs)
+{
+  SchemaBuilder* builder = data;
+  char* name_ptr = allocate_string(name);
+  size_t type_size = strlen("geometry()") + crs.len + 1;
+  char* type = malloc(type_size * sizeof(char));
+  snprintf(type, type_size, "geometry(%.*s)", (int)crs.len, crs.ptr);
+  PRINT_NO_CHILD_VISIT(type, name_ptr, sibling_list_id);
+  SchemaItem* item = add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
+}
+
+void visit_geography(void* data,
+                     uintptr_t sibling_list_id,
+                     struct KernelStringSlice name,
+                     bool is_nullable,
+                     const CMetadataMap * metadata,
+                     struct KernelStringSlice crs,
+                     struct KernelStringSlice algorithm)
+{
+  SchemaBuilder* builder = data;
+  char* name_ptr = allocate_string(name);
+  size_t type_size = strlen("geography(, )") + crs.len + algorithm.len + 1;
+  char* type = malloc(type_size * sizeof(char));
+  snprintf(
+    type,
+    type_size,
+    "geography(%.*s, %.*s)",
+    (int)crs.len,
+    crs.ptr,
+    (int)algorithm.len,
+    algorithm.ptr);
+  PRINT_NO_CHILD_VISIT(type, name_ptr, sibling_list_id);
+  SchemaItem* item = add_to_list(&builder->lists[sibling_list_id], name_ptr, type, is_nullable);
+  item->column_mapping_id = read_column_mapping_id(metadata, builder->engine);
+}
+
 // free all the data in the builder and the builder itself
 void free_builder(SchemaBuilder* builder)
 {
@@ -288,8 +337,8 @@ void free_builder(SchemaBuilder* builder)
       free(item->name);
       free(item->column_mapping_id); // NULL when the field carried no column-mapping id; free(NULL) is a no-op
       // don't free item->type, those are static strings
-      if (!strncmp(item->type, "decimal", 7)) {
-        // except decimal types, we malloc'd those :)
+      if (field_type_needs_free(item->type)) {
+        // except decimal and geo types, we malloc'd those :)
         free(item->type);
       }
     }
@@ -332,6 +381,8 @@ CSchema* get_cschema(SharedSnapshot* snapshot, SharedExternEngine* engine)
     .visit_date = visit_date,
     .visit_timestamp = visit_timestamp,
     .visit_timestamp_ntz = visit_timestamp_ntz,
+    .visit_geometry = visit_geometry,
+    .visit_geography = visit_geography,
     .visit_interval_year_month = visit_interval_year_month,
     .visit_interval_day_time = visit_interval_day_time,
     .visit_void = visit_void,

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -229,6 +229,33 @@ pub struct EngineSchemaVisitor {
         is_nullable: bool,
         metadata: &CMetadataMap,
     ),
+
+    /// Visit a `geometry` belonging to the list identified by `sibling_list_id`.
+    ///
+    /// `crs` is the coordinate reference system string for the geometry type.
+    pub visit_geometry: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        metadata: &CMetadataMap,
+        crs: KernelStringSlice,
+    ),
+
+    /// Visit a `geography` belonging to the list identified by `sibling_list_id`.
+    ///
+    /// `crs` is the coordinate reference system string for the geography type. `algorithm` is the
+    /// lowercase Delta protocol token for edge interpolation: `spherical`, `vincenty`, `thomas`,
+    /// `andoyer`, or `karney`.
+    pub visit_geography: extern "C" fn(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        metadata: &CMetadataMap,
+        crs: KernelStringSlice,
+        algorithm: KernelStringSlice,
+    ),
 }
 
 /// Visit the given `schema` using the provided `visitor`. See the documentation of
@@ -361,11 +388,19 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
             &DataType::INTERVAL_DAY_TIME => call!(visit_interval_day_time),
             &DataType::VOID => call!(visit_void),
             #[cfg(feature = "geo-type-in-dev")]
-            DataType::Primitive(PrimitiveType::Geometry(_))
-            | DataType::Primitive(PrimitiveType::Geography(_)) => {
-                // TODO(#2949): add visit_geometry / visit_geography callbacks carrying the CRS;
-                // skipping silently drops the column
-                tracing::warn!("Skipping unsupported geo field '{name}' in FFI schema visit");
+            DataType::Primitive(PrimitiveType::Geometry(geometry)) => {
+                let crs = geometry.crs();
+                call!(visit_geometry, kernel_string_slice!(crs))
+            }
+            #[cfg(feature = "geo-type-in-dev")]
+            DataType::Primitive(PrimitiveType::Geography(geography)) => {
+                let crs = geography.crs();
+                let algorithm = geography.algorithm().to_string();
+                call!(
+                    visit_geography,
+                    kernel_string_slice!(crs),
+                    kernel_string_slice!(algorithm)
+                )
             }
         }
     }
@@ -378,6 +413,10 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::panic)]
 
     use delta_kernel::schema::schema;
+    #[cfg(feature = "geo-type-in-dev")]
+    use delta_kernel::schema::{
+        EdgeInterpolationAlgorithm, GeographyType, GeometryType, StructField,
+    };
 
     use super::*;
     use crate::TryFromStringSlice;
@@ -388,6 +427,49 @@ mod tests {
         data_type: &'static str,
         is_nullable: bool,
         children: Option<usize>,
+        geo: Option<VisitedGeoType>,
+    }
+
+    impl VisitedField {
+        fn new(
+            name: &str,
+            data_type: &'static str,
+            is_nullable: bool,
+            children: Option<usize>,
+        ) -> Self {
+            Self {
+                name: name.to_string(),
+                data_type,
+                is_nullable,
+                children,
+                geo: None,
+            }
+        }
+
+        fn geo(
+            name: &str,
+            data_type: &'static str,
+            is_nullable: bool,
+            crs: &str,
+            algorithm: Option<&str>,
+        ) -> Self {
+            Self {
+                name: name.to_string(),
+                data_type,
+                is_nullable,
+                children: None,
+                geo: Some(VisitedGeoType {
+                    crs: crs.to_string(),
+                    algorithm: algorithm.map(str::to_string),
+                }),
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct VisitedGeoType {
+        crs: String,
+        algorithm: Option<String>,
     }
 
     #[derive(Default)]
@@ -411,12 +493,13 @@ mod tests {
         children: Option<usize>,
     ) {
         let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
-        builder.lists[sibling_list_id].push(VisitedField {
-            name: unsafe { String::try_from_slice(&name) }.unwrap(),
+        let name = unsafe { String::try_from_slice(&name) }.unwrap();
+        builder.lists[sibling_list_id].push(VisitedField::new(
+            &name,
             data_type,
             is_nullable,
             children,
-        });
+        ));
     }
 
     macro_rules! visit_nested_type {
@@ -488,6 +571,48 @@ mod tests {
     visit_simple_type!(visit_void, "void");
     visit_simple_type!(visit_variant, "variant");
 
+    extern "C" fn visit_geometry(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CMetadataMap,
+        crs: KernelStringSlice,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
+        let name = unsafe { String::try_from_slice(&name) }.unwrap();
+        let crs = unsafe { String::try_from_slice(&crs) }.unwrap();
+        builder.lists[sibling_list_id].push(VisitedField::geo(
+            &name,
+            "geometry",
+            is_nullable,
+            &crs,
+            None,
+        ));
+    }
+
+    extern "C" fn visit_geography(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+        is_nullable: bool,
+        _metadata: &CMetadataMap,
+        crs: KernelStringSlice,
+        algorithm: KernelStringSlice,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestSchemaBuilder) };
+        let name = unsafe { String::try_from_slice(&name) }.unwrap();
+        let crs = unsafe { String::try_from_slice(&crs) }.unwrap();
+        let algorithm = unsafe { String::try_from_slice(&algorithm) }.unwrap();
+        builder.lists[sibling_list_id].push(VisitedField::geo(
+            &name,
+            "geography",
+            is_nullable,
+            &crs,
+            Some(&algorithm),
+        ));
+    }
+
     fn test_visitor(builder: &mut TestSchemaBuilder) -> EngineSchemaVisitor {
         EngineSchemaVisitor {
             data: builder as *mut _ as *mut c_void,
@@ -512,6 +637,8 @@ mod tests {
             visit_interval_day_time,
             visit_void,
             visit_variant,
+            visit_geometry,
+            visit_geography,
         }
     }
 
@@ -534,43 +661,83 @@ mod tests {
         assert_eq!(builder.lists[0].len(), 4);
         assert_eq!(
             builder.lists[0][0],
-            VisitedField {
-                name: "ym".to_string(),
-                data_type: "interval year to month",
-                is_nullable: true,
-                children: None,
-            }
+            VisitedField::new("ym", "interval year to month", true, None)
         );
         assert_eq!(
             builder.lists[0][1],
-            VisitedField {
-                name: "dt".to_string(),
-                data_type: "interval day to second",
-                is_nullable: false,
-                children: None,
-            }
+            VisitedField::new("dt", "interval day to second", false, None)
         );
 
         let nested_child_list_id = builder.lists[0][2].children.unwrap();
         assert_eq!(
             builder.lists[nested_child_list_id][0],
-            VisitedField {
-                name: "inner_ym".to_string(),
-                data_type: "interval year to month",
-                is_nullable: true,
-                children: None,
-            }
+            VisitedField::new("inner_ym", "interval year to month", true, None)
         );
 
         let array_child_list_id = builder.lists[0][3].children.unwrap();
         assert_eq!(
             builder.lists[array_child_list_id][0],
-            VisitedField {
-                name: "array_element".to_string(),
-                data_type: "interval day to second",
-                is_nullable: false,
-                children: None,
-            }
+            VisitedField::new("array_element", "interval day to second", false, None)
+        );
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[test]
+    fn visit_schema_preserves_geo_fields() {
+        let schema = StructType::try_new(vec![
+            StructField::nullable("geom", GeometryType::try_new("OGC:CRS84").unwrap()),
+            StructField::not_null(
+                "geog",
+                GeographyType::try_new("OGC:CRS84", EdgeInterpolationAlgorithm::Spherical).unwrap(),
+            ),
+        ])
+        .unwrap();
+
+        let mut builder = TestSchemaBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+        let top_level_id = visit_schema_impl(&schema, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(builder.lists[0].len(), 2);
+        assert_eq!(
+            builder.lists[0][0],
+            VisitedField::geo("geom", "geometry", true, "OGC:CRS84", None)
+        );
+        assert_eq!(
+            builder.lists[0][1],
+            VisitedField::geo("geog", "geography", false, "OGC:CRS84", Some("spherical"))
+        );
+    }
+
+    #[cfg(feature = "geo-type-in-dev")]
+    #[rstest::rstest]
+    #[case(EdgeInterpolationAlgorithm::Spherical, "spherical")]
+    #[case(EdgeInterpolationAlgorithm::Vincenty, "vincenty")]
+    #[case(EdgeInterpolationAlgorithm::Thomas, "thomas")]
+    #[case(EdgeInterpolationAlgorithm::Andoyer, "andoyer")]
+    #[case(EdgeInterpolationAlgorithm::Karney, "karney")]
+    fn visit_schema_preserves_geography_algorithm_protocol_token(
+        #[case] algorithm: EdgeInterpolationAlgorithm,
+        #[case] expected: &str,
+    ) {
+        let schema = StructType::try_new(vec![StructField::not_null(
+            "geog",
+            GeographyType::try_new("OGC:CRS84", algorithm).unwrap(),
+        )])
+        .unwrap();
+
+        let mut builder = TestSchemaBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+        let top_level_id = visit_schema_impl(&schema, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(builder.lists[0].len(), 1);
+        assert_eq!(
+            builder.lists[0][0]
+                .geo
+                .as_ref()
+                .and_then(|geo| geo.algorithm.as_deref()),
+            Some(expected)
         );
     }
 }

--- a/ffi/tests/read-table-testing/expected-data/table-with-geo.expected
+++ b/ffi/tests/read-table-testing/expected-data/table-with-geo.expected
@@ -1,0 +1,8 @@
+Reading table at ../../../../kernel/tests/data/table-with-geo/
+version: 0
+
+Schema:
+├─ geom: geometry(OGC:CRS84)
+└─ geog: geography(OGC:CRS84, spherical)
+
+[No data]

--- a/kernel/tests/data/table-with-geo/_delta_log/00000000000000000000.json
+++ b/kernel/tests/data/table-with-geo/_delta_log/00000000000000000000.json
@@ -1,0 +1,2 @@
+{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["geospatial"],"writerFeatures":["geospatial"]}}
+{"metaData":{"id":"table-with-geo","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"geom\",\"type\":\"geometry(OGC:CRS84)\",\"nullable\":true,\"metadata\":{}},{\"name\":\"geog\",\"type\":\"geography(OGC:CRS84, spherical)\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":0}}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds geometry and geography callbacks to the FFI schema visitor so `visit_schema` emits geo
fields instead of skipping them.

### This PR affects the following public APIs

Adds `visit_geometry` and `visit_geography` function pointers to `EngineSchemaVisitor` in the
FFI C/C++ header contract. 

## How was this change tested?

New unit test was added.
