### PR TITLE
feat: add generic table-feature ALTER transactions

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -294,6 +294,7 @@ mod tests {
             "UPDATE",
             "DELETE",
             "OPTIMIZE",
+            "ADD FEATURE",
             "CREATE TABLE",
             "REPLACE TABLE",
             "CREATE TABLE AS SELECT",

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -73,6 +73,7 @@ const INCREMENTAL_SAFE_OPS: &[&str] = &[
     "UPDATE",
     "DELETE",
     "OPTIMIZE",
+    "ADD FEATURE",
     "CREATE TABLE",
     "REPLACE TABLE",
     "CREATE TABLE AS SELECT",

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -893,8 +893,8 @@ impl Snapshot {
         Transaction::try_new_existing_table(self, committer, engine)
     }
 
-    /// Creates a builder for altering this table's metadata. Currently supports schema change
-    /// operations.
+    /// Creates a builder for altering this table's protocol or metadata. Currently supports
+    /// adding selected table features and schema change operations.
     ///
     /// The returned builder allows chaining operations before building an
     /// [`AlterTableTransaction`] that can be committed.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -894,7 +894,8 @@ impl Snapshot {
     }
 
     /// Creates a builder for altering this table's protocol or metadata. Currently supports
-    /// adding selected table features and schema change operations.
+    /// schema change operations. Selected table-feature additions are experimental and available
+    /// only with the `internal-api` feature.
     ///
     /// The returned builder allows chaining operations before building an
     /// [`AlterTableTransaction`] that can be committed.

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -30,9 +30,9 @@ use crate::schema::{
 use crate::table_features::validate_geospatial_feature_support;
 use crate::table_features::{
     check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
-    get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
-    validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
-    FeatureType, KernelSupport, Operation, TableFeature, LEGACY_WRITER_FEATURES,
+    extract_enabled_writer_features, get_any_level_column_physical_name,
+    validate_iceberg_compat_if_needed, validate_timestamp_ntz_feature_support, ColumnMappingMode,
+    EnablementCheck, FeatureRequirement, FeatureType, KernelSupport, Operation, TableFeature,
     MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
     TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
 };
@@ -251,15 +251,29 @@ impl TableConfiguration {
             });
         }
 
-        // note that while we could pick apart the protocol/metadata updates and validate them
-        // individually, instead we just re-parse so that we can recycle the try_new validation
-        // (instead of duplicating it here).
-        Self::try_new(
+        // Note that while we could pick apart the protocol/metadata updates and validate them
+        // individually, instead we re-parse so that we can recycle the try_new validation.
+        let protocol_changed = new_protocol.is_some();
+        let evolved = Self::try_new(
             new_metadata.unwrap_or_else(|| table_configuration.metadata.clone()),
             new_protocol.unwrap_or_else(|| table_configuration.protocol.clone()),
             table_configuration.table_root.clone(),
             new_version,
-        )
+        )?;
+
+        if protocol_changed {
+            // Validate dependencies for newly explicit features against the evolved metadata.
+            // This intentionally does not run the broad write-support gate: ADD FEATURE may
+            // preserve unsupported existing capabilities, and supporting a feature need not
+            // enable its property.
+            for feature in evolved.get_enabled_writer_features() {
+                if !table_configuration.is_feature_supported(&feature) {
+                    evolved.validate_feature_requirements(&feature)?;
+                }
+            }
+        }
+
+        Ok(evolved)
     }
 
     /// Creates a new [`TableConfiguration`] representing the table configuration immediately
