### PR TITLE
fix: import CollectInto from crate::utils to fix default-feature build

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -24,8 +24,8 @@ use crate::table_features::{
     StaleAnnotationPolicy,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
-use crate::utils::require;
-use crate::{CollectInto, DeltaResult, Error};
+use crate::utils::{require, CollectInto};
+use crate::{DeltaResult, Error};
 
 pub(crate) mod column_default;
 pub use column_default::ColumnDefault;


### PR DESCRIPTION
`schema/mod.rs` imported `CollectInto` from the crate root, but that re-export is gated behind the `internal-api` feature. `cargo publish` verifies the packaged crate with default features (`delta_kernel`'s `default = []`), so the crate failed to compile without `internal-api` (E0432 unresolved import) -- which blocked the v0.27.0 publish. The `--all-features` CI build enabled `internal-api`, so it never exercised this path.

Fix: import `CollectInto` from `crate::utils` (where it's defined), which resolves regardless of feature flags.

Verified with `cargo check -p delta_kernel --no-default-features`: compiles with 0 errors (previously E0432).