### PR TITLE
docs: correct stale CLAUDE.md and related docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,21 @@
 
 Delta-kernel-rs is a Rust library for building Delta Lake connectors. It encapsulates the
 Delta protocol so connectors can read and write Delta tables without understanding protocol
-internals. Kernel never does I/O directly -- it defines _what_ to do via its APIs
+internals. Kernel never does I/O directly: it defines _what_ to do via its APIs
 (`Snapshot`, `Scan`, `Transaction`) and delegates _how_ to the `Engine` trait.
 
-Current capabilities: table reads with predicates, data skipping, deletion vectors, change
-data feed, checkpoints (V1 & V2), log compaction (disabled, #2337), blind append writes, table creation
-(including clustered tables), catalog-managed table support, and incremental scan over a
-version range (`incremental_scan`).
+Current capabilities include table reads with predicates, data skipping, deletion vectors,
+change data feed, incremental scans (`incremental_scan_builder`) and commit ranges, checkpoints
+(V1 & V2), version checksums, blind appends, file removals, table creation (including clustered
+tables), limited schema alteration, and catalog-managed tables. Log compaction remains disabled
+(#2337).
 
 ## Build & Test Commands
 
-> **`datafusion_executor` is a separate workspace,** so the `--workspace` commands below do NOT
-> touch it. Build/test it on its own -- see `datafusion-executor/CLAUDE.md`.
+> **`datafusion-executor` and `integration-tests` are separate workspaces.** Root `--workspace`
+> commands do not include them. For `datafusion_executor` commands, see
+> `datafusion-executor/CLAUDE.md`. `integration-tests/test-all-arrow-versions.sh` tests each
+> supported Arrow version.
 
 ```bash
 # Build
@@ -27,10 +30,10 @@ cargo nextest run --workspace --all-features
 # Run tests for a specific crate
 cargo nextest run -p delta_kernel --all-features
 
-# Run a single test in a specific crate (fastest -- only compiles that crate)
+# Run a single test in a specific crate (fastest: only compiles that crate)
 cargo nextest run -p delta_kernel --lib --all-features test_name_here
 
-# Run a test by name, searching all crates (slow -- compiles everything)
+# Run a test by name, searching all crates (slow: compiles everything)
 cargo nextest run --workspace --all-features test_name_here
 
 # Format, lint, and doc check (always run after code changes)
@@ -55,15 +58,22 @@ cargo +nightly fmt \
 |--------------------------------------|---------------------------------------|--------------------------------------------------------------------------|
 | `delta_kernel`                       | `kernel/`                             | Core library                                                             |
 | `delta_kernel_default_engine`        | `default-engine/`                     | Default Arrow/Tokio `Engine` implementation                              |
+| `delta_kernel_default_engine_test_utils` | `default-engine/test-utils/`      | Default-engine test utilities                                            |
 | `delta_kernel_ffi`                   | `ffi/`                                | C/C++ FFI bindings                                                       |
+| `delta_kernel_ffi_macros`            | `ffi-proc-macros/`                    | FFI proc macros                                                          |
 | `delta_kernel_derive`                | `derive-macros/`                      | Proc macros                                                              |
 | `acceptance`                         | `acceptance/`                         | Acceptance tests (DAT)                                                   |
 | `test_utils`                         | `test-utils/`                         | Shared test utilities                                                    |
 | `delta_kernel_workloads`             | `workloads/`                          | Shared workload spec types + SQL predicate parser                        |
+| `delta_kernel_benchmarks`            | `benchmarks/`                         | Workload benchmarks                                                      |
 | `feature_tests`                      | `feature-tests/`                      | Feature flag tests                                                       |
+| `mem-test`                           | `mem-test/`                           | Memory-usage test executable                                             |
 | `delta-kernel-unity-catalog`         | `delta-kernel-unity-catalog/`         | Unity Catalog integration (UCCommitter, snapshot + create-table helpers) |
 | `unity-catalog-delta-client-api`     | `unity-catalog-delta-client-api/`     | Transport-agnostic UC client traits + wire models                        |
 | `unity-catalog-delta-rest-client`    | `unity-catalog-delta-rest-client/`    | REST/HTTP client for the Unity Catalog Delta Tables API                  |
+
+Packages under `kernel/examples/` are also workspace members. Use the package name from the
+example's `Cargo.toml` with `-p`.
 
 ### Feature Flags
 
@@ -71,45 +81,49 @@ Some noteworthy ones (see `[features]` in `kernel/Cargo.toml` for the full list)
 
 - TLS backend selection (`rustls` / `native-tls`) lives on the `delta_kernel_default_engine`
   crate, not on kernel itself.
-- `arrow`, `arrow-XX`, `arrow-YY` -- Arrow version selection (kernel tracks the latest two
-  major Arrow releases; `arrow` defaults to latest). Kernel itself does not depend on Arrow,
-  but the default engine does.
-- `arrow-conversion`, `arrow-expression` -- Arrow interop (auto-enabled by `default-engine-base`)
-- `prettyprint` -- enables Arrow pretty-print helpers (primarily test/example oriented)
-- `clustered-table` -- clustered table write support (experimental)
-- `adaptive-metadata-in-dev` -- adaptiveMetadata (Iceberg V4 adaptive metadata tree) support
+- `arrow`, `arrow-XX`, `arrow-YY`: Arrow version selection (kernel tracks the latest two
+  major Arrow releases; `arrow` defaults to latest). Kernel's core APIs are Arrow-independent;
+  the Arrow dependencies are optional, while the default engine requires one version.
+- `arrow-conversion`, `arrow-expression`: Arrow interop (auto-enabled by `default-engine-base`)
+- `prettyprint`: enables Arrow pretty-print helpers (primarily test/example oriented)
+- `schema-diff`: experimental schema diffing
+- `check-constraints-in-dev`: enables the internal SQL tokenizer and single-comparison parser for
+  check-constraint development
+- `adaptive-metadata-in-dev`: adaptiveMetadata (Iceberg V4 adaptive metadata tree) support
   (experimental, in development). Gates `KernelSupport::Supported` for the
-  `adaptiveMetadata-preview` reader+writer feature (reads/writes to tables listing it are blocked
-  with the cargo feature off).
-- `geo-type-in-dev` -- geospatial type support (geometry and geography columns) (experimental,
+  `adaptiveMetadata-preview` reader+writer feature. Without it, reads and writes to tables listing
+  the feature are blocked.
+- `geo-type-in-dev`: geospatial type support (geometry and geography columns) (experimental,
   in development). Gates `KernelSupport` for the `geospatial` reader+writer feature: with the
   cargo feature off, any table listing it is rejected; with it on, scans and CDF are supported
   but writes are still blocked.
-- `internal-api` -- unstable APIs like `parallel_scan_metadata`. Items are marked with the
+- `internal-api`: unstable APIs like `parallel_scan_metadata`. Items are marked with the
   `#[internal_api]` proc macro attribute.
-- `declarative-plans` -- experimental declarative-plan IR (`kernel/src/plans/`) and the prost
-  proto wire format mirroring it (`kernel/proto/`). Auto-enables `internal-api` and `arrow`.
-- `test-utils`, `integration-test` -- development only (`test-utils` enables `prettyprint`)
+- `declarative-plans`: experimental declarative-plan IR (`kernel/src/plans/`) and the prost
+  proto wire format mirroring it (`kernel/proto/`). Auto-enables `internal-api`, but not Arrow.
+- `vendored-protoc`: supplies `protoc` for `declarative-plans`; without it, set `PROTOC` to a
+  system or hermetic protobuf compiler.
+- `test-utils`, `integration-test`: development only (`test-utils` enables `prettyprint`)
 
 ## Architecture at a Glance
 
-**Snapshot** is the entry point for everything -- an immutable view of a table at a specific
-version. From it you build a `Scan` (reads) or `Transaction` (writes).
+**Snapshot** is the primary entry point for existing-table operations: an immutable view of a
+table at a specific version. From it you build a `Scan` (reads) or `Transaction` (writes).
 
-**Read path:** `Snapshot` -> `ScanBuilder` -> `Scan` -> data. Three execution paths:
+**Read path:** `Snapshot` -> `ScanBuilder` -> `Scan` -> data. Execution paths:
 `execute()` (simple), `scan_metadata()` (advanced/distributed),
 `parallel_scan_metadata()` (two-phase distributed log replay).
 
-**Write path:** `Snapshot` -> `Transaction` -> `commit()`. Kernel provides `WriteContext`
-(via `partitioned_write_context` or `unpartitioned_write_context`), assembles commit
-actions, enforces protocol compliance, delegates atomic commit to a `Committer`.
+**Existing-table write path:** `Snapshot` -> `Transaction` -> `commit()`. Kernel provides
+a `WriteContext` via `partitioned_write_context` or `unpartitioned_write_context`, assembles commit
+actions, enforces protocol compliance, and delegates atomic commit to a `Committer`.
 
-**Engine trait:** five handlers (`StorageHandler`, `JsonHandler`, `ParquetHandler`,
-`EvaluationHandler`, optional `MetricsReporter`). `DefaultEngine` lives in
-`kernel/src/engine/default/`.
+**Engine trait:** exposes `StorageHandler`, `JsonHandler`, `ParquetHandler`, and
+`EvaluationHandler`, plus an optional `PlanExecutor` under `declarative-plans`. Metrics use tracing
+layers rather than an engine handler. `DefaultEngine` lives in `default-engine/src/`.
 
 **EngineData:** opaque columnar data interface. NEVER access `EngineData` columns
-directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` accessors).
+directly: ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` accessors).
 
 ## Testing
 
@@ -120,26 +134,25 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
   for a catalog of available test tables (schema, protocol, features, and which tests use
   them). Consult it before creating new test data to avoid duplication.
 - **Consider `TestTableBuilder` (`test_utils::table_builder`) to build the table under test.**
-  Unlike `create_table`, which produces an empty table (just `00.json`) with a given set of
-  features and data layout, the builder *builds up* a multi-version table: data files written
-  across many commits, plus checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or
-  post-cleanup logs. So when a test needs a populated table history in a specific state, the
-  builder is often a good fit, composing `LogState`, `FeatureSet`, `DataLayoutConfig`, and
-  `TableConfig` through the real kernel write path so the table is protocol-correct by
-  construction. Load a snapshot at any `VersionTarget` with the `build_snapshot!` macro. For
-  coverage across many table states, the `default_sweep` cross-product template
-  (`LogState x FeatureSet x (DataLayoutConfig, TableConfig) x VersionTarget` -- data layout and
-  table config are bundled into one axis to avoid a cartesian explosion), or a per-axis template
-  with your own `#[values]`, can help; see
-  `kernel/tests/integration/cross_product/mod.rs`. Drop to lower-level setup like
-  `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) only when necessary --
-  e.g. for states the builder cannot express, such as corrupt or malformed logs.
+  Unlike `create_table`, which builds a single create transaction with a given set of features and
+  data layout, the builder *builds up* a multi-version table: data files written across many
+  commits, plus checkpoints, CRC files, a stale/missing `_last_checkpoint` hint, or post-cleanup
+  logs. So when a test needs a populated table history in a specific state, the builder is often a
+  good fit, composing `LogState`, `FeatureSet`, `DataLayoutConfig`, and `TableConfig` through the
+  real kernel write path so the table is protocol-correct by construction. Load a snapshot at any
+  `VersionTarget` with the `build_snapshot!` macro. For coverage across many table states, the
+  `default_sweep` cross-product template
+  (`LogState x FeatureSet x (DataLayoutConfig, TableConfig) x VersionTarget`: data layout and table
+  config are bundled into one axis to avoid a cartesian explosion), or a per-axis template with
+  your own `#[values]`, can help; see `kernel/tests/integration/cross_product/mod.rs`. Drop to
+  lower-level setup like `test_table_setup` (or hand-rolled `add_commit` / `LocalMockTable`) only
+  when necessary: e.g. for states the builder cannot express, such as corrupt or malformed logs.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific
   version (time travel), and updating from an existing snapshot.
-- Consider table state: only deltas (`00.json` to `0N.json`), after a checkpoint, after
-  a CRC (`0N.crc`) file, after log compaction, etc.
+- Consider table state: only versioned JSON commits, after a checkpoint, after a version
+  checksum (`.crc`) file, after log compaction, etc.
 - Prefer descriptive test names over doc comments. Encode the scenario and expected
   behavior in the test name. Only add a test doc comment when the intent is too
   verbose or complex to express succinctly in the name.
@@ -158,34 +171,34 @@ directly -- ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` ac
 - **Committing in tests:** Use `txn.commit(engine)?.unwrap_committed()` to assert a
   successful commit and get the `CommittedTransaction`. When you only need the resulting
   snapshot, use `txn.commit(engine)?.unwrap_post_commit_snapshot()` to get the
-  `SnapshotRef` directly. Do NOT use `match` + `panic!` for either -- they provide a clear
+  `SnapshotRef` directly. Do NOT use `match` + `panic!` for either: both helpers provide a clear
   error message on failure. Available under `#[cfg(test)]` and the `test-utils` feature.
 - **Prefer snapshot/public API assertions over reading raw commit JSON.** Only read raw
   commit JSON when the data is inaccessible via public API (e.g., system domain metadata
   is blocked by `get_domain_metadata`). For commit JSON reads, use `read_actions_from_commit`
-  from `test_utils` -- do NOT write local helpers that duplicate this.
+  from `test_utils`: do NOT write local helpers that duplicate this.
 - **`add_commit` and table setup in tests:** `add_commit` takes a `table_root` string and
   resolves it to an absolute object-store path. The `table_root` must be a proper URL string
   with a trailing slash (e.g. `"memory:///"`, `"file:///tmp/my_table/"`). Avoid using the
-  `Url` type directly -- most test helpers and kernel APIs accept `impl AsRef<str>`, so pass
+  `Url` type directly: most test helpers and kernel APIs accept `impl AsRef<str>`, so pass
   URL strings instead. When using local storage, use an un-prefixed store
   (`LocalFileSystem::new()`) with a `file:///` URL string. Do NOT use
-  `LocalFileSystem::new_with_prefix()` with `add_commit` -- the prefix causes double-nesting
-  because `add_commit` already resolves the full path from the URL. For in-memory tests, use
-  `InMemory::new()` with `"memory:///"`. ALWAYS use the same `table_root` URL string for
-  both `add_commit` (writing log files) and `snapshot`/`Snapshot::try_new` (reading the
-  table). ALWAYS include a trailing slash in directory URLs to ensure correct path joining.
+  `LocalFileSystem::new_with_prefix()` with `add_commit`: `add_commit` already resolves the full
+  path from the URL, so the prefix causes double-nesting. For in-memory tests, use
+  `InMemory::new()` with `"memory:///"`. ALWAYS use the same `table_root` URL string for both
+  `add_commit` (writing log files) and `Snapshot::builder_for` (reading the table). ALWAYS include
+  a trailing slash in directory URLs to ensure correct path joining.
 
-### Common test helpers
+### Common Test Helpers
 
 Before writing a custom helper, check this curated list and the locations below.
-This list is non-exhaustive -- when in doubt, browse the source files directly
+This list is non-exhaustive: when in doubt, browse the source files directly
 (`test-utils/src/lib.rs`, `kernel/tests/integration/common/`,
 `kernel/tests/integration/<topic>/mod.rs`).
 
 **Arrow construction (from `delta_kernel::arrow`)**
 
-- `arrow::array::new_null_array(&arrow_type, n)` -- Arrow array of `n` nulls of any Arrow
+- `arrow::array::new_null_array(&arrow_type, n)`: Arrow array of `n` nulls of any Arrow
   type. Prefer this over per-type `Int32Array::from(vec![None as Option<i32>])` builders.
 - `engine::arrow_conversion::TryIntoArrow`:
   `(&kernel_data_type).try_into_arrow()` for `DataType`,
@@ -193,17 +206,17 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 
 **Engine + table setup (from `test_utils`)**
 
-- `test_table_setup()` / `test_table_setup_mt()` -- engine + temp table path. Use the `_mt`
+- `test_table_setup()` / `test_table_setup_mt()`: engine + temp table path. Use the `_mt`
   variant under `#[tokio::test(flavor = "multi_thread")]`. Required whenever a test calls
   `snapshot.checkpoint()`: it issues nested `block_on` calls that deadlock on a single-threaded
   runtime / `TokioBackgroundExecutor`.
-- `engine_store_setup(name, opts)` -- returns `(store, engine, table_location)` when a test
-  needs direct object-store access.
-- `setup_test_tables(...)` -- multiple pre-built tables for read/scan tests.
+- `engine_store_setup(table_name, local_directory)`: returns
+  `(store, engine, table_location)` when a test needs direct object-store access.
+- `setup_test_tables(...)`: multiple pre-built tables for read/scan tests.
 
 **Table creation in tests**
 
-- `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand) -- worth
+- `test_utils::table_builder::TestTableBuilder` (and the `test_table(...)` shorthand): worth
   considering for a table in a specific state: composes `LogState`, `FeatureSet`,
   `DataLayoutConfig`, and `TableConfig` through the real write path. Pair with the
   `build_snapshot!` macro and, for broad coverage, the `default_sweep` template. See the Testing
@@ -225,16 +238,17 @@ This list is non-exhaustive -- when in doubt, browse the source files directly
 
 **Commit + read helpers (from `test_utils`)**
 
-- `add_commit`, `add_staged_commit` -- write a JSON commit at a given version.
-- `read_actions_from_commit` -- read raw JSON actions from a specific commit. Use this
-  instead of hand-rolled `serde_json` parsing.
-- `test_read` -- full-scan read of a table; use for round-trip assertions.
-- `into_record_batch` -- convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
+- `add_commit`, `add_staged_commit`: write a JSON commit at a given version.
+- `read_actions_from_commit`: read raw JSON actions from a specific local-file commit. Use
+  this instead of hand-rolled `serde_json` parsing.
+- `test_read`: full-scan read of a table; use for round-trip assertions.
+- `into_record_batch`: convert `Box<dyn EngineData>` to Arrow `RecordBatch`.
 
 **Assertion helpers (from `test_utils`)**
 
-- `assert_schema_has_field(schema, &["a", "b"])` -- assert a (possibly nested) field path.
-- `assert_result_error_with_message(result, "needle")` -- assert an error contains a
+- `assert_schema_has_field(schema, &["a".into(), "b".into()])`: assert a (possibly nested)
+  field path.
+- `assert_result_error_with_message(result, "needle")`: assert an error contains a
   substring.
 
 **If a name here doesn't match what's in code:** the list may have drifted from a rename.
@@ -247,37 +261,39 @@ and update this section in your PR. The same pattern works for
 The [Delta protocol spec](https://raw.githubusercontent.com/delta-io/delta/master/PROTOCOL.md)
 is the source of truth. Key concepts:
 
-- **Actions** -- atomic units of a transaction: Metadata, Add File, Remove File, Add CDC
-  File, Protocol, CommitInfo, Domain Metadata, Sidecar, Checkpoint Metadata
-- **Log structure** -- JSON commit files, checkpoints (V1 parquet, V2 multi-part), log
+- **Actions**: records in commits and checkpoints: Metadata, Add File, Remove File, Add CDC
+  File, Protocol, CommitInfo, SetTransaction, Domain Metadata, Sidecar, Checkpoint Metadata,
+  and the feature-gated adaptive metadata `checkpoint` action
+- **Log structure**: JSON commit files, checkpoints (V1 parquet, V2 multi-part), log
   compaction files, version checksum (CRC) files, `_last_checkpoint`
-- **Protocol versioning** -- (readerVersion, writerVersion) pair. At (3, 7) switches to
-  explicit table features via `readerFeatures`/`writerFeatures` arrays. Features cannot be
-  removed once added.
-- **Data skipping** -- per-file column statistics (min, max, null count, row count) with
+- **Protocol versioning**: `(readerVersion, writerVersion)` pair. Reader version 3 requires
+  `readerFeatures`; writer version 7 requires `writerFeatures`. Follow each feature's rules for
+  activation, dependencies, and any permitted removal.
+- **Data skipping**: per-file column statistics (min, max, null count, row count) with
   tight/wide bounds
-- **Schemas** -- JSON serialization format for StructType/StructField/DataType
-- **Stats and partition values** -- per-file column statistics (min, max, nullCount) and
-  partition values are stored as JSON strings in Add file actions. The stats JSON structure
-  mirrors the table schema. See the protocol spec sections on "Per-file Statistics" and
-  "Partition Value Serialization" for the exact formats.
+- **Schemas**: JSON serialization format for StructType/StructField/DataType
+- **Stats and partition values**: per-file statistics are stored as a JSON-encoded string in
+  the Add action's `stats` field. `partitionValues` is a JSON map from column names to serialized
+  string or null values. The stats structure mirrors the table schema. See the protocol spec
+  sections on "Per-file Statistics" and "Partition Value Serialization" for the exact formats.
 
 **Table features**:
 
 - Writer: `allowColumnDefaults`, `appendOnly`, `changeDataFeed`, `checkConstraints`,
   `clustering`, `domainMetadata`, `generatedColumns`, `icebergCompatV1`, `icebergCompatV2`,
-  `icebergCompatV3`, `identityColumns`, `inCommitTimestamp`, `invariants`, `rowTracking`
+  `icebergCompatV3`, `identityColumns`, `inCommitTimestamp`, `invariants`,
+  `materializePartitionColumns`, `rowTracking`
 - Reader + writer: `adaptiveMetadata-preview`, `catalogManaged`, `catalogOwned-preview`,
   `columnMapping`, `deletionVectors`, `geospatial`, `timestampNtz`,
-  `typeWidening`, `v2Checkpoint`, `vacuumProtocolCheck`, `variantShredding`,
-  `variantShredding-preview`, `variantType`, `variantType-preview`
+  `typeWidening`, `typeWidening-preview`, `v2Checkpoint`, `vacuumProtocolCheck`,
+  `variantShredding`, `variantShredding-preview`, `variantType`, `variantType-preview`
 
 Keep this list updated when new protocol features are added to kernel.
 
 ## Common Gotchas
 
 - **EngineData is opaque:** NEVER downcast to `ArrowEngineData` or any concrete type
-  in production code (ok in tests). NEVER assume one batch per file -- ALWAYS iterate.
+  in production code (ok in tests). NEVER assume one batch per file: ALWAYS iterate.
 - **Column mapping:** Physical column names can differ from logical names. ALWAYS use
   the schema from `Snapshot::schema()` for user data columns. Metadata/system schema
   column names (defined by the protocol) are not subject to column mapping.
@@ -297,7 +313,7 @@ Keep this list updated when new protocol features are added to kernel.
 
 - Line width is 100 characters. Wrap comments and string literals at 100, not 80.
 - Place `use` imports at the top of the file (for non-test code) or at the top of the
-  `mod tests` block (for test code) -- never inside function bodies.
+  `mod tests` block (for test code): never inside function bodies.
 - Prefer `==` over `matches!` for simple single-variant enum comparisons. `matches!` is
   for patterns with bindings or guards. For example: `self == Variant` not
   `matches!(self, Variant)`.
@@ -309,9 +325,9 @@ Keep this list updated when new protocol features are added to kernel.
   and constructors like `StructField::new`/`nullable`/`not_null`, `ArrayType::new`, and
   `MapType::new` accept `impl Into<DataType>`. So:
   - When passing to a parameter that accepts `impl Into<DataType>`, pass the container
-    type directly: `StructField::nullable("a", ArrayType::new(DataType::INTEGER, true))`
-    -- do NOT wrap in `DataType::from(...)` or `.into()` (redundant at best, and an
-    ambiguous-type compile error at worst).
+    type directly: `StructField::nullable("a", ArrayType::new(DataType::INTEGER, true))`; do NOT
+    wrap in `DataType::from(...)` or `.into()` (redundant at best, and an ambiguous-type compile
+    error at worst).
   - When a concrete `DataType` value is actually required (e.g. a `DataType`-typed
     binding/field, a `[DataType]`/`Vec<DataType>` element, or a `&DataType` argument),
     prefer `DataType::from(ArrayType::new(...))` over
@@ -330,12 +346,13 @@ Keep this list updated when new protocol features are added to kernel.
   `StructField::nullable(ACTION_NAME, Action::to_schema())` or projecting from
   `get_commit_schema()`. Prefer `StructType::try_new` or schema builder/patch APIs for complex
   data-dependent schema manipulation.
-- NEVER panic in production code -- use errors instead. Panicking
-  (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test code only.
+- NEVER panic in production code: use errors instead. Panicking
+  (including `unwrap()`, `expect()`, `panic!()`, `unreachable!()`, etc) is acceptable in test
+  code only.
 - Order a file so the most important APIs and impls come first; put private helper functions
   toward the bottom. Within that, order by visibility: `pub` first, then `pub(crate)`, then
   private. A reader scanning top to bottom should hit the public surface before the private
-  plumbing. (Order-sensitive items like `macro_rules!` used within the file are exempt -- they
+  plumbing. (Order-sensitive items like `macro_rules!` used within the file are exempt: they
   must precede their use.)
 
 ## Comment & Doc Style
@@ -344,10 +361,10 @@ Keep this list updated when new protocol features are added to kernel.
 - MUST document function parameters, return values, and errors.
 - Doc comments focus on "what" (contract with caller) more than "how" (implementation),
   unless the "how" meaningfully impacts the "what".
-- Code comments state intent and explain "why" -- don't restate what the code self-documents.
+- Code comments state intent and explain "why": don't restate what the code self-documents.
 - Be succinct. No verbose AI-slop comments. With well-written and well-named code,
   verbose comments are worse than none.
-- Say each thing once, in the right place -- don't repeat the same idea across
+- Say each thing once, in the right place: don't repeat the same idea across
   doc comment and inline comment.
 - Comments earn their place only for hidden invariants, real-bug workarounds, or
   constraints the reader can't see from the code itself.
@@ -356,7 +373,7 @@ Keep this list updated when new protocol features are added to kernel.
 - No stale-prone anchors in durable docs or source comments: counts ("the 10
   variants", "5-arm match"), line numbers, or enumeration lists. Describe the
   shape; let the reader grep.
-- Comments MUST NOT include temporal references -- only refer to current code and
+- Comments MUST NOT include temporal references: only refer to current code and
   design, not past iterations.
 - Keep comments up-to-date with code changes.
 - Include examples in doc comments for complex functions only.
@@ -375,21 +392,22 @@ Examples: `feat: add checkpoint stream support`, `fix: handle empty log segment`
 Breaking change examples: `feat!: make_physical takes column mapping and sets parquet field ids`,
 `chore!: remove the arrow-55 feature`
 
-**Description:** follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Error on the
-side of simplicity -- don't list every change. Focus on key API changes, functionality,
+**Description:** follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Err on the
+side of simplicity: don't list every change. Focus on key API changes, functionality,
 and data flow. Keep it concise.
 
 ## Deep Context
 
 Read these when relevant to the task at hand:
-- `CLAUDE/architecture.md` -- kernel architecture: snapshot loading, read/write paths,
+
+- `CLAUDE/architecture.md`: kernel architecture: snapshot loading, read/write paths,
   engine trait system, EngineData, key modules, catalog-managed tables
-- `docs/user-guide/CLAUDE.md` -- writing standards for the mdBook user guide
+- `docs/user-guide/CLAUDE.md`: writing standards for the mdBook user guide
 - Always cross-check protocol behavior against the
   [Delta protocol spec](https://raw.githubusercontent.com/delta-io/delta/master/PROTOCOL.md)
 
-**Keeping docs current:** If you notice anything inaccurate in these docs -- renamed
-structs, traits, functions, modules, crates, APIs, stale data flows, wrong file paths --
+**Keeping docs current:** If you notice renamed structs, traits, functions, modules, crates, APIs,
+stale data flows, or wrong file paths in these docs,
 inform the user so they can be updated. After major changes, update this file,
 `CLAUDE/architecture.md`, `ffi/CLAUDE.md`, `.github/CLAUDE.md`, and any relevant
 `<crate>/CLAUDE.md` files.

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -14,17 +14,17 @@ Compute Engine (Spark, Flink, DuckDB, Polars, ...)
 ```
 
 Kernel handles the Delta protocol; connectors handle execution, distribution, and data flow.
-Kernel never does I/O directly -- it delegates all I/O to the Engine trait. Kernel also avoids
-making memory allocation and scheduling decisions, leaving those to the connector and engine.
-For example, during log replay or checkpoint writes, kernel receives opaque `EngineData` batches,
-inspects them via the visitor pattern, updates a selection vector, and hands them back to the
-engine -- it never deserializes the full batch into in-memory structs.
+Kernel never does I/O directly: it delegates all I/O to the Engine trait. Kernel also leaves
+columnar memory representation and I/O scheduling to the connector and engine. For example, during
+log replay or checkpoint writes, kernel receives opaque `EngineData` batches, inspects them via the
+visitor pattern, updates a selection vector, and hands them back to the engine: it never
+deserializes the full batch into in-memory structs.
 
 ## Snapshot
 
-`Snapshot` (`kernel/src/snapshot.rs`) is the entry point for everything. It is an immutable
-point-in-time view of a Delta table at a specific version, providing the table schema, metadata,
-properties, and version number.
+`Snapshot` (`kernel/src/snapshot/`) is the primary entry point for operations on an existing table.
+It is an immutable point-in-time view of a Delta table at a specific version, providing the table
+schema, metadata, properties, and version number.
 
 Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 `.at_version(v).build(engine)` (specific version). For catalog-managed tables,
@@ -32,10 +32,10 @@ Built via `Snapshot::builder_for(url).build(engine)` (latest version) or
 `.with_max_catalog_version(v)` caps the snapshot at the latest catalog-ratified version.
 
 **Snapshot loading internals:**
-1. **LogSegment** (`kernel/src/log_segment/`) -- discovers commits + checkpoints for the
+1. **LogSegment** (`kernel/src/log_segment/`): discovers commits + checkpoints for the
    requested version, replays Protocol and Metadata (`protocol_metadata_replay.rs`), and
    replays domain metadata (`domain_metadata_replay.rs`)
-2. **Log replay** (`kernel/src/log_replay.rs`) -- file-action deduplication via
+2. **Log replay** (`kernel/src/log_replay/`): file-action deduplication via
    `FileActionDeduplicator` and `LogReplayProcessor` trait (distinct from Protocol/Metadata
    replay above)
 
@@ -54,14 +54,14 @@ column mapping, schema evolution) -> deletion vector filtering.
 set), `data_skipping.rs` (rewrite predicates against min/max/nullCount stats and partition values).
 
 **Execution paths:**