@@ -678,24 +692,7 @@ impl TableConfiguration {
     /// For table features protocol (v7), returns the explicit writer_features list.
     /// For legacy protocol (v1-6), infers features from the version number.
     fn get_enabled_writer_features(&self) -> Vec<TableFeature> {
-        match self.protocol.min_writer_version() {
-            TABLE_FEATURES_MIN_WRITER_VERSION => {
-                // Table features writer: use explicit writer_features list
-                self.protocol
-                    .writer_features()
-                    .map(|f| f.to_vec())
-                    .unwrap_or_default()
-            }
-            v if (1..=6).contains(&v) => {
-                // Legacy writer: infer features from version
-                LEGACY_WRITER_FEATURES
-                    .iter()
-                    .filter(|f| f.is_valid_for_legacy_writer(v))
-                    .cloned()
-                    .collect()
-            }
-            _ => Vec::new(),
-        }
+        extract_enabled_writer_features(&self.protocol)
     }
 
     /// Returns `Ok` if the kernel supports the given operation on this table. This checks that

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -263,6 +263,14 @@ impl TableConfiguration {
 
     /// Validate that the kernel supports adding `feature` to this table configuration.
     pub(crate) fn validate_feature_for_addition(&self, feature: &TableFeature) -> DeltaResult<()> {
+        require!(
+            !matches!(
+                feature,
+                TableFeature::CatalogManaged | TableFeature::CatalogOwnedPreview
+            ),
+            Error::unsupported("Upgrading an existing table to catalog-managed is not supported")
+        );
+
         match feature.feature_type() {
             FeatureType::WriterOnly => self.check_feature_support(feature, Operation::Write),
             FeatureType::ReaderWriter => {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -271,6 +271,17 @@ impl TableConfiguration {
             Error::unsupported("Upgrading an existing table to catalog-managed is not supported")
         );
 
+        // Adding protocol support would immediately activate ICT, but this generic path cannot
+        // emit the required enablement metadata or first in-commit timestamp.
+        require!(
+            feature != &TableFeature::InCommitTimestamp
+                || self.table_properties().enable_in_commit_timestamps != Some(true),
+            Error::unsupported(
+                "Adding 'inCommitTimestamp' to an existing table with \
+                 'delta.enableInCommitTimestamps=true' is not supported"
+            )
+        );
+
         match feature.feature_type() {
             FeatureType::WriterOnly => self.check_feature_support(feature, Operation::Write),
             FeatureType::ReaderWriter => {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -253,27 +253,22 @@ impl TableConfiguration {
 
         // Note that while we could pick apart the protocol/metadata updates and validate them
         // individually, instead we re-parse so that we can recycle the try_new validation.
-        let protocol_changed = new_protocol.is_some();
-        let evolved = Self::try_new(
+        Self::try_new(
             new_metadata.unwrap_or_else(|| table_configuration.metadata.clone()),
             new_protocol.unwrap_or_else(|| table_configuration.protocol.clone()),
             table_configuration.table_root.clone(),
             new_version,
-        )?;
+        )
+    }
 
-        if protocol_changed {
-            // Validate dependencies for newly explicit features against the evolved metadata.
-            // This intentionally does not run the broad write-support gate: ADD FEATURE may
-            // preserve unsupported existing capabilities, and supporting a feature need not
-            // enable its property.
-            for feature in evolved.get_enabled_writer_features() {
-                if !table_configuration.is_feature_supported(&feature) {
-                    evolved.validate_feature_requirements(&feature)?;
-                }
+    /// Validate dependencies for features supported by this configuration but not by `previous`.
+    pub(crate) fn validate_added_feature_requirements(&self, previous: &Self) -> DeltaResult<()> {
+        for feature in self.get_enabled_writer_features() {
+            if !previous.is_feature_supported(&feature) {
+                self.validate_feature_requirements(&feature)?;
             }
         }
-
-        Ok(evolved)
+        Ok(())
     }
 
     /// Creates a new [`TableConfiguration`] representing the table configuration immediately

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -261,14 +261,18 @@ impl TableConfiguration {
         )
     }
 
-    /// Validate dependencies for features supported by this configuration but not by `previous`.
-    pub(crate) fn validate_added_feature_requirements(&self, previous: &Self) -> DeltaResult<()> {
-        for feature in self.get_enabled_writer_features() {
-            if !previous.is_feature_supported(&feature) {
-                self.validate_feature_requirements(&feature)?;
+    /// Validate that the kernel supports adding `feature` to this table configuration.
+    pub(crate) fn validate_feature_for_addition(&self, feature: &TableFeature) -> DeltaResult<()> {
+        match feature.feature_type() {
+            FeatureType::WriterOnly => self.check_feature_support(feature, Operation::Write),
+            FeatureType::ReaderWriter => {
+                self.check_feature_support(feature, Operation::Scan)?;
+                self.check_feature_support(feature, Operation::Write)
             }
+            FeatureType::Unknown => Err(Error::unsupported(format!(
+                "Unknown feature '{feature}' cannot be added"
+            ))),
         }
-        Ok(())
     }
 
     /// Creates a new [`TableConfiguration`] representing the table configuration immediately
@@ -1016,6 +1020,31 @@ mod test {
         .unwrap();
         let table_root = Url::try_from("file:///").unwrap();
         TableConfiguration::try_new(metadata, protocol, table_root, 0).unwrap()
+    }
+
+    #[test]
+    fn validate_feature_for_addition_checks_required_kernel_operations() {
+        let supported_writer = create_mock_table_config(&[], &[TableFeature::DomainMetadata]);
+        assert!(supported_writer
+            .validate_feature_for_addition(&TableFeature::DomainMetadata)
+            .is_ok());
+
+        let supported_reader_writer =
+            create_mock_table_config(&[], &[TableFeature::DeletionVectors]);
+        assert!(supported_reader_writer
+            .validate_feature_for_addition(&TableFeature::DeletionVectors)
+            .is_ok());
+
+        let unsupported = create_mock_table_config(&[], &[TableFeature::GeospatialType]);
+        assert!(unsupported
+            .validate_feature_for_addition(&TableFeature::GeospatialType)
+            .is_err());
+
+        let write_unsupported = create_mock_table_config(&[], &[TableFeature::TypeWidening]);
+        assert_result_error_with_message(
+            write_unsupported.validate_feature_for_addition(&TableFeature::TypeWidening),
+            "Feature 'typeWidening' is not supported for writes",
+        );
     }
 
     #[test]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -852,6 +852,23 @@ pub(crate) fn extract_enabled_reader_features(protocol: &Protocol) -> Vec<TableF
     }
 }
 
+/// Extract the writer features enabled for `protocol`. For `min_writer_version == 7` returns the
+/// explicit `writer_features` list; for `1..=6` returns the legacy-inferred features.
+pub(crate) fn extract_enabled_writer_features(protocol: &Protocol) -> Vec<TableFeature> {
+    match protocol.min_writer_version() {
+        TABLE_FEATURES_MIN_WRITER_VERSION => protocol
+            .writer_features()
+            .map(|f| f.to_vec())
+            .unwrap_or_default(),
+        v if (1..=6).contains(&v) => LEGACY_WRITER_FEATURES
+            .iter()
+            .filter(|f| f.is_valid_for_legacy_writer(v))
+            .cloned()
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Add `feature` to the appropriate feature list(s) for its type, skipping duplicates.
 pub(crate) fn add_feature_to_lists(
     feature: TableFeature,
@@ -873,6 +890,113 @@ pub(crate) fn add_feature_to_lists(
             }
         }
     }
+}
+
+/// Construct a table-feature protocol that preserves all current explicit or legacy-implied
+/// features and adds the requested features.
+pub(crate) fn protocol_with_added_features(
+    protocol: &Protocol,
+    requested_features: impl IntoIterator<Item = TableFeature>,
+    allow_protocol_versions_increase: bool,
+) -> DeltaResult<Protocol> {
+    let requested_features: Vec<_> = requested_features.into_iter().collect();
+    require!(
+        !requested_features.is_empty(),
+        Error::invalid_protocol("At least one table feature must be requested")
+    );
+    require!(
+        requested_features
+            .iter()
+            .all(|feature| feature.feature_type() != FeatureType::Unknown),
+        Error::invalid_protocol(
+            "Unknown table features cannot be added because their reader/writer type is unknown"
+        )
+    );
+    require!(
+        protocol.min_reader_version() <= TABLE_FEATURES_MIN_READER_VERSION
+            && protocol.min_writer_version() <= TABLE_FEATURES_MIN_WRITER_VERSION,
+        Error::invalid_protocol(
+            "Adding table features must not lower the current protocol versions"
+        )
+    );
+
+    let target_reader_version =
+        requested_features
+            .iter()
+            .fold(
+                protocol.min_reader_version(),
+                |target, feature| match feature.feature_type() {
+                    FeatureType::ReaderWriter
+                        if protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION
+                            && feature
+                                .is_valid_for_legacy_reader(protocol.min_reader_version()) =>
+                    {
+                        target
+                    }
+                    FeatureType::ReaderWriter => TABLE_FEATURES_MIN_READER_VERSION,
+                    FeatureType::WriterOnly | FeatureType::Unknown => target,
+                },
+            );
+    let versions_must_increase = target_reader_version > protocol.min_reader_version()
+        || TABLE_FEATURES_MIN_WRITER_VERSION > protocol.min_writer_version();
+    require!(
+        allow_protocol_versions_increase || !versions_must_increase,
+        Error::invalid_protocol(
+            "Adding table features requires increasing the protocol versions; set allow_protocol_versions_increase to true"
+        )
+    );
+
+    // Preserve explicit feature lists exactly, then append only capabilities that must become
+    // explicit as part of the transition to writer version 7 (and, when needed, reader version 3).
+    let mut reader_features = protocol.reader_features().unwrap_or_default().to_vec();
+    let mut writer_features = protocol.writer_features().unwrap_or_default().to_vec();
+
+    if protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION {
+        for feature in extract_enabled_writer_features(protocol) {
+            if !writer_features.contains(&feature) {
+                writer_features.push(feature);
+            }
+        }
+    }
+
+    if protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION {
+        for feature in extract_enabled_reader_features(protocol) {
+            if !writer_features.contains(&feature) {
+                writer_features.push(feature.clone());
+            }
+            if target_reader_version == TABLE_FEATURES_MIN_READER_VERSION
+                && !reader_features.contains(&feature)
+            {
+                reader_features.push(feature);
+            }
+        }
+    } else {
+        // Explicit reader features, including unknown payloads, are necessarily writer features.
+        for feature in &reader_features {
+            if !writer_features.contains(feature) {
+                writer_features.push(feature.clone());
+            }
+        }
+    }
+
+    for feature in requested_features {
+        if !writer_features.contains(&feature) {
+            writer_features.push(feature.clone());
+        }
+        if feature.feature_type() == FeatureType::ReaderWriter
+            && target_reader_version == TABLE_FEATURES_MIN_READER_VERSION
+            && !reader_features.contains(&feature)
+        {
+            reader_features.push(feature);
+        }
+    }
+
+    Protocol::try_new(
+        target_reader_version,
+        TABLE_FEATURES_MIN_WRITER_VERSION,
+        (target_reader_version == TABLE_FEATURES_MIN_READER_VERSION).then_some(reader_features),
+        Some(writer_features),
+    )
 }
 
 /// Enable each `allowed_table_features` entry whose [`EnablementCheck::EnabledIf`] check is
@@ -949,6 +1073,221 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    fn assert_feature_protocol(
+        protocol: &Protocol,
+        expected_reader_version: i32,
+        expected_reader: Option<&[TableFeature]>,
+        expected_writer: &[TableFeature],
+    ) {
+        assert_eq!(protocol.min_reader_version(), expected_reader_version);
+        assert_eq!(
+            protocol.min_writer_version(),
+            TABLE_FEATURES_MIN_WRITER_VERSION
+        );
+        assert_eq!(protocol.reader_features(), expected_reader);
+        assert_eq!(protocol.writer_features().unwrap(), expected_writer);
+    }
+
+    #[test]
+    fn adding_writer_only_feature_to_versions_1_1_targets_1_7() {
+        let protocol = Protocol::try_new_legacy(1, 1).unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], true).unwrap();
+
+        assert_feature_protocol(&evolved, 1, None, &[TableFeature::DomainMetadata]);
+    }
+
+    #[test]
+    fn adding_writer_only_feature_preserves_reader_2_and_all_legacy_capabilities() {
+        let protocol = Protocol::try_new_legacy(2, 5).unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], true).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            2,
+            None,
+            &[
+                TableFeature::AppendOnly,
+                TableFeature::Invariants,
+                TableFeature::CheckConstraints,
+                TableFeature::ChangeDataFeed,
+                TableFeature::GeneratedColumns,
+                TableFeature::ColumnMapping,
+                TableFeature::DomainMetadata,
+            ],
+        );
+    }
+
+    #[test]
+    fn adding_reader_writer_feature_to_legacy_protocol_targets_3_7() {
+        let protocol = Protocol::try_new_legacy(1, 2).unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DeletionVectors], true).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            3,
+            Some(&[TableFeature::DeletionVectors]),
+            &[
+                TableFeature::AppendOnly,
+                TableFeature::Invariants,
+                TableFeature::DeletionVectors,
+            ],
+        );
+    }
+
+    #[test]
+    fn adding_column_mapping_keeps_legacy_reader_2() {
+        let protocol = Protocol::try_new_legacy(2, 5).unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::ColumnMapping], true).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            2,
+            None,
+            &[
+                TableFeature::AppendOnly,
+                TableFeature::Invariants,
+                TableFeature::CheckConstraints,
+                TableFeature::ChangeDataFeed,
+                TableFeature::GeneratedColumns,
+                TableFeature::ColumnMapping,
+            ],
+        );
+    }
+
+    #[test]
+    fn adding_writer_only_feature_extends_existing_1_7_without_permission() {
+        let protocol = Protocol::try_new(
+            1,
+            7,
+            None::<Vec<TableFeature>>,
+            Some([TableFeature::AppendOnly]),
+        )
+        .unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], false).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            1,
+            None,
+            &[TableFeature::AppendOnly, TableFeature::DomainMetadata],
+        );
+    }
+
+    #[test]
+    fn adding_features_preserves_explicit_lists_and_unknown_payloads() {
+        let unknown_reader = TableFeature::unknown("futureReaderWriter");
+        let unknown_writer = TableFeature::unknown("futureWriterOnly");
+        let protocol = Protocol::try_new_modern(
+            [
+                TableFeature::DeletionVectors,
+                unknown_reader.clone(),
+                TableFeature::V2Checkpoint,
+            ],
+            [
+                TableFeature::DeletionVectors,
+                unknown_reader.clone(),
+                TableFeature::AppendOnly,
+                unknown_writer.clone(),
+                TableFeature::V2Checkpoint,
+            ],
+        )
+        .unwrap();
+
+        let evolved = protocol_with_added_features(
+            &protocol,
+            [TableFeature::DomainMetadata, TableFeature::DomainMetadata],
+            false,
+        )
+        .unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            3,
+            Some(&[
+                TableFeature::DeletionVectors,
+                unknown_reader.clone(),
+                TableFeature::V2Checkpoint,
+            ]),
+            &[
+                TableFeature::DeletionVectors,
+                unknown_reader,
+                TableFeature::AppendOnly,
+                unknown_writer,
+                TableFeature::V2Checkpoint,
+                TableFeature::DomainMetadata,
+            ],
+        );
+    }
+
+    #[rstest]
+    #[case::writer_only(1, 1, TableFeature::DomainMetadata)]
+    #[case::reader_writer(1, 2, TableFeature::DeletionVectors)]
+    fn adding_feature_rejects_required_version_increase_without_permission(
+        #[case] reader_version: i32,
+        #[case] writer_version: i32,
+        #[case] feature: TableFeature,
+    ) {
+        let protocol = Protocol::try_new_legacy(reader_version, writer_version).unwrap();
+        let result = protocol_with_added_features(&protocol, [feature], false);
+
+        assert!(
+            matches!(result, Err(Error::InvalidProtocol(message)) if message.contains("allow_protocol_versions_increase"))
+        );
+    }
+
+    #[test]
+    fn adding_features_rejects_empty_and_unknown_requests() {
+        let protocol =
+            Protocol::try_new_modern(Vec::<TableFeature>::new(), Vec::<TableFeature>::new())
+                .unwrap();
+
+        let empty = protocol_with_added_features(&protocol, [], false);
+        assert!(matches!(empty, Err(Error::InvalidProtocol(_))));
+
+        let unknown = protocol_with_added_features(
+            &protocol,
+            [TableFeature::unknown("futureFeature")],
+            false,
+        );
+        assert!(
+            matches!(unknown, Err(Error::InvalidProtocol(message)) if message.contains("reader/writer type"))
+        );
+    }
+
+    #[rstest]
+    #[case::reader_above_table_feature_version(4, 7)]
+    #[case::writer_above_table_feature_version(1, 8)]
+    fn adding_features_rejects_protocol_version_downgrade(
+        #[case] reader_version: i32,
+        #[case] writer_version: i32,
+    ) {
+        let protocol = Protocol::try_new(
+            reader_version,
+            writer_version,
+            if reader_version == 3 {
+                Some(Vec::<TableFeature>::new())
+            } else {
+                None
+            },
+            if writer_version == 7 {
+                Some(Vec::<TableFeature>::new())
+            } else {
+                None
+            },
+        )
+        .unwrap();
+        let result = protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], true);
+
+        assert!(
+            matches!(result, Err(Error::InvalidProtocol(message)) if message.contains("must not lower"))
+        );
+    }
 
     #[test]
     fn test_unknown_features() {

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -943,17 +943,21 @@ pub(crate) fn protocol_with_added_features(
     // explicit as part of the transition to writer version 7 (and, when needed, reader version 3).
     let mut reader_features = protocol.reader_features().unwrap_or_default().to_vec();
     let mut writer_features = protocol.writer_features().unwrap_or_default().to_vec();
+    let enabled_writer_features = extract_enabled_writer_features(protocol);
 
     if protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION {
-        for feature in extract_enabled_writer_features(protocol) {
-            if !writer_features.contains(&feature) {
-                writer_features.push(feature);
+        for feature in &enabled_writer_features {
+            if !writer_features.contains(feature) {
+                writer_features.push(feature.clone());
             }
         }
     }
 
     if protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION {
         for feature in extract_enabled_reader_features(protocol) {
+            if !enabled_writer_features.contains(&feature) {
+                continue;
+            }
             if !writer_features.contains(&feature) {
                 writer_features.push(feature.clone());
             }
@@ -1150,6 +1154,77 @@ mod tests {
                 TableFeature::ColumnMapping,
             ],
         );
+    }
+
+    #[test]
+    fn adding_unrelated_feature_does_not_expand_reader_2_writer_7_capabilities() {
+        let protocol = Protocol::try_new(
+            2,
+            7,
+            None::<Vec<TableFeature>>,
+            Some(Vec::<TableFeature>::new()),
+        )
+        .unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], false).unwrap();
+
+        assert_feature_protocol(&evolved, 2, None, &[TableFeature::DomainMetadata]);
+    }
+
+    #[test]
+    fn adding_unrelated_feature_does_not_expand_reader_2_writer_4_capabilities() {
+        let protocol = Protocol::try_new_legacy(2, 4).unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], true).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            2,
+            None,
+            &[
+                TableFeature::AppendOnly,
+                TableFeature::Invariants,
+                TableFeature::CheckConstraints,
+                TableFeature::ChangeDataFeed,
+                TableFeature::GeneratedColumns,
+                TableFeature::DomainMetadata,
+            ],
+        );
+    }
+
+    #[test]
+    fn adding_unrelated_feature_preserves_explicit_column_mapping_writer_support() {
+        let protocol = Protocol::try_new(
+            2,
+            7,
+            None::<Vec<TableFeature>>,
+            Some([TableFeature::ColumnMapping]),
+        )
+        .unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], false).unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            2,
+            None,
+            &[TableFeature::ColumnMapping, TableFeature::DomainMetadata],
+        );
+    }
+
+    #[test]
+    fn explicitly_adding_column_mapping_to_reader_2_writer_7_adds_writer_support() {
+        let protocol = Protocol::try_new(
+            2,
+            7,
+            None::<Vec<TableFeature>>,
+            Some(Vec::<TableFeature>::new()),
+        )
+        .unwrap();
+        let evolved =
+            protocol_with_added_features(&protocol, [TableFeature::ColumnMapping], false).unwrap();
+
+        assert_feature_protocol(&evolved, 2, None, &[TableFeature::ColumnMapping]);
     }
 
     #[test]

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -899,7 +899,7 @@ pub(crate) fn protocol_with_added_features(
     requested_features: impl IntoIterator<Item = TableFeature>,
     allow_protocol_versions_increase: bool,
 ) -> DeltaResult<Protocol> {
-    let requested_features: Vec<_> = requested_features.into_iter().collect();
+    let mut requested_features: Vec<_> = requested_features.into_iter().collect();
     require!(
         !requested_features.is_empty(),
         Error::invalid_protocol("At least one table feature must be requested")
@@ -917,6 +917,20 @@ pub(crate) fn protocol_with_added_features(
             && protocol.min_writer_version() <= TABLE_FEATURES_MIN_WRITER_VERSION,
         Error::invalid_protocol(
             "Adding table features must not lower the current protocol versions"
+        )
+    );
+
+    let enabled_reader_features = extract_enabled_reader_features(protocol);
+    let enabled_writer_features = extract_enabled_writer_features(protocol);
+    requested_features.retain(|feature| {
+        !enabled_writer_features.contains(feature)
+            || (feature.feature_type() == FeatureType::ReaderWriter
+                && !enabled_reader_features.contains(feature))
+    });
+    require!(
+        !requested_features.is_empty(),
+        Error::invalid_protocol(
+            "All requested table features are already supported by the current protocol"
         )
     );
 
@@ -943,7 +957,6 @@ pub(crate) fn protocol_with_added_features(
     // explicit as part of the transition to writer version 7 (and, when needed, reader version 3).
     let mut reader_features = protocol.reader_features().unwrap_or_default().to_vec();
     let mut writer_features = protocol.writer_features().unwrap_or_default().to_vec();
-    let enabled_writer_features = extract_enabled_writer_features(protocol);
 
     if protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION {
         for feature in &enabled_writer_features {
@@ -1136,10 +1149,10 @@ mod tests {
     }
 
     #[test]
-    fn adding_column_mapping_keeps_legacy_reader_2() {
+    fn adding_writer_only_feature_keeps_legacy_reader_2() {
         let protocol = Protocol::try_new_legacy(2, 5).unwrap();
         let evolved =
-            protocol_with_added_features(&protocol, [TableFeature::ColumnMapping], true).unwrap();
+            protocol_with_added_features(&protocol, [TableFeature::DomainMetadata], true).unwrap();
 
         assert_feature_protocol(
             &evolved,
@@ -1152,6 +1165,44 @@ mod tests {
                 TableFeature::ChangeDataFeed,
                 TableFeature::GeneratedColumns,
                 TableFeature::ColumnMapping,
+                TableFeature::DomainMetadata,
+            ],
+        );
+    }
+
+    #[rstest]
+    #[case::append_only(1, 2, TableFeature::AppendOnly)]
+    #[case::column_mapping(2, 5, TableFeature::ColumnMapping)]
+    fn adding_legacy_supported_feature_returns_already_supported(
+        #[case] reader_version: i32,
+        #[case] writer_version: i32,
+        #[case] feature: TableFeature,
+    ) {
+        let protocol = Protocol::try_new_legacy(reader_version, writer_version).unwrap();
+
+        let error = protocol_with_added_features(&protocol, [feature], false).unwrap_err();
+
+        assert!(error.to_string().contains("already supported"));
+    }
+
+    #[test]
+    fn adding_new_feature_ignores_already_supported_legacy_feature() {
+        let protocol = Protocol::try_new_legacy(1, 2).unwrap();
+        let evolved = protocol_with_added_features(
+            &protocol,
+            [TableFeature::AppendOnly, TableFeature::DomainMetadata],
+            true,
+        )
+        .unwrap();
+
+        assert_feature_protocol(
+            &evolved,
+            1,
+            None,
+            &[
+                TableFeature::AppendOnly,
+                TableFeature::Invariants,
+                TableFeature::DomainMetadata,
             ],
         );
     }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -920,23 +920,16 @@ pub(crate) fn protocol_with_added_features(
         )
     );
 
-    let target_reader_version =
-        requested_features
-            .iter()
-            .fold(
-                protocol.min_reader_version(),
-                |target, feature| match feature.feature_type() {
-                    FeatureType::ReaderWriter
-                        if protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION
-                            && feature
-                                .is_valid_for_legacy_reader(protocol.min_reader_version()) =>
-                    {
-                        target
-                    }
-                    FeatureType::ReaderWriter => TABLE_FEATURES_MIN_READER_VERSION,
-                    FeatureType::WriterOnly | FeatureType::Unknown => target,
-                },
-            );
+    let current_reader_version = protocol.min_reader_version();
+    let requires_modern_reader = requested_features.iter().any(|feature| {
+        feature.feature_type() == FeatureType::ReaderWriter
+            && !feature.is_valid_for_legacy_reader(current_reader_version)
+    });
+    let target_reader_version = if requires_modern_reader {
+        TABLE_FEATURES_MIN_READER_VERSION
+    } else {
+        current_reader_version
+    };
     let versions_must_increase = target_reader_version > protocol.min_reader_version()
         || TABLE_FEATURES_MIN_WRITER_VERSION > protocol.min_writer_version();
     require!(

--- a/kernel/src/transaction/alter_table.rs
+++ b/kernel/src/transaction/alter_table.rs
@@ -25,27 +25,27 @@ use crate::DeltaResult;
 pub type AlterTableTransaction = Transaction<AlterTable>;
 
 impl AlterTableTransaction {
-    /// Create a new transaction for altering a table's schema. Produces a metadata-only commit
-    /// that emits an updated Metadata action with the evolved schema.
+    /// Create a new transaction for altering a table's protocol and/or metadata.
     ///
-    /// The `effective_table_config` is the evolved table configuration (new schema, same
-    /// protocol). It must be fully validated before calling this constructor (e.g. schema
-    /// operations applied, protocol feature checks passed). The `read_snapshot` provides the
-    /// pre-commit table state (version, previous protocol/metadata, ICT timestamps) used for
-    /// commit versioning and post-commit snapshots.
+    /// The `effective_table_config` is the fully validated evolved table configuration. The
+    /// `read_snapshot` provides the pre-commit table state (version, previous protocol/metadata,
+    /// ICT timestamps) used for commit versioning and post-commit snapshots.
     ///
     /// This is typically called via `AlterTableTransactionBuilder::build()` rather than directly.
     pub(crate) fn try_new_alter_table(
         read_snapshot: SnapshotRef,
         effective_table_config: TableConfiguration,
         committer: Box<dyn Committer>,
+        should_emit_protocol: bool,
+        should_emit_metadata: bool,
+        operation: &'static str,
         correlation_id: Option<Arc<str>>,
     ) -> DeltaResult<Self> {
         let span = tracing::info_span!(
             "txn",
             path = %read_snapshot.table_root(),
             read_version = read_snapshot.version(),
-            operation = "ALTER TABLE",
+            operation,
         );
 
         Ok(Transaction {
@@ -54,10 +54,10 @@ impl AlterTableTransaction {
             correlation_id,
             read_snapshot_opt: Some(read_snapshot),
             effective_table_config,
-            should_emit_protocol: false,
-            should_emit_metadata: true,
+            should_emit_protocol,
+            should_emit_metadata,
             committer,
-            operation: Some("ALTER TABLE".to_string()),
+            operation: Some(operation.to_string()),
             engine_info: None,
             add_files_metadata: vec![],
             remove_files_metadata: vec![],

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -1,4 +1,4 @@
-//! Builder for ALTER TABLE (schema evolution) transactions.
+//! Builder for ALTER TABLE transactions.
 //!
 //! This module contains [`AlterTableTransactionBuilder`], which uses a type-state pattern to
 //! enforce valid operation chaining at compile time.
@@ -7,13 +7,13 @@
 //!
 //! - [`Ready`]: Initial state. Operations are available, but `build()` is not (at least one
 //!   operation is required).
-//! - [`Modifying`]: After any chainable schema operation. More ops can be chained, and `build()` is
+//! - [`Modifying`]: After any chainable operation. More ops can be chained, and `build()` is
 //!   available. See [`AlterTableTransactionBuilder<Modifying>`] for ops.
 //!
 //! # Transitions
 //!
 //! Each `impl` block below is gated by a state bound and documents which operations that
-//! state enables. Chainable schema operations live on `impl<S: Chainable>` and transition
+//! state enables. Chainable operations live on `impl<S: Chainable>` and transition
 //! the builder to a chainable state; `build()` lives on states that are buildable.
 //!
 //! ```ignore
@@ -27,14 +27,16 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
+
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata, ColumnMappingMode,
-    Operation, TableFeature,
+    protocol_with_added_features, schema_has_column_mapping_metadata,
+    strip_stray_column_mapping_metadata, ColumnMappingMode, Operation, TableFeature,
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
@@ -67,7 +69,7 @@ mod sealed {
     impl Sealed for super::Modifying {}
 }
 
-/// Builder for constructing an [`AlterTableTransaction`] with schema evolution operations.
+/// Builder for constructing an [`AlterTableTransaction`] with protocol or schema operations.
 ///
 /// Uses a type-state pattern (`S`) to enforce at compile time:
 /// - At least one schema operation must be queued before `build()` is callable.
@@ -76,6 +78,8 @@ mod sealed {
 pub struct AlterTableTransactionBuilder<S = Ready> {
     snapshot: SnapshotRef,
     operations: Vec<SchemaOperation>,
+    table_features: Vec<TableFeature>,
+    allow_protocol_versions_increase: bool,
     correlation_id: Option<Arc<str>>,
     // PhantomData marker for builder state (Ready or Modifying).
     // Zero-sized; only affects which methods are available at compile time.
@@ -93,6 +97,8 @@ impl<S> AlterTableTransactionBuilder<S> {
         AlterTableTransactionBuilder {
             snapshot: self.snapshot,
             operations: self.operations,
+            table_features: self.table_features,
+            allow_protocol_versions_increase: self.allow_protocol_versions_increase,
             correlation_id: self.correlation_id,
             _state: PhantomData,
         }
@@ -104,6 +110,14 @@ impl<S> AlterTableTransactionBuilder<S> {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
         self
     }
+
+    /// Allow adding table features to increase the writer protocol to 7 and, when required by a
+    /// requested reader-writer feature, the reader protocol to 3.
+    #[internal_api]
+    pub(crate) fn with_allow_protocol_versions_increase(mut self, allow: bool) -> Self {
+        self.allow_protocol_versions_increase = allow;
+        self
+    }
 }
 
 impl AlterTableTransactionBuilder<Ready> {
@@ -112,6 +126,8 @@ impl AlterTableTransactionBuilder<Ready> {
         AlterTableTransactionBuilder {
             snapshot,
             operations: Vec::new(),
+            table_features: Vec::new(),
+            allow_protocol_versions_increase: false,
             correlation_id: None,
             _state: PhantomData,
         }
@@ -119,6 +135,16 @@ impl AlterTableTransactionBuilder<Ready> {
 }
 
 impl<S: Chainable> AlterTableTransactionBuilder<S> {
+    /// Add a supported table feature while conservatively preserving current capabilities.
+    #[internal_api]
+    pub(crate) fn add_table_feature(
+        mut self,
+        feature: TableFeature,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.table_features.push(feature);
+        self.transition()
+    }
+
     /// Add a new top-level column to the table schema.
     ///
     /// The field must not already exist in the schema (case-insensitive). The field must be
@@ -144,14 +170,15 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
 }
 
 impl AlterTableTransactionBuilder<Modifying> {
-    /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
+    /// Validate and apply protocol or schema operations, then build the
+    /// [`AlterTableTransaction`].
     ///
     /// This method:
-    /// 1. Validates the table supports writes
-    /// 2. Applies each operation sequentially against the evolving schema
-    /// 3. Constructs new Metadata action with evolved schema
-    /// 4. Builds the evolved table configuration
-    /// 5. Creates the transaction
+    /// 1. Validates schema changes against the table's write capabilities
+    /// 2. Applies schema operations sequentially when present
+    /// 3. Conservatively evolves and extends the table-feature Protocol when features are requested
+    /// 4. Validates the evolved table configuration
+    /// 5. Creates the transaction with explicit Protocol and Metadata emission flags
     ///
     /// # Errors
     ///
@@ -167,74 +194,103 @@ impl AlterTableTransactionBuilder<Modifying> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
-        // We don't support ALTER TABLE on tables with icebergCompatV3 enabled yet. See
-        // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
-        if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            return Err(Error::unsupported(
-                "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
-            ));
-        }
-        // TODO(#2630): Support ALTER TABLE on tables with column defaults.
-        if table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults) {
-            return Err(Error::unsupported(
-                "ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled",
-            ));
-        }
-        // Rejects writes to tables kernel can't safely commit to: writer version out of
-        // kernel's supported range, unsupported writer features, or schemas with SQL-expression
-        // invariants. Runs on the pre-alter snapshot; future ALTER variants that change the
-        // protocol must also re-check this on the evolved `TableConfiguration`.
-        table_config.ensure_operation_supported(Operation::Write)?;
+        let has_schema_operations = !self.operations.is_empty();
+        let has_feature_operations = !self.table_features.is_empty();
 
-        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
-        let column_mapping_mode = table_config.column_mapping_mode();
-        let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
-        // Whether the pre-alter schema already carried column-mapping metadata -- the only fact the
-        // strip below needs from it. Captured as a bool (not a clone) before
-        // `apply_schema_operations` consumes `schema` by value. Short-circuits outside
-        // `None` mode, where no strip fires.
-        let current_has_cm = column_mapping_mode == ColumnMappingMode::None
-            && schema_has_column_mapping_metadata(&schema);
-        let SchemaEvolutionResult {
-            schema: evolved_schema,
-            new_max_column_id,
-        } = apply_schema_operations(
-            schema,
-            self.operations,
-            column_mapping_mode,
-            current_max_column_id,
-        )?;
+        let evolved_metadata = if has_schema_operations {
+            // Schema ALTER behavior retains the broad write gate and feature restrictions.
+            if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+                return Err(Error::unsupported(
+                    "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
+                ));
+            }
+            // TODO(#2630): Support ALTER TABLE on tables with column defaults.
+            if table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults) {
+                return Err(Error::unsupported(
+                    "ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled",
+                ));
+            }
+            table_config.ensure_operation_supported(Operation::Write)?;
 
-        // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
-        // that was clean before it, strip them; residual annotations already present on the
-        // table are left in place (see `strip_stray_column_mapping_metadata`).
-        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
-            strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
-                .map_or(evolved_schema, Arc::new)
+            let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+            let column_mapping_mode = table_config.column_mapping_mode();
+            let current_max_column_id =
+                table_config.table_properties().column_mapping_max_column_id;
+            let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+                && schema_has_column_mapping_metadata(&schema);
+            let SchemaEvolutionResult {
+                schema: evolved_schema,
+                new_max_column_id,
+            } = apply_schema_operations(
+                schema,
+                self.operations,
+                column_mapping_mode,
+                current_max_column_id,
+            )?;
+
+            let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+                strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+                    .map_or(evolved_schema, Arc::new)
+            } else {
+                evolved_schema
+            };
+
+            let metadata = table_config
+                .metadata()
+                .clone()
+                .with_schema(evolved_schema.clone())?
+                .fold_with(new_max_column_id, |evolved_metadata, id| {
+                    evolved_metadata
+                        .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+                });
+            Some((metadata, evolved_schema))
         } else {
-            evolved_schema
+            None
         };
 
-        let evolved_metadata = table_config
-            .metadata()
-            .clone()
-            .with_schema(evolved_schema.clone())?
-            .fold_with(new_max_column_id, |evolved_metadata, id| {
-                evolved_metadata
-                    .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
-            });
+        let evolved_protocol = has_feature_operations
+            .then(|| {
+                protocol_with_added_features(
+                    table_config.protocol(),
+                    self.table_features,
+                    self.allow_protocol_versions_increase,
+                )
+            })
+            .transpose()?;
 
-        // Validates the evolved metadata against the protocol.
-        let evolved_table_config = TableConfiguration::try_new_with_schema(
-            table_config,
-            evolved_metadata,
-            evolved_schema,
-        )?;
+        // Preserve the existing schema-only construction path. When Protocol also changes,
+        // re-parse the combined target configuration before publication.
+        let evolved_table_config = match (evolved_metadata.as_ref(), evolved_protocol.clone()) {
+            (Some((metadata, _)), Some(protocol)) => TableConfiguration::try_new_from(
+                table_config,
+                Some(metadata.clone()),
+                Some(protocol),
+                table_config.version(),
+            )?,
+            (Some((metadata, schema)), None) => TableConfiguration::try_new_with_schema(
+                table_config,
+                metadata.clone(),
+                schema.clone(),
+            )?,
+            (None, protocol) => TableConfiguration::try_new_from(
+                table_config,
+                None,
+                protocol,
+                table_config.version(),
+            )?,
+        };
 
         AlterTableTransaction::try_new_alter_table(
             self.snapshot,
             evolved_table_config,
             committer,
+            evolved_protocol.is_some(),
+            has_schema_operations,
+            if has_feature_operations {
+                "ADD FEATURE"
+            } else {
+                "ALTER TABLE"
+            },
             self.correlation_id,
         )
     }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -7,13 +7,15 @@
 //!
 //! - [`Ready`]: Initial state. Operations are available, but `build()` is not (at least one
 //!   operation is required).
-//! - [`Modifying`]: After any chainable operation. More ops can be chained, and `build()` is
-//!   available. See [`AlterTableTransactionBuilder<Modifying>`] for ops.
+//! - [`Modifying`]: After a schema operation. More schema ops can be chained, and `build()` is
+//!   available.
+//! - [`AddingFeatures`]: After a table feature operation. More features can be added, and
+//!   `build()` is available.
 //!
 //! # Transitions
 //!
 //! Each `impl` block below is gated by a state bound and documents which operations that
-//! state enables. Chainable operations live on `impl<S: Chainable>` and transition
+//! state enables. Chainable schema operations live on `impl<S: Chainable>` and transition
 //! the builder to a chainable state; `build()` lives on states that are buildable.
 //!
 //! ```ignore
@@ -50,9 +52,13 @@ use crate::{DeltaResult, Engine, Error};
 /// See [`Chainable`] for the operations available on this state.
 pub struct Ready;
 
-/// State after at least one operation has been added. `build()` is available.
+/// State after at least one schema operation has been added. `build()` is available.
 /// See [`Chainable`] for the operations available on this state.
 pub struct Modifying;
+
+/// State after at least one table feature has been added. `build()` is available, but schema
+/// operations are not.
+pub struct AddingFeatures;
 
 /// Marker trait for builder states that accept chainable schema operations. Grouping states
 /// under one bound lets each op (like `add_column`) live on a single `impl<S: Chainable>`
@@ -72,7 +78,7 @@ mod sealed {
 /// Builder for constructing an [`AlterTableTransaction`] with protocol or schema operations.
 ///
 /// Uses a type-state pattern (`S`) to enforce at compile time:
-/// - At least one schema operation must be queued before `build()` is callable.
+/// - At least one operation must be queued before `build()` is callable.
 /// - Only operations valid for the current state can be chained. This will disallow incompatible
 ///   chaining.
 pub struct AlterTableTransactionBuilder<S = Ready> {
@@ -81,7 +87,7 @@ pub struct AlterTableTransactionBuilder<S = Ready> {
     table_features: Vec<TableFeature>,
     allow_protocol_versions_increase: bool,
     correlation_id: Option<Arc<str>>,
-    // PhantomData marker for builder state (Ready or Modifying).
+    // PhantomData marker for builder state (Ready, Modifying, or AddingFeatures).
     // Zero-sized; only affects which methods are available at compile time.
     _state: PhantomData<S>,
 }
@@ -110,14 +116,6 @@ impl<S> AlterTableTransactionBuilder<S> {
         self.correlation_id = Some(correlation_id.into()).filter(|id| !id.is_empty());
         self
     }
-
-    /// Allow adding table features to increase the writer protocol to 7 and, when required by a
-    /// requested reader-writer feature, the reader protocol to 3.
-    #[internal_api]
-    pub(crate) fn with_allow_protocol_versions_increase(mut self, allow: bool) -> Self {
-        self.allow_protocol_versions_increase = allow;
-        self
-    }
 }
 
 impl AlterTableTransactionBuilder<Ready> {
@@ -132,19 +130,19 @@ impl AlterTableTransactionBuilder<Ready> {
             _state: PhantomData,
         }
     }
-}
 
-impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// Add a supported table feature while conservatively preserving current capabilities.
     #[internal_api]
     pub(crate) fn add_table_feature(
         mut self,
         feature: TableFeature,
-    ) -> AlterTableTransactionBuilder<Modifying> {
+    ) -> AlterTableTransactionBuilder<AddingFeatures> {
         self.table_features.push(feature);
         self.transition()
     }
+}
 
+impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// Add a new top-level column to the table schema.
     ///
     /// The field must not already exist in the schema (case-insensitive). The field must be
@@ -170,15 +168,14 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
 }
 
 impl AlterTableTransactionBuilder<Modifying> {
-    /// Validate and apply protocol or schema operations, then build the
-    /// [`AlterTableTransaction`].
+    /// Validate and apply schema operations, then build the [`AlterTableTransaction`].
     ///
     /// This method:
-    /// 1. Validates schema changes against the table's write capabilities
-    /// 2. Applies schema operations sequentially when present
-    /// 3. Conservatively evolves and extends the table-feature Protocol when features are requested
-    /// 4. Validates the evolved table configuration
-    /// 5. Creates the transaction with explicit Protocol and Metadata emission flags
+    /// 1. Validates the table supports writes
+    /// 2. Applies each operation sequentially against the evolving schema
+    /// 3. Constructs new Metadata action with evolved schema
+    /// 4. Builds the evolved table configuration
+    /// 5. Creates the transaction
     ///
     /// # Errors
     ///
@@ -194,103 +191,117 @@ impl AlterTableTransactionBuilder<Modifying> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
-        let has_schema_operations = !self.operations.is_empty();
-        let has_feature_operations = !self.table_features.is_empty();
+        // We don't support ALTER TABLE on tables with icebergCompatV3 enabled yet. See
+        // [`crate::table_features::ICEBERG_COMPAT_V3_INFO`] for the tracking issue.
+        if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+            return Err(Error::unsupported(
+                "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
+            ));
+        }
+        // TODO(#2630): Support ALTER TABLE on tables with column defaults.
+        if table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults) {
+            return Err(Error::unsupported(
+                "ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled",
+            ));
+        }
+        // Rejects writes to tables kernel can't safely commit to: writer version out of
+        // kernel's supported range, unsupported writer features, or schemas with SQL-expression
+        // invariants.
+        table_config.ensure_operation_supported(Operation::Write)?;
 
-        let evolved_metadata = if has_schema_operations {
-            // Schema ALTER behavior retains the broad write gate and feature restrictions.
-            if table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-                return Err(Error::unsupported(
-                    "ALTER TABLE is not yet supported on tables with icebergCompatV3 enabled",
-                ));
-            }
-            // TODO(#2630): Support ALTER TABLE on tables with column defaults.
-            if table_config.is_feature_enabled(&TableFeature::AllowColumnDefaults) {
-                return Err(Error::unsupported(
-                    "ALTER TABLE is not yet supported on tables with allowColumnDefaults enabled",
-                ));
-            }
-            table_config.ensure_operation_supported(Operation::Write)?;
+        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+        let column_mapping_mode = table_config.column_mapping_mode();
+        let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+        let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+            && schema_has_column_mapping_metadata(&schema);
+        let SchemaEvolutionResult {
+            schema: evolved_schema,
+            new_max_column_id,
+        } = apply_schema_operations(
+            schema,
+            self.operations,
+            column_mapping_mode,
+            current_max_column_id,
+        )?;
 
-            let schema = Arc::unwrap_or_clone(table_config.logical_schema());
-            let column_mapping_mode = table_config.column_mapping_mode();
-            let current_max_column_id =
-                table_config.table_properties().column_mapping_max_column_id;
-            let current_has_cm = column_mapping_mode == ColumnMappingMode::None
-                && schema_has_column_mapping_metadata(&schema);
-            let SchemaEvolutionResult {
-                schema: evolved_schema,
-                new_max_column_id,
-            } = apply_schema_operations(
-                schema,
-                self.operations,
-                column_mapping_mode,
-                current_max_column_id,
-            )?;
-
-            let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
-                strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
-                    .map_or(evolved_schema, Arc::new)
-            } else {
-                evolved_schema
-            };
-
-            let metadata = table_config
-                .metadata()
-                .clone()
-                .with_schema(evolved_schema.clone())?
-                .fold_with(new_max_column_id, |evolved_metadata, id| {
-                    evolved_metadata
-                        .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
-                });
-            Some((metadata, evolved_schema))
+        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+            strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+                .map_or(evolved_schema, Arc::new)
         } else {
-            None
+            evolved_schema
         };
 
-        let evolved_protocol = has_feature_operations
-            .then(|| {
-                protocol_with_added_features(
-                    table_config.protocol(),
-                    self.table_features,
-                    self.allow_protocol_versions_increase,
-                )
-            })
-            .transpose()?;
+        let evolved_metadata = table_config
+            .metadata()
+            .clone()
+            .with_schema(evolved_schema.clone())?
+            .fold_with(new_max_column_id, |evolved_metadata, id| {
+                evolved_metadata
+                    .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+            });
 
-        // Preserve the existing schema-only construction path. When Protocol also changes,
-        // re-parse the combined target configuration before publication.
-        let evolved_table_config = match (evolved_metadata.as_ref(), evolved_protocol.clone()) {
-            (Some((metadata, _)), Some(protocol)) => TableConfiguration::try_new_from(
-                table_config,
-                Some(metadata.clone()),
-                Some(protocol),
-                table_config.version(),
-            )?,
-            (Some((metadata, schema)), None) => TableConfiguration::try_new_with_schema(
-                table_config,
-                metadata.clone(),
-                schema.clone(),
-            )?,
-            (None, protocol) => TableConfiguration::try_new_from(
-                table_config,
-                None,
-                protocol,
-                table_config.version(),
-            )?,
-        };
+        // Validates the evolved metadata against the protocol.
+        let evolved_table_config = TableConfiguration::try_new_with_schema(
+            table_config,
+            evolved_metadata,
+            evolved_schema,
+        )?;
 
         AlterTableTransaction::try_new_alter_table(
             self.snapshot,
             evolved_table_config,
             committer,
-            evolved_protocol.is_some(),
-            has_schema_operations,
-            if has_feature_operations {
-                "ADD FEATURE"
-            } else {
-                "ALTER TABLE"
-            },
+            false,
+            true,
+            "ALTER TABLE",
+            self.correlation_id,
+        )
+    }
+}
+
+impl AlterTableTransactionBuilder<AddingFeatures> {
+    /// Add another supported table feature to this protocol-only transaction.
+    #[internal_api]
+    pub(crate) fn add_table_feature(mut self, feature: TableFeature) -> Self {
+        self.table_features.push(feature);
+        self
+    }
+
+    /// Allow adding table features to increase the writer protocol to 7 and, when required by a
+    /// requested reader-writer feature, the reader protocol to 3.
+    #[internal_api]
+    pub(crate) fn with_allow_protocol_versions_increase(mut self, allow: bool) -> Self {
+        self.allow_protocol_versions_increase = allow;
+        self
+    }
+
+    /// Validate and apply table feature operations, then build a protocol-only transaction.
+    pub fn build(
+        self,
+        _engine: &dyn Engine,
+        committer: Box<dyn Committer>,
+    ) -> DeltaResult<AlterTableTransaction> {
+        let table_config = self.snapshot.table_configuration();
+        let evolved_protocol = protocol_with_added_features(
+            table_config.protocol(),
+            self.table_features,
+            self.allow_protocol_versions_increase,
+        )?;
+        let evolved_table_config = TableConfiguration::try_new_from(
+            table_config,
+            None,
+            Some(evolved_protocol),
+            table_config.version(),
+        )?;
+        evolved_table_config.validate_added_feature_requirements(table_config)?;
+
+        AlterTableTransaction::try_new_alter_table(
+            self.snapshot,
+            evolved_table_config,
+            committer,
+            true,
+            false,
+            "ADD FEATURE",
             self.correlation_id,
         )
     }

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -9,8 +9,8 @@
 //!   operation is required).
 //! - [`Modifying`]: After a schema operation. More schema ops can be chained, and `build()` is
 //!   available.
-//! - [`AddingFeatures`]: After a table feature operation. More features can be added, and
-//!   `build()` is available.
+//! - [`AddingFeatures`]: After a table feature operation. More features can be added, and `build()`
+//!   is available.
 //!
 //! # Transitions
 //!
@@ -306,7 +306,16 @@ impl AlterTableTransactionBuilder<AddingFeatures> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
-        let requested_features = self.table_features;
+        let requested_features: Vec<_> = self
+            .table_features
+            .into_iter()
+            .filter(|feature| !table_config.is_feature_supported(feature))
+            .collect();
+        if requested_features.is_empty() {
+            return Err(Error::invalid_protocol(
+                "All requested table features are already supported by the current protocol",
+            ));
+        }
         let evolved_protocol = protocol_with_added_features(
             table_config.protocol(),
             requested_features.iter().cloned(),

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -53,11 +53,35 @@ use crate::{DeltaResult, Engine, Error};
 pub struct Ready;
 
 /// State after at least one schema operation has been added. `build()` is available.
+///
+/// Feature operations are unavailable once schema modification begins:
+///
+/// ```compile_fail
+/// # use delta_kernel::table_features::TableFeature;
+/// # use delta_kernel::transaction::builder::alter_table::{
+/// #     AlterTableTransactionBuilder, Modifying,
+/// # };
+/// # fn cannot_add_feature(builder: AlterTableTransactionBuilder<Modifying>) {
+/// builder.add_table_feature(TableFeature::DeletionVectors);
+/// # }
+/// ```
 /// See [`Chainable`] for the operations available on this state.
 pub struct Modifying;
 
 /// State after at least one table feature has been added. `build()` is available, but schema
 /// operations are not.
+///
+/// Schema operations are unavailable once feature addition begins:
+///
+/// ```compile_fail
+/// # use delta_kernel::schema::{DataType, StructField};
+/// # use delta_kernel::transaction::builder::alter_table::{
+/// #     AddingFeatures, AlterTableTransactionBuilder,
+/// # };
+/// # fn cannot_add_column(builder: AlterTableTransactionBuilder<AddingFeatures>) {
+/// builder.add_column(StructField::nullable("value", DataType::INTEGER));
+/// # }
+/// ```
 pub struct AddingFeatures;
 
 /// Marker trait for builder states that accept chainable schema operations. Grouping states

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -282,9 +282,10 @@ impl AlterTableTransactionBuilder<AddingFeatures> {
         committer: Box<dyn Committer>,
     ) -> DeltaResult<AlterTableTransaction> {
         let table_config = self.snapshot.table_configuration();
+        let requested_features = self.table_features;
         let evolved_protocol = protocol_with_added_features(
             table_config.protocol(),
-            self.table_features,
+            requested_features.iter().cloned(),
             self.allow_protocol_versions_increase,
         )?;
         let evolved_table_config = TableConfiguration::try_new_from(
@@ -293,7 +294,9 @@ impl AlterTableTransactionBuilder<AddingFeatures> {
             Some(evolved_protocol),
             table_config.version(),
         )?;
-        evolved_table_config.validate_added_feature_requirements(table_config)?;
+        for feature in &requested_features {
+            evolved_table_config.validate_feature_for_addition(feature)?;
+        }
 
         AlterTableTransaction::try_new_alter_table(
             self.snapshot,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -162,10 +162,11 @@ pub struct ExistingTable;
 #[derive(Debug)]
 pub struct CreateTable;
 
-/// Marker type for alter-table (schema evolution) transactions.
+/// Marker type for alter-table transactions.
 ///
-/// Transactions in this state perform metadata-only commits. Data file operations are not
-/// available at compile time because `AlterTable` does not implement [`SupportsDataFiles`].
+/// Transactions in this state perform protocol and/or metadata-only commits. Data file operations
+/// are not available at compile time because `AlterTable` does not implement
+/// [`SupportsDataFiles`].
 #[derive(Debug)]
 pub struct AlterTable;
 
@@ -173,7 +174,7 @@ pub struct AlterTable;
 ///
 /// Only transaction types that implement this trait can access methods for adding, removing, or
 /// updating data files. This prevents compile-time misuse by states like `AlterTable` that
-/// only perform metadata-only commits.
+/// only perform protocol and/or metadata-only commits.
 pub trait SupportsDataFiles {}
 impl SupportsDataFiles for ExistingTable {}
 impl SupportsDataFiles for CreateTable {}
@@ -211,9 +212,9 @@ pub struct Transaction<S = ExistingTable> {
     // config, this is cloned from the read snapshot; when the config changes (e.g. schema
     // evolution), it is constructed separately with the new schema/protocol.
     effective_table_config: TableConfiguration,
-    // Whether to emit a Protocol action. True for CREATE TABLE and ALTER TABLE, false otherwise.
+    // Whether to emit a Protocol action. True for CREATE TABLE and protocol-changing ALTER TABLE.
     should_emit_protocol: bool,
-    // Whether to emit a Metadata action. True for CREATE TABLE and ALTER TABLE, false otherwise.
+    // Whether to emit a Metadata action. True for CREATE TABLE and metadata-changing ALTER TABLE.
     should_emit_metadata: bool,
     committer: Box<dyn Committer>,
     operation: Option<String>,
@@ -482,10 +483,8 @@ impl<S> Transaction<S> {
         let remove_actions =
             self.generate_remove_actions(engine, self.remove_files_metadata.iter(), &[])?;
 
-        // Build the action chain
-        // For create-table: CommitInfo -> Protocol -> Metadata -> adds -> txns -> domain_metadata
-        // -> removes For existing table: CommitInfo -> adds -> txns -> domain_metadata ->
-        // removes
+        // Build the action chain: CommitInfo -> optional Protocol -> optional Metadata -> adds ->
+        // txns -> domain_metadata -> removes.
         let actions = iter::once(commit_info_action)
             .chain(protocol_action.map(Ok))
             .chain(metadata_action.map(Ok))

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -13,9 +13,10 @@ use delta_kernel::schema::{
     StructType,
 };
 use delta_kernel::snapshot::Snapshot;
-use delta_kernel::table_features::ColumnMappingMode;
+use delta_kernel::table_features::{ColumnMappingMode, Operation, TableFeature};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::CommitResult;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
@@ -36,6 +37,286 @@ fn simple_schema() -> SchemaRef {
 
 fn committer() -> Box<FileSystemCommitter> {
     Box::new(FileSystemCommitter::new())
+}
+
+fn read_commit_actions(table_path: &str, version: u64) -> Vec<serde_json::Value> {
+    let path = std::path::Path::new(table_path).join(format!("_delta_log/{version:020}.json"));
+    std::fs::read_to_string(path)
+        .expect("commit file should be readable")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("commit action should be valid JSON"))
+        .collect()
+}
+
+fn feature_only_table_json(reader_version: i32, writer_version: i32) -> String {
+    let schema = serde_json::to_string(&simple_schema()).unwrap();
+    let schema = serde_json::to_string(&schema).unwrap();
+    format!(
+        r#"{{"protocol":{{"minReaderVersion":{reader_version},"minWriterVersion":{writer_version}}}}}
+{{"metaData":{{"id":"feature-test","format":{{"provider":"parquet","options":{{}}}},"schemaString":{schema},"partitionColumns":[],"configuration":{{}},"createdTime":1700000000000}}}}
+"#
+    )
+}
+
+// ============================================================================
+// Table feature tests
+// ============================================================================
+
+#[tokio::test]
+async fn add_writer_only_feature_commits_only_protocol_and_preserves_schema_alter_shape(
+) -> DeltaResult<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let table_path = temp_dir.path().to_string_lossy().into_owned();
+    let table_url = url::Url::from_directory_path(temp_dir.path())
+        .map_err(|_| delta_kernel::Error::generic("Invalid table path"))?;
+    let (store, engine, _) = engine_store_setup("unused", Some(&table_url));
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(1, 1),
+    )
+    .await
+    .map_err(|error| delta_kernel::Error::generic(error.to_string()))?;
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+    let committed = snapshot
+        .clone()
+        .alter_table()
+        .add_table_feature(TableFeature::InCommitTimestamp)
+        .with_allow_protocol_versions_increase(true)
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    assert_eq!(committed.commit_version(), 1);
+    let post_commit = committed
+        .post_commit_snapshot()
+        .expect("feature commit should return a post-commit snapshot");
+    assert_eq!(post_commit.version(), 1);
+    let protocol = post_commit.table_configuration().protocol();
+    assert_eq!(protocol.min_reader_version(), 1);
+    assert!(protocol.reader_features().is_none());
+    assert!(protocol
+        .writer_features()
+        .is_some_and(|features| features.contains(&TableFeature::InCommitTimestamp)));
+
+    let feature_actions = read_commit_actions(&table_path, 1);
+    assert_eq!(feature_actions.len(), 2);
+    assert_eq!(feature_actions[0]["commitInfo"]["operation"], "ADD FEATURE");
+    assert!(feature_actions[1].get("protocol").is_some());
+    assert_eq!(
+        feature_actions
+            .iter()
+            .filter(|action| action.get("protocol").is_some())
+            .count(),
+        1
+    );
+    assert!(!feature_actions.iter().any(|action| {
+        action.get("metaData").is_some()
+            || action.get("add").is_some()
+            || action.get("remove").is_some()
+            || action.get("domainMetadata").is_some()
+    }));
+
+    let reloaded = Snapshot::builder_for(&table_path).build(&engine)?;
+    assert_eq!(reloaded.version(), 1);
+    assert!(reloaded
+        .table_configuration()
+        .is_feature_supported(&TableFeature::InCommitTimestamp));
+    assert!(!reloaded
+        .table_configuration()
+        .is_feature_enabled(&TableFeature::InCommitTimestamp));
+
+    reloaded
+        .alter_table()
+        .add_column(StructField::nullable("region", DataType::STRING))
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    let schema_actions = read_commit_actions(&table_path, 2);
+    assert_eq!(schema_actions.len(), 2);
+    assert_eq!(schema_actions[0]["commitInfo"]["operation"], "ALTER TABLE");
+    assert!(schema_actions[1].get("metaData").is_some());
+    assert!(!schema_actions
+        .iter()
+        .any(|action| action.get("protocol").is_some()));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_reader_writer_feature_can_be_combined_with_schema_alter() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let committed = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::DeletionVectors)
+        .add_column(StructField::nullable("region", DataType::STRING))
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let post_commit = committed.post_commit_snapshot().unwrap();
+    assert!(post_commit.schema().field("region").is_some());
+    assert!(post_commit
+        .table_configuration()
+        .is_feature_supported(&TableFeature::DeletionVectors));
+    let protocol = post_commit.table_configuration().protocol();
+    assert_eq!(protocol.min_reader_version(), 3);
+    assert!(protocol
+        .reader_features()
+        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
+    assert!(protocol
+        .writer_features()
+        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
+
+    let actions = read_commit_actions(&table_path, 1);
+    assert_eq!(actions.len(), 3);
+    assert_eq!(actions[0]["commitInfo"]["operation"], "ADD FEATURE");
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|action| action.get("protocol").is_some())
+            .count(),
+        1
+    );
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|action| action.get("metaData").is_some())
+            .count(),
+        1
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_table_feature_validates_dependencies_without_auto_enabling_properties(
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let error = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::RowTracking)
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())
+        .expect_err("rowTracking without domainMetadata must be rejected");
+
+    assert!(error
+        .to_string()
+        .contains("requires 'domainMetadata' to be supported"));
+    assert_eq!(
+        Snapshot::builder_for(&table_path)
+            .build(engine.as_ref())?
+            .version(),
+        0
+    );
+    Ok(())
+}
+
+#[rstest]
+#[case::writer_3(1, 3)]
+#[case::writer_4(1, 4)]
+#[case::writer_6(2, 6)]
+#[tokio::test]
+async fn add_table_feature_bypasses_general_write_gate_for_legacy_protocols(
+    #[case] reader_version: i32,
+    #[case] writer_version: i32,
+) -> DeltaResult<()> {
+    let (store, engine, table_url) = engine_store_setup("feature_legacy", None);
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(reader_version, writer_version),
+    )
+    .await
+    .unwrap();
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    assert!(snapshot
+        .table_configuration()
+        .ensure_operation_supported(Operation::Write)
+        .is_err());
+
+    let committed = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::DomainMetadata)
+        .with_allow_protocol_versions_increase(true)
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    assert_eq!(committed.commit_version(), 1);
+    assert!(committed
+        .post_commit_snapshot()
+        .unwrap()
+        .table_configuration()
+        .is_feature_supported(&TableFeature::DomainMetadata));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_table_feature_requires_version_permission_and_conflicts_when_stale() -> DeltaResult<()>
+{
+    let (store, refusal_engine, refusal_url) = engine_store_setup("feature_refusal", None);
+    add_commit(
+        refusal_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(1, 2),
+    )
+    .await
+    .unwrap();
+    let refusal_snapshot = Snapshot::builder_for(refusal_url.clone()).build(&refusal_engine)?;
+    let refusal = refusal_snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::DomainMetadata)
+        .build(&refusal_engine, committer());
+    assert!(refusal
+        .unwrap_err()
+        .to_string()
+        .contains("allow_protocol_versions_increase"));
+    assert_eq!(
+        Snapshot::builder_for(refusal_url)
+            .build(&refusal_engine)?
+            .version(),
+        0
+    );
+
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let first = snapshot
+        .clone()
+        .alter_table()
+        .add_table_feature(TableFeature::DomainMetadata)
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())?;
+    let stale = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::DomainMetadata)
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())?;
+
+    first.commit(engine.as_ref())?.unwrap_committed();
+    let result = stale.commit(engine.as_ref())?;
+    assert!(matches!(result, CommitResult::ConflictedTransaction(_)));
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    assert_eq!(reloaded.version(), 1);
+    assert!(reloaded
+        .table_configuration()
+        .is_feature_supported(&TableFeature::DomainMetadata));
+    Ok(())
 }
 
 /// Reads `delta.columnMapping.maxColumnId` from the snapshot's metadata. Returns

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -293,6 +293,37 @@ async fn add_unsupported_known_feature_fails_without_commit() -> DeltaResult<()>
 }
 
 #[rstest]
