### PR TITLE
feat!: add element-at expression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "chrono-tz",
  "crc",
  "criterion",
  "delta_kernel",

--- a/datafusion-executor/Cargo.lock
+++ b/datafusion-executor/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "arrow",
  "bytes",
  "chrono",
+ "chrono-tz",
  "crc",
  "delta_kernel_derive",
  "indexmap",

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -16,11 +16,13 @@ use datafusion::logical_expr::{
 };
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
+use delta_kernel::engine::arrow_expression::evaluate_expression as kernel_expression;
 use delta_kernel::engine::parse_json;
 use delta_kernel::expressions::{
     BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
-    ParseJsonExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
+    MapToStructOptions, ParseJsonExpression, UnaryExpressionOp, VariadicExpression,
+    VariadicExpressionOp,
 };
 use delta_kernel::schema::{
     DataType as KernelDataType, PrimitiveType, SchemaRef as KernelSchemaRef, StructField,
@@ -366,6 +368,11 @@ fn map_to_struct_to_df_expr(
 ) -> DeltaResult<DFExpr> {
     let target = require_struct_output(output_type, "MapToStruct")?;
     let map = to_df_expr(&map_to_struct.map_expr, input_schema, None)?;
+    if let Some(timestamp_timezone) = map_to_struct.options.timestamp_timezone() {
+        let udf =
+            KernelMapToStructUdf::try_new(Arc::new(target.clone()), timestamp_timezone.to_owned())?;
+        return Ok(ScalarUDF::new_from_impl(udf).call(vec![map]));
+    }
 
     let mut args = Vec::with_capacity(target.num_fields() * 2);
     for field in target.fields() {
@@ -392,6 +399,70 @@ fn map_to_struct_to_df_expr(
     }
 
     Ok(struct_null_when_not(map.is_not_null(), named_struct(args)))
+}
+
+/// A DataFusion scalar UDF that delegates timezone-aware partition parsing to kernel's Arrow
+/// evaluator.
+#[derive(Debug, PartialEq, Eq)]
+struct KernelMapToStructUdf {
+    output_schema: KernelSchemaRef,
+    timestamp_timezone: String,
+    return_type: ArrowDataType,
+    signature: Signature,
+}
+
+impl std::hash::Hash for KernelMapToStructUdf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for field in self.output_schema.fields() {
+            field.name().hash(state);
+            field.data_type().to_string().hash(state);
+        }
+        self.timestamp_timezone.hash(state);
+    }
+}
+
+impl KernelMapToStructUdf {
+    fn try_new(output_schema: KernelSchemaRef, timestamp_timezone: String) -> DeltaResult<Self> {
+        let arrow_schema: ArrowSchema = output_schema
+            .as_ref()
+            .try_into_arrow()
+            .map_err(Error::generic_err)?;
+        Ok(Self {
+            return_type: ArrowDataType::Struct(arrow_schema.fields().clone()),
+            output_schema,
+            timestamp_timezone,
+            signature: Signature::any(1, Volatility::Immutable),
+        })
+    }
+}
+
+impl ScalarUDFImpl for KernelMapToStructUdf {
+    fn name(&self) -> &str {
+        "kernel_map_to_struct_with_timestamp_timezone"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> Result<ArrowDataType, DataFusionError> {
+        Ok(self.return_type.clone())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
+        let num_rows = args.number_rows;
+        let [map] = take_function_args(self.name(), args.args)?;
+        let batch = RecordBatch::try_from_iter([("map", map.into_array(num_rows)?)])?;
+        let expression = KernelExpression::map_to_struct(
+            KernelExpression::column(["map"]),
+            MapToStructOptions::default().with_timestamp_timezone(self.timestamp_timezone.clone()),
+        );
+        let output_type = KernelDataType::from(self.output_schema.as_ref().clone());
+        let result =
+            kernel_expression::evaluate_expression(&expression, &batch, Some(&output_type))
+                .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(ColumnarValue::Array(result))
+    }
 }
 
 /// Lowers a `ParseJson` (parse a JSON-string column into a struct) to a call of the
@@ -489,13 +560,17 @@ impl ScalarUDFImpl for ParseJsonUdf {
 
 #[cfg(test)]
 mod tests {
-    use datafusion::arrow::array::{Array, AsArray, StringArray};
+    use datafusion::arrow::array::{
+        Array, AsArray, MapBuilder, StringArray, StringBuilder, TimestampMicrosecondArray,
+    };
+    use datafusion::arrow::datatypes::Field as ArrowField;
     use datafusion::assert_batches_eq;
     use datafusion::common::DFSchema;
     use datafusion::physical_expr::create_physical_expr;
     use datafusion::physical_expr::execution_props::ExecutionProps;
     use delta_kernel::expressions::{
         col, lit, Expression as KernelExpr, ExpressionStructPatch, ExpressionStructPatchBuilder,
+        MapToStructOptions,
     };
     use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
     use rstest::rstest;
@@ -971,7 +1046,7 @@ mod tests {
     /// Lowers a `MapToStruct` over `pv` targeting `output_schema` and renders it as a `Display`
     /// string.
     fn lower_map_to_struct(output_schema: StructType) -> String {
-        let kernel = KernelExpr::map_to_struct(col!("pv"));
+        let kernel = KernelExpr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let target: DataType = output_schema.into();
         to_df_expr(&kernel, &pv_map_schema(), Some(&target))
             .unwrap()
@@ -1034,11 +1109,60 @@ mod tests {
         #[case] output_type: Option<DataType>,
         #[case] expected_message: &str,
     ) {
-        let kernel = KernelExpr::map_to_struct(col!("pv"));
+        let kernel = KernelExpr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let err = to_df_expr(&kernel, &pv_map_schema(), output_type.as_ref())
             .unwrap_err()
             .to_string();
         assert!(err.contains(expected_message), "{err}");
+    }
+
+    #[test]
+    fn map_to_struct_with_timezone_lowers_to_kernel_udf() {
+        let target =
+            StructType::try_new([StructField::nullable("ts", DataType::TIMESTAMP)]).unwrap();
+        let map = KernelExpr::map_to_struct(
+            col!("pv"),
+            MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+        );
+        assert_eq!(
+            to_df_expr(&map, &pv_map_schema(), Some(&DataType::from(target)))
+                .unwrap()
+                .to_string(),
+            "kernel_map_to_struct_with_timestamp_timezone(pv)"
+        );
+    }
+
+    #[test]
+    fn map_to_struct_with_timezone_executes_in_reader_timezone() {
+        let mut maps = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        maps.keys().append_value("ts");
+        maps.values().append_value("2024-06-15 09:30:00");
+        maps.append(true).unwrap();
+        let map = Arc::new(maps.finish()) as ArrayRef;
+        let arrow_schema =
+            ArrowSchema::new(vec![ArrowField::new("pv", map.data_type().clone(), true)]);
+        let batch = RecordBatch::try_new(Arc::new(arrow_schema.clone()), vec![map]).unwrap();
+        let target =
+            StructType::try_new([StructField::nullable("ts", DataType::TIMESTAMP)]).unwrap();
+        let logical = to_df_expr(
+            &KernelExpr::map_to_struct(
+                col!("pv"),
+                MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+            ),
+            &pv_map_schema(),
+            Some(&DataType::from(target)),
+        )
+        .unwrap();
+        let df_schema = DFSchema::try_from(arrow_schema).unwrap();
+        let physical = create_physical_expr(&logical, &df_schema, &ExecutionProps::new()).unwrap();
+        let result = physical.evaluate(&batch).unwrap().into_array(1).unwrap();
+        let timestamps = result
+            .as_struct()
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        assert_eq!(timestamps.value(0), 1_718_469_000_000_000);
     }
 
     // === ParseJson Shared Helpers ===

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -19,7 +19,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::arrow_expression::evaluate_expression as kernel_expression;
 use delta_kernel::engine::parse_json;
 use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
+    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName, ElementAtExpression,
     Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
     MapToStructOptions, ParseJsonExpression, UnaryExpressionOp, VariadicExpression,
     VariadicExpressionOp,
@@ -69,6 +69,7 @@ pub fn to_df_expr(
         KernelExpression::MapToStruct(map_to_struct) => {
             map_to_struct_to_df_expr(map_to_struct, input_schema, output_type)
         }
+        KernelExpression::ElementAt(element_at) => element_at_to_df_expr(element_at, input_schema),
         KernelExpression::ParseJson(parse) => parse_json_to_df_expr(parse, input_schema),
 
         KernelExpression::Unary(u) => match u.op {
@@ -88,6 +89,72 @@ pub fn to_df_expr(
         KernelExpression::Unknown(name) => Err(Error::unsupported(format!(
             "cannot convert Unknown expression {name:?}"
         ))),
+    }
+}
+
+/// Lowers an `ElementAt` map lookup to a UDF backed by kernel's Arrow evaluator.
+///
+/// # Errors
+/// Returns an error when either child expression cannot be converted.
+fn element_at_to_df_expr(
+    element_at: &ElementAtExpression,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    let map = to_df_expr(&element_at.map_expr, input_schema, None)?;
+    let key = to_df_expr(
+        &element_at.key_expr,
+        input_schema,
+        Some(&KernelDataType::STRING),
+    )?;
+    Ok(ScalarUDF::new_from_impl(ElementAtUdf::new()).call(vec![map, key]))
+}
+
+/// A DataFusion scalar UDF that delegates `ElementAt` evaluation to kernel, preserving dynamic-key
+/// and rightmost-duplicate semantics across executors.
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct ElementAtUdf {
+    signature: Signature,
+}
+
+impl ElementAtUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for ElementAtUdf {
+    fn name(&self) -> &str {
+        "kernel_element_at"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> Result<ArrowDataType, DataFusionError> {
+        Ok(ArrowDataType::Utf8)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
+        let num_rows = args.number_rows;
+        let [map, key] = take_function_args(self.name(), args.args)?;
+        let batch = RecordBatch::try_from_iter([
+            ("map", map.into_array(num_rows)?),
+            ("key", key.into_array(num_rows)?),
+        ])?;
+        let expression = KernelExpression::element_at(
+            KernelExpression::column(["map"]),
+            KernelExpression::column(["key"]),
+        );
+        let result = kernel_expression::evaluate_expression(
+            &expression,
+            &batch,
+            Some(&KernelDataType::STRING),
+        )
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(ColumnarValue::Array(result))
     }
 }
 
@@ -1051,6 +1118,69 @@ mod tests {
         to_df_expr(&kernel, &pv_map_schema(), Some(&target))
             .unwrap()
             .to_string()
+    }
+
+    #[test]
+    fn element_at_lowers_to_kernel_udf() {
+        let kernel = KernelExpr::element_at(col!("pv"), lit("region"));
+        let rendered = to_df_expr(&kernel, &pv_map_schema(), Some(&DataType::STRING))
+            .unwrap()
+            .to_string();
+        assert_eq!(rendered, "kernel_element_at(pv, Utf8(\"region\"))");
+    }
+
+    #[test]
+    fn element_at_executes_dynamic_keys_and_rightmost_duplicates() {
+        let mut maps = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        maps.keys().append_value("region");
+        maps.values().append_value("first");
+        maps.keys().append_value("region");
+        maps.values().append_value("last");
+        maps.append(true).unwrap();
+        maps.keys().append_value("a");
+        maps.values().append_value("A");
+        maps.keys().append_value("b");
+        maps.values().append_value("B");
+        maps.append(true).unwrap();
+        maps.append(false).unwrap();
+        maps.keys().append_value("a");
+        maps.values().append_value("A");
+        maps.append(true).unwrap();
+
+        let map = Arc::new(maps.finish()) as ArrayRef;
+        let key = Arc::new(StringArray::from(vec![
+            Some("region"),
+            Some("b"),
+            Some("a"),
+            None,
+        ])) as ArrayRef;
+        let logical = to_df_expr(
+            &KernelExpr::element_at(col!("pv"), col!("key")),
+            &StructType::try_new([
+                StructField::nullable("pv", MapType::new(DataType::STRING, DataType::STRING, true)),
+                StructField::nullable("key", DataType::STRING),
+            ])
+            .unwrap(),
+            Some(&DataType::STRING),
+        )
+        .unwrap();
+        let input_schema = ArrowSchema::new(vec![
+            ArrowField::new("pv", map.data_type().clone(), true),
+            ArrowField::new("key", ArrowDataType::Utf8, true),
+        ]);
+        let batch = RecordBatch::try_new(Arc::new(input_schema.clone()), vec![map, key]).unwrap();
+        let df_schema = DFSchema::try_from(input_schema).unwrap();
+        let physical = create_physical_expr(&logical, &df_schema, &ExecutionProps::new()).unwrap();
+        let result = physical
+            .evaluate(&batch)
+            .unwrap()
+            .into_array(batch.num_rows())
+            .unwrap();
+        let result = result.as_string::<i32>();
+        assert_eq!(
+            result,
+            &StringArray::from(vec![Some("last"), Some("B"), None, None])
+        );
     }
 
     /// Each target field extracts its value with `cast(get_field(pv, name), T)`, and the whole

--- a/docs/user-guide/src/reading/scan_metadata.md
+++ b/docs/user-guide/src/reading/scan_metadata.md
@@ -249,9 +249,9 @@ If the scan has no predicate, this returns `None`.
 ## Typed partition values
 
 Kernel reads each file's partition values from the Delta log and exposes them on its
-`ScanFile` as a raw string map. Kernel's `transform_to_logical` could materialize them as
-typed columns. If your connector assembles output rows itself instead of using that transform,
-it parses the string map per file.
+`ScanFile` as a raw string map. `transform_to_logical` materializes them as typed columns. A
+connector that assembles output rows itself instead of using that transform would otherwise need
+to parse the string map per file.
 
 To have Kernel hand you the typed values directly, opt in with `with_partition_values`:
 
@@ -270,7 +270,10 @@ To have Kernel hand you the typed values directly, opt in with `with_partition_v
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
 let scan = snapshot
     .scan_builder()
-    .with_partition_values(PartitionValuesOptions::with_struct())
+    .with_partition_values(
+        PartitionValuesOptions::with_struct()
+            .with_timestamp_timezone("America/Los_Angeles"),
+    )
     .build()?;
 # Ok(())
 # }
@@ -281,9 +284,18 @@ nullable field per partition column (by physical name). You read it as a typed c
 of parsing the string map per file. The raw string map is still present, so this option only
 adds the typed column.
 
+By default, offset-less `TIMESTAMP` partition strings are interpreted in UTC. Use
+`with_timestamp_timezone` with an IANA timezone or fixed offset when the reader uses another
+timezone. An explicit offset in a partition value takes precedence. This setting affects typed
+`scan_metadata` output, internal partition pruning, and the partition-column row transforms used
+by `Scan::execute`. Incremental scans expose the raw partition-value map. For daylight-saving
+transitions, ambiguous local times use the earlier instant, and nonexistent local times use the
+offset from before the transition.
+
 > [!TIP]
 > When the checkpoint already stores typed partition values, Kernel reads that column directly
-> and skips parsing entirely.
+> unless a reader timezone requires zoned `TIMESTAMP` values to be reinterpreted. In that case,
+> Kernel reparses the raw partition map.
 
 ## Cancelling a scan
 

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -679,7 +679,16 @@ fn visit_expression_impl(
                 schema_handle
             );
         }
-        Expression::MapToStruct(MapToStructExpression { map_expr }) => {
+        Expression::MapToStruct(map_to_struct)
+            if map_to_struct.options.timestamp_timezone().is_some() =>
+        {
+            visit_unknown(
+                visitor,
+                sibling_list_id,
+                "map_to_struct_with_timestamp_timezone",
+            )
+        }
+        Expression::MapToStruct(MapToStructExpression { map_expr, .. }) => {
             let child_list_id = call!(visitor, make_field_list, 1);
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
@@ -754,15 +763,26 @@ fn visit_predicate_internal(predicate: &Predicate, visitor: &mut EngineExpressio
 
 #[cfg(test)]
 mod tests {
-    use delta_kernel::expressions::{Expression, Scalar};
+    use delta_kernel::expressions::{Expression, MapToStructOptions, Scalar};
     use rstest::rstest;
 
     use super::*;
+    use crate::TryFromStringSlice;
 
     #[derive(Debug, PartialEq, Eq)]
     enum LiteralEvent {
-        IntervalYearMonth { sibling_list_id: usize, value: i32 },
-        IntervalDayTime { sibling_list_id: usize, value: i64 },
+        IntervalYearMonth {
+            sibling_list_id: usize,
+            value: i32,
+        },
+        IntervalDayTime {
+            sibling_list_id: usize,
+            value: i64,
+        },
+        Unknown {
+            sibling_list_id: usize,
+            name: String,
+        },
     }
 
     #[derive(Default)]
@@ -799,6 +819,19 @@ mod tests {
         builder.events.push(LiteralEvent::IntervalDayTime {
             sibling_list_id,
             value,
+        });
+    }
+
+    extern "C" fn visit_unknown_name(
+        data: *mut c_void,
+        sibling_list_id: usize,
+        name: KernelStringSlice,
+    ) {
+        let builder = unsafe { &mut *(data as *mut TestExpressionBuilder) };
+        let name = unsafe { String::try_from_slice(&name) }.unwrap();
+        builder.events.push(LiteralEvent::Unknown {
+            sibling_list_id,
+            name,
         });
     }
 
@@ -881,7 +914,7 @@ mod tests {
             visit_field_patch: ignore_field_patch,
             visit_opaque_expr: ignore_opaque_expr,
             visit_opaque_pred: ignore_opaque_pred,
-            visit_unknown: ignore_column,
+            visit_unknown: visit_unknown_name,
         }
     }
 
@@ -929,5 +962,26 @@ mod tests {
 
         assert_eq!(top_level_id, 0);
         assert_eq!(builder.events, vec![expected]);
+    }
+
+    #[test]
+    fn timezone_aware_map_to_struct_visits_unknown() {
+        let expression = Expression::map_to_struct(
+            Expression::column(["partitionValues"]),
+            MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+        );
+        let mut builder = TestExpressionBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+
+        let top_level_id = visit_expression_internal(&expression, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(
+            builder.events,
+            vec![LiteralEvent::Unknown {
+                sibling_list_id: 0,
+                name: "map_to_struct_with_timestamp_timezone".to_string(),
+            }]
+        );
     }
 }

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -693,6 +693,9 @@ fn visit_expression_impl(
             visit_expression_impl(visitor, map_expr, child_list_id);
             call!(visitor, visit_map_to_struct, sibling_list_id, child_list_id);
         }
+        // The FFI expression visitor has no ElementAt callback. Surface an explicit unknown node
+        // so engines cannot silently interpret it as another expression.
+        Expression::ElementAt(_) => visit_unknown(visitor, sibling_list_id, "element_at"),
         // TODO(#2975): Add a dedicated visitor callback for cast expressions.
         Expression::Cast(cast) => visit_unknown(
             visitor,
@@ -981,6 +984,27 @@ mod tests {
             vec![LiteralEvent::Unknown {
                 sibling_list_id: 0,
                 name: "map_to_struct_with_timestamp_timezone".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn element_at_visits_unknown() {
+        let expression = Expression::element_at(
+            Expression::column(["partitionValues"]),
+            Expression::literal("key"),
+        );
+        let mut builder = TestExpressionBuilder::default();
+        let mut visitor = test_visitor(&mut builder);
+
+        let top_level_id = visit_expression_internal(&expression, &mut visitor);
+
+        assert_eq!(top_level_id, 0);
+        assert_eq!(
+            builder.events,
+            vec![LiteralEvent::Unknown {
+                sibling_list_id: 0,
+                name: "element_at".to_string(),
             }]
         );
     }

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 #[cfg(feature = "default-engine-base")]
 use delta_kernel::engine::arrow_expression::opaque::ArrowOpaquePredicate;
 use delta_kernel::expressions::{
-    BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, JunctionPredicateOp, Predicate,
-    Scalar, UnaryPredicateOp,
+    BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, JunctionPredicateOp,
+    MapToStructOptions, Predicate, Scalar, UnaryPredicateOp,
 };
 use delta_kernel::schema::{DataType, PrimitiveType};
 use delta_kernel::DeltaResult;
@@ -671,7 +671,10 @@ pub extern "C" fn visit_expression_map_to_struct(
     child_expr: usize,
 ) -> usize {
     unwrap_kernel_expression(state, child_expr).map_or(0, |expr| {
-        wrap_expression(state, Expression::map_to_struct(expr))
+        wrap_expression(
+            state,
+            Expression::map_to_struct(expr, MapToStructOptions::default()),
+        )
     })
 }
 

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -6,8 +6,9 @@ use std::sync::Arc;
 
 use delta_kernel::expressions::{
     col, column_name, column_pred, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
-    Expression as Expr, ExpressionStructPatchBuilder, MapData, OpaqueExpressionOp,
-    OpaquePredicateOp, Predicate as Pred, Scalar, ScalarExpressionEvaluator, StructData,
+    Expression as Expr, ExpressionStructPatchBuilder, MapData, MapToStructOptions,
+    OpaqueExpressionOp, OpaquePredicateOp, Predicate as Pred, Scalar, ScalarExpressionEvaluator,
+    StructData,
 };
 use delta_kernel::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -161,7 +162,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
             vec![Expr::literal(42), Expr::literal(1.111)],
         ),
         Expr::unknown("mystery"),
-        Expr::map_to_struct(col!("pv")),
+        Expr::map_to_struct(col!("pv"), MapToStructOptions::default()),
         Expr::coalesce([col!("col"), lit(0_i32)]),
         Expr::array([Expr::literal(1_i32), Expr::literal(2_i32)]),
     ];
@@ -283,7 +284,7 @@ pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<Shared
             Expr::literal(2_i64),
             Expr::literal(3.0_f64),
         ]),
-        Expr::map_to_struct(col!("partitionValues")),
+        Expr::map_to_struct(col!("partitionValues"), MapToStructOptions::default()),
     ];
     Arc::new(Expr::struct_from(sub_exprs)).into()
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -42,6 +42,7 @@ pre-release-hook = [
 delta_kernel_derive = { path = "../derive-macros", version = "0.27.1" }
 bytes = "1.10"
 chrono = "0.4.41"
+chrono-tz = "0.10.4"
 crc = "3.2.2"
 indexmap = "2.10.0"
 itertools = "0.14"

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -161,6 +161,11 @@ message MapToStructExpression {
   MapToStructOptions options = 2;
 }
 
+message ElementAtExpression {
+  Expression map_expr = 1;
+  Expression key_expr = 2;
+}
+
 // `nullability_predicate` is optional: when set and it evaluates to false/null, the whole
 // struct is null.
 message StructExpression {
@@ -246,5 +251,6 @@ message Expression {
     ParseJsonExpression parse_json = 11;
     MapToStructExpression map_to_struct = 12;
     string unknown = 13;
+    ElementAtExpression element_at = 14;
   }
 }

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -150,8 +150,15 @@ message ParseJsonExpression {
   delta.kernel.schema.StructType output_schema = 2;
 }
 
+message MapToStructOptions {
+  // Optional IANA timezone or fixed offset for interpreting offset-less TIMESTAMP values. An
+  // explicit offset in a value takes precedence; absence preserves the default UTC behavior.
+  optional string timestamp_timezone = 1;
+}
+
 message MapToStructExpression {
   Expression map_expr = 1;
+  MapToStructOptions options = 2;
 }
 
 // `nullability_predicate` is optional: when set and it evaluates to false/null, the whole

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -1,10 +1,8 @@
 //! Resolves a checkpoint shape. This falls into the following cases: no checkpoint,
 //! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
-//! When stats are requested, also reports whether the checkpoint has compatible parsed stats.
+//! When schemas are requested, also reports whether the checkpoint has compatible parsed stats
+//! and partition values.
 //! Driven through a [`PlanExecutor`].
-
-// No in-crate caller yet; following PRs will use this.
-#![allow(dead_code)]
 
 use url::Url;
 
@@ -29,7 +27,7 @@ pub(crate) enum CheckpointType {
     Manifest,
 }
 
-/// A snapshot's resolved checkpoint type and parsed-stats schema.
+/// A snapshot's resolved checkpoint type and compatible parsed schemas.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CheckpointShape {
     /// What kind of checkpoint this is.
@@ -37,15 +35,19 @@ pub(crate) struct CheckpointShape {
     /// The requested stats schema when the checkpoint has a compatible `add.stats_parsed` struct
     /// to read it from; `None` when stats were not requested or no compatible parsed stats exist.
     pub(crate) parsed_stats_schema: Option<SchemaRef>,
+    /// The requested partition schema when the checkpoint has a compatible
+    /// `add.partitionValues_parsed` struct; `None` when partition values were not requested or no
+    /// compatible parsed partition values exist.
+    pub(crate) parsed_partition_schema: Option<SchemaRef>,
 }
 
 impl CheckpointShape {
-    /// Resolve `snapshot`'s checkpoint shape. Determines the checkpoint type and, when
-    /// `stats_schema` is `Some`, whether the checkpoint contains parsed stats compatible with it.
+    /// Resolve `snapshot`'s checkpoint shape and compatible parsed stats and partition schemas.
     pub(crate) fn try_new(
         exec: &dyn PlanExecutor,
         snapshot: &Snapshot,
         stats_schema: Option<&SchemaRef>,
+        partition_schema: Option<&SchemaRef>,
     ) -> DeltaResult<CheckpointShape> {
         let segment = snapshot.log_segment();
 
@@ -56,15 +58,21 @@ impl CheckpointShape {
                 return Ok(CheckpointShape {
                     checkpoint_type: CheckpointType::None,
                     parsed_stats_schema: None,
+                    parsed_partition_schema: None,
                 })
             }
         };
 
         // Classify from a V2 checkpoint's `_last_checkpoint` hint when possible, else inspect the
         // file.
-        if let Some(shape) =
-            Self::from_v2_checkpoint_hint(exec, segment, root_checkpoint, file_type, stats_schema)?
-        {
+        if let Some(shape) = Self::from_v2_checkpoint_hint(
+            exec,
+            segment,
+            root_checkpoint,
+            file_type,
+            stats_schema,
+            partition_schema,
+        )? {
             return Ok(shape);
         }
 
@@ -77,13 +85,23 @@ impl CheckpointShape {
                 };
                 // No `sidecar` column means the file actions are inline, so this is a leaf.
                 if !cp_schema.contains(SIDECAR_NAME) {
-                    return Ok(Self::try_new_leaf(Some(cp_schema), stats_schema));
+                    return Ok(Self::try_new_leaf(
+                        Some(cp_schema),
+                        stats_schema,
+                        partition_schema,
+                    ));
                 }
                 // The `sidecar` column may still be all-null (not a manifest), so scan it to
                 // confirm whether a sidecar is actually present.
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(Some(cp_schema), stats_schema)),
+                    Some(sidecar) => {
+                        Self::try_new_manifest(exec, sidecar, stats_schema, partition_schema)
+                    }
+                    None => Ok(Self::try_new_leaf(
+                        Some(cp_schema),
+                        stats_schema,
+                        partition_schema,
+                    )),
                 }
             }
             // A JSON checkpoint has no footer schema to inspect, so try to collect a sidecar to
@@ -91,8 +109,10 @@ impl CheckpointShape {
             // hence no parsed stats.
             FileType::Json => {
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
-                    None => Ok(Self::try_new_leaf(None, stats_schema)),
+                    Some(sidecar) => {
+                        Self::try_new_manifest(exec, sidecar, stats_schema, partition_schema)
+                    }
+                    None => Ok(Self::try_new_leaf(None, stats_schema, partition_schema)),
                 }
             }
         }
@@ -109,18 +129,20 @@ impl CheckpointShape {
         root_checkpoint: &FileMeta,
         file_type: FileType,
         stats_schema: Option<&SchemaRef>,
+        partition_schema: Option<&SchemaRef>,
     ) -> DeltaResult<Option<CheckpointShape>> {
         match segment.checkpoint_hint_sidecars().map(Vec::as_slice) {
             Some([sidecar, ..]) => {
                 let sidecar_meta = sidecar.to_filemeta(&segment.log_root)?;
-                let result = Self::try_new_manifest(exec, sidecar_meta, stats_schema)?;
+                let result =
+                    Self::try_new_manifest(exec, sidecar_meta, stats_schema, partition_schema)?;
                 Ok(Some(result))
             }
             Some([]) => {
-                // A parquet leaf's stats live in its own schema; read it only when stats are
-                // requested. A JSON leaf has no readable schema.
+                // A parquet leaf's parsed stats and partition values live in its own schema; read
+                // it when either schema is requested. A JSON leaf has no readable schema.
                 let leaf_schema = match file_type {
-                    FileType::Parquet if stats_schema.is_some() => {
+                    FileType::Parquet if stats_schema.is_some() || partition_schema.is_some() => {
                         Some(match segment.checkpoint_hint_schema() {
                             Some(schema) => schema,
                             None => exec.read_parquet_footer(root_checkpoint.clone())?.schema,
@@ -128,31 +150,46 @@ impl CheckpointShape {
                     }
                     _ => None,
                 };
-                Ok(Some(Self::try_new_leaf(leaf_schema, stats_schema)))
+                Ok(Some(Self::try_new_leaf(
+                    leaf_schema,
+                    stats_schema,
+                    partition_schema,
+                )))
             }
             None => Ok(None),
         }
     }
 
-    /// Build the shape for a manifest checkpoint. Its file actions and their stats live in the
-    /// sidecars, so probe a sidecar's (parquet) footer -- but only when stats were requested. All
-    /// sidecars of a checkpoint share one schema, so probing the first is sufficient.
+    /// Build the shape for a manifest checkpoint. File actions live in sidecars, so probe the first
+    /// sidecar footer when stats or partition schemas are requested; all sidecars share one schema.
     fn try_new_manifest(
         exec: &dyn PlanExecutor,
         sidecar: FileMeta,
         stats_schema: Option<&SchemaRef>,
+        partition_schema: Option<&SchemaRef>,
     ) -> DeltaResult<CheckpointShape> {
-        let parsed_stats_schema = match stats_schema {
-            Some(stats_schema) => {
-                let footer_schema = exec.read_parquet_footer(sidecar)?.schema;
-                LogSegment::schema_has_compatible_stats_parsed(footer_schema.as_ref(), stats_schema)
-                    .then(|| stats_schema.clone())
-            }
-            None => None,
+        let footer_schema = if stats_schema.is_some() || partition_schema.is_some() {
+            Some(exec.read_parquet_footer(sidecar)?.schema)
+        } else {
+            None
         };
+        let parsed_stats_schema = stats_schema.filter(|stats_schema| {
+            footer_schema.as_ref().is_some_and(|footer_schema| {
+                LogSegment::schema_has_compatible_stats_parsed(footer_schema, stats_schema)
+            })
+        });
+        let parsed_partition_schema = partition_schema.filter(|partition_schema| {
+            footer_schema.as_ref().is_some_and(|footer_schema| {
+                LogSegment::schema_has_compatible_partition_values_parsed(
+                    footer_schema,
+                    partition_schema,
+                )
+            })
+        });
         Ok(CheckpointShape {
             checkpoint_type: CheckpointType::Manifest,
-            parsed_stats_schema,
+            parsed_stats_schema: parsed_stats_schema.cloned(),
+            parsed_partition_schema: parsed_partition_schema.cloned(),
         })
     }
 
@@ -161,15 +198,25 @@ impl CheckpointShape {
     fn try_new_leaf(
         leaf_schema: Option<SchemaRef>,
         stats_schema: Option<&SchemaRef>,
+        partition_schema: Option<&SchemaRef>,
     ) -> CheckpointShape {
         let parsed_stats_schema = stats_schema.filter(|stats_schema| {
             leaf_schema.as_ref().is_some_and(|leaf_schema| {
                 LogSegment::schema_has_compatible_stats_parsed(leaf_schema.as_ref(), stats_schema)
             })
         });
+        let parsed_partition_schema = partition_schema.filter(|partition_schema| {
+            leaf_schema.as_ref().is_some_and(|leaf_schema| {
+                LogSegment::schema_has_compatible_partition_values_parsed(
+                    leaf_schema,
+                    partition_schema,
+                )
+            })
+        });
         CheckpointShape {
             checkpoint_type: CheckpointType::Leaf,
             parsed_stats_schema: parsed_stats_schema.cloned(),
+            parsed_partition_schema: parsed_partition_schema.cloned(),
         }
     }
 }
@@ -301,8 +348,8 @@ mod tests {
         let exec = SyncPlanExecutor::default();
         let stats_schema = expect_parsed.map(|_| probe_stats_schema());
 
-        let shape =
-            CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.as_ref()).unwrap();
+        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), stats_schema.as_ref(), None)
+            .unwrap();
 
         assert_eq!(
             shape.checkpoint_type, expected_checkpoint,
@@ -353,8 +400,9 @@ mod tests {
             load_test_table("v2-checkpoints-parquet-with-sidecars").unwrap();
         let exec = CountingExecutor::new();
 
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape =
+            CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()), None)
+                .unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert_eq!(
@@ -391,8 +439,9 @@ mod tests {
             .unwrap();
 
         let exec = CountingExecutor::new();
-        let shape = CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()))
-            .unwrap();
+        let shape =
+            CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&probe_stats_schema()), None)
+                .unwrap();
 
         assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
         assert!(
@@ -468,6 +517,7 @@ mod tests {
             root,
             file_type,
             stats_schema.as_ref(),
+            None,
         )
         .unwrap()
         .expect("an empty-sidecars hint must classify without falling through");

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -16,7 +16,7 @@
 use std::sync::{Arc, LazyLock};
 
 use crate::actions::{ADD_NAME, STATS_PARSED as STATS_PARSED_FIELD};
-use crate::expressions::{col, Expression, ExpressionRef, UnaryExpressionOp};
+use crate::expressions::{col, Expression, ExpressionRef, MapToStructOptions, UnaryExpressionOp};
 use crate::schema::{DataType, SchemaRef, SchemaStructPatchBuilder, StructField, StructType};
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::table_properties::TableProperties;
@@ -211,7 +211,10 @@ fn build_stats_parsed_expr(stats_schema: &SchemaRef) -> ExpressionRef {
 fn build_partition_values_parsed_expr() -> ExpressionRef {
     Arc::new(Expression::coalesce([
         col!(ADD_NAME, PARTITION_VALUES_PARSED_FIELD),
-        Expression::map_to_struct(col!(ADD_NAME, PARTITION_VALUES_FIELD)),
+        Expression::map_to_struct(
+            col!(ADD_NAME, PARTITION_VALUES_FIELD),
+            MapToStructOptions::default(),
+        ),
     ]))
 }
 

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -29,6 +29,7 @@ use crate::arrow::json::writer::{make_encoder, EncoderOptions};
 use crate::arrow::json::StructMode;
 use crate::delta_kernel_derive::internal_api;
 use crate::engine::arrow_conversion::{TryFromKernel, TryIntoArrow, LIST_ARRAY_ROOT};
+use crate::engine::arrow_data::as_string_accessor;
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpressionOpAdaptor, ArrowOpaquePredicateOpAdaptor,
 };
@@ -396,6 +397,14 @@ pub fn evaluate_expression(
         }
         (MapToStruct(_), dt) => Err(Error::Generic(format!(
             "MapToStruct expression requires a DataType::Struct result type, but got {dt:?}"
+        ))),
+        (ElementAt(e), None | Some(&DataType::STRING)) => {
+            let map_arr = evaluate_expression(&e.map_expr, batch, None)?;
+            let key_arr = evaluate_expression(&e.key_expr, batch, Some(&DataType::STRING))?;
+            evaluate_element_at(&map_arr, &key_arr)
+        }
+        (ElementAt(_), Some(data_type)) => Err(Error::generic(format!(
+            "ElementAt expression requires a STRING result type, but got {data_type:?}"
         ))),
         (Cast(c), result_type) => {
             let input = evaluate_expression(&c.expr, batch, None)?;
@@ -1103,6 +1112,43 @@ fn evaluate_map_to_struct(
     )?)
 }
 
+fn evaluate_element_at(map_arr: &ArrayRef, key_arr: &ArrayRef) -> DeltaResult<ArrayRef> {
+    let map_array = map_arr
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .ok_or_else(|| Error::generic("ElementAt requires a MapArray as input"))?;
+    let map_keys = as_string_accessor(map_array.keys().as_ref())
+        .ok_or_else(|| Error::generic("ElementAt requires maps with string keys"))?;
+    let map_values = as_string_accessor(map_array.values().as_ref())
+        .ok_or_else(|| Error::generic("ElementAt requires maps with string values"))?;
+    let key_array = as_string_accessor(key_arr.as_ref())
+        .ok_or_else(|| Error::generic("ElementAt requires string keys"))?;
+    if map_array.len() != key_array.len() {
+        return Err(Error::generic(format!(
+            "ElementAt map has {} rows, but key has {} rows",
+            map_array.len(),
+            key_array.len()
+        )));
+    }
+
+    let offsets = map_array.value_offsets();
+    let values = (0..map_array.len()).map(|row| {
+        if map_array.is_null(row) || !key_array.is_valid(row) {
+            return None;
+        }
+        let key = key_array.value(row);
+        let entry_start = offsets[row] as usize;
+        let entry_end = offsets[row + 1] as usize;
+        let entry_idx = (entry_start..entry_end)
+            .rev()
+            .find(|entry_idx| map_keys.value(*entry_idx) == key)?;
+        map_values
+            .is_valid(entry_idx)
+            .then(|| map_values.value(entry_idx))
+    });
+    Ok(Arc::new(StringArray::from_iter(values)))
+}
+
 fn validate_array_type(array: ArrayRef, expected: Option<&DataType>) -> DeltaResult<ArrayRef> {
     if let Some(expected) = expected {
         ensure_data_types(expected, array.data_type(), ValidationMode::TypesAndNames)?;
@@ -1118,9 +1164,9 @@ mod tests {
 
     use super::*;
     use crate::arrow::array::{
-        ArrayRef, BinaryArray, BooleanArray, Float64Array, Int32Array, Int64Array,
-        LargeStringArray, ListArray, MapBuilder, StringArray, StringBuilder, StructArray,
-        TimestampMicrosecondArray,
+        ArrayRef, BinaryArray, BooleanArray, Float64Array, Int32Array, Int32Builder, Int64Array,
+        LargeStringArray, ListArray, MapBuilder, StringArray, StringBuilder, StringViewArray,
+        StructArray, TimestampMicrosecondArray,
     };
     use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use crate::arrow::datatypes::{
@@ -2687,6 +2733,225 @@ mod tests {
             true,
         )]);
         RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap()
+    }
+
+    fn element_at_batch(map: ArrayRef, key: ArrayRef) -> RecordBatch {
+        let schema = ArrowSchema::new(vec![
+            ArrowField::new("map", map.data_type().clone(), true),
+            ArrowField::new("key", key.data_type().clone(), true),
+        ]);
+        RecordBatch::try_new(Arc::new(schema), vec![map, key]).unwrap()
+    }
+
+    #[test]
+    fn test_element_at_returns_matching_value() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("region");
+        builder.values().append_value("us");
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![Some("region")])),
+        );
+
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        )
+        .unwrap();
+        let values = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(values, &StringArray::from(vec![Some("us")]));
+    }
+
+    #[rstest]
+    fn test_element_at_accepts_all_arrow_string_representations(
+        #[values(ArrowDataType::Utf8, ArrowDataType::LargeUtf8, ArrowDataType::Utf8View)]
+        string_type: ArrowDataType,
+    ) {
+        let make_array = |value: &str| -> ArrayRef {
+            match &string_type {
+                ArrowDataType::Utf8 => Arc::new(StringArray::from(vec![Some(value)])),
+                ArrowDataType::LargeUtf8 => Arc::new(LargeStringArray::from(vec![Some(value)])),
+                ArrowDataType::Utf8View => Arc::new(StringViewArray::from(vec![Some(value)])),
+                other => panic!("unexpected string type: {other:?}"),
+            }
+        };
+        let fields: Fields = vec![
+            Arc::new(ArrowField::new("key", string_type.clone(), false)),
+            Arc::new(ArrowField::new("value", string_type.clone(), true)),
+        ]
+        .into();
+        let entries = StructArray::try_new(
+            fields.clone(),
+            vec![make_array("region"), make_array("us")],
+            None,
+        )
+        .unwrap();
+        let map = MapArray::try_new(
+            Arc::new(ArrowField::new(
+                "entries",
+                ArrowDataType::Struct(fields),
+                false,
+            )),
+            OffsetBuffer::new(vec![0i32, 1].into()),
+            entries,
+            None,
+            false,
+        )
+        .unwrap();
+        let batch = element_at_batch(Arc::new(map), make_array("region"));
+
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        )
+        .unwrap();
+        let values = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(values, &StringArray::from(vec![Some("us")]));
+    }
+
+    #[test]
+    fn test_element_at_returns_null_for_missing_key_null_map_null_key_and_null_value() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("other");
+        builder.values().append_value("value");
+        builder.append(true).unwrap();
+        builder.append(false).unwrap();
+        builder.keys().append_value("region");
+        builder.values().append_value("us");
+        builder.append(true).unwrap();
+        builder.keys().append_value("region");
+        builder.values().append_null();
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![
+                Some("region"),
+                Some("region"),
+                None,
+                Some("region"),
+            ])),
+        );
+
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        )
+        .unwrap();
+        let values = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(values.null_count(), 4);
+    }
+
+    #[test]
+    fn test_element_at_uses_rightmost_duplicate_key() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("region");
+        builder.values().append_value("first");
+        builder.keys().append_value("region");
+        builder.values().append_value("last");
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![Some("region")])),
+        );
+
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        )
+        .unwrap();
+        let values = result.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(values.value(0), "last");
+    }
+
+    #[test]
+    fn test_element_at_rejects_non_map_input() {
+        let batch = element_at_batch(
+            Arc::new(StringArray::from(vec![Some("not a map")])),
+            Arc::new(StringArray::from(vec![Some("key")])),
+        );
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        );
+        assert_result_error_with_message(result, "requires a MapArray");
+    }
+
+    #[test]
+    fn test_element_at_rejects_non_string_map_keys() {
+        let mut builder = MapBuilder::new(None, Int32Builder::new(), StringBuilder::new());
+        builder.keys().append_value(1);
+        builder.values().append_value("one");
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![Some("1")])),
+        );
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        );
+        assert_result_error_with_message(result, "maps with string keys");
+    }
+
+    #[test]
+    fn test_element_at_rejects_non_string_map_values() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), Int32Builder::new());
+        builder.keys().append_value("one");
+        builder.values().append_value(1);
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![Some("one")])),
+        );
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        );
+        assert_result_error_with_message(result, "maps with string values");
+    }
+
+    #[test]
+    fn test_element_at_rejects_non_string_key_expression() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("one");
+        builder.values().append_value("value");
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(Int32Array::from(vec![Some(1)])),
+        );
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::STRING),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_element_at_rejects_non_string_result_type() {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("one");
+        builder.values().append_value("value");
+        builder.append(true).unwrap();
+        let batch = element_at_batch(
+            Arc::new(builder.finish()),
+            Arc::new(StringArray::from(vec![Some("one")])),
+        );
+        let result = evaluate_expression(
+            &Expr::element_at(col!("map"), col!("key")),
+            &batch,
+            Some(&DataType::INTEGER),
+        );
+        assert_result_error_with_message(result, "requires a STRING result type");
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -3,11 +3,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use chrono::{FixedOffset, MappedLocalTime, NaiveDateTime, Offset, TimeDelta, TimeZone, Utc};
 use itertools::Itertools;
 use tracing::warn;
 
-use crate::arrow::array::timezone::Tz;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
@@ -15,7 +13,7 @@ use crate::arrow::array::{
     RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
-use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
+use crate::arrow::compute::kernels::cast_utils::Parser;
 use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
 use crate::arrow::compute::kernels::comparison::in_list_utf8;
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
@@ -44,6 +42,7 @@ use crate::expressions::{
     UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
 };
 use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+use crate::timestamp_timezone::TimestampTimezone;
 
 #[internal_api]
 pub(crate) trait ProvidesColumnByName {
@@ -411,99 +410,6 @@ pub fn evaluate_expression(
             validate_array_type(output, result_type)
         }
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
-    }
-}
-
-#[derive(Clone, Copy)]
-enum TimestampTimezone {
-    Arrow(Tz),
-    Fixed(FixedOffset),
-}
-
-impl TimestampTimezone {
-    fn parse(value: &str) -> DeltaResult<Self> {
-        if value.starts_with('+') || value.starts_with('-') {
-            return parse_fixed_offset(value)
-                .map(Self::Fixed)
-                .ok_or_else(|| Error::generic(format!("Invalid timestamp timezone: {value}")));
-        }
-        value
-            .parse::<Tz>()
-            .map(Self::Arrow)
-            .map_err(|_| Error::generic(format!("Invalid timestamp timezone: {value}")))
-    }
-
-    fn parse_timestamp(self, raw: &str) -> Result<i64, ArrowError> {
-        match self {
-            Self::Arrow(timezone) => parse_timestamp_with_timezone(timezone, raw),
-            Self::Fixed(timezone) => parse_timestamp_with_timezone(timezone, raw),
-        }
-    }
-}
-
-fn parse_fixed_offset(value: &str) -> Option<FixedOffset> {
-    let (sign, value) = match value.as_bytes().first()? {
-        b'+' => (1, &value[1..]),
-        b'-' => (-1, &value[1..]),
-        _ => return None,
-    };
-    let mut parts = value.split(':');
-    let parse_component = |part: &str| {
-        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
-            .then(|| part.parse::<i32>().ok())
-            .flatten()
-    };
-    let hours = parse_component(parts.next()?)?;
-    let minutes = parts.next().map_or(Some(0), parse_component)?;
-    let seconds = parts.next().map_or(Some(0), parse_component)?;
-    if parts.next().is_some()
-        || value.is_empty()
-        || hours > 18
-        || minutes > 59
-        || seconds > 59
-        || (hours == 18 && (minutes != 0 || seconds != 0))
-    {
-        return None;
-    }
-    FixedOffset::east_opt(sign * (hours * 3_600 + minutes * 60 + seconds))
-}
-
-fn parse_timestamp_with_timezone<T: TimeZone + Copy>(
-    timezone: T,
-    raw: &str,
-) -> Result<i64, ArrowError> {
-    if let Ok(timestamp) = string_to_datetime(&timezone, raw) {
-        return Ok(timestamp.timestamp_micros());
-    }
-    let local_datetime = string_to_datetime(&Utc, raw)?.naive_utc();
-    resolve_local_timestamp(local_datetime, timezone).ok_or_else(|| {
-        ArrowError::ParseError(format!("Error resolving local timestamp from '{raw}'"))
-    })
-}
-
-fn resolve_local_timestamp<T: TimeZone + Copy>(
-    local_datetime: NaiveDateTime,
-    timezone: T,
-) -> Option<i64> {
-    match timezone.from_local_datetime(&local_datetime) {
-        MappedLocalTime::Single(timestamp) => Some(timestamp.timestamp_micros()),
-        MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.timestamp_micros()),
-        MappedLocalTime::None => {
-            // A forward transition can skip more than one hour, so walk backward until reaching
-            // the pre-transition side of the gap.
-            let offset = (1..=48).find_map(|hours| {
-                let before_transition =
-                    local_datetime.checked_sub_signed(TimeDelta::hours(hours))?;
-                match timezone.from_local_datetime(&before_transition) {
-                    MappedLocalTime::Single(timestamp) => Some(timestamp.offset().fix()),
-                    MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.offset().fix()),
-                    MappedLocalTime::None => None,
-                }
-            })?;
-            local_datetime
-                .checked_sub_signed(TimeDelta::seconds(i64::from(offset.local_minus_utc())))
-                .map(|utc_datetime| utc_datetime.and_utc().timestamp_micros())
-        }
     }
 }
 
@@ -1059,16 +965,10 @@ fn parse_partition_scalar(
             return Ok(Some(Scalar::Date(days)));
         }
         PrimitiveType::Timestamp => {
-            let micros = timestamp_timezone.parse_timestamp(raw).map_err(|_| {
+            let micros = timestamp_timezone.parse_timestamp(raw).ok_or_else(|| {
                 Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone()))
             })?;
             return Ok(Some(Scalar::Timestamp(micros)));
-        }
-        PrimitiveType::TimestampNtz => {
-            let micros = string_to_datetime(&Utc, raw)
-                .map_err(|_| Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone())))?
-                .timestamp_micros();
-            return Ok(Some(Scalar::TimestampNtz(micros)));
         }
         _ => {}
     }
@@ -3025,35 +2925,6 @@ mod tests {
             evaluate_map_timestamp_timezone(raw, DataType::TIMESTAMP, timestamp_timezone).unwrap(),
             Some(expected_timestamp_micros(expected))
         );
-    }
-
-    #[rstest]
-    #[case::zero("+0", 0)]
-    #[case::hours("+5", 18_000)]
-    #[case::hours_minutes("-05:30", -19_800)]
-    #[case::hours_minutes_seconds("+12:45:30", 45_930)]
-    #[case::positive_limit("+18:00:00", 64_800)]
-    #[case::negative_limit("-18", -64_800)]
-    fn test_parse_fixed_offset_accepts_supported_forms(
-        #[case] timezone: &str,
-        #[case] expected_seconds: i32,
-    ) {
-        assert_eq!(
-            parse_fixed_offset(timezone).map(|offset| offset.local_minus_utc()),
-            Some(expected_seconds)
-        );
-    }
-
-    #[rstest]
-    #[case::empty("")]
-    #[case::bare_positive_sign("+")]
-    #[case::over_max_second("+18:00:01")]
-    #[case::over_max_hour("+19")]
-    #[case::minutes_out_of_range("+00:60")]
-    #[case::seconds_out_of_range("+00:00:60")]
-    #[case::extra_component("+05:30:00:00")]
-    fn test_parse_fixed_offset_rejects_invalid_forms(#[case] timezone: &str) {
-        assert_eq!(parse_fixed_offset(timezone), None);
     }
 
     #[test]

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -3,10 +3,11 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use chrono::Utc;
+use chrono::{FixedOffset, MappedLocalTime, NaiveDateTime, Offset, TimeDelta, TimeZone, Utc};
 use itertools::Itertools;
 use tracing::warn;
 
+use crate::arrow::array::timezone::Tz;
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
     self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
@@ -389,7 +390,9 @@ pub fn evaluate_expression(
         }
         (MapToStruct(m), Some(DataType::Struct(output_schema))) => {
             let map_arr = evaluate_expression(&m.map_expr, batch, None)?;
-            let result = evaluate_map_to_struct(&map_arr, output_schema)?;
+            let timestamp_timezone =
+                TimestampTimezone::parse(m.options.timestamp_timezone().unwrap_or("UTC"))?;
+            let result = evaluate_map_to_struct(&map_arr, output_schema, timestamp_timezone)?;
             Ok(Arc::new(result) as ArrayRef)
         }
         (MapToStruct(_), dt) => Err(Error::Generic(format!(
@@ -408,6 +411,99 @@ pub fn evaluate_expression(
             validate_array_type(output, result_type)
         }
         (Unknown(name), _) => Err(Error::unsupported(format!("Unknown expression: {name:?}"))),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum TimestampTimezone {
+    Arrow(Tz),
+    Fixed(FixedOffset),
+}
+
+impl TimestampTimezone {
+    fn parse(value: &str) -> DeltaResult<Self> {
+        if value.starts_with('+') || value.starts_with('-') {
+            return parse_fixed_offset(value)
+                .map(Self::Fixed)
+                .ok_or_else(|| Error::generic(format!("Invalid timestamp timezone: {value}")));
+        }
+        value
+            .parse::<Tz>()
+            .map(Self::Arrow)
+            .map_err(|_| Error::generic(format!("Invalid timestamp timezone: {value}")))
+    }
+
+    fn parse_timestamp(self, raw: &str) -> Result<i64, ArrowError> {
+        match self {
+            Self::Arrow(timezone) => parse_timestamp_with_timezone(timezone, raw),
+            Self::Fixed(timezone) => parse_timestamp_with_timezone(timezone, raw),
+        }
+    }
+}
+
+fn parse_fixed_offset(value: &str) -> Option<FixedOffset> {
+    let (sign, value) = match value.as_bytes().first()? {
+        b'+' => (1, &value[1..]),
+        b'-' => (-1, &value[1..]),
+        _ => return None,
+    };
+    let mut parts = value.split(':');
+    let parse_component = |part: &str| {
+        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| part.parse::<i32>().ok())
+            .flatten()
+    };
+    let hours = parse_component(parts.next()?)?;
+    let minutes = parts.next().map_or(Some(0), parse_component)?;
+    let seconds = parts.next().map_or(Some(0), parse_component)?;
+    if parts.next().is_some()
+        || value.is_empty()
+        || hours > 18
+        || minutes > 59
+        || seconds > 59
+        || (hours == 18 && (minutes != 0 || seconds != 0))
+    {
+        return None;
+    }
+    FixedOffset::east_opt(sign * (hours * 3_600 + minutes * 60 + seconds))
+}
+
+fn parse_timestamp_with_timezone<T: TimeZone + Copy>(
+    timezone: T,
+    raw: &str,
+) -> Result<i64, ArrowError> {
+    if let Ok(timestamp) = string_to_datetime(&timezone, raw) {
+        return Ok(timestamp.timestamp_micros());
+    }
+    let local_datetime = string_to_datetime(&Utc, raw)?.naive_utc();
+    resolve_local_timestamp(local_datetime, timezone).ok_or_else(|| {
+        ArrowError::ParseError(format!("Error resolving local timestamp from '{raw}'"))
+    })
+}
+
+fn resolve_local_timestamp<T: TimeZone + Copy>(
+    local_datetime: NaiveDateTime,
+    timezone: T,
+) -> Option<i64> {
+    match timezone.from_local_datetime(&local_datetime) {
+        MappedLocalTime::Single(timestamp) => Some(timestamp.timestamp_micros()),
+        MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.timestamp_micros()),
+        MappedLocalTime::None => {
+            // A forward transition can skip more than one hour, so walk backward until reaching
+            // the pre-transition side of the gap.
+            let offset = (1..=48).find_map(|hours| {
+                let before_transition =
+                    local_datetime.checked_sub_signed(TimeDelta::hours(hours))?;
+                match timezone.from_local_datetime(&before_transition) {
+                    MappedLocalTime::Single(timestamp) => Some(timestamp.offset().fix()),
+                    MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.offset().fix()),
+                    MappedLocalTime::None => None,
+                }
+            })?;
+            local_datetime
+                .checked_sub_signed(TimeDelta::seconds(i64::from(offset.local_minus_utc())))
+                .map(|utc_datetime| utc_datetime.and_utc().timestamp_micros())
+        }
     }
 }
 
@@ -944,13 +1040,14 @@ pub fn coalesce_arrays(
 ///
 /// An empty string casts via [`PrimitiveType::empty_string_partition_cast`].
 ///
-/// Date and timestamp use arrow's `Date32Type::parse` / `string_to_datetime`, which are much
-/// faster than `parse_scalar`'s chrono path and yield the same value for valid Delta partition
-/// values. These arrow parsers accept a superset of the canonical formats (e.g. `20240115`, or a
-/// timestamp carrying an explicit offset) and interpret no-offset timestamps as UTC, matching
-/// `parse_scalar`; spec-compliant writers only emit canonical values, so the extra leniency is
-/// harmless on the read path. All other types go through `parse_scalar`.
-fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option<Scalar>> {
+/// Dates use Arrow's `Date32Type::parse`, while zoned timestamps use `timestamp_timezone` for
+/// offset-less values and honor an explicit offset in the value. `TIMESTAMP_NTZ` retains its UTC
+/// wall-clock representation. All other types go through `parse_scalar`.
+fn parse_partition_scalar(
+    prim: &PrimitiveType,
+    raw: &str,
+    timestamp_timezone: TimestampTimezone,
+) -> DeltaResult<Option<Scalar>> {
     if raw.is_empty() {
         return Ok(prim.empty_string_partition_cast());
     }
@@ -962,9 +1059,9 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
             return Ok(Some(Scalar::Date(days)));
         }
         PrimitiveType::Timestamp => {
-            let micros = string_to_datetime(&Utc, raw)
-                .map_err(|_| Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone())))?
-                .timestamp_micros();
+            let micros = timestamp_timezone.parse_timestamp(raw).map_err(|_| {
+                Error::ParseError(raw.to_string(), DataType::Primitive(prim.clone()))
+            })?;
             return Ok(Some(Scalar::Timestamp(micros)));
         }
         PrimitiveType::TimestampNtz => {
@@ -982,6 +1079,7 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 /// Evaluates `MAP_TO_STRUCT(map_col, output_schema)`: extracts keys from a `Map<String, String>`
 /// and parses each value into its target type, producing a `StructArray`. An empty-string value
 /// casts via [`PrimitiveType::empty_string_partition_cast`].
+/// `timestamp_timezone` controls the interpretation of offset-less `TIMESTAMP` values.
 ///
 /// - Missing keys produce null values
 /// - Parse errors are propagated (indicating a broken table)
@@ -989,6 +1087,7 @@ fn parse_partition_scalar(prim: &PrimitiveType, raw: &str) -> DeltaResult<Option
 fn evaluate_map_to_struct(
     map_arr: &ArrayRef,
     output_schema: &StructType,
+    timestamp_timezone: TimestampTimezone,
 ) -> DeltaResult<StructArray> {
     let map_array = map_arr
         .as_any()
@@ -1069,7 +1168,7 @@ fn evaluate_map_to_struct(
             // and where the value is non-null.
             if entry_idx >= entry_start && map_values.is_valid(entry_idx as usize) {
                 let raw = map_values.value(entry_idx as usize);
-                match parse_partition_scalar(target_types[i], raw)? {
+                match parse_partition_scalar(target_types[i], raw, timestamp_timezone)? {
                     Some(scalar) => scalar.append_to(builder, 1)?,
                     None => Scalar::append_null(builder, field.data_type(), 1)?,
                 }
@@ -1130,7 +1229,7 @@ mod tests {
     use crate::expressions::{
         col, column_expr_ref, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
         Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData,
-        Predicate as Pred, StructData,
+        MapToStructOptions, Predicate as Pred, StructData,
     };
     use crate::schema::{
         schema, schema_ref, ArrayType, DataType, MapType, StructField, StructType,
@@ -2701,7 +2800,7 @@ mod tests {
             StructField::nullable("date", DataType::DATE),
         ]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -2742,7 +2841,7 @@ mod tests {
         let batch = create_partition_map_batch();
         let output_schema = schema! { nullable "nonexistent": STRING };
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
         let col = structs
@@ -2778,7 +2877,7 @@ mod tests {
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("region", DataType::STRING)]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -2809,7 +2908,7 @@ mod tests {
 
         let output_schema = schema! { nullable "count": INTEGER };
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type));
         assert!(result.is_err());
     }
@@ -2832,7 +2931,7 @@ mod tests {
         let output_schema =
             StructType::new_unchecked(vec![StructField::nullable("ts", DataType::TIMESTAMP)]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
         let ts = structs
@@ -2841,6 +2940,154 @@ mod tests {
             .downcast_ref::<TimestampMicrosecondArray>()
             .unwrap();
         assert_eq!(ts.value(0), 1718443800000000); // 2024-06-15T09:30:00Z
+    }
+
+    fn expected_timestamp_micros(value: &str) -> i64 {
+        chrono::DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .timestamp_micros()
+    }
+
+    fn evaluate_map_timestamp_timezone(
+        raw: &str,
+        target: DataType,
+        timestamp_timezone: Option<&str>,
+    ) -> DeltaResult<Option<i64>> {
+        let mut builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        builder.keys().append_value("ts");
+        builder.values().append_value(raw);
+        builder.append(true).unwrap();
+        let map = builder.finish();
+        let schema = ArrowSchema::new(vec![ArrowField::new("pv", map.data_type().clone(), true)]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map)]).unwrap();
+        let output_schema = StructType::new_unchecked(vec![StructField::nullable("ts", target)]);
+        let result_type = DataType::from(output_schema);
+        let expr = match timestamp_timezone {
+            Some(timezone) => Expr::map_to_struct(
+                col!("pv"),
+                MapToStructOptions::default().with_timestamp_timezone(timezone),
+            ),
+            None => Expr::map_to_struct(col!("pv"), MapToStructOptions::default()),
+        };
+        let result = evaluate_expression(&expr, &batch, Some(&result_type))?;
+        let result = result.as_any().downcast_ref::<StructArray>().unwrap();
+        let timestamps = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        Ok(timestamps.is_valid(0).then(|| timestamps.value(0)))
+    }
+
+    #[rstest]
+    #[case::default_compatibility(
+        None,
+        "2024-01-15 12:30:45.123456",
+        "2024-01-15T12:30:45.123456Z"
+    )]
+    #[case::iana_winter(
+        Some("America/Los_Angeles"),
+        "2024-01-15 12:30:45.123456",
+        "2024-01-15T20:30:45.123456Z"
+    )]
+    #[case::iana_summer(
+        Some("America/Los_Angeles"),
+        "2024-06-15 08:00:00.500500",
+        "2024-06-15T15:00:00.500500Z"
+    )]
+    #[case::fixed_offset_with_seconds(
+        Some("+12:45:30"),
+        "2024-01-15 12:30:45.123456",
+        "2024-01-14T23:45:15.123456Z"
+    )]
+    #[case::explicit_input_offset(
+        Some("America/Los_Angeles"),
+        "2024-01-15 12:30:45+02:00",
+        "2024-01-15T10:30:45Z"
+    )]
+    #[case::dst_overlap(
+        Some("America/Los_Angeles"),
+        "2024-11-03 01:30:00",
+        "2024-11-03T08:30:00Z"
+    )]
+    #[case::dst_gap(
+        Some("America/Los_Angeles"),
+        "2024-03-10 02:30:00",
+        "2024-03-10T10:30:00Z"
+    )]
+    #[case::skipped_day(Some("Pacific/Apia"), "2011-12-30 12:00:00", "2011-12-30T22:00:00Z")]
+    fn test_map_to_struct_timestamp_timezone(
+        #[case] timestamp_timezone: Option<&str>,
+        #[case] raw: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            evaluate_map_timestamp_timezone(raw, DataType::TIMESTAMP, timestamp_timezone).unwrap(),
+            Some(expected_timestamp_micros(expected))
+        );
+    }
+
+    #[rstest]
+    #[case::zero("+0", 0)]
+    #[case::hours("+5", 18_000)]
+    #[case::hours_minutes("-05:30", -19_800)]
+    #[case::hours_minutes_seconds("+12:45:30", 45_930)]
+    #[case::positive_limit("+18:00:00", 64_800)]
+    #[case::negative_limit("-18", -64_800)]
+    fn test_parse_fixed_offset_accepts_supported_forms(
+        #[case] timezone: &str,
+        #[case] expected_seconds: i32,
+    ) {
+        assert_eq!(
+            parse_fixed_offset(timezone).map(|offset| offset.local_minus_utc()),
+            Some(expected_seconds)
+        );
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::bare_positive_sign("+")]
+    #[case::over_max_second("+18:00:01")]
+    #[case::over_max_hour("+19")]
+    #[case::minutes_out_of_range("+00:60")]
+    #[case::seconds_out_of_range("+00:00:60")]
+    #[case::extra_component("+05:30:00:00")]
+    fn test_parse_fixed_offset_rejects_invalid_forms(#[case] timezone: &str) {
+        assert_eq!(parse_fixed_offset(timezone), None);
+    }
+
+    #[test]
+    fn test_map_to_struct_timestamp_timezone_does_not_affect_timestamp_ntz() {
+        let raw = "2024-01-15 12:30:45.123456";
+        assert_eq!(
+            evaluate_map_timestamp_timezone(
+                raw,
+                DataType::TIMESTAMP_NTZ,
+                Some("America/Los_Angeles")
+            )
+            .unwrap(),
+            Some(expected_timestamp_micros("2024-01-15T12:30:45.123456Z"))
+        );
+    }
+
+    #[test]
+    fn test_map_to_struct_timestamp_timezone_reports_invalid_inputs() {
+        let invalid_timezone = evaluate_map_timestamp_timezone(
+            "2024-01-15 12:30:45",
+            DataType::TIMESTAMP,
+            Some("Not/AZone"),
+        )
+        .unwrap_err();
+        assert!(invalid_timezone.to_string().contains("Not/AZone"));
+
+        assert!(matches!(
+            evaluate_map_timestamp_timezone(
+                "not a timestamp",
+                DataType::TIMESTAMP,
+                Some("America/Los_Angeles")
+            ),
+            Err(Error::ParseError(..))
+        ));
     }
 
     #[test]
@@ -2862,7 +3109,7 @@ mod tests {
 
         let output_schema = schema! { nullable "x": STRING };
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
         let col = structs
@@ -2916,7 +3163,7 @@ mod tests {
             StructField::new("id", DataType::INTEGER, false),
         ]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -2952,7 +3199,10 @@ mod tests {
 
         let output_schema = schema! { not_null "date": DATE };
         let result_type = DataType::from(output_schema);
-        let expr = Expr::coalesce([col!("pv_parsed"), Expr::map_to_struct(col!("pv"))]);
+        let expr = Expr::coalesce([
+            col!("pv_parsed"),
+            Expr::map_to_struct(col!("pv"), MapToStructOptions::default()),
+        ]);
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -2970,7 +3220,7 @@ mod tests {
 
         let output_schema = schema! { nullable "x": STRING };
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("s"));
+        let expr = Expr::map_to_struct(col!("s"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type));
         assert!(result.is_err());
     }
@@ -3002,7 +3252,7 @@ mod tests {
             StructField::nullable("count", DataType::INTEGER),
         ]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 
@@ -3054,7 +3304,7 @@ mod tests {
             StructField::nullable("ts", DataType::TIMESTAMP_NTZ),
         ]);
         let result_type = DataType::from(output_schema);
-        let expr = Expr::map_to_struct(col!("pv"));
+        let expr = Expr::map_to_struct(col!("pv"), MapToStructOptions::default());
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
         let structs = result.as_any().downcast_ref::<StructArray>().unwrap();
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -359,6 +359,19 @@ pub struct ParseJsonExpression {
     pub output_schema: SchemaRef,
 }
 
+/// Looks up one value in a `Map<String, String>` for each input row.
+///
+/// Missing keys, null maps, and null keys evaluate to NULL. Duplicate keys are resolved by taking
+/// the rightmost entry.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ElementAtExpression {
+    /// The expression that evaluates to a `Map<String, String>` column.
+    pub map_expr: Box<Expression>,
+
+    /// The expression that evaluates to a STRING key column.
+    pub key_expr: Box<Expression>,
+}
+
 /// An expression that casts a child expression to a target type, following SQL `CAST` semantics: a
 /// value that cannot be represented in the target type evaluates to NULL rather than erroring.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -517,6 +530,8 @@ pub enum Expression {
     /// Extract keys from a `Map<String, String>` and parse values into a typed struct. See
     /// [`MapToStructExpression`] for how values are parsed.
     MapToStruct(MapToStructExpression),
+    /// Looks up a STRING value in a `Map<String, String>`.
+    ElementAt(ElementAtExpression),
     /// Cast a child expression to a target type. See [`CastExpression`].
     Cast(CastExpression),
 }
@@ -668,6 +683,15 @@ impl MapToStructOptions {
 
     fn is_default(&self) -> bool {
         self.timestamp_timezone.is_none()
+    }
+}
+
+impl ElementAtExpression {
+    pub(crate) fn new(map_expr: impl Into<Expression>, key_expr: impl Into<Expression>) -> Self {
+        Self {
+            map_expr: Box::new(map_expr.into()),
+            key_expr: Box::new(key_expr.into()),
+        }
     }
 }
 
@@ -897,6 +921,11 @@ impl Expression {
     /// contract.
     pub fn map_to_struct(map_expr: impl Into<Expression>, options: MapToStructOptions) -> Self {
         Self::MapToStruct(MapToStructExpression::new(map_expr, options))
+    }
+
+    /// Looks up a STRING value in a `Map<String, String>` for each input row.
+    pub fn element_at(map_expr: impl Into<Expression>, key_expr: impl Into<Expression>) -> Self {
+        Self::ElementAt(ElementAtExpression::new(map_expr, key_expr))
     }
 
     /// Creates a new cast of `expr` to `target`, following SQL `CAST` semantics (unrepresentable
@@ -1197,6 +1226,7 @@ impl Display for Expression {
                 ),
                 None => write!(f, "MAP_TO_STRUCT({})", m.map_expr),
             },
+            ElementAt(e) => write!(f, "ELEMENT_AT({}, {})", e.map_expr, e.key_expr),
             Cast(c) => write!(f, "CAST({} AS {})", c.expr, c.target),
         }
     }
@@ -1654,6 +1684,12 @@ mod tests {
             for expr in &cases {
                 assert_roundtrip(expr);
             }
+        }
+
+        #[test]
+        fn test_element_at_expression_roundtrip() {
+            let expr = Expression::element_at(col!("partitionValues"), col!("partitionKey"));
+            assert_roundtrip(&expr);
         }
 
         // ==================== Predicate Tests ====================

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -641,29 +641,62 @@ impl ParseJsonExpression {
     }
 }
 
+/// Options controlling how a [`MapToStructExpression`] parses map values.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct MapToStructOptions {
+    /// Reader timezone used to interpret offset-less `TIMESTAMP` values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timestamp_timezone: Option<String>,
+}
+
+impl MapToStructOptions {
+    /// Interpret offset-less `TIMESTAMP` values in `timestamp_timezone`.
+    ///
+    /// The timezone may be an IANA name or a fixed offset such as `+12:45:30`. Explicit offsets in
+    /// values take precedence. Ambiguous local times use the earlier instant, while nonexistent
+    /// local times use the pre-transition offset. Invalid timezones are reported during
+    /// evaluation.
+    pub fn with_timestamp_timezone(mut self, timestamp_timezone: impl Into<String>) -> Self {
+        self.timestamp_timezone = Some(timestamp_timezone.into());
+        self
+    }
+
+    /// Returns the timezone used to interpret offset-less `TIMESTAMP` values.
+    pub fn timestamp_timezone(&self) -> Option<&str> {
+        self.timestamp_timezone.as_deref()
+    }
+
+    fn is_default(&self) -> bool {
+        self.timestamp_timezone.is_none()
+    }
+}
+
 /// Transforms a `Map<String, String>` column into a struct whose schema is provided by the
 /// evaluator's output type (via `result_type`). Each row in the map column becomes one row in
 /// the output struct column: a `key` -> `value` mapping in the map means the struct field named
-/// `key` receives `value`, parsed into the field's target type via [`PrimitiveType::parse_scalar`].
-/// An empty-string value is the exception (aligning with Spark): it casts to itself for string, to
-/// empty bytes for binary, and to null for every other type. This empty-string rule is specific to
-/// this operator; [`ParseJsonExpression`] does not share it.
+/// `key` receives `value`, parsed into the field's target type. Offset-less `TIMESTAMP` values use
+/// the timezone in [`MapToStructOptions`], or UTC when no timezone is configured. An empty-string
+/// value is the exception (aligning with Spark): it casts to itself for string, to empty bytes for
+/// binary, and to null for every other type. This empty-string rule is specific to this operator;
+/// [`ParseJsonExpression`] does not share it.
 ///
 /// - Missing keys produce null values
 /// - A value that cannot be parsed as its target field type returns [`Error::ParseError`]
 /// - Duplicate map keys are resolved by taking the rightmost entry
-///
-/// [`PrimitiveType::parse_scalar`]: crate::schema::PrimitiveType::parse_scalar
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MapToStructExpression {
     /// The expression that evaluates to a `Map<String, String>` column.
     pub map_expr: Box<Expression>,
+    /// Options controlling value parsing.
+    #[serde(default, skip_serializing_if = "MapToStructOptions::is_default")]
+    pub options: MapToStructOptions,
 }
 
 impl MapToStructExpression {
-    pub(crate) fn new(map_expr: impl Into<Expression>) -> Self {
+    pub(crate) fn new(map_expr: impl Into<Expression>, options: MapToStructOptions) -> Self {
         Self {
             map_expr: Box::new(map_expr.into()),
+            options,
         }
     }
 }
@@ -856,12 +889,14 @@ impl Expression {
         Self::ParseJson(ParseJsonExpression::new(json_expr, output_schema))
     }
 
-    /// Extracts keys from a `Map<String, String>` and parses values into a typed struct. The output
-    /// struct schema is determined by the evaluator's `result_type`. An empty-string value is the
-    /// exception (aligning with Spark): it casts to itself for string, to empty bytes for binary,
-    /// and to null for every other type. See [`MapToStructExpression`] for the full contract.
-    pub fn map_to_struct(map_expr: impl Into<Expression>) -> Self {
-        Self::MapToStruct(MapToStructExpression::new(map_expr))
+    /// Extracts keys from a `Map<String, String>` and parses values into a typed struct according
+    /// to `options`. The output struct schema is determined by the evaluator's `result_type`.
+    /// [`MapToStructOptions::default`] interprets offset-less timestamps in UTC. An empty-string
+    /// value is the exception (aligning with Spark): it casts to itself for string, to empty bytes
+    /// for binary, and to null for every other type. See [`MapToStructExpression`] for the full
+    /// contract.
+    pub fn map_to_struct(map_expr: impl Into<Expression>, options: MapToStructOptions) -> Self {
+        Self::MapToStruct(MapToStructExpression::new(map_expr, options))
     }
 
     /// Creates a new cast of `expr` to `target`, following SQL `CAST` semantics (unrepresentable
@@ -1154,7 +1189,14 @@ impl Display for Expression {
                     p.output_schema.fields().len()
                 )
             }
-            MapToStruct(m) => write!(f, "MAP_TO_STRUCT({})", m.map_expr),
+            MapToStruct(m) => match m.options.timestamp_timezone() {
+                Some(timezone) => write!(
+                    f,
+                    "MAP_TO_STRUCT({}, timestamp_timezone=\"{}\")",
+                    m.map_expr, timezone
+                ),
+                None => write!(f, "MAP_TO_STRUCT({})", m.map_expr),
+            },
             Cast(c) => write!(f, "CAST({} AS {})", c.expr, c.target),
         }
     }
@@ -1265,7 +1307,9 @@ mod tests {
     use serde::de::DeserializeOwned;
     use serde::Serialize;
 
-    use super::{col, column_pred, lit, DataType, Expression as Expr, Predicate as Pred};
+    use super::{
+        col, column_pred, lit, DataType, Expression as Expr, MapToStructOptions, Predicate as Pred,
+    };
 
     /// Helper function to verify roundtrip serialization/deserialization
     fn assert_roundtrip<T: Serialize + DeserializeOwned + PartialEq + Debug>(value: &T) {
@@ -1300,6 +1344,32 @@ mod tests {
             let result = format!("{expr}");
             assert_eq!(result, expected);
         }
+    }
+
+    #[test]
+    fn test_map_to_struct_options_state_and_format() {
+        let default = Expr::map_to_struct(col!("m"), MapToStructOptions::default());
+        let Expr::MapToStruct(default_state) = &default else {
+            panic!("expected map-to-struct expression");
+        };
+        assert_eq!(default_state.options.timestamp_timezone(), None);
+        assert_eq!(format!("{default}"), "MAP_TO_STRUCT(Column(m))");
+
+        let configured = Expr::map_to_struct(
+            col!("m"),
+            MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+        );
+        let Expr::MapToStruct(configured_state) = &configured else {
+            panic!("expected map-to-struct expression");
+        };
+        assert_eq!(
+            configured_state.options.timestamp_timezone(),
+            Some("America/Los_Angeles")
+        );
+        assert_eq!(
+            format!("{configured}"),
+            "MAP_TO_STRUCT(Column(m), timestamp_timezone=\"America/Los_Angeles\")"
+        );
     }
 
     #[test]
@@ -1342,7 +1412,7 @@ mod tests {
         use crate::expressions::scalars::{ArrayData, DecimalData, MapData, StructData};
         use crate::expressions::{
             col, column_name, lit, BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression,
-            ExpressionStructPatchBuilder, Predicate, Scalar, UnaryExpressionOp,
+            ExpressionStructPatchBuilder, MapToStructOptions, Predicate, Scalar, UnaryExpressionOp,
         };
         use crate::schema::{ArrayType, DataType, DecimalType, MapType, StructField};
         use crate::unit_test_utils::assert_result_error_with_message;
@@ -1573,8 +1643,12 @@ mod tests {
         #[test]
         fn test_map_to_struct_expression_roundtrip() {
             let cases: Vec<Expression> = vec![
-                Expression::map_to_struct(col!("pv")),
-                Expression::map_to_struct(lit("ignored")),
+                Expression::map_to_struct(col!("pv"), MapToStructOptions::default()),
+                Expression::map_to_struct(lit("ignored"), MapToStructOptions::default()),
+                Expression::map_to_struct(
+                    col!("pv"),
+                    MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+                ),
             ];
 
             for expr in &cases {

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -202,6 +202,7 @@ pub trait KernelPredicateEvaluator {
             | Expr::Variadic(_)
             | Expr::ParseJson(_)
             | Expr::MapToStruct(_)
+            | Expr::ElementAt(_)
             | Expr::Cast(_)
             | Expr::Unknown(_) => None,
         }
@@ -233,6 +234,7 @@ pub trait KernelPredicateEvaluator {
                 | Expr::Opaque(_)
                 | Expr::ParseJson { .. }
                 | Expr::MapToStruct(_)
+                | Expr::ElementAt(_)
                 | Expr::Cast(_)
                 | Expr::Unknown(_) => {
                     debug!("Unsupported operand: IS [NOT] NULL: {expr:?}");
@@ -682,8 +684,9 @@ impl<R: ResolveColumnAsScalar> DefaultKernelPredicateEvaluator<R> {
                 })
                 .ok(),
             Expr::Cast(c) => cast_scalar(self.eval_expr(&c.expr)?, &c.target),
-            // ParseJson and MapToStruct produce structured output, not scalar values
-            Expr::ParseJson(_) | Expr::MapToStruct(_) => None,
+            // ParseJson and MapToStruct produce structured output, and ElementAt is unsupported by
+            // this scalar evaluator.
+            Expr::ParseJson(_) | Expr::MapToStruct(_) | Expr::ElementAt(_) => None,
             Expr::Unknown(_) => None,
         }
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -116,6 +116,7 @@ pub mod table_changes;
 pub mod table_configuration;
 pub mod table_features;
 pub mod table_properties;
+mod timestamp_timezone;
 pub mod transaction;
 pub mod transforms;
 

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -12,11 +12,11 @@ use super::{
 };
 use crate::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
-    ColumnName, DecimalData, Expression, ExpressionFieldPatch, ExpressionStructPatch,
-    JunctionPredicate, JunctionPredicateOp, MapData, MapToStructExpression, MapToStructOptions,
-    OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate, Scalar, StructData,
-    UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
-    VariadicExpressionOp,
+    ColumnName, DecimalData, ElementAtExpression, Expression, ExpressionFieldPatch,
+    ExpressionStructPatch, JunctionPredicate, JunctionPredicateOp, MapData, MapToStructExpression,
+    MapToStructOptions, OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate, Scalar,
+    StructData, UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp,
+    VariadicExpression, VariadicExpressionOp,
 };
 use crate::plans::ir::nodes::{
     Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
@@ -325,6 +325,7 @@ impl From<&Expression> for proto_expr::Expression {
             Expression::MapToStruct(map_to_struct) => {
                 Kind::MapToStruct(Box::new(map_to_struct.into()))
             }
+            Expression::ElementAt(element_at) => Kind::ElementAt(Box::new(element_at.into())),
             // No proto cast node yet; serialize as an opaque unknown.
             Expression::Cast(cast) => Kind::Unknown(format!("cast_to_{}", cast.target)),
         };
@@ -416,6 +417,15 @@ impl From<&MapToStructOptions> for proto_expr::MapToStructOptions {
     fn from(options: &MapToStructOptions) -> Self {
         Self {
             timestamp_timezone: options.timestamp_timezone().map(ToOwned::to_owned),
+        }
+    }
+}
+
+impl From<&ElementAtExpression> for proto_expr::ElementAtExpression {
+    fn from(element_at: &ElementAtExpression) -> Self {
+        Self {
+            map_expr: Some(Box::new(element_at.map_expr.as_ref().into())),
+            key_expr: Some(Box::new(element_at.key_expr.as_ref().into())),
         }
     }
 }
@@ -1583,6 +1593,7 @@ mod tests {
         Expression::map_to_struct(col!("m"), MapToStructOptions::default()),
         "map_to_struct"
     )]
+    #[case(Expression::element_at(col!("m"), lit("key")), "element_at")]
     #[case(Expression::unknown("x"), "unknown")]
     fn from_expression(#[case] expr: Expression, #[case] expected: &str) {
         use proto_expr::expression::Kind;
@@ -1600,6 +1611,7 @@ mod tests {
             Kind::ParseJson(_) => "parse_json",
             Kind::MapToStruct(_) => "map_to_struct",
             Kind::Unknown(_) => "unknown",
+            Kind::ElementAt(_) => "element_at",
         };
         assert_eq!(kind, expected);
     }
@@ -1686,6 +1698,17 @@ mod tests {
             proto_expr::VariadicExpressionOp::Coalesce as i32
         );
         assert_eq!(variadic.exprs.len(), 3);
+    }
+
+    #[test]
+    fn from_element_at_expression() {
+        let proto_expr::expression::Kind::ElementAt(element_at) =
+            expr_kind_of(Expression::element_at(col!("map"), col!("key")))
+        else {
+            panic!("expected an element-at expression");
+        };
+        assert!(element_at.map_expr.is_some());
+        assert!(element_at.key_expr.is_some());
     }
 
     #[test]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -13,9 +13,10 @@ use super::{
 use crate::expressions::{
     ArrayData, BinaryExpression, BinaryExpressionOp, BinaryPredicate, BinaryPredicateOp,
     ColumnName, DecimalData, Expression, ExpressionFieldPatch, ExpressionStructPatch,
-    JunctionPredicate, JunctionPredicateOp, MapData, MapToStructExpression, OpaqueExpression,
-    OpaquePredicate, ParseJsonExpression, Predicate, Scalar, StructData, UnaryExpression,
-    UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression, VariadicExpressionOp,
+    JunctionPredicate, JunctionPredicateOp, MapData, MapToStructExpression, MapToStructOptions,
+    OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate, Scalar, StructData,
+    UnaryExpression, UnaryExpressionOp, UnaryPredicate, UnaryPredicateOp, VariadicExpression,
+    VariadicExpressionOp,
 };
 use crate::plans::ir::nodes::{
     Agg, Aggregate, DynamicScan, FileType, Filter, Operator, Project, ScanFile, ScanJson,
@@ -405,6 +406,16 @@ impl From<&MapToStructExpression> for proto_expr::MapToStructExpression {
     fn from(map_to_struct: &MapToStructExpression) -> Self {
         proto_expr::MapToStructExpression {
             map_expr: Some(Box::new(map_to_struct.map_expr.as_ref().into())),
+            options: (map_to_struct.options != MapToStructOptions::default())
+                .then(|| (&map_to_struct.options).into()),
+        }
+    }
+}
+
+impl From<&MapToStructOptions> for proto_expr::MapToStructOptions {
+    fn from(options: &MapToStructOptions) -> Self {
+        Self {
+            timestamp_timezone: options.timestamp_timezone().map(ToOwned::to_owned),
         }
     }
 }
@@ -979,9 +990,9 @@ mod tests {
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::expressions::{
         col, column_name, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp, DecimalData,
-        Expression, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData, OpaqueExpressionOp,
-        OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator, StructData,
-        UnaryExpressionOp, UnaryPredicateOp, VariadicExpressionOp,
+        Expression, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData, MapToStructOptions,
+        OpaqueExpressionOp, OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator,
+        StructData, UnaryExpressionOp, UnaryPredicateOp, VariadicExpressionOp,
     };
     use crate::kernel_predicates::{
         DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -1568,7 +1579,10 @@ mod tests {
     #[case(Expression::coalesce([lit(1), lit(2)]), "variadic")]
     #[case(Expression::opaque(TestOpaqueExprOp, [lit(1)]), "opaque")]
     #[case(Expression::parse_json(lit("{}"), sample_schema()), "parse_json")]
-    #[case(Expression::map_to_struct(col!("m")), "map_to_struct")]
+    #[case(
+        Expression::map_to_struct(col!("m"), MapToStructOptions::default()),
+        "map_to_struct"
+    )]
     #[case(Expression::unknown("x"), "unknown")]
     fn from_expression(#[case] expr: Expression, #[case] expected: &str) {
         use proto_expr::expression::Kind;
@@ -1698,12 +1712,29 @@ mod tests {
 
     #[test]
     fn from_map_to_struct_expression() {
-        let proto_expr::expression::Kind::MapToStruct(map_to_struct) =
-            expr_kind_of(Expression::map_to_struct(col!("m")))
-        else {
+        let proto_expr::expression::Kind::MapToStruct(map_to_struct) = expr_kind_of(
+            Expression::map_to_struct(col!("m"), MapToStructOptions::default()),
+        ) else {
             panic!("expected a map_to_struct expression");
         };
         assert!(map_to_struct.map_expr.is_some());
+        assert_eq!(map_to_struct.options, None);
+
+        let proto_expr::expression::Kind::MapToStruct(map_to_struct) =
+            expr_kind_of(Expression::map_to_struct(
+                col!("m"),
+                MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+            ))
+        else {
+            panic!("expected a map_to_struct expression");
+        };
+        assert_eq!(
+            map_to_struct
+                .options
+                .as_ref()
+                .and_then(|options| options.timestamp_timezone.as_deref()),
+            Some("America/Los_Angeles")
+        );
     }
 
     #[test]

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -10,8 +10,8 @@ use crate::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use crate::error::DeltaResult;
 use crate::expressions::{
     col, column_name, column_pred, lit, BinaryPredicateOp, ColumnName, Expression as Expr,
-    ExpressionRef, JunctionPredicateOp, OpaquePredicateOpRef, Predicate as Pred, PredicateRef,
-    Scalar,
+    ExpressionRef, JunctionPredicateOp, MapToStructOptions, OpaquePredicateOpRef,
+    Predicate as Pred, PredicateRef, Scalar,
 };
 use crate::kernel_predicates::{
     DataSkippingPredicateEvaluator, KernelPredicateEvaluator, KernelPredicateEvaluatorDefaults,
@@ -276,7 +276,10 @@ impl DataSkippingFilter {
             col!("add.stats"),
             physical_stats_schema.clone(),
         ));
-        let partition_expr = Arc::new(Expr::map_to_struct(col!("add.partitionValues")));
+        let partition_expr = Arc::new(Expr::map_to_struct(
+            col!("add.partitionValues"),
+            MapToStructOptions::default(),
+        ));
         let is_add_expr = Arc::new(Pred::is_not_null(col!("add.path")).into());
         Self::new(
             engine,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -12,8 +12,8 @@ use super::{PhysicalPredicate, ScanMetadata, COMMIT_READ_SCHEMA};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{EngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
-    col, column_expr_ref, column_name, ColumnName, Expression, ExpressionRef, Predicate,
-    PredicateRef, UnaryExpressionOp,
+    col, column_expr_ref, column_name, ColumnName, Expression, ExpressionRef, MapToStructOptions,
+    Predicate, PredicateRef, UnaryExpressionOp,
 };
 use crate::log_replay::deduplicator::{CheckpointDeduplicator, Deduplicator, FileActionInfo};
 use crate::log_replay::{
@@ -879,7 +879,7 @@ fn get_add_transform_expr(
             col!("add.partitionValues_parsed")
         } else {
             // No native column (JSON commit): reconstruct from the string map.
-            Expression::map_to_struct(col!("add.partitionValues"))
+            Expression::map_to_struct(col!("add.partitionValues"), MapToStructOptions::default())
         };
         fields.push(Arc::new(pv_parsed_expr));
     }

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -2154,6 +2154,7 @@ mod tests {
             }
             Expression::ParseJson(p) => count_to_json(&p.json_expr),
             Expression::MapToStruct(m) => count_to_json(&m.map_expr),
+            Expression::ElementAt(e) => count_to_json(&e.map_expr) + count_to_json(&e.key_expr),
             Expression::Cast(c) => count_to_json(&c.expr),
             Expression::Predicate(_)
             | Expression::Literal(_)

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -28,6 +28,7 @@ use crate::schema::{
     StructField, StructType, ToSchema as _,
 };
 use crate::table_features::ColumnMappingMode;
+use crate::timestamp_timezone::TimestampTimezone;
 use crate::utils::{require, FoldWithOption as _};
 use crate::{DeltaResult, Engine, Error, ExpressionEvaluator};
 
@@ -54,11 +55,14 @@ impl Default for ScanStatsOptions {
 }
 
 /// Read-time partition value toggles consumed by [`ScanLogReplayProcessor`].
-#[derive(Clone, Copy, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ScanPartitionValuesOptions {
     /// Emit the typed `partitionValues_parsed` struct column in scan metadata output,
     /// independent of any predicate.
     pub(crate) parsed_struct: bool,
+    /// Reader timezone used to interpret offset-less zoned timestamp partition strings.
+    #[serde(default)]
+    pub(crate) timestamp_timezone: Option<String>,
 }
 
 /// Internal serializable state (schemas, transform spec, column mapping, etc.)
@@ -242,6 +246,7 @@ impl ScanLogReplayProcessor {
             skip_stats,
             synthesize_json,
         } = stats_options;
+        let timestamp_timezone = partition_values_options.timestamp_timezone.as_deref();
 
         // Create metrics first so we can pass them to DataSkippingFilter
         let metrics = Arc::new(ScanMetrics::default());
@@ -315,6 +320,7 @@ impl ScanLogReplayProcessor {
                     synthesize_json,
                     partition_schema_for_transform.clone(),
                     false,
+                    timestamp_timezone,
                 ),
                 output_schema.clone().into(),
             )?,
@@ -328,6 +334,7 @@ impl ScanLogReplayProcessor {
                     synthesize_json,
                     partition_schema_for_transform,
                     has_partition_values_parsed,
+                    timestamp_timezone,
                 ),
                 output_schema.into(),
             )?,
@@ -565,6 +572,7 @@ struct AddRemoveDedupVisitor<'a, D: Deduplicator> {
     deduplicator: D,
     selection_vector: Vec<bool>,
     state_info: Arc<StateInfo>,
+    timestamp_timezone: TimestampTimezone,
     row_transform_exprs: Vec<Option<ExpressionRef>>,
     active_add_file_sizes: Vec<u64>,
     metrics: &'a ScanMetrics,
@@ -576,16 +584,22 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         selection_vector: Vec<bool>,
         state_info: Arc<StateInfo>,
         metrics: &'a ScanMetrics,
-    ) -> AddRemoveDedupVisitor<'a, D> {
+        timestamp_timezone: Option<&str>,
+    ) -> DeltaResult<AddRemoveDedupVisitor<'a, D>> {
         let active_add_file_sizes = vec![0; selection_vector.len()];
-        AddRemoveDedupVisitor {
+        let timestamp_timezone = timestamp_timezone.map_or_else(
+            || Ok(TimestampTimezone::default()),
+            TimestampTimezone::parse,
+        )?;
+        Ok(AddRemoveDedupVisitor {
             deduplicator,
             selection_vector,
             state_info,
+            timestamp_timezone,
             row_transform_exprs: Vec::new(),
             active_add_file_sizes,
             metrics,
-        }
+        })
     }
 
     /// True if this row contains an Add action that should survive log replay. Skip it if the row
@@ -643,6 +657,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
                     transform,
                     &partition_values,
                     self.state_info.column_mapping_mode,
+                    self.timestamp_timezone,
                 )?
             }
             _ => Default::default(),
@@ -817,6 +832,7 @@ fn scan_row_schema_with_parsed_columns(
 /// - `has_partition_values_parsed`: Whether the source carries a native `partitionValues_parsed`
 ///   column (checkpoint). When true it is read directly; otherwise the struct is reconstructed from
 ///   the `partitionValues` string map.
+/// - `timestamp_timezone`: Reader timezone for offset-less zoned timestamp partition strings.
 ///
 /// The transform includes `stats_parsed` only when `physical_stats_schema` is Some,
 /// and `partitionValues_parsed` only when `partition_schema` is Some.
@@ -828,6 +844,7 @@ fn get_add_transform_expr(
     synthesize_json: bool,
     partition_schema: Option<SchemaRef>,
     has_partition_values_parsed: bool,
+    timestamp_timezone: Option<&str>,
 ) -> ExpressionRef {
     let stats_expr = if skip_stats {
         Arc::new(Expression::Literal(Scalar::Null(DataType::STRING)))
@@ -873,18 +890,57 @@ fn get_add_transform_expr(
 
     // Add partitionValues_parsed when partition columns are needed for data skipping or for the
     // engine-facing typed output column.
-    if partition_schema.is_some() {
-        let pv_parsed_expr = if has_partition_values_parsed {
-            // Checkpoint carries a native partitionValues_parsed column - read it directly.
-            col!("add.partitionValues_parsed")
-        } else {
-            // No native column (JSON commit): reconstruct from the string map.
-            Expression::map_to_struct(col!("add.partitionValues"), MapToStructOptions::default())
-        };
+    if let Some(partition_schema) = partition_schema {
+        let base_partition_values =
+            has_partition_values_parsed.then(|| column_name!("add.partitionValues_parsed"));
+        let pv_parsed_expr = parsed_partition_values_expr(
+            col!("add.partitionValues"),
+            base_partition_values,
+            &partition_schema,
+            timestamp_timezone,
+        );
         fields.push(Arc::new(pv_parsed_expr));
     }
 
     Arc::new(Expression::struct_from(fields))
+}
+
+/// Build typed partition values, reparsing the raw map when reader-timezone interpretation is
+/// required.
+pub(super) fn parsed_partition_values_expr(
+    raw_partition_values: Expression,
+    base_partition_values: Option<ColumnName>,
+    partition_schema: &StructType,
+    timestamp_timezone: Option<&str>,
+) -> Expression {
+    let full_parse = || match timestamp_timezone {
+        Some(timestamp_timezone) => Expression::map_to_struct(
+            raw_partition_values.clone(),
+            MapToStructOptions::default().with_timestamp_timezone(timestamp_timezone),
+        ),
+        None => {
+            Expression::map_to_struct(raw_partition_values.clone(), MapToStructOptions::default())
+        }
+    };
+
+    match base_partition_values {
+        Some(base_partition_values)
+            if !partition_schema.fields().any(|field| {
+                partition_value_requires_timezone_reparse(field.data_type(), timestamp_timezone)
+            }) =>
+        {
+            Expression::from(base_partition_values)
+        }
+        _ => full_parse(),
+    }
+}
+
+/// Whether a native checkpoint partition value must be replaced with a reader-timezone parse.
+pub(super) fn partition_value_requires_timezone_reparse(
+    data_type: &DataType,
+    timestamp_timezone: Option<&str>,
+) -> bool {
+    timestamp_timezone.is_some() && data_type == &DataType::TIMESTAMP
 }
 
 // TODO: Move this to transaction/mod.rs once `scan_metadata_from` is pub, as this is used for
@@ -960,7 +1016,8 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
                 pre_dedup_selection,
                 self.state_info.clone(),
                 &self.metrics,
-            );
+                self.partition_values_options.timestamp_timezone.as_deref(),
+            )?;
             visitor.visit_rows_of(actions.as_ref())?;
             (
                 visitor.selection_vector,
@@ -1059,7 +1116,8 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 pre_dedup_selection,
                 self.state_info.clone(),
                 &self.metrics,
-            );
+                self.partition_values_options.timestamp_timezone.as_deref(),
+            )?;
             visitor.visit_rows_of(actions.as_ref())?;
             (
                 visitor.selection_vector,
@@ -1150,14 +1208,15 @@ mod tests {
     use rstest::rstest;
 
     use super::{
-        get_add_transform_expr, scan_action_iter, InternalScanState, ScanLogReplayProcessor,
-        ScanPartitionValuesOptions, ScanStatsOptions, SerializableScanState,
+        get_add_transform_expr, parsed_partition_values_expr, scan_action_iter, InternalScanState,
+        ScanLogReplayProcessor, ScanPartitionValuesOptions, ScanStatsOptions,
+        SerializableScanState,
     };
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{
-        col, column_name, lit, BinaryExpressionOp, Expression, OpaquePredicateOp, Predicate,
-        Scalar, ScalarExpressionEvaluator, UnaryExpressionOp,
+        col, column_name, lit, BinaryExpressionOp, Expression, MapToStructOptions,
+        OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator, UnaryExpressionOp,
     };
     use crate::kernel_predicates::{
         DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -1181,6 +1240,94 @@ mod tests {
     use crate::table_features::ColumnMappingMode;
     use crate::unit_test_utils::assert_result_error_with_message;
     use crate::{DeltaResult, Expression as Expr, ExpressionRef};
+
+    #[test]
+    fn partition_values_options_serde_preserves_timezone_and_defaults_when_absent() {
+        let options = ScanPartitionValuesOptions {
+            parsed_struct: true,
+            timestamp_timezone: Some("America/Los_Angeles".to_string()),
+        };
+        let encoded = serde_json::to_string(&options).unwrap();
+        let decoded: ScanPartitionValuesOptions = serde_json::from_str(&encoded).unwrap();
+        assert!(decoded.parsed_struct);
+        assert_eq!(
+            decoded.timestamp_timezone.as_deref(),
+            Some("America/Los_Angeles")
+        );
+
+        let old: ScanPartitionValuesOptions =
+            serde_json::from_str(r#"{"parsed_struct":true}"#).unwrap();
+        assert!(old.parsed_struct);
+        assert_eq!(old.timestamp_timezone, None);
+    }
+
+    #[test]
+    fn parsed_partition_values_expr_parses_map_when_native_struct_is_absent() {
+        let raw = col!("add.partitionValues");
+        let schema =
+            StructType::new_unchecked([StructField::nullable("physical_ts", DataType::TIMESTAMP)]);
+
+        assert_eq!(
+            parsed_partition_values_expr(raw.clone(), None, &schema, None),
+            Expression::map_to_struct(raw.clone(), MapToStructOptions::default())
+        );
+        assert_eq!(
+            parsed_partition_values_expr(raw.clone(), None, &schema, Some("America/Los_Angeles")),
+            Expression::map_to_struct(
+                raw,
+                MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+            )
+        );
+    }
+
+    #[test]
+    fn parsed_partition_values_expr_returns_native_struct_when_reparse_is_unnecessary() {
+        let raw = col!("add.partitionValues");
+        let base = column_name!("add.partitionValues_parsed");
+        let timestamp_schema =
+            StructType::new_unchecked([StructField::nullable("physical_ts", DataType::TIMESTAMP)]);
+        let timestamp_free_schema = StructType::new_unchecked([
+            StructField::nullable("physical_ntz", DataType::TIMESTAMP_NTZ),
+            StructField::nullable("physical_int", DataType::INTEGER),
+        ]);
+
+        assert_eq!(
+            parsed_partition_values_expr(raw.clone(), Some(base.clone()), &timestamp_schema, None),
+            Expression::from(base.clone())
+        );
+        assert_eq!(
+            parsed_partition_values_expr(
+                raw,
+                Some(base.clone()),
+                &timestamp_free_schema,
+                Some("America/Los_Angeles")
+            ),
+            Expression::from(base)
+        );
+    }
+
+    #[test]
+    fn parsed_partition_values_expr_reparses_complete_map_for_reader_timezone() {
+        let raw = col!("add.partitionValues");
+        let base = column_name!("add.partitionValues_parsed");
+        let schema = StructType::new_unchecked([
+            StructField::nullable("physical_ts", DataType::TIMESTAMP),
+            StructField::nullable("physical_ntz", DataType::TIMESTAMP_NTZ),
+            StructField::nullable("physical_int", DataType::INTEGER),
+        ]);
+
+        let actual = parsed_partition_values_expr(
+            raw.clone(),
+            Some(base.clone()),
+            &schema,
+            Some("America/Los_Angeles"),
+        );
+        let expected = Expression::map_to_struct(
+            raw,
+            MapToStructOptions::default().with_timestamp_timezone("America/Los_Angeles"),
+        );
+        assert_eq!(actual, expected);
+    }
 
     fn test_checkpoint_info() -> CheckpointReadInfo {
         CheckpointReadInfo::without_stats_parsed()
@@ -2036,6 +2183,7 @@ mod tests {
             true,  // synthesize_json
             partition_schema.clone(),
             false, // has_partition_values_parsed
+            None,  // timestamp_timezone
         );
         assert_eq!(
             count_to_json(&with_synthesis),
@@ -2051,6 +2199,7 @@ mod tests {
             false, // synthesize_json
             partition_schema,
             false, // has_partition_values_parsed
+            None,  // timestamp_timezone
         );
         assert_eq!(
             count_to_json(&without_synthesis),

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -200,11 +200,14 @@ impl StatsOptions {
 /// `partitionValues_parsed` struct column with one typed nullable field per partition column
 /// (physical names, table partition-column order). On non-partitioned tables the column is
 /// omitted. Values come directly from the checkpoint's native `partitionValues_parsed` column
-/// when present, otherwise from parsing the string map.
+/// when present, otherwise from parsing the string map. If a requested reader timezone changes
+/// zoned timestamp interpretation, Kernel reparses the complete string map.
 #[derive(Clone, Debug, Default)]
 pub struct PartitionValuesOptions {
     /// Whether to emit the typed `partitionValues_parsed` struct column.
     pub(crate) parsed_struct: bool,
+    /// Reader timezone used to interpret offset-less zoned timestamp partition strings.
+    pub(crate) timestamp_timezone: Option<String>,
 }
 
 impl PartitionValuesOptions {
@@ -218,7 +221,22 @@ impl PartitionValuesOptions {
     pub fn with_struct() -> Self {
         Self {
             parsed_struct: true,
+            timestamp_timezone: None,
         }
+    }
+
+    /// Interpret offset-less zoned `TIMESTAMP` partition strings in `timestamp_timezone`.
+    ///
+    /// The timezone may be an IANA name or a fixed offset. Explicit offsets in partition values
+    /// take precedence. Ambiguous local times use the earlier instant, and nonexistent local times
+    /// use the pre-transition offset. This option applies to typed scan metadata, internal
+    /// partition pruning, and partition-column row transforms used by [`Scan::execute`] for full
+    /// snapshot scans. Incremental scans continue to expose the raw partition-value map. Without
+    /// this option, Kernel interprets offset-less timestamps as UTC. Invalid timezones are reported
+    /// when scan metadata is evaluated.
+    pub fn with_timestamp_timezone(mut self, timestamp_timezone: impl Into<String>) -> Self {
+        self.timestamp_timezone = Some(timestamp_timezone.into());
+        self
     }
 }
 
@@ -798,6 +816,7 @@ impl Scan {
     fn partition_values_options(&self) -> log_replay::ScanPartitionValuesOptions {
         log_replay::ScanPartitionValuesOptions {
             parsed_struct: self.partition_values.parsed_struct,
+            timestamp_timezone: self.partition_values.timestamp_timezone.clone(),
         }
     }
 
@@ -1085,12 +1104,13 @@ impl Scan {
     /// or if log discovery, checkpoint inspection, or plan construction fails.
     pub fn declarative_metadata_scan_plan(&self, engine: &dyn Engine) -> DeltaResult<Option<Plan>> {
         // Resolve the checkpoint shape once: it selects the leaf-vs-manifest arm and reports
-        // whether the checkpoint carries a compatible parsed-stats column.
+        // whether the checkpoint carries compatible parsed stats and partition columns.
         let plan_executor = engine.require_plan_executor()?;
         let shape = CheckpointShape::try_new(
             plan_executor.as_ref(),
             &self.snapshot,
             self.state_info.physical_stats_schema.as_ref(),
+            self.state_info.physical_partition_schema.as_ref(),
         )?;
         self.build_metadata_scan_plan(&shape)
     }
@@ -1156,6 +1176,12 @@ impl Scan {
         let mut floating_partition_columns = HashSet::new();
         if let Some(schema) = self.state_info.physical_partition_schema.as_ref() {
             for field in schema.fields() {
+                if log_replay::partition_value_requires_timezone_reparse(
+                    field.data_type(),
+                    self.partition_values.timestamp_timezone.as_deref(),
+                ) {
+                    continue;
+                }
                 let column = ColumnName::new([field.name()]);
                 if field.data_type() == &DataType::FLOAT || field.data_type() == &DataType::DOUBLE {
                     floating_partition_columns.insert(column.clone());

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -17,7 +17,8 @@ use crate::actions::{
 };
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
-    col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
+    col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef,
+    MapToStructOptions, Predicate,
 };
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
@@ -491,7 +492,10 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         match physical_partitions {
             Some(schema) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone());
-                let expr = Expr::map_to_struct(col!(ADD_NAME, PARTITION_VALUES));
+                let expr = Expr::map_to_struct(
+                    col!(ADD_NAME, PARTITION_VALUES),
+                    MapToStructOptions::default(),
+                );
                 if has_partition_values_parsed {
                     let expr = Expr::coalesce([col!(ADD_NAME, PARTITION_VALUES_PARSED), expr]);
                     self.replace_at(add, PARTITION_VALUES_PARSED, field, expr)

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -17,12 +17,13 @@ use crate::actions::{
 };
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
-    col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef,
-    MapToStructOptions, Predicate,
+    col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
 };
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
-use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
+use crate::scan::log_replay::{
+    parsed_partition_values_expr, PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME,
+};
 use crate::schema::{
     lazy_schema_ref, schema, schema_ref, DataType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
@@ -125,24 +126,34 @@ impl Scan {
     ///            stats_parsed, partitionValues_parsed
     ///          ),
     ///          add.stats_parsed AS stats_parsed,
-    ///          MAP_TO_STRUCT(add.partitionValues, physical_partitions) AS partitionValues_parsed
+    ///          PARSED_PARTITION_VALUES(
+    ///            add.partitionValues,
+    ///            add.partitionValues_parsed,
+    ///            physical_partitions,
+    ///            reader_timezone
+    ///          ) AS partitionValues_parsed
     ///        ) AS add,
     ///        version, add.path IS NOT NULL AS is_add, file_key(add) AS key
     /// FROM checkpoint_actions
     /// WHERE add.path IS NOT NULL
     ///
     /// When the checkpoint lacks native parsed stats, `FROM_JSON(add.stats, physical_stats)`
-    /// replaces `add.stats_parsed` above. A parsed field is omitted when its schema is absent.
+    /// replaces `add.stats_parsed` above. Parsed partition values reuse the native struct when
+    /// possible and rebuild from the raw map when a reader timezone changes zoned timestamp
+    /// interpretation or no compatible native struct exists. A parsed field is omitted when its
+    /// schema is absent.
     fn checkpoint_arm(&self, shape: &CheckpointShape) -> DeltaResult<PlanBuilder> {
         let log_segment = self.snapshot.log_segment();
         let physical_stats = self.state_info.physical_stats_schema.as_ref();
         let physical_partitions = self.state_info.physical_partition_schema.as_ref();
         let source_physical_stats = shape.parsed_stats_schema.as_ref();
+        let source_physical_partitions = shape.parsed_partition_schema.as_ref();
         let checkpoint = log_segment.checkpoint_version_tagged_scan_files()?;
 
         let actions = match (&shape.checkpoint_type, checkpoint) {
             (CheckpointType::Leaf, Some((FileType::Parquet, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema =
+                    parquet_read_schema(source_physical_stats, source_physical_partitions)?;
                 PlanBuilder::scan_parquet(parts, &[VERSION], schema)
             }
             (CheckpointType::Leaf, Some((FileType::Json, parts))) => {
@@ -153,7 +164,8 @@ impl Scan {
                 )
             }
             (CheckpointType::Manifest, Some((file_type, parts))) => {
-                let schema = parquet_read_schema(source_physical_stats, None)?;
+                let schema =
+                    parquet_read_schema(source_physical_stats, source_physical_partitions)?;
                 match log_segment.checkpoint_hint_version_tagged_sidecar_scan_files()? {
                     Some(sidecars) => PlanBuilder::scan_parquet(sidecars, &[VERSION], schema),
                     // Without a complete hint, load the sidecars referenced by the manifest.
@@ -170,7 +182,10 @@ impl Scan {
             .project_patch(|patch| {
                 patch
                     .with_parsed_add_stats(physical_stats)
-                    .with_parsed_add_partition_values(physical_partitions)
+                    .with_parsed_add_partition_values(
+                        physical_partitions,
+                        self.partition_values.timestamp_timezone.as_deref(),
+                    )
                     .append(
                         StructField::not_null(IS_ADD, DataType::BOOLEAN),
                         Expr::from(col!("add.path").is_not_null()),
@@ -212,6 +227,7 @@ impl Scan {
                     .with_parsed_add_stats(self.state_info.physical_stats_schema.as_ref())
                     .with_parsed_add_partition_values(
                         self.state_info.physical_partition_schema.as_ref(),
+                        self.partition_values.timestamp_timezone.as_deref(),
                     )
                     .append(
                         StructField::not_null(IS_ADD, DataType::BOOLEAN),
@@ -461,7 +477,11 @@ trait ProjectionStructPatchBuilderExt<'a> {
     fn with_parsed_add_stats(self, physical_stats: Option<&SchemaRef>) -> Self;
 
     /// Parses add partition values, preferring a compatible parsed field.
-    fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self;
+    fn with_parsed_add_partition_values(
+        self,
+        physical_partitions: Option<&SchemaRef>,
+        timestamp_timezone: Option<&str>,
+    ) -> Self;
 }
 
 impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a> {
@@ -484,7 +504,11 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         }
     }
 
-    fn with_parsed_add_partition_values(self, physical_partitions: Option<&SchemaRef>) -> Self {
+    fn with_parsed_add_partition_values(
+        self,
+        physical_partitions: Option<&SchemaRef>,
+        timestamp_timezone: Option<&str>,
+    ) -> Self {
         let has_partition_values_parsed = self
             .input_schema()
             .contains_col([ADD_NAME, PARTITION_VALUES_PARSED_NAME]);
@@ -492,12 +516,15 @@ impl<'a> ProjectionStructPatchBuilderExt<'a> for ProjectionStructPatchBuilder<'a
         match physical_partitions {
             Some(schema) => {
                 let field = StructField::nullable(PARTITION_VALUES_PARSED, schema.as_ref().clone());
-                let expr = Expr::map_to_struct(
+                let base_partition_values = has_partition_values_parsed
+                    .then(|| column_name!(ADD_NAME, PARTITION_VALUES_PARSED));
+                let expr = parsed_partition_values_expr(
                     col!(ADD_NAME, PARTITION_VALUES),
-                    MapToStructOptions::default(),
+                    base_partition_values,
+                    schema,
+                    timestamp_timezone,
                 );
                 if has_partition_values_parsed {
-                    let expr = Expr::coalesce([col!(ADD_NAME, PARTITION_VALUES_PARSED), expr]);
                     self.replace_at(add, PARTITION_VALUES_PARSED, field, expr)
                 } else {
                     self.append_at(add, field, expr)
@@ -668,6 +695,7 @@ mod tests {
         CheckpointShape {
             checkpoint_type,
             parsed_stats_schema: parsed_stats,
+            parsed_partition_schema: None,
         }
     }
 
@@ -825,8 +853,13 @@ mod tests {
             .with_stats(stats)
             .with_partition_values(partition_values)
             .build()?;
+        let checkpoint_shape = CheckpointShape {
+            checkpoint_type: CheckpointType::Manifest,
+            parsed_stats_schema: parsed_stats,
+            parsed_partition_schema: scan.state_info.physical_partition_schema.clone(),
+        };
         let plan = scan
-            .build_metadata_scan_plan(&shape(CheckpointType::Manifest, parsed_stats))?
+            .build_metadata_scan_plan(&checkpoint_shape)?
             .expect("non-empty");
 
         let dynamic_scan = plan
@@ -846,8 +879,8 @@ mod tests {
         assert!(
             add_struct(&dynamic_scan.schema)
                 .field(PARTITION_VALUES_PARSED)
-                .is_none(),
-            "native parsed partition values are not requested yet"
+                .is_some(),
+            "compatible native parsed partition values must be read from sidecars"
         );
         Ok(())
     }

--- a/kernel/src/scan/scan_plan/tests.rs
+++ b/kernel/src/scan/scan_plan/tests.rs
@@ -1,10 +1,13 @@
+use std::path::Path;
 use std::sync::Arc;
 
+use ::test_utils::add_commit;
 use ::test_utils::table_builder::{
     checkpoint_json_stats, checkpoint_struct_stats, no_checkpoint_stats, DataLayoutConfig,
     FeatureSet, LogState, TableConfig, TestTableBuilder,
 };
 use rstest::rstest;
+use url::Url;
 
 use super::*;
 use crate::arrow::array::{Array, ArrayRef, BooleanArray, StringArray, StructArray};
@@ -15,7 +18,9 @@ use crate::arrow::util::pretty::pretty_format_batches;
 use crate::engine::arrow_data::EngineDataArrowExt as _;
 use crate::engine::sync::SyncEngine;
 use crate::engine::test_delegating::DelegatingEngine;
-use crate::expressions::{col, column_name, lit, Predicate as Pred};
+use crate::expressions::{col, column_name, lit, Predicate as Pred, Scalar};
+use crate::object_store::local::LocalFileSystem;
+use crate::object_store::DynObjectStore;
 use crate::plans::ir::nodes::Operator;
 use crate::plans::Operation as PlanOperation;
 use crate::scan::{PartitionValuesOptions, Scan, StatsOptions, StructStats};
@@ -251,6 +256,152 @@ fn declarative_metadata_matches_imperative_scan(
     } else {
         assert_metadata_eq(&actual, &expected, &format!("table {table}"))
     }
+}
+
+#[rstest]
+#[case::json_commit(LogState::with_latest_version(1), FeatureSet::new())]
+#[case::v1_checkpoint(
+    LogState::with_latest_version(1).with_checkpoint_at([1]),
+    FeatureSet::new()
+)]
+#[case::v2_sidecar(
+    LogState::with_latest_version(1)
+        .with_checkpoint_at([1])
+        .with_sidecars_if_enabled(None),
+    FeatureSet::new().v2_checkpoint()
+)]
+#[case::column_mapping(
+    LogState::with_latest_version(1).with_checkpoint_at([1]),
+    FeatureSet::new().column_mapping("id")
+)]
+fn declarative_metadata_matches_imperative_with_reader_timezone(
+    #[case] log_state: LogState,
+    #[case] features: FeatureSet,
+) -> DeltaResult<()> {
+    let table = TestTableBuilder::new()
+        .with_log_state(log_state)
+        .with_features(features)
+        .with_table_config(TableConfig::new().write_stats_as_struct(true))
+        .with_data_layout(DataLayoutConfig::PartitionedAllTypes)
+        .build()
+        .expect("build reader-timezone parity table");
+    let engine = SyncEngine::new_with_store(table.store().clone());
+    let snapshot = Snapshot::builder_for(table.table_root()).build(&engine)?;
+    let partition_values =
+        || PartitionValuesOptions::with_struct().with_timestamp_timezone("America/Los_Angeles");
+    let predicate: PredicateRef = Pred::gt(col!("part_ts"), Scalar::Timestamp(0)).into();
+
+    let expected = imperative_metadata(
+        snapshot
+            .clone()
+            .scan_builder()
+            .with_partition_values(partition_values())
+            .with_predicate(predicate.clone())
+            .build()?,
+        &engine,
+    )?;
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(partition_values())
+        .with_predicate(predicate)
+        .build()?;
+    let actual = declarative_metadata(&scan, &engine)?;
+
+    assert_metadata_eq(&actual, &expected, "reader-timezone metadata parity")
+}
+
+fn write_timezone_partition_table(table_path: &Path) -> Url {
+    std::fs::create_dir_all(table_path).unwrap();
+    let url = Url::from_directory_path(table_path).unwrap();
+    let table_root = url.to_string();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let schema_string = serde_json::json!({
+        "type": "struct",
+        "fields": [
+            {"name": "p_ts", "type": "timestamp", "nullable": true, "metadata": {}},
+            {"name": "value", "type": "integer", "nullable": true, "metadata": {}},
+        ],
+    })
+    .to_string();
+    let protocol = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}"#;
+    let metadata = serde_json::json!({
+        "metaData": {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": ["p_ts"],
+            "configuration": {"delta.checkpoint.writeStatsAsStruct": "true"},
+            "createdTime": 1700000000000_i64,
+        },
+    })
+    .to_string();
+    futures::executor::block_on(add_commit(
+        &table_root,
+        store.as_ref(),
+        0,
+        format!("{protocol}\n{metadata}"),
+    ))
+    .unwrap();
+    let add = serde_json::json!({
+        "add": {
+            "path": "part.parquet",
+            "partitionValues": {"p_ts": "2024-01-15 12:30:45"},
+            "size": 100,
+            "modificationTime": 1700000000000_i64,
+            "dataChange": true,
+            "stats": "{\"numRecords\":1}",
+        },
+    });
+    futures::executor::block_on(add_commit(&table_root, store.as_ref(), 1, add.to_string()))
+        .unwrap();
+    url
+}
+
+#[rstest]
+fn reader_timezone_controls_partition_pruning_across_metadata_paths(
+    #[values(false, true)] native_checkpoint: bool,
+) -> DeltaResult<()> {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let url = write_timezone_partition_table(temp_dir.path());
+    let engine = SyncEngine::new();
+    if native_checkpoint {
+        Snapshot::builder_for(url.clone())
+            .build(&engine)?
+            .checkpoint(&engine, None)?;
+    }
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
+    let partition_values =
+        || PartitionValuesOptions::with_struct().with_timestamp_timezone("America/Los_Angeles");
+    let predicate: PredicateRef =
+        Pred::gt(col!("p_ts"), Scalar::Timestamp(1_705_334_400_000_000)).into();
+
+    let expected = imperative_metadata(
+        snapshot
+            .clone()
+            .scan_builder()
+            .with_partition_values(partition_values())
+            .with_predicate(predicate.clone())
+            .build()?,
+        &engine,
+    )?;
+    assert_eq!(
+        metadata_row_count(&expected),
+        1,
+        "imperative pruning must use the configured reader timezone"
+    );
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(partition_values())
+        .with_predicate(predicate)
+        .build()?;
+    let actual = declarative_metadata(&scan, &engine)?;
+    assert_eq!(
+        metadata_row_count(&actual),
+        1,
+        "declarative pruning must use the configured reader timezone"
+    );
+
+    assert_metadata_eq(&actual, &expected, "reader-timezone metadata parity")
 }
 
 #[rstest]

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -23,6 +23,8 @@ use crate::expressions::{
     col, column_name, column_pred, lit, Expression as Expr, Predicate as Pred,
 };
 use crate::object_store::memory::InMemory;
+use crate::object_store::path::Path;
+use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
@@ -38,6 +40,19 @@ use crate::{
 
 fn field_names(s: &StructArray) -> Vec<String> {
     s.fields().iter().map(|f| f.name().clone()).collect()
+}
+
+#[test]
+fn partition_values_options_carry_optional_timestamp_timezone() {
+    let default = PartitionValuesOptions::with_struct();
+    assert!(default.parsed_struct);
+    assert_eq!(default.timestamp_timezone, None);
+
+    let zoned = default.with_timestamp_timezone("America/Los_Angeles");
+    assert_eq!(
+        zoned.timestamp_timezone.as_deref(),
+        Some("America/Los_Angeles")
+    );
 }
 
 #[test]
@@ -771,6 +786,7 @@ fn test_get_partition_value() {
         let value = crate::scan::transform_spec::parse_partition_value_raw(
             Some(&raw.to_string()),
             &DataType::Primitive(data_type.clone()),
+            crate::timestamp_timezone::TimestampTimezone::default(),
         )
         .unwrap();
         assert_eq!(value, *expected);
@@ -1142,6 +1158,73 @@ fn test_build_actions_meta_predicate_partition_only(
     assert_eq!(
         refs,
         vec!["add.partitionValues_parsed.modified".to_string()]
+    );
+}
+
+#[test]
+fn checkpoint_reader_timezone_omits_only_zoned_timestamp_partition_from_meta_predicate() {
+    let store = Arc::new(InMemory::new());
+    let commit = r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["timestampNtz"],"writerFeatures":["timestampNtz"]}}
+{"metaData":{"id":"test","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"part_ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"part_ts_ntz\",\"type\":\"timestamp_ntz\",\"nullable\":true,\"metadata\":{}},{\"name\":\"part_int\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["part_ts","part_ts_ntz","part_int"],"configuration":{},"createdTime":0}}"#;
+    futures::executor::block_on(store.put(
+        &Path::from("_delta_log/00000000000000000000.json"),
+        commit.into(),
+    ))
+    .unwrap();
+    let engine = SyncEngine::new_with_store(store);
+    let snapshot = Snapshot::builder_for("memory:///").build(&engine).unwrap();
+    let predicate = Arc::new(Pred::and(
+        Pred::gt(col!("part_ts"), Scalar::Timestamp(0)),
+        Pred::and(
+            Pred::gt(col!("part_ts_ntz"), Scalar::TimestampNtz(0)),
+            Pred::gt(col!("part_int"), lit(0)),
+        ),
+    ));
+
+    let zoned_scan = snapshot
+        .clone()
+        .scan_builder()
+        .with_predicate(predicate.clone())
+        .with_partition_values(
+            PartitionValuesOptions::with_struct().with_timestamp_timezone("America/Los_Angeles"),
+        )
+        .build()
+        .unwrap();
+    let zoned_refs: HashSet<_> = zoned_scan
+        .build_actions_meta_predicate()
+        .expect("safe partition leaves should retain a checkpoint predicate")
+        .references()
+        .into_iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(
+        zoned_refs,
+        HashSet::from([
+            "add.partitionValues_parsed.part_int".to_string(),
+            "add.partitionValues_parsed.part_ts_ntz".to_string(),
+        ])
+    );
+
+    let utc_scan = snapshot
+        .scan_builder()
+        .with_predicate(predicate)
+        .with_partition_values(PartitionValuesOptions::with_struct())
+        .build()
+        .unwrap();
+    let utc_refs: HashSet<_> = utc_scan
+        .build_actions_meta_predicate()
+        .expect("all UTC partition leaves should retain a checkpoint predicate")
+        .references()
+        .into_iter()
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(
+        utc_refs,
+        HashSet::from([
+            "add.partitionValues_parsed.part_int".to_string(),
+            "add.partitionValues_parsed.part_ts".to_string(),
+            "add.partitionValues_parsed.part_ts_ntz".to_string(),
+        ])
     );
 }
 

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::expressions::{lit, Expression, ExpressionRef, ExpressionStructPatchBuilder, Scalar};
 use crate::schema::{DataType, SchemaRef, StructType};
 use crate::table_features::ColumnMappingMode;
+use crate::timestamp_timezone::TimestampTimezone;
 use crate::{DeltaResult, Error};
 
 /// A list of field transforms used to convert physical file data to logical scan output.
@@ -77,6 +78,7 @@ pub(crate) fn parse_partition_value(
     logical_schema: &SchemaRef,
     partition_values: &HashMap<String, String>,
     column_mapping_mode: ColumnMappingMode,
+    timestamp_timezone: TimestampTimezone,
 ) -> DeltaResult<(usize, (String, Scalar))> {
     let Some(field) = logical_schema.field_at_index(field_idx) else {
         return Err(Error::InternalError(format!(
@@ -84,7 +86,11 @@ pub(crate) fn parse_partition_value(
         )));
     };
     let name = field.physical_name(column_mapping_mode);
-    let partition_value = parse_partition_value_raw(partition_values.get(name), field.data_type())?;
+    let partition_value = parse_partition_value_raw(
+        partition_values.get(name),
+        field.data_type(),
+        timestamp_timezone,
+    )?;
     Ok((field_idx, (name.to_string(), partition_value)))
 }
 
@@ -94,6 +100,7 @@ pub(crate) fn parse_partition_values(
     transform_spec: &TransformSpec,
     partition_values: &HashMap<String, String>,
     column_mapping_mode: ColumnMappingMode,
+    timestamp_timezone: TimestampTimezone,
 ) -> DeltaResult<HashMap<usize, (String, Scalar)>> {
     transform_spec
         .iter()
@@ -104,6 +111,7 @@ pub(crate) fn parse_partition_values(
                     logical_schema,
                     partition_values,
                     column_mapping_mode,
+                    timestamp_timezone,
                 ))
             }
             FieldTransformSpec::DynamicColumn { .. }
@@ -214,11 +222,18 @@ fn apply_insert_after(
 pub(crate) fn parse_partition_value_raw(
     raw: Option<&String>,
     data_type: &DataType,
+    timestamp_timezone: TimestampTimezone,
 ) -> DeltaResult<Scalar> {
     match (raw, data_type.as_primitive_opt()) {
         (Some(v), Some(primitive)) if v.is_empty() => Ok(primitive
             .empty_string_partition_cast()
             .unwrap_or_else(|| Scalar::Null(data_type.clone()))),
+        (Some(v), Some(primitive)) if primitive == &crate::schema::PrimitiveType::Timestamp => {
+            timestamp_timezone
+                .parse_timestamp(v)
+                .map(Scalar::Timestamp)
+                .ok_or_else(|| Error::ParseError(v.clone(), data_type.clone()))
+        }
         (Some(v), Some(primitive)) => primitive.parse_scalar(v),
         (Some(_), None) => Err(Error::generic(format!(
             "Unexpected partition column type: {data_type:?}"
@@ -245,7 +260,13 @@ mod tests {
         )]));
         let partition_values = HashMap::new();
 
-        let result = parse_partition_value(5, &schema, &partition_values, ColumnMappingMode::None);
+        let result = parse_partition_value(
+            5,
+            &schema,
+            &partition_values,
+            ColumnMappingMode::None,
+            TimestampTimezone::default(),
+        );
         assert_result_error_with_message(result, "out of bounds");
     }
 
@@ -285,6 +306,7 @@ mod tests {
             &transform_spec,
             &partition_values,
             ColumnMappingMode::None,
+            TimestampTimezone::default(),
         )
         .unwrap();
         assert_eq!(result.len(), 2);
@@ -311,6 +333,7 @@ mod tests {
             &transform_spec,
             &partition_values,
             ColumnMappingMode::None,
+            TimestampTimezone::default(),
         )
         .unwrap();
         assert!(result.is_empty());
@@ -319,8 +342,12 @@ mod tests {
     // Tests for parse_partition_value_raw function
     #[test]
     fn test_parse_partition_value_raw_string() {
-        let result =
-            parse_partition_value_raw(Some(&"test_string".to_string()), &DataType::STRING).unwrap();
+        let result = parse_partition_value_raw(
+            Some(&"test_string".to_string()),
+            &DataType::STRING,
+            TimestampTimezone::default(),
+        )
+        .unwrap();
         assert_eq!(result, Scalar::String("test_string".to_string()));
     }
 
@@ -329,6 +356,7 @@ mod tests {
         let result = parse_partition_value_raw(
             Some(&"42".to_string()),
             &DataType::Primitive(PrimitiveType::Integer),
+            TimestampTimezone::default(),
         )
         .unwrap();
         assert_eq!(result, Scalar::Integer(42));
@@ -336,7 +364,9 @@ mod tests {
 
     #[test]
     fn test_parse_partition_value_raw_null() {
-        let result = parse_partition_value_raw(None, &DataType::STRING).unwrap();
+        let result =
+            parse_partition_value_raw(None, &DataType::STRING, TimestampTimezone::default())
+                .unwrap();
         assert!(result.is_null());
     }
 
@@ -347,15 +377,28 @@ mod tests {
         // writer, since kernel serializes its own empty and null partition values to JSON null.
         let empty = String::new();
 
-        let string_value = parse_partition_value_raw(Some(&empty), &DataType::STRING).unwrap();
+        let string_value = parse_partition_value_raw(
+            Some(&empty),
+            &DataType::STRING,
+            TimestampTimezone::default(),
+        )
+        .unwrap();
         assert_eq!(string_value, Scalar::String(String::new()));
 
-        let binary_value = parse_partition_value_raw(Some(&empty), &DataType::BINARY).unwrap();
+        let binary_value = parse_partition_value_raw(
+            Some(&empty),
+            &DataType::BINARY,
+            TimestampTimezone::default(),
+        )
+        .unwrap();
         assert_eq!(binary_value, Scalar::Binary(Vec::new()));
 
-        let int_value =
-            parse_partition_value_raw(Some(&empty), &DataType::Primitive(PrimitiveType::Integer))
-                .unwrap();
+        let int_value = parse_partition_value_raw(
+            Some(&empty),
+            &DataType::Primitive(PrimitiveType::Integer),
+            TimestampTimezone::default(),
+        )
+        .unwrap();
         assert!(int_value.is_null());
     }
 
@@ -364,6 +407,7 @@ mod tests {
         let result = parse_partition_value_raw(
             Some(&"value".to_string()),
             &DataType::struct_type_unchecked(vec![]), // Non-primitive type
+            TimestampTimezone::default(),
         );
         assert_result_error_with_message(result, "Unexpected partition column type");
     }
@@ -373,6 +417,7 @@ mod tests {
         let result = parse_partition_value_raw(
             Some(&"not_a_number".to_string()),
             &DataType::Primitive(PrimitiveType::Integer),
+            TimestampTimezone::default(),
         );
         assert_result_error_with_message(result, "Failed to parse value");
     }

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -6,6 +6,7 @@ use crate::expressions::Scalar;
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values};
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::timestamp_timezone::TimestampTimezone;
 use crate::{DeltaResult, Error, ExpressionRef};
 
 /// Gets CDF metadata columns from the logical schema and scan file.
@@ -109,6 +110,7 @@ pub(crate) fn get_cdf_transform_expr(
         transform_spec,
         &scan_file.partition_values,
         state_info.column_mapping_mode,
+        TimestampTimezone::default(),
     )?;
     partition_values.extend(parsed_values);
 

--- a/kernel/src/timestamp_timezone.rs
+++ b/kernel/src/timestamp_timezone.rs
@@ -1,0 +1,199 @@
+//! Reader-timezone handling for offset-less timestamp strings.
+
+use chrono::{
+    DateTime, FixedOffset, MappedLocalTime, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeDelta,
+    TimeZone,
+};
+use chrono_tz::Tz;
+
+use crate::{DeltaResult, Error};
+
+/// A validated IANA timezone or fixed UTC offset used to interpret local timestamps.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TimestampTimezone {
+    Iana(Tz),
+    Fixed(FixedOffset),
+}
+
+impl Default for TimestampTimezone {
+    fn default() -> Self {
+        Self::Iana(chrono_tz::UTC)
+    }
+}
+
+impl TimestampTimezone {
+    /// Parses an IANA timezone name or a fixed offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `value` is neither a known IANA timezone nor a supported fixed
+    /// offset.
+    pub(crate) fn parse(value: &str) -> DeltaResult<Self> {
+        if value.starts_with('+') || value.starts_with('-') {
+            return parse_fixed_offset(value)
+                .map(Self::Fixed)
+                .ok_or_else(|| Error::generic(format!("Invalid timestamp timezone: {value}")));
+        }
+        value
+            .parse::<Tz>()
+            .map(Self::Iana)
+            .map_err(|_| Error::generic(format!("Invalid timestamp timezone: {value}")))
+    }
+
+    /// Parses a timestamp string, honoring an explicit offset in `raw` when present.
+    ///
+    /// Returns `None` when `raw` is not a valid timestamp or cannot be represented.
+    pub(crate) fn parse_timestamp(self, raw: &str) -> Option<i64> {
+        if let Ok(timestamp) = DateTime::parse_from_str(raw, "%+") {
+            return Some(timestamp.timestamp_micros());
+        }
+        let local_datetime = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f")
+            .or_else(|_| NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S%.f"))
+            .or_else(|_| {
+                NaiveDate::parse_from_str(raw, "%Y-%m-%d").map(|date| date.and_time(NaiveTime::MIN))
+            })
+            .ok()?;
+        match self {
+            Self::Iana(timezone) => resolve_local_timestamp(local_datetime, timezone),
+            Self::Fixed(timezone) => resolve_local_timestamp(local_datetime, timezone),
+        }
+    }
+}
+
+fn parse_fixed_offset(value: &str) -> Option<FixedOffset> {
+    let (sign, value) = match value.as_bytes().first()? {
+        b'+' => (1, &value[1..]),
+        b'-' => (-1, &value[1..]),
+        _ => return None,
+    };
+    let mut parts = value.split(':');
+    let parse_component = |part: &str| {
+        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| part.parse::<i32>().ok())
+            .flatten()
+    };
+    let hours = parse_component(parts.next()?)?;
+    let minutes = parts.next().map_or(Some(0), parse_component)?;
+    let seconds = parts.next().map_or(Some(0), parse_component)?;
+    if parts.next().is_some()
+        || value.is_empty()
+        || hours > 18
+        || minutes > 59
+        || seconds > 59
+        || (hours == 18 && (minutes != 0 || seconds != 0))
+    {
+        return None;
+    }
+    FixedOffset::east_opt(sign * (hours * 3_600 + minutes * 60 + seconds))
+}
+
+fn resolve_local_timestamp<T: TimeZone + Copy>(
+    local_datetime: NaiveDateTime,
+    timezone: T,
+) -> Option<i64> {
+    match timezone.from_local_datetime(&local_datetime) {
+        MappedLocalTime::Single(timestamp) => Some(timestamp.timestamp_micros()),
+        MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.timestamp_micros()),
+        MappedLocalTime::None => {
+            // A forward transition can skip more than one hour, so walk backward until reaching
+            // the pre-transition side of the gap.
+            let offset = (1..=48).find_map(|hours| {
+                let before_transition =
+                    local_datetime.checked_sub_signed(TimeDelta::hours(hours))?;
+                match timezone.from_local_datetime(&before_transition) {
+                    MappedLocalTime::Single(timestamp) => Some(timestamp.offset().fix()),
+                    MappedLocalTime::Ambiguous(earlier, _) => Some(earlier.offset().fix()),
+                    MappedLocalTime::None => None,
+                }
+            })?;
+            local_datetime
+                .checked_sub_signed(TimeDelta::seconds(i64::from(offset.local_minus_utc())))
+                .map(|utc_datetime| utc_datetime.and_utc().timestamp_micros())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn expected_timestamp_micros(value: &str) -> i64 {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .timestamp_micros()
+    }
+
+    #[rstest]
+    #[case::utc("UTC", "2024-01-15 12:30:45.123456", "2024-01-15T12:30:45.123456Z")]
+    #[case::iana_winter(
+        "America/Los_Angeles",
+        "2024-01-15 12:30:45.123456",
+        "2024-01-15T20:30:45.123456Z"
+    )]
+    #[case::iana_summer(
+        "America/Los_Angeles",
+        "2024-06-15 08:00:00.500500",
+        "2024-06-15T15:00:00.500500Z"
+    )]
+    #[case::fixed_offset(
+        "+12:45:30",
+        "2024-01-15 12:30:45.123456",
+        "2024-01-14T23:45:15.123456Z"
+    )]
+    #[case::explicit_offset_wins(
+        "America/Los_Angeles",
+        "2024-01-15 12:30:45+02:00",
+        "2024-01-15T10:30:45Z"
+    )]
+    #[case::iso_t_separator("UTC", "2024-01-15T12:30:45", "2024-01-15T12:30:45Z")]
+    #[case::date_only("UTC", "2024-01-15", "2024-01-15T00:00:00Z")]
+    #[case::dst_overlap("America/Los_Angeles", "2024-11-03 01:30:00", "2024-11-03T08:30:00Z")]
+    #[case::dst_gap("America/Los_Angeles", "2024-03-10 02:30:00", "2024-03-10T10:30:00Z")]
+    #[case::skipped_day("Pacific/Apia", "2011-12-30 12:00:00", "2011-12-30T22:00:00Z")]
+    fn parses_timestamp_in_reader_timezone(
+        #[case] timezone: &str,
+        #[case] raw: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            TimestampTimezone::parse(timezone)
+                .unwrap()
+                .parse_timestamp(raw),
+            Some(expected_timestamp_micros(expected))
+        );
+    }
+
+    #[rstest]
+    #[case::zero("+0")]
+    #[case::hours("+5")]
+    #[case::hours_minutes("-05:30")]
+    #[case::hours_minutes_seconds("+12:45:30")]
+    #[case::positive_limit("+18:00:00")]
+    #[case::negative_limit("-18")]
+    fn accepts_supported_fixed_offsets(#[case] timezone: &str) {
+        assert!(TimestampTimezone::parse(timezone).is_ok());
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::bare_positive_sign("+")]
+    #[case::over_max_second("+18:00:01")]
+    #[case::over_max_hour("+19")]
+    #[case::minutes_out_of_range("+00:60")]
+    #[case::seconds_out_of_range("+00:00:60")]
+    #[case::extra_component("+05:30:00:00")]
+    #[case::unknown_name("Not/AZone")]
+    fn rejects_invalid_timezones(#[case] timezone: &str) {
+        assert!(TimestampTimezone::parse(timezone).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_timestamp() {
+        assert_eq!(
+            TimestampTimezone::default().parse_timestamp("not a timestamp"),
+            None
+        );
+    }
+}

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -2,10 +2,10 @@ use std::borrow::{Cow, ToOwned};
 use std::sync::Arc;
 
 use crate::expressions::{
-    BinaryExpression, BinaryPredicate, CastExpression, ColumnName, Expression, ExpressionRef,
-    ExpressionStructPatch, JunctionPredicate, MapToStructExpression, OpaqueExpression,
-    OpaquePredicate, ParseJsonExpression, Predicate, Scalar, UnaryExpression, UnaryPredicate,
-    VariadicExpression,
+    BinaryExpression, BinaryPredicate, CastExpression, ColumnName, ElementAtExpression, Expression,
+    ExpressionRef, ExpressionStructPatch, JunctionPredicate, MapToStructExpression,
+    OpaqueExpression, OpaquePredicate, ParseJsonExpression, Predicate, Scalar, UnaryExpression,
+    UnaryPredicate, VariadicExpression,
 };
 use crate::transforms::{
     map_owned_children_or_else, map_owned_or_else, map_owned_pair_or_else, transform_output_type,
@@ -139,6 +139,14 @@ pub trait ExpressionTransform<'a> {
         self.recurse_into_expr_map_to_struct(expr)
     }
 
+    /// Called for each element-at expression encountered during the traversal.
+    fn transform_expr_element_at(
+        &mut self,
+        expr: &'a ElementAtExpression,
+    ) -> Self::Output<ElementAtExpression> {
+        self.recurse_into_expr_element_at(expr)
+    }
+
     /// Called for each cast expression encountered during the traversal. The provided
     /// implementation just forwards to [`Self::recurse_into_expr_cast`].
     fn transform_expr_cast(&mut self, expr: &'a CastExpression) -> Self::Output<CastExpression> {
@@ -268,6 +276,10 @@ pub trait ExpressionTransform<'a> {
                 let child = self.transform_expr_map_to_struct(m);
                 map_owned_or_else(expr, child, Expression::MapToStruct)
             }
+            Expression::ElementAt(e) => {
+                let child = self.transform_expr_element_at(e);
+                map_owned_or_else(expr, child, Expression::ElementAt)
+            }
             Expression::Cast(c) => {
                 let child = self.transform_expr_cast(c);
                 map_owned_or_else(expr, child, Expression::Cast)
@@ -349,6 +361,17 @@ pub trait ExpressionTransform<'a> {
             options: expr.options.clone(),
         };
         map_owned_or_else(expr, nested, rebuild)
+    }
+
+    /// Recursively transforms both children of an element-at expression.
+    fn recurse_into_expr_element_at(
+        &mut self,
+        expr: &'a ElementAtExpression,
+    ) -> Self::Output<ElementAtExpression> {
+        let map_expr = self.transform_expr(&expr.map_expr);
+        let key_expr = self.transform_expr(&expr.key_expr);
+        let rebuild = |(map_expr, key_expr)| ElementAtExpression::new(map_expr, key_expr);
+        map_owned_pair_or_else(expr, map_expr, key_expr, rebuild)
     }
 
     /// Recursively transforms the child expression of a cast expression (unary).
@@ -556,6 +579,10 @@ impl<'a> ExpressionTransform<'a> for ExpressionDepthChecker {
 
     fn transform_expr_map_to_struct(&mut self, expr: &'a MapToStructExpression) -> DeltaResult<()> {
         self.depth_limited(Self::recurse_into_expr_map_to_struct, expr)
+    }
+
+    fn transform_expr_element_at(&mut self, expr: &'a ElementAtExpression) -> DeltaResult<()> {
+        self.depth_limited(Self::recurse_into_expr_element_at, expr)
     }
 }
 
@@ -1119,6 +1146,44 @@ mod tests {
         assert_eq!(
             ExpressionDepthChecker::check_expr_with_call_count(&expr, 0),
             (1, 2)
+        );
+    }
+
+    #[test]
+    fn test_element_at_references_and_transforms_both_children() {
+        let expr = Expr::element_at(col!("old_col"), col!("partitionKey"));
+        let references = expr.references();
+        assert_eq!(references.len(), 2);
+        assert!(references.contains(&ColumnName::new(["old_col"])));
+        assert!(references.contains(&ColumnName::new(["partitionKey"])));
+
+        let transformed = ColumnReplacer.transform_expr(&expr).into_owned();
+        assert_eq!(
+            transformed,
+            Expr::element_at(col!("new_col"), col!("partitionKey"))
+        );
+
+        struct ColumnRemover;
+        impl<'a> ExpressionTransform<'a> for ColumnRemover {
+            transform_output_type!(|'a, T| Option<Cow<'a, T>>);
+
+            fn transform_expr_column(
+                &mut self,
+                name: &'a ColumnName,
+            ) -> Option<Cow<'a, ColumnName>> {
+                (name[0] != "partitionKey").then_some(Cow::Borrowed(name))
+            }
+        }
+        assert!(ColumnRemover.transform_expr(&expr).is_none());
+    }
+
+    #[test]
+    fn test_depth_checker_counts_element_at_expressions() {
+        let expr = Expr::element_at(col!("partitionValues"), col!("partitionKey"));
+
+        assert_eq!(
+            ExpressionDepthChecker::check_expr_with_call_count(&expr, 0),
+            (0, 1)
         );
     }
 

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -344,7 +344,11 @@ pub trait ExpressionTransform<'a> {
         expr: &'a MapToStructExpression,
     ) -> Self::Output<MapToStructExpression> {
         let nested = self.transform_expr(&expr.map_expr);
-        map_owned_or_else(expr, nested, MapToStructExpression::new)
+        let rebuild = |map_expr| MapToStructExpression {
+            map_expr: Box::new(map_expr),
+            options: expr.options.clone(),
+        };
+        map_owned_or_else(expr, nested, rebuild)
     }
 
     /// Recursively transforms the child expression of a cast expression (unary).
@@ -563,8 +567,8 @@ mod tests {
     use super::*;
     use crate::expressions::VariadicExpressionOp::Coalesce;
     use crate::expressions::{
-        col, column_name, column_pred, lit, Expression, Expression as Expr, OpaqueExpressionOp,
-        OpaquePredicateOp, ParseJsonExpression, Predicate as Pred, Scalar,
+        col, column_name, column_pred, lit, Expression, Expression as Expr, MapToStructOptions,
+        OpaqueExpressionOp, OpaquePredicateOp, ParseJsonExpression, Predicate as Pred, Scalar,
         ScalarExpressionEvaluator, VariadicExpression,
     };
     use crate::kernel_predicates::{
@@ -875,6 +879,23 @@ mod tests {
             // Schema should be preserved
             assert_eq!(result_expr.output_schema, test_output_schema());
         }
+    }
+
+    #[test]
+    fn test_map_to_struct_options_survive_child_transform() {
+        let expr = Expr::map_to_struct(
+            col!("old_col"),
+            MapToStructOptions::default().with_timestamp_timezone("Europe/Berlin"),
+        );
+        let Expr::MapToStruct(transformed) = ColumnReplacer.transform_expr(&expr).into_owned()
+        else {
+            panic!("expected map-to-struct expression");
+        };
+        assert_eq!(transformed.map_expr.as_ref(), &col!("new_col"));
+        assert_eq!(
+            transformed.options.timestamp_timezone(),
+            Some("Europe/Berlin")
+        );
     }
 
     #[test]

--- a/kernel/tests/integration/parsed_partition_values.rs
+++ b/kernel/tests/integration/parsed_partition_values.rs
@@ -1,15 +1,18 @@
 //! Integration tests for parsed partition-value output (`partitionValues_parsed`).
 
+use std::fs::File;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
-    Array, BinaryArray, BooleanArray, Int32Array, RecordBatch, StringArray, StructArray,
+    Array, ArrayRef, BinaryArray, BooleanArray, Int32Array, RecordBatch, StringArray, StructArray,
+    TimestampMicrosecondArray,
 };
 use delta_kernel::arrow::compute::filter_record_batch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::{col, lit, ColumnName, Predicate};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::DynObjectStore;
+use delta_kernel::parquet::arrow::ArrowWriter;
 use delta_kernel::scan::state::ScanFile;
 use delta_kernel::scan::PartitionValuesOptions;
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
@@ -390,4 +393,278 @@ async fn empty_string_partition_pruning(#[values(false, true)] native_checkpoint
         vec![other.clone()],
         "empty-bytes file must be pruned under p_bin = X'6f74686572'"
     );
+}
+
+async fn write_timezone_partition_table(table_path: &std::path::Path, timestamp: &str) -> Url {
+    std::fs::create_dir_all(table_path).unwrap();
+    let values: ArrayRef = Arc::new(Int32Array::from(vec![42]));
+    let batch = RecordBatch::try_from_iter([("value", values)]).unwrap();
+    let mut writer = ArrowWriter::try_new(
+        File::create(table_path.join("part.parquet")).unwrap(),
+        batch.schema(),
+        None,
+    )
+    .unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    let file_size = std::fs::metadata(table_path.join("part.parquet"))
+        .unwrap()
+        .len();
+    let url = Url::from_directory_path(table_path).unwrap();
+    let table_root = url.to_string();
+    let store: Arc<DynObjectStore> = Arc::new(LocalFileSystem::new());
+    let schema_string = serde_json::json!({
+        "type": "struct",
+        "fields": [
+            {"name": "p_ts", "type": "timestamp", "nullable": true, "metadata": {}},
+            {"name": "p_ntz", "type": "timestamp_ntz", "nullable": true, "metadata": {}},
+            {"name": "p_int", "type": "integer", "nullable": true, "metadata": {}},
+            {"name": "value", "type": "integer", "nullable": true, "metadata": {}},
+        ],
+    })
+    .to_string();
+    let protocol = r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["timestampNtz"],"writerFeatures":["timestampNtz"]}}"#;
+    let metadata = serde_json::json!({
+        "metaData": {
+            "id": "00000000-0000-0000-0000-000000000000",
+            "format": {"provider": "parquet", "options": {}},
+            "schemaString": schema_string,
+            "partitionColumns": ["p_ts", "p_ntz", "p_int"],
+            "configuration": {"delta.checkpoint.writeStatsAsStruct": "true"},
+            "createdTime": 1700000000000_i64,
+        },
+    })
+    .to_string();
+    add_commit(
+        &table_root,
+        store.as_ref(),
+        0,
+        format!("{protocol}\n{metadata}"),
+    )
+    .await
+    .unwrap();
+    let add = serde_json::json!({
+        "add": {
+            "path": "part.parquet",
+            "partitionValues": {
+                "p_ts": timestamp,
+                "p_ntz": "2024-01-15 12:30:45.123456",
+                "p_int": "7",
+            },
+            "size": file_size,
+            "modificationTime": 1700000000000_i64,
+            "dataChange": true,
+            "stats": "{\"numRecords\":1}",
+        },
+    });
+    add_commit(&table_root, store.as_ref(), 1, add.to_string())
+        .await
+        .unwrap();
+    url
+}
+
+#[rstest]
+#[case::utc(None, "2024-01-15 12:30:45.123456", "2024-01-15T12:30:45.123456Z")]
+#[case::los_angeles_winter(
+    Some("America/Los_Angeles"),
+    "2024-01-15 12:30:45.123456",
+    "2024-01-15T20:30:45.123456Z"
+)]
+#[case::los_angeles_summer(
+    Some("America/Los_Angeles"),
+    "2024-06-15 08:00:00.500500",
+    "2024-06-15T15:00:00.500500Z"
+)]
+#[case::fixed_offset_seconds(
+    Some("+12:45:30"),
+    "2024-01-15 12:30:45.123456",
+    "2024-01-14T23:45:15.123456Z"
+)]
+#[case::explicit_offset_wins(
+    Some("America/Los_Angeles"),
+    "2024-01-15 12:30:45+02:00",
+    "2024-01-15T10:30:45Z"
+)]
+#[case::dst_overlap_uses_earlier_instant(
+    Some("America/Los_Angeles"),
+    "2024-11-03 01:30:00",
+    "2024-11-03T08:30:00Z"
+)]
+#[case::dst_gap_uses_pre_transition_offset(
+    Some("America/Los_Angeles"),
+    "2024-03-10 02:30:00",
+    "2024-03-10T10:30:00Z"
+)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timezone_aware_parsed_partition_values_across_json_and_native_checkpoint(
+    #[case] timestamp_timezone: Option<&str>,
+    #[case] raw_timestamp: &str,
+    #[case] expected_timestamp: &str,
+    #[values(false, true)] native_checkpoint: bool,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let url = write_timezone_partition_table(temp_dir.path(), raw_timestamp).await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+    if native_checkpoint {
+        let snapshot = Snapshot::builder_for(url.clone())
+            .build(engine.as_ref())
+            .unwrap();
+        snapshot.checkpoint(engine.as_ref(), None).unwrap();
+    }
+
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let partition_values = timestamp_timezone
+        .map_or_else(PartitionValuesOptions::with_struct, |timezone| {
+            PartitionValuesOptions::with_struct().with_timestamp_timezone(timezone)
+        });
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(partition_values)
+        .build()
+        .unwrap();
+    let mut rows = 0;
+    for metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        let (data, selection) = metadata.unwrap().scan_files.into_parts();
+        let batch: RecordBatch = ArrowEngineData::try_from_engine_data(data).unwrap().into();
+        let batch = filter_record_batch(&batch, &BooleanArray::from(selection)).unwrap();
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let parsed = get_column!(batch, "partitionValues_parsed", StructArray);
+        let timestamp = parsed
+            .column_by_name("p_ts")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        let timestamp_ntz = parsed
+            .column_by_name("p_ntz")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .unwrap();
+        let integer = parsed
+            .column_by_name("p_int")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(
+            timestamp.value(0),
+            chrono::DateTime::parse_from_rfc3339(expected_timestamp)
+                .unwrap()
+                .timestamp_micros()
+        );
+        assert_eq!(
+            timestamp_ntz.value(0),
+            chrono::DateTime::parse_from_rfc3339("2024-01-15T12:30:45.123456Z")
+                .unwrap()
+                .timestamp_micros(),
+            "reader timezone must not affect TIMESTAMP_NTZ"
+        );
+        assert_eq!(integer.value(0), 7);
+        rows += batch.num_rows();
+    }
+    assert_eq!(rows, 1);
+}
+
+#[rstest]
+#[case::reader_timezone(
+    "2024-01-15 12:30:45.123456",
+    "America/Los_Angeles",
+    "2024-01-15T20:30:45.123456Z"
+)]
+#[case::explicit_offset_wins(
+    "2024-01-15 12:30:45+02:00",
+    "America/Los_Angeles",
+    "2024-01-15T10:30:45Z"
+)]
+#[case::dst_overlap_uses_earlier_instant(
+    "2024-11-03 01:30:00",
+    "America/Los_Angeles",
+    "2024-11-03T08:30:00Z"
+)]
+#[case::dst_gap_uses_pre_transition_offset(
+    "2024-03-10 02:30:00",
+    "America/Los_Angeles",
+    "2024-03-10T10:30:00Z"
+)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_execute_partition_row_transform_respects_reader_timezone(
+    #[case] raw_timestamp: &str,
+    #[case] timestamp_timezone: &str,
+    #[case] expected_timestamp: &str,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let url = write_timezone_partition_table(temp_dir.path(), raw_timestamp).await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(
+            PartitionValuesOptions::string_map_only().with_timestamp_timezone(timestamp_timezone),
+        )
+        .build()
+        .unwrap();
+
+    let batches: Vec<RecordBatch> = scan
+        .execute(engine)
+        .unwrap()
+        .map(|result| {
+            ArrowEngineData::try_from_engine_data(result.unwrap())
+                .unwrap()
+                .into()
+        })
+        .collect();
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    assert_eq!(batch.num_rows(), 1);
+    let timestamp = get_column!(batch, "p_ts", TimestampMicrosecondArray);
+    let timestamp_ntz = get_column!(batch, "p_ntz", TimestampMicrosecondArray);
+    let integer = get_column!(batch, "p_int", Int32Array);
+    assert_eq!(
+        timestamp.value(0),
+        chrono::DateTime::parse_from_rfc3339(expected_timestamp)
+            .unwrap()
+            .timestamp_micros()
+    );
+    assert_eq!(
+        timestamp_ntz.value(0),
+        chrono::DateTime::parse_from_rfc3339("2024-01-15T12:30:45.123456Z")
+            .unwrap()
+            .timestamp_micros(),
+        "reader timezone must not affect TIMESTAMP_NTZ"
+    );
+    assert_eq!(integer.value(0), 7);
+}
+
+#[rstest]
+#[case::invalid_zone("2024-01-15 12:30:45", "Not/AZone", "Not/AZone")]
+#[case::invalid_timestamp("not a timestamp", "America/Los_Angeles", "not a timestamp")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timezone_aware_parsed_partition_values_report_invalid_input(
+    #[case] raw_timestamp: &str,
+    #[case] timestamp_timezone: &str,
+    #[case] expected_error: &str,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let url = write_timezone_partition_table(temp_dir.path(), raw_timestamp).await;
+    let engine = create_default_engine_mt_executor(&url).unwrap();
+    let snapshot = Snapshot::builder_for(url).build(engine.as_ref()).unwrap();
+    let scan = snapshot
+        .scan_builder()
+        .with_partition_values(
+            PartitionValuesOptions::with_struct().with_timestamp_timezone(timestamp_timezone),
+        )
+        .build()
+        .unwrap();
+    let result = scan
+        .scan_metadata(engine.as_ref())
+        .unwrap()
+        .next()
+        .expect("one metadata result");
+    let Err(error) = result else {
+        panic!("invalid timestamp input must fail map parsing");
+    };
+    assert!(error.to_string().contains(expected_error), "{error}");
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3120/files/a512f72dd36563b32775903386b5638dab0b8554..3400443287310ee00fb8504b19ccdf1fc2583c3f) to review incremental changes.
- [stack/kernel-partition-timezone-expressions](https://github.com/delta-io/delta-kernel-rs/pull/3118) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3118/files)]
  - [stack/kernel-partition-timezone-parsing](https://github.com/delta-io/delta-kernel-rs/pull/3119) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3119/files/3529fd11f8b35a83475b6b311479d220da1c12ea..a512f72dd36563b32775903386b5638dab0b8554)]
    - [**stack/kernel-partition-timezone-scans**](https://github.com/delta-io/delta-kernel-rs/pull/3120) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3120/files/a512f72dd36563b32775903386b5638dab0b8554..3400443287310ee00fb8504b19ccdf1fc2583c3f)] ← _this PR_
      - [stack/kernel-partition-timezone-cast](https://github.com/delta-io/delta-kernel-rs/pull/3129) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3129/files/3400443287310ee00fb8504b19ccdf1fc2583c3f..eab4ed5bb463e05fffe95fa0c0863cbed942ab04)]
        - [stack/kernel-partition-timezone-selective](https://github.com/delta-io/delta-kernel-rs/pull/3130) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3130/files/eab4ed5bb463e05fffe95fa0c0863cbed942ab04..daeae1fa1e9b0442df387894b7f5a75da76de56f)]

---------
## What changes are proposed in this pull request?

Add an `ElementAt` expression for row-wise `Map<String, String>` lookup with dynamic keys and rightmost-duplicate semantics. Arrow and DataFusion share the behavior, predicate handling remains conservative, and unsupported FFI visitors receive an explicit unknown node.

### This PR affects the following public APIs

Add `ElementAtExpression`, `Expression::element_at`, and the `ElementAt` expression variant.

## How was this change tested?

Unit, executor, serialization, predicate, and FFI tests cover dynamic and missing keys, nulls, duplicate keys, and expression traversal.