-- `scan.execute(engine)` -- kernel handles everything end-to-end, returns `EngineData`
-- `scan.scan_metadata(engine)` -- returns file list + transforms; connector reads files and
+- `scan.execute(engine)`: kernel handles everything end-to-end, returns `EngineData`
+- `scan.scan_metadata(engine)`: returns file list + transforms; connector reads files and
   calls `transform_to_logical` / `DvInfo::get_selection_vector`
-- `scan.parallel_scan_metadata(engine)` -- two-phase distributed log replay (`pub(crate)`,
-  requires `internal-api` feature)
+- `scan.parallel_scan_metadata(engine)`: two-phase distributed log replay (requires the
+  `internal-api` feature)
 
 **Incremental read:** `Snapshot::incremental_scan_builder(base_version)` streams the file-action
-diff over `(base_version, target_version]` -- live Adds as a `FilteredEngineData` iterator
+diff over `(base_version, target_version]`: live Adds as a `FilteredEngineData` iterator
 plus a terminal summary of live Add and Remove file keys. Use this to advance a cached
 file listing without re-scanning the table.
 
@@ -71,25 +71,27 @@ file listing without re-scanning the table.
 
 The kernel coordinates the write transaction: it provides the write context (validated partition
 values, recommended write directory, physical schema, stats columns), assembles commit