+#[case::catalog_managed(TableFeature::CatalogManaged)]
+#[case::catalog_owned_preview(TableFeature::CatalogOwnedPreview)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_catalog_management_feature_fails_without_commit(
+    #[case] feature: TableFeature,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let error = snapshot
+        .alter_table()
+        .add_table_feature(feature)
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())
+        .expect_err("catalog-management transition must be rejected");
+
+    assert!(error
+        .to_string()
+        .contains("Upgrading an existing table to catalog-managed is not supported"));
+    assert_eq!(
+        Snapshot::builder_for(&table_path)
+            .build(engine.as_ref())?
+            .version(),
+        0
+    );
+
+    Ok(())
+}
+
+#[rstest]
 #[case::writer_3(1, 3)]
 #[case::writer_4(1, 4)]
 #[case::writer_6(2, 6)]

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -12,7 +12,7 @@ use delta_kernel::schema::{
     ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
     StructType,
 };
-use delta_kernel::snapshot::Snapshot;
+use delta_kernel::snapshot::{ChecksumWriteResult, Snapshot};
 use delta_kernel::table_features::{ColumnMappingMode, Operation, TableFeature};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -49,11 +49,19 @@ fn read_commit_actions(table_path: &str, version: u64) -> Vec<serde_json::Value>
 }
 
 fn feature_only_table_json(reader_version: i32, writer_version: i32) -> String {
+    feature_only_table_json_with_configuration(reader_version, writer_version, "{}")
+}
+
+fn feature_only_table_json_with_configuration(
+    reader_version: i32,
+    writer_version: i32,
+    configuration: &str,
+) -> String {
     let schema = serde_json::to_string(&simple_schema()).unwrap();
     let schema = serde_json::to_string(&schema).unwrap();
     format!(
         r#"{{"protocol":{{"minReaderVersion":{reader_version},"minWriterVersion":{writer_version}}}}}
-{{"metaData":{{"id":"feature-test","format":{{"provider":"parquet","options":{{}}}},"schemaString":{schema},"partitionColumns":[],"configuration":{{}},"createdTime":1700000000000}}}}
+{{"metaData":{{"id":"feature-test","format":{{"provider":"parquet","options":{{}}}},"schemaString":{schema},"partitionColumns":[],"configuration":{configuration},"createdTime":1700000000000}}}}
 "#
     )
 }
