### PR TITLE
ci: isolate kernel no-default-features check

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,48 @@
+[alias]
+clippy-no-default-kernel-dependents = [
+  "clippy",
+  "--locked",
+  "--workspace",
+  "--no-default-features",
+  "--exclude",
+  "delta_kernel",
+  "--exclude",
+  "delta_kernel_ffi",
+  "--exclude",
+  "delta_kernel_derive",
+  "--exclude",
+  "delta_kernel_ffi_macros",
+  "--",
+  "-D",
+  "warnings",
+]
+check-no-default-kernel = [
+  "check",
+  "--locked",
+  "--no-default-features",
+  "--package",
+  "delta_kernel",
+]
+check-no-default-engine = [
+  "check",
+  "--locked",
+  "--no-default-features",
+  "--package",
+  "delta_kernel_default_engine",
+  "--features",
+  "arrow",
+]
+clippy-no-default-kernel-leaves = [
+  "clippy",
+  "--locked",
+  "--no-default-features",
+  "--package",
+  "delta_kernel_ffi",
+  "--package",
+  "delta_kernel_derive",
+  "--package",
+  "delta_kernel_ffi_macros",
+  "--",
+  "-D",
+  "warnings",
+]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
   # enabled, the kernel will be compiled with those features (even if we specify
   # --no-default-features).
   #
-  # To cope with this, we split build/clippy --no-default-features into two runs:
+  # To cope with this, we split build/clippy --no-default-features into separate runs:
   # 1. build/clippy all packages that depend on the kernel with some features enabled:
   #    - acceptance
   #    - test_utils
@@ -161,11 +161,9 @@ jobs:
   #    - read-table-changes
   #    - read-table-multi-threaded
   #    - read-table-single-threaded
-  # 2. build/clippy all packages that only have no-feature kernel dependency
-  #    - delta_kernel
-  #    - delta_kernel_derive
-  #    - delta_kernel_ffi
-  #    - delta_kernel_ffi_macros
+  # 2. build the kernel by itself, so no other selected package can enable kernel features.
+  # 3. build the default engine by itself with defaults off and an explicit Arrow feature.
+  # 4. lint the remaining packages that only have no-feature kernel dependency.
   build:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -189,8 +187,14 @@ jobs:
         run: cargo clippy --locked --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
         run: cargo clippy --locked --workspace --no-default-features --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
+      - name: check without default features - kernel
+        env:
+          RUSTFLAGS: --cap-lints=warn
+        run: cargo check --locked --no-default-features --package delta_kernel
+      - name: check without default features - default engine
+        run: cargo check --locked --no-default-features --package delta_kernel_default_engine --features arrow
       - name: lint without default features - packages which don't depend on kernel with features enabled
-        run: cargo clippy --locked --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
+        run: cargo clippy --locked --no-default-features --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
       - name: check kernel declarative-plans feature-only build
         run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc
       - name: lint kernel declarative-plans feature-only build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,15 +186,15 @@ jobs:
       - name: build and lint with clippy
         run: cargo clippy --locked --benches --tests --all-features -- -D warnings
       - name: lint without default features - packages which depend on kernel with features enabled
-        run: cargo clippy --locked --workspace --no-default-features --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
+        run: cargo clippy-no-default-kernel-dependents
       - name: check without default features - kernel
         env:
           RUSTFLAGS: --cap-lints=warn
-        run: cargo check --locked --no-default-features --package delta_kernel
+        run: cargo check-no-default-kernel
       - name: check without default features - default engine
-        run: cargo check --locked --no-default-features --package delta_kernel_default_engine --features arrow
+        run: cargo check-no-default-engine
       - name: lint without default features - packages which don't depend on kernel with features enabled
-        run: cargo clippy --locked --no-default-features --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings
+        run: cargo clippy-no-default-kernel-leaves
       - name: check kernel declarative-plans feature-only build
         run: cargo check --locked -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc
       - name: lint kernel declarative-plans feature-only build


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add isolated no-default-features CI checks so core crates are compiled without sibling workspace
packages enabling features through Cargo feature unification.

This adds:
- `delta_kernel` by itself with no default features.
- `delta_kernel_default_engine` by itself with no default features and an explicit Arrow feature.

## How was this change tested?

- `RUSTFLAGS='--cap-lints=warn' cargo check --locked --no-default-features --package delta_kernel`
- `cargo check --locked --no-default-features --package delta_kernel_default_engine --features arrow`
- `cargo clippy --locked --no-default-features --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings`