-actions (CommitInfo, Add files), enforces protocol compliance (table features, schema validation),
-and delegates the atomic commit to a `Committer`.
+actions (CommitInfo, Add files, Remove files), enforces protocol compliance (table features, schema
+validation), and delegates the atomic commit to a `Committer`.
 
-**Steps:**
+**Data-write steps:**
 1. Create `Transaction` from a snapshot with a `Committer` (e.g. `FileSystemCommitter`)
 2. Get `WriteContext` via `partitioned_write_context(values)` or `unpartitioned_write_context()`
 3. Write Parquet files (via engine), collect file metadata
-4. Register files via `txn.add_files(metadata)`
+4. Register files via `txn.add_files(metadata)` and stage any removals or deletion-vector updates
 5. Commit: returns `CommittedTransaction`, `ConflictedTransaction`, or `RetryableTransaction`
 
-- **Transaction** (`kernel/src/transaction/`) -- blind append writes, table creation (via
-  `create_table` builder, including clustered tables via `DataLayout`)
-- **Committer** (`kernel/src/committer/`) -- commit coordination. `FileSystemCommitter` for
+- **Transaction** (`kernel/src/transaction/`): blind append writes, file removals, deletion-vector
+  updates, table creation (including clustered tables via `DataLayout`), and limited schema
+  evolution
+- **Committer** (`kernel/src/committer/`): commit coordination. `FileSystemCommitter` for
   filesystem tables (atomic put-if-absent to `_delta_log/`); custom `Committer` implementations
   for catalog-managed tables (staging, ratifying, publishing).
 
 ## Engine Trait System
 