@@ -79,6 +87,14 @@ async fn add_writer_only_feature_commits_only_protocol_and_preserves_schema_alte
     .await
     .map_err(|error| delta_kernel::Error::generic(error.to_string()))?;
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+    let (checksum_result, snapshot) = Arc::new(snapshot).write_checksum(&engine)?;
+    assert_eq!(checksum_result, ChecksumWriteResult::Written);
+
+    let initial_stats = snapshot
+        .get_file_stats_if_present()
+        .expect("version 0 checksum should contain complete file statistics");
+    assert_eq!(initial_stats.num_files(), 0);
+    assert_eq!(initial_stats.table_size_bytes(), 0);
 
     let committed = snapshot
         .clone()
@@ -94,6 +110,15 @@ async fn add_writer_only_feature_commits_only_protocol_and_preserves_schema_alte
         .post_commit_snapshot()
         .expect("feature commit should return a post-commit snapshot");
     assert_eq!(post_commit.version(), 1);
+    let post_commit_stats = post_commit
+        .get_file_stats_if_present()
+        .expect("protocol-only commit should preserve complete file statistics");
+    assert_eq!(post_commit_stats.num_files(), 0);
+    assert_eq!(post_commit_stats.table_size_bytes(), 0);
+
+    let (checksum_result, _) = post_commit.write_checksum(&engine)?;
+    assert_eq!(checksum_result, ChecksumWriteResult::Written);
+
     let protocol = post_commit.table_configuration().protocol();
     assert_eq!(protocol.min_reader_version(), 1);
     assert!(protocol.reader_features().is_none());
@@ -142,6 +167,43 @@ async fn add_writer_only_feature_commits_only_protocol_and_preserves_schema_alte
     assert!(!schema_actions
         .iter()
         .any(|action| action.get("protocol").is_some()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_in_commit_timestamp_rejects_activation_without_commit() -> DeltaResult<()> {
+    let (store, engine, table_url) = engine_store_setup("feature_ict_activation", None);
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json_with_configuration(
+            1,
+            1,
+            r#"{"delta.enableInCommitTimestamps":"true"}"#,
+        ),
+    )
+    .await
+    .unwrap();
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+
+    let error = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::InCommitTimestamp)
+        .with_allow_protocol_versions_increase(true)
+        .build(&engine, committer())
+        .expect_err("generic feature addition must not activate in-commit timestamps");
+
+    assert!(error
+        .to_string()
+        .contains("delta.enableInCommitTimestamps=true"));
+
+    let reloaded = Snapshot::builder_for(table_url).build(&engine)?;
+    assert_eq!(reloaded.version(), 0);
+    assert!(!reloaded
+        .table_configuration()
+        .is_feature_supported(&TableFeature::InCommitTimestamp));
 
     Ok(())
 }
@@ -361,6 +423,78 @@ async fn add_table_feature_bypasses_general_write_gate_for_legacy_protocols(
         .unwrap()
         .table_configuration()
         .is_feature_supported(&TableFeature::DomainMetadata));