-The kernel is built around the `Engine` trait (`kernel/src/lib.rs`), which provides four handlers:
+The kernel is built around the `Engine` trait (`kernel/src/lib.rs`), which provides the required
+handlers below and an optional `PlanExecutor` under the `declarative-plans` feature:
 
 | Handler              | Purpose                          | Key Methods                                |
 |----------------------|----------------------------------|--------------------------------------------|
@@ -97,17 +99,17 @@ The kernel is built around the `Engine` trait (`kernel/src/lib.rs`), which provi
 | `JsonHandler`        | Delta log commit parsing/writing | `parse_json`, `read_json_files`            |
 | `ParquetHandler`     | Data file and checkpoint I/O     | `read_parquet_files`, `write_parquet_file`  |
 | `EvaluationHandler`  | Expression/predicate evaluation  | `new_expression_evaluator`, etc.           |
-| `MetricsReporter`    | Optional observability           | `get_metrics_reporter` (default: None)     |
 
-A `DefaultEngine` (Arrow + `object_store` + Tokio) lives in `kernel/src/engine/default/`. Custom
-engines only need to replace specific handlers -- they can reuse defaults for the rest.
+Metrics are emitted as tracing events and collected by tracing layers. A `DefaultEngine` (Arrow +
+`object_store` + Tokio) lives in `default-engine/src/`. Custom engines only need to replace
+specific handlers: they can reuse defaults for the rest.
 
 ## EngineData Trait
 
-Kernel never assumes data is Arrow. It uses the `EngineData` trait -- an opaque columnar data
+Kernel never assumes data is Arrow. It uses the `EngineData` trait: an opaque columnar data
 interface. The kernel extracts data via a visitor pattern (`visit_rows` with typed `GetData`
 accessors), not by inspecting columns directly. Never downcast `EngineData` to a concrete type
-(e.g. `ArrowEngineData`) in prod kernel code -- only engine *implementations* know the concrete
+(e.g. `ArrowEngineData`) in prod kernel code: only engine *implementations* know the concrete
 type. (Unit tests using the default engine may legitimately downcast.)
 
 `DefaultEngine` uses `ArrowEngineData` (wrapping Arrow `RecordBatch`). Custom engines implement
@@ -117,45 +119,48 @@ Key methods: `visit_rows`, `len`, `append_columns` (for partition value injectio
 `apply_selection_vector` (for deletion vectors).
 
 **IMPORTANT:** Never assume that reading one file produces exactly one batch. Always iterate over
-all returned batches -- the engine may split a single file across multiple batches.
+all returned batches: the engine may split a single file across multiple batches.
 
 ## Key Modules
 
-- `kernel/src/snapshot/` -- `Snapshot`, `SnapshotBuilder`, entry point for reads/writes
-- `kernel/src/scan/` -- `Scan`, `ScanBuilder`, log replay, data skipping
-- `kernel/src/incremental_scan/` -- `IncrementalScanBuilder`, streaming file-action diff
+- `kernel/src/snapshot/`: `Snapshot`, `SnapshotBuilder`, entry point for reads/writes
+- `kernel/src/scan/`: `Scan`, `ScanBuilder`, log replay, data skipping
+- `kernel/src/incremental_scan/`: `IncrementalScanBuilder`, streaming file-action diff
   between two versions
-- `kernel/src/transaction/` -- `Transaction`, `WriteContext`, `create_table` builder
-- `kernel/src/partition/` -- partition value validation, serialization, Hive-style path
+- `kernel/src/commit_range/`: ordered actions over a range of commits
+- `kernel/src/transaction/`: `Transaction`, `WriteContext`, `create_table` builder
+- `kernel/src/partition/`: partition value validation, serialization, Hive-style path
    encoding, URI encoding for `add.path`
-- `kernel/src/committer/` -- `Committer` trait, `FileSystemCommitter`
-- `kernel/src/log_segment/` -- log file discovery, Protocol/Metadata replay
-- `kernel/src/log_replay.rs` -- file-action deduplication, `LogReplayProcessor` trait
-- `kernel/src/log_reader/` -- I/O layer for reading commit and checkpoint files
-- `kernel/src/actions/` -- Delta action types (Protocol, Metadata, CommitInfo, Add, Remove, Cdc,
+- `kernel/src/committer/`: `Committer` trait, `FileSystemCommitter`
+- `kernel/src/log_segment/`: log file discovery, Protocol/Metadata replay
+- `kernel/src/log_replay/`: file-action deduplication, `LogReplayProcessor` trait
+- `kernel/src/log_reader/`: I/O layer for reading commit and checkpoint files
+- `kernel/src/actions/`: Delta action types (Protocol, Metadata, CommitInfo, Add, Remove, Cdc,
    SetTransaction, DomainMetadata, Sidecar, CheckpointMetadata)
-- `kernel/src/schema/` -- `StructType`/`StructField`/`DataType`, projections
-- `kernel/src/expressions/` -- expression AST (`Expression`, `Predicate`, `Scalar`),
+- `kernel/src/schema/`: `StructType`/`StructField`/`DataType`, projections
+- `kernel/src/expressions/`: expression AST (`Expression`, `Predicate`, `Scalar`),
   `col!` macro
-- `kernel/src/transforms/` -- generic recursive transforms (`ExpressionTransform`,
+- `kernel/src/transforms/`: generic recursive transforms (`ExpressionTransform`,
   `SchemaTransform`)
-- `kernel/src/checkpoint/` -- classic-named checkpoint writing (V1; V2 with or without sidecars)
-- `kernel/src/table_configuration.rs` -- table metadata, properties, feature management
-- `kernel/src/table_features/` -- protocol feature definitions, `TableFeature` enum
-- `kernel/src/table_properties.rs` -- table property parsing (delta.appendOnly, etc.)
-- `kernel/src/table_changes/` -- Change Data Feed (CDF) API (`TableChanges`)
-- `kernel/src/path.rs` -- Delta log path parsing
+- `kernel/src/checkpoint/`: V1 and V2 checkpoint writing (V2 with or without sidecars)
+- `kernel/src/crc/`: version checksum reading, writing, and state tracking
+- `kernel/src/table_configuration.rs`: table metadata, properties, feature management
+- `kernel/src/table_features/`: protocol feature definitions, `TableFeature` enum
+- `kernel/src/table_properties.rs`: table property parsing (delta.appendOnly, etc.)
+- `kernel/src/table_changes/`: Change Data Feed (CDF) API (`TableChanges`)
+- `kernel/src/path.rs`: Delta log path parsing
 
 ## Catalog-Managed Tables
 
 Tables whose commits go through a catalog (e.g. Unity Catalog) instead of direct filesystem
-writes. Kernel doesn't know about catalogs -- the catalog client provides a log tail via
+writes. Kernel doesn't know about catalogs: the catalog client provides a log tail via
 `SnapshotBuilder::with_log_tail()`, caps the version via `with_max_catalog_version()`, and
 uses a custom `Committer` for staging/ratifying/publishing commits.
 
-The `UCCommitter` (in the `delta-kernel-unity-catalog` crate) is the reference implementation of a catalog
-committer for Unity Catalog. It stages commits to `_staged_commits/`, calls the UC commit API to
-ratify them, and publishes by copying to `_delta_log/`.
+The `UCCommitter` (in the `delta-kernel-unity-catalog` crate) is the reference implementation of a
+catalog committer for Unity Catalog. It writes version 0 directly to `_delta_log/`. For later
+versions, it stages commits in `_staged_commits/`, calls the UC commit API to ratify them, and
+publishes them by atomically copying them to `_delta_log/`.
 
-Commit types: staged (written to `_staged_commits/`), ratified (accepted by catalog for a
-version), published (copied to `_delta_log/` as a normal delta file).
+For versions after 0, commit types are staged (written to `_staged_commits/`), ratified (accepted
+by the catalog for a version), and published (copied to `_delta_log/` as a normal Delta file).

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -1,12 +1,11 @@
 //! # Delta Kernel
 //!
 //! Delta-kernel-rs is an experimental [Delta](https://github.com/delta-io/delta/) implementation
-//! focused on interoperability with a wide range of query engines. It supports reads and
-//! (experimental) writes (only blind appends in the write path currently). This library defines a
-//! number of traits which must be implemented to provide a working delta implementation. They are
-//! detailed below. There is a provided "default engine" that implements all these traits and can
-//! be used to ease integration work. See [`DefaultEngine`](engine/default/index.html) for more
-//! information.
+//! focused on interoperability with a wide range of query engines. It supports table reads, table
+//! creation, appends, file removals, deletion-vector updates, and limited schema evolution. This
+//! library defines the traits that connectors implement to provide I/O and expression evaluation.
+//! The [`delta_kernel_default_engine`](https://docs.rs/delta_kernel_default_engine) crate provides
+//! a ready-to-use implementation based on Arrow, `object_store`, and Tokio.
 //!
 //! A full `rust` example for reading table data using the default engine can be found in the
 //! [read-table-single-threaded] example (and for a more complex multi-threaded reader see the
@@ -26,15 +25,13 @@
 //! # Engine trait
 //!
 //! The [`Engine`] trait allows connectors to bring their own implementation of functionality such
-//! as reading parquet files, listing files in a file system, parsing a JSON string etc. This
-//! trait exposes methods to get sub-engines which expose the core functionalities customizable by
-//! connectors.
+//! as reading and writing Parquet and JSON files, listing files in storage, and evaluating
+//! expressions. It exposes handler traits for each capability.
 //!
 //! ## Expression handling
 //!
-//! Expression handling is done via the [`EvaluationHandler`], which in turn allows the creation of
-//! [`ExpressionEvaluator`]s. These evaluators are created for a specific predicate [`Expression`]
-//! and allow evaluation of that predicate for a specific batch of data.
+//! [`EvaluationHandler`] creates an [`ExpressionEvaluator`] for an [`Expression`] or a
+//! [`PredicateEvaluator`] for a [`Predicate`]. Each evaluator can process multiple data batches.
 //!
 //! ## File system interactions
 //!
@@ -45,10 +42,9 @@
 //!
 //! ## Reading log and data files
 //!
-//! Delta Kernel requires the capability to read and write json files and read parquet files, which
-//! is exposed via the [`JsonHandler`] and [`ParquetHandler`] respectively. When reading files,
-//! connectors are asked to provide the context information they require to execute the actual
-//! operation. This is done by invoking methods on the [`StorageHandler`] trait.
+//! Delta Kernel requires the capability to read and write JSON and Parquet files, exposed via the
+//! [`JsonHandler`] and [`ParquetHandler`] respectively. Their read methods receive the context
+//! needed to execute the operation.
 
 #![cfg_attr(all(doc, NIGHTLY_CHANNEL), feature(doc_cfg))]
 #![warn(
@@ -1067,11 +1063,10 @@ pub trait ParquetHandler: AsAny {
     }
 }
 
-/// The `Engine` trait encapsulates all the functionality an engine or connector needs to provide
-/// to the Delta Kernel in order to read the Delta table.
+/// The `Engine` trait encapsulates the functionality an engine or connector provides to operate
+/// on Delta tables.
 ///
-/// Engines/Connectors are expected to pass an implementation of this trait when reading a Delta
-/// table.
+/// Connectors pass an implementation of this trait to Delta Kernel operations.
 pub trait Engine: AsAny {
     /// Get the connector provided [`EvaluationHandler`].
     fn evaluation_handler(&self) -> Arc<dyn EvaluationHandler>;


### PR DESCRIPTION
## What changes are proposed in this pull request?

The root `CLAUDE.md`, `CLAUDE/architecture.md`, and the crate-level docs in `kernel/src/lib.rs` had become stale and, in several places, incorrect.

The biggest corrections are:

- document current write support, including file removals, deletion-vector updates, table creation, and limited schema evolution
- replace the obsolete `MetricsReporter` handler and old `DefaultEngine` location with the current engine and tracing architecture
- correct protocol feature behavior, Cargo feature relationships, table feature lists, and action lists
- update stale API examples, module paths, workspace boundaries, and Unity Catalog version 0 commit behavior

This also applies small style fixes in `CLAUDE.md`, including consistent `:` separators in prose, while keeping the existing build commands and detailed testing guidance intact.

## How was this change tested?

Docs only change. CI.