+    Ok(())
+}
+
+#[rstest]
+#[case::append_only(1, 2, TableFeature::AppendOnly)]
+#[case::column_mapping(2, 5, TableFeature::ColumnMapping)]
+#[tokio::test]
+async fn add_legacy_supported_feature_fails_without_protocol_upgrade(
+    #[case] reader_version: i32,
+    #[case] writer_version: i32,
+    #[case] feature: TableFeature,
+) -> DeltaResult<()> {
+    let (store, engine, table_url) = engine_store_setup("feature_already_supported", None);
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(reader_version, writer_version),
+    )
+    .await
+    .unwrap();
+    let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
+
+    let error = snapshot
+        .clone()
+        .alter_table()
+        .add_table_feature(feature)
+        .build(&engine, committer())
+        .expect_err("already-supported feature must not produce an ALTER transaction");
+
+    assert!(error.to_string().contains("already supported"));
+    let reloaded = Snapshot::builder_for(table_url).build(&engine)?;
+    assert_eq!(reloaded.version(), 0);
+    assert_eq!(
+        reloaded.table_configuration().protocol(),
+        snapshot.table_configuration().protocol()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_new_feature_ignores_unsupported_legacy_implied_feature() -> DeltaResult<()> {
+    let (store, engine, table_url) = engine_store_setup("feature_mixed_legacy", None);
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(1, 2),
+    )
+    .await
+    .unwrap();
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+    let committed = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::Invariants)
+        .add_table_feature(TableFeature::DomainMetadata)
+        .with_allow_protocol_versions_increase(true)
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    let protocol = committed
+        .post_commit_snapshot()
+        .unwrap()
+        .table_configuration()
+        .protocol();
+    assert_eq!(protocol.min_reader_version(), 1);
+    assert_eq!(protocol.min_writer_version(), 7);
+    assert!(protocol
+        .writer_features()
+        .is_some_and(|features| features.contains(&TableFeature::DomainMetadata)));
     Ok(())
 }
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -147,56 +147,6 @@ async fn add_writer_only_feature_commits_only_protocol_and_preserves_schema_alte
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn add_reader_writer_feature_can_be_combined_with_schema_alter() -> DeltaResult<()> {
-    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    let snapshot =
-        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
-
-    let committed = snapshot
-        .alter_table()
-        .add_table_feature(TableFeature::DeletionVectors)
-        .add_column(StructField::nullable("region", DataType::STRING))
-        .with_allow_protocol_versions_increase(true)
-        .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
-        .unwrap_committed();
-
-    let post_commit = committed.post_commit_snapshot().unwrap();
-    assert!(post_commit.schema().field("region").is_some());
-    assert!(post_commit
-        .table_configuration()
-        .is_feature_supported(&TableFeature::DeletionVectors));
-    let protocol = post_commit.table_configuration().protocol();
-    assert_eq!(protocol.min_reader_version(), 3);
-    assert!(protocol
-        .reader_features()
-        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
-    assert!(protocol
-        .writer_features()
-        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
-
-    let actions = read_commit_actions(&table_path, 1);
-    assert_eq!(actions.len(), 3);
-    assert_eq!(actions[0]["commitInfo"]["operation"], "ADD FEATURE");
-    assert_eq!(
-        actions
-            .iter()
-            .filter(|action| action.get("protocol").is_some())
-            .count(),
-        1
-    );
-    assert_eq!(
-        actions
-            .iter()
-            .filter(|action| action.get("metaData").is_some())
-            .count(),
-        1
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn add_table_feature_validates_dependencies_without_auto_enabling_properties(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -173,6 +173,102 @@ async fn add_table_feature_validates_dependencies_without_auto_enabling_properti
 }
 
 #[rstest]
+#[case::dependency_first([TableFeature::DomainMetadata, TableFeature::RowTracking])]
+#[case::dependent_first([TableFeature::RowTracking, TableFeature::DomainMetadata])]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_table_features_validates_dependencies_against_all_requested_features(
+    #[case] features: [TableFeature; 2],
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+    let mut builder = snapshot
+        .alter_table()
+        .add_table_feature(features[0].clone());
+    builder = builder.add_table_feature(features[1].clone());
+
+    let committed = builder
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let post_commit = committed.post_commit_snapshot().unwrap();
+    assert!(post_commit
+        .table_configuration()
+        .is_feature_supported(&TableFeature::DomainMetadata));
+    assert!(post_commit
+        .table_configuration()
+        .is_feature_supported(&TableFeature::RowTracking));
+    assert!(!post_commit
+        .table_configuration()
+        .is_feature_enabled(&TableFeature::RowTracking));
+
+    let actions = read_commit_actions(&table_path, 1);
+    assert_eq!(actions.len(), 2);
+    assert_eq!(actions[0]["commitInfo"]["operation"], "ADD FEATURE");
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|action| action.get("protocol").is_some())
+            .count(),
+        1
+    );
+    assert!(!actions
+        .iter()
+        .any(|action| action.get("metaData").is_some()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_reader_writer_feature_commits_protocol_only_and_survives_reload() -> DeltaResult<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let table_path = temp_dir.path().to_string_lossy().into_owned();
+    let table_url = url::Url::from_directory_path(temp_dir.path())
+        .map_err(|_| delta_kernel::Error::generic("Invalid table path"))?;
+    let (store, engine, _) = engine_store_setup("unused", Some(&table_url));
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        0,
+        feature_only_table_json(1, 2),
+    )
+    .await
+    .map_err(|error| delta_kernel::Error::generic(error.to_string()))?;
+    let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
+
+    snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::DeletionVectors)
+        .with_allow_protocol_versions_increase(true)
+        .build(&engine, committer())?
+        .commit(&engine)?
+        .unwrap_committed();
+
+    let actions = read_commit_actions(&table_path, 1);
+    assert_eq!(actions.len(), 2);
+    assert_eq!(actions[0]["commitInfo"]["operation"], "ADD FEATURE");
+    assert!(actions[1].get("protocol").is_some());
+    assert!(!actions
+        .iter()
+        .any(|action| action.get("metaData").is_some()));
+
+    let reloaded = Snapshot::builder_for(&table_path).build(&engine)?;
+    let protocol = reloaded.table_configuration().protocol();
+    assert_eq!(protocol.min_reader_version(), 3);
+    assert_eq!(protocol.min_writer_version(), 7);
+    assert!(protocol
+        .reader_features()
+        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
+    assert!(protocol
+        .writer_features()
+        .is_some_and(|features| features.contains(&TableFeature::DeletionVectors)));
+
+    Ok(())
+}
+
+#[rstest]
 #[case::writer_3(1, 3)]
 #[case::writer_4(1, 4)]
 #[case::writer_6(2, 6)]

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -268,6 +268,30 @@ async fn add_reader_writer_feature_commits_protocol_only_and_survives_reload() -
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn add_unsupported_known_feature_fails_without_commit() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, simple_schema(), engine.as_ref(), &[])?;
+
+    let error = snapshot
+        .alter_table()
+        .add_table_feature(TableFeature::GeospatialType)
+        .with_allow_protocol_versions_increase(true)
+        .build(engine.as_ref(), committer())
+        .expect_err("unsupported known feature must be rejected");
+
+    assert!(error.to_string().contains("not supported"));
+    assert_eq!(
+        Snapshot::builder_for(&table_path)
+            .build(engine.as_ref())?
+            .version(),
+        0
+    );
+
+    Ok(())
+}
+
 #[rstest]
 #[case::writer_3(1, 3)]
 #[case::writer_4(1, 4)]


### PR DESCRIPTION
# feat: add generic table-feature ALTER transactions

## What changes are proposed in this pull request?

This change added protocol-only table-feature additions to the ALTER TABLE builder under the experimental `internal-api` feature.

* Added protocol evolution that preserves explicit and legacy-implied reader and writer capabilities while adding requested writer-only or reader-writer features.
* Separated schema modification and feature addition into distinct builder states so they cannot be combined in one ALTER transaction.
* Validated only explicitly requested features for Kernel scan and write support, dependency requirements, unsupported catalog-management transitions, and unsafe In-Commit Timestamp activation.
* Avoided protocol upgrades when every requested feature is already supported, while ignoring already-supported features in mixed requests.
* Emitted protocol-only commits with the `ADD FEATURE` operation and preserved incremental CRC file statistics for those commits.
* Added unit, integration, reload, conflict, dependency-order, no-commit failure, checksum, and compile-fail coverage.

> [!NOTE]
> Maintainer guidance is requested for two feature-specific transitions exposed by the generic API:
>
> * Variant Shredding requires Variant Type according to the Delta protocol, but that dependency is not currently represented by its `FeatureInfo`. Should this PR encode the dependency, temporarily reject the addition, or leave it for a follow-up?
> * Clustered Table addition requires partition validation and clustering domain metadata. Should generic addition reject it until a dedicated ALTER operation implements those transition requirements?

## How was this change tested?

* `cargo +nightly fmt -- --check`
* `cargo clippy --locked --benches --tests --all-features -- -D warnings`
* `cargo test --locked --workspace --all-features -- --skip read_table_version_hdfs --skip invalid_handle_code`
* `cargo test --locked --workspace --all-features --doc`
* `RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace --all-features --no-deps`
