### PR TITLE
refactor: use schema macros for declarative schemas

### DIFF
--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -18,7 +18,7 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::parse_json;
 use delta_kernel::expressions::{
-    null_lit, BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
+    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
     ParseJsonExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
 };
@@ -495,28 +495,25 @@ mod tests {
     use datafusion::physical_expr::create_physical_expr;
     use datafusion::physical_expr::execution_props::ExecutionProps;
     use delta_kernel::expressions::{
-        col, lit, Expression as KernelExpr, ExpressionStructPatch, ExpressionStructPatchBuilder,
+        col, lit, null_lit, Expression as KernelExpr, ExpressionStructPatch,
+        ExpressionStructPatchBuilder,
     };
-    use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
+    use delta_kernel::schema::{schema, schema_ref, ArrayType, DataType, MapType, StructType};
     use rstest::rstest;
 
     use super::*;
 
     /// Name-resolution scope for these tests: `a: { b: { c: long } }`, plus top-level `b` and `x`.
     fn test_schema() -> StructType {
-        StructType::try_new([
-            StructField::nullable(
-                "a",
-                StructType::try_new([StructField::nullable(
-                    "b",
-                    StructType::try_new([StructField::nullable("c", DataType::LONG)]).unwrap(),
-                )])
-                .unwrap(),
-            ),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable("x", DataType::LONG),
-        ])
-        .unwrap()
+        schema! {
+            nullable "a": {
+                nullable "b": {
+                    nullable "c": LONG,
+                },
+            },
+            nullable "b": LONG,
+            nullable "x": LONG,
+        }
     }
 
     /// Lowers an expression against [`test_schema`] and renders it as a DataFusion `Display`
@@ -619,7 +616,7 @@ mod tests {
     fn nested_array_of_array_peels_element_type_at_each_level() {
         let inner = KernelExpr::array([KernelExpr::struct_from([col!("b")])]);
         let kernel = KernelExpr::array([inner]);
-        let leaf = StructType::try_new([StructField::nullable("p", DataType::LONG)]).unwrap();
+        let leaf = schema! { nullable "p": LONG };
         let target: DataType = ArrayType::new(ArrayType::new(leaf, true), true).into();
         assert_eq!(
             lower_typed(kernel, target),
@@ -664,11 +661,10 @@ mod tests {
 
     /// Output schema with names distinct from the input schema, proving names come from the target.
     fn pq_output_schema() -> StructType {
-        StructType::try_new([
-            StructField::nullable("p", DataType::LONG),
-            StructField::nullable("q", DataType::LONG),
-        ])
-        .unwrap()
+        schema! {
+            nullable "p": LONG,
+            nullable "q": LONG,
+        }
     }
 
     #[test]
@@ -684,8 +680,7 @@ mod tests {
     fn nested_struct_recurses_with_child_target_names() {
         let inner = KernelExpr::struct_from([col!("b"), lit(1i64)]);
         let kernel = KernelExpr::struct_from([inner]);
-        let target =
-            StructType::try_new([StructField::nullable("outer", pq_output_schema())]).unwrap();
+        let target = schema! { nullable "outer": (pq_output_schema()) };
         assert_eq!(
             lower_typed(kernel, target.into()),
             "named_struct(Utf8(\"outer\"), named_struct(Utf8(\"p\"), b, Utf8(\"q\"), Int64(1)))"
@@ -716,9 +711,7 @@ mod tests {
     #[test]
     fn struct_arity_mismatch_is_an_error() {
         let kernel = KernelExpr::struct_from([col!("b"), lit(1i64)]);
-        let target: DataType = StructType::try_new([StructField::nullable("p", DataType::LONG)])
-            .unwrap()
-            .into();
+        let target: DataType = schema! { nullable "p": LONG }.into();
         to_df_expr(&kernel, &test_schema(), Some(&target)).unwrap_err();
     }
 
@@ -740,11 +733,10 @@ mod tests {
     /// Input struct `{ a: long, b: long }` for patch tests: the whole input schema for a top-level
     /// patch, or the nested source struct for a nested one.
     fn ab_schema() -> StructType {
-        StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ])
-        .unwrap()
+        schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+        }
     }
 
     /// Asserts `res` is an error whose message contains `message`.
@@ -781,7 +773,7 @@ mod tests {
             .drop("a")
             .build()
             .unwrap();
-        let target = StructType::try_new([StructField::nullable("q", DataType::LONG)]).unwrap();
+        let target = schema! { nullable "q": LONG };
         assert_eq!(
             lower_patch(patch, &ab_schema(), &target),
             "named_struct(Utf8(\"q\"), b)"
@@ -795,13 +787,12 @@ mod tests {
             .append(lit(9i64))
             .build()
             .unwrap();
-        let target = StructType::try_new([
-            StructField::nullable("first", DataType::LONG),
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable("last", DataType::LONG),
-        ])
-        .unwrap();
+        let target = schema! {
+            nullable "first": LONG,
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "last": LONG,
+        };
         assert_eq!(
             lower_patch(patch, &ab_schema(), &target),
             "named_struct(Utf8(\"first\"), Int64(0), Utf8(\"a\"), a, Utf8(\"b\"), b, \
@@ -815,12 +806,11 @@ mod tests {
             .insert_after("a", lit(5i64))
             .build()
             .unwrap();
-        let target = StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("inserted", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ])
-        .unwrap();
+        let target = schema! {
+            nullable "a": LONG,
+            nullable "inserted": LONG,
+            nullable "b": LONG,
+        };
         assert_eq!(
             lower_patch(patch, &ab_schema(), &target),
             "named_struct(Utf8(\"a\"), a, Utf8(\"inserted\"), Int64(5), Utf8(\"b\"), b)"
@@ -830,7 +820,7 @@ mod tests {
     #[test]
     fn nested_patch_wraps_in_null_guard_case() {
         // Input schema: { s: { a: long, b: long } }. Patch replaces s.a with a literal.
-        let input = StructType::try_new([StructField::nullable("s", ab_schema())]).unwrap();
+        let input = schema! { nullable "s": (ab_schema()) };
         let patch = ExpressionStructPatchBuilder::new_nested(["s"])
             .replace("a", lit(7i64))
             .build()
@@ -846,12 +836,11 @@ mod tests {
     fn patch_too_many_output_fields_is_an_error() {
         // Empty patch passes 2 fields; target declares 3.
         let patch = ExpressionStructPatchBuilder::new().build().unwrap();
-        let target: DataType = StructType::try_new([
-            StructField::nullable("p", DataType::LONG),
-            StructField::nullable("q", DataType::LONG),
-            StructField::nullable("r", DataType::LONG),
-        ])
-        .unwrap()
+        let target: DataType = schema! {
+            nullable "p": LONG,
+            nullable "q": LONG,
+            nullable "r": LONG,
+        }
         .into();
         let expr = KernelExpr::struct_patch(patch).unwrap();
         assert_error_message(
@@ -864,9 +853,7 @@ mod tests {
     fn patch_too_few_output_fields_is_an_error() {
         // Empty patch passes 2 fields; target declares 1.
         let patch = ExpressionStructPatchBuilder::new().build().unwrap();
-        let target: DataType = StructType::try_new([StructField::nullable("p", DataType::LONG)])
-            .unwrap()
-            .into();
+        let target: DataType = schema! { nullable "p": LONG }.into();
         let expr = KernelExpr::struct_patch(patch).unwrap();
         assert_error_message(
             to_df_expr(&expr, &ab_schema(), Some(&target)),
@@ -898,7 +885,7 @@ mod tests {
             .replace("nonexistent", lit(1i64))
             .build()
             .unwrap(),
-        StructType::try_new([StructField::nullable("p", DataType::LONG)]).unwrap()
+        schema! { nullable "p": LONG }
     )]
     fn required_patch_on_missing_field_is_an_error(
         #[case] patch: ExpressionStructPatch,
@@ -937,19 +924,15 @@ mod tests {
             .append(middle)
             .build()
             .unwrap();
-        let target = StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable(
-                "g",
-                StructType::try_new([StructField::nullable(
-                    "h",
-                    StructType::try_new([StructField::nullable("leaf", DataType::LONG)]).unwrap(),
-                )])
-                .unwrap(),
-            ),
-        ])
-        .unwrap();
+        let target = schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "g": {
+                nullable "h": {
+                    nullable "leaf": LONG,
+                },
+            },
+        };
         assert_eq!(
             lower_patch(patch, &ab_schema(), &target),
             "named_struct(Utf8(\"a\"), a, Utf8(\"b\"), b, Utf8(\"g\"), \
@@ -961,11 +944,7 @@ mod tests {
 
     /// Input schema for map tests: `{ pv: map<string, string> }`.
     fn pv_map_schema() -> StructType {
-        StructType::try_new([StructField::nullable(
-            "pv",
-            MapType::new(DataType::STRING, DataType::STRING, true),
-        )])
-        .unwrap()
+        schema! { nullable "pv": { STRING => nullable STRING } }
     }
 
     /// Lowers a `MapToStruct` over `pv` targeting `output_schema` and renders it as a `Display`
@@ -984,11 +963,10 @@ mod tests {
     /// than here.
     #[test]
     fn map_to_struct_lowers_to_named_struct_over_get_field() {
-        let target = StructType::try_new([
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("id", DataType::INTEGER),
-        ])
-        .unwrap();
+        let target = schema! {
+            nullable "region": STRING,
+            nullable "id": INTEGER,
+        };
         let rendered = lower_map_to_struct(target);
         assert_eq!(
             rendered,
@@ -1014,7 +992,7 @@ mod tests {
         #[case] field_type: DataType,
         #[case] expected_value: &str,
     ) {
-        let target = StructType::try_new([StructField::nullable("f", field_type)]).unwrap();
+        let target = schema! { nullable "f": (field_type) };
         let expected =
             format!("CASE WHEN pv IS NOT NULL THEN named_struct(Utf8(\"f\"), {expected_value}) ELSE NULL END");
         assert_eq!(lower_map_to_struct(target), expected);
@@ -1025,9 +1003,9 @@ mod tests {
     #[rstest]
     #[case::no_target(None, "MapToStruct expression requires a struct output type")]
     #[case::non_primitive_field(
-        Some(DataType::from(
-            StructType::try_new([StructField::nullable("nested", pq_output_schema())]).unwrap()
-        )),
+        Some(DataType::from(schema! {
+            nullable "nested": (pq_output_schema()),
+        })),
         "MapToStruct only supports primitive target types, but field 'nested' is"
     )]
     fn map_to_struct_with_unsupported_target_is_an_error(
@@ -1045,15 +1023,14 @@ mod tests {
 
     /// Input schema for JSON tests: `{ j: string }`.
     fn json_input_schema() -> StructType {
-        StructType::try_new([StructField::nullable("j", DataType::STRING)]).unwrap()
+        schema! { nullable "j": STRING }
     }
 
     fn nested_parse_type() -> StructType {
-        StructType::try_new([
-            StructField::nullable("n", DataType::LONG),
-            StructField::nullable("s", DataType::STRING),
-        ])
-        .unwrap()
+        schema! {
+            nullable "n": LONG,
+            nullable "s": STRING,
+        }
     }
 
     /// Target parse schema `{ n: long, s: string }`.
@@ -1137,23 +1114,20 @@ mod tests {
     /// through kernel's stringify-then-safe-cast path. Asserts they all land typed to the target.
     #[test]
     fn parse_json_decodes_all_supported_primitive_types() {
-        let target: KernelSchemaRef = Arc::new(
-            StructType::try_new([
-                StructField::nullable("str", DataType::STRING),
-                StructField::nullable("long", DataType::LONG),
-                StructField::nullable("int", DataType::INTEGER),
-                StructField::nullable("short", DataType::SHORT),
-                StructField::nullable("byte", DataType::BYTE),
-                StructField::nullable("float", DataType::FLOAT),
-                StructField::nullable("double", DataType::DOUBLE),
-                StructField::nullable("bool", DataType::BOOLEAN),
-                StructField::nullable("date", DataType::DATE),
-                StructField::nullable("ts", DataType::TIMESTAMP),
-                StructField::nullable("ts_ntz", DataType::TIMESTAMP_NTZ),
-                StructField::nullable("dec", DataType::decimal(10, 2).unwrap()),
-            ])
-            .unwrap(),
-        );
+        let target: KernelSchemaRef = schema_ref! {
+            nullable "str": STRING,
+            nullable "long": LONG,
+            nullable "int": INTEGER,
+            nullable "short": SHORT,
+            nullable "byte": BYTE,
+            nullable "float": FLOAT,
+            nullable "double": DOUBLE,
+            nullable "bool": BOOLEAN,
+            nullable "date": DATE,
+            nullable "ts": TIMESTAMP,
+            nullable "ts_ntz": TIMESTAMP_NTZ,
+            nullable "dec": (DataType::decimal(10, 2).unwrap()),
+        };
         let row = r#"{
             "str": "a", "long": 1, "int": 2, "short": 3, "byte": 4,
             "float": 1.5, "double": 2.5, "bool": true, "date": "2024-01-02",
@@ -1208,31 +1182,17 @@ mod tests {
         "[[1, ], [2, 3]]"
     )]
     #[case::struct_of_structs(
-        DataType::from(
-            StructType::try_new([StructField::nullable("inner", nested_parse_type())]).unwrap()
-        ),
+        DataType::from(schema! { nullable "inner": (nested_parse_type()) }),
         r#"{"inner": {"n": 1, "s": "a"}}"#,
         "{inner: {n: 1, s: a}}"
     )]
     #[case::struct_of_arrays(
-        DataType::from(
-            StructType::try_new([StructField::nullable(
-                "items",
-                ArrayType::new(DataType::INTEGER, true),
-            )])
-            .unwrap()
-        ),
+        DataType::from(schema! { nullable "items": [ nullable INTEGER ] }),
         r#"{"items": [1, null, 3]}"#,
         "{items: [1, , 3]}"
     )]
     #[case::struct_of_maps(
-        DataType::from(
-            StructType::try_new([StructField::nullable(
-                "items",
-                MapType::new(DataType::STRING, DataType::LONG, true),
-            )])
-            .unwrap()
-        ),
+        DataType::from(schema! { nullable "items": { STRING => nullable LONG } }),
         r#"{"items": {"x": 1, "y": null}}"#,
         "{items: {x: 1, y: }}"
     )]
@@ -1264,8 +1224,7 @@ mod tests {
         #[case] json_value: &str,
         #[case] expected_value: &str,
     ) {
-        let target: KernelSchemaRef =
-            Arc::new(StructType::try_new([StructField::nullable("value", field_type)]).unwrap());
+        let target: KernelSchemaRef = schema_ref! { nullable "value": (field_type) };
         let row = format!(r#"{{"value": {json_value}}}"#);
         let batch = eval_parse_json_batch(target.clone(), vec![Some(row.as_str())]);
         assert_matches_target(&batch, &target);
@@ -1289,8 +1248,7 @@ mod tests {
     /// unsupported through this path rather than silently mis-decoding.
     #[test]
     fn parse_json_binary_leaf_is_unsupported_and_yields_all_null_struct() {
-        let target: KernelSchemaRef =
-            Arc::new(StructType::try_new([StructField::nullable("b", DataType::BINARY)]).unwrap());
+        let target: KernelSchemaRef = schema_ref! { nullable "b": BINARY };
         let out = eval_parse_json(target, vec![Some(r#"{"b": "aGk="}"#)]);
         assert_eq!(out.len(), 1);
         assert!(out.column(0).is_null(0));
@@ -1348,12 +1306,7 @@ mod tests {
         #[case] left: DataType,
         #[case] right: DataType,
     ) {
-        let udf = |dt: DataType| {
-            ParseJsonUdf::try_new(Arc::new(
-                StructType::try_new([StructField::nullable("a", dt)]).unwrap(),
-            ))
-            .unwrap()
-        };
+        let udf = |dt: DataType| ParseJsonUdf::try_new(schema_ref! { nullable "a": (dt) }).unwrap();
         let (left, right) = (udf(left), udf(right));
         assert_eq!(
             left.return_type, right.return_type,

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -6,7 +6,7 @@ use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
 use delta_kernel::expressions::{
-    null_lit, ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
+    ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
     BinaryPredicateOp as KernelBinaryPredicateOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
     JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,
@@ -195,9 +195,10 @@ mod tests {
     use datafusion::prelude::SessionContext;
     use delta_kernel::engine::arrow_conversion::TryIntoArrow;
     use delta_kernel::expressions::{
-        col, lit, ArrayData as KernelArrayData, Expression as KernelExpr, Predicate as KernelPred,
+        col, lit, null_lit, ArrayData as KernelArrayData, Expression as KernelExpr,
+        Predicate as KernelPred,
     };
-    use delta_kernel::schema::{ArrayType, DataType, StructField};
+    use delta_kernel::schema::{schema, ArrayType, DataType};
     use rstest::rstest;
 
     use super::*;
@@ -207,13 +208,12 @@ mod tests {
     /// Columns these tests resolve against: top-level `a`, `b`, `c` (all `long`) and `list`
     /// (an array of nullable `long`, the right-hand side of a list-column `IN`).
     fn test_schema() -> StructType {
-        StructType::try_new([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable("c", DataType::LONG),
-            StructField::nullable("list", ArrayType::new(DataType::LONG, true)),
-        ])
-        .unwrap()
+        schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "c": LONG,
+            nullable "list": [ nullable LONG ],
+        }
     }
 
     /// Lowers a predicate and returns its DataFusion `Display` string.

--- a/datafusion-executor/src/scalar.rs
+++ b/datafusion-executor/src/scalar.rs
@@ -136,7 +136,7 @@ mod tests {
     use datafusion::arrow::datatypes::Int32Type;
     use datafusion::arrow::util::pretty::pretty_format_columns;
     use delta_kernel::schema::{
-        ArrayType, DataType as KernelDataType, MapType, StructField, StructType,
+        schema, ArrayType, DataType as KernelDataType, MapType, StructField, StructType,
     };
     use rstest::rstest;
 
@@ -156,11 +156,10 @@ mod tests {
     }
 
     fn sample_struct_type() -> StructType {
-        StructType::try_new([
-            StructField::not_null("a", KernelDataType::INTEGER),
-            StructField::nullable("b", KernelDataType::STRING),
-        ])
-        .unwrap()
+        schema! {
+            not_null "a": INTEGER,
+            nullable "b": STRING,
+        }
     }
 
     fn sample_struct_scalar() -> KernelScalar {
@@ -272,11 +271,10 @@ mod tests {
 
     #[test]
     fn null_struct_with_non_null_subfields_converts_to_null_struct() {
-        let struct_type = StructType::try_new([
-            StructField::not_null("a", KernelDataType::INTEGER),
-            StructField::not_null("b", KernelDataType::STRING),
-        ])
-        .unwrap();
+        let struct_type = schema! {
+            not_null "a": INTEGER,
+            not_null "b": STRING,
+        };
         let value = to_df_scalar(&KernelScalar::null(struct_type)).unwrap();
         assert!(matches!(value, DFScalarValue::Struct(_)), "got {value:?}");
         assert!(value.is_null(), "expected a null struct, got {value:?}");

--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -613,7 +613,7 @@ mod tests {
     };
     use delta_kernel::parquet::arrow::{ARROW_SCHEMA_META_KEY, PARQUET_FIELD_ID_META_KEY};
     use delta_kernel::schema::{
-        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+        schema, schema_ref, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
     };
     use delta_kernel::EngineData;
     use delta_kernel_default_engine_test_utils::{
@@ -635,7 +635,7 @@ mod tests {
     use crate::DEFAULT_BATCH_SIZE;
 
     fn long_schema(name: &str) -> StructType {
-        StructType::new_unchecked([StructField::nullable(name, DataType::LONG)])
+        schema! { nullable (name): LONG }
     }
 
     /// Test `ObjectStore` that counts footer fetches. `get_opts` (footer range GETs) is counted;
@@ -1658,21 +1658,18 @@ mod tests {
         writer.close().unwrap();
 
         // Create kernel schema with DIFFERENT names but SAME field IDs
-        let kernel_schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::new("user_id", delta_kernel::schema::DataType::LONG, false)
+        let kernel_schema = schema_ref! {
+            (StructField::new("user_id", delta_kernel::schema::DataType::LONG, false)
                     .with_metadata([(
                         ColumnMetadataKey::ParquetFieldId.as_ref(),
                         MetadataValue::Number(1),
-                    )]),
-                StructField::new("user_name", delta_kernel::schema::DataType::STRING, false)
+                    )])),
+            (StructField::new("user_name", delta_kernel::schema::DataType::STRING, false)
                     .with_metadata([(
                         ColumnMetadataKey::ParquetFieldId.as_ref(),
                         MetadataValue::Number(2),
-                    )]),
-            ])
-            .unwrap(),
-        );
+                    )])),
+        };
 
         // Read using kernel schema with different column names
         let store = Arc::new(LocalFileSystem::new());

--- a/default-engine/src/stats.rs
+++ b/default-engine/src/stats.rs
@@ -911,7 +911,7 @@ mod tests {
     use delta_kernel::engine::arrow_expression::evaluate_expression::to_json;
     use delta_kernel::expressions::column_name;
     use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-    use delta_kernel::schema::StructField;
+    use delta_kernel::schema::schema;
     use test_utils::assert_result_error_with_message;
 
     use super::*;
@@ -2754,11 +2754,10 @@ mod tests {
             Field::new("span", arrow_type.clone(), true),
             Field::new("n", DataType::Int64, true),
         ]));
-        let physical_schema = StructType::try_new([
-            StructField::nullable("span", interval_type),
-            StructField::nullable("n", KernelDataType::LONG),
-        ])
-        .unwrap();
+        let physical_schema = schema! {
+            nullable "span": (interval_type),
+            nullable "n": LONG,
+        };
         let mk = |spans: &[i64], ns: &[i64]| {
             let span: ArrayRef = match arrow_type {
                 DataType::Int32 => Arc::new(Int32Array::from(

--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -194,7 +194,7 @@ mod tests {
 
     use delta_kernel::expressions::column_name;
     use delta_kernel::object_store::memory::InMemory;
-    use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
+    use delta_kernel::schema::{schema_ref, SchemaRef};
     use delta_kernel::snapshot::Snapshot;
     use delta_kernel::transaction::create_table::create_table;
     use delta_kernel::transaction::data_layout::DataLayout;
@@ -248,13 +248,10 @@ mod tests {
         let storage = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(storage).build();
         let table_path = "memory:///test_create_req/";
-        let schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::new("id", DataType::INTEGER, true),
-                StructField::new("region", DataType::STRING, true),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "region": STRING,
+        };
 
         let disk_props = get_required_properties_for_disk("test-table-id-456");
         let req = create_v0_and_build_request(
@@ -414,9 +411,7 @@ mod tests {
         let storage = Arc::new(InMemory::new());
         let engine = DefaultEngineBuilder::new(storage).build();
         let table_path = "memory:///test_create_req_version/";
-        let schema = Arc::new(
-            StructType::try_new(vec![StructField::new("id", DataType::INTEGER, true)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "id": INTEGER };
 
         // Create a table (version 0) and append (version 1).
         let disk_props = get_required_properties_for_disk("test-table-id");

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray};
 use delta_kernel::object_store::local::LocalFileSystem;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{Engine, Snapshot};
 use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
@@ -255,10 +255,10 @@ async fn test_append_scan_back_and_incremental_read() -> Result<(), TestError> {
 
     let client = Arc::new(InMemoryUpdateTableClient::new());
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("val", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "val": STRING,
+    };
 
     // v0 create: writes 000.json directly to storage, does not call the catalog.
     create_table(table_uri.as_str(), schema, "delta-kernel-uc-test")

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use delta_kernel::arrow::array::{ArrayRef, Int32Array, StringArray, StructArray};
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field};
 use delta_kernel::expressions::column_name;
-use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, SchemaRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{Engine, Snapshot};
@@ -176,21 +176,14 @@ async fn live_create_table() {
     // ===== Step 3: Define the schema =====
     // A nested struct so clustering can target both a top-level and a nested
     // column.
-    let schema: SchemaRef = Arc::new(
-        StructType::try_new(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable(
-                "address",
-                StructType::try_new(vec![
-                    StructField::nullable("city", DataType::STRING),
-                    StructField::nullable("zip", DataType::STRING),
-                ])
-                .expect("failed to build nested schema"),
-            ),
-        ])
-        .expect("failed to build schema"),
-    );
+    let schema: SchemaRef = schema_ref! {
+        not_null "id": INTEGER,
+        nullable "name": STRING,
+        nullable "address": {
+            nullable "city": STRING,
+            nullable "zip": STRING,
+        },
+    };
 
     // ===== Step 4: Invoke kernel to write the v0 commit (00.json) via the UC committer =====
     // The v0 path writes directly to storage and does not call the catalog. Enable row tracking so

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -226,10 +226,8 @@ fn evaluate_expression_impl(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use delta_kernel::expressions::lit;
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::schema::schema_ref;
 
     use super::{free_expression_evaluator, new_expression_evaluator};
     use crate::ffi_test_utils::ok_or_panic;
@@ -240,9 +238,7 @@ mod tests {
     #[test]
     fn test_new_expression_evaluator() {
         let engine = get_default_engine("memory:///doesntmatter/foo");
-        let in_schema = Arc::new(
-            StructType::try_new(vec![StructField::new("a", DataType::LONG, true)]).unwrap(),
-        );
+        let in_schema = schema_ref! { nullable "a": LONG };
         let expr = lit(1);
         let output_type: Handle<SharedSchema> = in_schema.clone().into();
         let in_schema_handle: Handle<SharedSchema> = in_schema.into();

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -839,7 +839,7 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
     use delta_kernel::expressions::{col, lit, Scalar};
-    use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
+    use delta_kernel::schema::{schema, ArrayType, DataType, MapType};
     use rstest::rstest;
 
     use super::*;
@@ -886,9 +886,7 @@ mod tests {
 
     #[test]
     fn from_data_type_non_primitive_produces_sentinel() {
-        let struct_type = DataType::from(
-            StructType::try_new(vec![StructField::not_null("a", DataType::INTEGER)]).unwrap(),
-        );
+        let struct_type = DataType::from(schema! { not_null "a": INTEGER });
         assert_eq!(
             NullTypeTag::from_data_type(&struct_type),
             (NullTypeTag::NonPrimitive, 0, 0)

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1903,7 +1903,7 @@ mod tests {
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::object_store::path::Path;
     use delta_kernel::object_store::{DynObjectStore, ObjectStore as _, ObjectStoreExt as _};
-    use delta_kernel::schema::StructType;
+    use delta_kernel::schema::schema_ref;
     use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
     use delta_kernel_default_engine::DefaultEngineBuilder;
     use rstest::rstest;
@@ -2307,7 +2307,7 @@ mod tests {
         create_table(
             storage.clone(),
             Url::parse(table_root)?,
-            Arc::new(StructType::try_new([]).unwrap()),
+            schema_ref! {},
             &[],
             true,
             vec![],
@@ -2359,7 +2359,7 @@ mod tests {
         create_table(
             storage.clone(),
             Url::parse(table_root)?,
-            Arc::new(StructType::try_new([]).unwrap()),
+            schema_ref! {},
             &[],
             true,
             vec![],

--- a/ffi/src/plans/executor.rs
+++ b/ffi/src/plans/executor.rs
@@ -107,7 +107,7 @@ mod tests {
 
     use delta_kernel::arrow::array::ffi::FFI_ArrowArray;
     use delta_kernel::plans::proto::{operation as proto, schema as proto_schema};
-    use delta_kernel::schema::{DataType as KernelDataType, StructField, StructType};
+    use delta_kernel::schema::{schema, DataType as KernelDataType};
     use delta_kernel::Error;
     use prost::Message;
     use url::Url;
@@ -291,9 +291,7 @@ mod tests {
 
     #[test]
     fn execute_op_parquet_footer_variant() {
-        let schema =
-            StructType::try_new(vec![StructField::nullable("id", KernelDataType::INTEGER)])
-                .unwrap();
+        let schema = schema! { nullable "id": INTEGER };
         let bytes = proto_schema::StructType::from(&schema).encode_to_vec();
         let schema_proto = unsafe { allocate_kernel_bytes(kernel_bytes_slice!(bytes)) };
         let footer = CParquetFooter { schema_proto };

--- a/ffi/src/schema.rs
+++ b/ffi/src/schema.rs
@@ -377,7 +377,7 @@ fn visit_schema_impl(schema: &StructType, visitor: &mut EngineSchemaVisitor) -> 
 mod tests {
     #![allow(clippy::unwrap_used, clippy::panic)]
 
-    use delta_kernel::schema::{ArrayType, StructField};
+    use delta_kernel::schema::schema;
 
     use super::*;
     use crate::TryFromStringSlice;
@@ -517,23 +517,14 @@ mod tests {
 
     #[test]
     fn visit_schema_preserves_interval_fields() {
-        let schema = StructType::try_new(vec![
-            StructField::nullable("ym", DataType::INTERVAL_YEAR_MONTH),
-            StructField::not_null("dt", DataType::INTERVAL_DAY_TIME),
-            StructField::nullable(
-                "nested",
-                StructType::try_new(vec![StructField::nullable(
-                    "inner_ym",
-                    DataType::INTERVAL_YEAR_MONTH,
-                )])
-                .unwrap(),
-            ),
-            StructField::nullable(
-                "intervals",
-                ArrayType::new(DataType::INTERVAL_DAY_TIME, false),
-            ),
-        ])
-        .unwrap();
+        let schema = schema! {
+            nullable "ym": INTERVAL_YEAR_MONTH,
+            not_null "dt": INTERVAL_DAY_TIME,
+            nullable "nested": {
+                nullable "inner_ym": INTERVAL_YEAR_MONTH,
+            },
+            nullable "intervals": [ not_null INTERVAL_DAY_TIME ],
+        };
 
         let mut builder = TestSchemaBuilder::default();
         let mut visitor = test_visitor(&mut builder);

--- a/ffi/src/table_changes.rs
+++ b/ffi/src/table_changes.rs
@@ -344,7 +344,7 @@ mod tests {
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::object_store::path::Path;
     use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::schema::{schema_ref, StructType};
     use delta_kernel::Engine;
     use delta_kernel_default_engine::DefaultEngineBuilder;
     use delta_kernel_ffi::engine_data::get_engine_data;
@@ -474,15 +474,12 @@ mod tests {
     }
 
     pub fn get_batch_schema() -> Arc<StructType> {
-        Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("id", DataType::INTEGER),
-                StructField::nullable("val", DataType::STRING),
-                StructField::nullable("_change_type", DataType::STRING),
-                StructField::nullable("_commit_version", DataType::INTEGER),
-            ])
-            .unwrap(),
-        )
+        schema_ref! {
+            nullable "id": INTEGER,
+            nullable "val": STRING,
+            nullable "_change_type": STRING,
+            nullable "_commit_version": INTEGER,
+        }
     }
 
     fn check_columns_in_schema(fields: &[&str], schema: &StructType) -> bool {
@@ -796,12 +793,12 @@ mod tests {
         let batches: Vec<RecordBatch> = batches.into_iter().flatten().collect();
         let filtered_batches: Vec<RecordBatch> = filter_batches(batches);
 
-        let table_schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("val", DataType::STRING),
-            StructField::nullable("_change_type", DataType::STRING),
-            StructField::nullable("_commit_version", DataType::INTEGER),
-        ])?);
+        let table_schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "val": STRING,
+            nullable "_change_type": STRING,
+            nullable "_commit_version": INTEGER,
+        };
         let expected = &ArrowEngineData::new(RecordBatch::try_new(
             Arc::new(table_schema.as_ref().try_into_arrow()?),
             vec![

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -792,8 +792,7 @@ mod tests {
     use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
     use delta_kernel::parquet::file::properties::WriterProperties;
     use delta_kernel::schema::{
-        schema_ref, try_schema, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField,
-        StructType,
+        schema_ref, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField,
     };
     use delta_kernel::table_features::TableFeature;
     use delta_kernel_ffi::engine_data::{get_engine_data, ArrowFFIData};
@@ -978,10 +977,10 @@ mod tests {
         ignore = "local-filesystem commit calls `linkat`, unsupported under Miri"
     )]
     async fn test_basic_append() -> Result<(), Box<dyn std::error::Error>> {
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("number", DataType::INTEGER),
-            StructField::nullable("string", DataType::STRING),
-        ])?);
+        let schema = schema_ref! {
+            nullable "number": INTEGER,
+            nullable "string": STRING,
+        };
 
         // TODO: test with partitions
         let (_tmp_test_dir, tables) = setup_local_test_tables(schema, &[], "test_table").await?;
@@ -1163,11 +1162,11 @@ mod tests {
     async fn test_partitioned_append() -> Result<(), Box<dyn std::error::Error>> {
         // Partition column `part` is listed last in the schema; the physical write schema must
         // exclude it (CM=none, partition columns are not materialized).
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("number", DataType::INTEGER),
-            StructField::nullable("string", DataType::STRING),
-            StructField::nullable("part", DataType::INTEGER),
-        ])?);
+        let schema = schema_ref! {
+            nullable "number": INTEGER,
+            nullable "string": STRING,
+            nullable "part": INTEGER,
+        };
 
         let (_tmp_test_dir, tables) =
             setup_local_test_tables(schema, &["part"], "test_partitioned_table").await?;
@@ -1353,10 +1352,7 @@ mod tests {
     #[tokio::test]
     async fn test_partitioned_write_context_rejects_unpartitioned_table(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-            "number",
-            DataType::INTEGER,
-        )])?);
+        let schema = schema_ref! { nullable "number": INTEGER };
         let tables = setup_test_tables(schema, &[], None, "test_unpartitioned").await?;
 
         for (table_url, _engine, store, _table_name) in tables {
@@ -1405,10 +1401,10 @@ mod tests {
     async fn test_visit_partition_values_surfaces_null() -> Result<(), Box<dyn std::error::Error>> {
         // A null partition value must surface across the visitor as `is_null = true` with an
         // empty value slice (the documented C contract).
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("number", DataType::INTEGER),
-            StructField::nullable("part", DataType::INTEGER),
-        ])?);
+        let schema = schema_ref! {
+            nullable "number": INTEGER,
+            nullable "part": INTEGER,
+        };
         let tables = setup_test_tables(schema, &["part"], None, "test_null_partition").await?;
 
         for (table_url, _engine, store, _table_name) in tables {
@@ -1461,11 +1457,11 @@ mod tests {
     {
         // Multiple partition columns must be visited in deterministic (sorted) key order,
         // regardless of insertion order or the underlying HashMap layout.
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("number", DataType::INTEGER),
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("year", DataType::INTEGER),
-        ])?);
+        let schema = schema_ref! {
+            nullable "number": INTEGER,
+            nullable "region": STRING,
+            nullable "year": INTEGER,
+        };
         let tables =
             setup_test_tables(schema, &["year", "region"], None, "test_multi_partition").await?;
 
@@ -1552,7 +1548,7 @@ mod tests {
         name: &str,
     ) -> Result<(Url, Arc<DynObjectStore>, Handle<SharedExternEngine>), Box<dyn std::error::Error>>
     {
-        let schema = Arc::new(try_schema! { nullable "id": INTEGER }?);
+        let schema = schema_ref! { nullable "id": INTEGER };
         let (store, _test_engine, table_location) = test_utils::engine_store_setup(name, None);
         let table_url = test_utils::create_table(
             store.clone(),
@@ -1706,7 +1702,7 @@ mod tests {
         let tmp_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
 
         // Create a table WITHOUT the domainMetadata writer feature (v1/v1 protocol)
-        let schema = Arc::new(try_schema! { nullable "id": INTEGER }?);
+        let schema = schema_ref! { nullable "id": INTEGER };
         let (store, _test_engine, table_location) =
             test_utils::engine_store_setup("test_dm_no_feature", Some(&tmp_dir_url));
         let table_url = test_utils::create_table(
@@ -2987,7 +2983,7 @@ mod tests {
 
         // Build a DV-enabled table; create_table sets delta.enableDeletionVectors for the
         // writer feature.
-        let schema = Arc::new(try_schema! { nullable "id": INTEGER }?);
+        let schema = schema_ref! { nullable "id": INTEGER };
         let (store, _test_engine, table_location) =
             test_utils::engine_store_setup("test_dv_ffi", None);
         let table_url = test_utils::create_table(

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -1786,10 +1786,10 @@ mod tests {
             OptionalValue::None
         }
 
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("number", DataType::INTEGER),
-            StructField::nullable("string", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "number": INTEGER,
+            nullable "string": STRING,
+        };
 
         // Create a catalog-managed table so UCCommitter (a catalog committer) is allowed.
         let (store, _test_engine, table_location) =

--- a/ffi/src/transaction/transaction_id.rs
+++ b/ffi/src/transaction/transaction_id.rs
@@ -76,7 +76,7 @@ fn get_app_id_version_impl(
 mod tests {
     use std::sync::Arc;
 
-    use delta_kernel::schema::{DataType, StructField, StructType};
+    use delta_kernel::schema::schema_ref;
     use delta_kernel::Snapshot;
     use test_utils::setup_test_tables;
 
@@ -89,9 +89,7 @@ mod tests {
     #[tokio::test]
     async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
         // create a simple table: one int column named 'number'
-        let schema = Arc::new(
-            StructType::try_new(vec![StructField::nullable("number", DataType::INTEGER)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "number": INTEGER };
 
         for (table_url, engine, store, _table_name) in
             setup_test_tables(schema, &[], None, "test_table").await?

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1432,7 +1432,7 @@ mod tests {
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::expressions::Scalar;
-    use crate::schema::{schema_ref, DataType, MapType, StructField};
+    use crate::schema::{schema, schema_ref, DataType, MapType, StructField};
     use crate::unit_test_utils::assert_result_error_with_message;
     use crate::{
         Engine, EvaluationHandler, IntoEngineData, JsonHandler, ParquetHandler, StorageHandler,
@@ -1636,10 +1636,8 @@ mod tests {
 
     fn nested_schema(depth: usize) -> StructType {
         (0..depth).fold(
-            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
-            |schema, depth| {
-                StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
-            },
+            schema! { nullable "leaf": INTEGER },
+            |nested, depth| schema! { nullable (format!("level_{depth}")): (nested) },
         )
     }
 
@@ -1684,13 +1682,13 @@ mod tests {
     fn deletion_vector_field() -> StructField {
         StructField::nullable(
             "deletionVector",
-            DataType::struct_type_unchecked([
-                StructField::not_null("storageType", DataType::STRING),
-                StructField::not_null("pathOrInlineDv", DataType::STRING),
-                StructField::nullable("offset", DataType::INTEGER),
-                StructField::not_null("sizeInBytes", DataType::INTEGER),
-                StructField::not_null("cardinality", DataType::LONG),
-            ]),
+            schema! {
+                not_null "storageType": STRING,
+                not_null "pathOrInlineDv": STRING,
+                nullable "offset": INTEGER,
+                not_null "sizeInBytes": INTEGER,
+                not_null "cardinality": LONG,
+            },
         )
     }
 
@@ -1737,12 +1735,12 @@ mod tests {
     #[test]
     fn test_sidecar_schema() {
         let schema = Sidecar::to_schema();
-        let expected = StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null("sizeInBytes", DataType::LONG),
-            StructField::not_null("modificationTime", DataType::LONG),
-            tags_field(),
-        ]);
+        let expected = schema! {
+            not_null "path": STRING,
+            not_null "sizeInBytes": LONG,
+            not_null "modificationTime": LONG,
+            (tags_field()),
+        };
         assert_eq!(schema, expected);
     }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -1432,7 +1432,7 @@ mod tests {
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::arrow_expression::ArrowEvaluationHandler;
     use crate::expressions::Scalar;
-    use crate::schema::{schema_ref, ArrayType, DataType, MapType, StructField};
+    use crate::schema::{schema_ref, DataType, MapType, StructField};
     use crate::unit_test_utils::assert_result_error_with_message;
     use crate::{
         Engine, EvaluationHandler, IntoEngineData, JsonHandler, ParquetHandler, StorageHandler,
@@ -1526,31 +1526,21 @@ mod tests {
             .project(&[METADATA_NAME])
             .expect("Couldn't get metaData field");
 
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "metaData",
-            StructType::new_unchecked([
-                StructField::not_null("id", DataType::STRING),
-                StructField::nullable("name", DataType::STRING),
-                StructField::nullable("description", DataType::STRING),
-                StructField::not_null(
-                    "format",
-                    StructType::new_unchecked([
-                        StructField::not_null("provider", DataType::STRING),
-                        StructField::not_null(
-                            "options",
-                            MapType::new(DataType::STRING, DataType::STRING, false),
-                        ),
-                    ]),
-                ),
-                StructField::not_null("schemaString", DataType::STRING),
-                StructField::not_null("partitionColumns", ArrayType::new(DataType::STRING, false)),
-                StructField::nullable("createdTime", DataType::LONG),
-                StructField::not_null(
-                    "configuration",
-                    MapType::new(DataType::STRING, DataType::STRING, false),
-                ),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "metaData": {
+                not_null "id": STRING,
+                nullable "name": STRING,
+                nullable "description": STRING,
+                not_null "format": {
+                    not_null "provider": STRING,
+                    not_null "options": { STRING => not_null STRING },
+                },
+                not_null "schemaString": STRING,
+                not_null "partitionColumns": [ not_null STRING ],
+                nullable "createdTime": LONG,
+                not_null "configuration": { STRING => not_null STRING },
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1659,28 +1649,21 @@ mod tests {
             .project(&[ADD_NAME])
             .expect("Couldn't get add field");
 
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "add",
-            StructType::new_unchecked([
-                StructField::not_null("path", DataType::STRING),
-                StructField::not_null(
-                    "partitionValues",
-                    MapType::new(DataType::STRING, DataType::STRING, true),
-                ),
-                StructField::not_null("size", DataType::LONG),
-                StructField::not_null("modificationTime", DataType::LONG),
-                StructField::not_null("dataChange", DataType::BOOLEAN),
-                StructField::nullable("stats", DataType::STRING),
-                StructField::nullable(
-                    "tags",
-                    MapType::new(DataType::STRING, DataType::STRING, true),
-                ),
-                deletion_vector_field(),
-                StructField::nullable("baseRowId", DataType::LONG),
-                StructField::nullable("defaultRowCommitVersion", DataType::LONG),
-                StructField::nullable("clusteringProvider", DataType::STRING),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "add": {
+                not_null "path": STRING,
+                not_null "partitionValues": { STRING => nullable STRING },
+                not_null "size": LONG,
+                not_null "modificationTime": LONG,
+                not_null "dataChange": BOOLEAN,
+                nullable "stats": STRING,
+                nullable "tags": { STRING => nullable STRING },
+                (deletion_vector_field()),
+                nullable "baseRowId": LONG,
+                nullable "defaultRowCommitVersion": LONG,
+                nullable "clusteringProvider": STRING,
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1716,22 +1699,21 @@ mod tests {
         let schema = get_commit_schema()
             .project(&[REMOVE_NAME])
             .expect("Couldn't get remove field");
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "remove",
-            StructType::new_unchecked([
-                StructField::not_null("path", DataType::STRING),
-                StructField::nullable("deletionTimestamp", DataType::LONG),
-                StructField::not_null("dataChange", DataType::BOOLEAN),
-                StructField::nullable("extendedFileMetadata", DataType::BOOLEAN),
-                partition_values_field(),
-                StructField::nullable("size", DataType::LONG),
-                StructField::nullable("stats", DataType::STRING),
-                tags_field(),
-                deletion_vector_field(),
-                StructField::nullable("baseRowId", DataType::LONG),
-                StructField::nullable("defaultRowCommitVersion", DataType::LONG),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "remove": {
+                not_null "path": STRING,
+                nullable "deletionTimestamp": LONG,
+                not_null "dataChange": BOOLEAN,
+                nullable "extendedFileMetadata": BOOLEAN,
+                (partition_values_field()),
+                nullable "size": LONG,
+                nullable "stats": STRING,
+                (tags_field()),
+                (deletion_vector_field()),
+                nullable "baseRowId": LONG,
+                nullable "defaultRowCommitVersion": LONG,
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1740,19 +1722,15 @@ mod tests {
         let schema = get_commit_schema()
             .project(&[CDC_NAME])
             .expect("Couldn't get cdc field");
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "cdc",
-            StructType::new_unchecked([
-                StructField::not_null("path", DataType::STRING),
-                StructField::not_null(
-                    "partitionValues",
-                    MapType::new(DataType::STRING, DataType::STRING, true),
-                ),
-                StructField::not_null("size", DataType::LONG),
-                StructField::not_null("dataChange", DataType::BOOLEAN),
-                tags_field(),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "cdc": {
+                not_null "path": STRING,
+                not_null "partitionValues": { STRING => nullable STRING },
+                not_null "size": LONG,
+                not_null "dataChange": BOOLEAN,
+                (tags_field()),
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1773,13 +1751,12 @@ mod tests {
         let schema = get_all_actions_schema()
             .project(&[CHECKPOINT_METADATA_NAME])
             .expect("Couldn't get checkpointMetadata field");
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "checkpointMetadata",
-            StructType::new_unchecked([
-                StructField::not_null("version", DataType::LONG),
-                tags_field(),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "checkpointMetadata": {
+                not_null "version": LONG,
+                (tags_field()),
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1789,14 +1766,13 @@ mod tests {
             .project(&["txn"])
             .expect("Couldn't get transaction field");
 
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "txn",
-            StructType::new_unchecked([
-                StructField::not_null("appId", DataType::STRING),
-                StructField::not_null("version", DataType::LONG),
-                StructField::nullable("lastUpdated", DataType::LONG),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "txn": {
+                not_null "appId": STRING,
+                not_null "version": LONG,
+                nullable "lastUpdated": LONG,
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1806,22 +1782,18 @@ mod tests {
             .project(&["commitInfo"])
             .expect("Couldn't get commitInfo field");
 
-        let expected = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
-            "commitInfo",
-            StructType::new_unchecked(vec![
-                StructField::nullable("timestamp", DataType::LONG),
-                StructField::nullable("inCommitTimestamp", DataType::LONG),
-                StructField::nullable("operation", DataType::STRING),
-                StructField::nullable(
-                    "operationParameters",
-                    MapType::new(DataType::STRING, DataType::STRING, false),
-                ),
-                StructField::nullable("kernelVersion", DataType::STRING),
-                StructField::nullable("isBlindAppend", DataType::BOOLEAN),
-                StructField::nullable("engineInfo", DataType::STRING),
-                StructField::nullable("txnId", DataType::STRING),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "commitInfo": {
+                nullable "timestamp": LONG,
+                nullable "inCommitTimestamp": LONG,
+                nullable "operation": STRING,
+                nullable "operationParameters": { STRING => not_null STRING },
+                nullable "kernelVersion": STRING,
+                nullable "isBlindAppend": BOOLEAN,
+                nullable "engineInfo": STRING,
+                nullable "txnId": STRING,
+            },
+        };
         assert_eq!(schema, expected);
     }
 
@@ -1830,14 +1802,13 @@ mod tests {
         let schema = get_commit_schema()
             .project(&[DOMAIN_METADATA_NAME])
             .expect("Couldn't get domainMetadata field");
-        let expected = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "domainMetadata",
-            StructType::new_unchecked([
-                StructField::not_null("domain", DataType::STRING),
-                StructField::not_null("configuration", DataType::STRING),
-                StructField::not_null("removed", DataType::BOOLEAN),
-            ]),
-        )]));
+        let expected = schema_ref! {
+            nullable "domainMetadata": {
+                not_null "domain": STRING,
+                not_null "configuration": STRING,
+                not_null "removed": BOOLEAN,
+            },
+        };
         assert_eq!(schema, expected);
     }
 

--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -192,6 +192,7 @@ fn checkpoint_action_field() -> impl IntoIterator<Item = &'static StructField> {
     }
 }
 
+#[cfg(any(test, feature = "internal-api"))]
 static COMMIT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     (&ADD_FIELD),
     (&REMOVE_FIELD),
@@ -250,6 +251,7 @@ pub(crate) static LOG_TXN_SCHEMA: LazyLock<SchemaRef> =
 pub(crate) static LOG_DOMAIN_METADATA_SCHEMA: LazyLock<SchemaRef> =
     lazy_schema_ref! { (&DOMAIN_METADATA_FIELD) };
 
+#[cfg(any(test, feature = "internal-api"))]
 #[internal_api]
 /// Gets the schema for all actions that can appear in commits
 /// logs.  This excludes actions that can only appear in checkpoints.

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -12,7 +12,7 @@ use super::*;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::log_segment::DomainMetadataMap;
 use crate::schema::{
-    column_name, lazy_schema_ref, ColumnName, ColumnNamesAndTypes, DataType, Schema,
+    column_name, lazy_schema_ref, ColumnName, ColumnNamesAndTypes, DataType, Schema, SchemaRef,
 };
 use crate::utils::require;
 use crate::{DeltaResult, Error};
@@ -643,7 +643,7 @@ impl InCommitTimestampVisitor {
     #[allow(unused)]
     /// Get the schema that the visitor expects the data to have.
     pub(crate) fn schema() -> Arc<Schema> {
-        static SCHEMA: LazyLock<Arc<Schema>> = lazy_schema_ref! {
+        static SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
             nullable COMMIT_INFO_NAME: {
                 nullable "inCommitTimestamp": LONG,
             },

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -11,7 +11,9 @@ use super::deletion_vector::DeletionVectorDescriptor;
 use super::*;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::log_segment::DomainMetadataMap;
-use crate::schema::{column_name, ColumnName, ColumnNamesAndTypes, DataType, Schema, StructField};
+use crate::schema::{
+    column_name, lazy_schema_ref, ColumnName, ColumnNamesAndTypes, DataType, Schema,
+};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -641,14 +643,11 @@ impl InCommitTimestampVisitor {
     #[allow(unused)]
     /// Get the schema that the visitor expects the data to have.
     pub(crate) fn schema() -> Arc<Schema> {
-        static SCHEMA: LazyLock<Arc<Schema>> = LazyLock::new(|| {
-            let ict_type = StructField::new("inCommitTimestamp", DataType::LONG, true);
-            Arc::new(StructType::new_unchecked(vec![StructField::new(
-                COMMIT_INFO_NAME,
-                StructType::new_unchecked([ict_type]),
-                true,
-            )]))
-        });
+        static SCHEMA: LazyLock<Arc<Schema>> = lazy_schema_ref! {
+            nullable COMMIT_INFO_NAME: {
+                nullable "inCommitTimestamp": LONG,
+            },
+        };
         SCHEMA.clone()
     }
 }

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -207,7 +207,6 @@ fn collect_single_sidecar(
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
 
     use rstest::rstest;
 
@@ -215,7 +214,7 @@ mod tests {
     use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::plans::{IoOperation, PlanResult};
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, StructField, StructType};
     use crate::unit_test_utils::load_test_table;
 
     /// Counts ops by kind and delegates to `SyncPlanExecutor`, to assert which I/O the fast path
@@ -338,11 +337,11 @@ mod tests {
                 StructField::nullable("value", DataType::STRING),
             ])
         };
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(MIN_VALUES, columns()),
-            StructField::nullable(MAX_VALUES, columns()),
-        ]))
+        schema_ref! {
+            nullable NUM_RECORDS: LONG,
+            nullable MIN_VALUES: (columns()),
+            nullable MAX_VALUES: (columns()),
+        }
     }
 
     /// Fast path on a manifest hint: one sidecar footer read, no drain (`query_scans == 0`). Guards

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -214,7 +214,7 @@ mod tests {
     use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::plans::{IoOperation, PlanResult};
-    use crate::schema::{schema_ref, DataType, StructField, StructType};
+    use crate::schema::{schema, schema_ref};
     use crate::unit_test_utils::load_test_table;
 
     /// Counts ops by kind and delegates to `SyncPlanExecutor`, to assert which I/O the fast path
@@ -331,12 +331,7 @@ mod tests {
     /// Requested stats schema for the `*-struct-stats-only` fixtures (`id: long`, `value: string`),
     /// so compatibility does real per-column matching.
     fn probe_stats_schema() -> SchemaRef {
-        let columns = || {
-            StructType::new_unchecked([
-                StructField::nullable("id", DataType::LONG),
-                StructField::nullable("value", DataType::STRING),
-            ])
-        };
+        let columns = || schema! { nullable "id": LONG, nullable "value": STRING };
         schema_ref! {
             nullable NUM_RECORDS: LONG,
             nullable MIN_VALUES: (columns()),

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -272,7 +272,7 @@ mod tests {
     use super::*;
     use crate::actions::NUM_RECORDS;
     use crate::expressions::ExpressionStructPatch;
-    use crate::schema::MapType;
+    use crate::schema::{schema, schema_ref, MapType};
 
     #[test]
     fn test_config_defaults() {
@@ -353,10 +353,9 @@ mod tests {
         stats_schema: &SchemaRef,
         partition_schema: Option<&SchemaRef>,
     ) -> (SchemaRef, ExpressionRef) {
-        let base_schema = StructType::new_unchecked([StructField::nullable(
-            ADD_NAME,
-            add_schema(partition_schema.is_some()),
-        )]);
+        let base_schema = schema! {
+            nullable ADD_NAME: (add_schema(partition_schema.is_some())),
+        };
         let read_schema = build_checkpoint_read_schema(
             &base_schema,
             stats_schema.as_ref(),
@@ -387,7 +386,7 @@ mod tests {
             write_stats_as_json: true,
             write_stats_as_struct: false,
         };
-        let stats_schema = Arc::new(StructType::new_unchecked([]));
+        let stats_schema = schema_ref! {};
         let (_, transform_expr) = build_checkpoint_transform(&config, &stats_schema, None);
 
         let (_, inner) = extract_patches(&transform_expr);
@@ -411,11 +410,11 @@ mod tests {
             write_stats_as_json: true,
             write_stats_as_struct: true,
         };
-        let stats_schema = Arc::new(StructType::new_unchecked([]));
-        let pv_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("year", DataType::INTEGER),
-            StructField::nullable("month", DataType::INTEGER),
-        ]));
+        let stats_schema = schema_ref! {};
+        let pv_schema = schema_ref! {
+            nullable "year": INTEGER,
+            nullable "month": INTEGER,
+        };
         let (_, transform_expr) =
             build_checkpoint_transform(&config, &stats_schema, Some(&pv_schema));
 
@@ -479,13 +478,14 @@ mod tests {
             write_stats_as_json,
             write_stats_as_struct,
         };
-        let num_records = StructField::nullable(NUM_RECORDS, DataType::LONG);
-        let stats_schema = Arc::new(StructType::new_unchecked([num_records]));
+        let stats_schema = schema_ref! {
+            nullable NUM_RECORDS: LONG,
+        };
         let pv_schema = with_partition_schema.then(|| {
-            Arc::new(StructType::new_unchecked([
-                StructField::nullable("year", DataType::INTEGER),
-                StructField::nullable("month", DataType::INTEGER),
-            ]))
+            schema_ref! {
+                nullable "year": INTEGER,
+                nullable "month": INTEGER,
+            }
         });
 
         let (output_schema, _) =

--- a/kernel/src/checkpoint/checkpoint_transform.rs
+++ b/kernel/src/checkpoint/checkpoint_transform.rs
@@ -367,15 +367,17 @@ mod tests {
     }
 
     fn add_schema(with_partition_schema: bool) -> StructType {
-        let fields = [
-            Some(StructField::not_null("path", DataType::STRING)),
-            with_partition_schema.then(|| {
-                let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
-                StructField::nullable(PARTITION_VALUES_FIELD, partition_values)
-            }),
-            Some(StructField::nullable(STATS_FIELD, DataType::STRING)),
-        ];
-        StructType::new_unchecked(fields.into_iter().flatten())
+        let partition_values = with_partition_schema.then(|| {
+            StructField::nullable(
+                PARTITION_VALUES_FIELD,
+                MapType::new(DataType::STRING, DataType::STRING, true),
+            )
+        });
+        schema! {
+            not_null "path": STRING,
+            ..(partition_values),
+            nullable STATS_FIELD: STRING,
+        }
     }
 
     #[test]

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -121,7 +121,7 @@ use crate::expressions::{
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
-use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField, StructType};
+use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
@@ -302,16 +302,13 @@ pub enum V2CheckpointConfig {
 /// Schema of the `_last_checkpoint` file
 /// We cannot use `LastCheckpointInfo::to_schema()` as it would include the 'checkpoint_schema'
 /// field, which is only known at runtime.
-static LAST_CHECKPOINT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    StructType::new_unchecked([
-        StructField::not_null("version", DataType::LONG),
-        StructField::not_null("size", DataType::LONG),
-        StructField::nullable("parts", DataType::LONG),
-        StructField::nullable("sizeInBytes", DataType::LONG),
-        StructField::nullable("numOfAddFiles", DataType::LONG),
-    ])
-    .into()
-});
+static LAST_CHECKPOINT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    not_null "version": LONG,
+    not_null "size": LONG,
+    nullable "parts": LONG,
+    nullable "sizeInBytes": LONG,
+    nullable "numOfAddFiles": LONG,
+};
 
 /// Action fields shared by V1 and V2 checkpoint schemas.
 fn base_checkpoint_action_fields() -> [&'static LazyLock<StructField>; 7] {

--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -121,7 +121,7 @@ use crate::expressions::{
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::log_replay::LogReplayProcessor;
 use crate::path::{self, ParsedLogPath};
-use crate::schema::{lazy_schema_ref, DataType, SchemaRef, StructField};
+use crate::schema::{lazy_schema_ref, schema, DataType, SchemaRef, StructField};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::TableFeature;
 use crate::table_properties::TableProperties;
@@ -333,7 +333,7 @@ static CHECKPOINT_ACTIONS_SCHEMA_V1: LazyLock<SchemaRef> =
 fn checkpoint_metadata_field() -> StructField {
     StructField::nullable(
         CHECKPOINT_METADATA_NAME,
-        DataType::struct_type_unchecked([StructField::not_null("version", DataType::LONG)]),
+        schema! { not_null "version": LONG },
     )
 }
 

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -8,7 +8,7 @@ use crate::engine_data::filter_by_predicate;
 use crate::expressions::{
     col, null_lit, Expression, ExpressionStructPatchBuilder, Predicate, Scalar, StructData,
 };
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{try_schema, DataType, SchemaRef, StructField};
 use crate::{
     DeltaResult, Engine, EngineData, Error, EvaluationHandler, ExpressionEvaluator, FileMeta,
     PredicateEvaluator,
@@ -178,8 +178,10 @@ impl SidecarSplitter {
                 "Checkpoint data schema '{REMOVE_NAME}' field must be nullable"
             )));
         }
-        let sidecar_output_schema: SchemaRef =
-            StructType::try_new([add_field.clone(), remove_field.clone()])?.into();
+        let sidecar_output_schema = Arc::new(try_schema! {
+            (add_field),
+            (remove_field),
+        }?);
 
         // Sidecar projector: select only add/remove columns.
         let file_action_projector = eval_handler.new_expression_evaluator(

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -24,7 +24,7 @@ use crate::object_store::memory::InMemory;
 use crate::object_store::path::Path;
 use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
+use crate::schema::{schema, schema_ref, DataType, StructType};
 use crate::unit_test_utils::Action;
 use crate::{DeltaResult, Engine, EngineData, Snapshot};
 
@@ -691,25 +691,25 @@ fn dummy_struct() -> DataType {
 
 #[rstest]
 #[case::missing_add(
-    StructType::new_unchecked([StructField::nullable("remove", dummy_struct())]),
+    schema! { nullable "remove": (dummy_struct()) },
     "missing 'add'"
 )]
 #[case::missing_remove(
-    StructType::new_unchecked([StructField::nullable("add", dummy_struct())]),
+    schema! { nullable "add": (dummy_struct()) },
     "missing 'remove'"
 )]
 #[case::non_nullable_add(
-    StructType::new_unchecked([
-        StructField::not_null("add", dummy_struct()),
-        StructField::nullable("remove", dummy_struct()),
-    ]),
+    schema! {
+        not_null "add": (dummy_struct()),
+        nullable "remove": (dummy_struct()),
+    },
     "'add' field must be nullable"
 )]
 #[case::non_nullable_remove(
-    StructType::new_unchecked([
-        StructField::nullable("add", dummy_struct()),
-        StructField::not_null("remove", dummy_struct()),
-    ]),
+    schema! {
+        nullable "add": (dummy_struct()),
+        not_null "remove": (dummy_struct()),
+    },
     "'remove' field must be nullable"
 )]
 fn test_splitter_rejects_invalid_schema(#[case] schema: StructType, #[case] expected_msg: &str) {

--- a/kernel/src/checkpoint/sidecar/tests.rs
+++ b/kernel/src/checkpoint/sidecar/tests.rs
@@ -24,7 +24,7 @@ use crate::object_store::memory::InMemory;
 use crate::object_store::path::Path;
 use crate::object_store::ObjectStoreExt as _;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use crate::schema::{DataType, StructField, StructType};
+use crate::schema::{schema, schema_ref, DataType, StructField, StructType};
 use crate::unit_test_utils::Action;
 use crate::{DeltaResult, Engine, EngineData, Snapshot};
 
@@ -686,7 +686,7 @@ async fn test_splitter_no_file_actions() -> DeltaResult<()> {
 
 /// Dummy struct type used as the data type for add/remove fields in schema validation tests.
 fn dummy_struct() -> DataType {
-    StructType::new_unchecked([]).into()
+    schema! {}.into()
 }
 
 #[rstest]
@@ -725,11 +725,10 @@ fn test_splitter_rejects_invalid_schema(#[case] schema: StructType, #[case] expe
 
 #[test]
 fn test_single_sidecar_data_iterator_rejects_zero_max_file_actions_hint() {
-    let schema: Arc<StructType> = StructType::new_unchecked([
-        StructField::nullable("add", dummy_struct()),
-        StructField::nullable("remove", dummy_struct()),
-    ])
-    .into();
+    let schema = schema_ref! {
+        nullable "add": (dummy_struct()),
+        nullable "remove": (dummy_struct()),
+    };
     let iter = ActionReconciliationIterator::new(Box::new(std::iter::empty()));
     let splitter = SidecarSplitter::new_mut_shared(iter, &ArrowEvaluationHandler, schema).unwrap();
     let result = SingleSidecarDataIterator::new(splitter, 0);

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -25,7 +25,7 @@ use crate::log_replay::HasSelectionVector;
 use crate::object_store::memory::InMemory;
 use crate::object_store::path::Path;
 use crate::object_store::ObjectStoreExt as _;
-use crate::schema::{schema_ref, DataType as KernelDataType, StructField, StructType};
+use crate::schema::{schema_ref, DataType as KernelDataType, StructField};
 use crate::table_features::TableFeature;
 use crate::transaction::create_table::create_table;
 use crate::unit_test_utils::Action;
@@ -1004,12 +1004,11 @@ pub(super) fn create_metadata_with_stats_config_and_partitions(
         Metadata::try_new(
             Some("test-table".into()),
             None,
-            StructType::new_unchecked([
-                StructField::nullable("id", KernelDataType::LONG),
-                StructField::nullable("name", KernelDataType::STRING),
-                StructField::nullable("category", KernelDataType::STRING),
-            ])
-            .into(),
+            schema_ref! {
+                nullable "id": LONG,
+                nullable "name": STRING,
+                nullable "category": STRING,
+            },
             partition_columns,
             0,
             config,
@@ -1269,10 +1268,10 @@ async fn test_checkpoint_with_varchar_metadata_on_field() -> DeltaResult<()> {
     ]);
 
     // Version 0: schema WITHOUT __CHAR_VARCHAR_TYPE_STRING + add with stats
-    let schema_v0 = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", KernelDataType::LONG),
-        StructField::nullable("name", KernelDataType::STRING),
-    ]));
+    let schema_v0 = schema_ref! {
+        nullable "id": LONG,
+        nullable "name": STRING,
+    };
     write_commit_to_store(
         &store,
         vec![
@@ -1308,13 +1307,13 @@ async fn test_checkpoint_with_varchar_metadata_on_field() -> DeltaResult<()> {
         .checkpoint(&engine, None)?;
 
     // Version 1: new metadata WITH __CHAR_VARCHAR_TYPE_STRING on the "name" field
-    let schema_v1 = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", KernelDataType::LONG),
-        StructField::nullable("name", KernelDataType::STRING).with_metadata([(
-            "__CHAR_VARCHAR_TYPE_STRING",
-            crate::schema::MetadataValue::String("varchar(255)".to_string()),
-        )]),
-    ]));
+    let schema_v1 = schema_ref! {
+        nullable "id": LONG,
+        (StructField::nullable("name", KernelDataType::STRING).with_metadata([(
+                "__CHAR_VARCHAR_TYPE_STRING",
+                crate::schema::MetadataValue::String("varchar(255)".to_string()),
+            )])),
+    };
     write_commit_to_store(
         &store,
         vec![Action::Metadata(

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -192,8 +192,7 @@ mod tests {
 
     #[test]
     fn test_validate_clustering_columns_not_found() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "id": INTEGER };
         let columns = vec![column_name!("nonexistent")];
         let result = validate_clustering_columns(&schema, &columns);
         assert!(result.is_err());
@@ -236,8 +235,7 @@ mod tests {
 
     #[test]
     fn test_validate_clustering_nested_intermediate_not_struct() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("flat_col", DataType::STRING, false)]);
+        let schema = schema! { not_null "flat_col": STRING };
 
         // Trying to traverse into a non-struct field should fail
         let columns = vec![column_name!("flat_col", "child")];
@@ -385,8 +383,7 @@ mod tests {
         #[case] column_names: Vec<&str>,
         #[case] expected_error: &str,
     ) {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "id": INTEGER };
         let columns: Vec<ColumnName> = column_names
             .into_iter()
             .map(|s| ColumnName::new([s]))
@@ -402,8 +399,7 @@ mod tests {
 
     #[test]
     fn test_validate_clustering_columns_empty_name_rejected() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "id": INTEGER };
         // Create a ColumnName with empty path (can't easily express in rstest case)
         let columns: Vec<ColumnName> = vec![ColumnName::new(Vec::<String>::new())];
         let result = validate_clustering_columns(&schema, &columns);

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -1,13 +1,13 @@
 //! Commit metadata types for the committer module.
 
 use std::collections::HashMap;
-#[cfg(any(test, feature = "test-utils"))]
-use std::sync::Arc;
 
 use url::Url;
 
 use crate::actions::{DomainMetadata, Metadata, Protocol};
 use crate::path::LogRoot;
+#[cfg(any(test, feature = "test-utils"))]
+use crate::schema::schema_ref;
 use crate::{DeltaResult, Version};
 
 /// The type of commit operation being performed. This communicates to the committer whether this
@@ -269,7 +269,7 @@ impl CommitMetadata {
     ) -> DeltaResult<Self> {
         let log_root = crate::path::LogRoot::new(table_root)?;
         let protocol = Protocol::try_new_modern(reader_features, writer_features)?;
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let schema = schema_ref! {};
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, configuration)?;
         Ok(Self::new(
             log_root,
@@ -332,8 +332,6 @@ pub enum CommitResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use url::Url;
 
     use super::*;
@@ -347,7 +345,7 @@ mod tests {
         let ts = 1234;
         let max_published_version = Some(42);
         let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let schema = schema_ref! {};
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
 
         let commit_metadata = CommitMetadata::new(

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -96,6 +96,7 @@ mod tests {
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::path::LogRoot;
+    use crate::schema::schema_ref;
     use crate::IntoEngineData;
 
     #[tokio::test]
@@ -139,7 +140,7 @@ mod tests {
         let committer = FileSystemCommitter::new();
         let log_root = LogRoot::new(table_root).unwrap();
         let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let schema = schema_ref! {};
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
         let action = metadata
             .clone()
@@ -187,7 +188,7 @@ mod tests {
 
         let committer = FileSystemCommitter::new();
         let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![]));
+        let schema = schema_ref! {};
         let metadata1 =
             Metadata::try_new(None, None, schema.clone(), vec![], 0, HashMap::new()).unwrap();
         let metadata2 = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();

--- a/kernel/src/content_tree/dv_conversion.rs
+++ b/kernel/src/content_tree/dv_conversion.rs
@@ -1,12 +1,10 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
 use crate::content_tree::DeletionVectorInfo;
 use crate::engine_data::{GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{ArrayData, Scalar};
-use crate::schema::{
-    column_name, ArrayType, ColumnName, DataType, SchemaRef, StructField, StructType,
-};
+use crate::schema::{column_name, lazy_schema_ref, ArrayType, ColumnName, DataType, SchemaRef};
 use crate::{DeltaResult, EngineData, Error};
 
 /// Extracts deletion vector content from a DeletionVectorDescriptor.
@@ -61,14 +59,12 @@ const DV_SIZE_IN_BYTES: &str = "_dv_size_in_bytes";
 const DV_CARDINALITY: &str = "_dv_cardinality";
 
 /// Schema of [`DV_LOCATION`] etc., for [`EngineData::append_columns`].
-static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::nullable(DV_LOCATION, DataType::STRING),
-        StructField::nullable(DV_OFFSET, DataType::LONG),
-        StructField::nullable(DV_SIZE_IN_BYTES, DataType::LONG),
-        StructField::nullable(DV_CARDINALITY, DataType::LONG),
-    ]))
-});
+static DV_DECODED_FLAT_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    nullable DV_LOCATION: STRING,
+    nullable DV_OFFSET: LONG,
+    nullable DV_SIZE_IN_BYTES: LONG,
+    nullable DV_CARDINALITY: LONG,
+};
 
 /// Types of the DV descriptor leaves [`DecodedDvVisitor`] decodes, in getter order. Shared across
 /// all source layouts: only the *names* (the projection path to the DV struct) vary per layout, so
@@ -233,7 +229,7 @@ mod tests {
     use crate::actions::deletion_vector::{DeletionVectorDescriptor, DeletionVectorStorageType};
     use crate::engine::sync::SyncEngine;
     use crate::expressions::StructData;
-    use crate::schema::{ColumnNamesAndTypes, ToSchema};
+    use crate::schema::{schema_ref, ColumnNamesAndTypes, StructField, StructType, ToSchema};
     use crate::Engine;
 
     /// Decoded DV columns read back from an augmented batch, one entry per row.
@@ -344,15 +340,16 @@ mod tests {
     impl DvColumnShape {
         /// Schema projecting `dv_schema` at this shape's location.
         fn schema(self, dv_schema: StructType) -> SchemaRef {
-            let dv_field = StructField::nullable("deletionVector", dv_schema);
-            let root = match self {
-                DvColumnShape::ScanRow => StructType::new_unchecked([dv_field]),
-                DvColumnShape::LogBatch => StructType::new_unchecked([StructField::nullable(
-                    "add",
-                    StructType::new_unchecked([dv_field]),
-                )]),
-            };
-            Arc::new(root)
+            match self {
+                DvColumnShape::ScanRow => schema_ref! {
+                    nullable "deletionVector": (dv_schema),
+                },
+                DvColumnShape::LogBatch => schema_ref! {
+                    nullable "add": {
+                        nullable "deletionVector": (dv_schema),
+                    },
+                },
+            }
         }
 
         /// Wraps a DV struct scalar (or a null placeholder) at this shape's root field, matching

--- a/kernel/src/engine/arrow_conversion/mod.rs
+++ b/kernel/src/engine/arrow_conversion/mod.rs
@@ -667,8 +667,8 @@ mod tests {
     #[cfg(feature = "geo-type-in-dev")]
     use crate::schema::EdgeInterpolationAlgorithm;
     use crate::schema::{
-        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, PrimitiveType, StructField,
-        StructType,
+        schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, PrimitiveType,
+        StructField, StructType,
     };
     use crate::transforms::{transform_output_type, SchemaTransform};
     use crate::unit_test_utils::{
@@ -683,10 +683,9 @@ mod tests {
     #[rstest]
     #[case(geometry_type("EPSG:4326"))]
     #[case(geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical))]
-    #[case(DataType::from(StructType::try_new([StructField::nullable(
-        "g",
-        geometry_type("EPSG:4326"),
-    )]).unwrap()))]
+    #[case(DataType::from(schema! {
+        nullable "g": (geometry_type("EPSG:4326")),
+    }))]
     #[case(DataType::from(ArrayType::new(geometry_type("EPSG:4326"), true)))]
     #[case(DataType::from(MapType::new(
         DataType::STRING,
@@ -800,10 +799,10 @@ mod tests {
     #[test]
     fn test_void_field_in_struct() -> DeltaResult<()> {
         // A struct schema with a void column should convert to Arrow with a Null field
-        let schema = StructType::try_new([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("void_col", DataType::VOID),
-        ])?;
+        let schema = schema! {
+            nullable "id": INTEGER,
+            nullable "void_col": VOID,
+        };
 
         let arrow_schema = ArrowSchema::try_from_kernel(&schema)?;
         assert_eq!(arrow_schema.fields().len(), 2);
@@ -954,68 +953,56 @@ mod tests {
         // }
 
         // Build nested struct
-        let inner_struct_type = StructType::try_new(vec![StructField::new(
-            "inner_field",
-            DataType::STRING,
-            false,
-        )
-        .with_metadata([(
-            ColumnMetadataKey::ParquetFieldId.as_ref(),
-            MetadataValue::Number(3),
-        )])])?;
+        let inner_struct_type = schema! {
+            (StructField::not_null("inner_field", DataType::STRING).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(3),
+            )])),
+        };
 
         // Build array element struct
-        let array_item_struct = StructType::try_new(vec![StructField::new(
-            "array_item",
-            DataType::INTEGER,
-            false,
-        )
-        .with_metadata([(
-            ColumnMetadataKey::ParquetFieldId.as_ref(),
-            MetadataValue::Number(5),
-        )])])?;
+        let array_item_struct = schema! {
+            (StructField::not_null("array_item", DataType::INTEGER).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(5),
+            )])),
+        };
         let array_type = ArrayType::new(array_item_struct, false);
 
         // Build map with struct key and struct value (both with field IDs)
-        let map_key_struct = StructType::try_new(vec![StructField::new(
-            "map_key_field",
-            DataType::STRING,
-            false,
-        )
-        .with_metadata([(
-            ColumnMetadataKey::ParquetFieldId.as_ref(),
-            MetadataValue::Number(7),
-        )])])?;
-        let map_value_struct = StructType::try_new(vec![StructField::new(
-            "map_value_field",
-            DataType::INTEGER,
-            false,
-        )
-        .with_metadata([(
-            ColumnMetadataKey::ParquetFieldId.as_ref(),
-            MetadataValue::Number(8),
-        )])])?;
+        let map_key_struct = schema! {
+            (StructField::not_null("map_key_field", DataType::STRING).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(7),
+            )])),
+        };
+        let map_value_struct = schema! {
+            (StructField::not_null("map_value_field", DataType::INTEGER).with_metadata([(
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(8),
+            )])),
+        };
         let map_type = MapType::new(map_key_struct, map_value_struct, false);
 
         // Build top-level struct
-        let top_struct = StructType::try_new(vec![
-            StructField::new("simple_field", DataType::INTEGER, false).with_metadata([(
+        let top_struct = schema! {
+            (StructField::not_null("simple_field", DataType::INTEGER).with_metadata([(
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(1),
-            )]),
-            StructField::new("nested_struct", inner_struct_type, false).with_metadata([(
+            )])),
+            (StructField::not_null("nested_struct", inner_struct_type).with_metadata([(
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(2),
-            )]),
-            StructField::new("array_field", array_type, false).with_metadata([(
+            )])),
+            (StructField::not_null("array_field", array_type).with_metadata([(
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(4),
-            )]),
-            StructField::new("map_field", map_type, false).with_metadata([(
+            )])),
+            (StructField::not_null("map_field", map_type).with_metadata([(
                 ColumnMetadataKey::ParquetFieldId.as_ref(),
                 MetadataValue::Number(6),
-            )]),
-        ])?;
+            )])),
+        };
 
         // Convert to Arrow schema
         let arrow_schema = ArrowSchema::try_from_kernel(&top_struct)?;

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -647,10 +647,10 @@ mod tests {
         ];
 
         // Create schema for the new columns
-        let new_schema = Arc::new(StructType::new_unchecked([
-            StructField::new("age", DataType::INTEGER, true),
-            StructField::new("active", DataType::BOOLEAN, false),
-        ]));
+        let new_schema = schema_ref! {
+            nullable "age": INTEGER,
+            not_null "active": BOOLEAN,
+        };
 
         // Test the append_columns method
         let arrow_data = arrow_data.append_columns(new_schema, new_columns)?;
@@ -733,10 +733,10 @@ mod tests {
             vec![Some("Alice".to_string()), Some("Bob".to_string())],
         )?];
 
-        let new_schema = Arc::new(StructType::new_unchecked([
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("email", DataType::STRING, true), // Extra field in schema
-        ]));
+        let new_schema = schema_ref! {
+            nullable "name": STRING,
+            nullable "email": STRING, // Extra field in schema
+        };
 
         let result = arrow_data.append_columns(new_schema, new_columns);
         assert_result_error_with_message(
@@ -793,7 +793,7 @@ mod tests {
 
         // Create empty schema and columns
         let new_columns = vec![];
-        let new_schema = Arc::new(StructType::new_unchecked([]));
+        let new_schema = schema_ref! {};
 
         let result_data = arrow_data.append_columns(new_schema, new_columns)?;
         let result_batch = extract_record_batch(result_data.as_ref())?;
@@ -830,10 +830,10 @@ mod tests {
             )?,
         ];
 
-        let new_schema = Arc::new(StructType::new_unchecked([
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("age", DataType::INTEGER, true),
-        ]));
+        let new_schema = schema_ref! {
+            nullable "name": STRING,
+            nullable "age": INTEGER,
+        };
 
         let result_data = arrow_data.append_columns(new_schema, new_columns)?;
         let result_batch = extract_record_batch(result_data.as_ref())?;
@@ -872,11 +872,11 @@ mod tests {
             ArrayData::try_new(ArrayType::new(DataType::BOOLEAN, false), vec![true, false])?,
         ];
 
-        let new_schema = Arc::new(StructType::new_unchecked([
-            StructField::new("big_number", DataType::LONG, false),
-            StructField::new("pi", DataType::DOUBLE, true),
-            StructField::new("flag", DataType::BOOLEAN, false),
-        ]));
+        let new_schema = schema_ref! {
+            not_null "big_number": LONG,
+            nullable "pi": DOUBLE,
+            not_null "flag": BOOLEAN,
+        };
 
         let result_data = arrow_data.append_columns(new_schema, new_columns)?;
         let result_batch = extract_record_batch(result_data.as_ref())?;

--- a/kernel/src/engine/arrow_data.rs
+++ b/kernel/src/engine/arrow_data.rs
@@ -569,9 +569,7 @@ mod tests {
     use crate::engine::test_utils::{struct_list_fixture_as, CollectNVisitor, ListFlavor};
     use crate::engine_data::{GetData, ListItem, MapItem, RowVisitor, TypedGetData};
     use crate::expressions::{column_name, ArrayData};
-    use crate::schema::{
-        schema_ref, ArrayType, ColumnName, ColumnNamesAndTypes, DataType, StructField, StructType,
-    };
+    use crate::schema::{schema, schema_ref, ArrayType, ColumnName, ColumnNamesAndTypes, DataType};
     use crate::table_features::TableFeature;
     use crate::unit_test_utils::{assert_result_error_with_message, string_array_to_engine_data};
     use crate::{DeltaResult, Engine as _, EngineData as _};
@@ -1852,8 +1850,7 @@ mod tests {
     impl RowVisitor for StructListVisitor {
         fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
             static NT: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-                let element =
-                    StructType::new_unchecked([StructField::not_null("n", DataType::INTEGER)]);
+                let element = schema! { not_null "n": INTEGER };
                 (
                     vec![ColumnName::new(["items"])],
                     vec![ArrayType::new(element, false).into()],
@@ -1927,8 +1924,7 @@ mod tests {
                 &self,
             ) -> (&'static [ColumnName], &'static [DataType]) {
                 static NT: LazyLock<ColumnNamesAndTypes> = LazyLock::new(|| {
-                    let element =
-                        StructType::new_unchecked([StructField::not_null("n", DataType::INTEGER)]);
+                    let element = schema! { not_null "n": INTEGER };
                     (
                         vec![ColumnName::new(["items"])],
                         // contains_null = true

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1201,11 +1201,11 @@ mod tests {
 
         // Test 1: Empty patch (identity) - should be exactly equal to input
         let patch = ExpressionStructPatchBuilder::new();
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("b", DataType::INTEGER, false),
-            StructField::new("c", DataType::INTEGER, false),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
 
         let expr = Expr::struct_patch(patch).unwrap();
         let result =
@@ -1223,10 +1223,10 @@ mod tests {
         let nested_batch = create_nested_test_batch();
         let nested_patch = ExpressionStructPatchBuilder::new_nested(["nested"]);
 
-        let nested_output_schema = StructType::new_unchecked(vec![
-            StructField::new("x", DataType::INTEGER, false),
-            StructField::new("y", DataType::INTEGER, false),
-        ]);
+        let nested_output_schema = schema! {
+            not_null "x": INTEGER,
+            not_null "y": INTEGER,
+        };
 
         let expr_nested = Expr::struct_patch(nested_patch).unwrap();
         let result_nested = evaluate_expression(
@@ -1272,17 +1272,17 @@ mod tests {
             .insert_after("c", lit(99))
             .append(lit(7));
 
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::new("pre1", DataType::INTEGER, false), // prepend 1
-            StructField::new("pre2", DataType::INTEGER, false), // prepend 2
-            StructField::new("pre3", DataType::INTEGER, false), // prepend 3 (column c)
-            StructField::new("a", DataType::INTEGER, false),    // replaced with column b
-            StructField::new("c", DataType::INTEGER, false),    // passed through
-            StructField::new("after_c1", DataType::INTEGER, false), // first insertion after c
-            StructField::new("after_c2", DataType::INTEGER, false), // second insertion after c
-            StructField::new("after_c3", DataType::INTEGER, false), // third insertion after c
-            StructField::new("append1", DataType::INTEGER, false), // true append
-        ]);
+        let output_schema = schema! {
+            not_null "pre1": INTEGER,
+            not_null "pre2": INTEGER,
+            not_null "pre3": INTEGER,
+            not_null "a": INTEGER,
+            not_null "c": INTEGER,
+            not_null "after_c1": INTEGER,
+            not_null "after_c2": INTEGER,
+            not_null "after_c3": INTEGER,
+            not_null "append1": INTEGER,
+        };
 
         let expr = Expr::struct_patch(patch).unwrap();
         let result =
@@ -1320,20 +1320,16 @@ mod tests {
             .insert_after("a", lit(42))
             .replace("a", col!("b"));
 
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("after_a", DataType::INTEGER, false),
-            StructField::new("b", DataType::INTEGER, false),
-            StructField::new("c", DataType::INTEGER, false),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "after_a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
 
         let expr = Expr::struct_patch(patch).unwrap();
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
 
         let struct_result = result.as_any().downcast_ref::<StructArray>().unwrap();
         validate_i32_column(struct_result, 0, &[10, 20, 30]); // replacement column b
@@ -1349,10 +1345,10 @@ mod tests {
         // Test 1: Simple struct relocation (copy nested struct to top level unchanged)
         let copy_patch = ExpressionStructPatchBuilder::new_nested(["nested"]);
 
-        let copy_output_schema = StructType::new_unchecked(vec![
-            StructField::new("x", DataType::INTEGER, false),
-            StructField::new("y", DataType::INTEGER, false),
-        ]);
+        let copy_output_schema = schema! {
+            not_null "x": INTEGER,
+            not_null "y": INTEGER,
+        };
 
         let expr_copy = Expr::struct_patch(copy_patch).unwrap();
         let result_copy = evaluate_expression(
@@ -1383,11 +1379,11 @@ mod tests {
             .replace("x", lit(777))
             .insert_after("y", lit(555));
 
-        let modify_output_schema = StructType::new_unchecked(vec![
-            StructField::new("x", DataType::INTEGER, false), // replaced with literal 777
-            StructField::new("y", DataType::INTEGER, false), // passed through
-            StructField::new("new_field", DataType::INTEGER, false), // inserted after y
-        ]);
+        let modify_output_schema = schema! {
+            not_null "x": INTEGER,
+            not_null "y": INTEGER,
+            not_null "new_field": INTEGER,
+        };
 
         let expr_modify = Expr::struct_patch(modify_patch).unwrap();
         let result_modify = evaluate_expression(
@@ -1420,11 +1416,11 @@ mod tests {
 
         // Test unused replacement keys
         let patch = ExpressionStructPatchBuilder::new().replace("missing", lit(1));
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
 
         let expr = Expr::struct_patch(patch).unwrap();
         let result =
@@ -1450,11 +1446,11 @@ mod tests {
         // Test column count mismatch -- too many output schema fields
         let drop_patch = ExpressionStructPatchBuilder::new().drop("a");
 
-        let wrong_output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("a", DataType::INTEGER), // expects a field that was dropped
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let wrong_output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
 
         let expr3 = Expr::struct_patch(drop_patch).unwrap();
         let result3 =
@@ -1468,8 +1464,7 @@ mod tests {
         // Test column count mismatch -- too few output schema fields
         let drop_patch = ExpressionStructPatchBuilder::new().drop("a");
 
-        let wrong_output_schema =
-            StructType::new_unchecked(vec![StructField::not_null("c", DataType::INTEGER)]);
+        let wrong_output_schema = schema! { not_null "c": INTEGER };
 
         let expr3 = Expr::struct_patch(drop_patch).unwrap();
         let result3 =
@@ -1494,20 +1489,17 @@ mod tests {
     #[test]
     fn test_replacement_occupies_field_position() {
         let batch = create_test_batch();
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
 
         let patch = ExpressionStructPatchBuilder::new().replace("a", lit(1));
         let expr = Expr::struct_patch(patch).unwrap();
-        let result = evaluate_expression(
-            &expr,
-            &batch,
-            Some(&DataType::Struct(Box::new(output_schema.clone()))),
-        )
-        .unwrap();
+        let result =
+            evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema.clone())))
+                .unwrap();
         let result = result.as_any().downcast_ref::<StructArray>().unwrap();
         validate_i32_column(result, 0, &[1, 1, 1]);
         validate_i32_column(result, 1, &[10, 20, 30]);
@@ -1518,10 +1510,10 @@ mod tests {
     fn test_drop_field_if_exists_present() {
         let batch = create_test_batch();
         let patch = ExpressionStructPatchBuilder::new().drop_if_exists("a");
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
         let expr = Expr::struct_patch(patch).unwrap();
         let result =
             evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
@@ -1534,11 +1526,11 @@ mod tests {
     fn test_drop_field_if_exists_missing() {
         let batch = create_test_batch();
         let patch = ExpressionStructPatchBuilder::new().drop_if_exists("nonexistent");
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
         let expr = Expr::struct_patch(patch).unwrap();
         let result =
             evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema))).unwrap();
@@ -1552,11 +1544,11 @@ mod tests {
     fn test_drop_field_non_optional_missing_still_errors() {
         let batch = create_test_batch();
         let patch = ExpressionStructPatchBuilder::new().drop("nonexistent");
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::not_null("b", DataType::INTEGER),
-            StructField::not_null("c", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+            not_null "c": INTEGER,
+        };
         let expr = Expr::struct_patch(patch).unwrap();
         let result = evaluate_expression(&expr, &batch, Some(&DataType::from(output_schema)));
         assert!(result
@@ -1573,11 +1565,11 @@ mod tests {
             (
                 "too many schema fields",
                 Expr::struct_from([column_expr_ref!("a"), column_expr_ref!("b")]),
-                StructType::new_unchecked(vec![
-                    StructField::not_null("a", DataType::INTEGER),
-                    StructField::not_null("b", DataType::INTEGER),
-                    StructField::not_null("c", DataType::INTEGER),
-                ]),
+                schema! {
+                    not_null "a": INTEGER,
+                    not_null "b": INTEGER,
+                    not_null "c": INTEGER,
+                },
             ),
             (
                 "too few schema fields",
@@ -1586,10 +1578,10 @@ mod tests {
                     column_expr_ref!("b"),
                     column_expr_ref!("c"),
                 ]),
-                StructType::new_unchecked(vec![
-                    StructField::not_null("a", DataType::INTEGER),
-                    StructField::not_null("b", DataType::INTEGER),
-                ]),
+                schema! {
+                    not_null "a": INTEGER,
+                    not_null "b": INTEGER,
+                },
             ),
         ];
 
@@ -2182,9 +2174,7 @@ mod tests {
         )
         .unwrap();
 
-        let output_type = DataType::Struct(Box::new(StructType::new_unchecked(vec![
-            StructField::nullable("v", DataType::INTEGER),
-        ])));
+        let output_type = DataType::from(schema! { nullable "v": INTEGER });
         let expr = Expr::struct_with_nullability_from(
             [Arc::new(col!("v"))],
             Arc::new(Expr::from_pred(Pred::from_expr(col!("p")))),
@@ -2694,11 +2684,11 @@ mod tests {
         use crate::arrow::array::Date32Array;
 
         let batch = create_partition_map_batch();
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("date", DataType::DATE),
-        ]);
+        let output_schema = schema! {
+            nullable "region": STRING,
+            nullable "id": INTEGER,
+            nullable "date": DATE,
+        };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -2774,8 +2764,7 @@ mod tests {
         )]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
 
-        let output_schema =
-            StructType::new_unchecked(vec![StructField::nullable("region", DataType::STRING)]);
+        let output_schema = schema! { nullable "region": STRING };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -2828,8 +2817,7 @@ mod tests {
         )]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
 
-        let output_schema =
-            StructType::new_unchecked(vec![StructField::nullable("ts", DataType::TIMESTAMP)]);
+        let output_schema = schema! { nullable "ts": TIMESTAMP };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -2910,10 +2898,10 @@ mod tests {
         )]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
 
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::new("region", DataType::STRING, false),
-            StructField::new("id", DataType::INTEGER, false),
-        ]);
+        let output_schema = schema! {
+            not_null "region": STRING,
+            not_null "id": INTEGER,
+        };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -2995,11 +2983,11 @@ mod tests {
         )]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
 
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("blob", DataType::BINARY),
-            StructField::nullable("count", DataType::INTEGER),
-        ]);
+        let output_schema = schema! {
+            nullable "region": STRING,
+            nullable "blob": BINARY,
+            nullable "count": INTEGER,
+        };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -3048,10 +3036,10 @@ mod tests {
         )]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(map_array)]).unwrap();
 
-        let output_schema = StructType::new_unchecked(vec![
-            StructField::nullable("d", DataType::DATE),
-            StructField::nullable("ts", DataType::TIMESTAMP_NTZ),
-        ]);
+        let output_schema = schema! {
+            nullable "d": DATE,
+            nullable "ts": TIMESTAMP_NTZ,
+        };
         let result_type = DataType::from(output_schema);
         let expr = Expr::map_to_struct(col!("pv"));
         let result = evaluate_expression(&expr, &batch, Some(&result_type)).unwrap();
@@ -3172,10 +3160,10 @@ mod tests {
             ],
         )
         .unwrap();
-        let schema = DataType::from(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::INTEGER, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]));
+        let schema = DataType::from(schema! {
+            nullable "a": INTEGER,
+            nullable "b": INTEGER,
+        });
         let expr = Expr::struct_with_nullability_from(
             [column_expr_ref!("a"), column_expr_ref!("b")],
             column_expr_ref!("is_valid"),
@@ -3233,11 +3221,10 @@ mod tests {
             ],
         );
 
-        let logical_type = DataType::try_struct_type([
-            StructField::nullable("my_column", DataType::LONG),
-            StructField::nullable("other_column", DataType::LONG),
-        ])
-        .unwrap();
+        let logical_type = DataType::from(schema! {
+            nullable "my_column": LONG,
+            nullable "other_column": LONG,
+        });
 
         let expr = col!("stats");
         let result = evaluate_expression(&expr, &batch, Some(&logical_type));
@@ -3257,11 +3244,10 @@ mod tests {
             ],
         );
 
-        let logical_type = DataType::try_struct_type([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ])
-        .unwrap();
+        let logical_type = DataType::from(schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+        });
 
         let expr = col!("stats");
         let result = evaluate_expression(&expr, &batch, Some(&logical_type));
@@ -3281,11 +3267,10 @@ mod tests {
             ],
         );
 
-        let logical_type = DataType::try_struct_type([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ])
-        .unwrap();
+        let logical_type = DataType::from(schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+        });
 
         let expr = col!("stats");
         let result = evaluate_expression(&expr, &batch, Some(&logical_type));
@@ -3342,17 +3327,13 @@ mod tests {
         ]);
 
         // Output schema uses logical names (differs from physical names in the batch)
-        let output_type = DataType::try_struct_type([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable(
-                "stats_parsed",
-                DataType::struct_type_unchecked([
-                    StructField::nullable("id", DataType::LONG),
-                    StructField::nullable("value", DataType::LONG),
-                ]),
-            ),
-        ])
-        .unwrap();
+        let output_type = DataType::from(schema! {
+            nullable "path": STRING,
+            nullable "stats_parsed": {
+                nullable "id": LONG,
+                nullable "value": LONG,
+            },
+        });
 
         let result = evaluate_expression(&expr, &batch, Some(&output_type));
         assert_result_error_with_message(result, "Missing Struct fields");
@@ -3521,10 +3502,10 @@ mod tests {
     // `expected` is indexed as `expected[row][element_in_list][field_in_struct]`.
     #[rstest]
     #[case::array_of_two_field_structs(
-        StructType::try_new([
-            StructField::not_null("x", DataType::INTEGER),
-            StructField::not_null("y", DataType::INTEGER),
-        ]).unwrap(),
+        schema! {
+            not_null "x": INTEGER,
+            not_null "y": INTEGER,
+        },
         Expr::array([
             Expr::struct_from([col!("a"), col!("b")]),
             Expr::struct_from([col!("b"), col!("c")]),
@@ -3536,7 +3517,7 @@ mod tests {
         ],
     )]
     #[case::coalesce_of_arrays_of_structs(
-        StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap(),
+        schema! { not_null "x": INTEGER },
         Expr::coalesce([
             Expr::array([
                 Expr::struct_from([col!("a")]),
@@ -3586,8 +3567,7 @@ mod tests {
         // guard operates on struct-level nulls only, so this must succeed and pass the
         // inner null through to the output.
         let batch = ab_batch_with_b_nulls();
-        let inner_field_schema =
-            StructType::try_new([StructField::nullable("value", DataType::INTEGER)]).unwrap();
+        let inner_field_schema = schema! { nullable "value": INTEGER };
         let array_ty = DataType::from(crate::schema::ArrayType::new(
             inner_field_schema,
             /* contains_null = */ false,

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -2328,10 +2328,9 @@ mod tests {
         #[case] input: Vec<Option<&str>>,
         #[case] expected_null_count: usize,
     ) {
-        let output_schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
-            "a",
-            DataType::LONG,
-        )]));
+        let output_schema = schema_ref! {
+            nullable "a": LONG,
+        };
         let schema = ArrowSchema::new(vec![ArrowField::new("s", ArrowDataType::Utf8, true)]);
         let batch = RecordBatch::try_new(
             Arc::new(schema),
@@ -2350,10 +2349,10 @@ mod tests {
         let batch = create_json_batch();
 
         // Define the output schema for parsing
-        let output_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::STRING, true),
-        ]));
+        let output_schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        };
 
         let expr = Expr::parse_json(col!("json_col"), output_schema);
         let result = evaluate_expression(&expr, &batch, None).unwrap();
@@ -2427,10 +2426,10 @@ mod tests {
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap();
 
-        let output_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::STRING, true),
-        ]));
+        let output_schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        };
 
         let expr = Expr::parse_json(col!("json_col"), output_schema);
         let result = evaluate_expression(&expr, &batch, None).unwrap();
@@ -2563,10 +2562,10 @@ mod tests {
         ]);
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap();
 
-        let output_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::STRING, true),
-        ]));
+        let output_schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        };
 
         let expr = Expr::parse_json(col!("json_col"), output_schema);
         let result = evaluate_expression(&expr, &batch, None).unwrap();
@@ -2604,10 +2603,10 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(json_strings)]).unwrap();
 
         // Schema only asks for "a" and "b"
-        let output_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::STRING, true),
-        ]));
+        let output_schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        };
 
         let expr = Expr::parse_json(col!("json_col"), output_schema);
         let result = evaluate_expression(&expr, &batch, None).unwrap();

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -27,7 +27,9 @@ use crate::kernel_predicates::{
 };
 #[cfg(feature = "geo-type-in-dev")]
 use crate::schema::EdgeInterpolationAlgorithm;
-use crate::schema::{ArrayType, DataType as KernelDataType, MapType, StructField, StructType};
+use crate::schema::{
+    schema_ref, ArrayType, DataType as KernelDataType, MapType, StructField, StructType,
+};
 use crate::unit_test_utils::assert_result_error_with_message;
 #[cfg(feature = "geo-type-in-dev")]
 use crate::unit_test_utils::{geography_type, geometry_type};
@@ -768,16 +770,13 @@ fn test_opaque() {
 #[test]
 fn test_null_row() {
     // note that we _allow_ nested nulls, since the top-level struct can be NULL
-    let schema = Arc::new(StructType::new_unchecked(vec![
-        StructField::nullable(
-            "x",
-            StructType::new_unchecked([
-                StructField::nullable("a", KernelDataType::INTEGER),
-                StructField::not_null("b", KernelDataType::STRING),
-            ]),
-        ),
-        StructField::nullable("c", KernelDataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "x": {
+            nullable "a": INTEGER,
+            not_null "b": STRING,
+        },
+        nullable "c": STRING,
+    };
     let handler = ArrowEvaluationHandler;
     let result = handler.null_row(schema.clone()).unwrap();
     let expected = RecordBatch::try_new(
@@ -802,10 +801,9 @@ fn test_null_row() {
 
 #[test]
 fn test_null_row_err() {
-    let not_null_schema = Arc::new(StructType::new_unchecked(vec![StructField::not_null(
-        "a",
-        KernelDataType::STRING,
-    )]));
+    let not_null_schema = schema_ref! {
+        not_null "a": STRING,
+    };
     let handler = ArrowEvaluationHandler;
     assert_result_error_with_message(
         handler.null_row(not_null_schema),
@@ -829,12 +827,12 @@ fn test_create_one() {
         3.into(),
         Scalar::Null(KernelDataType::INTEGER),
     ];
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", KernelDataType::INTEGER),
-        StructField::nullable("b", KernelDataType::STRING),
-        StructField::not_null("c", KernelDataType::INTEGER),
-        StructField::nullable("d", KernelDataType::INTEGER),
-    ]));
+    let schema = schema_ref! {
+        nullable "a": INTEGER,
+        nullable "b": STRING,
+        not_null "c": INTEGER,
+        nullable "d": INTEGER,
+    };
 
     let expected_schema = Arc::new(Schema::new(vec![
         Field::new("a", DataType::Int32, true),
@@ -858,13 +856,12 @@ fn test_create_one() {
 #[test]
 fn test_create_one_nested() {
     let values: &[Scalar] = &[1.into(), 2.into()];
-    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "a",
-        KernelDataType::struct_type_unchecked([
-            StructField::nullable("b", KernelDataType::INTEGER),
-            StructField::not_null("c", KernelDataType::INTEGER),
-        ]),
-    )]));
+    let schema = schema_ref! {
+        not_null "a": {
+            nullable "b": INTEGER,
+            not_null "c": INTEGER,
+        },
+    };
     let expected_schema = Arc::new(Schema::new(vec![Field::new(
         "a",
         DataType::Struct(
@@ -896,13 +893,12 @@ fn test_create_one_nested() {
 #[test]
 fn test_create_one_nested_null() {
     let values: &[Scalar] = &[Scalar::Null(KernelDataType::INTEGER), 1.into()];
-    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "a",
-        KernelDataType::struct_type_unchecked([
-            StructField::nullable("b", KernelDataType::INTEGER),
-            StructField::not_null("c", KernelDataType::INTEGER),
-        ]),
-    )]));
+    let schema = schema_ref! {
+        not_null "a": {
+            nullable "b": INTEGER,
+            not_null "c": INTEGER,
+        },
+    };
     let expected_schema = Arc::new(Schema::new(vec![Field::new(
         "a",
         DataType::Struct(
@@ -935,10 +931,9 @@ fn test_create_one_nested_null() {
 fn test_create_one_mismatching_scalar_types() {
     // Scalar is a LONG but schema specifies INTEGER
     let values: &[Scalar] = &[Scalar::Long(10)];
-    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "version",
-        KernelDataType::INTEGER,
-    )]));
+    let schema = schema_ref! {
+        not_null "version": INTEGER,
+    };
     let handler = ArrowEvaluationHandler;
     assert_result_error_with_message(
         handler.create_one(schema, values),
@@ -954,13 +949,12 @@ fn test_create_one_not_null_struct() {
         Scalar::Null(KernelDataType::INTEGER),
         Scalar::Null(KernelDataType::INTEGER),
     ];
-    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "a",
-        KernelDataType::struct_type_unchecked([
-            StructField::not_null("b", KernelDataType::INTEGER),
-            StructField::nullable("c", KernelDataType::INTEGER),
-        ]),
-    )]));
+    let schema = schema_ref! {
+        not_null "a": {
+            not_null "b": INTEGER,
+            nullable "c": INTEGER,
+        },
+    };
     let handler = ArrowEvaluationHandler;
     assert_result_error_with_message(
         handler.create_one(schema, values),
@@ -975,10 +969,9 @@ fn test_create_one_top_level_null() {
     let values = &[Scalar::Null(KernelDataType::INTEGER)];
     let handler = ArrowEvaluationHandler;
 
-    let schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "col_1",
-        KernelDataType::INTEGER,
-    )]));
+    let schema = schema_ref! {
+        not_null "col_1": INTEGER,
+    };
     assert_result_error_with_message(
         handler.create_one(schema, values),
         "Column 'col_1' is declared as non-nullable but contains null values",
@@ -1284,10 +1277,9 @@ fn test_evaluator_mixed_string_types_struct_expression() {
     let engine_data = ArrowEngineData::new(batch);
 
     let fields = mixed_string_kernel_fields();
-    let input_schema = Arc::new(StructType::new_unchecked([StructField::not_null(
-        "st",
-        KernelDataType::struct_type_unchecked(fields.clone()),
-    )]));
+    let input_schema = schema_ref! {
+        not_null "st": (KernelDataType::struct_type_unchecked(fields.clone())),
+    };
     let output_type = KernelDataType::from(StructType::new_unchecked(fields));
 
     let handler = ArrowEvaluationHandler;
@@ -1312,10 +1304,10 @@ fn test_create_many_multiple_rows() {
     let row1: &[Scalar] = &[1.into(), "A".into()];
     let row2: &[Scalar] = &[2.into(), "B".into()];
     let row3: &[Scalar] = &[Scalar::Null(KernelDataType::INTEGER), "C".into()];
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", KernelDataType::INTEGER),
-        StructField::nullable("name", KernelDataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    };
     let expected_schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, true),
         Field::new("name", DataType::Utf8, true),
@@ -1333,10 +1325,10 @@ fn test_create_many_multiple_rows() {
 
 #[test]
 fn test_create_many_empty_rows_returns_zero_row_batch() {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", KernelDataType::INTEGER),
-        StructField::nullable("b", KernelDataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "a": INTEGER,
+        nullable "b": STRING,
+    };
     let handler = ArrowEvaluationHandler;
     let result = handler.create_many(schema.clone(), &[]).unwrap();
     assert_eq!(result.len(), 0);
@@ -1347,10 +1339,10 @@ fn test_create_many_empty_rows_returns_zero_row_batch() {
 
 #[test]
 fn test_create_many_wrong_field_count_returns_error() {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", KernelDataType::INTEGER),
-        StructField::nullable("b", KernelDataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "a": INTEGER,
+        nullable "b": STRING,
+    };
     // Row has 3 scalars but schema has 2 fields
     let bad_row: &[Scalar] = &[1.into(), "x".into(), 99.into()];
     let handler = ArrowEvaluationHandler;
@@ -1362,10 +1354,10 @@ fn test_create_many_wrong_field_count_returns_error() {
 
 #[test]
 fn test_create_many_wrong_field_type_returns_error() {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", KernelDataType::INTEGER),
-        StructField::nullable("b", KernelDataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "a": INTEGER,
+        nullable "b": STRING,
+    };
     // Row 1 passes a Long where an Integer is expected for field "a"
     let good_row: &[Scalar] = &[1.into(), "x".into()];
     let bad_row: &[Scalar] = &[1i64.into(), "y".into()];
@@ -1384,11 +1376,11 @@ fn test_create_many_single_row_matches_create_one() {
         "hello".into(),
         Scalar::Null(KernelDataType::INTEGER),
     ];
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", KernelDataType::INTEGER),
-        StructField::nullable("b", KernelDataType::STRING),
-        StructField::nullable("c", KernelDataType::INTEGER),
-    ]));
+    let schema = schema_ref! {
+        nullable "a": INTEGER,
+        nullable "b": STRING,
+        nullable "c": INTEGER,
+    };
     let handler = ArrowEvaluationHandler;
     let from_one = handler
         .create_one(schema.clone(), values)
@@ -1410,10 +1402,10 @@ fn test_create_many_nested_struct() {
         StructField::nullable("x", KernelDataType::INTEGER),
         StructField::nullable("y", KernelDataType::STRING),
     ]);
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("inner", inner_type.clone()),
-        StructField::nullable("flag", KernelDataType::BOOLEAN),
-    ]));
+    let schema = schema_ref! {
+        nullable "inner": (inner_type.clone()),
+        nullable "flag": BOOLEAN,
+    };
 
     // Row 1: inner = Struct { x: 10, y: "hello" }, flag = true
     let row1: &[Scalar] = &[

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -28,7 +28,7 @@ use crate::kernel_predicates::{
 #[cfg(feature = "geo-type-in-dev")]
 use crate::schema::EdgeInterpolationAlgorithm;
 use crate::schema::{
-    schema_ref, ArrayType, DataType as KernelDataType, MapType, StructField, StructType,
+    schema, schema_ref, ArrayType, DataType as KernelDataType, MapType, StructField, StructType,
 };
 use crate::unit_test_utils::assert_result_error_with_message;
 #[cfg(feature = "geo-type-in-dev")]
@@ -279,14 +279,14 @@ fn test_literal_complex_type_array() {
         )
         .unwrap(),
     );
-    let struct_fields = vec![
-        StructField::nullable("scalar", KernelDataType::INTEGER),
-        StructField::nullable("list", array_type.clone()),
-        StructField::nullable("null_list", array_type.clone()),
-        StructField::nullable("map", map_type.clone()),
-        StructField::nullable("null_map", map_type.clone()),
-    ];
-    let struct_type = StructType::new_unchecked(struct_fields.clone());
+    let struct_type = schema! {
+        nullable "scalar": INTEGER,
+        nullable "list": (array_type.clone()),
+        nullable "null_list": (array_type.clone()),
+        nullable "map": (map_type.clone()),
+        nullable "null_map": (map_type.clone()),
+    };
+    let struct_fields = struct_type.fields().cloned().collect::<Vec<_>>();
     let struct_value = Scalar::Struct(
         crate::expressions::StructData::try_new(
             struct_fields.clone(),
@@ -1048,10 +1048,10 @@ fn test_apply_schema_column_count_mismatch() {
     ]);
 
     // Create a schema with only 2 fields (mismatch)
-    let schema = KernelDataType::from(StructType::new_unchecked([
-        StructField::not_null("a", KernelDataType::INTEGER),
-        StructField::not_null("b", KernelDataType::INTEGER),
-    ]));
+    let schema = KernelDataType::from(schema! {
+        not_null "a": INTEGER,
+        not_null "b": INTEGER,
+    });
 
     let result = apply_schema(&struct_array, &schema);
 
@@ -1234,12 +1234,12 @@ fn make_mixed_string_batch() -> RecordBatch {
     .unwrap()
 }
 
-fn mixed_string_kernel_fields() -> [StructField; 3] {
-    [
-        StructField::nullable("s_utf8", KernelDataType::STRING),
-        StructField::nullable("s_large", KernelDataType::STRING),
-        StructField::nullable("s_view", KernelDataType::STRING),
-    ]
+fn mixed_string_kernel_schema() -> StructType {
+    schema! {
+        nullable "s_utf8": STRING,
+        nullable "s_large": STRING,
+        nullable "s_view": STRING,
+    }
 }
 
 /// Evaluator must succeed when a struct contains Utf8, LargeUtf8, and Utf8View columns in the
@@ -1248,9 +1248,9 @@ fn mixed_string_kernel_fields() -> [StructField; 3] {
 #[test]
 fn test_evaluator_mixed_string_types_identity_transform() {
     let engine_data = ArrowEngineData::new(make_mixed_string_batch());
-    let fields = mixed_string_kernel_fields();
-    let input_schema = Arc::new(StructType::new_unchecked(fields.clone()));
-    let output_type = KernelDataType::from(StructType::new_unchecked(fields));
+    let schema = mixed_string_kernel_schema();
+    let input_schema = Arc::new(schema.clone());
+    let output_type = KernelDataType::from(schema);
 
     let handler = ArrowEvaluationHandler;
     let expression: ExpressionRef =
@@ -1276,11 +1276,11 @@ fn test_evaluator_mixed_string_types_struct_expression() {
     .unwrap();
     let engine_data = ArrowEngineData::new(batch);
 
-    let fields = mixed_string_kernel_fields();
+    let schema = mixed_string_kernel_schema();
     let input_schema = schema_ref! {
-        not_null "st": (KernelDataType::struct_type_unchecked(fields.clone())),
+        not_null "st": (schema.clone()),
     };
-    let output_type = KernelDataType::from(StructType::new_unchecked(fields));
+    let output_type = KernelDataType::from(schema);
 
     let handler = ArrowEvaluationHandler;
     let expression: ExpressionRef = Arc::new(col!("st"));
@@ -1398,10 +1398,10 @@ fn test_create_many_single_row_matches_create_one() {
 #[test]
 fn test_create_many_nested_struct() {
     // Schema: outer { inner: Struct { x: INT, y: STRING }, flag: BOOLEAN }
-    let inner_type = KernelDataType::struct_type_unchecked([
-        StructField::nullable("x", KernelDataType::INTEGER),
-        StructField::nullable("y", KernelDataType::STRING),
-    ]);
+    let inner_type = KernelDataType::from(schema! {
+        nullable "x": INTEGER,
+        nullable "y": STRING,
+    });
     let schema = schema_ref! {
         nullable "inner": (inner_type.clone()),
         nullable "flag": BOOLEAN,

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -391,7 +391,9 @@ mod apply_schema_validation_tests {
         DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
     use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
-    use crate::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
+    use crate::schema::{
+        schema, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
     use crate::unit_test_utils::{
         array_in_map_arrow_data_without_field_ids, array_in_map_kernel_schema,
         array_in_map_with_field_ids, assert_result_error_with_message,
@@ -463,10 +465,10 @@ mod apply_schema_validation_tests {
     }
 
     fn create_target_schema_2_fields() -> StructType {
-        StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("b", DataType::INTEGER, false),
-        ])
+        schema! {
+            not_null "a": INTEGER,
+            not_null "b": INTEGER,
+        }
     }
 
     /// Test that apply_schema handles structs with top-level nulls correctly.
@@ -500,10 +502,10 @@ mod apply_schema_validation_tests {
         .unwrap();
 
         // Target schema with nullable fields
-        let target_schema = DataType::from(StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, true),
-            StructField::new("b", DataType::INTEGER, true),
-        ]));
+        let target_schema = DataType::from(schema! {
+            nullable "a": INTEGER,
+            nullable "b": INTEGER,
+        });
 
         // Apply schema - should successfully convert to RecordBatch
         let result = apply_schema(&struct_array, &target_schema).unwrap();
@@ -548,9 +550,10 @@ mod apply_schema_validation_tests {
     #[test]
     fn test_apply_schema_transforms_parquet_field_id_metadata() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
-        let target_schema =
-            StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)
-                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])]);
+        let target_schema = schema! {
+            (StructField::new("a", DataType::INTEGER, false)
+                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
+        };
 
         let arrow_field = ArrowField::new("a", ArrowDataType::Int32, false);
         let input_array = StructArray::try_new(
@@ -584,9 +587,10 @@ mod apply_schema_validation_tests {
     #[test]
     fn test_apply_schema_matching_field_ids_succeed() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
-        let target_schema =
-            StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)
-                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])]);
+        let target_schema = schema! {
+            (StructField::new("a", DataType::INTEGER, false)
+                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
+        };
 
         let arrow_field = ArrowField::new("a", ArrowDataType::Int32, false)
             .with_metadata([(PARQUET_FIELD_ID_META_KEY.to_string(), "42".to_string())].into());
@@ -606,9 +610,10 @@ mod apply_schema_validation_tests {
     #[test]
     fn test_apply_schema_conflicting_field_ids_fail() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
-        let target_schema =
-            StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)
-                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])]);
+        let target_schema = schema! {
+            (StructField::new("a", DataType::INTEGER, false)
+                .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
+        };
 
         let arrow_field = ArrowField::new("a", ArrowDataType::Int32, false)
             .with_metadata([(PARQUET_FIELD_ID_META_KEY.to_string(), "99".to_string())].into());

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -2268,13 +2268,11 @@ mod tests {
     #[test]
     fn mask_with_map() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = schema! {
-                (StructField::not_null(
-                    logical_name(0),
-                    MapType::new(DataType::INTEGER, DataType::STRING, false),
-                )
-                .with_metadata(column_mapping_metadata(0, mode))),
-            }
+            let requested_schema = StructType::new_unchecked([StructField::not_null(
+                logical_name(0),
+                MapType::new(DataType::INTEGER, DataType::STRING, false),
+            )
+            .with_metadata(column_mapping_metadata(0, mode))])
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2965,13 +2963,11 @@ mod tests {
     #[test]
     fn list_skip_earlier_element() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = schema! {
-                (StructField::not_null(
-                    logical_name(1),
-                    ArrayType::new(DataType::INTEGER, false),
-                )
-                .with_metadata(column_mapping_metadata(1, mode))),
-            }
+            let requested_schema = StructType::new_unchecked([StructField::not_null(
+                logical_name(1),
+                ArrayType::new(DataType::INTEGER, false),
+            )
+            .with_metadata(column_mapping_metadata(1, mode))])
             .make_physical(mode)
             .unwrap()
             .into();

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -35,7 +35,7 @@ use crate::parquet::arrow::{ProjectionMask, PARQUET_FIELD_ID_META_KEY};
 use crate::parquet::file::metadata::RowGroupMetaData;
 use crate::parquet::schema::types::SchemaDescriptor;
 use crate::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec, MetadataValue,
+    schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataColumnSpec, MetadataValue,
     PrimitiveType, Schema, SchemaRef, StructField, StructType,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
@@ -531,11 +531,13 @@ fn get_indices(
                     // we just want to transparently recurse into lists, need to transform the
                     // kernel list data type into a schema
                     if let DataType::Array(array_type) = requested_field.data_type() {
-                        let requested_schema = StructType::new_unchecked([StructField::new(
-                            list_field.name().clone(), // so we find it in the inner call
-                            array_type.element_type.clone(),
-                            array_type.contains_null,
-                        )]);
+                        let requested_schema = schema! {
+                            (StructField::new(
+                                list_field.name().clone(), // so we find it in the inner call
+                                array_type.element_type.clone(),
+                                array_type.contains_null,
+                            )),
+                        };
                         let mask_before = mask_indices.len();
                         let (parquet_advance, mut children) = get_indices(
                             parquet_index + parquet_offset,
@@ -1686,14 +1688,11 @@ mod tests {
             );
         }
 
-        let requested_schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::STRING),
-                StructField::nullable("c", DataType::INTEGER),
-            ])
-            .unwrap(),
-        );
+        let requested_schema = schema_ref! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+            nullable "c": INTEGER,
+        };
         let input: Vec<&str> = vec![];
         let result = parse_json_impl(&StringArray::from(input), requested_schema.clone()).unwrap();
         assert_eq!(result.num_rows(), 0);
@@ -1728,9 +1727,7 @@ mod tests {
     #[test]
     fn test_parse_json_with_long_strings() {
         // See issue#1139: https://github.com/delta-io/delta-kernel-rs/issues/1139
-        let schema = Arc::new(
-            StructType::try_new(vec![StructField::nullable("long_val", DataType::STRING)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "long_val": STRING };
         let long_string = "a".repeat(1_000_000); // 1MB string
         let json_string = format!(r#"{{"long_val": "{long_string}"}}"#);
         let input: Vec<Option<&str>> = vec![Some(&json_string)];
@@ -1816,9 +1813,7 @@ mod tests {
     fn test_parse_json_impl_strict_leaf_errors_propagate() {
         // Type mismatches on strict (non-failure-prone) leaves still surface as batch-level
         // errors, so the expression-level caller can fall back to its all-null backstop.
-        let schema = Arc::new(
-            StructType::try_new(vec![StructField::nullable("a", DataType::LONG)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "a": LONG };
         let input: Vec<Option<&str>> = vec![Some(r#"{"a": "not_a_number"}"#)];
         assert!(parse_json_impl(&StringArray::from(input), schema).is_err());
     }
@@ -1833,9 +1828,7 @@ mod tests {
         inputs: &[&str],
         expected_null_rows: &[usize],
     ) {
-        let schema = Arc::new(
-            StructType::try_new(vec![StructField::nullable(column_name, leaf_type)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable (column_name): (leaf_type) };
         let inputs: Vec<Option<&str>> = inputs.iter().copied().map(Some).collect();
         let batch = parse_json_impl(&StringArray::from(inputs.clone()), schema)
             .expect("parse_json_impl should not error on failure-prone leaf parse failures");
@@ -1904,15 +1897,12 @@ mod tests {
         // Single struct with mixed failure-prone and strict leaves. The bad EventTime on row 1
         // must not contaminate IngestTime / Price / UserId on the same row, nor any field on
         // rows 0 / 2. This is the per-cell isolation property end-to-end.
-        let schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("EventTime", DataType::TIMESTAMP),
-                StructField::nullable("IngestTime", DataType::TIMESTAMP),
-                StructField::nullable("Price", DataType::decimal(10, 2).unwrap()),
-                StructField::nullable("UserId", DataType::LONG),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "EventTime": TIMESTAMP,
+            nullable "IngestTime": TIMESTAMP,
+            nullable "Price": (DataType::decimal(10, 2).unwrap()),
+            nullable "UserId": LONG,
+        };
         let inputs: Vec<Option<&str>> = vec![
             Some(
                 r#"{"EventTime": "2024-01-01T00:00:00Z", "IngestTime": "2024-01-01T00:00:01Z", "Price": "10.50", "UserId": 1}"#,
@@ -1951,26 +1941,22 @@ mod tests {
         //     minValues: { EventTime: Timestamp, UserId: Long },
         //     maxValues: { EventTime: Timestamp, UserId: Long },
         //     tightBounds: Bool }
-        let null_count_struct = StructType::try_new(vec![
-            StructField::nullable("EventTime", DataType::LONG),
-            StructField::nullable("UserId", DataType::LONG),
-        ])
-        .unwrap();
-        let min_max_struct = StructType::try_new(vec![
-            StructField::nullable("EventTime", DataType::TIMESTAMP),
-            StructField::nullable("UserId", DataType::LONG),
-        ])
-        .unwrap();
-        let schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("numRecords", DataType::LONG),
-                StructField::nullable("nullCount", null_count_struct),
-                StructField::nullable("minValues", min_max_struct.clone()),
-                StructField::nullable("maxValues", min_max_struct),
-                StructField::nullable("tightBounds", DataType::BOOLEAN),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "numRecords": LONG,
+            nullable "nullCount": {
+                nullable "EventTime": LONG,
+                nullable "UserId": LONG,
+            },
+            nullable "minValues": {
+                nullable "EventTime": TIMESTAMP,
+                nullable "UserId": LONG,
+            },
+            nullable "maxValues": {
+                nullable "EventTime": TIMESTAMP,
+                nullable "UserId": LONG,
+            },
+            nullable "tightBounds": BOOLEAN,
+        };
 
         let inputs: Vec<Option<&str>> = vec![
             Some(
@@ -2017,13 +2003,10 @@ mod tests {
     fn test_parse_json_safe_cast_all_null_input() {
         // Every row decodes to `{}` (the unwrap_or default for `None`), so every output cell
         // is NULL and no error surfaces from the safe-cast pass.
-        let schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("ts", DataType::TIMESTAMP),
-                StructField::nullable("n", DataType::LONG),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "ts": TIMESTAMP,
+            nullable "n": LONG,
+        };
         let inputs: Vec<Option<&str>> = vec![None, None, None];
         let batch = parse_json_impl(&StringArray::from(inputs), schema).unwrap();
         assert_eq!(batch.num_rows(), 3);
@@ -2049,14 +2032,14 @@ mod tests {
     #[test]
     fn simple_mask_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::nullable(logical_name(1), DataType::STRING)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::nullable(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::nullable(logical_name(1), DataType::STRING)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::nullable(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2223,12 +2206,12 @@ mod tests {
     #[test]
     fn ensure_data_types_fails_correctly() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::nullable(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::nullable(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2244,12 +2227,12 @@ mod tests {
                 "Invalid argument error: Incorrect datatype. Expected integer, got Utf8",
             );
 
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::nullable(logical_name(1), DataType::STRING)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::nullable(logical_name(1), DataType::STRING)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2268,11 +2251,13 @@ mod tests {
     #[test]
     fn mask_with_map() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([StructField::not_null(
-                logical_name(0),
-                MapType::new(DataType::INTEGER, DataType::STRING, false),
-            )
-            .with_metadata(column_mapping_metadata(0, mode))])
+            let requested_schema = schema! {
+                (StructField::not_null(
+                    logical_name(0),
+                    MapType::new(DataType::INTEGER, DataType::STRING, false),
+                )
+                .with_metadata(column_mapping_metadata(0, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2299,14 +2284,14 @@ mod tests {
     #[test]
     fn simple_reorder_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::nullable(logical_name(1), DataType::STRING)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::nullable(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::nullable(logical_name(1), DataType::STRING)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::nullable(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2334,14 +2319,14 @@ mod tests {
     #[test]
     fn simple_nullable_field_missing() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::nullable(logical_name(1), DataType::STRING)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::nullable(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::nullable(logical_name(1), DataType::STRING)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::nullable(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2371,14 +2356,14 @@ mod tests {
 
     #[test]
     fn get_requested_indices_by_id_only() {
-        let requested_schema = StructType::new_unchecked([
-            StructField::not_null("i_logical", DataType::INTEGER)
-                .with_metadata(kernel_fid_and_name(1, "i_physical")),
-            StructField::nullable("s_logical", DataType::STRING)
-                .with_metadata(kernel_fid_and_name(2, "s_physical")),
-            StructField::nullable("i2_logical", DataType::INTEGER)
-                .with_metadata(kernel_fid_and_name(3, "i2_physical")),
-        ])
+        let requested_schema = schema! {
+            (StructField::not_null("i_logical", DataType::INTEGER)
+                .with_metadata(kernel_fid_and_name(1, "i_physical"))),
+            (StructField::nullable("s_logical", DataType::STRING)
+                .with_metadata(kernel_fid_and_name(2, "s_physical"))),
+            (StructField::nullable("i2_logical", DataType::INTEGER)
+                .with_metadata(kernel_fid_and_name(3, "i2_physical"))),
+        }
         .make_physical(ColumnMappingMode::Id)
         .unwrap()
         .into();
@@ -2405,14 +2390,14 @@ mod tests {
 
     #[test]
     fn get_requested_indices_by_id_falls_back_to_name() {
-        let requested_schema = StructType::new_unchecked([
-            StructField::not_null("i_logical", DataType::INTEGER)
-                .with_metadata(kernel_fid_and_name(1, "i_physical")),
-            StructField::nullable("s_logical", DataType::STRING)
-                .with_metadata(kernel_fid_and_name(2, "s_physical")),
-            StructField::nullable("i2_logical", DataType::INTEGER)
-                .with_metadata(kernel_fid_and_name(3, "i2_physical")),
-        ])
+        let requested_schema = schema! {
+            (StructField::not_null("i_logical", DataType::INTEGER)
+                .with_metadata(kernel_fid_and_name(1, "i_physical"))),
+            (StructField::nullable("s_logical", DataType::STRING)
+                .with_metadata(kernel_fid_and_name(2, "s_physical"))),
+            (StructField::nullable("i2_logical", DataType::INTEGER)
+                .with_metadata(kernel_fid_and_name(3, "i2_physical"))),
+        }
         .make_physical(ColumnMappingMode::Id)
         .unwrap()
         .into();
@@ -2462,11 +2447,14 @@ mod tests {
 
     #[test]
     fn test_match_parquet_fields_filters_metadata_columns() {
-        let kernel_schema = StructType::new_unchecked([
-            StructField::not_null("regular_field", DataType::INTEGER),
-            StructField::create_metadata_column("row_index", MetadataColumnSpec::RowIndex),
-            StructField::nullable("another_field", DataType::STRING),
-        ]);
+        let kernel_schema = schema! {
+            not_null "regular_field": INTEGER,
+            (StructField::create_metadata_column(
+                "row_index",
+                MetadataColumnSpec::RowIndex,
+            )),
+            nullable "another_field": STRING,
+        };
 
         let parquet_fields: ArrowFields = vec![
             ArrowField::new("regular_field", ArrowDataType::Int32, false),
@@ -2765,22 +2753,22 @@ mod tests {
     #[test]
     fn nested_indices() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(
                     logical_name(3),
-                    StructType::new_unchecked([
-                        StructField::not_null(logical_name(4), DataType::INTEGER)
-                            .with_metadata(column_mapping_metadata(4, mode)),
-                        StructField::not_null(logical_name(5), DataType::STRING)
-                            .with_metadata(column_mapping_metadata(5, mode)),
-                    ]),
+                    schema! {
+                        (StructField::not_null(logical_name(4), DataType::INTEGER)
+                            .with_metadata(column_mapping_metadata(4, mode))),
+                        (StructField::not_null(logical_name(5), DataType::STRING)
+                            .with_metadata(column_mapping_metadata(5, mode))),
+                    },
                 )
-                .with_metadata(column_mapping_metadata(3, mode)),
-                StructField::not_null(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(3, mode))),
+                (StructField::not_null(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2803,22 +2791,22 @@ mod tests {
     #[test]
     fn nested_indices_reorder() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(
                     logical_name(3),
-                    StructType::new_unchecked([
-                        StructField::not_null(logical_name(5), DataType::STRING)
-                            .with_metadata(column_mapping_metadata(5, mode)),
-                        StructField::not_null(logical_name(4), DataType::INTEGER)
-                            .with_metadata(column_mapping_metadata(4, mode)),
-                    ]),
+                    schema! {
+                        (StructField::not_null(logical_name(5), DataType::STRING)
+                            .with_metadata(column_mapping_metadata(5, mode))),
+                        (StructField::not_null(logical_name(4), DataType::INTEGER)
+                            .with_metadata(column_mapping_metadata(4, mode))),
+                    },
                 )
-                .with_metadata(column_mapping_metadata(3, mode)),
-                StructField::not_null(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(3, mode))),
+                (StructField::not_null(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2842,21 +2830,20 @@ mod tests {
     #[test]
     fn nested_indices_mask_inner() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(
                     logical_name(3),
-                    StructType::new_unchecked([StructField::not_null(
-                        logical_name(4),
-                        DataType::INTEGER,
-                    )
-                    .with_metadata(column_mapping_metadata(4, mode))]),
+                    schema! {
+                        (StructField::not_null(logical_name(4), DataType::INTEGER)
+                            .with_metadata(column_mapping_metadata(4, mode))),
+                    },
                 )
-                .with_metadata(column_mapping_metadata(3, mode)),
-                StructField::not_null(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(3, mode))),
+                (StructField::not_null(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2920,14 +2907,14 @@ mod tests {
     #[test]
     fn simple_list_mask() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(logical_name(2), ArrayType::new(DataType::INTEGER, false))
-                    .with_metadata(column_mapping_metadata(2, mode)),
-                StructField::not_null(logical_name(3), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(3, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(logical_name(2), ArrayType::new(DataType::INTEGER, false))
+                    .with_metadata(column_mapping_metadata(2, mode))),
+                (StructField::not_null(logical_name(3), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(3, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2963,11 +2950,10 @@ mod tests {
     #[test]
     fn list_skip_earlier_element() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([StructField::not_null(
-                logical_name(1),
-                ArrayType::new(DataType::INTEGER, false),
-            )
-            .with_metadata(column_mapping_metadata(1, mode))])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), ArrayType::new(DataType::INTEGER, false))
+                    .with_metadata(column_mapping_metadata(1, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2996,25 +2982,25 @@ mod tests {
     #[test]
     fn nested_indices_list() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(0), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(0, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(0), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(0, mode))),
+                (StructField::not_null(
                     logical_name(1),
                     ArrayType::new(
-                        StructType::new_unchecked([
-                            StructField::not_null(logical_name(3), DataType::INTEGER)
-                                .with_metadata(column_mapping_metadata(3, mode)),
-                            StructField::not_null(logical_name(4), DataType::STRING)
-                                .with_metadata(column_mapping_metadata(4, mode)),
-                        ]),
+                        schema! {
+                            (StructField::not_null(logical_name(3), DataType::INTEGER)
+                                .with_metadata(column_mapping_metadata(3, mode))),
+                            (StructField::not_null(logical_name(4), DataType::STRING)
+                                .with_metadata(column_mapping_metadata(4, mode))),
+                        },
                         false,
                     ),
                 )
-                .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3061,12 +3047,12 @@ mod tests {
     #[test]
     fn nested_indices_unselected_list() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(logical_name(3), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(3, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(logical_name(3), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(3, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3106,24 +3092,23 @@ mod tests {
     #[test]
     fn nested_indices_list_mask_inner() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(
                     logical_name(2),
                     ArrayType::new(
-                        StructType::new_unchecked([StructField::not_null(
-                            logical_name(4),
-                            DataType::INTEGER,
-                        )
-                        .with_metadata(column_mapping_metadata(4, mode))]),
+                        schema! {
+                            (StructField::not_null(logical_name(4), DataType::INTEGER)
+                                .with_metadata(column_mapping_metadata(4, mode))),
+                        },
                         false,
                     ),
                 )
-                .with_metadata(column_mapping_metadata(2, mode)),
-                StructField::not_null(logical_name(3), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(3, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(2, mode))),
+                (StructField::not_null(logical_name(3), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(3, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3167,25 +3152,25 @@ mod tests {
     #[test]
     fn nested_indices_list_mask_inner_reorder() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(
                     logical_name(2),
                     ArrayType::new(
-                        StructType::new_unchecked([
-                            StructField::not_null(logical_name(6), DataType::STRING)
-                                .with_metadata(column_mapping_metadata(6, mode)),
-                            StructField::not_null(logical_name(5), DataType::INTEGER)
-                                .with_metadata(column_mapping_metadata(5, mode)),
-                        ]),
+                        schema! {
+                            (StructField::not_null(logical_name(6), DataType::STRING)
+                                .with_metadata(column_mapping_metadata(6, mode))),
+                            (StructField::not_null(logical_name(5), DataType::INTEGER)
+                                .with_metadata(column_mapping_metadata(5, mode))),
+                        },
                         false,
                     ),
                 )
-                .with_metadata(column_mapping_metadata(2, mode)),
-                StructField::not_null(logical_name(3), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(3, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(2, mode))),
+                (StructField::not_null(logical_name(3), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(3, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3234,22 +3219,22 @@ mod tests {
     #[test]
     fn skipped_struct() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::not_null(logical_name(1), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::not_null(
+            let requested_schema = schema! {
+                (StructField::not_null(logical_name(1), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::not_null(
                     logical_name(2),
-                    StructType::new_unchecked([
-                        StructField::not_null(logical_name(4), DataType::INTEGER)
-                            .with_metadata(column_mapping_metadata(4, mode)),
-                        StructField::not_null(logical_name(5), DataType::STRING)
-                            .with_metadata(column_mapping_metadata(5, mode)),
-                    ]),
+                    schema! {
+                        (StructField::not_null(logical_name(4), DataType::INTEGER)
+                            .with_metadata(column_mapping_metadata(4, mode))),
+                        (StructField::not_null(logical_name(5), DataType::STRING)
+                            .with_metadata(column_mapping_metadata(5, mode))),
+                    },
                 )
-                .with_metadata(column_mapping_metadata(2, mode)),
-                StructField::not_null(logical_name(3), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(3, mode)),
-            ])
+                .with_metadata(column_mapping_metadata(2, mode))),
+                (StructField::not_null(logical_name(3), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(3, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3569,12 +3554,12 @@ mod tests {
     #[test]
     fn no_matches() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([
-                StructField::nullable(logical_name(1), DataType::STRING)
-                    .with_metadata(column_mapping_metadata(1, mode)),
-                StructField::nullable(logical_name(2), DataType::INTEGER)
-                    .with_metadata(column_mapping_metadata(2, mode)),
-            ])
+            let requested_schema = schema! {
+                (StructField::nullable(logical_name(1), DataType::STRING)
+                    .with_metadata(column_mapping_metadata(1, mode))),
+                (StructField::nullable(logical_name(2), DataType::INTEGER)
+                    .with_metadata(column_mapping_metadata(2, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3826,40 +3811,40 @@ mod tests {
     /// correctly insert (or omit) the `_file` column at the position declared in the schema.
     #[rstest]
     #[case::no_file_path(JsonInsertCase {
-        schema: StructType::new_unchecked([
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::INTEGER),
-        ]),
+        schema: schema! {
+            not_null "a": INTEGER,
+            nullable "b": INTEGER,
+        },
         expected_json_names: &["a", "b"],
         expected_output_names: &["a", "b"],
         file_path_col: None,
     })]
     #[case::file_path_at_start(JsonInsertCase {
-        schema: StructType::new_unchecked([
-            StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::INTEGER),
-        ]),
+        schema: schema! {
+            (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+            not_null "a": INTEGER,
+            nullable "b": INTEGER,
+        },
         expected_json_names: &["a", "b"],
         expected_output_names: &["_file", "a", "b"],
         file_path_col: Some(0),
     })]
     #[case::file_path_in_middle(JsonInsertCase {
-        schema: StructType::new_unchecked([
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-            StructField::nullable("b", DataType::INTEGER),
-        ]),
+        schema: schema! {
+            not_null "a": INTEGER,
+            (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+            nullable "b": INTEGER,
+        },
         expected_json_names: &["a", "b"],
         expected_output_names: &["a", "_file", "b"],
         file_path_col: Some(1),
     })]
     #[case::file_path_at_end(JsonInsertCase {
-        schema: StructType::new_unchecked([
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::INTEGER),
-            StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-        ]),
+        schema: schema! {
+            not_null "a": INTEGER,
+            nullable "b": INTEGER,
+            (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+        },
         expected_json_names: &["a", "b"],
         expected_output_names: &["a", "b", "_file"],
         file_path_col: Some(2),
@@ -3915,10 +3900,13 @@ mod tests {
         // RowIndex is not supported for JSON reads. All metadata column specs are non-nullable,
         // so the Missing transform inserts a null array — reorder_struct_array errors because
         // the field is declared non-nullable.
-        let schema = StructType::new_unchecked([
-            StructField::not_null("a", DataType::INTEGER),
-            StructField::create_metadata_column("row_index", MetadataColumnSpec::RowIndex),
-        ]);
+        let schema = schema! {
+            not_null "a": INTEGER,
+            (StructField::create_metadata_column(
+                "row_index",
+                MetadataColumnSpec::RowIndex,
+            )),
+        };
         let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "a",
             ArrowDataType::Int32,
@@ -3991,15 +3979,9 @@ mod tests {
         // When a struct exists in parquet but none of its children match the requested
         // schema, the struct should be treated as missing regardless of its nullability.
         let info_field = if struct_nullable {
-            StructField::nullable(
-                "info",
-                StructType::new_unchecked([StructField::nullable("z", DataType::LONG)]),
-            )
+            StructField::nullable("info", schema! { nullable "z": LONG })
         } else {
-            StructField::not_null(
-                "info",
-                StructType::new_unchecked([StructField::nullable("z", DataType::LONG)]),
-            )
+            StructField::not_null("info", schema! { nullable "z": LONG })
         };
         let requested_schema = schema_ref! {
             not_null "a": LONG,

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1755,10 +1755,10 @@ mod tests {
             RecordBatch::try_new(schema, vec![Arc::new(large_strings) as ArrowArrayRef]).unwrap();
         let engine_data: Box<dyn crate::EngineData> = Box::new(ArrowEngineData::new(batch));
 
-        let output_schema: crate::schema::SchemaRef = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::STRING),
-        ]));
+        let output_schema: crate::schema::SchemaRef = schema_ref! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+        };
         let result = parse_json(engine_data, output_schema).unwrap();
         let result = ArrowEngineData::try_from_engine_data(result).unwrap();
         let batch: RecordBatch = result.into();
@@ -1780,10 +1780,10 @@ mod tests {
             RecordBatch::try_new(schema, vec![Arc::new(view_strings) as ArrowArrayRef]).unwrap();
         let engine_data: Box<dyn crate::EngineData> = Box::new(ArrowEngineData::new(batch));
 
-        let output_schema: crate::schema::SchemaRef = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::STRING),
-        ]));
+        let output_schema: crate::schema::SchemaRef = schema_ref! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+        };
         let result = parse_json(engine_data, output_schema).unwrap();
         let result = ArrowEngineData::try_from_engine_data(result).unwrap();
         let batch: RecordBatch = result.into();
@@ -2150,10 +2150,11 @@ mod tests {
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
 
         // Struct of Variant
-        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "struct_v",
-            StructType::new_unchecked([StructField::nullable("v", DataType::unshredded_variant())]),
-        )]));
+        let requested_schema = schema_ref! {
+            nullable "struct_v": {
+                nullable "v": unshredded_variant(),
+            },
+        };
         let unshredded_parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "struct_v",
             ArrowDataType::Struct(vec![unshredded_variant_parquet_schema()].into()),
@@ -2171,10 +2172,9 @@ mod tests {
         assert!(matches!(result_shredded,
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
         // Array of Variant
-        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "array_v",
-            ArrayType::new(DataType::unshredded_variant(), true),
-        )]));
+        let requested_schema = schema_ref! {
+            nullable "array_v": [ nullable unshredded_variant() ],
+        };
         let unshredded_parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "array_v",
             ArrowDataType::List(Arc::new(unshredded_variant_parquet_schema())),
@@ -2193,10 +2193,9 @@ mod tests {
             Err(e) if e.to_string().contains("The default engine does not support shredded reads")));
 
         // Map of Variant
-        let requested_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "map_v",
-            MapType::new(DataType::STRING, DataType::unshredded_variant(), true),
-        )]));
+        let requested_schema = schema_ref! {
+            nullable "map_v": { STRING => nullable unshredded_variant() },
+        };
         let unshredded_parquet_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new_map(
             "map_v",
             "struc_v",
@@ -2269,11 +2268,13 @@ mod tests {
     #[test]
     fn mask_with_map() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([StructField::not_null(
-                logical_name(0),
-                MapType::new(DataType::INTEGER, DataType::STRING, false),
-            )
-            .with_metadata(column_mapping_metadata(0, mode))])
+            let requested_schema = schema! {
+                (StructField::not_null(
+                    logical_name(0),
+                    MapType::new(DataType::INTEGER, DataType::STRING, false),
+                )
+                .with_metadata(column_mapping_metadata(0, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -2566,11 +2567,11 @@ mod tests {
 
     #[test]
     fn simple_row_index_field() {
-        let requested_schema = Arc::new(StructType::new_unchecked([
-            StructField::not_null("i", DataType::INTEGER),
-            StructField::create_metadata_column("my_row_index", MetadataColumnSpec::RowIndex),
-            StructField::nullable("i2", DataType::INTEGER),
-        ]));
+        let requested_schema = schema_ref! {
+            not_null "i": INTEGER,
+            (StructField::create_metadata_column("my_row_index", MetadataColumnSpec::RowIndex)),
+            nullable "i2": INTEGER,
+        };
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", ArrowDataType::Int32, false),
             ArrowField::new("i2", ArrowDataType::Int32, true),
@@ -2595,11 +2596,11 @@ mod tests {
 
     #[test]
     fn simple_file_path_field() {
-        let requested_schema = Arc::new(StructType::new_unchecked([
-            StructField::not_null("i", DataType::INTEGER),
-            StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-            StructField::nullable("i2", DataType::INTEGER),
-        ]));
+        let requested_schema = schema_ref! {
+            not_null "i": INTEGER,
+            (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+            nullable "i2": INTEGER,
+        };
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", ArrowDataType::Int32, false),
             ArrowField::new("i2", ArrowDataType::Int32, true),
@@ -2880,13 +2881,12 @@ mod tests {
         // Regression: when a struct with no matching children appears BEFORE a selected
         // leaf in parquet order, the Missing entry must be deferred so the leaf's
         // Identity entry gets the correct parquet_position in reorder_struct_array.
-        let requested_schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable(
-                "stats",
-                StructType::new_unchecked([StructField::nullable("age", DataType::LONG)]),
-            ),
-        ]));
+        let requested_schema: SchemaRef = schema_ref! {
+            nullable "a": LONG,
+            nullable "stats": {
+                nullable "age": LONG,
+            },
+        };
         // Parquet has stats BEFORE a
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new(
@@ -2965,11 +2965,13 @@ mod tests {
     #[test]
     fn list_skip_earlier_element() {
         column_mapping_cases().into_iter().for_each(|mode| {
-            let requested_schema = StructType::new_unchecked([StructField::not_null(
-                logical_name(1),
-                ArrayType::new(DataType::INTEGER, false),
-            )
-            .with_metadata(column_mapping_metadata(1, mode))])
+            let requested_schema = schema! {
+                (StructField::not_null(
+                    logical_name(1),
+                    ArrayType::new(DataType::INTEGER, false),
+                )
+                .with_metadata(column_mapping_metadata(1, mode))),
+            }
             .make_physical(mode)
             .unwrap()
             .into();
@@ -3610,7 +3612,7 @@ mod tests {
 
     #[test]
     fn empty_requested_schema() {
-        let requested_schema = Arc::new(StructType::new_unchecked([]));
+        let requested_schema = schema_ref! {};
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", ArrowDataType::Int32, false),
             ArrowField::new("s", ArrowDataType::Utf8, true),
@@ -4003,10 +4005,10 @@ mod tests {
                 StructType::new_unchecked([StructField::nullable("z", DataType::LONG)]),
             )
         };
-        let requested_schema = Arc::new(StructType::new_unchecked([
-            StructField::not_null("a", DataType::LONG),
-            info_field,
-        ]));
+        let requested_schema = schema_ref! {
+            not_null "a": LONG,
+            (info_field),
+        };
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("a", ArrowDataType::Int64, true),
             ArrowField::new(
@@ -4097,10 +4099,10 @@ mod tests {
     fn empty_struct_is_matched() {
         // Delta protocol allows empty structs. An empty struct has no children, so no
         // leaf columns are selected, but the struct itself should still be matched.
-        let requested_schema = Arc::new(StructType::new_unchecked([
-            StructField::not_null("a", DataType::LONG),
-            StructField::not_null("empty", StructType::new_unchecked([])),
-        ]));
+        let requested_schema = schema_ref! {
+            not_null "a": LONG,
+            not_null "empty": {},
+        };
         let parquet_schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("a", ArrowDataType::Int64, true),
             ArrowField::new("empty", ArrowDataType::Struct(ArrowFields::empty()), false),
@@ -4195,17 +4197,12 @@ mod tests {
         let batch = RecordBatch::try_new(src_schema, vec![outer_col]).unwrap();
 
         // Kernel target: all nullable where Arrow allows it.
-        let target_schema: SchemaRef =
-            Arc::new(StructType::new_unchecked([StructField::nullable(
-                "outer",
-                StructType::new_unchecked([
-                    StructField::nullable("lst", ArrayType::new(DataType::INTEGER, true)),
-                    StructField::nullable(
-                        "mp",
-                        MapType::new(DataType::STRING, DataType::INTEGER, true),
-                    ),
-                ]),
-            )]));
+        let target_schema: SchemaRef = schema_ref! {
+            nullable "outer": {
+                nullable "lst": [ nullable INTEGER ],
+                nullable "mp": { STRING => nullable INTEGER },
+            },
+        };
 
         let ordering = [ReorderIndex::identity(0)];
         let result =

--- a/kernel/src/engine/ensure_data_types.rs
+++ b/kernel/src/engine/ensure_data_types.rs
@@ -354,7 +354,7 @@ mod tests {
     use super::*;
     use crate::arrow::datatypes::{DataType as ArrowDataType, Field as ArrowField, Fields};
     use crate::engine::arrow_conversion::TryFromKernel as _;
-    use crate::schema::{ArrayType, DataType, MapType, StructField};
+    use crate::schema::{schema, ArrayType, DataType, MapType};
     use crate::unit_test_utils::assert_result_error_with_message;
 
     #[test]
@@ -637,34 +637,24 @@ mod tests {
 
     #[test]
     fn ensure_struct() {
-        let schema = DataType::struct_type_unchecked([StructField::nullable(
-            "a",
-            ArrayType::new(
-                DataType::struct_type_unchecked([
-                    StructField::nullable("w", DataType::LONG),
-                    StructField::nullable("x", ArrayType::new(DataType::LONG, true)),
-                    StructField::nullable(
-                        "y",
-                        MapType::new(DataType::LONG, DataType::STRING, true),
-                    ),
-                    StructField::nullable(
-                        "z",
-                        DataType::struct_type_unchecked([
-                            StructField::nullable("n", DataType::LONG),
-                            StructField::nullable("m", DataType::STRING),
-                        ]),
-                    ),
-                ]),
-                true,
-            ),
-        )]);
+        let schema = DataType::from(schema! {
+            nullable "a": [ nullable {
+                nullable "w": LONG,
+                nullable "x": [ nullable LONG ],
+                nullable "y": { LONG => nullable STRING },
+                nullable "z": {
+                    nullable "n": LONG,
+                    nullable "m": STRING,
+                },
+            } ],
+        });
         let arrow_struct = ArrowDataType::try_from_kernel(&schema).unwrap();
         assert!(ensure_data_types(&schema, &arrow_struct, ValidationMode::Full).is_ok());
 
-        let kernel_simple = DataType::struct_type_unchecked([
-            StructField::nullable("w", DataType::LONG),
-            StructField::nullable("x", DataType::LONG),
-        ]);
+        let kernel_simple = DataType::from(schema! {
+            nullable "w": LONG,
+            nullable "x": LONG,
+        });
 
         let arrow_simple_ok = ArrowField::new_struct(
             "arrow_struct",
@@ -717,10 +707,10 @@ mod tests {
     fn name_based_matching_pairs_fields_by_name_with_interleaved_extra() {
         // The arrow struct has an unselected `extra` field between the matched ones. `x` must be
         // paired with the arrow `x`, not positionally with `extra`.
-        let kernel = DataType::struct_type_unchecked([
-            StructField::nullable("w", DataType::LONG),
-            StructField::nullable("x", DataType::STRING),
-        ]);
+        let kernel = DataType::from(schema! {
+            nullable "w": LONG,
+            nullable "x": STRING,
+        });
         let arrow = ArrowDataType::Struct(Fields::from(vec![
             ArrowField::new("w", ArrowDataType::Int64, true),
             ArrowField::new("extra", ArrowDataType::Int64, true),
@@ -735,10 +725,10 @@ mod tests {
     #[test]
     fn name_based_matching_rejects_wrong_type_behind_interleaved_extra() {
         // An unselected `extra` field must not mask a type mismatch on the real `x` field.
-        let kernel = DataType::struct_type_unchecked([
-            StructField::nullable("w", DataType::LONG),
-            StructField::nullable("x", DataType::LONG),
-        ]);
+        let kernel = DataType::from(schema! {
+            nullable "w": LONG,
+            nullable "x": LONG,
+        });
         let arrow = ArrowDataType::Struct(Fields::from(vec![
             ArrowField::new("w", ArrowDataType::Int64, true),
             ArrowField::new("extra", ArrowDataType::Int64, true),
@@ -951,10 +941,10 @@ mod tests {
 
     #[test]
     fn types_only_matches_struct_by_ordinal_ignoring_names() {
-        let kernel = DataType::struct_type_unchecked([
-            StructField::nullable("logical_a", DataType::LONG),
-            StructField::nullable("logical_b", DataType::STRING),
-        ]);
+        let kernel = DataType::from(schema! {
+            nullable "logical_a": LONG,
+            nullable "logical_b": STRING,
+        });
         let arrow = ArrowDataType::Struct(
             vec![
                 ArrowField::new("physical_x", ArrowDataType::Int64, true),
@@ -967,10 +957,10 @@ mod tests {
 
     #[test]
     fn types_only_rejects_struct_field_count_mismatch() {
-        let kernel = DataType::struct_type_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ]);
+        let kernel = DataType::from(schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+        });
         let arrow =
             ArrowDataType::Struct(vec![ArrowField::new("x", ArrowDataType::Int64, true)].into());
         assert_result_error_with_message(
@@ -981,10 +971,10 @@ mod tests {
 
     #[test]
     fn types_only_rejects_struct_type_mismatch_by_ordinal() {
-        let kernel = DataType::struct_type_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-        ]);
+        let kernel = DataType::from(schema! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+        });
         let arrow = ArrowDataType::Struct(
             vec![
                 ArrowField::new("x", ArrowDataType::Int64, true),

--- a/kernel/src/engine/plans/json.rs
+++ b/kernel/src/engine/plans/json.rs
@@ -94,7 +94,7 @@ mod tests {
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::FilteredEngineData;
-    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::schema::{schema_ref, SchemaRef};
     use crate::{
         DeltaResult, Engine as _, EngineData, FileDataReadResultIterator, FileMeta,
         JsonHandler as _, ParquetHandler as _,
@@ -158,8 +158,7 @@ mod tests {
     #[test]
     fn test_read_json_files() {
         let (_temp, file_meta) = temp_json_file(&[r#"{"x": 1}"#, r#"{"x": 2}"#, r#"{"x": 3}"#]);
-        let schema =
-            Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap());
+        let schema = schema_ref! { not_null "x": INTEGER };
 
         let mut iter = make_handler()
             .read_json_files(&[file_meta], schema, None)
@@ -183,7 +182,7 @@ mod tests {
     }
 
     fn test_schema() -> SchemaRef {
-        Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap())
+        schema_ref! { not_null "x": INTEGER }
     }
 
     /// No files -> an absent plan -> a zero-row result (no rows, no error), for either handler.
@@ -205,8 +204,7 @@ mod tests {
         .unwrap();
         let input: Box<dyn EngineData> = Box::new(ArrowEngineData::new(input_batch));
 
-        let output_schema =
-            Arc::new(StructType::try_new([StructField::not_null("x", DataType::INTEGER)]).unwrap());
+        let output_schema = schema_ref! { not_null "x": INTEGER };
 
         let parsed = make_handler().parse_json(input, output_schema).unwrap();
         let record_batch: RecordBatch = ArrowEngineData::try_from_engine_data(parsed)

--- a/kernel/src/engine/plans/parquet.rs
+++ b/kernel/src/engine/plans/parquet.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::engine::sync::plan::SyncPlanExecutor;
     use crate::engine::sync::SyncEngine;
     use crate::parquet::arrow::arrow_writer::ArrowWriter;
-    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::schema::{schema_ref, SchemaRef};
     use crate::{Engine as _, EngineData, FileMeta, ParquetHandler as _};
 
     fn make_handler() -> PlanBasedParquetHandler {
@@ -119,9 +119,7 @@ mod tests {
             .unwrap();
 
         // Read it back to confirm the fallback actually wrote the rows.
-        let schema: SchemaRef = Arc::new(
-            StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "value": LONG };
         let file_meta = FileMeta {
             location: url,
             last_modified: 0,
@@ -194,9 +192,7 @@ mod tests {
     /// No files -> an absent plan -> a zero-row result (no rows, no error).
     #[test]
     fn test_read_parquet_files_empty_is_empty() {
-        let schema: SchemaRef = Arc::new(
-            StructType::try_new([StructField::nullable("value", DataType::LONG)]).unwrap(),
-        );
+        let schema = schema_ref! { nullable "value": LONG };
         let rows: usize = make_handler()
             .read_parquet_files(&[], schema, None)
             .unwrap()

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -502,7 +502,7 @@ mod tests {
     use crate::arrow::array::StructArray;
     use crate::arrow::buffer::{BooleanBuffer, NullBuffer};
     use crate::expressions::{column_name, StructData};
-    use crate::schema::{StructField, ToSchema as _};
+    use crate::schema::{schema, schema_ref, ToSchema as _};
 
     #[test]
     fn encode_keys_as_rows_synthesizes_empty_keys_when_ungrouped() -> DeltaResult<()> {
@@ -545,19 +545,19 @@ mod tests {
         last_modified: Scalar,
         dv: Scalar,
     ) -> DeltaResult<Vec<ScanFile>> {
-        let input_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable("size", DataType::LONG),
-            StructField::nullable("filemod", DataType::LONG),
-            StructField::nullable("dv", DeletionVectorDescriptor::to_schema()),
-        ]));
+        let input_schema = schema_ref! {
+            nullable "path": STRING,
+            nullable "size": LONG,
+            nullable "filemod": LONG,
+            nullable "dv": (DeletionVectorDescriptor::to_schema()),
+        };
         let input = values_to_record_batch(Values::new(
             input_schema,
             vec![vec![path, size, last_modified, dv]],
         ))
         .unwrap();
         let dynamic_scan = DynamicScan {
-            schema: Arc::new(StructType::new_unchecked(Vec::<StructField>::new())),
+            schema: schema_ref! {},
             file_type: FileType::Parquet,
             base_url: Url::parse("memory:///").unwrap(),
             file_constant_columns: vec![],
@@ -651,14 +651,15 @@ mod tests {
 
     #[test]
     fn dynamic_scan_treats_dv_under_null_ancestor_as_null() {
-        let dv_field = StructField::nullable("dv", DeletionVectorDescriptor::to_schema());
-        let metadata_type = StructType::new_unchecked([dv_field]);
-        let input_schema = Arc::new(StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null("size", DataType::LONG),
-            StructField::not_null("filemod", DataType::LONG),
-            StructField::nullable("metadata", metadata_type.clone()),
-        ]));
+        let metadata_type = schema! {
+            nullable "dv": (DeletionVectorDescriptor::to_schema()),
+        };
+        let input_schema = schema_ref! {
+            not_null "path": STRING,
+            not_null "size": LONG,
+            not_null "filemod": LONG,
+            nullable "metadata": (metadata_type.clone()),
+        };
         let metadata_schema: ArrowSchema = (&metadata_type).try_into_arrow().unwrap();
         let metadata = StructArray::new(
             metadata_schema.fields().clone(),
@@ -677,7 +678,7 @@ mod tests {
         )
         .unwrap();
         let dynamic_scan = DynamicScan {
-            schema: Arc::new(StructType::new_unchecked(Vec::<StructField>::new())),
+            schema: schema_ref! {},
             file_type: FileType::Parquet,
             base_url: Url::parse("memory:///").unwrap(),
             file_constant_columns: vec![],

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -155,7 +155,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::{lit, ArrayData, MapData};
-    use crate::schema::{schema_ref, SchemaRef, StructField, StructType};
+    use crate::schema::{schema, schema_ref, SchemaRef, StructField};
     use crate::DataType as DeltaDataTypes;
 
     // helper to take values/schema to pass to `create_one` and assert the result = expected
@@ -282,7 +282,10 @@ mod tests {
         let field_b = StructField::new("b", DeltaDataTypes::INTEGER, test_schema.b_nullable);
         let field_x = StructField::new(
             "x",
-            StructType::new_unchecked([field_a.clone(), field_b.clone()]),
+            schema! {
+                (field_a.clone()),
+                (field_b.clone()),
+            },
             test_schema.x_nullable,
         );
         let schema = schema_ref! {

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -150,8 +150,6 @@ impl<'a, T: Iterator<Item = &'a Scalar>> SchemaTransform<'a> for LiteralExpressi
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use paste::paste;
     use Expression as Expr;
 
@@ -189,30 +187,29 @@ mod tests {
     #[test]
     fn test_create_one_missing_values() {
         let values = &[1.into()];
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("col_1", DeltaDataTypes::INTEGER),
-            StructField::nullable("col_2", DeltaDataTypes::INTEGER),
-        ]));
+        let schema = schema_ref! {
+            nullable "col_1": INTEGER,
+            nullable "col_2": INTEGER,
+        };
         assert_single_row_transform(values, schema, Err(()));
     }
 
     #[test]
     fn test_create_one_extra_values() {
         let values = &[1.into(), 2.into(), 3.into()];
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("col_1", DeltaDataTypes::INTEGER),
-            StructField::nullable("col_2", DeltaDataTypes::INTEGER),
-        ]));
+        let schema = schema_ref! {
+            nullable "col_1": INTEGER,
+            nullable "col_2": INTEGER,
+        };
         assert_single_row_transform(values, schema, Err(()));
     }
 
     #[test]
     fn test_create_one_incorrect_schema() {
         let values = &["a".into()];
-        let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "col_1",
-            DeltaDataTypes::INTEGER,
-        )]));
+        let schema = schema_ref! {
+            nullable "col_1": INTEGER,
+        };
         assert_single_row_transform(values, schema, Err(()));
     }
 
@@ -247,10 +244,10 @@ mod tests {
             Scalar::Map(map_data.clone()),
             Scalar::Array(array_data.clone()),
         ];
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("map", map_type),
-            StructField::nullable("array", array_type),
-        ]));
+        let schema = schema_ref! {
+            nullable "map": (map_type),
+            nullable "array": (array_type),
+        };
         let expected = Expr::struct_from(vec![lit(map_data), lit(array_data)]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
@@ -288,7 +285,9 @@ mod tests {
             StructType::new_unchecked([field_a.clone(), field_b.clone()]),
             test_schema.x_nullable,
         );
-        let schema = Arc::new(StructType::new_unchecked([field_x.clone()]));
+        let schema = schema_ref! {
+            (field_x.clone()),
+        };
 
         let expected_result = match expected {
             Expected::Noop => {

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -1283,7 +1283,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::{col, lit, BinaryPredicateOp};
-    use crate::schema::ToSchema as _;
+    use crate::schema::{schema, ToSchema as _};
     use crate::table_features::TableFeature;
     use crate::unit_test_utils::assert_result_error_with_message;
     use crate::Predicate as Pred;
@@ -2282,10 +2282,10 @@ mod tests {
     fn derived_struct_conversion_checks_null_field_data_type() {
         // `Option::try_from` rejects a typed null whose data type does not match `T`.
         let address = StructData::from_values_unchecked(
-            StructType::new_unchecked([
-                StructField::not_null("city", DataType::STRING),
-                StructField::nullable("zip", DataType::STRING),
-            ]),
+            schema! {
+                not_null "city": STRING,
+                nullable "zip": STRING,
+            },
             vec![Scalar::from("NYC"), Scalar::null(DataType::STRING)],
         );
         assert_result_error_with_message(

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -347,7 +347,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::{DecimalData, Expression};
-    use crate::schema::{ArrayType, DataType, DecimalType, MapType, StructField};
+    use crate::schema::{schema, ArrayType, DataType, DecimalType, MapType};
 
     fn date_days(year: i32, month: u32, day: u32) -> i32 {
         let nd = NaiveDate::from_ymd_opt(year, month, day)
@@ -764,19 +764,15 @@ mod tests {
     }
 
     fn struct_ty() -> DataType {
-        DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
+        DataType::from(schema! { nullable "a": INTEGER })
     }
 
     fn array_ty() -> DataType {
-        DataType::Array(Box::new(ArrayType::new(DataType::INTEGER, true)))
+        DataType::from(ArrayType::new(DataType::INTEGER, true))
     }
 
     fn map_ty() -> DataType {
-        DataType::Map(Box::new(MapType::new(
-            DataType::STRING,
-            DataType::INTEGER,
-            true,
-        )))
+        DataType::from(MapType::new(DataType::STRING, DataType::INTEGER, true))
     }
 
     #[rstest]

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -909,7 +909,7 @@ mod tests {
     use crate::actions::{CommitInfo, Metadata, Protocol};
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
-    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::schema::{schema_ref, SchemaRef};
     use crate::snapshot::{Snapshot, SnapshotBuilder};
     use crate::table_features::TableFeature;
     use crate::unit_test_utils::{Action, LocalMockTable};
@@ -917,10 +917,9 @@ mod tests {
     use crate::Version;
 
     fn get_test_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "value",
-            DataType::INTEGER,
-        )]))
+        schema_ref! {
+            nullable "value": INTEGER,
+        }
     }
 
     fn set_mod_time(mock_table: &LocalMockTable, version: Version, timestamp: Timestamp) {

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -238,7 +238,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema;
     use crate::table_features::TableFeature;
     use crate::unit_test_utils::create_log_path;
 
@@ -659,7 +659,7 @@ mod tests {
         assert_eq!(metadata.format_provider(), "parquet", "{table}: format");
         assert_eq!(
             metadata.parse_schema()?,
-            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]),
+            schema! { nullable "id": LONG },
             "{table}: metadata schema"
         );
         assert!(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -195,7 +195,7 @@ pub use expressions::{Expression, ExpressionRef, Predicate, PredicateRef};
 pub use log_compaction::{should_compact, LogCompactionWriter};
 #[cfg(feature = "declarative-plans")]
 pub use plans::{IoOperation, Operation, PlanBuilder, PlanExecutor, PlanResult};
-use schema::{StructField, StructType};
+use schema::{schema_ref, StructField};
 pub use snapshot::{Snapshot, SnapshotRef};
 
 #[cfg(any(
@@ -546,10 +546,9 @@ trait EvaluationHandlerExtension: EvaluationHandler {
     // future)
     fn create_one(&self, schema: SchemaRef, values: &[Scalar]) -> DeltaResult<Box<dyn EngineData>> {
         // just get a single int column (arbitrary)
-        let null_row_schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
-            "null_col",
-            DataType::INTEGER,
-        )]));
+        let null_row_schema = schema_ref! {
+            nullable "null_col": INTEGER,
+        };
         let null_row = self.null_row(null_row_schema.clone())?;
 
         // Convert schema and leaf values to an expression

--- a/kernel/src/log_compaction/tests.rs
+++ b/kernel/src/log_compaction/tests.rs
@@ -259,17 +259,16 @@ async fn test_no_compaction_staged_commits() {
 
     // Create basic commits with proper metadata and protocol
     use crate::actions::{Metadata, Protocol};
-    use crate::schema::{DataType as KernelDataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::unit_test_utils::Action;
 
     let metadata = Action::Metadata(
         Metadata::try_new(
             Some("test-table".into()),
             None,
-            Arc::new(StructType::new_unchecked([StructField::nullable(
-                "value",
-                KernelDataType::INTEGER,
-            )])),
+            schema_ref! {
+                nullable "value": INTEGER,
+            },
             vec![],
             0,
             std::collections::HashMap::new(),

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -31,38 +31,33 @@ use crate::engine_data::{GetData, TypedGetData as _};
 use crate::metrics::ProtocolMetadataSource;
 use crate::path::ParsedLogPath;
 use crate::schema::{
-    column_name, schema, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec, SchemaRef,
+    column_name, lazy_schema_ref, ColumnName, ColumnNamesAndTypes, DataType, MetadataColumnSpec,
+    SchemaRef, StructField,
 };
 use crate::snapshot::IncrementalReplay;
 use crate::utils::require;
 use crate::{DeltaResult, Engine, Error, FileMeta, RowVisitor, Version};
 
-#[allow(clippy::expect_used)]
-static REPLAY_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    let base = schema! {
-        // size is the only Add leaf the visitor reads, and it is required, so its presence marks
-        // an Add row.
-        nullable ADD_NAME: { not_null "size": LONG },
-        // remove.size is optional, so we read remove.path (required) to know a row is a Remove
-        // before reading its size.
-        nullable REMOVE_NAME: {
-            not_null "path": STRING,
-            nullable "size": LONG,
-        },
-        (&PROTOCOL_FIELD),
-        (&METADATA_FIELD),
-        (&SET_TRANSACTION_FIELD),
-        (&DOMAIN_METADATA_FIELD),
-        nullable COMMIT_INFO_NAME: {
-            nullable "operation": STRING,
-            nullable "inCommitTimestamp": LONG,
-        },
-    };
-    let with_file = base
-        .add_metadata_column("_file", MetadataColumnSpec::FilePath)
-        .expect("add _file metadata column");
-    Arc::new(with_file)
-});
+static REPLAY_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    // size is the only Add leaf the visitor reads, and it is required, so its presence marks
+    // an Add row.
+    nullable ADD_NAME: { not_null "size": LONG },
+    // remove.size is optional, so we read remove.path (required) to know a row is a Remove
+    // before reading its size.
+    nullable REMOVE_NAME: {
+        not_null "path": STRING,
+        nullable "size": LONG,
+    },
+    (&PROTOCOL_FIELD),
+    (&METADATA_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+    nullable COMMIT_INFO_NAME: {
+        nullable "operation": STRING,
+        nullable "inCommitTimestamp": LONG,
+    },
+    (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+};
 
 impl LogSegment {
     /// Try to build the CRC at this segment's `end_version` from the caller's resolved `base` CRC.
@@ -642,16 +637,13 @@ impl RowVisitor for CommitCrcVisitor<'_> {
 /// accumulator needs. `add.size` is the only Add leaf read, and it is required, so its presence
 /// marks an Add row (a checkpoint Add missing `size` errors at read time). A checkpoint has no
 /// `remove` or `commitInfo` to project.
-#[allow(clippy::expect_used)]
-static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(schema! {
-        nullable ADD_NAME: { not_null "size": LONG },
-        (&PROTOCOL_FIELD),
-        (&METADATA_FIELD),
-        (&SET_TRANSACTION_FIELD),
-        (&DOMAIN_METADATA_FIELD),
-    })
-});
+static CHECKPOINT_CRC_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    nullable ADD_NAME: { not_null "size": LONG },
+    (&PROTOCOL_FIELD),
+    (&METADATA_FIELD),
+    (&SET_TRANSACTION_FIELD),
+    (&DOMAIN_METADATA_FIELD),
+};
 
 // A checkpoint has no source-specific columns, so its projection is the shared columns.
 

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -139,7 +139,7 @@ mod tests {
     use crate::committer::FileSystemCommitter;
     use crate::engine::sync::SyncEngine;
     use crate::object_store::memory::InMemory;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::transaction::create_table::create_table as create_table_txn;
     use crate::{RowVisitor as _, Snapshot};
 
@@ -158,11 +158,9 @@ mod tests {
         // The domainMetadata writer feature is enabled so domain metadata actions are valid.
         let _ = create_table_txn(
             url.as_str(),
-            Arc::new(StructType::new_unchecked(vec![StructField::new(
-                "id",
-                DataType::INTEGER,
-                true,
-            )])),
+            schema_ref! {
+                nullable "id": INTEGER,
+            },
             "test",
         )
         .with_table_properties([("delta.feature.domainMetadata", "supported")])

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3205,10 +3205,9 @@ async fn test_get_file_actions_schema_v2_identity_filter(
     let cp_size = get_file_size(&store, &format!("_delta_log/{selected}")).await;
 
     // A distinct hint schema so we can tell whether the hint or the footer was used.
-    let hint_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
-        "metadata",
-        StructType::new_unchecked([]),
-    )]));
+    let hint_schema: SchemaRef = schema_ref! {
+        nullable "metadata": {},
+    };
     let hint_name = if identity_matches { selected } else { other };
 
     let commit_v2_path = log_root.join("00000000000000000002.json")?.to_string();
@@ -4118,19 +4117,15 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
         get_file_size(&store, "_delta_log/00000000000000000001.checkpoint.parquet").await;
 
     // Use a read schema that includes the add field
-    let read_schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::nullable(
-        "add",
-        StructType::new_unchecked([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable(
-                "partitionValues",
-                crate::schema::MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("size", DataType::LONG),
-            StructField::nullable("modificationTime", DataType::LONG),
-            StructField::nullable("dataChange", DataType::BOOLEAN),
-        ]),
-    )]));
+    let read_schema: SchemaRef = schema_ref! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "partitionValues": { STRING => nullable STRING },
+            nullable "size": LONG,
+            nullable "modificationTime": LONG,
+            nullable "dataChange": BOOLEAN,
+        },
+    };
 
     let log_segment = LogSegment::try_new(
         LogSegmentFiles {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3263,15 +3263,15 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 
     // Build a V1 checkpoint schema with stats_parsed containing an integer column.
     let v1_schema = schema_ref! {
-        nullable (ADD_NAME): {
+        nullable ADD_NAME: {
             nullable "path": STRING,
             nullable "stats_parsed": {
-                nullable (NUM_RECORDS): LONG,
-                nullable (MIN_VALUES): { nullable "id": LONG },
-                nullable (MAX_VALUES): { nullable "id": LONG },
+                nullable NUM_RECORDS: LONG,
+                nullable MIN_VALUES: { nullable "id": LONG },
+                nullable MAX_VALUES: { nullable "id": LONG },
             },
         },
-        nullable (REMOVE_NAME): {
+        nullable REMOVE_NAME: {
             nullable "path": STRING,
         },
     };
@@ -3444,9 +3444,9 @@ fn create_checkpoint_schema_with_stats_parsed(min_values_fields: Vec<StructField
         nullable "add": {
             nullable "path": STRING,
             nullable "stats_parsed": {
-                nullable (NUM_RECORDS): LONG,
-                nullable (MIN_VALUES): { ..(min_values_fields.clone()) },
-                nullable (MAX_VALUES): { ..(min_values_fields) },
+                nullable NUM_RECORDS: LONG,
+                nullable MIN_VALUES: { ..(min_values_fields.clone()) },
+                nullable MAX_VALUES: { ..(min_values_fields) },
             },
         },
     }
@@ -3459,9 +3459,9 @@ fn create_checkpoint_file_schema_with_stats_parsed(
     let stats_parsed = StructField::nullable(
         "stats_parsed",
         schema! {
-            nullable (NUM_RECORDS): LONG,
-            nullable (MIN_VALUES): { ..(min_values_fields.clone()) },
-            nullable (MAX_VALUES): { ..(min_values_fields) },
+            nullable NUM_RECORDS: LONG,
+            nullable MIN_VALUES: { ..(min_values_fields.clone()) },
+            nullable MAX_VALUES: { ..(min_values_fields) },
         },
     );
     let patch = SchemaStructPatchBuilder::new().append_at(["add"], stats_parsed);
@@ -3476,9 +3476,9 @@ fn create_checkpoint_file_schema_with_stats_parsed(
 // Helper to create a stats_schema with proper structure (numRecords, minValues, maxValues)
 fn create_stats_schema(column_fields: Vec<StructField>) -> StructType {
     schema! {
-        nullable (NUM_RECORDS): LONG,
-        nullable (MIN_VALUES): { ..(column_fields.clone()) },
-        nullable (MAX_VALUES): { ..(column_fields) },
+        nullable NUM_RECORDS: LONG,
+        nullable MIN_VALUES: { ..(column_fields.clone()) },
+        nullable MAX_VALUES: { ..(column_fields) },
     }
 }
 
@@ -3715,7 +3715,7 @@ fn test_schema_has_compatible_stats_parsed_missing_min_max_values() {
         nullable "add": {
             nullable "path": STRING,
             nullable "stats_parsed": {
-                nullable (NUM_RECORDS): LONG,
+                nullable NUM_RECORDS: LONG,
                 // No minValues or maxValues fields
             },
         },
@@ -3737,10 +3737,10 @@ fn test_schema_has_compatible_stats_parsed_min_values_not_struct() {
         nullable "add": {
             nullable "path": STRING,
             nullable "stats_parsed": {
-                nullable (NUM_RECORDS): LONG,
+                nullable NUM_RECORDS: LONG,
                 // minValues/maxValues are primitives instead of Structs
-                nullable (MIN_VALUES): STRING,
-                nullable (MAX_VALUES): STRING,
+                nullable MIN_VALUES: STRING,
+                nullable MAX_VALUES: STRING,
             },
         },
     };
@@ -3757,10 +3757,10 @@ fn test_schema_has_compatible_stats_parsed_min_values_not_struct() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_nested_struct() {
     // Create a nested struct: user: { name: string, age: integer }
-    let user_struct = StructType::new_unchecked([
-        StructField::nullable("name", DataType::STRING),
-        StructField::nullable("age", DataType::INTEGER),
-    ]);
+    let user_struct = schema! {
+        nullable "name": STRING,
+        nullable "age": INTEGER,
+    };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3779,11 +3779,11 @@ fn test_schema_has_compatible_stats_parsed_nested_struct() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_nested_struct_with_extra_fields() {
     // Checkpoint has extra nested fields not needed by stats schema
-    let checkpoint_user = StructType::new_unchecked([
-        StructField::nullable("name", DataType::STRING),
-        StructField::nullable("age", DataType::INTEGER),
-        StructField::nullable("extra", DataType::STRING), // extra field
-    ]);
+    let checkpoint_user = schema! {
+        nullable "name": STRING,
+        nullable "age": INTEGER,
+        nullable "extra": STRING,
+    };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3792,7 +3792,7 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_with_extra_fields() {
         )]);
 
     // Stats schema only needs a subset of fields
-    let stats_user = StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
+    let stats_user = schema! { nullable "name": STRING };
 
     let stats_schema = create_stats_schema(vec![StructField::nullable("user", stats_user)]);
 
@@ -3806,8 +3806,7 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_with_extra_fields() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_nested_struct_missing_field_ok() {
     // Checkpoint is missing a nested field that stats schema needs
-    let checkpoint_user =
-        StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
+    let checkpoint_user = schema! { nullable "name": STRING };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3816,10 +3815,10 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_missing_field_ok() {
         )]);
 
     // Stats schema needs more fields than checkpoint has
-    let stats_user = StructType::new_unchecked([
-        StructField::nullable("name", DataType::STRING),
-        StructField::nullable("age", DataType::INTEGER), // missing in checkpoint
-    ]);
+    let stats_user = schema! {
+        nullable "name": STRING,
+        nullable "age": INTEGER,
+    };
 
     let stats_schema = create_stats_schema(vec![StructField::nullable("user", stats_user)]);
 
@@ -3833,9 +3832,7 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_missing_field_ok() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_nested_struct_type_mismatch() {
     // Checkpoint has incompatible type in nested field
-    let checkpoint_user = StructType::new_unchecked([
-        StructField::nullable("name", DataType::INTEGER), // wrong type!
-    ]);
+    let checkpoint_user = schema! { nullable "name": INTEGER };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3843,7 +3840,7 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_type_mismatch() {
             checkpoint_user,
         )]);
 
-    let stats_user = StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
+    let stats_user = schema! { nullable "name": STRING };
 
     let stats_schema = create_stats_schema(vec![StructField::nullable("user", stats_user)]);
 
@@ -3857,9 +3854,11 @@ fn test_schema_has_compatible_stats_parsed_nested_struct_type_mismatch() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_deeply_nested() {
     // Deeply nested: company: { department: { team: { name: string } } }
-    let team = StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-    let department = StructType::new_unchecked([StructField::nullable("team", team.clone())]);
-    let company = StructType::new_unchecked([StructField::nullable("department", department)]);
+    let company = schema! {
+        nullable "department": {
+            nullable "team": { nullable "name": STRING },
+        },
+    };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3878,12 +3877,11 @@ fn test_schema_has_compatible_stats_parsed_deeply_nested() {
 #[test]
 fn test_schema_has_compatible_stats_parsed_deeply_nested_type_mismatch() {
     // Type mismatch deep in nested structure
-    let checkpoint_team =
-        StructType::new_unchecked([StructField::nullable("name", DataType::INTEGER)]); // wrong!
-    let checkpoint_dept =
-        StructType::new_unchecked([StructField::nullable("team", checkpoint_team)]);
-    let checkpoint_company =
-        StructType::new_unchecked([StructField::nullable("department", checkpoint_dept)]);
+    let checkpoint_company = schema! {
+        nullable "department": {
+            nullable "team": { nullable "name": INTEGER },
+        },
+    };
 
     let checkpoint_schema =
         create_checkpoint_schema_with_stats_parsed(vec![StructField::nullable(
@@ -3891,10 +3889,11 @@ fn test_schema_has_compatible_stats_parsed_deeply_nested_type_mismatch() {
             checkpoint_company,
         )]);
 
-    let stats_team = StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-    let stats_dept = StructType::new_unchecked([StructField::nullable("team", stats_team)]);
-    let stats_company =
-        StructType::new_unchecked([StructField::nullable("department", stats_dept)]);
+    let stats_company = schema! {
+        nullable "department": {
+            nullable "team": { nullable "name": STRING },
+        },
+    };
 
     let stats_schema = create_stats_schema(vec![StructField::nullable("company", stats_company)]);
 
@@ -4139,8 +4138,7 @@ async fn test_checkpoint_stream_sets_has_partition_values_parsed() -> DeltaResul
     )?;
 
     // Pass a partition schema to trigger partitionValues_parsed detection
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("id", DataType::INTEGER)]);
+    let partition_schema = schema! { nullable "id": INTEGER };
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         read_schema,
@@ -4205,8 +4203,7 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
     )?;
 
     // Pass a partition schema — but the checkpoint doesn't have partitionValues_parsed
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("id", DataType::INTEGER)]);
+    let partition_schema = schema! { nullable "id": INTEGER };
     let checkpoint_result = log_segment.create_checkpoint_stream(
         &engine,
         read_schema.clone(),
@@ -4247,18 +4244,19 @@ async fn test_checkpoint_stream_no_partition_values_parsed_when_incompatible() -
 fn create_checkpoint_schema_with_partition_parsed(
     partition_fields: Vec<StructField>,
 ) -> StructType {
-    let partition_parsed = StructType::new_unchecked(partition_fields);
-    let add_struct = StructType::new_unchecked([
-        StructField::nullable("path", DataType::STRING),
-        StructField::nullable("partitionValues_parsed", partition_parsed),
-    ]);
-    StructType::new_unchecked([StructField::nullable("add", add_struct)])
+    schema! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "partitionValues_parsed": {
+                ..(partition_fields),
+            },
+        },
+    }
 }
 
 /// Helper to create a checkpoint schema without `partitionValues_parsed`.
 fn create_checkpoint_schema_without_partition_parsed() -> StructType {
-    let add_struct = StructType::new_unchecked([StructField::nullable("path", DataType::STRING)]);
-    StructType::new_unchecked([StructField::nullable("add", add_struct)])
+    schema! { nullable "add": { nullable "path": STRING } }
 }
 
 #[test]
@@ -4267,10 +4265,10 @@ fn test_partition_values_parsed_compatible_basic() {
         StructField::nullable("date", DataType::DATE),
         StructField::nullable("region", DataType::STRING),
     ]);
-    let partition_schema = StructType::new_unchecked([
-        StructField::nullable("date", DataType::DATE),
-        StructField::nullable("region", DataType::STRING),
-    ]);
+    let partition_schema = schema! {
+        nullable "date": DATE,
+        nullable "region": STRING,
+    };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4286,10 +4284,10 @@ fn test_partition_values_parsed_missing_field() {
         )]);
     // Partition schema expects both date and region, but checkpoint only has date.
     // Missing fields are OK — they just won't contribute to row group skipping.
-    let partition_schema = StructType::new_unchecked([
-        StructField::nullable("date", DataType::DATE),
-        StructField::nullable("region", DataType::STRING),
-    ]);
+    let partition_schema = schema! {
+        nullable "date": DATE,
+        nullable "region": STRING,
+    };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4304,8 +4302,7 @@ fn test_partition_values_parsed_extra_field() {
         StructField::nullable("region", DataType::STRING),
         StructField::nullable("extra", DataType::INTEGER),
     ]);
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("date", DataType::DATE)]);
+    let partition_schema = schema! { nullable "date": DATE };
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4319,8 +4316,7 @@ fn test_partition_values_parsed_type_mismatch() {
             "date",
             DataType::STRING,
         )]);
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("date", DataType::DATE)]);
+    let partition_schema = schema! { nullable "date": DATE };
     assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4330,8 +4326,7 @@ fn test_partition_values_parsed_type_mismatch() {
 #[test]
 fn test_partition_values_parsed_not_present() {
     let checkpoint_schema = create_checkpoint_schema_without_partition_parsed();
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("date", DataType::DATE)]);
+    let partition_schema = schema! { nullable "date": DATE };
     assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4341,13 +4336,13 @@ fn test_partition_values_parsed_not_present() {
 #[test]
 fn test_partition_values_parsed_not_a_struct() {
     // partitionValues_parsed is a string instead of a struct
-    let add_struct = StructType::new_unchecked([
-        StructField::nullable("path", DataType::STRING),
-        StructField::nullable("partitionValues_parsed", DataType::STRING),
-    ]);
-    let checkpoint_schema = StructType::new_unchecked([StructField::nullable("add", add_struct)]);
-    let partition_schema =
-        StructType::new_unchecked([StructField::nullable("date", DataType::DATE)]);
+    let checkpoint_schema = schema! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "partitionValues_parsed": STRING,
+        },
+    };
+    let partition_schema = schema! { nullable "date": DATE };
     assert!(!LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4362,7 +4357,7 @@ fn test_partition_values_parsed_empty_partition_schema() {
             DataType::DATE,
         )]);
     // Empty partition schema — any partitionValues_parsed is compatible
-    let partition_schema = StructType::new_unchecked(Vec::<StructField>::new());
+    let partition_schema = schema! {};
     assert!(LogSegment::schema_has_compatible_partition_values_parsed(
         &checkpoint_schema,
         &partition_schema,
@@ -4766,45 +4761,45 @@ async fn test_segment_crc_filtering(#[case] case: CrcPruningCase) {
 }
 
 #[rstest::rstest]
-#[case::empty_schema(StructType::new_unchecked([]), None)]
+#[case::empty_schema(schema! {}, None)]
 #[case::add_field(
-    schema! { nullable (ADD_NAME): {} },
+    schema! { nullable ADD_NAME: {} },
     Some(Arc::new(
         col!(ADD_NAME, "path").is_not_null(),
     )),
 )]
 #[case::remove_field(
-    schema! { nullable (REMOVE_NAME): {} },
+    schema! { nullable REMOVE_NAME: {} },
     Some(Arc::new(
         col!(REMOVE_NAME, "path").is_not_null(),
     )),
 )]
 #[case::action_without_required_leaf_returns_none(
-    schema! { nullable (COMMIT_INFO_NAME): {} },
+    schema! { nullable COMMIT_INFO_NAME: {} },
     None,
 )]
 #[case::add_and_remove_fields(
-    StructType::new_unchecked([
-        StructField::nullable(ADD_NAME, StructType::new_unchecked([])),
-        StructField::nullable(REMOVE_NAME, StructType::new_unchecked([])),
-    ]),
+    schema! {
+        nullable ADD_NAME: {},
+        nullable REMOVE_NAME: {},
+    },
     Some(Arc::new(Predicate::or(
         col!(ADD_NAME, "path").is_not_null(),
         col!(REMOVE_NAME, "path").is_not_null(),
     ))),
 )]
 #[case::witness_and_witnessless_field_returns_none(
-    StructType::new_unchecked([
-        StructField::nullable(METADATA_NAME, StructType::new_unchecked([])),
-        StructField::nullable(COMMIT_INFO_NAME, StructType::new_unchecked([])),
-    ]),
+    schema! {
+        nullable METADATA_NAME: {},
+        nullable COMMIT_INFO_NAME: {},
+    },
     None,
 )]
 #[case::known_and_unknown_field_returns_none(
-    StructType::new_unchecked([
-        StructField::nullable(ADD_NAME, StructType::new_unchecked([])),
-        StructField::nullable("futureAction", StructType::new_unchecked([])),
-    ]),
+    schema! {
+        nullable ADD_NAME: {},
+        nullable "futureAction": {},
+    },
     None,
 )]
 fn test_checkpoint_action_projection_predicate(

--- a/kernel/src/metrics/metered_json.rs
+++ b/kernel/src/metrics/metered_json.rs
@@ -112,7 +112,7 @@ mod tests {
     use crate::arrow::datatypes::Schema;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::metrics::MetricEvent;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     #[derive(Debug, Default)]
@@ -185,7 +185,7 @@ mod tests {
     }
 
     fn delta_schema() -> SchemaRef {
-        Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
+        schema_ref! { nullable "x": INTEGER }
     }
 
     #[test]

--- a/kernel/src/metrics/metered_parquet.rs
+++ b/kernel/src/metrics/metered_parquet.rs
@@ -114,7 +114,7 @@ mod tests {
 
     use super::*;
     use crate::metrics::MetricEvent;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     #[derive(Debug, Default)]
@@ -174,7 +174,7 @@ mod tests {
     }
 
     fn delta_schema() -> SchemaRef {
-        Arc::new(StructType::try_new([StructField::nullable("x", DataType::INTEGER)]).unwrap())
+        schema_ref! { nullable "x": INTEGER }
     }
 
     #[test]

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -148,7 +148,7 @@ mod tests {
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::get_simple_state_info;
     use crate::scan::{ScanBuilder, StatsOptions};
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, StructField, StructType};
     use crate::unit_test_utils::{
         install_thread_local_metrics_reporter, load_test_table, parse_json_batch, CapturingReporter,
     };
@@ -186,10 +186,9 @@ mod tests {
 
     /// Creates a simple table schema for tests
     fn test_schema() -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "value",
-            DataType::INTEGER,
-        )]))
+        schema_ref! {
+            nullable "value": INTEGER,
+        }
     }
 
     /// Creates a ScanLogReplayProcessor with a pre-populated HashMap.

--- a/kernel/src/parallel/parallel_scan_metadata.rs
+++ b/kernel/src/parallel/parallel_scan_metadata.rs
@@ -299,18 +299,16 @@ mod tests {
     };
     use crate::scan::state_info::StateInfo;
     use crate::scan::PhysicalPredicate;
-    use crate::schema::{DataType, SchemaRef, StructField, StructType};
+    use crate::schema::{schema_ref, SchemaRef};
     use crate::table_features::ColumnMappingMode;
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     #[test]
     fn test_parallel_state_log_metrics_carries_round_tripped_table_type() {
         let engine = SyncEngine::new();
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
-            "id",
-            DataType::INTEGER,
-            true,
-        )]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "id": INTEGER,
+        };
         let state_info = Arc::new(StateInfo {
             logical_schema: schema.clone(),
             physical_schema: schema,

--- a/kernel/src/partition/validation.rs
+++ b/kernel/src/partition/validation.rs
@@ -174,16 +174,16 @@ mod tests {
 
     use super::*;
     use crate::expressions::Scalar;
-    use crate::schema::{ArrayType, DataType, MapType, StructField};
+    use crate::schema::{schema, ArrayType, DataType, MapType};
 
     fn assert_type_ok(data_type: DataType, value: Scalar) {
-        let schema = StructType::new_unchecked(vec![StructField::not_null("p", data_type)]);
+        let schema = schema! { not_null "p": (data_type) };
         let values = HashMap::from([("p".to_string(), value)]);
         validate_types(&schema, &values).unwrap();
     }
 
     fn assert_type_err(data_type: DataType, value: Scalar) -> String {
-        let schema = StructType::new_unchecked(vec![StructField::not_null("p", data_type)]);
+        let schema = schema! { not_null "p": (data_type) };
         let values = HashMap::from([("p".to_string(), value)]);
         validate_types(&schema, &values).unwrap_err().to_string()
     }
@@ -191,7 +191,7 @@ mod tests {
     /// Like [`assert_type_ok`] but uses a `nullable` schema field. Used by null-value cases,
     /// since null scalars are only valid for nullable partition columns.
     fn assert_type_ok_nullable(data_type: DataType, value: Scalar) {
-        let schema = StructType::new_unchecked(vec![StructField::nullable("p", data_type)]);
+        let schema = schema! { nullable "p": (data_type) };
         let values = HashMap::from([("p".to_string(), value)]);
         validate_types(&schema, &values).unwrap();
     }
@@ -452,7 +452,7 @@ mod tests {
     /// Complex types (struct, array, map) are rejected as partition column types.
     #[rstest]
     #[case(
-        DataType::from(StructType::new_unchecked(vec![StructField::not_null("x", DataType::INTEGER)])),
+        DataType::from(schema! { not_null "x": INTEGER }),
         Scalar::Null(DataType::STRING)
     )]
     #[case(
@@ -473,8 +473,7 @@ mod tests {
 
     #[test]
     fn test_validate_types_column_not_in_schema_returns_error() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::not_null("year", DataType::INTEGER)]);
+        let schema = schema! { not_null "year": INTEGER };
         let values = HashMap::from([("nonexistent".to_string(), Scalar::Integer(42))]);
         let result = validate_types(&schema, &values);
         assert!(result.is_err());
@@ -486,11 +485,11 @@ mod tests {
     #[test]
     fn test_validate_partition_values_with_case_mismatch_succeeds() {
         let partition_cols = vec!["Year".to_string(), "Region".to_string()];
-        let schema = StructType::new_unchecked(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::not_null("Year", DataType::INTEGER),
-            StructField::nullable("Region", DataType::STRING),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            not_null "Year": INTEGER,
+            nullable "Region": STRING,
+        };
         let values = HashMap::from([
             ("YEAR".to_string(), Scalar::Integer(2024)),
             ("region".to_string(), Scalar::String("US".into())),

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -652,7 +652,7 @@ mod tests {
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::expressions::{col, column_name, lit, Expression};
     use crate::plans::ir::nodes::FileType;
-    use crate::schema::{DataType, MetadataColumnSpec, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, MetadataColumnSpec, StructField, StructType};
     use crate::FileMeta;
 
     /// A single-file scan (present), no file-constant columns -- the trivial scan fixture.
@@ -669,17 +669,15 @@ mod tests {
     }
 
     fn id_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "id",
-            DataType::STRING,
-        )]))
+        schema_ref! {
+            nullable "id": STRING,
+        }
     }
 
     fn x_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([StructField::nullable(
-            "x",
-            DataType::LONG,
-        )]))
+        schema_ref! {
+            nullable "x": LONG,
+        }
     }
 
     /// A one-row (all-null) `Values` source over `schema` -- the common present-source fixture.
@@ -723,10 +721,10 @@ mod tests {
 
     /// `{ id, part }`, with `part` used as a file-constant column.
     fn part_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("part", DataType::STRING),
-        ]))
+        schema_ref! {
+            nullable "id": STRING,
+            nullable "part": STRING,
+        }
     }
 
     /// A single-file scan with one file constant `"p1"` for the `part` column.
@@ -1013,16 +1011,13 @@ mod tests {
 
     /// `{ outer: { a, b }, c }` -- a nested schema for exercising `project_patch`.
     fn nested_ab_c() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable(
-                "outer",
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::LONG),
-                    StructField::nullable("b", DataType::STRING),
-                ]),
-            ),
-            StructField::nullable("c", DataType::LONG),
-        ]))
+        schema_ref! {
+            nullable "outer": {
+                nullable "a": LONG,
+                nullable "b": STRING,
+            },
+            nullable "c": LONG,
+        }
     }
 
     /// `project_patch` lowers field edits and the output schema together: a nested replace, a
@@ -1040,16 +1035,13 @@ mod tests {
             .drop("c")
         })?;
 
-        let expected: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::nullable(
-                "outer",
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::LONG),
-                    StructField::nullable("b2", DataType::LONG),
-                ]),
-            ),
-            StructField::nullable("d", DataType::LONG),
-        ]));
+        let expected: SchemaRef = schema_ref! {
+            nullable "outer": {
+                nullable "a": LONG,
+                nullable "b2": LONG,
+            },
+            nullable "d": LONG,
+        };
         assert_eq!(patched.schema(), &expected);
         assert_plan(patched, &[(&[], "values"), (&[0], "project")]);
         Ok(())
@@ -1122,20 +1114,20 @@ mod tests {
     }
 
     fn dynamic_scan_input_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null("size", DataType::LONG),
-            StructField::not_null("filemod", DataType::LONG),
-            StructField::nullable("dv", DeletionVectorDescriptor::to_schema()),
-            StructField::nullable("version", DataType::LONG),
-        ]))
+        schema_ref! {
+            not_null "path": STRING,
+            not_null "size": LONG,
+            not_null "filemod": LONG,
+            nullable "dv": (DeletionVectorDescriptor::to_schema()),
+            nullable "version": LONG,
+        }
     }
 
     fn dynamic_scan_output_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("version", DataType::LONG),
-        ]))
+        schema_ref! {
+            nullable "id": STRING,
+            nullable "version": LONG,
+        }
     }
 
     #[test]

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -652,7 +652,9 @@ mod tests {
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::expressions::{col, column_name, lit, Expression};
     use crate::plans::ir::nodes::FileType;
-    use crate::schema::{schema_ref, DataType, MetadataColumnSpec, StructField, StructType};
+    use crate::schema::{
+        schema, schema_ref, DataType, MetadataColumnSpec, StructField, StructType,
+    };
     use crate::FileMeta;
 
     /// A single-file scan (present), no file-constant columns -- the trivial scan fixture.
@@ -1189,16 +1191,17 @@ mod tests {
         let base_schema = dynamic_scan_input_schema();
         let metadata = StructField::new(
             "metadata",
-            StructType::new_unchecked([
-                StructField::not_null("path", DataType::STRING),
-                StructField::not_null("size", DataType::LONG),
-                StructField::not_null("filemod", DataType::LONG),
-            ]),
+            schema! {
+                not_null "path": STRING,
+                not_null "size": LONG,
+                not_null "filemod": LONG,
+            },
             parent_nullable,
         );
-        let input = Arc::new(StructType::new_unchecked(
-            base_schema.fields().cloned().chain([metadata]),
-        ));
+        let input = schema_ref! {
+            ..(base_schema.fields()),
+            (metadata),
+        };
         let mut columns = [
             column_name!("path"),
             column_name!("size"),
@@ -1233,16 +1236,14 @@ mod tests {
     ) {
         let metadata = StructField::new(
             "metadata",
-            StructType::new_unchecked([StructField::nullable(
-                "dv",
-                DeletionVectorDescriptor::to_schema(),
-            )]),
+            schema! { nullable "dv": (DeletionVectorDescriptor::to_schema()) },
             parent_nullable,
         );
         let base_schema = dynamic_scan_input_schema();
-        let input = Arc::new(StructType::new_unchecked(
-            base_schema.fields().cloned().chain([metadata]),
-        ));
+        let input = schema_ref! {
+            ..(base_schema.fields()),
+            (metadata),
+        };
 
         DynamicScan::try_new(
             &input,

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -1112,7 +1112,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::column_name;
-    use crate::schema::{DataType, MetadataValue, StructField};
+    use crate::schema::{schema_ref, DataType, MetadataValue, StructField};
     use crate::unit_test_utils::assert_result_error_with_message;
 
     /// Builds a flat `LONG` schema from `(name, nullable)` pairs.
@@ -1139,11 +1139,11 @@ mod tests {
     #[test]
     fn output_fields_preserve_input_field_metadata() {
         let metadata = [("k", MetadataValue::Number(7))];
-        let input = Arc::new(StructType::new_unchecked([
-            StructField::not_null("g", DataType::LONG).with_metadata(metadata.clone()),
-            StructField::not_null("a", DataType::LONG).with_metadata(metadata.clone()),
-            StructField::not_null("s", DataType::LONG).with_metadata(metadata),
-        ]));
+        let input = schema_ref! {
+            (StructField::not_null("g", DataType::LONG).with_metadata(metadata.clone())),
+            (StructField::not_null("a", DataType::LONG).with_metadata(metadata.clone())),
+            (StructField::not_null("s", DataType::LONG).with_metadata(metadata)),
+        };
         let agg = Aggregate::group_by(input, [column_name!("g")])
             .max(column_name!("a"))
             .sum(column_name!("s"))

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -998,8 +998,8 @@ mod tests {
     };
     use crate::plans::{IoOperation, Operation};
     use crate::schema::{
-        ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType, SchemaRef,
-        StructField, StructType, ToSchema as _,
+        schema_ref, ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType,
+        SchemaRef, StructField, StructType, ToSchema as _,
     };
     #[cfg(feature = "geo-type-in-dev")]
     use crate::schema::{EdgeInterpolationAlgorithm, GeographyType, GeometryType};
@@ -1417,20 +1417,20 @@ mod tests {
     }
 
     fn sample_dynamic_scan_input_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null("size", DataType::LONG),
-            StructField::not_null("filemod", DataType::LONG),
-            StructField::nullable("dv", DeletionVectorDescriptor::to_schema()),
-            StructField::nullable("c", DataType::INTEGER),
-        ]))
+        schema_ref! {
+            not_null "path": STRING,
+            not_null "size": LONG,
+            not_null "filemod": LONG,
+            nullable "dv": (DeletionVectorDescriptor::to_schema()),
+            nullable "c": INTEGER,
+        }
     }
 
     fn sample_dynamic_scan_output_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("c", DataType::INTEGER),
-        ]))
+        schema_ref! {
+            nullable "id": INTEGER,
+            nullable "c": INTEGER,
+        }
     }
 
     #[rstest]

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -796,11 +796,9 @@ impl TryFrom<proto_schema::DataType> for DataType {
             .ok_or_else(|| Error::schema("DataType proto missing kind"))?;
         let data_type = match kind {
             DataTypeKind::Primitive(primitive) => DataType::Primitive(primitive.try_into()?),
-            DataTypeKind::Array(array) => DataType::Array(Box::new((*array).try_into()?)),
-            DataTypeKind::Struct(struct_type) => {
-                DataType::Struct(Box::new(struct_type.try_into()?))
-            }
-            DataTypeKind::Map(map) => DataType::Map(Box::new((*map).try_into()?)),
+            DataTypeKind::Array(array) => DataType::from(ArrayType::try_from(*array)?),
+            DataTypeKind::Struct(struct_type) => DataType::from(StructType::try_from(struct_type)?),
+            DataTypeKind::Map(map) => DataType::from(MapType::try_from(*map)?),
             // Kernel does not support shredded variants, so always decode as unshredded.
             DataTypeKind::Variant(_) => DataType::unshredded_variant(),
         };
@@ -998,8 +996,8 @@ mod tests {
     };
     use crate::plans::{IoOperation, Operation};
     use crate::schema::{
-        schema_ref, ArrayType, DataType, DecimalType, MapType, MetadataValue, PrimitiveType,
-        SchemaRef, StructField, StructType, ToSchema as _,
+        schema, schema_ref, ArrayType, DataType, DecimalType, MapType, MetadataValue,
+        PrimitiveType, SchemaRef, StructField, StructType, ToSchema as _,
     };
     #[cfg(feature = "geo-type-in-dev")]
     use crate::schema::{EdgeInterpolationAlgorithm, GeographyType, GeometryType};
@@ -1066,7 +1064,7 @@ mod tests {
     }
 
     fn sample_schema() -> SchemaRef {
-        Arc::new(StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)]).unwrap())
+        schema_ref! { nullable "id": INTEGER }
     }
 
     fn decode(op: &Operation) -> proto_op::Operation {
@@ -1218,13 +1216,10 @@ mod tests {
 
     #[test]
     fn from_plan() {
-        let schema = Arc::new(
-            StructType::try_new(vec![
-                StructField::nullable("id", DataType::INTEGER),
-                StructField::not_null("name", DataType::STRING),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            not_null "name": STRING,
+        };
         let plan = Plan {
             nodes: vec![
                 PlanNode {
@@ -2025,12 +2020,7 @@ mod tests {
     #[rstest]
     #[case(DataType::INTEGER, "primitive")]
     #[case(ArrayType::new(DataType::INTEGER, true).into(), "array")]
-    #[case(
-        StructType::try_new(vec![StructField::nullable("a", DataType::INTEGER)])
-            .unwrap()
-            .into(),
-        "struct"
-    )]
+    #[case(DataType::from(schema! { nullable "a": INTEGER }), "struct")]
     #[case(MapType::new(DataType::STRING, DataType::INTEGER, true).into(), "map")]
     #[case(DataType::unshredded_variant(), "variant")]
     fn from_data_type(#[case] value: DataType, #[case] expected: &str) {
@@ -2119,11 +2109,10 @@ mod tests {
 
     #[test]
     fn from_struct_type() {
-        let struct_type = StructType::try_new(vec![
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::not_null("b", DataType::STRING),
-        ])
-        .unwrap();
+        let struct_type = schema! {
+            nullable "a": INTEGER,
+            not_null "b": STRING,
+        };
         let proto = proto_schema::StructType::from(&struct_type);
         assert_eq!(proto.fields.len(), 2);
         assert!(proto.fields[0].nullable);
@@ -2277,10 +2266,10 @@ mod tests {
         MapType::new(DataType::STRING, DataType::LONG, true),
         true
     )))]
-    #[case(DataType::from(StructType::try_new(vec![
-        StructField::nullable("a", DataType::INTEGER),
-        StructField::not_null("b", DataType::STRING),
-    ]).unwrap()))]
+    #[case(DataType::from(schema! {
+        nullable "a": INTEGER,
+        not_null "b": STRING,
+    }))]
     fn round_trip_composite(#[case] data_type: DataType) {
         assert_data_type_round_trips(data_type);
     }
@@ -2298,26 +2287,15 @@ mod tests {
 
     #[test]
     fn round_trip_full_schema() {
-        let schema = StructType::try_new(vec![
-            StructField::nullable("id", DataType::LONG)
-                .with_metadata([("k", MetadataValue::Number(7))]),
-            StructField::not_null("name", DataType::STRING),
-            StructField::nullable("scores", ArrayType::new(DataType::INTEGER, true)),
-            StructField::nullable(
-                "attrs",
-                MapType::new(DataType::STRING, DataType::LONG, true),
-            ),
-            StructField::nullable(
-                "price",
-                DataType::Primitive(PrimitiveType::decimal(10, 2).unwrap()),
-            ),
-            StructField::nullable(
-                "nested",
-                StructType::try_new(vec![StructField::not_null("inner", DataType::BOOLEAN)])
-                    .unwrap(),
-            ),
-        ])
-        .unwrap();
+        let schema = schema! {
+            (StructField::nullable("id", DataType::LONG)
+                .with_metadata([("k", MetadataValue::Number(7))])),
+            not_null "name": STRING,
+            nullable "scores": [ nullable INTEGER ],
+            nullable "attrs": { STRING => nullable LONG },
+            nullable "price": (PrimitiveType::decimal(10, 2).unwrap()),
+            nullable "nested": { not_null "inner": BOOLEAN },
+        };
         assert_schema_round_trips(schema);
     }
 
@@ -2325,14 +2303,11 @@ mod tests {
     /// decodes to the canonical unshredded form rather than round-tripping its inner struct.
     #[test]
     fn variant_decodes_to_unshredded() {
-        let shredded = DataType::Variant(Box::new(
-            StructType::try_new(vec![
-                StructField::not_null("metadata", DataType::BINARY),
-                StructField::not_null("value", DataType::BINARY),
-                StructField::nullable("typed_value", DataType::INTEGER),
-            ])
-            .unwrap(),
-        ));
+        let shredded = DataType::Variant(Box::new(schema! {
+            not_null "metadata": BINARY,
+            not_null "value": BINARY,
+            nullable "typed_value": INTEGER,
+        }));
         let decoded = DataType::try_from(proto_schema::DataType::from(&shredded));
         assert_eq!(
             decoded.expect("decode succeeds"),

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -19,7 +19,7 @@ use crate::kernel_predicates::{
 use crate::scan::data_skipping::stats_schema::is_skipping_eligible_datatype;
 use crate::scan::log_replay::PARTITION_VALUES_PARSED_NAME;
 use crate::scan::metrics::ScanMetrics;
-use crate::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
+use crate::schema::{lazy_schema_ref, schema_ref, DataType, PrimitiveType, SchemaRef};
 use crate::table_configuration::TableConfiguration;
 use crate::utils::require;
 use crate::{Engine, EngineData, Error, ExpressionEvaluator, PredicateEvaluator, RowVisitor as _};
@@ -150,12 +150,9 @@ impl DataSkippingFilter {
     ) -> Option<Self> {
         static FILTER_PRED: LazyLock<PredicateRef> =
             LazyLock::new(|| Arc::new(col!("output").distinct(lit(false))));
-        static FILTER_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-            Arc::new(StructType::new_unchecked([StructField::nullable(
-                "output",
-                DataType::BOOLEAN,
-            )]))
-        });
+        static FILTER_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+            nullable "output": BOOLEAN,
+        };
 
         let predicate = predicate?;
         debug!("Creating a data skipping filter for {:#?}", predicate);
@@ -330,30 +327,24 @@ impl DataSkippingFilter {
             })
             .unwrap_or_default();
 
-        let stats_field =
-            |stats: &SchemaRef| StructField::nullable("stats_parsed", stats.as_ref().clone());
-        let partition_field =
-            |ps: &SchemaRef| StructField::nullable("partitionValues_parsed", ps.as_ref().clone());
-        let is_add_field = StructField::not_null("is_add", DataType::BOOLEAN);
-
         // Always include an `is_add` boolean (extracted by the caller-provided `is_add_expr`,
         // true for Add rows and false for Remove/non-file rows) so that predicates can guard
         // against filtering Remove rows: partition predicates and opaque-predicate rewrites are
         // wrapped with `OR(NOT is_add, ...)` (see `guard_for_removes`).
         let unified_schema = match (physical_stats_schema, physical_partition_schema) {
-            (Some(stats), Some(ps)) => Arc::new(StructType::new_unchecked([
-                stats_field(stats),
-                partition_field(ps),
-                is_add_field,
-            ])),
-            (Some(stats), None) => Arc::new(StructType::new_unchecked([
-                stats_field(stats),
-                is_add_field,
-            ])),
-            (None, Some(ps)) => Arc::new(StructType::new_unchecked([
-                partition_field(ps),
-                is_add_field,
-            ])),
+            (Some(stats), Some(ps)) => schema_ref! {
+                nullable "stats_parsed": (stats.as_ref().clone()),
+                nullable "partitionValues_parsed": (ps.as_ref().clone()),
+                not_null "is_add": BOOLEAN,
+            },
+            (Some(stats), None) => schema_ref! {
+                nullable "stats_parsed": (stats.as_ref().clone()),
+                not_null "is_add": BOOLEAN,
+            },
+            (None, Some(ps)) => schema_ref! {
+                nullable "partitionValues_parsed": (ps.as_ref().clone()),
+                not_null "is_add": BOOLEAN,
+            },
             (None, None) => return None,
         };
 

--- a/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/column_filter.rs
@@ -246,7 +246,7 @@ impl<'col> StatsColumnFilter<'col> {
 mod tests {
     use super::*;
     use crate::expressions::column_name;
-    use crate::schema::StructType;
+    use crate::schema::{schema, StructType};
     use crate::table_properties::TableProperties;
 
     fn make_props_with_num_cols(n: u64) -> TableProperties {
@@ -267,11 +267,11 @@ mod tests {
 
     /// Standard 3-column schema for required column tests: a (LONG), b (STRING), c (INTEGER)
     fn abc_schema() -> StructType {
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::STRING),
-            StructField::nullable("c", DataType::INTEGER),
-        ])
+        schema! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+            nullable "c": INTEGER,
+        }
     }
 
     /// Helper to run column collection and return results
@@ -361,28 +361,24 @@ mod tests {
         // Required column is deeply nested: user.address.city
         let required_cols = vec![column_name!("user.address.city")];
 
-        let address_struct = StructType::new_unchecked([
-            StructField::nullable("street", DataType::STRING),
-            StructField::nullable("city", DataType::STRING), // required column
-            StructField::nullable("zip", DataType::STRING),
-        ]);
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("address", address_struct),
-        ]);
-        let other_struct = StructType::new_unchecked([
-            StructField::nullable("foo", DataType::STRING),
-            StructField::nullable("bar", DataType::STRING),
-        ]);
-
-        let schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("user", user_struct),
-            StructField::nullable("other", other_struct),
-            StructField::nullable("extra1", DataType::STRING),
-            StructField::nullable("extra2", DataType::STRING),
-        ]);
+        let schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "address": {
+                    nullable "street": STRING,
+                    nullable "city": STRING,
+                    nullable "zip": STRING,
+                },
+            },
+            nullable "other": {
+                nullable "foo": STRING,
+                nullable "bar": STRING,
+            },
+            nullable "extra1": STRING,
+            nullable "extra2": STRING,
+        };
 
         let columns = collect_stats_columns(&props, Some(&required_cols), &schema);
 

--- a/kernel/src/scan/data_skipping/stats_schema/mod.rs
+++ b/kernel/src/scan/data_skipping/stats_schema/mod.rs
@@ -404,7 +404,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::column_name;
-    use crate::schema::ArrayType;
+    use crate::schema::schema;
     #[cfg(feature = "geo-type-in-dev")]
     use crate::schema::{EdgeInterpolationAlgorithm, GeographyType, GeometryType};
     use crate::table_properties::TableProperties;
@@ -428,19 +428,19 @@ mod tests {
 
     /// Builds an expected stats schema from the given null count and min/max nested schemas.
     fn expected_stats(null_count: StructType, min_max: StructType) -> StructType {
-        StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, null_count),
-            StructField::nullable(MIN_VALUES, min_max.clone()),
-            StructField::nullable(MAX_VALUES, min_max),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ])
+        schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable NULL_COUNT: (null_count),
+            nullable MIN_VALUES: (min_max.clone()),
+            nullable MAX_VALUES: (min_max),
+            nullable TIGHT_BOUNDS: BOOLEAN,
+        }
     }
 
     #[test]
     fn test_stats_schema_simple() {
         let properties: TableProperties = [("key", "value")].into();
-        let file_schema = StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let file_schema = schema! { nullable "id": LONG };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -458,14 +458,13 @@ mod tests {
     fn test_stats_schema_nested() {
         let properties: TableProperties = [("key", "value")].into();
 
-        let user_struct = StructType::new_unchecked([
-            StructField::not_null("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::not_null("id", DataType::LONG),
-            StructField::not_null("user", user_struct.clone()),
-        ]);
+        let file_schema = schema! {
+            not_null "id": LONG,
+            not_null "user": {
+                not_null "name": STRING,
+                nullable "age": INTEGER,
+            },
+        };
         let stats_schema = expected_stats_schema(
             &file_schema,
             &stats_config_from_table_properties(&properties),
@@ -499,17 +498,14 @@ mod tests {
         //   - "tags" (ARRAY) - NOT eligible for data skipping
         //   - "score" (DOUBLE) - eligible for data skipping
 
-        // Create array type for a field that's not eligible for data skipping
-        let array_type = DataType::from(ArrayType::new(DataType::STRING, false));
-        let metadata_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("tags", array_type),
-            StructField::nullable("score", DataType::DOUBLE),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("metadata", metadata_struct.clone()),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "metadata": {
+                nullable "name": STRING,
+                nullable "tags": [ not_null STRING ],
+                nullable "score": DOUBLE,
+            },
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -520,24 +516,22 @@ mod tests {
         .unwrap();
 
         // nullCount includes array fields (tags) as leaf columns
-        let expected_null_nested = StructType::new_unchecked([
-            StructField::nullable("name", DataType::LONG),
-            StructField::nullable("tags", DataType::LONG),
-            StructField::nullable("score", DataType::LONG),
-        ]);
-        let expected_null = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("metadata", expected_null_nested),
-        ]);
+        let expected_null = schema! {
+            nullable "id": LONG,
+            nullable "metadata": {
+                nullable "name": LONG,
+                nullable "tags": LONG,
+                nullable "score": LONG,
+            },
+        };
 
-        let expected_nested = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("score", DataType::DOUBLE),
-        ]);
-        let expected_fields = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("metadata", expected_nested),
-        ]);
+        let expected_fields = schema! {
+            nullable "id": LONG,
+            nullable "metadata": {
+                nullable "name": STRING,
+                nullable "score": DOUBLE,
+            },
+        };
 
         let expected = expected_stats(expected_null, expected_fields);
 
@@ -552,14 +546,13 @@ mod tests {
         )]
         .into();
 
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user.info", user_struct.clone()),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user.info": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -569,10 +562,11 @@ mod tests {
         )
         .unwrap();
 
-        let expected_nested =
-            StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_fields =
-            StructType::new_unchecked([StructField::nullable("user.info", expected_nested)]);
+        let expected_fields = schema! {
+            nullable "user.info": {
+                nullable "name": STRING,
+            },
+        };
         let null_count = NullCountStatsTransform
             .transform_struct(&expected_fields)
             .into_owned();
@@ -592,15 +586,12 @@ mod tests {
         )]
         .into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
-            StructField::nullable(
-                "metadata",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "tags": [ not_null STRING ],
+            nullable "metadata": { STRING => nullable STRING },
+            nullable "name": STRING,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -611,22 +602,15 @@ mod tests {
         .unwrap();
 
         // nullCount: only id and tags (explicitly requested)
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("tags", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "id": LONG,
+            nullable "tags": LONG,
+        };
 
         // minValues/maxValues: only id (tags excluded by MinMaxStatsTransform)
-        let expected_min_max =
-            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let expected_min_max = schema! { nullable "id": LONG };
 
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, expected_null_count),
-            StructField::nullable(MIN_VALUES, expected_min_max.clone()),
-            StructField::nullable(MAX_VALUES, expected_min_max),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = expected_stats(expected_null_count, expected_min_max);
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -639,10 +623,10 @@ mod tests {
         )]
         .into();
 
-        let logical_schema = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
+        let logical_schema = schema! {
+            nullable "name": STRING,
+            nullable "age": INTEGER,
+        };
 
         let stats_schema = expected_stats_schema(
             &logical_schema,
@@ -652,8 +636,7 @@ mod tests {
         )
         .unwrap();
 
-        let expected_fields =
-            StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
+        let expected_fields = schema! { nullable "name": STRING };
         let null_count = NullCountStatsTransform
             .transform_struct(&expected_fields)
             .into_owned();
@@ -672,12 +655,12 @@ mod tests {
         // - "is_active" (BOOLEAN) - eligible for null count but NOT for min/max
         // - "metadata" (BINARY) - eligible for null count but NOT for min/max
         // - "duration" (INTERVAL_DAY_TIME) - eligible for null count but NOT for min/max
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("is_active", DataType::BOOLEAN),
-            StructField::nullable("metadata", DataType::BINARY),
-            StructField::nullable("duration", DataType::INTERVAL_DAY_TIME),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "is_active": BOOLEAN,
+            nullable "metadata": BINARY,
+            nullable "duration": INTERVAL_DAY_TIME,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -688,16 +671,15 @@ mod tests {
         .unwrap();
 
         // Expected nullCount schema: all fields converted to LONG
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("is_active", DataType::LONG),
-            StructField::nullable("metadata", DataType::LONG),
-            StructField::nullable("duration", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "id": LONG,
+            nullable "is_active": LONG,
+            nullable "metadata": LONG,
+            nullable "duration": LONG,
+        };
 
         // Expected minValues/maxValues schema: only eligible fields
-        let expected_min_max =
-            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let expected_min_max = schema! { nullable "id": LONG };
 
         let expected = expected_stats(expected_null_count, expected_min_max);
 
@@ -710,18 +692,16 @@ mod tests {
 
         // Create a nested schema where some nested fields are eligible for min/max and others
         // aren't
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING), // eligible for min/max
-            StructField::nullable("is_admin", DataType::BOOLEAN), // NOT eligible for min/max
-            StructField::nullable("age", DataType::INTEGER), // eligible for min/max
-            StructField::nullable("profile_pic", DataType::BINARY), // NOT eligible for min/max
-        ]);
-
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", user_struct.clone()),
-            StructField::nullable("is_deleted", DataType::BOOLEAN), // NOT eligible for min/max
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "is_admin": BOOLEAN,
+                nullable "age": INTEGER,
+                nullable "profile_pic": BINARY,
+            },
+            nullable "is_deleted": BOOLEAN,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -732,27 +712,25 @@ mod tests {
         .unwrap();
 
         // Expected nullCount schema: all fields converted to LONG, maintaining structure
-        let expected_null_user = StructType::new_unchecked([
-            StructField::nullable("name", DataType::LONG),
-            StructField::nullable("is_admin", DataType::LONG),
-            StructField::nullable("age", DataType::LONG),
-            StructField::nullable("profile_pic", DataType::LONG),
-        ]);
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", expected_null_user),
-            StructField::nullable("is_deleted", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": LONG,
+                nullable "is_admin": LONG,
+                nullable "age": LONG,
+                nullable "profile_pic": LONG,
+            },
+            nullable "is_deleted": LONG,
+        };
 
         // Expected minValues/maxValues schema: only eligible fields
-        let expected_minmax_user = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let expected_min_max = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", expected_minmax_user),
-        ]);
+        let expected_min_max = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+        };
 
         let expected = expected_stats(expected_null_count, expected_min_max);
 
@@ -764,12 +742,12 @@ mod tests {
         let properties: TableProperties = [("key", "value")].into();
 
         // Create a schema with only fields that are NOT eligible for min/max skipping
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("is_active", DataType::BOOLEAN),
-            StructField::nullable("metadata", DataType::BINARY),
-            StructField::nullable("duration", DataType::INTERVAL_DAY_TIME),
-            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
-        ]);
+        let file_schema = schema! {
+            nullable "is_active": BOOLEAN,
+            nullable "metadata": BINARY,
+            nullable "duration": INTERVAL_DAY_TIME,
+            nullable "tags": [ not_null STRING ],
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -780,19 +758,19 @@ mod tests {
         .unwrap();
 
         // nullCount includes all selected non-struct fields
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("is_active", DataType::LONG),
-            StructField::nullable("metadata", DataType::LONG),
-            StructField::nullable("duration", DataType::LONG),
-            StructField::nullable("tags", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "is_active": LONG,
+            nullable "metadata": LONG,
+            nullable "duration": LONG,
+            nullable "tags": LONG,
+        };
 
         // minValues/maxValues: no fields are eligible
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, expected_null_count),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable NULL_COUNT: (expected_null_count),
+            nullable TIGHT_BOUNDS: BOOLEAN,
+        };
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -806,10 +784,10 @@ mod tests {
         #[case] property_value: &str,
     ) {
         let properties: TableProperties = [(property_name, property_value)].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("iv", interval),
-            StructField::nullable("value", DataType::LONG),
-        ]);
+        let file_schema = schema! {
+            nullable "iv": (interval),
+            nullable "value": LONG,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -819,14 +797,13 @@ mod tests {
         )
         .unwrap();
 
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(
-                NULL_COUNT,
-                StructType::new_unchecked([StructField::nullable("iv", DataType::LONG)]),
-            ),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable NULL_COUNT: {
+                nullable "iv": LONG,
+            },
+            nullable TIGHT_BOUNDS: BOOLEAN,
+        };
         assert_eq!(expected, stats_schema);
     }
 
@@ -843,16 +820,13 @@ mod tests {
         )]
         .into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
-            StructField::nullable(
-                "metadata",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("v", DataType::unshredded_variant()),
-            StructField::nullable("col1", DataType::LONG),
-            StructField::nullable("col2", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "tags": [ not_null STRING ],
+            nullable "metadata": { STRING => nullable STRING },
+            nullable "v": unshredded_variant(),
+            nullable "col1": LONG,
+            nullable "col2": STRING,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -864,19 +838,19 @@ mod tests {
 
         // nullCount includes array, map, and variant (the first 3 leaf columns).
         // col1/col2 are excluded by the limit.
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("tags", DataType::LONG),
-            StructField::nullable("metadata", DataType::LONG),
-            StructField::nullable("v", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "tags": LONG,
+            nullable "metadata": LONG,
+            nullable "v": LONG,
+        };
 
         // minValues/maxValues: all 3 complex types are excluded by MinMaxStatsTransform,
         // and col1/col2 are past the limit, so no min/max fields at all.
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, expected_null_count),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable NULL_COUNT: (expected_null_count),
+            nullable TIGHT_BOUNDS: BOOLEAN,
+        };
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -892,11 +866,11 @@ mod tests {
         )]
         .into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "tags": [ not_null STRING ],
+            nullable "name": STRING,
+        };
 
         let stats_schema = expected_stats_schema(
             &file_schema,
@@ -907,22 +881,15 @@ mod tests {
         .unwrap();
 
         // nullCount: id and tags (first 2 leaf columns). name is excluded.
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("tags", DataType::LONG),
-        ]);
+        let expected_null_count = schema! {
+            nullable "id": LONG,
+            nullable "tags": LONG,
+        };
 
         // minValues/maxValues: only id (tags excluded by MinMaxStatsTransform, name past limit)
-        let expected_min_max =
-            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let expected_min_max = schema! { nullable "id": LONG };
 
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, expected_null_count),
-            StructField::nullable(MIN_VALUES, expected_min_max.clone()),
-            StructField::nullable(MAX_VALUES, expected_min_max),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = expected_stats(expected_null_count, expected_min_max);
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -933,14 +900,13 @@ mod tests {
     fn test_stats_column_names_default() {
         let properties: TableProperties = [("key", "value")].into();
 
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", user_struct),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+        };
 
         let config = StatsConfig {
             data_skipping_stats_columns: properties.data_skipping_stats_columns.as_deref(),
@@ -967,12 +933,12 @@ mod tests {
         )]
         .into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::STRING),
-            StructField::nullable("c", DataType::INTEGER),
-            StructField::nullable("d", DataType::DOUBLE),
-        ]);
+        let file_schema = schema! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+            nullable "c": INTEGER,
+            nullable "d": DOUBLE,
+        };
 
         let config = StatsConfig {
             data_skipping_stats_columns: properties.data_skipping_stats_columns.as_deref(),
@@ -992,15 +958,14 @@ mod tests {
         )]
         .into();
 
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", user_struct),
-            StructField::nullable("extra", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+            nullable "extra": STRING,
+        };
 
         let config = StatsConfig {
             data_skipping_stats_columns: properties.data_skipping_stats_columns.as_deref(),
@@ -1016,16 +981,13 @@ mod tests {
     fn test_stats_column_names_includes_complex_types() {
         let properties: TableProperties = [("key", "value")].into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("tags", ArrayType::new(DataType::STRING, false)),
-            StructField::nullable(
-                "metadata",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("v", DataType::unshredded_variant()),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "tags": [ not_null STRING ],
+            nullable "metadata": { STRING => nullable STRING },
+            nullable "v": unshredded_variant(),
+            nullable "name": STRING,
+        };
 
         let config = StatsConfig {
             data_skipping_stats_columns: properties.data_skipping_stats_columns.as_deref(),
@@ -1057,11 +1019,11 @@ mod tests {
         )]
         .into();
 
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::STRING),
-            StructField::nullable("c", DataType::INTEGER),
-        ]);
+        let file_schema = schema! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+            nullable "c": INTEGER,
+        };
 
         // "c" is a clustering column, should be included even though limit is 1
         let clustering_columns = vec![column_name!("c")];
@@ -1074,14 +1036,14 @@ mod tests {
         .unwrap();
 
         // Only "a" (first column) and "c" (clustering) should be included
-        let expected_null_count = StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("c", DataType::LONG),
-        ]);
-        let expected_min_max = StructType::new_unchecked([
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("c", DataType::INTEGER),
-        ]);
+        let expected_null_count = schema! {
+            nullable "a": LONG,
+            nullable "c": LONG,
+        };
+        let expected_min_max = schema! {
+            nullable "a": LONG,
+            nullable "c": INTEGER,
+        };
 
         let expected = expected_stats(expected_null_count, expected_min_max);
 
@@ -1093,11 +1055,11 @@ mod tests {
     #[test]
     fn test_requested_filters_to_single_column() {
         let properties: TableProperties = [("key", "value")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("value", DataType::INTEGER),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+            nullable "value": INTEGER,
+        };
 
         let columns = [column_name!("id")];
         let stats_schema = expected_stats_schema(
@@ -1108,8 +1070,7 @@ mod tests {
         )
         .unwrap();
 
-        let expected_nested =
-            StructType::new_unchecked([StructField::nullable("id", DataType::LONG)]);
+        let expected_nested = schema! { nullable "id": LONG };
 
         let expected = expected_stats(expected_nested.clone(), expected_nested);
 
@@ -1120,10 +1081,10 @@ mod tests {
     fn test_none_requested_returns_full_schema() {
         // None for requested_columns means no output filtering — include all columns
         let properties: TableProperties = [("key", "value")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+        };
 
         let with_none = expected_stats_schema(
             &file_schema,
@@ -1147,10 +1108,10 @@ mod tests {
     fn test_requested_column_outside_limit_excluded() {
         // requested_columns alone does NOT bypass the column limit — only required_columns does
         let properties: TableProperties = [("delta.dataSkippingNumIndexedCols", "1")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+        };
 
         // "name" is outside the limit (limit is 1), and is only requested, not required
         let columns = [column_name!("name")];
@@ -1163,10 +1124,10 @@ mod tests {
         .unwrap();
 
         // No data columns pass both filters, so only numRecords + tightBounds
-        let expected = StructType::new_unchecked([
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-        ]);
+        let expected = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable TIGHT_BOUNDS: BOOLEAN,
+        };
 
         assert_eq!(&expected, &stats_schema);
     }
@@ -1176,10 +1137,10 @@ mod tests {
         // When a column is both required AND requested, it bypasses the limit and
         // appears in the output. This is the pattern used by the read path.
         let properties: TableProperties = [("delta.dataSkippingNumIndexedCols", "1")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+        };
 
         let columns = [column_name!("name")];
         let stats_schema = expected_stats_schema(
@@ -1190,10 +1151,8 @@ mod tests {
         )
         .unwrap();
 
-        let expected_nested =
-            StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_null =
-            StructType::new_unchecked([StructField::nullable("name", DataType::LONG)]);
+        let expected_nested = schema! { nullable "name": STRING };
+        let expected_null = schema! { nullable "name": LONG };
 
         let expected = expected_stats(expected_null, expected_nested);
 
@@ -1206,11 +1165,11 @@ mod tests {
         // requested_columns=["name"] filters the output to just "name",
         // but "id" still counts toward the limit (so "value" stays excluded).
         let properties: TableProperties = [("delta.dataSkippingNumIndexedCols", "2")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("value", DataType::INTEGER),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+            nullable "value": INTEGER,
+        };
 
         let columns = [column_name!("name")];
         let stats_schema = expected_stats_schema(
@@ -1222,10 +1181,8 @@ mod tests {
         .unwrap();
 
         // Only "name" appears in the output (filtered), even though "id" counted toward the limit
-        let expected_nested =
-            StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_null =
-            StructType::new_unchecked([StructField::nullable("name", DataType::LONG)]);
+        let expected_nested = schema! { nullable "name": STRING };
+        let expected_null = schema! { nullable "name": LONG };
 
         let expected = expected_stats(expected_null, expected_nested);
 
@@ -1235,11 +1192,11 @@ mod tests {
     #[test]
     fn test_multiple_requested_columns() {
         let properties: TableProperties = [("key", "value")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("value", DataType::INTEGER),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+            nullable "value": INTEGER,
+        };
 
         let columns = [column_name!("id"), column_name!("name")];
         let stats_schema = expected_stats_schema(
@@ -1250,14 +1207,14 @@ mod tests {
         )
         .unwrap();
 
-        let expected_nested = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-        ]);
-        let expected_null = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::LONG),
-        ]);
+        let expected_nested = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+        };
+        let expected_null = schema! {
+            nullable "id": LONG,
+            nullable "name": LONG,
+        };
 
         let expected = expected_stats(expected_null, expected_nested);
 
@@ -1267,14 +1224,13 @@ mod tests {
     #[test]
     fn test_nested_requested_column() {
         let properties: TableProperties = [("key", "value")].into();
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", user_struct),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+        };
 
         let columns = [column_name!("user.name")];
         let stats_schema = expected_stats_schema(
@@ -1285,15 +1241,16 @@ mod tests {
         )
         .unwrap();
 
-        let expected_user_nested =
-            StructType::new_unchecked([StructField::nullable("name", DataType::STRING)]);
-        let expected_nested =
-            StructType::new_unchecked([StructField::nullable("user", expected_user_nested)]);
-
-        let expected_user_null =
-            StructType::new_unchecked([StructField::nullable("name", DataType::LONG)]);
-        let expected_null =
-            StructType::new_unchecked([StructField::nullable("user", expected_user_null)]);
+        let expected_nested = schema! {
+            nullable "user": {
+                nullable "name": STRING,
+            },
+        };
+        let expected_null = schema! {
+            nullable "user": {
+                nullable "name": LONG,
+            },
+        };
 
         let expected = expected_stats(expected_null, expected_nested);
 
@@ -1303,10 +1260,10 @@ mod tests {
     #[test]
     fn test_empty_requested_columns() {
         let properties: TableProperties = [("key", "value")].into();
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "name": STRING,
+        };
 
         // Empty columns list should return the full schema (same as None)
         let columns: [ColumnName; 0] = [];
@@ -1331,15 +1288,14 @@ mod tests {
     #[test]
     fn test_mixed_nested_and_top_requested() {
         let properties: TableProperties = [("key", "value")].into();
-        let user_struct = StructType::new_unchecked([
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("age", DataType::INTEGER),
-        ]);
-        let file_schema = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", user_struct),
-            StructField::nullable("value", DataType::DOUBLE),
-        ]);
+        let file_schema = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "name": STRING,
+                nullable "age": INTEGER,
+            },
+            nullable "value": DOUBLE,
+        };
 
         let columns = [column_name!("id"), column_name!("user.age")];
         let stats_schema = expected_stats_schema(
@@ -1350,19 +1306,19 @@ mod tests {
         )
         .unwrap();
 
-        let expected_user_nested =
-            StructType::new_unchecked([StructField::nullable("age", DataType::INTEGER)]);
-        let expected_nested = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", expected_user_nested.clone()),
-        ]);
+        let expected_nested = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "age": INTEGER,
+            },
+        };
 
-        let expected_user_null =
-            StructType::new_unchecked([StructField::nullable("age", DataType::LONG)]);
-        let expected_null = StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("user", expected_user_null),
-        ]);
+        let expected_null = schema! {
+            nullable "id": LONG,
+            nullable "user": {
+                nullable "age": LONG,
+            },
+        };
 
         let expected = expected_stats(expected_null, expected_nested);
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -1170,9 +1170,9 @@ fn test_partition_timestamp_column_no_adjustment() {
 fn test_interval_partition_columns_are_not_pruning_columns(
     #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] interval: DataType,
 ) {
-    let partition_schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-        "period", interval,
-    )]));
+    let partition_schema = schema_ref! {
+        nullable "period": (interval),
+    };
     let (_, _, partition_columns) = DataSkippingFilter::build_unified_schema_and_expr(
         None,
         column_expr_ref!("stats_parsed"),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -750,7 +750,7 @@ pub(crate) static PARTITION_VALUES_PARSED_NAME: &str = "partitionValues_parsed";
 // NB: If you update this schema, ensure you update the comment describing it in the doc comment
 // for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
 // indexes will be off, and [`get_add_transform_expr`] below to match it.
-pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = lazy_schema_ref! {
+pub(crate) static SCAN_ROW_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
     // Note that fields projected out of a nullable struct must be nullable
     nullable PATH_NAME: STRING,
     nullable SIZE_NAME: LONG,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -23,7 +23,7 @@ use crate::log_replay::{
 use crate::log_segment::CheckpointReadInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
 use crate::schema::{
-    schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
+    lazy_schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
 };
 use crate::table_features::ColumnMappingMode;
@@ -750,23 +750,21 @@ pub(crate) static PARTITION_VALUES_PARSED_NAME: &str = "partitionValues_parsed";
 // NB: If you update this schema, ensure you update the comment describing it in the doc comment
 // for `scan_row_schema` in scan/mod.rs! You'll also need to update ScanFileVisitor as the
 // indexes will be off, and [`get_add_transform_expr`] below to match it.
-pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
+pub(crate) static SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = lazy_schema_ref! {
     // Note that fields projected out of a nullable struct must be nullable
-    schema_ref! {
-        nullable PATH_NAME: STRING,
-        nullable SIZE_NAME: LONG,
-        nullable "modificationTime": LONG,
-        nullable "stats": STRING,
-        nullable "deletionVector": (DeletionVectorDescriptor::to_schema()),
-        nullable FILE_CONSTANT_VALUES_NAME: {
-            nullable PARTITION_VALUES_NAME: { STRING => nullable STRING },
-            nullable BASE_ROW_ID_NAME: LONG,
-            nullable DEFAULT_ROW_COMMIT_VERSION_NAME: LONG,
-            nullable "tags": { STRING => nullable STRING },
-            nullable CLUSTERING_PROVIDER_NAME: STRING,
-        },
-    }
-});
+    nullable PATH_NAME: STRING,
+    nullable SIZE_NAME: LONG,
+    nullable "modificationTime": LONG,
+    nullable "stats": STRING,
+    nullable "deletionVector": (DeletionVectorDescriptor::to_schema()),
+    nullable FILE_CONSTANT_VALUES_NAME: {
+        nullable PARTITION_VALUES_NAME: { STRING => nullable STRING },
+        nullable BASE_ROW_ID_NAME: LONG,
+        nullable DEFAULT_ROW_COMMIT_VERSION_NAME: LONG,
+        nullable "tags": { STRING => nullable STRING },
+        nullable CLUSTERING_PROVIDER_NAME: STRING,
+    },
+};
 
 /// Build the scan-row schema, appending the opt-in typed `stats_parsed` / `partitionValues_parsed`
 /// columns when requested.
@@ -1174,9 +1172,7 @@ mod tests {
         add_batch_with_remove, add_batch_with_remove_and_partition, run_with_validate_callback,
     };
     use crate::scan::PhysicalPredicate;
-    use crate::schema::{
-        schema_ref, DataType, MetadataColumnSpec, SchemaRef, StructField, StructType,
-    };
+    use crate::schema::{schema_ref, DataType, MetadataColumnSpec, SchemaRef};
     use crate::table_features::ColumnMappingMode;
     use crate::unit_test_utils::assert_result_error_with_message;
     use crate::{DeltaResult, Expression as Expr, ExpressionRef};
@@ -1267,7 +1263,7 @@ mod tests {
     #[test]
     fn test_no_transforms() {
         let batch = vec![add_batch_simple(get_commit_schema().clone())];
-        let logical_schema = Arc::new(StructType::new_unchecked(vec![]));
+        let logical_schema = schema_ref! {};
         let state_info = Arc::new(StateInfo {
             logical_schema: logical_schema.clone(),
             physical_schema: logical_schema.clone(),
@@ -1302,10 +1298,10 @@ mod tests {
 
     #[test]
     fn test_simple_transform() {
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-            StructField::new("date", DataType::DATE, true),
-        ]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "value": INTEGER,
+            nullable "date": DATE,
+        };
         let partition_cols = vec!["date".to_string()];
         let state_info = get_simple_state_info(schema, partition_cols).unwrap();
         let batch = vec![add_batch_with_partition_col()];
@@ -1436,10 +1432,10 @@ mod tests {
     fn test_serialization_basic_state_and_dv_dropping() {
         // Test basic StateInfo preservation and FileActionKey preservation
         let engine = SyncEngine::new();
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, true),
-            StructField::new("value", DataType::STRING, true),
-        ]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
         let checkpoint_info = test_checkpoint_info();
         let mut processor = ScanLogReplayProcessor::new(
             &engine,
@@ -1490,10 +1486,10 @@ mod tests {
     fn test_serialization_with_predicate() {
         // Test that PhysicalPredicate and predicate schema are preserved
         let engine = SyncEngine::new();
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, true),
-            StructField::new("value", DataType::STRING, true),
-        ]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
         let predicate = Arc::new(crate::expressions::Predicate::eq(col!("id"), lit(10i32)));
         let state_info = Arc::new(
             get_state_info(
@@ -1538,10 +1534,10 @@ mod tests {
     fn test_serialization_with_transforms() {
         // Test transform_spec preservation (partition columns + row tracking)
         let engine = SyncEngine::new();
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-            StructField::new("date", DataType::DATE, true),
-        ]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "value": INTEGER,
+            nullable "date": DATE,
+        };
         let state_info = Arc::new(
             get_state_info(
                 schema,
@@ -1692,11 +1688,9 @@ mod tests {
     #[rstest]
     fn test_serialization_round_trips_skip_row_transforms(#[values(false, true)] skip: bool) {
         let engine = SyncEngine::new();
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([StructField::new(
-            "id",
-            DataType::INTEGER,
-            true,
-        )]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "id": INTEGER,
+        };
         let state_info = Arc::new(StateInfo {
             logical_schema: schema.clone(),
             physical_schema: schema.clone(),
@@ -1841,10 +1835,10 @@ mod tests {
     #[test]
     fn test_scan_action_iter_with_skip_stats() {
         let batch = vec![add_batch_simple(get_commit_schema().clone())];
-        let schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-            StructField::new("date", DataType::DATE, true),
-        ]));
+        let schema: SchemaRef = schema_ref! {
+            nullable "value": INTEGER,
+            nullable "date": DATE,
+        };
         let state_info = get_simple_state_info(schema, vec!["date".to_string()]).unwrap();
 
         let (iter, _metrics) = scan_action_iter(
@@ -1888,27 +1882,19 @@ mod tests {
     /// otherwise turn null partition values into `false`, filtering the Remove.
     #[rstest]
     #[case::stats_only(
-        Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-        ])),
+        schema_ref! { nullable "value": INTEGER },
         vec![],
         Arc::new(col!("value").gt(lit(5i32))),
         false, // use batch without partition column
     )]
     #[case::partition_predicate(
-        Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-            StructField::new("date", DataType::DATE, true),
-        ])),
+        schema_ref! { nullable "value": INTEGER, nullable "date": DATE },
         vec!["date".to_string()],
         Arc::new(col!("date").eq(lit(Scalar::Date(17_510)))),
         true, // use batch with partition column
     )]
     #[case::mixed_stats_and_partition(
-        Arc::new(StructType::new_unchecked([
-            StructField::new("value", DataType::INTEGER, true),
-            StructField::new("date", DataType::DATE, true),
-        ])),
+        schema_ref! { nullable "value": INTEGER, nullable "date": DATE },
         vec!["date".to_string()],
         Arc::new(Predicate::and(
             col!("value").gt(lit(5i32)),
@@ -2019,13 +2005,13 @@ mod tests {
     /// `synthesize_json=true` leaves exactly one inside the COALESCE branch.
     #[test]
     fn add_transform_omits_to_json_when_synthesis_skipped() {
-        let stats_schema: SchemaRef = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("value", DataType::STRING),
-        ]));
-        let partition_schema: Option<SchemaRef> = Some(Arc::new(StructType::new_unchecked([
-            StructField::nullable("date", DataType::DATE),
-        ])));
+        let stats_schema: SchemaRef = schema_ref! {
+            nullable "id": LONG,
+            nullable "value": STRING,
+        };
+        let partition_schema: Option<SchemaRef> = Some(schema_ref! {
+            nullable "date": DATE,
+        });
 
         // Synthesis enabled: COALESCE branch present -> exactly one ToJson.
         let with_synthesis = get_add_transform_expr(

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -76,14 +76,10 @@ pub(crate) static CHECKPOINT_READ_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref!
 /// Discovery restores JSON stats when structured stats cannot satisfy the scan.
 pub(crate) static CHECKPOINT_READ_SCHEMA_NO_JSON_STATS: LazyLock<SchemaRef> = LazyLock::new(|| {
     let add_schema = Add::to_schema();
-    let fields_no_stats: Vec<_> = add_schema
-        .fields()
-        .filter(|f| f.name() != "stats")
-        .cloned()
-        .collect();
-    let add_no_stats = StructType::new_unchecked(fields_no_stats);
     schema_ref! {
-        nullable ADD_NAME: (add_no_stats),
+        nullable ADD_NAME: {
+            ..(add_schema.fields().filter(|f| f.name() != "stats")),
+        },
     }
 });
 

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -39,8 +39,8 @@ use crate::scan::log_replay::{
 use crate::scan::metrics::ScanMetrics;
 use crate::scan::state_info::StateInfo;
 use crate::schema::{
-    lazy_schema_ref, ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef, StructField,
-    StructType, ToSchema as _,
+    lazy_schema_ref, schema_ref, ArrayType, DataType, MapType, PrimitiveType, Schema, SchemaRef,
+    StructField, StructType, ToSchema as _,
 };
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode, Operation};
@@ -82,10 +82,9 @@ pub(crate) static CHECKPOINT_READ_SCHEMA_NO_JSON_STATS: LazyLock<SchemaRef> = La
         .cloned()
         .collect();
     let add_no_stats = StructType::new_unchecked(fields_no_stats);
-    Arc::new(StructType::new_unchecked([StructField::nullable(
-        ADD_NAME,
-        add_no_stats,
-    )]))
+    schema_ref! {
+        nullable ADD_NAME: (add_no_stats),
+    }
 });
 
 #[allow(unused)]
@@ -606,28 +605,20 @@ impl<'a> ExpressionTransform<'a> for ApplyColumnMappings {
     }
 }
 
-static RESTORED_ADD_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
-    StructType::new_unchecked(vec![StructField::nullable(
-        "add",
-        StructType::new_unchecked(vec![
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null("partitionValues", partition_values),
-            StructField::not_null("size", DataType::LONG),
-            StructField::nullable("modificationTime", DataType::LONG),
-            StructField::nullable("stats", DataType::STRING),
-            StructField::nullable(
-                "tags",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::nullable("deletionVector", DeletionVectorDescriptor::to_schema()),
-            StructField::nullable(BASE_ROW_ID_NAME, DataType::LONG),
-            StructField::nullable(DEFAULT_ROW_COMMIT_VERSION_NAME, DataType::LONG),
-            StructField::nullable(CLUSTERING_PROVIDER_NAME, DataType::STRING),
-        ]),
-    )])
-    .into()
-});
+static RESTORED_ADD_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    nullable "add": {
+        not_null "path": STRING,
+        not_null "partitionValues": { STRING => nullable STRING },
+        not_null "size": LONG,
+        nullable "modificationTime": LONG,
+        nullable "stats": STRING,
+        nullable "tags": { STRING => nullable STRING },
+        nullable "deletionVector": (DeletionVectorDescriptor::to_schema()),
+        nullable BASE_ROW_ID_NAME: LONG,
+        nullable DEFAULT_ROW_COMMIT_VERSION_NAME: LONG,
+        nullable CLUSTERING_PROVIDER_NAME: STRING,
+    },
+};
 
 pub(crate) fn restored_add_schema() -> &'static SchemaRef {
     &RESTORED_ADD_SCHEMA

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -614,10 +614,10 @@ mod tests {
     }
 
     fn partitioned_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("x", DataType::LONG),
-            StructField::nullable("p", DataType::STRING),
-        ]))
+        schema_ref! {
+            nullable "x": LONG,
+            nullable "p": STRING,
+        }
     }
 
     fn log_root() -> Url {

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -325,9 +325,7 @@ impl Scan {
         };
 
         let (add_schema, add_expr) = projection.build()?;
-        let schema = schema_ref! {
-            (StructField::nullable(ADD_NAME, add_schema.as_ref().clone()))
-        };
+        let schema = schema_ref! { nullable ADD_NAME: (add_schema.as_ref().clone()) };
         Ok((Arc::new(Expr::struct_from([add_expr])), schema))
     }
 }
@@ -347,16 +345,16 @@ fn sidecar_actions(
     const SIDECAR_FILE_MOD: &str = "modificationTime";
 
     static SIDECAR_FILE_META_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
-        not_null (FILE_PATH): STRING,
-        not_null (FILE_SIZE): LONG,
-        not_null (FILE_MOD): LONG,
-        nullable (DV): (DeletionVectorDescriptor::to_schema()),
-        nullable (VERSION): LONG,
+        not_null FILE_PATH: STRING,
+        not_null FILE_SIZE: LONG,
+        not_null FILE_MOD: LONG,
+        nullable DV: (DeletionVectorDescriptor::to_schema()),
+        nullable VERSION: LONG,
     };
 
     static SIDECAR_READ_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
         (&SIDECAR_FIELD),
-        nullable (VERSION): LONG,
+        nullable VERSION: LONG,
     };
 
     let scan = match file_type {
@@ -399,7 +397,7 @@ fn json_read_schema(include_remove: bool) -> SchemaRef {
     schema_ref! {
         (&ADD_FIELD),
         ..(include_remove.then_some(&REMOVE_FIELD)),
-        nullable (VERSION): LONG,
+        nullable VERSION: LONG,
     }
 }
 
@@ -419,8 +417,8 @@ fn parquet_read_schema(
             ))
         });
     Ok(schema_ref! {
-        (StructField::nullable(ADD_NAME, add_patch.build(&ADD_SCHEMA)?)),
-        nullable (VERSION): LONG,
+        nullable ADD_NAME: (add_patch.build(&ADD_SCHEMA)?),
+        nullable VERSION: LONG,
     })
 }
 

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -633,10 +633,10 @@ pub(crate) mod tests {
     #[test]
     fn no_partition_columns() {
         // Test case: No partition columns, no column mapping
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "value": LONG,
+        };
 
         let state_info = get_simple_state_info(schema.clone(), vec![]).unwrap();
 
@@ -654,11 +654,11 @@ pub(crate) mod tests {
     #[test]
     fn with_partition_columns() {
         // Test case: With partition columns
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("date", DataType::DATE), // Partition column
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "date": DATE, // Partition column
+            nullable "value": LONG,
+        };
 
         let state_info = get_simple_state_info(
             schema.clone(),
@@ -691,12 +691,12 @@ pub(crate) mod tests {
     #[test]
     fn multiple_partition_columns() {
         // Test case: Multiple partition columns interspersed with regular columns
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("col1", DataType::STRING),
-            StructField::nullable("part1", DataType::STRING), // Partition
-            StructField::nullable("col2", DataType::LONG),
-            StructField::nullable("part2", DataType::INTEGER), // Partition
-        ]));
+        let schema = schema_ref! {
+            nullable "col1": STRING,
+            nullable "part1": STRING, // Partition
+            nullable "col2": LONG,
+            nullable "part2": INTEGER, // Partition
+        };
 
         let state_info = get_simple_state_info(
             schema.clone(),
@@ -740,10 +740,10 @@ pub(crate) mod tests {
     #[test]
     fn with_predicate() {
         // Test case: With a valid predicate
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "value": LONG,
+        };
 
         let predicate = Arc::new(col!("value").gt(lit(10i64)));
 
@@ -770,11 +770,11 @@ pub(crate) mod tests {
     #[test]
     fn partition_at_beginning() {
         // Test case: Partition column at the beginning
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("date", DataType::DATE), // Partition column
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "date": DATE, // Partition column
+            nullable "id": STRING,
+            nullable "value": LONG,
+        };
 
         let state_info = get_simple_state_info(schema.clone(), vec!["date".to_string()]).unwrap();
 
@@ -956,10 +956,10 @@ pub(crate) mod tests {
 
     #[test]
     fn metadata_column_matches_partition_column() {
-        let table_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("part_col", DataType::STRING),
-        ]));
+        let table_schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "part_col": STRING,
+        };
         let metadata = Metadata::try_new(
             None,
             None,
@@ -1017,10 +1017,10 @@ pub(crate) mod tests {
 
     #[test]
     fn stats_columns_with_predicate() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "value": LONG,
+        };
 
         let predicate = Arc::new(col!("value").gt(lit(10i64)));
 
@@ -1051,11 +1051,11 @@ pub(crate) mod tests {
     fn stats_columns_with_predicate_merges_columns() {
         // When specific stats_columns are requested alongside a predicate, the stats
         // schema should include both the requested columns and predicate-referenced columns.
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-            StructField::nullable("extra", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "value": LONG,
+            nullable "extra": LONG,
+        };
 
         let predicate = Arc::new(col!("extra").gt(lit(5i64)));
 
@@ -1100,10 +1100,10 @@ pub(crate) mod tests {
 
     #[test]
     fn non_empty_stats_columns_filters_schema() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("value", DataType::LONG),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "value": LONG,
+        };
 
         let state_info = get_state_info_with_stats(
             schema,
@@ -1433,17 +1433,14 @@ pub(crate) mod tests {
     /// entire `s` struct, so a predicate on `s.c` produces no stats schema.
     #[test]
     fn predicate_on_nested_past_cap_leaf_drops_parent_struct() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked(vec![
-                    StructField::nullable("c", DataType::LONG),
-                    StructField::nullable("d", DataType::LONG),
-                ]),
-            ),
-        ]));
+        let schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "s": {
+                nullable "c": LONG,
+                nullable "d": LONG,
+            },
+        };
         // Predicate only on the past-cap leaf -> stats schema goes empty -> None.
         let predicate = Arc::new(col!("s.c").gt(lit(10i64)));
         let state_info = get_state_info(
@@ -1492,17 +1489,14 @@ pub(crate) mod tests {
     /// `minValues` / `maxValues` with `c` only.
     #[test]
     fn predicate_on_nested_mixed_keeps_intersection_under_parent_struct() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable("b", DataType::LONG),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked(vec![
-                    StructField::nullable("c", DataType::LONG),
-                    StructField::nullable("d", DataType::LONG),
-                ]),
-            ),
-        ]));
+        let schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "s": {
+                nullable "c": LONG,
+                nullable "d": LONG,
+            },
+        };
         let predicate = Arc::new(Pred::and(
             col!("s.c").gt(lit(10i64)),
             col!("s.d").gt(lit(10i64)),
@@ -1551,16 +1545,13 @@ pub(crate) mod tests {
     /// `"s"` should produce `{ s.c, s.d }` (and exclude `a`, which is not in the list).
     #[test]
     fn stats_columns_admits_all_children_of_nested_parent_in_explicit_list() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("a", DataType::LONG),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked(vec![
-                    StructField::nullable("c", DataType::LONG),
-                    StructField::nullable("d", DataType::LONG),
-                ]),
-            ),
-        ]));
+        let schema = schema_ref! {
+            nullable "a": LONG,
+            nullable "s": {
+                nullable "c": LONG,
+                nullable "d": LONG,
+            },
+        };
         let state_info = get_state_info(
             schema,
             vec![],

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -13,7 +13,7 @@ use crate::log_segment::CheckpointReadInfo;
 use crate::scan::log_replay::{scan_action_iter, ScanPartitionValuesOptions, ScanStatsOptions};
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::TransformSpec;
-use crate::schema::{SchemaRef, StructType};
+use crate::schema::{schema_ref, SchemaRef};
 use crate::table_features::ColumnMappingMode;
 use crate::unit_test_utils::string_array_to_engine_data;
 use crate::JsonHandler;
@@ -158,8 +158,7 @@ pub(crate) fn run_with_validate_callback<T: Clone>(
     context: T,
     validate_callback: ScanCallback<T>,
 ) {
-    let logical_schema =
-        logical_schema.unwrap_or_else(|| Arc::new(StructType::new_unchecked(vec![])));
+    let logical_schema = logical_schema.unwrap_or_else(|| schema_ref! {});
     let state_info = Arc::new(StateInfo {
         logical_schema: logical_schema.clone(),
         physical_schema: logical_schema,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -176,22 +176,21 @@ fn test_physical_predicate() {
             Pred::and(column_pred!("mapped.n"), Pred::TRUE),
             Some(PhysicalPredicate::Some(
                 Pred::and(column_pred!("phys_mapped.phys_n"), Pred::TRUE).into(),
-                StructType::new_unchecked(vec![StructField::nullable(
-                    "phys_mapped",
-                    StructType::new_unchecked(vec![StructField::nullable(
-                        "phys_n",
-                        DataType::LONG,
+                schema_ref! {
+                    (StructField::nullable(
+                        "phys_mapped",
+                        schema! {
+                            (StructField::nullable("phys_n", DataType::LONG).with_metadata([(
+                                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                                "phys_n",
+                            )])),
+                        },
                     )
                     .with_metadata([(
                         ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                        "phys_n",
-                    )])]),
-                )
-                .with_metadata([(
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    "phys_mapped",
-                )])])
-                .into(),
+                        "phys_mapped",
+                    )])),
+                },
             )),
         ),
         (

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -67,39 +67,40 @@ fn test_static_skipping() {
 
 #[test]
 fn test_physical_predicate() {
-    let logical_schema = StructType::new_unchecked(vec![
-        StructField::nullable("a", DataType::LONG),
-        StructField::nullable("b", DataType::LONG).with_metadata([(
+    let logical_schema = schema! {
+        nullable "a": LONG,
+        (StructField::nullable("b", DataType::LONG).with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_b",
-        )]),
-        StructField::nullable("phys_b", DataType::LONG).with_metadata([(
+        )])),
+        (StructField::nullable("phys_b", DataType::LONG).with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_c",
-        )]),
-        StructField::nullable(
+        )])),
+        (StructField::nullable(
             "nested",
-            StructType::new_unchecked(vec![
-                StructField::nullable("x", DataType::LONG),
-                StructField::nullable("y", DataType::LONG).with_metadata([(
+            schema! {
+                nullable "x": LONG,
+                (StructField::nullable("y", DataType::LONG).with_metadata([(
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     "phys_y",
-                )]),
-            ]),
-        ),
-        StructField::nullable(
+                )])),
+            },
+        )),
+        (StructField::nullable(
             "mapped",
-            StructType::new_unchecked(vec![StructField::nullable("n", DataType::LONG)
-                .with_metadata([(
+            schema! {
+                (StructField::nullable("n", DataType::LONG).with_metadata([(
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     "phys_n",
-                )])]),
+                )])),
+            },
         )
         .with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_mapped",
-        )]),
-    ]);
+        )])),
+    };
 
     // NOTE: We break several column mapping rules here because they don't matter for this
     // test. For example, we do not provide field ids, and not all columns have physical names.
@@ -215,10 +216,10 @@ fn test_physical_predicate() {
 #[rstest]
 #[case::without_column_mapping(
     // predicate: createdat > 500 AND value < 100, schema: createdAt, Value
-    StructType::new_unchecked(vec![
-        StructField::nullable("createdAt", DataType::LONG),
-        StructField::nullable("Value", DataType::LONG),
-    ]),
+    schema! {
+        nullable "createdAt": LONG,
+        nullable "Value": LONG,
+    },
     Pred::and(
         Pred::gt(col!("createdat"), lit(500i64)),
         Pred::lt(col!("value"), lit(100i64)),
@@ -237,16 +238,16 @@ fn test_physical_predicate() {
 )]
 #[case::with_column_mapping(
     // predicate: createdat > 500 AND value < 100, schema has physical name metadata
-    StructType::new_unchecked(vec![
-        StructField::nullable("createdAt", DataType::LONG).with_metadata([(
+    schema! {
+        (StructField::nullable("createdAt", DataType::LONG).with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_created",
-        )]),
-        StructField::nullable("Value", DataType::LONG).with_metadata([(
+        )])),
+        (StructField::nullable("Value", DataType::LONG).with_metadata([(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
             "phys_value",
-        )]),
-    ]),
+        )])),
+    },
     Pred::and(
         Pred::gt(col!("createdat"), lit(500i64)),
         Pred::lt(col!("value"), lit(100i64)),
@@ -271,9 +272,7 @@ fn test_physical_predicate() {
 )]
 #[case::duplicate_column_different_casing(
     // predicate references same column with different casings: value > 5 AND VALUE < 10
-    StructType::new_unchecked(vec![
-        StructField::nullable("Value", DataType::LONG),
-    ]),
+    schema! { nullable "Value": LONG },
     Pred::and(
         Pred::gt(col!("value"), lit(5i64)),
         Pred::lt(col!("VALUE"), lit(10i64)),
@@ -289,10 +288,11 @@ fn test_physical_predicate() {
 )]
 #[case::nested_fields(
     // predicate references nested.fieldname but schema has Nested.FieldName
-    StructType::new_unchecked(vec![StructField::nullable(
-        "Nested",
-        StructType::new_unchecked(vec![StructField::nullable("FieldName", DataType::LONG)]),
-    )]),
+    schema! {
+        nullable "Nested": {
+            nullable "FieldName": LONG,
+        },
+    },
     column_pred!("nested.fieldname"),
     ColumnMappingMode::None,
     PhysicalPredicate::Some(
@@ -318,8 +318,7 @@ fn test_physical_predicate_case_insensitive(
 /// Unknown column still fails even with case-insensitive matching.
 #[test]
 fn test_physical_predicate_case_insensitive_unknown_column() {
-    let logical_schema =
-        StructType::new_unchecked(vec![StructField::nullable("createdAt", DataType::LONG)]);
+    let logical_schema = schema! { nullable "createdAt": LONG };
     let result = PhysicalPredicate::try_new(
         &column_pred!("nonexistent"),
         &logical_schema,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -28,7 +28,8 @@ use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::scan::data_skipping::{all_referenced_columns, as_checkpoint_skipping_predicate};
 use crate::scan::state::ScanFile;
 use crate::schema::{
-    self, schema_ref, ColumnMetadataKey, DataType, MetadataColumnSpec, StructField, StructType,
+    self, schema, schema_ref, ColumnMetadataKey, DataType, MetadataColumnSpec, StructField,
+    StructType,
 };
 use crate::transaction::create_table::create_table;
 use crate::{
@@ -110,70 +111,65 @@ fn test_physical_predicate() {
             column_pred!("a"),
             Some(PhysicalPredicate::Some(
                 column_pred!("a").into(),
-                StructType::new_unchecked(vec![StructField::nullable("a", DataType::LONG)]).into(),
+                schema_ref! { nullable "a": LONG },
             )),
         ),
         (
             column_pred!("b"),
             Some(PhysicalPredicate::Some(
                 column_pred!("phys_b").into(),
-                StructType::new_unchecked(vec![StructField::nullable("phys_b", DataType::LONG)
-                    .with_metadata([(
+                schema_ref! {
+                    (StructField::nullable("phys_b", DataType::LONG).with_metadata([(
                         ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                         "phys_b",
-                    )])])
-                .into(),
+                    )])),
+                },
             )),
         ),
         (
             column_pred!("nested.x"),
             Some(PhysicalPredicate::Some(
                 column_pred!("nested.x").into(),
-                StructType::new_unchecked(vec![StructField::nullable(
-                    "nested",
-                    StructType::new_unchecked(vec![StructField::nullable("x", DataType::LONG)]),
-                )])
-                .into(),
+                schema_ref! {
+                    nullable "nested": {
+                        nullable "x": LONG,
+                    },
+                },
             )),
         ),
         (
             column_pred!("nested.y"),
             Some(PhysicalPredicate::Some(
                 column_pred!("nested.phys_y").into(),
-                StructType::new_unchecked(vec![StructField::nullable(
-                    "nested",
-                    StructType::new_unchecked(vec![StructField::nullable(
-                        "phys_y",
-                        DataType::LONG,
-                    )
-                    .with_metadata([(
-                        ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                        "phys_y",
-                    )])]),
-                )])
-                .into(),
+                schema_ref! {
+                    nullable "nested": {
+                        (StructField::nullable("phys_y", DataType::LONG).with_metadata([(
+                            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                            "phys_y",
+                        )])),
+                    },
+                },
             )),
         ),
         (
             column_pred!("mapped.n"),
             Some(PhysicalPredicate::Some(
                 column_pred!("phys_mapped.phys_n").into(),
-                StructType::new_unchecked(vec![StructField::nullable(
-                    "phys_mapped",
-                    StructType::new_unchecked(vec![StructField::nullable(
-                        "phys_n",
-                        DataType::LONG,
+                schema_ref! {
+                    (StructField::nullable(
+                        "phys_mapped",
+                        schema! {
+                            (StructField::nullable("phys_n", DataType::LONG).with_metadata([(
+                                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                                "phys_n",
+                            )])),
+                        },
                     )
                     .with_metadata([(
                         ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                        "phys_n",
-                    )])]),
-                )
-                .with_metadata([(
-                    ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-                    "phys_mapped",
-                )])])
-                .into(),
+                        "phys_mapped",
+                    )])),
+                },
             )),
         ),
         (
@@ -234,10 +230,10 @@ fn test_physical_predicate() {
             Pred::gt(col!("createdAt"), lit(500i64)),
             Pred::lt(col!("Value"), lit(100i64)),
         )),
-        StructType::new_unchecked(vec![
-            StructField::nullable("createdAt", DataType::LONG),
-            StructField::nullable("Value", DataType::LONG),
-        ]).into(),
+        schema_ref! {
+            nullable "createdAt": LONG,
+            nullable "Value": LONG,
+        },
     ),
 )]
 #[case::with_column_mapping(
@@ -262,16 +258,16 @@ fn test_physical_predicate() {
             Pred::gt(col!("phys_created"), lit(500i64)),
             Pred::lt(col!("phys_value"), lit(100i64)),
         )),
-        StructType::new_unchecked(vec![
-            StructField::nullable("phys_created", DataType::LONG).with_metadata([(
+        schema_ref! {
+            (StructField::nullable("phys_created", DataType::LONG).with_metadata([(
                 ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                 "phys_created",
-            )]),
-            StructField::nullable("phys_value", DataType::LONG).with_metadata([(
+            )])),
+            (StructField::nullable("phys_value", DataType::LONG).with_metadata([(
                 ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                 "phys_value",
-            )]),
-        ]).into(),
+            )])),
+        },
     ),
 )]
 #[case::duplicate_column_different_casing(
@@ -289,8 +285,7 @@ fn test_physical_predicate() {
             Pred::gt(col!("Value"), lit(5i64)),
             Pred::lt(col!("Value"), lit(10i64)),
         )),
-        StructType::new_unchecked(vec![StructField::nullable("Value", DataType::LONG)])
-            .into(),
+        schema_ref! { nullable "Value": LONG },
     ),
 )]
 #[case::nested_fields(
@@ -303,12 +298,11 @@ fn test_physical_predicate() {
     ColumnMappingMode::None,
     PhysicalPredicate::Some(
         column_pred!("Nested.FieldName").into(),
-        StructType::new_unchecked(vec![StructField::nullable(
-            "Nested",
-            StructType::new_unchecked(vec![
-                StructField::nullable("FieldName", DataType::LONG)
-            ]),
-        )]).into(),
+        schema_ref! {
+            nullable "Nested": {
+                nullable "FieldName": LONG,
+            },
+        },
     ),
 )]
 fn test_physical_predicate_case_insensitive(
@@ -341,10 +335,10 @@ fn test_scan_builder_accepts_predicate_on_unprojected_data_column() {
     let store = Arc::new(InMemory::new());
     let engine = SyncEngine::new_with_store(store);
 
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("number", DataType::LONG),
-        StructField::nullable("a_float", DataType::FLOAT),
-    ]));
+    let schema = schema_ref! {
+        nullable "number": LONG,
+        nullable "a_float": FLOAT,
+    };
     create_table(url, schema, "DefaultEngine")
         .build(&engine, Box::new(FileSystemCommitter::new()))
         .unwrap()

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -233,7 +233,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::{col, BinaryExpressionOp};
-    use crate::schema::{schema_ref, DataType, PrimitiveType, StructField, StructType};
+    use crate::schema::{schema, schema_ref, DataType, PrimitiveType};
     use crate::unit_test_utils::assert_result_error_with_message;
 
     // Tests for parse_partition_value function
@@ -362,7 +362,7 @@ mod tests {
     fn test_parse_partition_value_raw_invalid_type() {
         let result = parse_partition_value_raw(
             Some(&"value".to_string()),
-            &DataType::struct_type_unchecked(vec![]), // Non-primitive type
+            &DataType::from(schema! {}), // Non-primitive type
         );
         assert_result_error_with_message(result, "Unexpected partition column type");
     }
@@ -386,7 +386,7 @@ mod tests {
         let partition_values = HashMap::new(); // Missing required partition value
 
         // Create a minimal physical schema for test
-        let physical_schema = StructType::new_unchecked(vec![]);
+        let physical_schema = schema! {};
         let result = get_transform_expr(
             &transform_spec,
             partition_values,
@@ -411,10 +411,10 @@ mod tests {
         let metadata_values = HashMap::new();
 
         // Create a physical schema with the relevant columns
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("col1", DataType::STRING),
-            StructField::nullable("col2", DataType::LONG),
-        ]);
+        let physical_schema = schema! {
+            nullable "col1": STRING,
+            nullable "col2": LONG,
+        };
         let result = get_transform_expr(
             &transform_spec,
             metadata_values,
@@ -451,10 +451,10 @@ mod tests {
         }];
 
         // Physical schema contains change_type
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("_change_type", DataType::STRING),
-        ]);
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            nullable "_change_type": STRING,
+        };
         let metadata_values = HashMap::new();
 
         let result = get_transform_expr(
@@ -494,8 +494,7 @@ mod tests {
         }];
 
         // Physical schema does not contain change_type
-        let physical_schema =
-            StructType::new_unchecked(vec![StructField::nullable("id", DataType::STRING)]);
+        let physical_schema = schema! { nullable "id": STRING };
         let mut metadata_values = HashMap::new();
         metadata_values.insert(
             1,
@@ -538,8 +537,7 @@ mod tests {
             insert_after: Some("id".to_string()),
         }];
 
-        let physical_schema =
-            StructType::new_unchecked(vec![StructField::nullable("id", DataType::STRING)]);
+        let physical_schema = schema! { nullable "id": STRING };
         let mut metadata_values = HashMap::new();
         metadata_values.insert(1, ("year".to_string(), Scalar::Integer(2024)));
 
@@ -576,8 +574,7 @@ mod tests {
         }];
 
         // Physical schema without _change_type (so it needs to come from metadata)
-        let physical_schema =
-            StructType::new_unchecked(vec![StructField::nullable("id", DataType::STRING)]);
+        let physical_schema = schema! { nullable "id": STRING };
 
         // Empty metadata values - missing required _change_type
         let metadata_values = HashMap::new();
@@ -600,10 +597,10 @@ mod tests {
         }];
 
         // Physical schema contains row index col, but no row-id col
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::not_null("row_index_col", DataType::LONG),
-        ]);
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            not_null "row_index_col": LONG,
+        };
         let metadata_values = HashMap::new();
 
         let result = get_transform_expr(
@@ -641,10 +638,10 @@ mod tests {
         }];
 
         // Physical schema contains row index col, but no row-id col
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::not_null("row_index_col", DataType::LONG),
-        ]);
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            not_null "row_index_col": LONG,
+        };
         let metadata_values = HashMap::new();
 
         assert_result_error_with_message(

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -233,16 +233,15 @@ mod tests {
 
     use super::*;
     use crate::expressions::{col, BinaryExpressionOp};
-    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, PrimitiveType, StructField, StructType};
     use crate::unit_test_utils::assert_result_error_with_message;
 
     // Tests for parse_partition_value function
     #[test]
     fn test_parse_partition_value_invalid_index() {
-        let schema = Arc::new(StructType::new_unchecked(vec![StructField::nullable(
-            "col1",
-            DataType::STRING,
-        )]));
+        let schema = schema_ref! {
+            nullable "col1": STRING,
+        };
         let partition_values = HashMap::new();
 
         let result = parse_partition_value(5, &schema, &partition_values, ColumnMappingMode::None);
@@ -252,11 +251,11 @@ mod tests {
     // Tests for parse_partition_values function
     #[test]
     fn test_parse_partition_values_mixed_transforms() {
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("age", DataType::LONG),
-            StructField::nullable("_change_type", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "age": LONG,
+            nullable "_change_type": STRING,
+        };
         let transform_spec = vec![
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index: 1,
@@ -302,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_parse_partition_values_empty_spec() {
-        let schema = Arc::new(StructType::new_unchecked(vec![]));
+        let schema = schema_ref! {};
         let transform_spec = vec![];
         let partition_values = HashMap::new();
 

--- a/kernel/src/schema/column_default.rs
+++ b/kernel/src/schema/column_default.rs
@@ -233,15 +233,17 @@ mod tests {
 
     use super::*;
     use crate::expressions::col;
-    use crate::schema::{ArrayType, MapType, StructField};
+    use crate::schema::{schema, ArrayType, MapType, StructField};
 
     fn struct_ty() -> DataType {
-        DataType::try_struct_type([StructField::nullable("a", DataType::INTEGER)]).unwrap()
+        DataType::from(schema! { nullable "a": INTEGER })
     }
 
     /// A struct type whose single field `inner` carries an integer default.
     fn struct_with_inner_default() -> DataType {
-        DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap()
+        DataType::from(schema! {
+            (field_with_default("inner", DataType::INTEGER, "42")),
+        })
     }
 
     fn date_days(year: i32, month: u32, day: u32) -> i32 {
@@ -366,7 +368,9 @@ mod tests {
     #[case::nested_default(
         vec![StructField::nullable(
             "s",
-            DataType::try_struct_type([field_with_default("inner", DataType::INTEGER, "42")]).unwrap(),
+            schema! {
+                (field_with_default("inner", DataType::INTEGER, "42")),
+            },
         )],
         true,
         None
@@ -401,7 +405,7 @@ mod tests {
         #[case] container: DataType,
         #[case] expected_path: [&str; 3],
     ) {
-        let schema = StructType::try_new([StructField::nullable("arr", container)]).unwrap();
+        let schema = schema! { nullable "arr": (container) };
         let defaults = try_collect_column_defaults(&schema).unwrap();
         let [(path, _)] = defaults.try_into().expect("exactly one default");
         assert_eq!(path, expected_path.join("."));

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -214,9 +214,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::schema::compare::{Error, SchemaComparison, SchemaComparisonResult};
-    use crate::schema::{
-        schema, ArrayType, DataType, MapType, PrimitiveType, StructField, StructType,
-    };
+    use crate::schema::{schema, ArrayType, DataType, MapType, PrimitiveType, StructField};
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum ComparisonMode {
@@ -298,16 +296,16 @@ mod tests {
     #[test]
     fn different_field_name_case_fails() {
         // names differing only in case are not the same
-        let existing_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
-        let read_schema = StructType::new_unchecked([
-            StructField::new("Id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let existing_schema = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
+        let read_schema = schema! {
+            not_null "Id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
         assert!(matches!(
             existing_schema.can_read_as(&read_schema),
             Err(Error::FieldNameMismatch)
@@ -315,16 +313,16 @@ mod tests {
     }
     #[test]
     fn different_type_fails() {
-        let existing_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
-        let read_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let existing_schema = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
+        let read_schema = schema! {
+            not_null "id": INTEGER,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
         assert!(matches!(
             existing_schema.can_read_as(&read_schema),
             Err(Error::TypeMismatch)
@@ -332,30 +330,30 @@ mod tests {
     }
     #[test]
     fn set_nullable_to_true() {
-        let existing_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
-        let read_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let existing_schema = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
+        let read_schema = schema! {
+            not_null "id": LONG,
+            nullable "name": STRING,
+            nullable "age": INTEGER,
+        };
         assert!(existing_schema.can_read_as(&read_schema).is_ok());
     }
     #[test]
     fn set_nullable_to_false_fails() {
-        let existing_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
-        let read_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, false),
-        ]);
+        let existing_schema = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
+        let read_schema = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            not_null "age": INTEGER,
+        };
         assert!(matches!(
             existing_schema.can_read_as(&read_schema),
             Err(Error::NullabilityTightening)
@@ -363,18 +361,18 @@ mod tests {
     }
     #[test]
     fn differ_by_nullable_column() {
-        let a = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let a = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
 
-        let b = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-            StructField::new("location", DataType::STRING, true),
-        ]);
+        let b = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+            nullable "location": STRING,
+        };
 
         // Read `a` as `b`. `b` adds a new nullable column. This is compatible with `a`'s schema.
         assert!(a.can_read_as(&b).is_ok());
@@ -387,18 +385,18 @@ mod tests {
         #[values(ComparisonMode::AllowTypeWidening, ComparisonMode::ForbidTypeWidening)]
         mode: ComparisonMode,
     ) {
-        let a = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let a = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
 
-        let b = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-            StructField::new("location", DataType::STRING, false),
-        ]);
+        let b = schema! {
+            not_null "id": LONG,
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+            not_null "location": STRING,
+        };
 
         // Read `a` as `b`. `b` has an extra non-nullable column.
         assert!(matches!(
@@ -415,19 +413,19 @@ mod tests {
 
     #[test]
     fn duplicate_field_modulo_case() {
-        let existing_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("Id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let existing_schema = schema! {
+            (StructField::new("id", DataType::LONG, false)),
+            (StructField::new("Id", DataType::LONG, false)),
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
 
-        let read_schema = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("Id", DataType::LONG, false),
-            StructField::new("name", DataType::STRING, false),
-            StructField::new("age", DataType::INTEGER, true),
-        ]);
+        let read_schema = schema! {
+            (StructField::new("id", DataType::LONG, false)),
+            (StructField::new("Id", DataType::LONG, false)),
+            not_null "name": STRING,
+            nullable "age": INTEGER,
+        };
         assert!(matches!(
             existing_schema.can_read_as(&read_schema),
             Err(Error::InvalidSchema)
@@ -519,14 +517,14 @@ mod tests {
         #[values(ComparisonMode::AllowTypeWidening, ComparisonMode::ForbidTypeWidening)]
         mode: ComparisonMode,
     ) {
-        let source = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("value", DataType::FLOAT, true),
-        ]);
-        let target = StructType::new_unchecked([
-            StructField::new("id", DataType::LONG, false),
-            StructField::new("value", DataType::DOUBLE, true),
-        ]);
+        let source = schema! {
+            not_null "id": INTEGER,
+            nullable "value": FLOAT,
+        };
+        let target = schema! {
+            not_null "id": LONG,
+            nullable "value": DOUBLE,
+        };
 
         assert_eq!(
             mode.can_read_as(&source, &target).is_ok(),

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -737,7 +737,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::column_name;
-    use crate::schema::{ArrayType, DataType, MapType, StructField, StructType};
+    use crate::schema::{schema, ArrayType, DataType, MapType, StructField};
 
     fn create_field_with_id(
         name: &str,
@@ -760,10 +760,10 @@ mod tests {
 
     #[test]
     fn test_identical_schemas() {
-        let schema = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id("name", DataType::STRING, false, 2),
-        ]);
+        let schema = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id("name", DataType::STRING, false, 2)),
+        };
 
         let diff = SchemaDiff::new(&schema, &schema).unwrap();
         assert!(diff.is_empty());
@@ -772,15 +772,17 @@ mod tests {
 
     #[test]
     fn test_change_count() {
-        let before = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id("name", DataType::STRING, false, 2),
-        ]);
+        let before = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id("name", DataType::STRING, false, 2)),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, true, 1), // Changed
-            create_field_with_id("email", DataType::STRING, false, 3), // Added
-        ]);
+        let after = schema! {
+            // Changed
+            (create_field_with_id("id", DataType::LONG, true, 1)),
+            // Added
+            (create_field_with_id("email", DataType::STRING, false, 3)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -793,13 +795,14 @@ mod tests {
 
     #[test]
     fn test_top_level_added_field() {
-        let before =
-            StructType::new_unchecked([create_field_with_id("id", DataType::LONG, false, 1)]);
+        let before = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id("name", DataType::STRING, false, 2),
-        ]);
+        let after = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id("name", DataType::STRING, false, 2)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 1);
@@ -813,13 +816,14 @@ mod tests {
     #[test]
     fn test_added_required_field_is_breaking() {
         // Adding a non-nullable (required) field is breaking
-        let before =
-            StructType::new_unchecked([create_field_with_id("id", DataType::LONG, false, 1)]);
+        let before = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id("required_field", DataType::STRING, false, 2), // Non-nullable
-        ]);
+        let after = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id("required_field", DataType::STRING, false, 2)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 1);
@@ -831,13 +835,14 @@ mod tests {
     #[test]
     fn test_added_nullable_field_is_not_breaking() {
         // Adding a nullable (optional) field is NOT breaking
-        let before =
-            StructType::new_unchecked([create_field_with_id("id", DataType::LONG, false, 1)]);
+        let before = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id("optional_field", DataType::STRING, true, 2), // Nullable
-        ]);
+        let after = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id("optional_field", DataType::STRING, true, 2)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 1);
@@ -849,23 +854,24 @@ mod tests {
     #[test]
     fn test_physical_name_validation() {
         // Test: Physical names present and unchanged - valid schema evolution (just a rename)
-        let before = StructType::new_unchecked([StructField::new("name", DataType::STRING, false)
-            .add_metadata([
+        let before = schema! {
+            (StructField::new("name", DataType::STRING, false).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
                     MetadataValue::String("col_1".to_string()),
                 ),
-            ])]);
-        let after =
-            StructType::new_unchecked([StructField::new("full_name", DataType::STRING, false)
-                .add_metadata([
-                    ("delta.columnMapping.id", MetadataValue::Number(1)),
-                    (
-                        "delta.columnMapping.physicalName",
-                        MetadataValue::String("col_1".to_string()),
-                    ),
-                ])]);
+            ])),
+        };
+        let after = schema! {
+            (StructField::new("full_name", DataType::STRING, false).add_metadata([
+                ("delta.columnMapping.id", MetadataValue::Number(1)),
+                (
+                    "delta.columnMapping.physicalName",
+                    MetadataValue::String("col_1".to_string()),
+                ),
+            ])),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 0);
@@ -878,22 +884,24 @@ mod tests {
         assert!(!diff.has_breaking_changes()); // Rename is not breaking
 
         // Test: Physical name changed - INVALID (returns error)
-        let before = StructType::new_unchecked([StructField::new("name", DataType::STRING, false)
-            .add_metadata([
+        let before = schema! {
+            (StructField::new("name", DataType::STRING, false).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
                     MetadataValue::String("col_001".to_string()),
                 ),
-            ])]);
-        let after = StructType::new_unchecked([StructField::new("name", DataType::STRING, false)
-            .add_metadata([
+            ])),
+        };
+        let after = schema! {
+            (StructField::new("name", DataType::STRING, false).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
                     MetadataValue::String("col_002".to_string()),
                 ),
-            ])]);
+            ])),
+        };
 
         let result = SchemaDiff::new(&before, &after);
         assert!(matches!(
@@ -902,16 +910,19 @@ mod tests {
         ));
 
         // Test: Missing physical name in one schema - INVALID (returns error)
-        let before = StructType::new_unchecked([StructField::new("name", DataType::STRING, false)
-            .add_metadata([
+        let before = schema! {
+            (StructField::new("name", DataType::STRING, false).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
                     MetadataValue::String("col_1".to_string()),
                 ),
-            ])]);
-        let after = StructType::new_unchecked([StructField::new("name", DataType::STRING, false)
-            .add_metadata([("delta.columnMapping.id", MetadataValue::Number(1))])]);
+            ])),
+        };
+        let after = schema! {
+            (StructField::new("name", DataType::STRING, false)
+                .add_metadata([("delta.columnMapping.id", MetadataValue::Number(1))])),
+        };
 
         let result = SchemaDiff::new(&before, &after);
         assert!(matches!(
@@ -923,18 +934,17 @@ mod tests {
     #[test]
     fn test_multiple_change_types() {
         // Test that a field with multiple simultaneous changes produces FieldChangeType::Multiple
-        let before = StructType::new_unchecked([create_field_with_id(
-            "user_name",
-            DataType::STRING,
-            false,
-            1,
-        )
-        .add_metadata([("custom", MetadataValue::String("old_value".to_string()))])]);
+        let before = schema! {
+            (create_field_with_id("user_name", DataType::STRING, false, 1)
+                .add_metadata([("custom", MetadataValue::String("old_value".to_string()))])),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("userName", DataType::STRING, true, 1) // Renamed + nullability loosened
-                .add_metadata([("custom", MetadataValue::String("new_value".to_string()))]), // Metadata changed
-        ]);
+        let after = schema! {
+            // Metadata changed
+            // Renamed + nullability loosened
+            (create_field_with_id("userName", DataType::STRING, true, 1)
+                .add_metadata([("custom", MetadataValue::String("new_value".to_string()))])),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -961,18 +971,17 @@ mod tests {
     fn test_multiple_with_breaking_change() {
         // Test that Multiple changes are correctly identified as breaking when they contain
         // breaking changes
-        let before = StructType::new_unchecked([create_field_with_id(
-            "user_name",
-            DataType::STRING,
-            true,
-            1,
-        )
-        .add_metadata([("custom", MetadataValue::String("old_value".to_string()))])]);
+        let before = schema! {
+            (create_field_with_id("user_name", DataType::STRING, true, 1)
+                .add_metadata([("custom", MetadataValue::String("old_value".to_string()))])),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("userName", DataType::STRING, false, 1) // Renamed + nullability TIGHTENED
-                .add_metadata([("custom", MetadataValue::String("new_value".to_string()))]), // Metadata changed
-        ]);
+        let after = schema! {
+            // Metadata changed
+            // Renamed + nullability tightened
+            (create_field_with_id("userName", DataType::STRING, false, 1)
+                .add_metadata([("custom", MetadataValue::String("new_value".to_string()))])),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -997,10 +1006,10 @@ mod tests {
     #[test]
     fn test_duplicate_field_id_error() {
         // Test that duplicate field IDs in the same schema produce an error
-        let schema_with_duplicates = StructType::new_unchecked([
-            create_field_with_id("field1", DataType::STRING, false, 1),
-            create_field_with_id("field2", DataType::STRING, false, 1), // Same ID!
-        ]);
+        let schema_with_duplicates = schema! {
+            (create_field_with_id("field1", DataType::STRING, false, 1)),
+            (create_field_with_id("field2", DataType::STRING, false, 1)),
+        };
 
         let result = SchemaDiff::new(&schema_with_duplicates, &schema_with_duplicates);
 
@@ -1063,32 +1072,31 @@ mod tests {
     #[test]
     fn test_ancestor_filtering() {
         // Test that when a parent struct is added/removed, its children aren't reported separately
-        let without_user =
-            StructType::new_unchecked([create_field_with_id("id", DataType::LONG, false, 1)]);
+        let without_user = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+        };
 
-        let with_user = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id(
+        let with_user = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id(
                 "user",
-                DataType::try_struct_type([
-                    create_field_with_id("name", DataType::STRING, false, 3),
-                    create_field_with_id("email", DataType::STRING, true, 4),
-                    create_field_with_id(
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 3)),
+                    (create_field_with_id("email", DataType::STRING, true, 4)),
+                    (create_field_with_id(
                         "address",
-                        DataType::try_struct_type([
-                            create_field_with_id("street", DataType::STRING, false, 6),
-                            create_field_with_id("city", DataType::STRING, false, 7),
-                        ])
-                        .unwrap(),
+                        schema! {
+                            (create_field_with_id("street", DataType::STRING, false, 6)),
+                            (create_field_with_id("city", DataType::STRING, false, 7)),
+                        },
                         true,
                         5,
-                    ),
-                ])
-                .unwrap(),
+                    )),
+                },
                 false,
                 2,
-            ),
-        ]);
+            )),
+        };
 
         // CASE 1: Adding a parent struct - only parent should be reported, not nested fields
         let diff = SchemaDiff::new(&without_user, &with_user).unwrap();
@@ -1115,22 +1123,20 @@ mod tests {
     fn test_array_of_struct_addition_reports_only_ancestor_field() {
         // Before: no fields. After: items: array<struct<name: string>>
         // Expected: added_fields == [items], not [items, items.element.name]
-        let before = StructType::new_unchecked([]);
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
+        let before = schema! {};
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
                     false,
-                    2,
-                )])
-                .unwrap(),
-                false,
-            ),
-            true,
-            1,
-        )]);
+                ),
+                true,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 1);
@@ -1146,28 +1152,32 @@ mod tests {
     fn test_container_with_nested_changes_not_reported_as_type_change() {
         // Test that when a struct's nested fields change, the struct itself isn't reported as
         // TypeChanged
-        let before = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([
-                create_field_with_id("name", DataType::STRING, false, 2),
-                create_field_with_id("email", DataType::STRING, true, 3),
-            ])
-            .unwrap(),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 2)),
+                    (create_field_with_id("email", DataType::STRING, true, 3)),
+                },
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([
-                create_field_with_id("full_name", DataType::STRING, false, 2), // Renamed
-                create_field_with_id("email", DataType::STRING, true, 3),
-                create_field_with_id("age", DataType::INTEGER, true, 4), // Added
-            ])
-            .unwrap(),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    // Renamed
+                    (create_field_with_id("full_name", DataType::STRING, false, 2)),
+                    (create_field_with_id("email", DataType::STRING, true, 3)),
+                    // Added
+                    (create_field_with_id("age", DataType::INTEGER, true, 4)),
+                },
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1198,23 +1208,21 @@ mod tests {
     #[test]
     fn test_actual_struct_type_change_still_reported() {
         // Test that actual type changes (not just nested content changes) are still reported
-        let before =
-            StructType::new_unchecked([create_field_with_id("data", DataType::STRING, false, 1)]);
+        let before = schema! {
+            (create_field_with_id("data", DataType::STRING, false, 1)),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id(
+        let after = schema! {
+            // Changed from STRING to STRUCT
+            (create_field_with_id(
                 "data",
-                DataType::try_struct_type([create_field_with_id(
-                    "nested",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
+                schema! {
+                    (create_field_with_id("nested", DataType::STRING, false, 2)),
+                },
                 false,
                 1,
-            ), // Changed from STRING to STRUCT
-        ]);
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1237,34 +1245,34 @@ mod tests {
     #[test]
     fn test_array_with_struct_element_changes() {
         // Test that array containers aren't reported as changed when their struct elements change
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([
-                    create_field_with_id("title", DataType::STRING, false, 2), // Renamed
-                ])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        // Renamed
+                        (create_field_with_id("title", DataType::STRING, false, 2)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1293,46 +1301,39 @@ mod tests {
 
     #[test]
     fn test_ancestor_filtering_with_mixed_changes() {
-        let before = StructType::new_unchecked([
-            create_field_with_id("existing", DataType::STRING, false, 1),
-            create_field_with_id(
+        let before = schema! {
+            (create_field_with_id("existing", DataType::STRING, false, 1)),
+            (create_field_with_id(
                 "existing_struct",
-                DataType::try_struct_type([create_field_with_id(
-                    "old_name",
-                    DataType::STRING,
-                    false,
-                    3,
-                )])
-                .unwrap(),
+                schema! {
+                    (create_field_with_id("old_name", DataType::STRING, false, 3)),
+                },
                 false,
                 2,
-            ),
-        ]);
+            )),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("existing", DataType::STRING, true, 1), // Changed nullability
-            create_field_with_id(
+        let after = schema! {
+            // Changed nullability
+            (create_field_with_id("existing", DataType::STRING, true, 1)),
+            (create_field_with_id(
                 "existing_struct",
-                DataType::try_struct_type([
-                    create_field_with_id("new_name", DataType::STRING, false, 3), // Renamed
-                ])
-                .unwrap(),
+                schema! {
+                    // Renamed
+                    (create_field_with_id("new_name", DataType::STRING, false, 3)),
+                },
                 true, // Changed nullability
                 2,
-            ),
-            create_field_with_id(
+            )),
+            (create_field_with_id(
                 "new_struct", // Completely new struct
-                DataType::try_struct_type([create_field_with_id(
-                    "nested_field",
-                    DataType::INTEGER,
-                    false,
-                    5,
-                )])
-                .unwrap(),
+                schema! {
+                    (create_field_with_id("nested_field", DataType::INTEGER, false, 5)),
+                },
                 false,
                 4,
-            ),
-        ]);
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1355,23 +1356,28 @@ mod tests {
 
     #[test]
     fn test_nested_field_rename() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([create_field_with_id("name", DataType::STRING, false, 2)])
-                .unwrap(),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 2)),
+                },
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([
-                create_field_with_id("full_name", DataType::STRING, false, 2), // Renamed!
-            ])
-            .unwrap(),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    // Renamed!
+                    (create_field_with_id("full_name", DataType::STRING, false, 2)),
+                },
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 0);
@@ -1386,24 +1392,29 @@ mod tests {
 
     #[test]
     fn test_nested_field_added() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([create_field_with_id("name", DataType::STRING, false, 2)])
-                .unwrap(),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 2)),
+                },
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "user",
-            DataType::try_struct_type([
-                create_field_with_id("name", DataType::STRING, false, 2),
-                create_field_with_id("age", DataType::INTEGER, true, 3), // Added!
-            ])
-            .unwrap(),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "user",
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 2)),
+                    // Added!
+                    (create_field_with_id("age", DataType::INTEGER, true, 3)),
+                },
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 1);
@@ -1418,52 +1429,47 @@ mod tests {
 
     #[test]
     fn test_deeply_nested_changes() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "level1",
-            DataType::try_struct_type([create_field_with_id(
-                "level2",
-                DataType::try_struct_type([create_field_with_id(
-                    "deep_field",
-                    DataType::STRING,
-                    false,
-                    3,
-                )])
-                .unwrap(),
+        let before = schema! {
+            (create_field_with_id(
+                "level1",
+                schema! {
+                    (create_field_with_id(
+                        "level2",
+                        schema! {
+                            (create_field_with_id("deep_field", DataType::STRING, false, 3)),
+                        },
+                        false,
+                        2,
+                    )),
+                },
                 false,
-                2,
-            )])
-            .unwrap(),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after =
-            StructType::new_unchecked([
-                create_field_with_id(
-                    "level1",
-                    DataType::try_struct_type(
-                        [
-                            create_field_with_id(
-                                "level2",
-                                DataType::try_struct_type([
-                                    create_field_with_id(
-                                        "very_deep_field",
-                                        DataType::STRING,
-                                        false,
-                                        3,
-                                    ), // Renamed!
-                                ])
-                                .unwrap(),
+        let after = schema! {
+            (create_field_with_id(
+                "level1",
+                schema! {
+                    (create_field_with_id(
+                        "level2",
+                        schema! {
+                            // Renamed!
+                            (create_field_with_id(
+                                "very_deep_field",
+                                DataType::STRING,
                                 false,
-                                2,
-                            ),
-                        ],
-                    )
-                    .unwrap(),
-                    false,
-                    1,
-                ),
-            ]);
+                                3,
+                            )),
+                        },
+                        false,
+                        2,
+                    )),
+                },
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
         assert_eq!(diff.added_fields.len(), 0);
@@ -1477,35 +1483,33 @@ mod tests {
 
     #[test]
     fn test_top_level_vs_nested_filtering() {
-        let before = StructType::new_unchecked([
-            create_field_with_id("top_field", DataType::STRING, false, 1),
-            create_field_with_id(
+        let before = schema! {
+            (create_field_with_id("top_field", DataType::STRING, false, 1)),
+            (create_field_with_id(
                 "user",
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    3,
-                )])
-                .unwrap(),
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 3)),
+                },
                 false,
                 2,
-            ),
-        ]);
+            )),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("renamed_top", DataType::STRING, false, 1), // Renamed top-level
-            create_field_with_id(
+        let after = schema! {
+            // Renamed top-level
+            (create_field_with_id("renamed_top", DataType::STRING, false, 1)),
+            (create_field_with_id(
                 "user",
-                DataType::try_struct_type([
-                    create_field_with_id("full_name", DataType::STRING, false, 3), // Renamed nested
-                    create_field_with_id("age", DataType::INTEGER, true, 4),       // Added nested
-                ])
-                .unwrap(),
+                schema! {
+                    // Renamed nested
+                    (create_field_with_id("full_name", DataType::STRING, false, 3)),
+                    // Added nested
+                    (create_field_with_id("age", DataType::INTEGER, true, 4)),
+                },
                 false,
                 2,
-            ),
-        ]);
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1524,35 +1528,37 @@ mod tests {
 
     #[test]
     fn test_mixed_changes() {
-        let before = StructType::new_unchecked([
-            create_field_with_id("id", DataType::LONG, false, 1),
-            create_field_with_id(
+        let before = schema! {
+            (create_field_with_id("id", DataType::LONG, false, 1)),
+            (create_field_with_id(
                 "user",
-                DataType::try_struct_type([
-                    create_field_with_id("name", DataType::STRING, false, 3),
-                    create_field_with_id("email", DataType::STRING, true, 4),
-                ])
-                .unwrap(),
+                schema! {
+                    (create_field_with_id("name", DataType::STRING, false, 3)),
+                    (create_field_with_id("email", DataType::STRING, true, 4)),
+                },
                 false,
                 2,
-            ),
-        ]);
+            )),
+        };
 
-        let after = StructType::new_unchecked([
-            create_field_with_id("identifier", DataType::LONG, false, 1), // Renamed top-level
-            create_field_with_id(
+        let after = schema! {
+            // Renamed top-level
+            (create_field_with_id("identifier", DataType::LONG, false, 1)),
+            (create_field_with_id(
                 "user",
-                DataType::try_struct_type([
-                    create_field_with_id("full_name", DataType::STRING, false, 3), // Renamed nested
-                    // email removed (id=4)
-                    create_field_with_id("age", DataType::INTEGER, true, 5), // Added nested
-                ])
-                .unwrap(),
+                schema! {
+                    // Renamed nested
+                    (create_field_with_id("full_name", DataType::STRING, false, 3)),
+                    // Added nested
+                    (// email removed (id=4)
+                    create_field_with_id("age", DataType::INTEGER, true, 5)),
+                },
                 false,
                 2,
-            ),
-            create_field_with_id("created_at", DataType::TIMESTAMP, false, 6), // Added top-level
-        ]);
+            )),
+            // Added top-level
+            (create_field_with_id("created_at", DataType::TIMESTAMP, false, 6)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1578,33 +1584,37 @@ mod tests {
 
     #[test]
     fn test_array_element_struct_field_changes() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([
-                    create_field_with_id("name", DataType::STRING, false, 2),
-                    create_field_with_id("removed_field", DataType::INTEGER, true, 3),
-                ])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                        (create_field_with_id("removed_field", DataType::INTEGER, true, 3)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([
-                    create_field_with_id("title", DataType::STRING, false, 2), // Renamed!
-                    create_field_with_id("added_field", DataType::STRING, true, 4), // Added!
-                ])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        // Renamed!
+                        (create_field_with_id("title", DataType::STRING, false, 2)),
+                        // Added!
+                        (create_field_with_id("added_field", DataType::STRING, true, 4)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1636,19 +1646,23 @@ mod tests {
     fn test_doubly_nested_array_type_change() {
         // Test that we can detect type changes in doubly nested arrays: array<array<int>> ->
         // array<array<double>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(ArrayType::new(DataType::INTEGER, false), false),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(ArrayType::new(DataType::INTEGER, false), false),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(ArrayType::new(DataType::DOUBLE, false), false),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(ArrayType::new(DataType::DOUBLE, false), false),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1669,19 +1683,13 @@ mod tests {
     #[test]
     fn test_array_primitive_element_type_change() {
         // Test direct primitive element type change: array<string> -> array<int>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, false),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id("items", ArrayType::new(DataType::STRING, false), false, 1)),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::INTEGER, false),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id("items", ArrayType::new(DataType::INTEGER, false), false, 1)),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1700,25 +1708,29 @@ mod tests {
     fn test_nested_array_nullability_loosened() {
         // Test: array<array<int> not null> -> array<array<int>>
         // Outer array element nullability loosened (safe change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false),
-                false, // Outer array elements are non-nullable
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false),
+                    false, // Outer array elements are non-nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false),
-                true, // Outer array elements now nullable
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false),
+                    true, // Outer array elements now nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1737,25 +1749,29 @@ mod tests {
     fn test_nested_array_nullability_tightened() {
         // Test: array<array<int>> -> array<array<int> not null>
         // Outer array element nullability tightened (breaking change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false),
-                true, // Outer array elements are nullable
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false),
+                    true, // Outer array elements are nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false),
-                false, // Outer array elements now non-nullable
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false),
+                    false, // Outer array elements now non-nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1774,25 +1790,29 @@ mod tests {
     fn test_nested_array_inner_nullability_loosened() {
         // Test: array<array<int not null>> -> array<array<int>>
         // Inner array element nullability loosened (safe change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false), /* Inner elements non-nullable */
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false), /* Inner elements non-nullable */
+                    false,
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, true), /* Inner elements now nullable */
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, true), /* Inner elements now nullable */
+                    false,
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1811,25 +1831,29 @@ mod tests {
     fn test_nested_array_inner_nullability_tightened() {
         // Test: array<array<int>> -> array<array<int not null>>
         // Inner array element nullability tightened (breaking change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, true), /* Inner elements nullable */
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, true), /* Inner elements nullable */
+                    false,
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
-                ArrayType::new(DataType::INTEGER, false), /* Inner elements now non-nullable */
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
+                ArrayType::new(
+                    ArrayType::new(DataType::INTEGER, false), /* Inner elements now non-nullable */
+                    false,
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1846,20 +1870,24 @@ mod tests {
 
     #[test]
     fn test_array_nullability_loosened() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, false), /* Non-nullable
-                                                      * elements */
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::STRING, false), /* Non-nullable
+                                                          * elements */
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, true), /* Nullable elements now */
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::STRING, true), /* Nullable elements now */
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1876,19 +1904,23 @@ mod tests {
 
     #[test]
     fn test_array_nullability_tightened() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, true), // Nullable elements
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::STRING, true), // Nullable elements
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, false), // Non-nullable now
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::STRING, false), // Non-nullable now
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1904,35 +1936,39 @@ mod tests {
     }
     #[test]
     fn test_map_value_struct_field_changes() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([
-                    create_field_with_id("value", DataType::INTEGER, false, 2),
-                    create_field_with_id("removed_field", DataType::STRING, true, 3),
-                ])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    schema! {
+                        (create_field_with_id("value", DataType::INTEGER, false, 2)),
+                        (create_field_with_id("removed_field", DataType::STRING, true, 3)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([
-                    create_field_with_id("count", DataType::INTEGER, false, 2), // Renamed!
-                    create_field_with_id("added_field", DataType::STRING, true, 4), // Added!
-                ])
-                .unwrap(),
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    schema! {
+                        // Renamed!
+                        (create_field_with_id("count", DataType::INTEGER, false, 2)),
+                        // Added!
+                        (create_field_with_id("added_field", DataType::STRING, true, 4)),
+                    },
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -1964,37 +2000,33 @@ mod tests {
     fn test_array_struct_element_nullability_loosened() {
         // Test: array<struct<name: string> not null> -> array<struct<name: string>>
         // Struct element nullability loosened (safe change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                false, // Struct elements non-nullable
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
+                    false, // Struct elements non-nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                true, // Struct elements now nullable
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
+                    true, // Struct elements now nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2011,27 +2043,31 @@ mod tests {
 
     #[test]
     fn test_map_nullability_loosened() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::INTEGER,
-                false, // Non-nullable values
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    false, // Non-nullable values
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::INTEGER,
-                true, // Nullable values now
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    true, // Nullable values now
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2050,37 +2086,33 @@ mod tests {
     fn test_array_struct_element_nullability_tightened() {
         // Test: array<struct<name: string>> -> array<struct<name: string> not null>
         // Struct element nullability tightened (breaking change)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                true, // Struct elements nullable
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
+                    true, // Struct elements nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "name",
-                    DataType::STRING,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                false, // Struct elements now non-nullable
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id("name", DataType::STRING, false, 2)),
+                    },
+                    false, // Struct elements now non-nullable
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2097,27 +2129,31 @@ mod tests {
 
     #[test]
     fn test_map_nullability_tightened() {
-        let before = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::INTEGER,
-                true, // Nullable values
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    true, // Nullable values
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::INTEGER,
-                false, // Non-nullable now
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    DataType::INTEGER,
+                    false, // Non-nullable now
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2137,20 +2173,24 @@ mod tests {
         // Test that both nullability and type change can be exercised at once in a single diff.
         // Before: items: array<string> not null (elements non-nullable)
         // After: items: array<int> (elements nullable, type changed)
-        let before = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::STRING, false), /* Non-nullable
-                                                      * elements */
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::STRING, false), /* Non-nullable
+                                                          * elements */
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "items",
-            ArrayType::new(DataType::INTEGER, true), /* Nullable, type changed */
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "items",
+                ArrayType::new(DataType::INTEGER, true), /* Nullable, type changed */
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2168,39 +2208,40 @@ mod tests {
     #[test]
     fn test_map_with_struct_key() {
         // Test that maps with struct keys can be diffed
-        let before = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "id",
-                    DataType::INTEGER,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                DataType::STRING,
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let before = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    schema! {
+                        (create_field_with_id("id", DataType::INTEGER, false, 2)),
+                    },
+                    DataType::STRING,
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "identifier", // Renamed key field
-                    DataType::INTEGER,
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                DataType::STRING,
-                true,
-            ),
-            false,
-            1,
-        )]);
+        let after = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    schema! {
+                        (create_field_with_id(
+                            "identifier", // Renamed key field
+                            DataType::INTEGER,
+                            false,
+                            2,
+                        )),
+                    },
+                    DataType::STRING,
+                    true,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2221,76 +2262,80 @@ mod tests {
     #[test]
     fn test_nested_struct_in_array_in_struct_field_changes() {
         // struct<items: array<struct<inner: struct<a int, b string>>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "data",
-            DataType::try_struct_type([create_field_with_id(
-                "items",
-                ArrayType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "inner",
-                        DataType::try_struct_type([
-                            create_field_with_id("a", DataType::INTEGER, false, 3),
-                            create_field_with_id("removed", DataType::STRING, true, 4),
-                        ])
-                        .unwrap(),
-                        false,
-                        2,
-                    )])
-                    .unwrap(),
-                    false,
-                ),
-                false,
-                5,
-            )])
-            .unwrap(),
-            false,
-            1,
-        )]);
-
-        let after =
-            StructType::new_unchecked([create_field_with_id(
+        let before = schema! {
+            (create_field_with_id(
                 "data",
-                DataType::try_struct_type(
-                    [
-                        create_field_with_id(
-                            "items",
-                            ArrayType::new(
-                                DataType::try_struct_type(
-                                    [
-                                        create_field_with_id(
-                                            "inner",
-                                            DataType::try_struct_type([
-                                                create_field_with_id(
-                                                    "renamed_a",
-                                                    DataType::INTEGER,
-                                                    false,
-                                                    3,
-                                                ), // Renamed!
-                                                create_field_with_id(
-                                                    "added",
-                                                    DataType::LONG,
-                                                    true,
-                                                    6,
-                                                ), // Added!
-                                            ])
-                                            .unwrap(),
-                                            false,
-                                            2,
-                                        ),
-                                    ],
-                                )
-                                .unwrap(),
-                                false,
-                            ),
+                schema! {
+                    (create_field_with_id(
+                        "items",
+                        ArrayType::new(
+                            schema! {
+                                (create_field_with_id(
+                                    "inner",
+                                    schema! {
+                                        (create_field_with_id("a", DataType::INTEGER, false, 3)),
+                                        (create_field_with_id(
+                                            "removed",
+                                            DataType::STRING,
+                                            true,
+                                            4,
+                                        )),
+                                    },
+                                    false,
+                                    2,
+                                )),
+                            },
                             false,
-                            5,
                         ),
-                    ],
-                )
-                .unwrap(),
+                        false,
+                        5,
+                    )),
+                },
                 false,
                 1,
-            )]);
+            )),
+        };
+
+        let after = schema! {
+            (create_field_with_id(
+                "data",
+                schema! {
+                    (create_field_with_id(
+                        "items",
+                        ArrayType::new(
+                            schema! {
+                                (create_field_with_id(
+                                    "inner",
+                                    schema! {
+                                        // Renamed!
+                                        (create_field_with_id(
+                                            "renamed_a",
+                                            DataType::INTEGER,
+                                            false,
+                                            3,
+                                        )),
+                                        // Added!
+                                        (create_field_with_id(
+                                            "added",
+                                            DataType::LONG,
+                                            true,
+                                            6,
+                                        )),
+                                    },
+                                    false,
+                                    2,
+                                )),
+                            },
+                            false,
+                        ),
+                        false,
+                        5,
+                    )),
+                },
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2319,66 +2364,63 @@ mod tests {
     #[test]
     fn test_nested_map_within_struct_within_map() {
         // map<string, struct<nested: map<int, struct<x int>>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "lookup",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([create_field_with_id(
-                    "nested",
-                    MapType::new(
-                        DataType::INTEGER,
-                        DataType::try_struct_type([create_field_with_id(
-                            "x",
-                            DataType::INTEGER,
-                            false,
-                            3,
-                        )])
-                        .unwrap(),
-                        false,
-                    ),
-                    false,
-                    2,
-                )])
-                .unwrap(),
-                false,
-            ),
-            false,
-            1,
-        )]);
-
-        let after =
-            StructType::new_unchecked([create_field_with_id(
+        let before = schema! {
+            (create_field_with_id(
                 "lookup",
                 MapType::new(
                     DataType::STRING,
-                    DataType::try_struct_type(
-                        [
-                            create_field_with_id(
-                                "nested",
-                                MapType::new(
-                                    DataType::INTEGER,
-                                    DataType::try_struct_type([
-                                        create_field_with_id(
-                                            "renamed_x",
-                                            DataType::INTEGER,
-                                            false,
-                                            3,
-                                        ), // Renamed!
-                                    ])
-                                    .unwrap(),
-                                    false,
-                                ),
+                    schema! {
+                        (create_field_with_id(
+                            "nested",
+                            MapType::new(
+                                DataType::INTEGER,
+                                schema! {
+                                    (create_field_with_id("x", DataType::INTEGER, false, 3)),
+                                },
                                 false,
-                                2,
                             ),
-                        ],
-                    )
-                    .unwrap(),
+                            false,
+                            2,
+                        )),
+                    },
                     false,
                 ),
                 false,
                 1,
-            )]);
+            )),
+        };
+
+        let after = schema! {
+            (create_field_with_id(
+                "lookup",
+                MapType::new(
+                    DataType::STRING,
+                    schema! {
+                        (create_field_with_id(
+                            "nested",
+                            MapType::new(
+                                DataType::INTEGER,
+                                schema! {
+                                    // Renamed!
+                                    (create_field_with_id(
+                                        "renamed_x",
+                                        DataType::INTEGER,
+                                        false,
+                                        3,
+                                    )),
+                                },
+                                false,
+                            ),
+                            false,
+                            2,
+                        )),
+                    },
+                    false,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2399,41 +2441,42 @@ mod tests {
     #[test]
     fn test_doubly_nested_array_with_struct_elements() {
         // array<array<struct<x int>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
+        let before = schema! {
+            (create_field_with_id(
+                "matrix",
                 ArrayType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "x",
-                        DataType::INTEGER,
+                    ArrayType::new(
+                        schema! {
+                            (create_field_with_id("x", DataType::INTEGER, false, 2)),
+                        },
                         false,
-                        2,
-                    )])
-                    .unwrap(),
+                    ),
                     false,
                 ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "matrix",
-            ArrayType::new(
+        let after = schema! {
+            (create_field_with_id(
+                "matrix",
                 ArrayType::new(
-                    DataType::try_struct_type([
-                        create_field_with_id("renamed_x", DataType::INTEGER, false, 2), // Renamed!
-                        create_field_with_id("y", DataType::INTEGER, true, 3),          // Added!
-                    ])
-                    .unwrap(),
+                    ArrayType::new(
+                        schema! {
+                            // Renamed!
+                            (create_field_with_id("renamed_x", DataType::INTEGER, false, 2)),
+                            // Added!
+                            (create_field_with_id("y", DataType::INTEGER, true, 3)),
+                        },
+                        false,
+                    ),
                     false,
                 ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2458,70 +2501,63 @@ mod tests {
     #[test]
     fn test_map_with_array_of_struct_key_and_value() {
         // map<array<struct<a int>>, array<struct<b int>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "complex_map",
-            MapType::new(
-                ArrayType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "key_field",
-                        DataType::INTEGER,
+        let before = schema! {
+            (create_field_with_id(
+                "complex_map",
+                MapType::new(
+                    ArrayType::new(
+                        schema! {
+                            (create_field_with_id("key_field", DataType::INTEGER, false, 2)),
+                        },
                         false,
-                        2,
-                    )])
-                    .unwrap(),
-                    false,
-                ),
-                ArrayType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "value_field",
-                        DataType::STRING,
-                        false,
-                        3,
-                    )])
-                    .unwrap(),
-                    false,
-                ),
-                false,
-            ),
-            false,
-            1,
-        )]);
-
-        let after =
-            StructType::new_unchecked([
-                create_field_with_id(
-                    "complex_map",
-                    MapType::new(
-                        ArrayType::new(
-                            DataType::try_struct_type([
-                                create_field_with_id(
-                                    "renamed_key_field",
-                                    DataType::INTEGER,
-                                    false,
-                                    2,
-                                ), // Renamed!
-                            ])
-                            .unwrap(),
-                            false,
-                        ),
-                        ArrayType::new(
-                            DataType::try_struct_type([
-                                create_field_with_id(
-                                    "renamed_value_field",
-                                    DataType::STRING,
-                                    false,
-                                    3,
-                                ), // Renamed!
-                            ])
-                            .unwrap(),
-                            false,
-                        ),
+                    ),
+                    ArrayType::new(
+                        schema! {
+                            (create_field_with_id("value_field", DataType::STRING, false, 3)),
+                        },
                         false,
                     ),
                     false,
-                    1,
                 ),
-            ]);
+                false,
+                1,
+            )),
+        };
+
+        let after = schema! {
+            (create_field_with_id(
+                "complex_map",
+                MapType::new(
+                    ArrayType::new(
+                        schema! {
+                            // Renamed!
+                            (create_field_with_id(
+                                "renamed_key_field",
+                                DataType::INTEGER,
+                                false,
+                                2,
+                            )),
+                        },
+                        false,
+                    ),
+                    ArrayType::new(
+                        schema! {
+                            // Renamed!
+                            (create_field_with_id(
+                                "renamed_value_field",
+                                DataType::STRING,
+                                false,
+                                3,
+                            )),
+                        },
+                        false,
+                    ),
+                    false,
+                ),
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2540,67 +2576,65 @@ mod tests {
     #[test]
     fn test_map_struct_key_nested_map_value() {
         // map<struct<id int>, map<struct<key int>, struct<data string>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "nested_maps",
-            MapType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "outer_key",
-                    DataType::INTEGER,
-                    false,
-                    2,
-                )])
-                .unwrap(),
+        let before = schema! {
+            (create_field_with_id(
+                "nested_maps",
                 MapType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "inner_key",
-                        DataType::INTEGER,
+                    schema! {
+                        (create_field_with_id("outer_key", DataType::INTEGER, false, 2)),
+                    },
+                    MapType::new(
+                        schema! {
+                            (create_field_with_id("inner_key", DataType::INTEGER, false, 3)),
+                        },
+                        schema! {
+                            (create_field_with_id("data", DataType::STRING, false, 4)),
+                            (create_field_with_id("removed", DataType::INTEGER, true, 5)),
+                        },
                         false,
-                        3,
-                    )])
-                    .unwrap(),
-                    DataType::try_struct_type([
-                        create_field_with_id("data", DataType::STRING, false, 4),
-                        create_field_with_id("removed", DataType::INTEGER, true, 5),
-                    ])
-                    .unwrap(),
+                    ),
                     false,
                 ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "nested_maps",
-            MapType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "renamed_outer_key", // Renamed!
-                    DataType::INTEGER,
-                    false,
-                    2,
-                )])
-                .unwrap(),
+        let after = schema! {
+            (create_field_with_id(
+                "nested_maps",
                 MapType::new(
-                    DataType::try_struct_type([create_field_with_id(
-                        "renamed_inner_key", // Renamed!
-                        DataType::INTEGER,
+                    schema! {
+                        (create_field_with_id(
+                            "renamed_outer_key", // Renamed!
+                            DataType::INTEGER,
+                            false,
+                            2,
+                        )),
+                    },
+                    MapType::new(
+                        schema! {
+                            (create_field_with_id(
+                                "renamed_inner_key", // Renamed!
+                                DataType::INTEGER,
+                                false,
+                                3,
+                            )),
+                        },
+                        schema! {
+                            // Renamed!
+                            (create_field_with_id("renamed_data", DataType::STRING, false, 4)),
+                            // Added!
+                            (create_field_with_id("added", DataType::LONG, true, 6)),
+                        },
                         false,
-                        3,
-                    )])
-                    .unwrap(),
-                    DataType::try_struct_type([
-                        create_field_with_id("renamed_data", DataType::STRING, false, 4), // Renamed!
-                        create_field_with_id("added", DataType::LONG, true, 6),           // Added!
-                    ])
-                    .unwrap(),
+                    ),
                     false,
                 ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2629,73 +2663,60 @@ mod tests {
     fn test_deeply_nested_nullability_tightening_is_breaking() {
         // array<struct<items: array<struct<value int nullable>>>> -> array<struct<items:
         // array<struct<value int not null>>>>
-        let before =
-            StructType::new_unchecked([
-                create_field_with_id(
-                    "wrapper",
-                    ArrayType::new(
-                        DataType::try_struct_type(
-                            [
-                                create_field_with_id(
-                                    "items",
-                                    ArrayType::new(
-                                        DataType::try_struct_type([
-                                            create_field_with_id(
-                                                "value",
-                                                DataType::INTEGER,
-                                                true,
-                                                3,
-                                            ), // Nullable
-                                        ])
-                                        .unwrap(),
-                                        false,
-                                    ),
-                                    false,
-                                    2,
-                                ),
-                            ],
-                        )
-                        .unwrap(),
-                        false,
-                    ),
+        let before = schema! {
+            (create_field_with_id(
+                "wrapper",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id(
+                            "items",
+                            ArrayType::new(
+                                schema! {
+                                    // Nullable
+                                    (create_field_with_id("value", DataType::INTEGER, true, 3)),
+                                },
+                                false,
+                            ),
+                            false,
+                            2,
+                        )),
+                    },
                     false,
-                    1,
                 ),
-            ]);
+                false,
+                1,
+            )),
+        };
 
-        let after =
-            StructType::new_unchecked([
-                create_field_with_id(
-                    "wrapper",
-                    ArrayType::new(
-                        DataType::try_struct_type(
-                            [
-                                create_field_with_id(
-                                    "items",
-                                    ArrayType::new(
-                                        DataType::try_struct_type([
-                                            create_field_with_id(
-                                                "value",
-                                                DataType::INTEGER,
-                                                false,
-                                                3,
-                                            ), // Non-nullable now - BREAKING!
-                                        ])
-                                        .unwrap(),
+        let after = schema! {
+            (create_field_with_id(
+                "wrapper",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id(
+                            "items",
+                            ArrayType::new(
+                                schema! {
+                                    // Non-nullable now - BREAKING!
+                                    (create_field_with_id(
+                                        "value",
+                                        DataType::INTEGER,
                                         false,
-                                    ),
-                                    false,
-                                    2,
-                                ),
-                            ],
-                        )
-                        .unwrap(),
-                        false,
-                    ),
+                                        3,
+                                    )),
+                                },
+                                false,
+                            ),
+                            false,
+                            2,
+                        )),
+                    },
                     false,
-                    1,
                 ),
-            ]);
+                false,
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 
@@ -2717,55 +2738,53 @@ mod tests {
     fn test_deeply_nested_container_nullability_tightening_is_breaking() {
         // array<struct<items: array<struct<value int> nullable>>> -> array<struct<items:
         // array<struct<value int> not null>>>
-        let before = StructType::new_unchecked([create_field_with_id(
-            "wrapper",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "items",
-                    ArrayType::new(
-                        DataType::try_struct_type([create_field_with_id(
-                            "value",
-                            DataType::INTEGER,
+        let before = schema! {
+            (create_field_with_id(
+                "wrapper",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id(
+                            "items",
+                            ArrayType::new(
+                                schema! {
+                                    (create_field_with_id("value", DataType::INTEGER, false, 3)),
+                                },
+                                true, // Array elements are nullable
+                            ),
                             false,
-                            3,
-                        )])
-                        .unwrap(),
-                        true, // Array elements are nullable
-                    ),
+                            2,
+                        )),
+                    },
                     false,
-                    2,
-                )])
-                .unwrap(),
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
-        let after = StructType::new_unchecked([create_field_with_id(
-            "wrapper",
-            ArrayType::new(
-                DataType::try_struct_type([create_field_with_id(
-                    "items",
-                    ArrayType::new(
-                        DataType::try_struct_type([create_field_with_id(
-                            "value",
-                            DataType::INTEGER,
+        let after = schema! {
+            (create_field_with_id(
+                "wrapper",
+                ArrayType::new(
+                    schema! {
+                        (create_field_with_id(
+                            "items",
+                            ArrayType::new(
+                                schema! {
+                                    (create_field_with_id("value", DataType::INTEGER, false, 3)),
+                                },
+                                false, // Array elements now non-nullable - BREAKING!
+                            ),
                             false,
-                            3,
-                        )])
-                        .unwrap(),
-                        false, // Array elements now non-nullable - BREAKING!
-                    ),
+                            2,
+                        )),
+                    },
                     false,
-                    2,
-                )])
-                .unwrap(),
+                ),
                 false,
-            ),
-            false,
-            1,
-        )]);
+                1,
+            )),
+        };
 
         let diff = SchemaDiff::new(&before, &after).unwrap();
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1782,10 +1782,10 @@ impl MapType {
     /// Create a schema assuming the map is stored as a struct with the specified key and value
     /// field names
     pub fn as_struct_schema(&self, key_name: String, val_name: String) -> Schema {
-        StructType::new_unchecked([
-            StructField::not_null(key_name, self.key_type.clone()),
-            StructField::new(val_name, self.value_type.clone(), self.value_contains_null),
-        ])
+        schema! {
+            not_null (key_name): (self.key_type.clone()),
+            (StructField::new(val_name, self.value_type.clone(), self.value_contains_null)),
+        }
     }
 }
 
@@ -2464,10 +2464,10 @@ impl DataType {
     /// Create a new unshredded [`DataType::Variant`]. This data type is a struct of two not-null
     /// binary fields: `metadata` and `value`.
     pub fn unshredded_variant() -> Self {
-        DataType::Variant(Box::new(StructType::new_unchecked([
-            StructField::not_null("metadata", DataType::BINARY),
-            StructField::not_null("value", DataType::BINARY),
-        ])))
+        DataType::Variant(Box::new(schema! {
+            not_null "metadata": BINARY,
+            not_null "value": BINARY,
+        }))
     }
 
     /// Create a new [`DataType::Variant`] from the provided fields. For unshredded variants, you
@@ -3181,10 +3181,10 @@ mod tests {
     )]
     #[case(
         r#"{"type": "struct", "fields": [{"name": "a", "type": "integer", "nullable": false, "metadata": {}}, {"name": "b", "type": "string", "nullable": true, "metadata": {}}]}"#,
-        DataType::from(StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("b", DataType::STRING, true),
-        ]))
+        DataType::from(schema! {
+            not_null "a": INTEGER,
+            nullable "b": STRING,
+        })
     )]
     #[case(
         r#"{"type": "map", "keyType": "string", "valueType": "integer", "valueContainsNull": true}"#,
@@ -3227,13 +3227,8 @@ mod tests {
 
     #[test]
     fn test_make_physical_no_column_mapping() {
-        let field = StructField::nullable(
-            "e",
-            ArrayType::new(
-                StructType::new_unchecked([StructField::not_null("d", DataType::INTEGER)]),
-                true,
-            ),
-        );
+        let field =
+            StructField::nullable("e", ArrayType::new(schema! { not_null "d": INTEGER }, true));
         let physical_field = field.make_physical(ColumnMappingMode::None).unwrap();
 
         assert_eq!(physical_field.name, "e");
@@ -3322,15 +3317,15 @@ mod tests {
             ])
         }
 
-        let inner = StructType::new_unchecked([
-            cm_field("x", 3, DataType::INTEGER),
-            cm_field("y", 4, DataType::STRING),
-        ]);
-        let schema = StructType::new_unchecked([
-            cm_field("a", 1, DataType::INTEGER),
-            cm_field("b", 2, ArrayType::new(inner, true)),
-            cm_field("c", 3, DataType::STRING),
-        ]);
+        let inner = schema! {
+            (cm_field("x", 3, DataType::INTEGER)),
+            (cm_field("y", 4, DataType::STRING)),
+        };
+        let schema = schema! {
+            (cm_field("a", 1, DataType::INTEGER)),
+            (cm_field("b", 2, ArrayType::new(inner, true))),
+            (cm_field("c", 3, DataType::STRING)),
+        };
         assert_result_error_with_message(
             schema.make_physical(ColumnMappingMode::Id),
             "Duplicate column mapping ID",
@@ -3579,10 +3574,10 @@ mod tests {
     #[test]
     fn test_has_invariants() {
         // Schema with no invariants
-        let schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::STRING),
-            StructField::nullable("b", DataType::INTEGER),
-        ]);
+        let schema = schema! {
+            nullable "a": STRING,
+            nullable "b": INTEGER,
+        };
         assert!(!schema_has_invariants(&schema));
 
         // Schema with top-level invariant
@@ -3592,132 +3587,113 @@ mod tests {
             MetadataValue::String("c > 0".to_string()),
         );
 
-        let schema =
-            StructType::new_unchecked([StructField::nullable("a", DataType::STRING), field]);
+        let schema = schema! {
+            nullable "a": STRING,
+            (field),
+        };
         assert!(schema_has_invariants(&schema));
 
         // Schema with nested invariant in a struct
-        let nested_field = StructField::nullable(
-            "nested_c",
-            DataType::try_struct_type([{
+        let nested = schema! {
+            ({
                 let mut field = StructField::nullable("d", DataType::INTEGER);
                 field.metadata.insert(
                     ColumnMetadataKey::Invariants.as_ref().to_string(),
                     MetadataValue::String("d > 0".to_string()),
                 );
                 field
-            }])
-            .unwrap(),
-        );
+            }),
+        };
 
-        let schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::STRING),
-            StructField::nullable("b", DataType::INTEGER),
-            nested_field,
-        ]);
+        let schema = schema! {
+            nullable "a": STRING,
+            nullable "b": INTEGER,
+            nullable "nested_c": (nested),
+        };
         assert!(schema_has_invariants(&schema));
 
         // Schema with nested invariant in an array of structs
-        let array_field = StructField::nullable(
-            "array_field",
-            ArrayType::new(
-                DataType::try_struct_type([{
-                    let mut field = StructField::nullable("d", DataType::INTEGER);
-                    field.metadata.insert(
-                        ColumnMetadataKey::Invariants.as_ref().to_string(),
-                        MetadataValue::String("d > 0".to_string()),
-                    );
-                    field
-                }])
-                .unwrap(),
-                true,
-            ),
-        );
+        let array_element = schema! {
+            ({
+                let mut field = StructField::nullable("d", DataType::INTEGER);
+                field.metadata.insert(
+                    ColumnMetadataKey::Invariants.as_ref().to_string(),
+                    MetadataValue::String("d > 0".to_string()),
+                );
+                field
+            }),
+        };
 
-        let schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::STRING),
-            StructField::nullable("b", DataType::INTEGER),
-            array_field,
-        ]);
+        let schema = schema! {
+            nullable "a": STRING,
+            nullable "b": INTEGER,
+            nullable "array_field": [ nullable (array_element) ],
+        };
         assert!(schema_has_invariants(&schema));
 
         // Schema with nested invariant in a map value that's a struct
-        let map_field = StructField::nullable(
-            "map_field",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([{
-                    let mut field = StructField::nullable("d", DataType::INTEGER);
-                    field.metadata.insert(
-                        ColumnMetadataKey::Invariants.as_ref().to_string(),
-                        MetadataValue::String("d > 0".to_string()),
-                    );
-                    field
-                }])
-                .unwrap(),
-                true,
-            ),
-        );
+        let map_value = schema! {
+            ({
+                let mut field = StructField::nullable("d", DataType::INTEGER);
+                field.metadata.insert(
+                    ColumnMetadataKey::Invariants.as_ref().to_string(),
+                    MetadataValue::String("d > 0".to_string()),
+                );
+                field
+            }),
+        };
 
-        let schema = StructType::new_unchecked([
-            StructField::nullable("a", DataType::STRING),
-            StructField::nullable("b", DataType::INTEGER),
-            map_field,
-        ]);
+        let schema = schema! {
+            nullable "a": STRING,
+            nullable "b": INTEGER,
+            nullable "map_field": { STRING => nullable (map_value) },
+        };
         assert!(schema_has_invariants(&schema));
     }
 
     fn all_nullable_schema() -> StructType {
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::STRING),
-            StructField::nullable("b", DataType::INTEGER),
-        ])
+        schema! {
+            nullable "a": STRING,
+            nullable "b": INTEGER,
+        }
     }
 
     fn top_level_non_null_schema() -> StructType {
-        StructType::new_unchecked([
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
+        schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        }
     }
 
     fn nested_non_null_schema() -> StructType {
-        let nested_field = StructField::nullable(
-            "parent",
-            DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)]).unwrap(),
-        );
-        StructType::new_unchecked([StructField::nullable("a", DataType::STRING), nested_field])
+        schema! {
+            nullable "a": STRING,
+            nullable "parent": {
+                not_null "child": INTEGER,
+            },
+        }
     }
 
     fn array_non_null_schema() -> StructType {
-        let array_field = StructField::nullable(
-            "arr",
-            ArrayType::new(
-                DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)])
-                    .unwrap(),
-                true,
-            ),
-        );
-        StructType::new_unchecked([array_field])
+        schema! {
+            nullable "arr": [ nullable {
+                not_null "child": INTEGER,
+            } ],
+        }
     }
 
     fn map_non_null_schema() -> StructType {
-        let map_field = StructField::nullable(
-            "map",
-            MapType::new(
-                DataType::STRING,
-                DataType::try_struct_type([StructField::not_null("child", DataType::INTEGER)])
-                    .unwrap(),
-                true,
-            ),
-        );
-        StructType::new_unchecked([map_field])
+        schema! {
+            nullable "map": { STRING => nullable {
+                not_null "child": INTEGER,
+            } },
+        }
     }
 
     fn variant_only_schema() -> StructType {
         // Variant internal fields (metadata, value) are protocol-defined non-null but
         // must NOT be counted as user-controlled non-null fields.
-        StructType::new_unchecked([StructField::nullable("v", DataType::unshredded_variant())])
+        schema! { nullable "v": unshredded_variant() }
     }
 
     #[rstest]
@@ -4206,7 +4182,7 @@ mod tests {
 
     #[test]
     fn test_add_column() -> DeltaResult<()> {
-        let schema = StructType::try_new([StructField::nullable("col1", DataType::STRING)])?;
+        let schema = schema! { nullable "col1": STRING };
 
         let new_field = StructField::nullable("col2", DataType::INTEGER);
         let updated_schema = schema.add([new_field])?;
@@ -4219,7 +4195,7 @@ mod tests {
 
     #[test]
     fn test_add_metadata_column() -> DeltaResult<()> {
-        let schema = StructType::try_new([StructField::nullable("regular_col", DataType::STRING)])?;
+        let schema = schema! { nullable "regular_col": STRING };
 
         let schema_with_metadata =
             schema.add_metadata_column("my_row_index", MetadataColumnSpec::RowIndex)?;
@@ -4236,7 +4212,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_metadata_columns() -> DeltaResult<()> {
-        let schema = StructType::try_new([StructField::nullable("regular_col", DataType::STRING)])?;
+        let schema = schema! { nullable "regular_col": STRING };
 
         let schema_with_metadata =
             schema.add_metadata_column("row_index1", MetadataColumnSpec::RowIndex)?;
@@ -4353,10 +4329,13 @@ mod tests {
 
     #[test]
     fn test_column_identifier_trait() -> DeltaResult<()> {
-        let schema = StructType::try_new([
-            StructField::nullable("regular_col", DataType::STRING),
-            StructField::create_metadata_column("row_index_col", MetadataColumnSpec::RowIndex),
-        ])?;
+        let schema = schema! {
+            nullable "regular_col": STRING,
+            (StructField::create_metadata_column(
+                "row_index_col",
+                MetadataColumnSpec::RowIndex,
+            )),
+        };
 
         // Test string identifier
         assert!(schema.contains("regular_col"));
@@ -4394,7 +4373,7 @@ mod tests {
 
     #[test]
     fn test_all_metadata_column_specs() -> DeltaResult<()> {
-        let schema = StructType::try_new([StructField::nullable("regular_col", DataType::STRING)])?;
+        let schema = schema! { nullable "regular_col": STRING };
 
         let schema = schema
             .add_metadata_column("row_index", MetadataColumnSpec::RowIndex)?
@@ -4508,30 +4487,23 @@ mod tests {
     fn test_display_struct_type_stable_output() -> DeltaResult<()> {
         let nested_field_with_metadata =
             StructField::create_metadata_column("nested_row_index", MetadataColumnSpec::RowIndex);
-        let inner_struct =
-            StructType::new_unchecked([StructField::new("q", DataType::LONG, false)]);
-        let nested_struct = StructType::new_unchecked([
-            nested_field_with_metadata,
-            StructField::new("x", DataType::DOUBLE, true),
-            StructField::new("inner_struct", inner_struct, false),
-        ]);
-        let array_type = ArrayType::new(nested_struct.clone(), true);
-        let map_type = MapType::new(
-            nested_struct.clone(),
-            nested_struct.clone(), // kek
-            true,
-        );
-        let fields = vec![
-            StructField::new("x", DataType::DOUBLE, true),
-            StructField::new("y", DataType::FLOAT, false),
-            StructField::new("z", DataType::LONG, true),
-            StructField::new("s", nested_struct.clone(), false),
-            StructField::nullable("array_col", array_type),
-            StructField::nullable("map_col", map_type),
-            StructField::new("a", DataType::LONG, true),
-        ];
-
-        let struct_type = StructType::new_unchecked(fields);
+        let inner_struct = schema! { not_null "q": LONG };
+        let nested_struct = schema! {
+            (nested_field_with_metadata),
+            nullable "x": DOUBLE,
+            not_null "inner_struct": (inner_struct),
+        };
+        let struct_type = schema! {
+            nullable "x": DOUBLE,
+            not_null "y": FLOAT,
+            nullable "z": LONG,
+            not_null "s": (nested_struct.clone()),
+            nullable "array_col": [ nullable (nested_struct.clone()) ],
+            nullable "map_col": {
+                (nested_struct.clone()) => nullable (nested_struct.clone())
+            },
+            nullable "a": LONG,
+        };
         assert_eq!(
             struct_type.to_string(),
             "struct:
@@ -4564,7 +4536,7 @@ mod tests {
 "
         );
 
-        let schema = StructType::try_new([StructField::nullable("regular_col", DataType::STRING)])?;
+        let schema = schema! { nullable "regular_col": STRING };
         let schema = schema
             .add_metadata_column("row_index", MetadataColumnSpec::RowIndex)?
             .add_metadata_column("row_id", MetadataColumnSpec::RowId)?
@@ -4599,8 +4571,7 @@ mod tests {
 
     #[test]
     fn test_builder_from_schema() {
-        let base_schema =
-            StructType::try_new([StructField::new("id", DataType::INTEGER, false)]).unwrap();
+        let base_schema = schema! { not_null "id": INTEGER };
 
         let extended_schema = StructTypeBuilder::from_schema(&base_schema)
             .add_field(StructField::new("name", DataType::STRING, true))
@@ -4708,20 +4679,30 @@ mod tests {
 
     /// Schema: { a: { b: { c: double } } } — supports walks at depths 1, 2, and 3.
     fn walk_test_schema() -> StructType {
-        let l3 = StructType::new_unchecked([StructField::new("c", DataType::DOUBLE, false)]);
-        let l2 = StructType::new_unchecked([StructField::new("b", l3, false)]);
-        StructType::new_unchecked([StructField::new("a", l2, false)])
+        schema! {
+            not_null "a": {
+                not_null "b": {
+                    not_null "c": DOUBLE,
+                },
+            },
+        }
     }
 
     #[rstest::rstest]
-    #[case::single_level(vec!["a"], vec!["a"], DataType::from(StructType::new_unchecked([
-        StructField::new("b", StructType::new_unchecked([
-            StructField::new("c", DataType::DOUBLE, false)
-        ]), false)
-    ])))]
-    #[case::nested_2(vec!["a", "b"], vec!["a", "b"], DataType::from(StructType::new_unchecked([
-        StructField::new("c", DataType::DOUBLE, false)
-    ])))]
+    #[case::single_level(
+        vec!["a"],
+        vec!["a"],
+        DataType::from(schema! {
+            not_null "b": {
+                not_null "c": DOUBLE,
+            },
+        })
+    )]
+    #[case::nested_2(
+        vec!["a", "b"],
+        vec!["a", "b"],
+        DataType::from(schema! { not_null "c": DOUBLE })
+    )]
     #[case::nested_3(vec!["a", "b", "c"], vec!["a", "b", "c"], DataType::DOUBLE)]
     #[test]
     fn test_walk_column_fields_happy(
@@ -4754,13 +4735,13 @@ mod tests {
 
     #[test]
     fn test_normalize_column_names_to_schema_casing() {
-        let inner =
-            StructType::new_unchecked(vec![StructField::new("City", DataType::STRING, false)]);
-        let schema = StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("EventDate", DataType::DATE, false),
-            StructField::new("Address", inner, false),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            not_null "EventDate": DATE,
+            not_null "Address": {
+                not_null "City": STRING,
+            },
+        };
 
         // Mismatched casing -> normalized to schema
         let cols = vec![column_name!("eventdate")];

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -154,50 +154,45 @@ mod tests {
 
     use super::*;
     use crate::schema::{
-        schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField,
-        StructType,
+        schema, ArrayType, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
     };
 
     // === Schema builders for test cases ===
 
     fn simple_schema() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ])
+        schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        }
     }
 
     fn schema_with_underscores() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("col_1", DataType::INTEGER, false),
-            StructField::new("_private", DataType::STRING, true),
-            StructField::new("CamelCase123", DataType::LONG, false),
-        ])
+        schema! {
+            not_null "col_1": INTEGER,
+            nullable "_private": STRING,
+            not_null "CamelCase123": LONG,
+        }
     }
 
     fn schema_with_special_chars() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("my column", DataType::INTEGER, false),
-            StructField::new("col;name", DataType::STRING, true),
-        ])
+        schema! {
+            not_null "my column": INTEGER,
+            nullable "col;name": STRING,
+        }
     }
 
     fn schema_with_dot() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("a.b", DataType::INTEGER, false),
-            StructField::new("c", DataType::STRING, true),
-        ])
+        schema! {
+            not_null "a.b": INTEGER,
+            nullable "c": STRING,
+        }
     }
 
     fn schema_different_struct_children() -> StructType {
-        let inner_a =
-            StructType::new_unchecked(vec![StructField::new("child", DataType::INTEGER, false)]);
-        let inner_b =
-            StructType::new_unchecked(vec![StructField::new("CHILD", DataType::STRING, true)]);
-        StructType::new_unchecked(vec![
-            StructField::new("a", inner_a, false),
-            StructField::new("b", inner_b, false),
-        ])
+        schema! {
+            not_null "a": { not_null "child": INTEGER },
+            not_null "b": { nullable "CHILD": STRING },
+        }
     }
 
     fn schema_with_space() -> StructType {
@@ -250,11 +245,11 @@ mod tests {
     }
 
     fn schema_multi_bad() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::new("good", DataType::INTEGER, false),
-            StructField::new("bad column", DataType::STRING, true),
-            StructField::new("col;name", DataType::LONG, false),
-        ])
+        schema! {
+            not_null "good": INTEGER,
+            nullable "bad column": STRING,
+            not_null "col;name": LONG,
+        }
     }
 
     // === Helpers for building invariants metadata ===
@@ -275,36 +270,34 @@ mod tests {
     }
 
     fn schema_top_level_invariant() -> StructType {
-        StructType::new_unchecked(vec![
-            field_with_invariant("x", DataType::INTEGER, true),
-            StructField::new("y", DataType::INTEGER, true),
-        ])
+        schema! {
+            (field_with_invariant("x", DataType::INTEGER, true)),
+            nullable "y": INTEGER,
+        }
     }
 
     fn schema_nested_invariant() -> StructType {
-        let inner =
-            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
-        StructType::new_unchecked(vec![StructField::new("parent", inner, true)])
+        schema! {
+            nullable "parent": {
+                (field_with_invariant("child", DataType::INTEGER, true)),
+            },
+        }
     }
 
     fn schema_array_nested_invariant() -> StructType {
-        let inner =
-            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
-        StructType::new_unchecked(vec![StructField::new(
-            "arr",
-            ArrayType::new(inner, true),
-            true,
-        )])
+        schema! {
+            nullable "arr": [ nullable {
+                (field_with_invariant("child", DataType::INTEGER, true)),
+            } ],
+        }
     }
 
     fn schema_map_nested_invariant() -> StructType {
-        let inner =
-            StructType::new_unchecked(vec![field_with_invariant("child", DataType::INTEGER, true)]);
-        StructType::new_unchecked(vec![StructField::new(
-            "map",
-            MapType::new(DataType::STRING, inner, true),
-            true,
-        )])
+        schema! {
+            nullable "map": { STRING => nullable {
+                (field_with_invariant("child", DataType::INTEGER, true)),
+            } },
+        }
     }
 
     // === Valid schemas ===
@@ -315,9 +308,9 @@ mod tests {
     #[case::special_chars_with_cm(schema_with_special_chars(), ColumnMappingMode::Name)]
     #[case::dot_in_name_with_cm(schema_with_dot(), ColumnMappingMode::Name)]
     #[case::different_struct_children(schema_different_struct_children(), ColumnMappingMode::None)]
-    #[case::empty_no_cm(StructType::new_unchecked(vec![]), ColumnMappingMode::None)]
-    #[case::empty_cm_name(StructType::new_unchecked(vec![]), ColumnMappingMode::Name)]
-    #[case::empty_cm_id(StructType::new_unchecked(vec![]), ColumnMappingMode::Id)]
+    #[case::empty_no_cm(schema! {}, ColumnMappingMode::None)]
+    #[case::empty_cm_name(schema! {}, ColumnMappingMode::Name)]
+    #[case::empty_cm_id(schema! {}, ColumnMappingMode::Id)]
     fn valid_schema_accepted(#[case] schema: StructType, #[case] cm: ColumnMappingMode) {
         assert!(validate_schema(&schema, cm).is_ok());
     }

--- a/kernel/src/schema/void_utils.rs
+++ b/kernel/src/schema/void_utils.rs
@@ -190,7 +190,8 @@ fn add_void_stripping_inner<'a>(
 mod tests {
     use super::*;
     use crate::schema::{
-        ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+        schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField,
+        StructType,
     };
 
     // ---- validate_schema_for_write tests ----
@@ -218,7 +219,9 @@ mod tests {
         }
 
         // The dedicated validator is what actually catches this
-        let schema = StructType::new_unchecked([field]);
+        let schema = schema! {
+            (field),
+        };
         assert!(validate_schema_for_write(&schema).is_err());
     }
 
@@ -242,9 +245,7 @@ mod tests {
         "void in array inside struct",
         StructField::nullable(
             "outer",
-            StructType::new_unchecked([
-                StructField::nullable("inner", ArrayType::new(DataType::VOID, true)),
-            ])
+            schema! { nullable "inner": [ nullable VOID ] }
         ),
         "array element type"
     )]
@@ -261,10 +262,10 @@ mod tests {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::VOID),
-                ]),
+                schema! {
+                    nullable "a": INTEGER,
+                    nullable "b": VOID,
+                },
                 true,
             ),
         ),
@@ -276,10 +277,10 @@ mod tests {
             "m",
             MapType::new(
                 DataType::STRING,
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::VOID),
-                ]),
+                schema! {
+                    nullable "a": INTEGER,
+                    nullable "b": VOID,
+                },
                 true,
             ),
         ),
@@ -290,10 +291,10 @@ mod tests {
         StructField::nullable(
             "m",
             MapType::new(
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::VOID),
-                ]),
+                schema! {
+                    nullable "a": INTEGER,
+                    nullable "b": VOID,
+                },
                 DataType::STRING,
                 true,
             ),
@@ -306,10 +307,10 @@ mod tests {
             "outer",
             ArrayType::new(
                 ArrayType::new(
-                    StructType::new_unchecked([
-                        StructField::nullable("a", DataType::INTEGER),
-                        StructField::nullable("b", DataType::VOID),
-                    ]),
+                    schema! {
+                        nullable "a": INTEGER,
+                        nullable "b": VOID,
+                    },
                     true,
                 ),
                 true,
@@ -322,16 +323,13 @@ mod tests {
         StructField::nullable(
             "arr",
             ArrayType::new(
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable(
-                        "b",
-                        StructType::new_unchecked([
-                            StructField::nullable("x", DataType::INTEGER),
-                            StructField::nullable("y", DataType::VOID),
-                        ]),
-                    ),
-                ]),
+                schema! {
+                    nullable "a": INTEGER,
+                    nullable "b": {
+                        nullable "x": INTEGER,
+                        nullable "y": VOID,
+                    },
+                },
                 true,
             ),
         ),
@@ -342,16 +340,11 @@ mod tests {
         StructField::nullable(
             "outer",
             ArrayType::new(
-                StructType::new_unchecked([StructField::nullable(
-                    "inner",
-                    ArrayType::new(
-                        StructType::new_unchecked([StructField::nullable(
-                            "v",
-                            DataType::VOID,
-                        )]),
-                        true,
-                    ),
-                )]),
+                schema! {
+                    nullable "inner": [ nullable {
+                        nullable "v": VOID,
+                    } ],
+                },
                 true,
             ),
         ),
@@ -361,10 +354,7 @@ mod tests {
         "empty struct nested in array",
         StructField::nullable(
             "arr",
-            ArrayType::new(
-                StructType::new_unchecked(Vec::<StructField>::new()),
-                true,
-            ),
+            ArrayType::new(schema! {}, true),
         ),
         "struct nested in Array or Map must contain at least one non-void field"
     )]
@@ -374,10 +364,7 @@ mod tests {
             "m",
             MapType::new(
                 DataType::STRING,
-                StructType::new_unchecked([StructField::nullable(
-                    "x",
-                    DataType::VOID,
-                )]),
+                schema! { nullable "x": VOID },
                 true,
             ),
         ),
@@ -388,7 +375,9 @@ mod tests {
         #[case] field: StructField,
         #[case] expected_msg: &str,
     ) {
-        let schema = StructType::new_unchecked([field]);
+        let schema = schema! {
+            (field),
+        };
         let result = validate_schema_for_write(&schema);
         assert!(
             result.unwrap_err().to_string().contains(expected_msg),
@@ -399,54 +388,44 @@ mod tests {
     #[rstest::rstest]
     #[case(
         "void top level ok",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("void_col", DataType::VOID),
-        ])
+        schema! {
+            nullable "id": INTEGER,
+            nullable "void_col": VOID,
+        }
     )]
     #[case(
         "test no void ok",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
+        schema! {
+            nullable "id": INTEGER,
+            nullable "name": STRING,
+        }
     )]
     #[case(
         "void in nested struct",
-        StructType::new_unchecked([StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-            ]),
-        )])
+        schema! {
+            nullable "s": {
+                nullable "a": INTEGER,
+                nullable "b": VOID,
+            },
+        }
     )]
     #[case(
         "array of struct without void",
-        StructType::new_unchecked([StructField::nullable(
-            "arr",
-            ArrayType::new(
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::STRING),
-                ]),
-                true,
-            ),
-        )])
+        schema! {
+            nullable "arr": [ nullable {
+                nullable "a": INTEGER,
+                nullable "b": STRING,
+            } ],
+        }
     )]
     #[case(
         "map of struct without void",
-        StructType::new_unchecked([StructField::nullable(
-            "m",
-            MapType::new(
-                DataType::STRING,
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::STRING),
-                ]),
-                true,
-            ),
-        )])
+        schema! {
+            nullable "m": { STRING => nullable {
+                nullable "a": INTEGER,
+                nullable "b": STRING,
+            } },
+        }
     )]
     fn test_valid_schema_for_complex_types(#[case] desc: &str, #[case] schema: StructType) {
         validate_schema_for_write(&schema)
@@ -458,27 +437,26 @@ mod tests {
     #[rstest::rstest]
     #[case(
         "with void column",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("void_col", DataType::VOID),
-        ])
+        schema! {
+            nullable "id": INTEGER,
+            nullable "void_col": VOID,
+        }
     )]
     #[case(
         "no void",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
+        schema! {
+            nullable "id": INTEGER,
+            nullable "name": STRING,
+        }
     )]
     #[case(
         "struct with mixed void",
-        StructType::new_unchecked([StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-            ]),
-        )])
+        schema! {
+            nullable "s": {
+                nullable "a": INTEGER,
+                nullable "b": VOID,
+            },
+        }
     )]
     fn test_write_valid_schemas(#[case] desc: &str, #[case] schema: StructType) {
         validate_schema_for_write(&schema)
@@ -488,78 +466,56 @@ mod tests {
     #[rstest::rstest]
     #[case(
         "all void table",
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::VOID),
-            StructField::nullable("b", DataType::VOID),
-        ]),
+        schema! {
+            nullable "a": VOID,
+            nullable "b": VOID,
+        },
         "at least one non-void column"
     )]
     #[case(
         "all void struct",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked([
-                    StructField::nullable("x", DataType::VOID),
-                    StructField::nullable("y", DataType::VOID),
-                ]),
-            ),
-        ]),
+        schema! {
+            nullable "id": INTEGER,
+            nullable "s": {
+                nullable "x": VOID,
+                nullable "y": VOID,
+            },
+        },
         "contains no non-void fields"
     )]
     #[case(
         "void in array",
-        StructType::new_unchecked([StructField::nullable(
-            "arr",
-            ArrayType::new(DataType::VOID, true),
-        )]),
+        schema! { nullable "arr": [ nullable VOID ] },
         "array element type"
     )]
     #[case(
         "void in map",
-        StructType::new_unchecked([StructField::nullable(
-            "m",
-            MapType::new(
-                DataType::STRING,
-                DataType::VOID,
-                true,
-            ),
-        )]),
+        schema! { nullable "m": { STRING => nullable VOID } },
         "map value type"
     )]
     #[case(
         "nested all void struct",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable(
-                "outer",
-                StructType::new_unchecked([
-                    StructField::nullable(
-                        "inner",
-                        StructType::new_unchecked([StructField::nullable("x", DataType::VOID)]),
-                    ),
-                ]),
-            ),
-        ]),
+        schema! {
+            nullable "id": INTEGER,
+            nullable "outer": {
+                nullable "inner": {
+                    nullable "x": VOID,
+                },
+            },
+        },
         "contains no non-void fields"
     )]
     #[case(
         "empty struct at top level",
-        StructType::new_unchecked(Vec::<StructField>::new()),
+        schema! {},
         "at least one non-void column"
     )]
     #[case(
         "nested empty struct",
-        StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked(
-                    Vec::<StructField>::new(),
-                ),
-            ),
-        ]),
+        schema! {
+            nullable "id": INTEGER,
+            nullable "s": {},
+        },
         "contains no non-void fields"
     )]
     fn test_write_rejected_schemas(
@@ -579,64 +535,60 @@ mod tests {
     #[rstest::rstest]
     #[case(
         "schema with no void is noop",
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::STRING),
-        ]),
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::STRING),
-        ])
+        schema! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+        },
+        schema! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+        }
     )]
     #[case(
         "top-level void is dropped",
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("v", DataType::VOID),
-            StructField::nullable("b", DataType::STRING),
-        ]),
-        StructType::new_unchecked([
-            StructField::nullable("a", DataType::INTEGER),
-            StructField::nullable("b", DataType::STRING),
-        ])
+        schema! {
+            nullable "a": INTEGER,
+            nullable "v": VOID,
+            nullable "b": STRING,
+        },
+        schema! {
+            nullable "a": INTEGER,
+            nullable "b": STRING,
+        }
     )]
     #[case(
         "nested struct with mixed void",
-        StructType::new_unchecked([StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-                StructField::nullable("c", DataType::STRING),
-            ]),
-        )]),
-        StructType::new_unchecked([StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("c", DataType::STRING),
-            ]),
-        )])
+        schema! {
+            nullable "s": {
+                nullable "a": INTEGER,
+                nullable "b": VOID,
+                nullable "c": STRING,
+            },
+        },
+        schema! {
+            nullable "s": {
+                nullable "a": INTEGER,
+                nullable "c": STRING,
+            },
+        }
     )]
     #[case(
         "deeply nested void",
-        StructType::new_unchecked([StructField::nullable(
-            "outer",
-            StructType::new_unchecked([StructField::nullable(
-                "inner",
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("v", DataType::VOID),
-                ]),
-            )]),
-        )]),
-        StructType::new_unchecked([StructField::nullable(
-            "outer",
-            StructType::new_unchecked([StructField::nullable(
-                "inner",
-                StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]),
-            )]),
-        )])
+        schema! {
+            nullable "outer": {
+                nullable "inner": {
+                    nullable "a": INTEGER,
+                    nullable "v": VOID,
+                },
+            },
+        },
+        schema! {
+            nullable "outer": {
+                nullable "inner": {
+                    nullable "a": INTEGER,
+                },
+            },
+        }
     )]
     fn test_strip_void_from_schema(
         #[case] desc: &str,
@@ -676,10 +628,10 @@ mod tests {
     fn test_strip_preserves_metadata() {
         let mut s_field = StructField::nullable(
             "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-            ]),
+            schema! {
+                nullable "a": INTEGER,
+                nullable "b": VOID,
+            },
         );
         s_field.metadata.insert(
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref().into(),

--- a/kernel/src/schema/void_utils.rs
+++ b/kernel/src/schema/void_utils.rs
@@ -11,7 +11,7 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use super::{DataType, PrimitiveType, Schema, SchemaRef, StructField, StructType};
+use super::{schema_ref, DataType, PrimitiveType, Schema, SchemaRef, StructField, StructType};
 use crate::expressions::ExpressionStructPatchBuilder;
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::{DeltaResult, Error};
@@ -55,7 +55,7 @@ pub(crate) fn strip_void_from_schema(schema: SchemaRef) -> SchemaRef {
     match StripVoidFields.transform_struct(&schema) {
         Some(Cow::Owned(stripped)) => Arc::new(stripped),
         Some(Cow::Borrowed(_)) => schema,
-        None => Arc::new(StructType::new_unchecked(Vec::<StructField>::new())),
+        None => schema_ref! {},
     }
 }
 
@@ -663,10 +663,10 @@ mod tests {
         true
     )))]
     fn test_strip_drops_container_with_void(#[case] field_type: DataType) {
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("c", field_type),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "c": (field_type),
+        };
         let stripped = strip_void_from_schema(schema);
         assert!(stripped.field("id").is_some());
         assert!(stripped.field("c").is_none());
@@ -685,7 +685,9 @@ mod tests {
             ColumnMetadataKey::ColumnMappingPhysicalName.as_ref().into(),
             MetadataValue::String("phys_s".into()),
         );
-        let schema = Arc::new(StructType::new_unchecked([s_field]));
+        let schema = schema_ref! {
+            (s_field),
+        };
         let stripped = strip_void_from_schema(schema);
         assert_eq!(
             stripped

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -2356,21 +2356,14 @@ mod tests {
 
         let storage = Arc::new(InMemory::new());
         let engine = SyncEngine::new_with_store(storage);
-        let schema = Arc::new(
-            crate::schema::StructType::try_new(vec![
-                crate::schema::StructField::nullable("id", DataType::INTEGER),
-                crate::schema::StructField::nullable("region", DataType::STRING),
-                crate::schema::StructField::nullable(
-                    "address",
-                    crate::schema::StructType::try_new(vec![
-                        crate::schema::StructField::nullable("city", DataType::STRING),
-                        crate::schema::StructField::nullable("zip", DataType::INTEGER),
-                    ])
-                    .unwrap(),
-                ),
-            ])
-            .unwrap(),
-        );
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "region": STRING,
+            nullable "address": {
+                nullable "city": STRING,
+                nullable "zip": INTEGER,
+            },
+        };
         let _ = create_table("memory:///", schema, "test")
             .fold_with(clustering_cols.as_ref(), |builder, cols| {
                 let columns = cols
@@ -2512,9 +2505,7 @@ mod tests {
             Snapshot::builder_for("memory:///").build(&engine).unwrap()
         }
 
-        let small_schema = Arc::new(
-            StructType::try_new(vec![StructField::nullable("a", DataType::INTEGER)]).unwrap(),
-        );
+        let small_schema = schema_ref! { nullable "a": INTEGER };
         let wide_schema = Arc::new(
             StructType::try_new(
                 (0..50)

--- a/kernel/src/struct_patch.rs
+++ b/kernel/src/struct_patch.rs
@@ -936,7 +936,7 @@ mod tests {
     use crate::expressions::{
         lit, Expression as Expr, ExpressionRef, ExpressionStructPatch, ExpressionStructPatchBuilder,
     };
-    use crate::schema::{DataType, SchemaStructPatchBuilder, StructField, StructType};
+    use crate::schema::{schema, DataType, SchemaStructPatchBuilder, StructField, StructType};
     use crate::struct_patch::ProjectionStructPatchBuilder;
     use crate::unit_test_utils::assert_result_error_with_message;
 
@@ -1043,10 +1043,10 @@ mod tests {
     // Top-level schema with a "nested" struct field (holding `nested_a`, `nested_b`) and a
     // sibling top-level field, used to exercise nested-path patching.
     fn nested_input_schema() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::nullable("nested", schema(&["nested_a", "nested_b"])),
-            field("top"),
-        ])
+        schema! {
+            nullable "nested": (schema(&["nested_a", "nested_b"])),
+            (field("top")),
+        }
     }
 
     // Patches that leave the input schema fully unchanged (same fields, types, and order).
@@ -1073,7 +1073,7 @@ mod tests {
         SchemaStructPatchBuilder::new().append(field("appended_1")).append(field("appended_2")),
         &["a", "b", "appended_1", "appended_2"])]
     #[case::appends_to_empty_input(
-        StructType::new_unchecked(Vec::<StructField>::new()),
+        schema! {},
         SchemaStructPatchBuilder::new().append(field("only")),
         &["only"])]
     #[case::replaces_field_at_input_position(

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -16,7 +16,7 @@ use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
 use crate::scan::state::DvInfo;
 use crate::scan::PhysicalPredicate;
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
 use crate::table_changes::log_replay::LogReplayScanner;
 use crate::table_changes::test_utils::{
     row_tracking_metadata, row_tracking_table_config, test_deletion_vector,
@@ -29,10 +29,10 @@ use crate::unit_test_utils::{assert_result_error_with_message, Action, LocalMock
 use crate::{DeltaResult, Engine, Error, Predicate, Version};
 
 fn get_schema() -> SchemaRef {
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]))
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    }
 }
 
 fn get_default_table_config(table_root: &url::Url) -> TableConfiguration {
@@ -296,10 +296,10 @@ async fn column_mapping_should_succeed() {
         ]))
     }
 
-    let cm_schema = Arc::new(StructType::new_unchecked([
-        cm_field("id", DataType::INTEGER, 1),
-        cm_field("value", DataType::STRING, 2),
-    ]));
+    let cm_schema = schema_ref! {
+        (cm_field("id", DataType::INTEGER, 1)),
+        (cm_field("value", DataType::STRING, 2)),
+    };
 
     let engine = Arc::new(SyncEngine::new());
     let mut mock_table = LocalMockTable::new();
@@ -593,51 +593,51 @@ async fn incompatible_schemas_fail() {
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields: `id: long`, `value: string` and `year: int` (nullable).
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("value", DataType::STRING),
-        StructField::nullable("year", DataType::INTEGER),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "value": STRING,
+        nullable "year": INTEGER,
+    };
     assert_incompatible_schema(schema, get_schema()).await;
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields: `id: long` and `value: string`.
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "value": STRING,
+    };
     assert_incompatible_schema(schema, get_schema()).await;
 
     // NOTE: Once type widening is supported, this should not return an error.
     //
     // The CDF schema has fields: `id: long` and `value: string`.
     // This commit has schema with fields: `id: int` and `value: string`.
-    let cdf_schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("value", DataType::STRING),
-    ]));
-    let commit_schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let cdf_schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "value": STRING,
+    };
+    let commit_schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
     assert_incompatible_schema(cdf_schema, commit_schema).await;
 
     // Note: Once schema evolution is supported, this should not return an error.
     //
     // The CDF schema has fields: nullable `id`  and nullable `value`.
     // This commit has schema with fields: non-nullable `id` and nullable `value`.
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::not_null("id", DataType::LONG),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        not_null "id": LONG,
+        nullable "value": STRING,
+    };
     assert_incompatible_schema(schema, get_schema()).await;
 
     // The CDF schema has fields: `id: int` and `value: string`.
     // This commit has schema with fields:`id: string` and `value: string`.
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::STRING),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": STRING,
+        nullable "value": STRING,
+    };
     assert_incompatible_schema(schema, get_schema()).await;
 
     // Note: Once schema evolution is supported, this should not return an error.
@@ -703,15 +703,15 @@ async fn demonstration_schema_evolution_failures() {
     // Scenario 1: Adding a nullable column (safe evolution)
     // Initial: {id: int, value: string}
     // Evolved: {id: int, value: string, new_col: int?}
-    let initial = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]));
-    let evolved = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-        StructField::nullable("new_col", DataType::INTEGER),
-    ]));
+    let initial = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
+    let evolved = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+        nullable "new_col": INTEGER,
+    };
     let res = test_schema_evolution(initial, evolved).await;
     assert!(
         matches!(res, Err(Error::ChangeDataFeedIncompatibleSchema(_, _))),
@@ -721,14 +721,14 @@ async fn demonstration_schema_evolution_failures() {
     // Scenario 2: Type widening (int -> long) - supported by type widening feature
     // Initial: {id: int, value: string}
     // Evolved: {id: long, value: string}
-    let initial = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]));
-    let evolved = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let initial = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
+    let evolved = schema_ref! {
+        nullable "id": LONG,
+        nullable "value": STRING,
+    };
     let res = test_schema_evolution(initial, evolved).await;
     assert!(
         matches!(res, Err(Error::ChangeDataFeedIncompatibleSchema(_, _))),
@@ -738,14 +738,14 @@ async fn demonstration_schema_evolution_failures() {
     // Scenario 3: Changing nullability from non-null to nullable (safe evolution)
     // Initial: {id: int!, value: string}
     // Evolved: {id: int?, value: string}
-    let initial = Arc::new(StructType::new_unchecked([
-        StructField::not_null("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]));
-    let evolved = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ]));
+    let initial = schema_ref! {
+        not_null "id": INTEGER,
+        nullable "value": STRING,
+    };
+    let evolved = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
     let res = test_schema_evolution(initial, evolved).await;
     assert!(
         matches!(res, Err(Error::ChangeDataFeedIncompatibleSchema(_, _))),
@@ -1051,10 +1051,10 @@ async fn data_skipping_filter_prunes_partition_values_but_keeps_removes() {
         .await;
 
     // Partitioned schema: `part` is the partition column, `id` a data column.
-    let logical_schema: SchemaRef = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("part", DataType::STRING),
-    ]));
+    let logical_schema: SchemaRef = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "part": STRING,
+    };
     let metadata = Metadata::try_new(
         None,
         None,

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -16,7 +16,7 @@ use crate::log_segment::LogSegment;
 use crate::path::ParsedLogPath;
 use crate::scan::state::DvInfo;
 use crate::scan::PhysicalPredicate;
-use crate::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
+use crate::schema::{schema, schema_ref, DataType, SchemaRef, StructField};
 use crate::table_changes::log_replay::LogReplayScanner;
 use crate::table_changes::test_utils::{
     row_tracking_metadata, row_tracking_table_config, test_deletion_vector,
@@ -407,9 +407,7 @@ async fn row_tracking_unavailable_midstream_fails(#[case] properties: &[(&str, &
 }
 
 fn nested_id_type(value_type: DataType) -> DataType {
-    DataType::from(StructType::new_unchecked([StructField::nullable(
-        "value", value_type,
-    )]))
+    DataType::from(schema! { nullable "value": (value_type) })
 }
 
 #[rstest]
@@ -432,13 +430,11 @@ async fn row_tracking_schema_compatibility(
     #[case] expect_compatible: bool,
 ) {
     let schema = |id_type: DataType, has_year: bool| {
-        let fields = [
-            StructField::nullable("id", id_type),
-            StructField::nullable("value", DataType::STRING),
-        ]
-        .into_iter()
-        .chain(has_year.then(|| StructField::nullable("year", DataType::INTEGER)));
-        Arc::new(StructType::new_unchecked(fields))
+        schema_ref! {
+            nullable "id": (id_type),
+            nullable "value": STRING,
+            ..(has_year.then(|| StructField::nullable("year", DataType::INTEGER))),
+        }
     };
     let engine = Arc::new(SyncEngine::new());
     let mut mock_table = LocalMockTable::new();
@@ -471,8 +467,11 @@ fn row_tracking_schema_compatibility_checks_nullability(
     #[case] read_nullable: bool,
     #[case] expected: bool,
 ) {
-    let schema =
-        |nullable| StructType::new_unchecked([StructField::new("id", DataType::INTEGER, nullable)]);
+    let schema = |nullable| {
+        schema! {
+            (StructField::new("id", DataType::INTEGER, nullable)),
+        }
+    };
     assert_eq!(
         CdfMode::RowTracking
             .schemas_compatible(&schema(candidate_nullable), &schema(read_nullable),),
@@ -487,11 +486,15 @@ fn row_tracking_schema_compatibility_requires_new_columns_to_be_nullable(
     #[case] new_column_nullable: bool,
     #[case] expected: bool,
 ) {
-    let candidate = StructType::new_unchecked([StructField::nullable("id", DataType::INTEGER)]);
-    let read_schema = StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::new("new_column", DataType::STRING, new_column_nullable),
-    ]);
+    let candidate = schema! { nullable "id": INTEGER };
+    let read_schema = schema! {
+        nullable "id": INTEGER,
+        (StructField::new(
+            "new_column",
+            DataType::STRING,
+            new_column_nullable,
+        )),
+    };
     assert_eq!(
         CdfMode::RowTracking.schemas_compatible(&candidate, &read_schema),
         expected

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -47,7 +47,7 @@ use url::Url;
 use crate::log_segment::LogSegment;
 use crate::path::AsUrl;
 use crate::schema::compare::SchemaComparison as _;
-use crate::schema::{DataType, Schema, StructField, StructType};
+use crate::schema::{try_schema, DataType, Schema, StructField, StructType};
 use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{Operation, TableFeature};
@@ -382,13 +382,10 @@ impl TableChanges {
             return Err(mode.boundary_schema_error(start_schema.as_ref(), end_schema.as_ref()));
         }
 
-        let schema = StructType::try_new(
-            end_snapshot
-                .schema()
-                .fields()
-                .cloned()
-                .chain(CDF_FIELDS.clone()),
-        )?;
+        let schema = try_schema! {
+            ..(end_schema.fields()),
+            ..(CDF_FIELDS.clone()),
+        }?;
 
         Ok(TableChanges {
             table_root,

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -555,7 +555,7 @@ mod tests {
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::actions::{Add, Metadata, Protocol, Remove};
     use crate::engine::sync::SyncEngine;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, StructField, StructType};
     use crate::table_changes::test_utils::{
         row_tracking_properties, row_tracking_protocol, row_tracking_setup_actions,
         test_deletion_vector, TEST_MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
@@ -574,10 +574,10 @@ mod tests {
     use crate::{Engine, Error};
 
     fn listing_test_schema() -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ]))
+        schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        }
     }
 
     #[test]
@@ -713,15 +713,15 @@ mod tests {
         // the per-commit one.
         let engine: Arc<dyn Engine> = Arc::new(SyncEngine::new());
         let mut mock_table = LocalMockTable::new();
-        let start_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-            StructField::nullable("extra", DataType::INTEGER),
-        ]));
-        let end_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ]));
+        let start_schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+            nullable "extra": INTEGER,
+        };
+        let end_schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
         let rt_config = row_tracking_properties();
 
         // v0: start schema + row tracking. v1: a data commit (no metadata) using the start schema.

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -5,7 +5,7 @@ use super::{CHANGE_TYPE_COL_NAME, COMMIT_TIMESTAMP_COL_NAME, COMMIT_VERSION_COL_
 use crate::expressions::Scalar;
 use crate::scan::state_info::StateInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values};
-use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::schema::{schema_ref, SchemaRef, StructType};
 use crate::{DeltaResult, Error, ExpressionRef};
 
 /// Gets CDF metadata columns from the logical schema and scan file.
@@ -61,11 +61,12 @@ pub(crate) fn scan_file_physical_schema(
     physical_schema: &StructType,
 ) -> SchemaRef {
     if scan_file.scan_type == CdfScanFileType::Cdc {
-        let change_type = StructField::not_null(CHANGE_TYPE_COL_NAME, DataType::STRING);
-        let fields = physical_schema.fields().cloned().chain(Some(change_type));
         // NOTE: We don't validate the fields again because CHANGE_TYPE_COL_NAME should never be
         // used anywhere else
-        StructType::new_unchecked(fields).into()
+        schema_ref! {
+            ..(physical_schema.fields()),
+            not_null CHANGE_TYPE_COL_NAME: STRING,
+        }
     } else {
         physical_schema.clone().into()
     }
@@ -136,7 +137,7 @@ mod tests {
     use crate::scan::state_info::StateInfo;
     use crate::scan::transform_spec::FieldTransformSpec;
     use crate::scan::PhysicalPredicate;
-    use crate::schema::schema_ref;
+    use crate::schema::{schema, schema_ref, DataType};
     use crate::table_features::ColumnMappingMode;
 
     fn create_test_logical_schema() -> SchemaRef {
@@ -151,10 +152,10 @@ mod tests {
     }
 
     fn create_test_physical_schema() -> StructType {
-        StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("name", DataType::STRING),
-        ])
+        schema! {
+            nullable "id": STRING,
+            nullable "name": STRING,
+        }
     }
 
     fn create_test_cdf_scan_file() -> CdfScanFile {
@@ -293,11 +294,11 @@ mod tests {
 
         let logical_schema = create_test_logical_schema();
         // For CDC, physical schema needs _change_type column
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("_change_type", DataType::STRING),
-        ]);
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            nullable "name": STRING,
+            nullable "_change_type": STRING,
+        };
 
         // Request both partition and CDF columns
         let transform_spec = vec![
@@ -400,10 +401,10 @@ mod tests {
             nullable "name": STRING,
         };
 
-        let physical_schema = StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("name", DataType::STRING),
-        ]);
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            nullable "name": STRING,
+        };
 
         // Empty transform spec - no transformation needed.
         let transform_spec = vec![];

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -136,18 +136,18 @@ mod tests {
     use crate::scan::state_info::StateInfo;
     use crate::scan::transform_spec::FieldTransformSpec;
     use crate::scan::PhysicalPredicate;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::table_features::ColumnMappingMode;
 
     fn create_test_logical_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("age", DataType::LONG),
-            StructField::nullable("name", DataType::STRING),
-            StructField::nullable("_change_type", DataType::STRING),
-            StructField::nullable("_commit_version", DataType::LONG),
-            StructField::nullable("_commit_timestamp", DataType::TIMESTAMP),
-        ]))
+        schema_ref! {
+            nullable "id": STRING,
+            nullable "age": LONG,
+            nullable "name": STRING,
+            nullable "_change_type": STRING,
+            nullable "_commit_version": LONG,
+            nullable "_commit_timestamp": TIMESTAMP,
+        }
     }
 
     fn create_test_physical_schema() -> StructType {
@@ -395,10 +395,10 @@ mod tests {
         };
 
         // Create a simple schema without CDF metadata columns
-        let logical_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::nullable("id", DataType::STRING),
-            StructField::nullable("name", DataType::STRING),
-        ]));
+        let logical_schema = schema_ref! {
+            nullable "id": STRING,
+            nullable "name": STRING,
+        };
 
         let physical_schema = StructType::new_unchecked(vec![
             StructField::nullable("id", DataType::STRING),

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -361,7 +361,7 @@ mod tests {
     use crate::object_store::memory::InMemory;
     use crate::scan::transform_spec::FieldTransformSpec;
     use crate::scan::PhysicalPredicate;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::table_changes::{TableChanges, COMMIT_VERSION_COL_NAME};
     use crate::transaction::create_table::create_table;
     use crate::Predicate;
@@ -448,11 +448,10 @@ mod tests {
         // Check logical schema matches projection
         assert_eq!(
             *scan.logical_schema(),
-            StructType::new_unchecked([
-                StructField::nullable("id", DataType::INTEGER),
-                StructField::not_null("_commit_version", DataType::LONG),
-            ])
-            .into()
+            schema_ref! {
+                nullable "id": INTEGER,
+                not_null "_commit_version": LONG,
+            }
         );
 
         // Check physical schema only has the regular field 'id' (no CDF metadata columns)
@@ -493,10 +492,10 @@ mod tests {
         let store = Arc::new(InMemory::new());
         let engine = SyncEngine::new_with_store(store);
 
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("part", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "part": STRING,
+        };
         create_table(url_str, schema, "DefaultEngine")
             .with_table_properties([("delta.enableChangeDataFeed", "true")])
             .build(&engine, Box::new(FileSystemCommitter::new()))

--- a/kernel/src/table_changes/scan_file.rs
+++ b/kernel/src/table_changes/scan_file.rs
@@ -4,7 +4,7 @@
 //! [`cdf_scan_row_schema`]. You can convert engine data to this schema using the
 //! [`cdf_scan_row_expression`].
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use delta_kernel_derive::internal_api;
 use itertools::Itertools;
@@ -15,9 +15,7 @@ use crate::actions::visitors::visit_deletion_vector_at;
 use crate::engine_data::{GetData, TypedGetData};
 use crate::expressions::{col, lit, Expression};
 use crate::scan::state::DvInfo;
-use crate::schema::{
-    ColumnName, ColumnNamesAndTypes, DataType, MapType, SchemaRef, StructField, StructType,
-};
+use crate::schema::{lazy_schema_ref, ColumnName, ColumnNamesAndTypes, DataType, SchemaRef};
 use crate::utils::require;
 use crate::{DeltaResult, Error, RowVisitor};
 
@@ -404,48 +402,49 @@ impl<T> RowVisitor for CdfScanFileVisitor<'_, T> {
 
 /// Get the schema that scan rows (from [`TableChanges::scan_metadata`]) will be returned with.
 pub(crate) fn cdf_scan_row_schema() -> SchemaRef {
-    static CDF_SCAN_ROW_SCHEMA: LazyLock<Arc<StructType>> = LazyLock::new(|| {
-        let deletion_vector = StructType::new_unchecked([
-            StructField::nullable("storageType", DataType::STRING),
-            StructField::nullable("pathOrInlineDv", DataType::STRING),
-            StructField::nullable("offset", DataType::INTEGER),
-            StructField::nullable("sizeInBytes", DataType::INTEGER),
-            StructField::nullable("cardinality", DataType::LONG),
-        ]);
-        let partition_values = MapType::new(DataType::STRING, DataType::STRING, true);
-        let file_constant_values =
-            StructType::new_unchecked([StructField::nullable("partitionValues", partition_values)]);
-
-        let add = StructType::new_unchecked([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable("deletionVector", deletion_vector.clone()),
-            StructField::nullable("fileConstantValues", file_constant_values.clone()),
-            StructField::nullable("size", DataType::LONG),
-            StructField::nullable("baseRowId", DataType::LONG),
-            StructField::nullable("defaultRowCommitVersion", DataType::LONG),
-        ]);
-        let remove = StructType::new_unchecked([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable("deletionVector", deletion_vector),
-            StructField::nullable("fileConstantValues", file_constant_values.clone()),
-            StructField::nullable("size", DataType::LONG),
-            StructField::nullable("baseRowId", DataType::LONG),
-            StructField::nullable("defaultRowCommitVersion", DataType::LONG),
-        ]);
-        let cdc = StructType::new_unchecked([
-            StructField::nullable("path", DataType::STRING),
-            StructField::nullable("fileConstantValues", file_constant_values),
-            StructField::nullable("size", DataType::LONG),
-        ]);
-
-        Arc::new(StructType::new_unchecked([
-            StructField::nullable("add", add),
-            StructField::nullable("remove", remove),
-            StructField::nullable("cdc", cdc),
-            StructField::not_null("timestamp", DataType::LONG),
-            StructField::not_null("commit_version", DataType::LONG),
-        ]))
-    });
+    static CDF_SCAN_ROW_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+        nullable "add": {
+            nullable "path": STRING,
+            nullable "deletionVector": {
+                nullable "storageType": STRING,
+                nullable "pathOrInlineDv": STRING,
+                nullable "offset": INTEGER,
+                nullable "sizeInBytes": INTEGER,
+                nullable "cardinality": LONG,
+            },
+            nullable "fileConstantValues": {
+                nullable "partitionValues": { STRING => nullable STRING },
+            },
+            nullable "size": LONG,
+            nullable "baseRowId": LONG,
+            nullable "defaultRowCommitVersion": LONG,
+        },
+        nullable "remove": {
+            nullable "path": STRING,
+            nullable "deletionVector": {
+                nullable "storageType": STRING,
+                nullable "pathOrInlineDv": STRING,
+                nullable "offset": INTEGER,
+                nullable "sizeInBytes": INTEGER,
+                nullable "cardinality": LONG,
+            },
+            nullable "fileConstantValues": {
+                nullable "partitionValues": { STRING => nullable STRING },
+            },
+            nullable "size": LONG,
+            nullable "baseRowId": LONG,
+            nullable "defaultRowCommitVersion": LONG,
+        },
+        nullable "cdc": {
+            nullable "path": STRING,
+            nullable "fileConstantValues": {
+                nullable "partitionValues": { STRING => nullable STRING },
+            },
+            nullable "size": LONG,
+        },
+        not_null "timestamp": LONG,
+        not_null "commit_version": LONG,
+    };
     CDF_SCAN_ROW_SCHEMA.clone()
 }
 
@@ -493,7 +492,7 @@ mod tests {
     use crate::engine::sync::SyncEngine;
     use crate::log_segment::LogSegment;
     use crate::scan::state::DvInfo;
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::schema_ref;
     use crate::table_changes::log_replay::{
         table_changes_action_iter, table_changes_action_iter_with_mode,
     };
@@ -551,10 +550,10 @@ mod tests {
             None,
         )
         .unwrap();
-        let table_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ]));
+        let table_schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
         let table_config = row_tracking_table_config(table_root, table_schema.clone());
         let scan_metadata = table_changes_action_iter_with_mode(
             engine,
@@ -650,10 +649,10 @@ mod tests {
         let log_segment =
             LogSegment::for_table_changes(engine.storage_handler().as_ref(), log_root, 0, None)
                 .unwrap();
-        let table_schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ]));
+        let table_schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
 
         // Create a TableConfiguration for testing
         let metadata = Metadata::try_new(

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -934,16 +934,13 @@ impl TableConfiguration {
 mod test {
 
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     use rstest::rstest;
     use url::Url;
 
     use super::{InCommitTimestampEnablement, TableConfiguration};
     use crate::actions::{Metadata, Protocol, MIN_VALUES};
-    use crate::schema::{
-        column_name, schema_ref, ColumnName, DataType, SchemaRef, StructField, StructType,
-    };
+    use crate::schema::{column_name, schema_ref, ColumnName, DataType, SchemaRef, StructField};
     use crate::table_features::{
         ColumnMappingMode, FeatureType, Operation, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
         TABLE_FEATURES_MIN_WRITER_VERSION,
@@ -1050,10 +1047,10 @@ mod test {
 
     #[test]
     fn table_configuration_rejects_duplicate_partition_columns() {
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("value", DataType::INTEGER),
-            StructField::nullable("part", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "value": INTEGER,
+            nullable "part": STRING,
+        };
         let metadata = Metadata::try_new(
             None,
             None,
@@ -1496,10 +1493,9 @@ mod test {
 
     #[test]
     fn test_timestamp_ntz_legacy_alias_unblocks_read_and_write() {
-        let schema = Arc::new(StructType::new_unchecked([StructField::nullable(
-            "ts",
-            DataType::TIMESTAMP_NTZ,
-        )]));
+        let schema = schema_ref! {
+            nullable "ts": TIMESTAMP_NTZ,
+        };
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
 
         // Build the protocol from the legacy string alias to exercise the real read path.
@@ -1957,7 +1953,10 @@ mod test {
         )
         .unwrap();
 
-        Arc::new(StructType::new_unchecked([field_a, field_b]))
+        schema_ref! {
+            (field_a),
+            (field_b),
+        }
     }
 
     fn create_table_config_with_column_mapping(
@@ -2005,10 +2004,10 @@ mod test {
 
     #[test]
     fn test_build_expected_stats_schemas_no_column_mapping() {
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("col_a", DataType::LONG),
-            StructField::nullable("col_b", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "col_a": LONG,
+            nullable "col_b": STRING,
+        };
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
         let protocol = Protocol::try_new_legacy(1, 2).unwrap();
         let table_root = Url::try_from("file:///").unwrap();
@@ -2161,7 +2160,11 @@ mod test {
             }"#,
         )
         .unwrap();
-        Arc::new(StructType::new_unchecked([data_col, part_a, part_b]))
+        schema_ref! {
+            (data_col),
+            (part_a),
+            (part_b),
+        }
     }
 
     #[test]
@@ -2257,11 +2260,11 @@ mod test {
 
     #[test]
     fn test_physical_stats_column_names_excludes_partition_columns_no_column_mapping() {
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("data_col", DataType::LONG),
-            StructField::nullable("part_a", DataType::STRING),
-            StructField::nullable("part_b", DataType::INTEGER),
-        ]));
+        let schema = schema_ref! {
+            nullable "data_col": LONG,
+            nullable "part_a": STRING,
+            nullable "part_b": INTEGER,
+        };
         let metadata = Metadata::try_new(
             None,
             None,
@@ -2281,10 +2284,10 @@ mod test {
 
     #[test]
     fn test_physical_stats_column_names_all_partition_columns_returns_empty() {
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("part_a", DataType::STRING),
-            StructField::nullable("part_b", DataType::INTEGER),
-        ]));
+        let schema = schema_ref! {
+            nullable "part_a": STRING,
+            nullable "part_b": INTEGER,
+        };
         let metadata = Metadata::try_new(
             None,
             None,
@@ -2469,10 +2472,10 @@ mod test {
         // names equal logical names.
         // IcebergCompatV3 requires column mapping. This test bypasses that requirement for
         // convenience.
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("value", DataType::INTEGER),
-            StructField::nullable("pcol", DataType::STRING),
-        ]));
+        let schema = schema_ref! {
+            nullable "value": INTEGER,
+            nullable "pcol": STRING,
+        };
         let props: HashMap<String, String> = extra_props
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -2506,17 +2509,14 @@ mod test {
         // Pins the invariant that `physical_write_schema()` strips void columns from the
         // returned schema (top level and nested), so callers receive a Parquet-writable
         // schema without needing to apply `strip_void_from_schema` themselves.
-        let schema = Arc::new(StructType::new_unchecked([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("v", DataType::VOID),
-            StructField::nullable(
-                "s",
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("nested_void", DataType::VOID),
-                ]),
-            ),
-        ]));
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            nullable "v": VOID,
+            nullable "s": {
+                nullable "a": INTEGER,
+                nullable "nested_void": VOID,
+            },
+        };
         let metadata = Metadata::try_new(None, None, schema, vec![], 0, HashMap::new()).unwrap();
         let protocol = Protocol::try_new(
             TABLE_FEATURES_MIN_READER_VERSION,

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -909,7 +909,7 @@ mod tests {
 
     use super::*;
     use crate::expressions::{column_name, ColumnName};
-    use crate::schema::{DataType, MetadataValue, StructField, StructType};
+    use crate::schema::{schema, DataType, MetadataValue, StructField, StructType};
     use crate::unit_test_utils::{
         assert_result_error_with_message, column_mapping_physical_name_dedup_fixtures as fixtures,
         make_test_tc, test_deep_nested_schema_missing_leaf_cm,
@@ -1040,7 +1040,9 @@ mod tests {
             create_annotations(outer_id, outer_name)
         );
         println!("{schema}");
-        StructType::new_unchecked([serde_json::from_str(&schema).unwrap()])
+        schema! {
+            (serde_json::from_str::<StructField>(&schema).unwrap()),
+        }
     }
 
     #[test]
@@ -1150,13 +1152,10 @@ mod tests {
 
     #[test]
     fn test_annotation_validation_reaches_struct_fields_in_map_value() {
-        let unannotated =
-            StructType::new_unchecked([StructField::new("x", DataType::INTEGER, false)]);
-        let schema = StructType::new_unchecked([make_cm_field(
-            "b",
-            1,
-            MapType::new(DataType::STRING, unannotated, false),
-        )]);
+        let unannotated = schema! { not_null "x": INTEGER };
+        let schema = schema! {
+            (make_cm_field("b", 1, MapType::new(DataType::STRING, unannotated, false))),
+        };
         validate_schema_column_mapping(&schema, ColumnMappingMode::Id)
             .expect_err("missing annotation on struct field inside map value");
     }
@@ -1175,34 +1174,40 @@ mod tests {
         key: ColumnMetadataKey,
     ) {
         // Top-level field carrying only this key.
-        let top_level = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
-            .add_metadata([(key.as_ref(), MetadataValue::Number(1))])]);
+        let top_level = schema! {
+            (StructField::nullable("a", DataType::INTEGER)
+                .add_metadata([(key.as_ref(), MetadataValue::Number(1))])),
+        };
         assert!(schema_has_column_mapping_metadata(&top_level));
 
         // Same key on a nested struct leaf (clean top level).
-        let nested = StructType::new_unchecked([StructField::nullable(
-            "outer",
-            StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)
-                .add_metadata([(key.as_ref(), MetadataValue::Number(1))])]),
-        )]);
+        let nested = schema! {
+            (StructField::nullable(
+                "outer",
+                schema! {
+                    (StructField::nullable("leaf", DataType::INTEGER)
+                        .add_metadata([(key.as_ref(), MetadataValue::Number(1))])),
+                },
+            )),
+        };
         assert!(schema_has_column_mapping_metadata(&nested));
     }
 
     #[test]
     fn test_schema_has_column_mapping_metadata_edge_cases() {
         // Clean schema -> false.
-        let clean = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
+        let clean = schema! { nullable "a": INTEGER };
         assert!(!schema_has_column_mapping_metadata(&clean));
 
         // Detection is by key presence, not value type: a wrong-typed id still counts (it must, so
         // the stripper -- which removes by presence -- never leaves a key the detector deemed
         // absent).
-        let wrong_typed =
-            StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)
-                .add_metadata([(
-                    ColumnMetadataKey::ColumnMappingId.as_ref(),
-                    MetadataValue::String("not-a-number".to_string()),
-                )])]);
+        let wrong_typed = schema! {
+            (StructField::nullable("a", DataType::INTEGER).add_metadata([(
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::String("not-a-number".to_string()),
+            )])),
+        };
         assert!(schema_has_column_mapping_metadata(&wrong_typed));
     }
 
@@ -1220,13 +1225,15 @@ mod tests {
             ),
             ("delta.identity.start", MetadataValue::Number(7)),
         ]);
-        let schema = StructType::new_unchecked([
-            annotated_top,
-            StructField::nullable(
+        let schema = schema! {
+            (annotated_top),
+            (StructField::nullable(
                 "outer",
-                StructType::new_unchecked([make_cm_field("leaf", 2, DataType::INTEGER)]),
-            ),
-        ]);
+                schema! {
+                    (make_cm_field("leaf", 2, DataType::INTEGER)),
+                },
+            )),
+        };
 
         let stripped = drop_column_mapping_metadata(&schema);
         assert!(!schema_has_column_mapping_metadata(&stripped));
@@ -1250,12 +1257,16 @@ mod tests {
     #[test]
     fn test_drop_column_mapping_metadata_strips_array_and_map_nested_leaves() {
         // Annotated struct leaves living inside an array element and a map value.
-        let elem = StructType::new_unchecked([make_cm_field("in_arr", 3, DataType::INTEGER)]);
-        let val = StructType::new_unchecked([make_cm_field("in_map", 4, DataType::INTEGER)]);
-        let schema = StructType::new_unchecked([
-            StructField::nullable("arr", ArrayType::new(elem, true)),
-            StructField::nullable("m", MapType::new(DataType::STRING, val, true)),
-        ]);
+        let elem = schema! {
+            (make_cm_field("in_arr", 3, DataType::INTEGER)),
+        };
+        let val = schema! {
+            (make_cm_field("in_map", 4, DataType::INTEGER)),
+        };
+        let schema = schema! {
+            nullable "arr": (ArrayType::new(elem, true)),
+            nullable "m": (MapType::new(DataType::STRING, val, true)),
+        };
         assert!(schema_has_column_mapping_metadata(&schema));
 
         let stripped = drop_column_mapping_metadata(&schema);
@@ -1266,8 +1277,10 @@ mod tests {
     fn test_strip_stray_column_mapping_metadata() {
         // Mode gating lives at the call sites; this helper only decides strip-vs-leave from the
         // current-vs-candidate comparison.
-        let clean = StructType::new_unchecked([StructField::nullable("a", DataType::INTEGER)]);
-        let annotated = StructType::new_unchecked([make_cm_field("a", 1, DataType::INTEGER)]);
+        let clean = schema! { nullable "a": INTEGER };
+        let annotated = schema! {
+            (make_cm_field("a", 1, DataType::INTEGER)),
+        };
 
         // CREATE (no prior schema) introducing annotations -> stripped.
         let stripped = strip_stray_column_mapping_metadata(false, &annotated)
@@ -1298,42 +1311,50 @@ mod tests {
     }
 
     fn cm_schema_same_level_duplicates() -> StructType {
-        StructType::new_unchecked([
-            make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field("b", 1, DataType::INTEGER),
-        ])
+        schema! {
+            (make_cm_field("a", 1, DataType::INTEGER)),
+            (make_cm_field("b", 1, DataType::INTEGER)),
+        }
     }
 
     fn cm_schema_nested_duplicates() -> StructType {
-        let nested = StructType::new_unchecked([
-            make_cm_field("x", 5, DataType::INTEGER),
-            make_cm_field("y", 5, DataType::INTEGER),
-        ]);
-        StructType::new_unchecked([make_cm_field("outer", 10, nested)])
+        let nested = schema! {
+            (make_cm_field("x", 5, DataType::INTEGER)),
+            (make_cm_field("y", 5, DataType::INTEGER)),
+        };
+        schema! {
+            (make_cm_field("outer", 10, nested)),
+        }
     }
 
     fn cm_schema_cross_level_duplicates() -> StructType {
-        let nested = StructType::new_unchecked([make_cm_field("inner", 1, DataType::INTEGER)]);
-        StructType::new_unchecked([
-            make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field("b", 2, nested),
-        ])
+        let nested = schema! {
+            (make_cm_field("inner", 1, DataType::INTEGER)),
+        };
+        schema! {
+            (make_cm_field("a", 1, DataType::INTEGER)),
+            (make_cm_field("b", 2, nested)),
+        }
     }
 
     fn cm_schema_array_duplicates() -> StructType {
-        let element = StructType::new_unchecked([make_cm_field("x", 1, DataType::INTEGER)]);
-        StructType::new_unchecked([
-            make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field("b", 2, ArrayType::new(element, false)),
-        ])
+        let element = schema! {
+            (make_cm_field("x", 1, DataType::INTEGER)),
+        };
+        schema! {
+            (make_cm_field("a", 1, DataType::INTEGER)),
+            (make_cm_field("b", 2, ArrayType::new(element, false))),
+        }
     }
 
     fn cm_schema_map_duplicates() -> StructType {
-        let value = StructType::new_unchecked([make_cm_field("x", 1, DataType::INTEGER)]);
-        StructType::new_unchecked([
-            make_cm_field("a", 1, DataType::INTEGER),
-            make_cm_field("b", 2, MapType::new(DataType::STRING, value, false)),
-        ])
+        let value = schema! {
+            (make_cm_field("x", 1, DataType::INTEGER)),
+        };
+        schema! {
+            (make_cm_field("a", 1, DataType::INTEGER)),
+            (make_cm_field("b", 2, MapType::new(DataType::STRING, value, false))),
+        }
     }
 
     #[rstest::rstest]
@@ -1474,28 +1495,31 @@ mod tests {
         let path = |segments: &[&str]| segments.iter().map(|s| s.to_string()).collect();
         match shape {
             SchemaShape::Flat => {
-                let schema = StructType::new_unchecked([
-                    StructField::nullable("unannotated_sibling", DataType::STRING),
-                    field_under_test,
-                ]);
+                let schema = schema! {
+                    nullable "unannotated_sibling": STRING,
+                    (field_under_test),
+                };
                 (schema, path(&[FIELD_UNDER_TEST]))
             }
             SchemaShape::NestedStruct => {
-                let inner = StructType::new_unchecked([field_under_test]);
-                let schema = StructType::new_unchecked([
-                    StructField::nullable("unannotated_sibling", DataType::STRING),
-                    StructField::nullable("outer", inner),
-                ]);
+                let inner = schema! {
+                    (field_under_test),
+                };
+                let schema = schema! {
+                    nullable "unannotated_sibling": STRING,
+                    nullable "outer": (inner),
+                };
                 (schema, path(&["outer", FIELD_UNDER_TEST]))
             }
             SchemaShape::DeeplyNestedStruct => {
-                let innermost = StructType::new_unchecked([field_under_test]);
-                let middle =
-                    StructType::new_unchecked([StructField::nullable("middle", innermost)]);
-                let schema = StructType::new_unchecked([
-                    StructField::nullable("unannotated_sibling", DataType::STRING),
-                    StructField::nullable("outer", middle),
-                ]);
+                let innermost = schema! {
+                    (field_under_test),
+                };
+                let middle = schema! { nullable "middle": (innermost) };
+                let schema = schema! {
+                    nullable "unannotated_sibling": STRING,
+                    nullable "outer": (middle),
+                };
                 (schema, path(&["outer", "middle", FIELD_UNDER_TEST]))
             }
         }
@@ -1722,7 +1746,9 @@ mod tests {
         #[case] preserved_physical_name: Option<&str>,
     ) {
         let field = make_field_under_test(None, preserved_physical_name);
-        let schema = StructType::new_unchecked([field]);
+        let schema = schema! {
+            (field),
+        };
 
         let mut max_id = i64::MAX;
         let err = assign_column_mapping_metadata(&schema, &mut max_id, false)
@@ -1798,7 +1824,10 @@ mod tests {
                 ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                 MetadataValue::String("user-supplied".to_string()),
             )]);
-        let schema = StructType::new_unchecked([preserved, needs_allocation]);
+        let schema = schema! {
+            (preserved),
+            (needs_allocation),
+        };
 
         let mut max_id = find_max_column_id_in_schema(&schema).unwrap_or(0);
         let err = assign_column_mapping_metadata(&schema, &mut max_id, false)
@@ -1813,15 +1842,15 @@ mod tests {
 
     #[test]
     fn test_assign_column_mapping_metadata_nested_struct() {
-        let inner = StructType::new_unchecked([
-            StructField::new("x", DataType::INTEGER, false),
-            StructField::new("y", DataType::STRING, true),
-        ]);
+        let inner = schema! {
+            not_null "x": INTEGER,
+            nullable "y": STRING,
+        };
 
-        let schema = StructType::new_unchecked([
-            StructField::new("a", DataType::INTEGER, false),
-            StructField::new("nested", inner, true),
-        ]);
+        let schema = schema! {
+            not_null "a": INTEGER,
+            nullable "nested": (inner),
+        };
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1898,14 +1927,12 @@ mod tests {
         // Test: map<struct<k: int>, struct<v: int>>
         // Both key and value are structs that need column mapping metadata
 
-        let key_struct =
-            StructType::new_unchecked([StructField::new("k", DataType::INTEGER, false)]);
-        let value_struct =
-            StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
+        let key_struct = schema! { not_null "k": INTEGER };
+        let value_struct = schema! { not_null "v": INTEGER };
 
         let map_type = MapType::new(key_struct, value_struct, true);
 
-        let schema = StructType::new_unchecked([StructField::new("my_map", map_type, true)]);
+        let schema = schema! { nullable "my_map": (map_type) };
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1942,12 +1969,11 @@ mod tests {
     fn test_assign_column_mapping_metadata_array_with_struct_element() {
         // Test: array<struct<elem: int>>
 
-        let elem_struct =
-            StructType::new_unchecked([StructField::new("elem", DataType::INTEGER, false)]);
+        let elem_struct = schema! { not_null "elem": INTEGER };
 
         let array_type = ArrayType::new(elem_struct, true);
 
-        let schema = StructType::new_unchecked([StructField::new("my_array", array_type, true)]);
+        let schema = schema! { nullable "my_array": (array_type) };
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -1979,14 +2005,12 @@ mod tests {
     fn test_assign_column_mapping_metadata_double_nested_array() {
         // Test: array<array<struct<deep: int>>>
 
-        let deep_struct =
-            StructType::new_unchecked([StructField::new("deep", DataType::INTEGER, false)]);
+        let deep_struct = schema! { not_null "deep": INTEGER };
 
         let inner_array = ArrayType::new(deep_struct, true);
         let outer_array = ArrayType::new(inner_array, true);
 
-        let schema =
-            StructType::new_unchecked([StructField::new("nested_arrays", outer_array, true)]);
+        let schema = schema! { nullable "nested_arrays": (outer_array) };
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -2021,10 +2045,8 @@ mod tests {
         // Test: array<map<array<struct<k: int>>, array<struct<v: int>>>>
         // Deeply nested array-map-array-struct combination
 
-        let key_struct =
-            StructType::new_unchecked([StructField::new("k", DataType::INTEGER, false)]);
-        let value_struct =
-            StructType::new_unchecked([StructField::new("v", DataType::INTEGER, false)]);
+        let key_struct = schema! { not_null "k": INTEGER };
+        let value_struct = schema! { not_null "v": INTEGER };
 
         let key_array = ArrayType::new(key_struct, true);
         let value_array = ArrayType::new(value_struct, true);
@@ -2033,7 +2055,7 @@ mod tests {
 
         let outer_array = ArrayType::new(inner_map, true);
 
-        let schema = StructType::new_unchecked([StructField::new("cursed", outer_array, true)]);
+        let schema = schema! { nullable "cursed": (outer_array) };
 
         let mut max_id = 0;
         let result = assign_column_mapping_metadata(&schema, &mut max_id, false).unwrap();
@@ -2079,8 +2101,8 @@ mod tests {
 
     #[test]
     fn test_get_any_level_column_physical_name_success() {
-        let inner = StructType::new_unchecked([StructField::new("y", DataType::INTEGER, false)
-            .add_metadata([
+        let inner = schema! {
+            (StructField::new("y", DataType::INTEGER, false).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-inner-y".to_string()),
@@ -2089,10 +2111,11 @@ mod tests {
                     ColumnMetadataKey::ColumnMappingId.as_ref(),
                     MetadataValue::Number(2),
                 ),
-            ])]);
+            ])),
+        };
 
-        let schema =
-            StructType::new_unchecked([StructField::new("a", inner, true).add_metadata([
+        let schema = schema! {
+            (StructField::new("a", inner, true).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-outer-a".to_string()),
@@ -2101,7 +2124,8 @@ mod tests {
                     ColumnMetadataKey::ColumnMappingId.as_ref(),
                     MetadataValue::Number(1),
                 ),
-            ])]);
+            ])),
+        };
 
         // Top-level column
         let result = get_any_level_column_physical_name(
@@ -2136,7 +2160,7 @@ mod tests {
 
     #[test]
     fn test_get_any_level_column_physical_name_errors() {
-        let schema = StructType::new_unchecked([StructField::new("a", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "a": INTEGER };
 
         // Non-existent top-level column
         let result = get_any_level_column_physical_name(
@@ -2181,9 +2205,11 @@ mod tests {
             )]);
         }
 
-        let inner = StructType::new_unchecked([inner_field]);
-        let schema =
-            StructType::new_unchecked([StructField::new("a", inner, true).add_metadata([
+        let inner = schema! {
+            (inner_field),
+        };
+        let schema = schema! {
+            (StructField::new("a", inner, true).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-outer-a".to_string()),
@@ -2192,7 +2218,8 @@ mod tests {
                     ColumnMetadataKey::ColumnMappingId.as_ref(),
                     MetadataValue::Number(1),
                 ),
-            ])]);
+            ])),
+        };
 
         let err = get_any_level_column_physical_name(
             &schema,
@@ -2248,10 +2275,10 @@ mod tests {
 
     #[test]
     fn physical_to_logical_no_mapping() {
-        let schema = StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        };
         let physical_col = column_name!("id");
         let (logical, data_type) = physical_to_logical_column_name_and_type(
             &schema,
@@ -2269,7 +2296,7 @@ mod tests {
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-abc-123".to_string()),
         )]);
-        let schema = StructType::new_unchecked(vec![field]);
+        let schema = schema! { (field) };
 
         let physical_col = ColumnName::new(["col-abc-123"]);
         let (logical, data_type) = physical_to_logical_column_name_and_type(
@@ -2284,8 +2311,7 @@ mod tests {
 
     #[test]
     fn physical_to_logical_not_found() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "id": INTEGER };
         let physical_col = column_name!("nonexistent");
         let result = physical_to_logical_column_name_and_type(
             &schema,
@@ -2305,12 +2331,12 @@ mod tests {
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-inner-456".to_string()),
         )]);
-        let inner_struct = StructType::new_unchecked(vec![inner_field]);
+        let inner_struct = schema! { (inner_field) };
         let outer_field = StructField::new("address", inner_struct, true).with_metadata([(
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-outer-123".to_string()),
         )]);
-        let schema = StructType::new_unchecked(vec![outer_field]);
+        let schema = schema! { (outer_field) };
 
         let physical_col = ColumnName::new(["col-outer-123", "col-inner-456"]);
         let (logical, data_type) = physical_to_logical_column_name_and_type(
@@ -2325,8 +2351,7 @@ mod tests {
 
     #[test]
     fn physical_to_logical_non_struct_intermediate_errors() {
-        let schema =
-            StructType::new_unchecked(vec![StructField::new("id", DataType::INTEGER, false)]);
+        let schema = schema! { not_null "id": INTEGER };
         let physical_col = column_name!("id.nested");
         let result = physical_to_logical_column_name_and_type(
             &schema,
@@ -2353,68 +2378,57 @@ mod tests {
 
     #[test]
     fn find_max_column_id_empty_schema_is_none() {
-        let schema =
-            StructType::try_new(vec![StructField::nullable("a", DataType::STRING)]).unwrap();
+        let schema = schema! { nullable "a": STRING };
         assert_eq!(find_max_column_id_in_schema(&schema), None);
     }
 
     #[test]
     fn find_max_column_id_top_level_only() {
-        let schema = StructType::try_new(vec![
-            field_with_id("a", DataType::STRING, 1),
-            field_with_id("b", DataType::INTEGER, 3),
-            field_with_id("c", DataType::STRING, 2),
-        ])
-        .unwrap();
+        let schema = schema! {
+            (field_with_id("a", DataType::STRING, 1)),
+            (field_with_id("b", DataType::INTEGER, 3)),
+            (field_with_id("c", DataType::STRING, 2)),
+        };
         assert_eq!(find_max_column_id_in_schema(&schema), Some(3));
     }
 
     #[test]
     fn find_max_column_id_nested_struct() {
-        let inner = DataType::from(
-            StructType::try_new(vec![
-                field_with_id("x", DataType::STRING, 7),
-                field_with_id("y", DataType::STRING, 5),
-            ])
-            .unwrap(),
-        );
-        let schema = StructType::try_new(vec![
-            field_with_id("outer", inner, 2),
-            field_with_id("sibling", DataType::STRING, 3),
-        ])
-        .unwrap();
+        let inner = schema! {
+            (field_with_id("x", DataType::STRING, 7)),
+            (field_with_id("y", DataType::STRING, 5)),
+        };
+        let schema = schema! {
+            (field_with_id("outer", inner, 2)),
+            (field_with_id("sibling", DataType::STRING, 3)),
+        };
         assert_eq!(find_max_column_id_in_schema(&schema), Some(7));
     }
 
     #[test]
     fn find_max_column_id_array_and_map_recurse_into_element_types() {
-        let array_elem_struct = DataType::from(ArrayType::new(
-            StructType::try_new(vec![field_with_id("deep", DataType::STRING, 42)]).unwrap(),
+        let array_elem_struct = ArrayType::new(
+            schema! { (field_with_id("deep", DataType::STRING, 42)) },
             true,
-        ));
-        let map_ty = DataType::from(MapType::new(
+        );
+        let map_ty = MapType::new(
             DataType::STRING,
-            StructType::try_new(vec![field_with_id("inside", DataType::STRING, 9)]).unwrap(),
+            schema! { (field_with_id("inside", DataType::STRING, 9)) },
             false,
-        ));
-        let schema = StructType::try_new(vec![
-            field_with_id("arr", array_elem_struct, 1),
-            field_with_id("m", map_ty, 2),
-        ])
-        .unwrap();
+        );
+        let schema = schema! {
+            (field_with_id("arr", array_elem_struct, 1)),
+            (field_with_id("m", map_ty, 2)),
+        };
         assert_eq!(find_max_column_id_in_schema(&schema), Some(42));
     }
 
     #[test]
     fn find_max_column_id_map_with_struct_key_recurses() {
-        let key_struct = DataType::from(
-            StructType::try_new(vec![field_with_id("key_id", DataType::INTEGER, 17)]).unwrap(),
-        );
-        let value_struct = DataType::from(
-            StructType::try_new(vec![field_with_id("val_id", DataType::INTEGER, 11)]).unwrap(),
-        );
-        let map_ty = DataType::from(MapType::new(key_struct, value_struct, false));
-        let schema = StructType::try_new(vec![field_with_id("m", map_ty, 1)]).unwrap();
+        let key_struct = schema! { (field_with_id("key_id", DataType::INTEGER, 17)) };
+        let value_struct = schema! { (field_with_id("val_id", DataType::INTEGER, 11)) };
+        let map_ty = MapType::new(key_struct, value_struct, false);
+        let schema = schema! { (field_with_id("m", map_ty, 1)) };
         // Max should come from the key struct's `key_id = 17`, beating value's 11 and
         // top-level's 1.
         assert_eq!(find_max_column_id_in_schema(&schema), Some(17));
@@ -2425,15 +2439,12 @@ mod tests {
     /// top-level `v=4`.
     #[test]
     fn find_max_column_id_variant_recurses_into_inner_fields() {
-        let variant = DataType::Variant(Box::new(
-            StructType::try_new(vec![
-                field_with_id("metadata", DataType::BINARY, 10),
-                field_with_id("value", DataType::BINARY, 20),
-                field_with_id("shred", DataType::STRING, 23),
-            ])
-            .unwrap(),
-        ));
-        let schema = StructType::try_new(vec![field_with_id("v", variant, 4)]).unwrap();
+        let variant = DataType::Variant(Box::new(schema! {
+            (field_with_id("metadata", DataType::BINARY, 10)),
+            (field_with_id("value", DataType::BINARY, 20)),
+            (field_with_id("shred", DataType::STRING, 23)),
+        }));
+        let schema = schema! { (field_with_id("v", variant, 4)) };
         assert_eq!(find_max_column_id_in_schema(&schema), Some(23));
     }
 
@@ -2455,7 +2466,7 @@ mod tests {
                 "m.value": 99,
             })),
         );
-        let schema = StructType::try_new(vec![field]).unwrap();
+        let schema = schema! { (field) };
         assert_eq!(find_max_column_id_in_schema(&schema), Some(99));
     }
 }

--- a/kernel/src/table_features/geospatial.rs
+++ b/kernel/src/table_features/geospatial.rs
@@ -47,23 +47,26 @@ mod tests {
     use super::*;
     use crate::actions::Protocol;
     use crate::schema::{
-        ArrayType, DataType, EdgeInterpolationAlgorithm, MapType, StructField, StructType,
+        schema, ArrayType, DataType, EdgeInterpolationAlgorithm, MapType, StructType,
     };
     use crate::unit_test_utils::{assert_schema_feature_validation, geography_type, geometry_type};
 
     fn schema_with_field(dt: DataType) -> StructType {
-        StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("g", dt, true),
-        ])
+        schema! {
+            not_null "id": INTEGER,
+            nullable "g": (dt),
+        }
     }
 
     #[rstest]
     #[case::top_level_geometry(schema_with_field(geometry_type("EPSG:4326")), true)]
     #[case::nested_struct(
-        schema_with_field(DataType::Struct(Box::new(StructType::new_unchecked([
-            StructField::new("inner_geo", geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical), true),
-        ])))),
+        schema_with_field(DataType::from(schema! {
+            nullable "inner_geo": (geography_type(
+                "EPSG:4326",
+                EdgeInterpolationAlgorithm::Spherical,
+            )),
+        })),
         true
     )]
     #[case::in_array(schema_with_field(ArrayType::new(geometry_type("EPSG:4326"), true).into()), true)]
@@ -78,26 +81,23 @@ mod tests {
 
     #[test]
     fn test_geospatial_feature_validation() {
-        let schema_with_geotype = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("geom", geometry_type("EPSG:4326"), true),
-        ]);
-        let schema_without_geotype = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ]);
-        let nested_schema_with_geotype = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new(
-                "nested",
-                DataType::Struct(Box::new(StructType::new_unchecked([StructField::new(
-                    "inner_geo",
-                    geography_type("EPSG:4326", EdgeInterpolationAlgorithm::Spherical),
-                    true,
-                )]))),
-                true,
-            ),
-        ]);
+        let schema_with_geotype = schema! {
+            not_null "id": INTEGER,
+            nullable "geom": (geometry_type("EPSG:4326")),
+        };
+        let schema_without_geotype = schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        };
+        let nested_schema_with_geotype = schema! {
+            not_null "id": INTEGER,
+            nullable "nested": {
+                nullable "inner_geo": (geography_type(
+                    "EPSG:4326",
+                    EdgeInterpolationAlgorithm::Spherical,
+                )),
+            },
+        };
         let protocol_with_geotype = Protocol::try_new_modern(
             [TableFeature::GeospatialType],
             [TableFeature::GeospatialType],

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -143,7 +143,7 @@ mod column_default_tests {
     use super::iceberg_compat_v3_column_defaults_validation;
     use crate::actions::{Metadata, Protocol};
     use crate::schema::ColumnMetadataKey::CurrentDefault;
-    use crate::schema::{ArrayType, DataType, MetadataValue, StructField, StructType};
+    use crate::schema::{schema, ArrayType, DataType, MetadataValue, StructField, StructType};
     use crate::table_configuration::TableConfiguration;
     use crate::table_features::TableFeature;
 
@@ -184,51 +184,50 @@ mod column_default_tests {
 
     #[rstest]
     #[case::primitive_literal(
-        StructType::try_new([field_with_default("a", DataType::INTEGER, "42")]).unwrap(),
+        schema! {
+            (field_with_default("a", DataType::INTEGER, "42")),
+        },
         "a",
         None
     )]
     #[case::primitive_null(
-        StructType::try_new([field_with_default("a", DataType::INTEGER, "NULL")]).unwrap(),
+        schema! {
+            (field_with_default("a", DataType::INTEGER, "NULL")),
+        },
         "a",
         None
     )]
     #[case::non_literal_primitive(
-        StructType::try_new([field_with_default(
-            "a",
-            DataType::TIMESTAMP,
-            "current_timestamp()"
-        )]).unwrap(),
+        schema! {
+            (field_with_default("a", DataType::TIMESTAMP, "current_timestamp()")),
+        },
         "a",
         Some("could not verify")
     )]
     #[case::null_on_non_primitive(
-        StructType::try_new([field_with_default(
-            "a",
-            ArrayType::new(DataType::INTEGER, true),
-            "NULL"
-        )]).unwrap(),
+        schema! {
+            (field_with_default("a", ArrayType::new(DataType::INTEGER, true), "NULL")),
+        },
         "a",
         None
     )]
     #[case::non_null_on_non_primitive(
-        StructType::try_new([field_with_default(
-            "a",
-            ArrayType::new(DataType::INTEGER, true),
-            "ARRAY(1)"
-        )]).unwrap(),
+        schema! {
+            (field_with_default("a", ArrayType::new(DataType::INTEGER, true), "ARRAY(1)")),
+        },
         "a",
         Some("could not verify")
     )]
     #[case::nested_non_literal(
-        StructType::try_new([StructField::nullable(
-            "s",
-            DataType::try_struct_type([field_with_default(
+        schema! {
+            nullable "s": {
+                (field_with_default(
                 "inner",
                 DataType::TIMESTAMP,
                 "current_timestamp()"
-            )]).unwrap(),
-        )]).unwrap(),
+                )),
+            },
+        },
         "s.inner",
         Some("could not verify")
     )]

--- a/kernel/src/table_features/timestamp_ntz.rs
+++ b/kernel/src/table_features/timestamp_ntz.rs
@@ -44,32 +44,26 @@ impl<'a> SchemaTransform<'a> for UsesTimestampNtz {
 #[cfg(test)]
 mod tests {
     use crate::actions::Protocol;
-    use crate::schema::{DataType, PrimitiveType, StructField, StructType};
+    use crate::schema::schema;
     use crate::table_features::TableFeature;
     use crate::unit_test_utils::assert_schema_feature_validation;
 
     #[test]
     fn test_timestamp_ntz_feature_validation() {
-        let schema_with = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("ts", DataType::Primitive(PrimitiveType::TimestampNtz), true),
-        ]);
-        let schema_without = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ]);
-        let nested_schema_with = StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new(
-                "nested",
-                StructType::new_unchecked([StructField::new(
-                    "inner_ts",
-                    DataType::Primitive(PrimitiveType::TimestampNtz),
-                    true,
-                )]),
-                true,
-            ),
-        ]);
+        let schema_with = schema! {
+            not_null "id": INTEGER,
+            nullable "ts": TIMESTAMP_NTZ,
+        };
+        let schema_without = schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        };
+        let nested_schema_with = schema! {
+            not_null "id": INTEGER,
+            nullable "nested": {
+                nullable "inner_ts": TIMESTAMP_NTZ,
+            },
+        };
         let protocol_with = Protocol::try_new_modern(
             [TableFeature::TimestampWithoutTimezone],
             [TableFeature::TimestampWithoutTimezone],

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -1186,10 +1186,10 @@ mod tests {
         use crate::clustering::CLUSTERING_DOMAIN_NAME;
         use crate::expressions::column_name;
 
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-        ]));
+        let schema = schema_ref! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        };
 
         let mut reader_features = vec![];
         let mut writer_features = vec![];
@@ -1214,11 +1214,11 @@ mod tests {
     fn test_clustering_support_multiple_columns() {
         use crate::expressions::column_name;
 
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("date", DataType::STRING, true),
-            StructField::new("region", DataType::STRING, true),
-        ]));
+        let schema = schema_ref! {
+            not_null "id": INTEGER,
+            nullable "date": STRING,
+            nullable "region": STRING,
+        };
 
         let mut reader_features = vec![];
         let mut writer_features = vec![];
@@ -1271,10 +1271,10 @@ mod tests {
             StructField::new("city", DataType::STRING, true),
             StructField::new("zip", DataType::STRING, true),
         ]);
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("address", address_struct, true),
-        ]));
+        let schema = schema_ref! {
+            not_null "id": INTEGER,
+            nullable "address": (address_struct),
+        };
 
         let mut reader_features = vec![];
         let mut writer_features = vec![];
@@ -1334,11 +1334,11 @@ mod tests {
         &[TableFeature::TimestampWithoutTimezone],
     )]
     #[case::both_variant_and_ntz(
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("v", DataType::unshredded_variant(), true),
-            StructField::new("ts", DataType::TIMESTAMP_NTZ, true),
-        ])),
+        schema_ref! {
+            not_null "id": INTEGER,
+            nullable "v": unshredded_variant(),
+            nullable "ts": TIMESTAMP_NTZ,
+        },
         &[TableFeature::VariantType, TableFeature::TimestampWithoutTimezone],
     )]
     #[case::no_special_types(
@@ -1495,11 +1495,11 @@ mod tests {
     }
 
     fn multi_column_schema() -> SchemaRef {
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("date", DataType::DATE, true),
-        ]))
+        schema_ref! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+            nullable "date": DATE,
+        }
     }
 
     struct DataLayoutExpectation {

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -979,7 +979,7 @@ mod tests {
     use crate::expressions::{column_name, ColumnName};
     use crate::scan::data_skipping::stats_schema::StripFieldMetadataTransform;
     use crate::schema::{
-        schema_ref, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+        schema, schema_ref, try_schema, ColumnMetadataKey, DataType, MetadataValue, StructField,
     };
     use crate::table_features::FeatureType;
     use crate::table_properties::{
@@ -1267,13 +1267,12 @@ mod tests {
         use crate::clustering::CLUSTERING_DOMAIN_NAME;
         use crate::expressions::column_name;
 
-        let address_struct = StructType::new_unchecked(vec![
-            StructField::new("city", DataType::STRING, true),
-            StructField::new("zip", DataType::STRING, true),
-        ]);
         let schema = schema_ref! {
             not_null "id": INTEGER,
-            nullable "address": (address_struct),
+            nullable "address": {
+                nullable "city": STRING,
+                nullable "zip": STRING,
+            },
         };
 
         let mut reader_features = vec![];
@@ -1603,12 +1602,10 @@ mod tests {
 
     #[test]
     fn test_validate_partition_columns_nested_rejected() {
-        let address_struct =
-            StructType::new_unchecked(vec![StructField::new("city", DataType::STRING, true)]);
-        let schema = StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("address", address_struct, true),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            nullable "address": { nullable "city": STRING },
+        };
 
         let columns = vec![column_name!("address.city")];
         let result = validate_partition_columns(&schema, &columns);
@@ -1622,7 +1619,7 @@ mod tests {
     #[rstest::rstest]
     #[case::struct_type(
         "struct_col",
-        DataType::from(StructType::new_unchecked(vec![StructField::new("inner", DataType::STRING, false)])),
+        DataType::from(schema! { not_null "inner": STRING }),
     )]
     #[case::array_type(
         "array_col",
@@ -1636,10 +1633,10 @@ mod tests {
         #[case] col_name: &str,
         #[case] data_type: DataType,
     ) {
-        let schema = StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new(col_name, data_type, false),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            not_null col_name: (data_type),
+        };
         let columns = vec![ColumnName::new([col_name])];
         let result = validate_partition_columns(&schema, &columns);
         assert!(result.is_err());
@@ -1653,13 +1650,10 @@ mod tests {
     fn test_validate_partition_columns_nested_interval_types_rejected(
         #[values(DataType::INTERVAL_YEAR_MONTH, DataType::INTERVAL_DAY_TIME)] data_type: DataType,
     ) {
-        let schema = StructType::new_unchecked([
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::not_null(
-                "nested",
-                StructType::new_unchecked([StructField::not_null("col", data_type)]),
-            ),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            not_null "nested": { not_null "col": (data_type) },
+        };
 
         let error = validate_partition_columns(&schema, &[column_name!("nested.col")])
             .expect_err("nested partition columns must be rejected")
@@ -1677,10 +1671,10 @@ mod tests {
     #[case::interval_year_month(DataType::INTERVAL_YEAR_MONTH)]
     #[case::interval_day_time(DataType::INTERVAL_DAY_TIME)]
     fn test_validate_partition_columns_primitive_types_accepted(#[case] data_type: DataType) {
-        let schema = StructType::new_unchecked(vec![
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("col", data_type, false),
-        ]);
+        let schema = schema! {
+            not_null "id": INTEGER,
+            not_null "col": (data_type),
+        };
         let columns = vec![column_name!("col")];
         assert!(validate_partition_columns(&schema, &columns).is_ok());
     }
@@ -1820,9 +1814,13 @@ mod tests {
         let complex = StripFieldMetadataTransform
             .transform_struct(&with_metadata)
             .into_owned();
-        let mut fields: Vec<StructField> = complex.fields().cloned().collect();
-        fields.push(StructField::nullable("region", DataType::STRING));
-        Arc::new(StructType::try_new(fields).unwrap())
+        Arc::new(
+            try_schema! {
+                ..(complex.fields()),
+                nullable "region": STRING,
+            }
+            .unwrap(),
+        )
     }
 
     /// V3 create-table flow with the same schema for minimum and maximum feature sets.

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::committer::FileSystemCommitter;
     use crate::engine::arrow_conversion::TryIntoKernel;
     use crate::engine::arrow_data::ArrowEngineData;
-    use crate::schema::{Schema, SchemaRef, StructField, StructType, ToSchema};
+    use crate::schema::{schema_ref, Schema, SchemaRef, ToSchema};
     use crate::transaction::Transaction;
     use crate::unit_test_utils::load_test_table;
     use crate::utils::FoldWithOption as _;
@@ -443,7 +443,7 @@ mod tests {
     fn test_build_commit_info_empty_engine_schema() -> DeltaResult<()> {
         // A 0-row, 0-column RecordBatch with an empty kernel schema.
         let empty_batch = RecordBatch::new_empty(Arc::new(ArrowSchema::empty()));
-        let empty_schema = Arc::new(StructType::new_unchecked(Vec::<StructField>::new()));
+        let empty_schema = schema_ref! {};
         let (engine, txn) = make_txn(Some((
             Box::new(ArrowEngineData::new(empty_batch)),
             empty_schema,

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -89,7 +89,7 @@ impl<S> Transaction<S> {
                 // Delta log action format `{ "commitInfo": { merged fields... } }`, consistent
                 // with the None branch which uses `LOG_COMMIT_INFO_SCHEMA`.
                 let wrapped_expr = Expression::struct_from([patch]);
-                let wrapped_schema = schema_ref! { nullable (COMMIT_INFO_NAME): (output_schema) };
+                let wrapped_schema = schema_ref! { nullable COMMIT_INFO_NAME: (output_schema) };
                 let evaluator = engine.evaluation_handler().new_expression_evaluator(
                     engine_commit_info_schema.clone(),
                     Arc::new(wrapped_expr),

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -106,10 +106,10 @@ pub type CreateTableTransaction = Transaction<CreateTable>;
 /// use test_utils::delta_kernel_default_engine::storage::store_from_url;
 ///
 /// # fn main() -> delta_kernel::DeltaResult<()> {
-/// let schema = Arc::new(StructType::new_unchecked(vec![
-///     StructField::new("id", DataType::INTEGER, true),
-///     StructField::new("name", DataType::STRING, true),
-/// ]));
+/// let schema = Arc::new(StructType::try_new([
+///     StructField::nullable("id", DataType::INTEGER),
+///     StructField::nullable("name", DataType::STRING),
+/// ])?);
 ///
 /// let url = url::Url::parse("file:///tmp/my_table")?;
 /// let engine = DefaultEngineBuilder::new(store_from_url(&url)?).build();

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -40,8 +40,8 @@ use crate::scan::log_replay::{
 use crate::scan::scan_row_schema;
 use crate::schema::void_utils::{add_void_stripping, validate_schema_for_write};
 use crate::schema::{
-    lazy_schema_ref, ArrayType, ColumnDefault, SchemaRef, SchemaStructPatchBuilder, StructField,
-    StructType,
+    lazy_schema_ref, schema_ref, ArrayType, ColumnDefault, SchemaRef, SchemaStructPatchBuilder,
+    StructField, StructType,
 };
 use crate::snapshot::{Snapshot, SnapshotRef};
 use crate::struct_patch::ProjectionStructPatchBuilder;
@@ -1398,8 +1398,7 @@ impl<S> Transaction<S> {
                 let commit_versions_array =
                     ArrayData::try_new(ArrayType::new(DataType::LONG, true), commit_versions)?;
 
-                let row_tracking_schema =
-                    with_row_tracking_cols(&Arc::new(StructType::new_unchecked(vec![])))?;
+                let row_tracking_schema = with_row_tracking_cols(&schema_ref! {})?;
                 add_files_batch.append_columns(
                     row_tracking_schema,
                     vec![base_row_ids_array, commit_versions_array],
@@ -3258,16 +3257,13 @@ mod tests {
             StructField::nullable(MIN_VALUES, value_struct_type.clone()),
             StructField::nullable(MAX_VALUES, value_struct_type),
         ];
-        let schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null(
-                "partitionValues",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::not_null("size", DataType::LONG),
-            StructField::not_null("modificationTime", DataType::LONG),
-            StructField::nullable("stats", stats_type.clone()),
-        ]));
+        let schema = schema_ref! {
+            not_null "path": STRING,
+            not_null "partitionValues": { STRING => nullable STRING },
+            not_null "size": LONG,
+            not_null "modificationTime": LONG,
+            nullable "stats": (stats_type.clone()),
+        };
 
         let empty_map = Scalar::Map(
             MapData::try_new(
@@ -3455,9 +3451,7 @@ mod tests {
         let engine = crate::engine::sync::SyncEngine::new_with_store(storage);
 
         // Create a non-catalog-managed table using a catalog committer
-        let schema = Arc::new(crate::schema::StructType::new_unchecked(vec![
-            crate::schema::StructField::new("id", crate::schema::DataType::INTEGER, true),
-        ]));
+        let schema = schema_ref! { nullable "id": INTEGER };
         let committer = Box::new(MockCatalogCommitter);
         let err = create_table("memory:///", schema, "test-engine")
             .build(&engine, committer)

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1851,7 +1851,7 @@ mod tests {
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
     use crate::scan::log_replay::PATH_NAME;
-    use crate::schema::{schema_ref, MapType};
+    use crate::schema::{schema, schema_ref, MapType};
     use crate::table_features::ColumnMappingMode;
     use crate::table_properties::APPEND_ONLY;
     use crate::transaction::create_table::create_table;
@@ -2046,25 +2046,19 @@ mod tests {
             .with_engine_info("default engine");
 
         let schema = txn.add_files_schema();
-        let expected = StructType::new_unchecked(vec![
-            StructField::not_null("path", DataType::STRING),
-            StructField::not_null(
-                "partitionValues",
-                MapType::new(DataType::STRING, DataType::STRING, true),
-            ),
-            StructField::not_null("size", DataType::LONG),
-            StructField::not_null("modificationTime", DataType::LONG),
-            StructField::nullable(
-                "stats",
-                DataType::struct_type_unchecked(vec![
-                    StructField::nullable(NUM_RECORDS, DataType::LONG),
-                    StructField::nullable(NULL_COUNT, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(MIN_VALUES, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(MAX_VALUES, DataType::struct_type_unchecked(vec![])),
-                    StructField::nullable(TIGHT_BOUNDS, DataType::BOOLEAN),
-                ]),
-            ),
-        ]);
+        let expected = schema! {
+            not_null "path": STRING,
+            not_null "partitionValues": { STRING => nullable STRING },
+            not_null "size": LONG,
+            not_null "modificationTime": LONG,
+            nullable "stats": {
+                nullable NUM_RECORDS: LONG,
+                nullable NULL_COUNT: {},
+                nullable MIN_VALUES: {},
+                nullable MAX_VALUES: {},
+                nullable TIGHT_BOUNDS: BOOLEAN,
+            },
+        };
         assert_eq!(*schema, expected.into());
         Ok(())
     }
@@ -2185,14 +2179,10 @@ mod tests {
             .logical_schema()
             .contains("fresh_column"));
 
-        let mut evolved_fields: Vec<StructField> = txn
-            .effective_table_config
-            .logical_schema()
-            .fields()
-            .cloned()
-            .collect();
-        evolved_fields.push(StructField::nullable("fresh_column", DataType::INTEGER));
-        let evolved_schema = Arc::new(StructType::new_unchecked(evolved_fields));
+        let evolved_schema = schema_ref! {
+            ..(txn.effective_table_config.logical_schema().fields()),
+            nullable "fresh_column": INTEGER,
+        };
         let evolved_metadata = txn
             .effective_table_config
             .metadata()
@@ -2285,12 +2275,15 @@ mod tests {
 
         #[test]
         fn collects_present_defaults_and_skips_columns_without_one() {
-            let schema = StructType::try_new(vec![
-                field_with_default("parsable", DataType::INTEGER, "42"),
-                field_with_default("unparsable", DataType::TIMESTAMP, "current_timestamp()"),
-                StructField::nullable("no_default", DataType::STRING),
-            ])
-            .unwrap();
+            let schema = schema! {
+                (field_with_default("parsable", DataType::INTEGER, "42")),
+                (field_with_default(
+                    "unparsable",
+                    DataType::TIMESTAMP,
+                    "current_timestamp()",
+                )),
+                nullable "no_default": STRING,
+            };
             let txn = txn_with_schema(schema);
 
             let defaults = txn.top_level_column_defaults().unwrap();
@@ -2312,18 +2305,19 @@ mod tests {
 
         #[test]
         fn returns_empty_map_when_no_column_has_a_default() {
-            let schema = StructType::try_new(vec![
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::STRING),
-            ])
-            .unwrap();
+            let schema = schema! {
+                nullable "a": INTEGER,
+                nullable "b": STRING,
+            };
             let txn = txn_with_schema(schema);
             assert!(txn.top_level_column_defaults().unwrap().is_empty());
         }
 
         #[test]
         fn load_rejects_malformed_default() {
-            let schema = StructType::try_new(vec![field_with_invalid_default("c")]).unwrap();
+            let schema = schema! {
+                (field_with_invalid_default("c")),
+            };
 
             let err = try_table_config(&base_txn(), schema, [TableFeature::AllowColumnDefaults])
                 .expect_err("non-string CURRENT_DEFAULT must error at load")
@@ -2333,9 +2327,9 @@ mod tests {
 
         #[test]
         fn load_tolerates_default_present_but_feature_not_enabled() {
-            let schema =
-                StructType::try_new(vec![field_with_default("c", DataType::INTEGER, "42")])
-                    .unwrap();
+            let schema = schema! {
+                (field_with_default("c", DataType::INTEGER, "42")),
+            };
 
             // Orphaned column-default metadata (no `allowColumnDefaults` feature) is tolerated.
             let txn = txn_with_schema_and_writer_features(schema, []);
@@ -2487,15 +2481,15 @@ mod tests {
         let engine: Arc<dyn Engine> =
             Arc::new(SyncEngine::new_with_store(Arc::new(InMemory::new())));
         // Logical order: [p1, p2, d1, v(void), p3, p4, d2]; partition cols = p1, p2, p3, p4.
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::nullable("p1", DataType::STRING),
-            StructField::nullable("p2", DataType::INTEGER),
-            StructField::nullable("d1", DataType::INTEGER),
-            StructField::nullable("v", DataType::VOID),
-            StructField::nullable("p3", DataType::STRING),
-            StructField::nullable("p4", DataType::INTEGER),
-            StructField::nullable("d2", DataType::INTEGER),
-        ])?);
+        let schema = schema_ref! {
+            nullable "p1": STRING,
+            nullable "p2": INTEGER,
+            nullable "d1": INTEGER,
+            nullable "v": VOID,
+            nullable "p3": STRING,
+            nullable "p4": INTEGER,
+            nullable "d2": INTEGER,
+        };
         let txn = create_table("memory:///t", schema, "DefaultEngine")
             .with_data_layout(DataLayout::partitioned(["p1", "p2", "p3", "p4"]))
             .with_table_properties([
@@ -3243,20 +3237,17 @@ mod tests {
 
     /// Creates test add file metadata with configurable stats for the "value" column.
     fn create_test_add_files(paths: Vec<&str>, stats: Vec<TestFileStats>) -> Box<dyn EngineData> {
-        let value_fields = vec![StructField::nullable("value", DataType::LONG)];
-        let value_struct_type = DataType::struct_type_unchecked(value_fields.clone());
-        let stats_type = DataType::struct_type_unchecked(vec![
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, value_struct_type.clone()),
-            StructField::nullable(MIN_VALUES, value_struct_type.clone()),
-            StructField::nullable(MAX_VALUES, value_struct_type.clone()),
-        ]);
-        let stats_fields = vec![
-            StructField::nullable(NUM_RECORDS, DataType::LONG),
-            StructField::nullable(NULL_COUNT, value_struct_type.clone()),
-            StructField::nullable(MIN_VALUES, value_struct_type.clone()),
-            StructField::nullable(MAX_VALUES, value_struct_type),
-        ];
+        let value_schema = schema! { nullable "value": LONG };
+        let value_fields = value_schema.fields().cloned().collect::<Vec<_>>();
+        let value_struct_type = DataType::from(value_schema);
+        let stats_schema = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable NULL_COUNT: (value_struct_type.clone()),
+            nullable MIN_VALUES: (value_struct_type.clone()),
+            nullable MAX_VALUES: (value_struct_type.clone()),
+        };
+        let stats_fields = stats_schema.fields().cloned().collect::<Vec<_>>();
+        let stats_type = DataType::from(stats_schema);
         let schema = schema_ref! {
             not_null "path": STRING,
             not_null "partitionValues": { STRING => nullable STRING },

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -232,11 +232,10 @@ mod tests {
     };
 
     fn simple_schema() -> StructType {
-        StructType::try_new(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
-        .unwrap()
+        schema! {
+            not_null "id": INTEGER,
+            nullable "name": STRING,
+        }
     }
 
     fn add_col(name: &str, nullable: bool) -> SchemaOperation {
@@ -252,26 +251,19 @@ mod tests {
     // `validate_schema` (not just the top-level dup check or `StructType::try_new`) is
     // reached from `apply_schema_operations`.
     fn add_struct_with_nested_leaf(name: &str, leaf_name: &str) -> SchemaOperation {
-        let inner =
-            StructType::try_new(vec![StructField::nullable(leaf_name, DataType::STRING)]).unwrap();
         SchemaOperation::AddColumn {
-            field: StructField::nullable(name, inner),
+            field: StructField::nullable(name, schema! { nullable (leaf_name): STRING }),
         }
     }
 
     fn nested_schema() -> StructType {
-        StructType::try_new(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable(
-                "address",
-                StructType::try_new(vec![
-                    StructField::not_null("city", DataType::STRING),
-                    StructField::nullable("zip", DataType::STRING),
-                ])
-                .unwrap(),
-            ),
-        ])
-        .unwrap()
+        schema! {
+            not_null "id": INTEGER,
+            nullable "address": {
+                not_null "city": STRING,
+                nullable "zip": STRING,
+            },
+        }
     }
 
     // === modify_field_at_path tests ===
@@ -449,11 +441,11 @@ mod tests {
     /// `set_nullable_succeeds` rstest because it asserts on inner-field preservation.
     #[test]
     fn set_nullable_on_struct_itself_preserves_inner_fields() {
-        let schema = StructType::try_new(vec![StructField::not_null(
-            "address",
-            StructType::try_new(vec![StructField::not_null("city", DataType::STRING)]).unwrap(),
-        )])
-        .unwrap();
+        let schema = schema! {
+            not_null "address": {
+                not_null "city": STRING,
+            },
+        };
         let ops = vec![SchemaOperation::SetNullable {
             column: column_name!("address"),
         }];
@@ -490,16 +482,13 @@ mod tests {
     fn set_nullable_nested_preserves_top_level_order() {
         // SetNullable on a nested field within a middle top-level field must not reorder
         // the top-level IndexMap.
-        let schema = StructType::try_new(vec![
-            StructField::not_null("alpha", DataType::INTEGER),
-            StructField::nullable(
-                "beta",
-                StructType::try_new(vec![StructField::not_null("nested", DataType::STRING)])
-                    .unwrap(),
-            ),
-            StructField::not_null("gamma", DataType::STRING),
-        ])
-        .unwrap();
+        let schema = schema! {
+            not_null "alpha": INTEGER,
+            nullable "beta": {
+                not_null "nested": STRING,
+            },
+            not_null "gamma": STRING,
+        };
         let ops = vec![SchemaOperation::SetNullable {
             column: column_name!("beta.nested"),
         }];
@@ -595,13 +584,10 @@ mod tests {
     }
 
     fn struct_of_two_primitives() -> DataType {
-        DataType::from(
-            StructType::try_new(vec![
-                StructField::nullable("a", DataType::STRING),
-                StructField::nullable("b", DataType::STRING),
-            ])
-            .unwrap(),
-        )
+        DataType::from(schema! {
+            nullable "a": STRING,
+            nullable "b": STRING,
+        })
     }
 
     /// Adding a complex column on a CM table: every inner struct field reachable through
@@ -667,7 +653,9 @@ mod tests {
     #[case::top_level(field_with_id_only("tainted", DataType::STRING, 99))]
     #[case::nested_in_struct(StructField::nullable(
         "outer",
-        StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
+        schema! {
+            (field_with_id_only("inner", DataType::STRING, 99)),
+        },
     ))]
     fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
         let ops = vec![SchemaOperation::AddColumn { field }];
@@ -767,7 +755,9 @@ mod tests {
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
             MetadataValue::Number(42),
         );
-        let schema = StructType::try_new(vec![existing]).unwrap();
+        let schema = schema! {
+            (existing),
+        };
         let ops = vec![SchemaOperation::AddColumn {
             field: StructField::nullable("new", DataType::STRING),
         }];

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -31,7 +31,7 @@ use crate::metrics::MetricId;
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
-use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
+use crate::schema::{lazy_schema_ref, ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
     iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
@@ -450,15 +450,10 @@ fn struct_deletion_vector_schema() -> &'static ArrayType {
 /// Schema for the intermediate column holding new DV descriptors.
 /// This temporary column is dropped during transformation to final add actions.
 #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
-static NEW_DV_COLUMN_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::nullable(
-            NEW_DELETION_VECTOR_NAME,
-            DeletionVectorDescriptor::to_schema(),
-        ),
-        StructField::nullable(NEW_STATS_NAME, DataType::STRING),
-    ]))
-});
+static NEW_DV_COLUMN_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    nullable NEW_DELETION_VECTOR_NAME: (DeletionVectorDescriptor::to_schema()),
+    nullable NEW_STATS_NAME: STRING,
+};
 
 /// Returns the schema for the intermediate column holding new DV descriptors.
 #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -31,7 +31,7 @@ use crate::metrics::MetricId;
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
-use crate::schema::{lazy_schema_ref, ArrayType, SchemaRef, StructField, StructType, ToSchema};
+use crate::schema::{lazy_schema_ref, ArrayType, SchemaRef, StructField, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
     iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
@@ -386,17 +386,11 @@ static NEW_STATS_NAME: &str = "newStats";
 /// Schema for scan row data with an additional column for new deletion vector descriptors.
 /// This is an intermediate schema used during deletion vector updates before transforming to final
 /// add actions.
-static INTERMEDIATE_DV_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(StructType::new_unchecked(
-        scan_row_schema().fields().cloned().chain([
-            StructField::nullable(
-                NEW_DELETION_VECTOR_NAME.to_string(),
-                DeletionVectorDescriptor::to_schema(),
-            ),
-            StructField::nullable(NEW_STATS_NAME.to_string(), DataType::STRING),
-        ]),
-    ))
-});
+static INTERMEDIATE_DV_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
+    ..(scan_row_schema().fields()),
+    nullable NEW_DELETION_VECTOR_NAME: (DeletionVectorDescriptor::to_schema()),
+    nullable NEW_STATS_NAME: STRING,
+};
 
 /// Returns the intermediate schema with deletion vector column appended to scan row schema.
 fn intermediate_dv_schema() -> &'static SchemaRef {

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -571,7 +571,7 @@ mod tests {
         DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
         IndirectDataSkippingPredicateEvaluator,
     };
-    use crate::schema::{DataType, StructField, StructType};
+    use crate::schema::{schema_ref, DataType, StructType};
 
     #[derive(Debug, PartialEq)]
     struct OpaqueTestOp(String);
@@ -836,10 +836,10 @@ mod tests {
     }
 
     fn test_output_schema() -> Arc<StructType> {
-        Arc::new(StructType::new_unchecked(vec![
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::STRING, true),
-        ]))
+        schema_ref! {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        }
     }
 
     #[test]

--- a/kernel/src/transforms/schema.rs
+++ b/kernel/src/transforms/schema.rs
@@ -261,75 +261,37 @@ impl<'a> SchemaTransform<'a> for SchemaDepthChecker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schema::{DataType, StructField};
+    use crate::schema::{schema, DataType};
 
     #[test]
     fn test_depth_checker() {
-        let schema = DataType::try_struct_type([
-            StructField::nullable(
-                "a",
-                ArrayType::new(
-                    DataType::try_struct_type([
-                        StructField::nullable("w", DataType::LONG),
-                        StructField::nullable("x", ArrayType::new(DataType::LONG, true)),
-                        StructField::nullable(
-                            "y",
-                            MapType::new(DataType::LONG, DataType::STRING, true),
-                        ),
-                        StructField::nullable(
-                            "z",
-                            DataType::try_struct_type([
-                                StructField::nullable("n", DataType::LONG),
-                                StructField::nullable("m", DataType::STRING),
-                            ])
-                            .unwrap(),
-                        ),
-                    ])
-                    .unwrap(),
-                    true,
-                ),
-            ),
-            StructField::nullable(
-                "b",
-                DataType::try_struct_type([
-                    StructField::nullable("o", ArrayType::new(DataType::LONG, true)),
-                    StructField::nullable(
-                        "p",
-                        MapType::new(DataType::LONG, DataType::STRING, true),
-                    ),
-                    StructField::nullable(
-                        "q",
-                        DataType::try_struct_type([
-                            StructField::nullable(
-                                "s",
-                                DataType::try_struct_type([
-                                    StructField::nullable("u", DataType::LONG),
-                                    StructField::nullable("v", DataType::LONG),
-                                ])
-                                .unwrap(),
-                            ),
-                            StructField::nullable("t", DataType::LONG),
-                        ])
-                        .unwrap(),
-                    ),
-                    StructField::nullable("r", DataType::LONG),
-                ])
-                .unwrap(),
-            ),
-            StructField::nullable(
-                "c",
-                MapType::new(
-                    DataType::LONG,
-                    DataType::try_struct_type([
-                        StructField::nullable("f", DataType::LONG),
-                        StructField::nullable("g", DataType::STRING),
-                    ])
-                    .unwrap(),
-                    true,
-                ),
-            ),
-        ])
-        .unwrap();
+        let schema = DataType::from(schema! {
+            nullable "a": [ nullable {
+                nullable "w": LONG,
+                nullable "x": [ nullable LONG ],
+                nullable "y": { LONG => nullable STRING },
+                nullable "z": {
+                    nullable "n": LONG,
+                    nullable "m": STRING,
+                },
+            } ],
+            nullable "b": {
+                nullable "o": [ nullable LONG ],
+                nullable "p": { LONG => nullable STRING },
+                nullable "q": {
+                    nullable "s": {
+                        nullable "u": LONG,
+                        nullable "v": LONG,
+                    },
+                    nullable "t": LONG,
+                },
+                nullable "r": LONG,
+            },
+            nullable "c": { LONG => nullable {
+                nullable "f": LONG,
+                nullable "g": STRING,
+            } },
+        });
 
         // Similar to SchemaDepthChecker::check, but also returns call count
         let check_with_call_count =

--- a/kernel/src/unit_test_utils.rs
+++ b/kernel/src/unit_test_utils.rs
@@ -434,7 +434,9 @@ pub(crate) fn array_in_map_kernel_schema(
         ),
     )
     .with_metadata(metadata);
-    StructType::try_new(vec![array_in_map]).unwrap()
+    schema! {
+        (array_in_map),
+    }
 }
 
 /// Build an [`array_in_map_kernel_schema`] with `parquet.field.id` on the top-level field
@@ -577,9 +579,13 @@ fn build_arrow_input_with_stale_element_id() -> StructArray {
     let plain_inner = StructField::nullable("inner", complex_nested_inner_map_type());
     let plain_top = StructField::nullable(
         "top",
-        complex_nested_outer_map_type(StructType::try_new(vec![plain_inner]).unwrap()),
+        complex_nested_outer_map_type(schema! {
+            (plain_inner),
+        }),
     );
-    let plain_kernel_schema = StructType::try_new(vec![plain_top]).unwrap();
+    let plain_kernel_schema = schema! {
+        (plain_top),
+    };
     let plain_arrow_schema: ArrowSchema = (&plain_kernel_schema).try_into_arrow().unwrap();
 
     // Add stale `PARQUET:field_id` to the `top.key.element` field.
@@ -665,7 +671,9 @@ pub(crate) fn build_complex_nested_kernel_schema(nested_ids_meta_key: &str) -> S
         ]);
     let top_field = StructField::nullable(
         "top",
-        complex_nested_outer_map_type(StructType::try_new(vec![inner_field]).unwrap()),
+        complex_nested_outer_map_type(schema! {
+            (inner_field),
+        }),
     )
     .with_metadata([
         (
@@ -677,7 +685,9 @@ pub(crate) fn build_complex_nested_kernel_schema(nested_ids_meta_key: &str) -> S
             MetadataValue::Other(top_nested_ids),
         ),
     ]);
-    StructType::try_new(vec![top_field]).unwrap()
+    schema! {
+        (top_field),
+    }
 }
 
 /// Build the expected output Arrow schema for [`complex_nested_with_field_ids`].
@@ -757,10 +767,18 @@ pub(crate) fn test_schema_nested_with_column_mapping() -> SchemaRef {
         (cm_field("info", 2, "phys_info", schema! {
             (cm_field("name", 3, "phys_name", KernelDataType::STRING)),
             (cm_field("age", 4, "phys_age", KernelDataType::INTEGER)),
-            (cm_field("tags", 5, "phys_tags",
-                MapType::new(KernelDataType::STRING, KernelDataType::STRING, true))),
-            (cm_field("scores", 6, "phys_scores",
-                ArrayType::new(KernelDataType::INTEGER, true))),
+            (cm_field(
+                "tags",
+                5,
+                "phys_tags",
+                MapType::new(KernelDataType::STRING, KernelDataType::STRING, true),
+            )),
+            (cm_field(
+                "scores",
+                6,
+                "phys_scores",
+                ArrayType::new(KernelDataType::INTEGER, true),
+            )),
         })),
     }
 }
@@ -827,7 +845,9 @@ pub(crate) fn test_deep_nested_schema_missing_leaf_cm() -> StructType {
         true,
     );
     let array_type = ArrayType::new(
-        schema! { (cm_field("mid_field", 2, "phys_mid_field", map_type)) },
+        schema! {
+            (cm_field("mid_field", 2, "phys_mid_field", map_type)),
+        },
         true,
     );
     schema! {
@@ -981,22 +1001,26 @@ pub(crate) mod column_mapping_physical_name_dedup_fixtures {
 
     /// Two fields with the same physical name at different physical paths should be accepted.
     pub(crate) fn same_phy_name_different_paths() -> StructType {
-        let nested = StructType::new_unchecked([cm_field("id", 3, "id", DataType::INTEGER)]);
-        StructType::new_unchecked([
-            cm_field("id", 1, "id", DataType::INTEGER),
-            cm_field("nested", 2, "nested", nested),
-        ])
+        let nested = schema! {
+            (cm_field("id", 3, "id", DataType::INTEGER)),
+        };
+        schema! {
+            (cm_field("id", 1, "id", DataType::INTEGER)),
+            (cm_field("nested", 2, "nested", nested)),
+        }
     }
 
     /// Two nested fields with same physical path should be rejected.
     pub(crate) fn deeply_nested_repeat_physical_paths() -> StructType {
-        let inner = StructType::new_unchecked([
-            cm_field("a", 2, "x", DataType::INTEGER),
-            cm_field("b", 3, "x", DataType::INTEGER),
-        ]);
+        let inner = schema! {
+            (cm_field("a", 2, "x", DataType::INTEGER)),
+            (cm_field("b", 3, "x", DataType::INTEGER)),
+        };
         let arr_of_struct = ArrayType::new(inner, true);
         let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
-        StructType::new_unchecked([cm_field("outer", 1, "outer", map_to_arr)])
+        schema! {
+            (cm_field("outer", 1, "outer", map_to_arr)),
+        }
     }
 
     /// Full logical paths of the two colliding fields in
@@ -1017,12 +1041,31 @@ pub(crate) mod column_mapping_physical_name_dedup_fixtures {
     /// Dedup must error at the shallower site and never report the deeper one.
     pub(crate) fn multiple_physical_name_collisions() -> StructType {
         schema! {
-            (cm_field("a", 1, "p", schema! { (cm_field("aa", 6, "aa", DataType::INTEGER)) })),
-            (cm_field("b", 2, "p", schema! { (cm_field("bb", 7, "bb", DataType::INTEGER)) })),
-            (cm_field("nested", 3, "nested", schema! {
-                (cm_field("x", 4, "q", DataType::INTEGER)),
-                (cm_field("y", 5, "q", DataType::INTEGER)),
-            })),
+            (cm_field(
+                "a",
+                1,
+                "p",
+                schema! {
+                    (cm_field("aa", 6, "aa", DataType::INTEGER)),
+                },
+            )),
+            (cm_field(
+                "b",
+                2,
+                "p",
+                schema! {
+                    (cm_field("bb", 7, "bb", DataType::INTEGER)),
+                },
+            )),
+            (cm_field(
+                "nested",
+                3,
+                "nested",
+                schema! {
+                    (cm_field("x", 4, "q", DataType::INTEGER)),
+                    (cm_field("y", 5, "q", DataType::INTEGER)),
+                },
+            )),
         }
     }
 

--- a/kernel/tests/incremental_scan.rs
+++ b/kernel/tests/incremental_scan.rs
@@ -21,7 +21,7 @@ use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path as ObjectStorePath;
 use delta_kernel::object_store::ObjectStoreExt;
 use delta_kernel::scan::state::ScanFile;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, StructType};
 use delta_kernel::{
     Engine, EvaluationHandler, JsonHandler, ParquetHandler, Snapshot, SnapshotRef, StorageHandler,
 };
@@ -1870,10 +1870,9 @@ type MtEngine = DefaultEngine<TokioMultiThreadExecutor>;
 
 // Single-column `id: integer` table.
 fn id_schema() -> Arc<StructType> {
-    Arc::new(StructType::new_unchecked([StructField::nullable(
-        "id",
-        DataType::INTEGER,
-    )]))
+    schema_ref! {
+        nullable "id": INTEGER,
+    }
 }
 
 // One `RecordBatch` holding a single `id` value, so each written file gets a tight [id, id] range.

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -25,7 +25,7 @@ use delta_kernel::object_store::{DynObjectStore, ObjectStore, ObjectStoreExt};
 use delta_kernel::parquet::file::reader::{FileReader, SerializedFileReader};
 use delta_kernel::parquet::schema::types::Type as ParquetType;
 use delta_kernel::path::ParsedLogPath;
-use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, SchemaRef, StructType};
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::{CommitResult, Transaction, WriteContext};
 use delta_kernel::{DeltaResult, Engine, Snapshot, Version};
@@ -45,7 +45,7 @@ pub const ZERO_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
 /// Single-column nullable `id: int` schema.
 pub fn get_simple_schema() -> SchemaRef {
-    Arc::new(StructType::try_new(vec![StructField::new("id", DataType::INTEGER, true)]).unwrap())
+    schema_ref! { nullable "id": INTEGER }
 }
 
 /// Builds a `RecordBatch` matching [`get_simple_schema`] from a vector of `id` values.
@@ -263,7 +263,7 @@ pub async fn write_data_and_check_result_and_stats(
 
 /// A simple schema with a single nullable INTEGER column named `number`.
 pub fn get_simple_int_schema() -> Arc<StructType> {
-    Arc::new(StructType::try_new(vec![StructField::nullable("number", DataType::INTEGER)]).unwrap())
+    schema_ref! { nullable "number": INTEGER }
 }
 
 /// Write a metadata-update commit that sets a table property on the existing table.

--- a/kernel/tests/integration/create_table/clustering.rs
+++ b/kernel/tests/integration/create_table/clustering.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::{column_name, ColumnName};
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table;
@@ -19,20 +19,23 @@ use super::simple_schema;
 ///   { id: int, name: string, address: { city: string, zip: string },
 ///     l1: { l2: { l3: { l4: { value: double } } } } }
 fn clustering_test_schema() -> DeltaResult<Arc<StructType>> {
-    let address = StructType::try_new(vec![
-        StructField::new("city", DataType::STRING, true),
-        StructField::new("zip", DataType::STRING, true),
-    ])?;
-    let l4 = StructType::try_new(vec![StructField::new("value", DataType::DOUBLE, true)])?;
-    let l3 = StructType::try_new(vec![StructField::new("l4", l4, true)])?;
-    let l2 = StructType::try_new(vec![StructField::new("l3", l3, true)])?;
-    let l1 = StructType::try_new(vec![StructField::new("l2", l2, true)])?;
-    Ok(Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("name", DataType::STRING, true),
-        StructField::new("address", address, true),
-        StructField::new("l1", l1, true),
-    ])?))
+    Ok(schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+        nullable "address": {
+            nullable "city": STRING,
+            nullable "zip": STRING,
+        },
+        nullable "l1": {
+            nullable "l2": {
+                nullable "l3": {
+                    nullable "l4": {
+                        nullable "value": DOUBLE,
+                    },
+                },
+            },
+        },
+    })
 }
 
 #[rstest]

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -262,9 +262,7 @@ fn test_column_mapping_feature_only_without_mode() -> DeltaResult<()> {
 fn test_column_mapping_invalid_mode_rejected() {
     let (_temp_dir, table_path, engine) = test_table_setup().unwrap();
 
-    let schema = Arc::new(
-        StructType::try_new(vec![StructField::new("id", DataType::INTEGER, true)]).unwrap(),
-    );
+    let schema = schema_ref! { nullable "id": INTEGER };
 
     // Try to create table with invalid column mapping mode
     let result = create_table(&table_path, schema, "Test/1.0")
@@ -295,11 +293,11 @@ fn test_create_table_strips_stale_column_mapping_when_disabled(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::INTEGER)
-            .add_metadata([(key.as_ref(), MetadataValue::Number(2))]),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        (StructField::nullable("value", DataType::INTEGER)
+            .add_metadata([(key.as_ref(), MetadataValue::Number(2))])),
+    };
 
     // No column mapping mode set -> mode resolves to None -> the stray annotation is stripped.
     let snapshot = create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &[])?;
@@ -329,10 +327,10 @@ fn test_create_table_column_mapping_strip_is_none_mode_only(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        fixtures::cm_field("value", 2, "col-2f8a", DataType::INTEGER),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        (fixtures::cm_field("value", 2, "col-2f8a", DataType::INTEGER)),
+    };
 
     let snapshot =
         create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), properties)?;
@@ -410,15 +408,13 @@ fn test_column_mapping_nested_schema() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create nested schema
-    let address_type = StructType::try_new(vec![
-        StructField::new("street", DataType::STRING, true),
-        StructField::new("city", DataType::STRING, true),
-    ])?;
-
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("address", address_type, true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "address": {
+            nullable "street": STRING,
+            nullable "city": STRING,
+        },
+    };
 
     // Create table and load snapshot (validates column mapping for nested schema on read)
     let snapshot = create_table_and_load_snapshot(
@@ -722,7 +718,7 @@ fn test_create_table_preserves_or_fills_cm_metadata(
     #[case] expected_physical: Option<&str>,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let schema = Arc::new(StructType::try_new(vec![field])?);
+    let schema = schema_ref! { (field) };
 
     let snapshot = create_table_and_load_snapshot(
         &table_path,
@@ -762,14 +758,14 @@ fn test_create_table_preserves_or_fills_cm_metadata(
 fn test_create_table_sparse_preserved_ids_seed_assignment() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("bare1", DataType::STRING, true),
-        fixtures::cm_field("a", 1, "phys-a", DataType::INTEGER),
-        StructField::new("bare2", DataType::STRING, true),
-        fixtures::cm_field("b", 100, "phys-b", DataType::INTEGER),
-        fixtures::cm_field("c", 5, "phys-c", DataType::INTEGER),
-        StructField::new("bare3", DataType::STRING, true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "bare1": STRING,
+        (fixtures::cm_field("a", 1, "phys-a", DataType::INTEGER)),
+        nullable "bare2": STRING,
+        (fixtures::cm_field("b", 100, "phys-b", DataType::INTEGER)),
+        (fixtures::cm_field("c", 5, "phys-c", DataType::INTEGER)),
+        nullable "bare3": STRING,
+    };
 
     let snapshot = create_table_and_load_snapshot(
         &table_path,
@@ -808,17 +804,12 @@ fn test_create_table_preserves_preexisting_metadata_in_nested_types() -> DeltaRe
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Nested struct with one fully-annotated leaf preserved at id=42.
-    let nested_struct = StructType::try_new(vec![fixtures::cm_field(
-        "leaf",
-        42,
-        "phys-leaf",
-        DataType::INTEGER,
-    )])?;
-
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("bare", DataType::STRING, true),
-        StructField::new("outer", DataType::Struct(Box::new(nested_struct)), true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "bare": STRING,
+        nullable "outer": {
+            (fixtures::cm_field("leaf", 42, "phys-leaf", DataType::INTEGER)),
+        },
+    };
 
     let snapshot = create_table_and_load_snapshot(
         &table_path,

--- a/kernel/tests/integration/create_table/iceberg_compat.rs
+++ b/kernel/tests/integration/create_table/iceberg_compat.rs
@@ -1,10 +1,8 @@
 //! IcebergCompatV3 integration tests for the CreateTable API.
 
-use std::sync::Arc;
-
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::schema::{
-    schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, StructField, StructType,
+    schema, schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, StructField,
 };
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{ColumnMappingMode, TableFeature};
@@ -66,7 +64,7 @@ fn v3_create_table_rejects_incompatible_props(
 #[case::top_level(StructField::nullable("maybe", DataType::VOID))]
 #[case::in_struct(StructField::nullable(
     "s",
-    StructType::new_unchecked([StructField::nullable("x", DataType::VOID)]),
+    schema! { nullable "x": VOID },
 ))]
 #[case::in_array(StructField::nullable("arr", ArrayType::new(DataType::VOID, true),))]
 #[case::in_map_value(StructField::nullable(
@@ -75,10 +73,10 @@ fn v3_create_table_rejects_incompatible_props(
 ))]
 fn v3_create_table_rejects_void_column(#[case] void_field: StructField) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        void_field,
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        (void_field),
+    };
 
     let err = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.enableIcebergCompatV3", "true")])
@@ -101,17 +99,14 @@ fn v3_create_table_rejects_interval_column(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
     let interval_field = if nested {
-        StructField::nullable(
-            "nested",
-            StructType::new_unchecked([StructField::nullable("iv", interval)]),
-        )
+        StructField::nullable("nested", schema! { nullable "iv": (interval) })
     } else {
         StructField::nullable("iv", interval)
     };
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        interval_field,
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        (interval_field),
+    };
 
     let err = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.enableIcebergCompatV3", "true")])

--- a/kernel/tests/integration/create_table/interval.rs
+++ b/kernel/tests/integration/create_table/interval.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::column_name;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
@@ -55,22 +55,20 @@ mod supported {
 
     /// Top-level schema carrying the given interval `DataType`.
     fn top_level_interval_schema(interval: DataType) -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new("iv", interval, true),
-        ]))
+        schema_ref! {
+            not_null "id": INTEGER,
+            nullable "iv": (interval),
+        }
     }
 
     /// Schema with the given interval `DataType` nested inside a struct.
     fn nested_interval_schema(interval: DataType) -> SchemaRef {
-        Arc::new(StructType::new_unchecked([
-            StructField::new("id", DataType::INTEGER, false),
-            StructField::new(
-                "nested",
-                StructType::new_unchecked([StructField::new("inner_iv", interval, true)]),
-                true,
-            ),
-        ]))
+        schema_ref! {
+            not_null "id": INTEGER,
+            nullable "nested": {
+                nullable "inner_iv": (interval),
+            },
+        }
     }
 
     /// Creating a table with interval columns preserves its schema across column mapping modes.

--- a/kernel/tests/integration/create_table/interval.rs
+++ b/kernel/tests/integration/create_table/interval.rs
@@ -1,10 +1,8 @@
 //! Interval-type integration tests for the CreateTable API.
 
-use std::sync::Arc;
-
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::column_name;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::DeltaResult;
@@ -16,21 +14,23 @@ fn test_create_table_rejects_interval_clustering(
     #[values(false, true)] nested: bool,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let (interval_field, clustering_column) = if nested {
+    let (schema, clustering_column) = if nested {
         (
-            StructField::nullable(
-                "nested",
-                StructType::new_unchecked([StructField::nullable("iv", interval)]),
-            ),
+            schema_ref! {
+                not_null "id": INTEGER,
+                nullable "nested": { nullable "iv": (interval) },
+            },
             column_name!("nested.iv"),
         )
     } else {
-        (StructField::nullable("iv", interval), column_name!("iv"))
+        (
+            schema_ref! {
+                not_null "id": INTEGER,
+                nullable "iv": (interval),
+            },
+            column_name!("iv"),
+        )
     };
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::not_null("id", DataType::INTEGER),
-        interval_field,
-    ])?);
 
     let result = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::Clustered {

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -14,7 +14,9 @@ mod variant;
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{ColumnMetadataKey, DataType, MetadataValue, StructField, StructType};
+use delta_kernel::schema::{
+    schema_ref, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{
     TableFeature, TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION,
@@ -30,20 +32,20 @@ use test_utils::{assert_result_error_with_message, test_table_setup, test_table_
 /// Helper to create a simple two-column schema for tests.
 /// Shared with sub-modules.
 pub(crate) fn simple_schema() -> DeltaResult<Arc<StructType>> {
-    Ok(Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?))
+    Ok(schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    })
 }
 
 /// Helper to create a three-column schema for partition tests (id, date, value).
 /// Shared with sub-modules.
 pub(crate) fn partition_test_schema() -> DeltaResult<Arc<StructType>> {
-    Ok(Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("date", DataType::DATE),
-        StructField::nullable("value", DataType::STRING),
-    ])?))
+    Ok(schema_ref! {
+        nullable "id": INTEGER,
+        nullable "date": DATE,
+        nullable "value": STRING,
+    })
 }
 
 #[tokio::test]
@@ -51,13 +53,13 @@ async fn test_create_simple_table() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema for an events table
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("event_id", DataType::LONG),
-        StructField::nullable("user_id", DataType::LONG),
-        StructField::nullable("event_type", DataType::STRING),
-        StructField::nullable("timestamp", DataType::TIMESTAMP),
-        StructField::nullable("properties", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "event_id": LONG,
+        nullable "user_id": LONG,
+        nullable "event_type": STRING,
+        nullable "timestamp": TIMESTAMP,
+        nullable "properties": STRING,
+    };
 
     // Create table using new API
     let _ = create_table(&table_path, schema.clone(), "DeltaKernel-RS/0.17.0")
@@ -159,13 +161,13 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema for a user profiles table
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("user_id", DataType::LONG),
-        StructField::nullable("username", DataType::STRING),
-        StructField::nullable("email", DataType::STRING),
-        StructField::nullable("created_at", DataType::TIMESTAMP),
-        StructField::nullable("is_active", DataType::BOOLEAN),
-    ])?);
+    let schema = schema_ref! {
+        nullable "user_id": LONG,
+        nullable "username": STRING,
+        nullable "email": STRING,
+        nullable "created_at": TIMESTAMP,
+        nullable "is_active": BOOLEAN,
+    };
 
     // Create table first time
     let _ = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
@@ -187,7 +189,7 @@ async fn test_create_table_empty_schema_succeeds() -> DeltaResult<()> {
 
     // CREATE TABLE with no columns is a valid Delta operation; users may add columns
     // later via ALTER TABLE ADD COLUMN.
-    let schema = Arc::new(StructType::try_new(vec![])?);
+    let schema = schema_ref! {};
 
     create_table(&table_path, schema, "EmptySchemaApp/0.1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
@@ -216,7 +218,7 @@ async fn test_create_table_empty_schema_checkpoint_round_trip(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
 
-    let schema = Arc::new(StructType::try_new(vec![])?);
+    let schema = schema_ref! {};
     let mut builder = create_table(&table_path, schema, "EmptySchemaApp/0.1.0");
     if let Some(mode) = cm_mode {
         builder = builder.with_table_properties([("delta.columnMapping.mode", mode)]);
@@ -254,7 +256,7 @@ async fn test_create_table_empty_schema_layout_errors(
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![])?);
+    let schema = schema_ref! {};
     let result = create_table(&table_path, schema, "EmptySchemaApp/0.1.0")
         .with_data_layout(layout)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
@@ -265,22 +267,18 @@ async fn test_create_table_empty_schema_layout_errors(
 }
 
 fn top_level_non_null_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::not_null("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ])
-        .expect("non-null top-level schema should be valid"),
-    )
+    schema_ref! {
+        not_null "id": INTEGER,
+        nullable "value": STRING,
+    }
 }
 
 fn nested_non_null_schema() -> Arc<StructType> {
-    let nested = StructType::try_new(vec![StructField::not_null("child", DataType::INTEGER)])
-        .expect("nested non-null schema should be valid");
-    Arc::new(
-        StructType::try_new(vec![StructField::nullable("nested", nested)])
-            .expect("top-level nested schema should be valid"),
-    )
+    schema_ref! {
+        nullable "nested": {
+            not_null "child": INTEGER,
+        },
+    }
 }
 
 /// CREATE TABLE with non-null columns succeeds and auto-enables the `invariants`
@@ -368,7 +366,7 @@ async fn test_create_table_rejects_delta_invariants_metadata() -> DeltaResult<()
         ColumnMetadataKey::Invariants.as_ref().to_string(),
         MetadataValue::String(r#"{"expression": {"expression": "x > 0"}}"#.to_string()),
     );
-    let schema = Arc::new(StructType::try_new(vec![field])?);
+    let schema = schema_ref! { (field) };
 
     let result = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()));
@@ -383,10 +381,10 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Create schema
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("user_id", DataType::LONG),
-        StructField::nullable("action", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "user_id": LONG,
+        nullable "action": STRING,
+    };
 
     let engine_info = "AuditService/2.1.0";
 
@@ -503,13 +501,10 @@ fn create_test_create_table_txn() -> DeltaResult<(
     tempfile::TempDir,
 )> {
     let (tempdir, table_path, engine) = test_table_setup()?;
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
-        .expect("valid schema"),
-    );
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    };
     let txn = create_table(&table_path, schema, "test_engine")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
     Ok((engine, txn, tempdir))
@@ -680,10 +675,10 @@ fn test_create_table_with_enablement_property(
 fn test_create_table_special_char_column_name(#[case] cm_enabled: bool) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("valid_col", DataType::INTEGER),
-        StructField::nullable("bad column", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "valid_col": INTEGER,
+        nullable "bad column": STRING,
+    };
 
     let mut builder = create_table(&table_path, schema, "Test/1.0");
     if cm_enabled {

--- a/kernel/tests/integration/create_table/timestamp_ntz.rs
+++ b/kernel/tests/integration/create_table/timestamp_ntz.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{
     ColumnMappingMode, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
@@ -87,10 +87,10 @@ fn test_create_table_with_timestamp_ntz(
 fn test_create_table_no_timestamp_ntz_no_feature() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("name", DataType::STRING, true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    };
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?

--- a/kernel/tests/integration/create_table/timestamp_ntz.rs
+++ b/kernel/tests/integration/create_table/timestamp_ntz.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{
     ColumnMappingMode, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
@@ -113,11 +113,11 @@ fn test_create_table_no_timestamp_ntz_no_feature() -> DeltaResult<()> {
 fn test_create_table_timestamp_ntz_and_variant() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::new_unchecked(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("ts", DataType::TIMESTAMP_NTZ, true),
-        StructField::new("v", DataType::unshredded_variant(), true),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "ts": TIMESTAMP_NTZ,
+        nullable "v": unshredded_variant(),
+    };
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?

--- a/kernel/tests/integration/create_table/variant.rs
+++ b/kernel/tests/integration/create_table/variant.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, StructType};
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{
     ColumnMappingMode, TableFeature, TABLE_FEATURES_MIN_READER_VERSION,
@@ -94,10 +94,10 @@ fn test_create_table_with_variant(
 fn test_create_table_no_variant_no_feature() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("name", DataType::STRING, true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    };
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -25,7 +25,7 @@ use delta_kernel::expressions::{
 use delta_kernel::metrics::{MetricEvent, ScanType};
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::scan::{AfterSequentialScanMetadata, ParallelScanMetadata};
-use delta_kernel::schema::{DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema, schema_ref, DataType, SchemaRef, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::{Error, Snapshot, SnapshotRef};
@@ -284,13 +284,10 @@ async fn boundary_c1_prunes_all(
 // batch keep their stats and the predicate prunes them correctly.
 
 fn timestamp_stats_schema() -> SchemaRef {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("EventTime", DataType::TIMESTAMP),
-            StructField::nullable("UserId", DataType::LONG),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "EventTime": TIMESTAMP,
+        nullable "UserId": LONG,
+    }
 }
 
 /// Creates a `timestamp_stats_schema` table and returns the pieces needed to inject raw commits:
@@ -699,10 +696,10 @@ async fn scan_with_replace_table_schema_change(
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
 
     // Commit 1 creates the table with a string partition column.
-    let old_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("part", DataType::STRING),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let old_schema = schema_ref! {
+        nullable "part": STRING,
+        nullable "value": STRING,
+    };
     create_table(&table_path, old_schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["part"]))
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
@@ -760,10 +757,10 @@ async fn scan_with_replace_table_schema_change(
     }
 
     // Commit 3 replaces the table metadata and removes the addFiles.
-    let replacement_schema = StructType::try_new(vec![
-        StructField::nullable("part", DataType::LONG),
-        StructField::nullable("value", DataType::LONG),
-    ])?;
+    let replacement_schema = schema! {
+        nullable "part": LONG,
+        nullable "value": LONG,
+    };
     let replacement = [
         json!({
             "commitInfo": {
@@ -959,10 +956,10 @@ async fn partition_pruning_honors_rfc3339_offset_partition_values(
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("ts", DataType::TIMESTAMP),
-        StructField::nullable("v", DataType::LONG),
-    ])?);
+    let schema = schema_ref! {
+        nullable "ts": TIMESTAMP,
+        nullable "v": LONG,
+    };
     create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["ts"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
@@ -1036,16 +1033,16 @@ async fn interval_partition_values_do_not_prune_files(
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("period", interval),
-        StructField::nullable("v", DataType::LONG),
-    ])?);
+    let schema = schema_ref! {
+        nullable "period": (interval),
+        nullable "v": LONG,
+    };
     let mut snapshot = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["period"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
-    let data_schema = StructType::try_new([StructField::nullable("v", DataType::LONG)])?;
+    let data_schema = schema! { nullable "v": LONG };
     let batch = RecordBatch::try_new(
         Arc::new((&data_schema).try_into_arrow()?),
         vec![Arc::new(Int64Array::from(vec![1]))],
@@ -1135,10 +1132,7 @@ async fn all_null_files_pruned_regardless_of_source(
     #[values(false, true)] use_parallel: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "value",
-        DataType::LONG,
-    )])?);
+    let schema = schema_ref! { nullable "value": LONG };
     // For the struct-stats cases, also disable `writeStatsAsJson` so the checkpoint carries ONLY
     // `stats_parsed`. That forces the scan to read the pre-parsed struct (no JSON fallback),
     // genuinely validating that path. The JSON-stats case keeps the defaults

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -9,8 +9,8 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
 use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
-    StructType,
+    schema, schema_ref, try_schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue,
+    SchemaRef, StructField,
 };
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::ColumnMappingMode;
@@ -25,13 +25,10 @@ use test_utils::{
 };
 
 fn simple_schema() -> SchemaRef {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    }
 }
 
 fn committer() -> Box<FileSystemCommitter> {
@@ -198,10 +195,10 @@ async fn add_columns_lifecycle(
 #[case::struct_column(
     StructField::nullable(
         "address",
-        StructType::try_new(vec![
-            StructField::nullable("city", DataType::STRING),
-            StructField::nullable("zip", DataType::STRING),
-        ]).unwrap(),
+        schema! {
+            nullable "city": STRING,
+            nullable "zip": STRING,
+        },
     ),
     3,
 )]
@@ -217,11 +214,10 @@ async fn add_columns_lifecycle(
     StructField::nullable(
         "items",
         ArrayType::new(
-            StructType::try_new(vec![
-                StructField::nullable("a", DataType::STRING),
-                StructField::nullable("b", DataType::INTEGER),
-            ])
-            .unwrap(),
+            schema! {
+                nullable "a": STRING,
+                nullable "b": INTEGER,
+            },
             true,
         ),
     ),
@@ -232,11 +228,10 @@ async fn add_columns_lifecycle(
         "by_id",
         MapType::new(
             DataType::STRING,
-            StructType::try_new(vec![
-                StructField::nullable("a", DataType::STRING),
-                StructField::nullable("b", DataType::INTEGER),
-            ])
-            .unwrap(),
+            schema! {
+                nullable "a": STRING,
+                nullable "b": INTEGER,
+            },
             true,
         ),
     ),
@@ -246,11 +241,10 @@ async fn add_columns_lifecycle(
     StructField::nullable(
         "lookup",
         MapType::new(
-            StructType::try_new(vec![
-                StructField::nullable("a", DataType::STRING),
-                StructField::nullable("b", DataType::INTEGER),
-            ])
-            .unwrap(),
+            schema! {
+                nullable "a": STRING,
+                nullable "b": INTEGER,
+            },
             DataType::INTEGER,
             true,
         ),
@@ -447,7 +441,7 @@ async fn empty_create_then_add_column(
         .map(|m| vec![("delta.columnMapping.mode", m)])
         .unwrap_or_default();
 
-    let empty_schema = Arc::new(StructType::try_new(vec![])?);
+    let empty_schema = schema_ref! {};
     let v0 =
         create_table_and_load_snapshot(&table_path, empty_schema, engine.as_ref(), &properties)?;
     assert_eq!(v0.version(), 0);
@@ -543,23 +537,20 @@ async fn empty_create_then_add_column(
 #[rstest]
 #[case::already_nullable(simple_schema(), column_name!("name"))]
 #[case::required_top_level(
-    Arc::new(StructType::try_new(vec![
-        StructField::not_null("id", DataType::INTEGER),
-        StructField::nullable("name", DataType::STRING),
-    ]).unwrap()),
+    schema_ref! {
+        not_null "id": INTEGER,
+        nullable "name": STRING,
+    },
     column_name!("id")
 )]
 #[case::required_nested(
-    Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "address",
-            StructType::try_new(vec![
-                StructField::not_null("city", DataType::STRING),
-                StructField::nullable("zip", DataType::STRING),
-            ]).unwrap(),
-        ),
-    ]).unwrap()),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "address": {
+            not_null "city": STRING,
+            nullable "zip": STRING,
+        },
+    },
     column_name!("address.city")
 )]
 #[tokio::test]
@@ -618,10 +609,10 @@ async fn set_nullable_on_layout_column_with_checkpoint(
     let is_partitioned = matches!(layout, DataLayout::Partitioned { .. });
 
     // v0: create the table with the layout column as non-null.
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::not_null(col_name, DataType::STRING),
-    ])?);
+    let schema = Arc::new(try_schema! {
+        nullable "id": INTEGER,
+        not_null (col_name): STRING,
+    }?);
     let properties: Vec<(&str, &str)> = cm_mode
         .map(|m| vec![("delta.columnMapping.mode", m)])
         .unwrap_or_default();
@@ -732,10 +723,10 @@ async fn chain_add_column_and_set_nullable(
     #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
 ) -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::not_null("id", DataType::INTEGER),
-        StructField::not_null("name", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        not_null "id": INTEGER,
+        not_null "name": STRING,
+    };
     let properties: Vec<(&str, &str)> = cm_mode
         .map(|m| vec![("delta.columnMapping.mode", m)])
         .unwrap_or_default();
@@ -840,7 +831,9 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped(
     let (field, stripped_path): (StructField, Vec<String>) = if nested {
         let outer = StructField::nullable(
             "outer",
-            StructType::try_new(vec![field_with_stray_key("inner", &key, DataType::STRING)])?,
+            schema! {
+                (field_with_stray_key("inner", &key, DataType::STRING)),
+            },
         );
         (outer, vec!["outer".to_string(), "inner".to_string()])
     } else {
@@ -1152,10 +1145,10 @@ async fn add_column_with_id_below_max_column_id_succeeds() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
     // Pre-populate the table with sparse ids (1, 100) using the create-table preserve path.
-    let schema = Arc::new(StructType::try_new(vec![
-        fixtures::cm_field("a", 1, "phys-a", DataType::INTEGER),
-        fixtures::cm_field("b", 100, "phys-b", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        (fixtures::cm_field("a", 1, "phys-a", DataType::INTEGER)),
+        (fixtures::cm_field("b", 100, "phys-b", DataType::STRING)),
+    };
     let snapshot = create_table_and_load_snapshot(
         &table_path,
         schema,
@@ -1250,11 +1243,11 @@ async fn add_column_on_stale_table_leaves_schema_untouched(
 
     // `value` carries a stale id; protocol omits columnMapping and no mode is set (resolves to
     // None) -- residual annotations already on the table.
-    let stale_schema = StructType::try_new([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::INTEGER)
-            .add_metadata([("delta.columnMapping.id", MetadataValue::Number(2))]),
-    ])?;
+    let stale_schema = schema! {
+        nullable "id": INTEGER,
+        (StructField::nullable("value", DataType::INTEGER)
+            .add_metadata([("delta.columnMapping.id", MetadataValue::Number(2))])),
+    };
     let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?).unwrap();
     // v0 written directly to bypass create_table validation (which strips stale annotations).
     let v0 = format!(

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -7,7 +7,7 @@ use delta_kernel::arrow::util::pretty::pretty_format_batches;
 use delta_kernel::engine::arrow_conversion::TryFromKernel as _;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
 use delta_kernel::expressions::{col, lit, Predicate as Pred};
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use delta_kernel::table_changes::TableChanges;
 use delta_kernel::{DeltaResult, Error, PredicateRef, Version};
 use itertools::Itertools;
@@ -630,13 +630,10 @@ fn cdf_with_column_mapping_name_mode() -> Result<(), Box<dyn error::Error>> {
 /// file and returns zero rows.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cdf_per_cell_null_on_malformed_stats() -> Result<(), Box<dyn error::Error>> {
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("EventTime", DataType::TIMESTAMP),
-            StructField::nullable("UserId", DataType::LONG),
-        ])
-        .unwrap(),
-    );
+    let schema = schema_ref! {
+        nullable "EventTime": TIMESTAMP,
+        nullable "UserId": LONG,
+    };
 
     let tmp_dir = tempfile::tempdir()?;
     let tmp_url = Url::from_directory_path(tmp_dir.path()).unwrap();

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -11,7 +11,7 @@ use delta_kernel::actions::{MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS};
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::expressions::column_name;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -33,14 +33,11 @@ async fn test_clustered_table_write_and_checkpoint(
     #[case] use_fresh_snapshot: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::new("id", DataType::INTEGER, true),
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("city", DataType::STRING, true),
-        ])
-        .unwrap(),
-    );
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+        nullable "city": STRING,
+    };
     let expected_clustering = vec![column_name!("id"), column_name!("city")];
 
     // Create table clustered on "id" and "city"
@@ -151,13 +148,10 @@ async fn test_clustered_table_write_and_checkpoint(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_clustered_table_write_all_null_clustering_column() {
     let (_temp_dir, table_path, engine) = test_table_setup_mt().unwrap();
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::new("category", DataType::STRING, true),
-            StructField::new("region_id", DataType::INTEGER, true),
-        ])
-        .unwrap(),
-    );
+    let schema = schema_ref! {
+        nullable "category": STRING,
+        nullable "region_id": INTEGER,
+    };
 
     // Create table clustered on "category" and "region_id"
     let create_result = create_table(&table_path, schema, "Test/1.0")

--- a/kernel/tests/integration/features/column_mapping.rs
+++ b/kernel/tests/integration/features/column_mapping.rs
@@ -9,7 +9,7 @@ use delta_kernel::arrow::datatypes::{
 };
 use delta_kernel::object_store::path::Path as ObjectStorePath;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
-use delta_kernel::schema::{DataType, StructType};
+use delta_kernel::schema::{schema, DataType};
 use delta_kernel::table_features::TableFeature;
 use delta_kernel::Snapshot;
 use rstest::rstest;
@@ -30,15 +30,15 @@ const PAYLOAD_FIELD_ID: i64 = 2;
 /// the per-field `delta.columnMapping.{id,physicalName}` metadata; the physical names differ from
 /// the logical ones so the two read paths stay distinguishable.
 fn metadata_action(mode: &str) -> serde_json::Value {
-    let schema = StructType::new_unchecked([
-        cm_field(ID_LOGICAL, ID_FIELD_ID, ID_PHYSICAL, DataType::INTEGER),
-        cm_field(
+    let schema = schema! {
+        (cm_field(ID_LOGICAL, ID_FIELD_ID, ID_PHYSICAL, DataType::INTEGER)),
+        (cm_field(
             PAYLOAD_LOGICAL,
             PAYLOAD_FIELD_ID,
             PAYLOAD_PHYSICAL,
             DataType::STRING,
-        ),
-    ]);
+        )),
+    };
 
     json!({
         "metaData": {

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -12,7 +12,7 @@ use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::StatsOptions;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, EngineData, Snapshot};
 use itertools::Itertools;
@@ -143,10 +143,10 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     let _ = tracing_subscriber::fmt::try_init();
 
     // Create a table schema with id and value columns
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
 
     // Setup table with deletion vector support
     let temp_dir = tempdir()?;

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -21,7 +21,8 @@ use delta_kernel::object_store::DynObjectStore;
 use delta_kernel::parquet::basic::Type as ParquetPhysicalType;
 use delta_kernel::parquet::schema::types::Type as ParquetType;
 use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+    schema, schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue,
+    StructField, StructType,
 };
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
@@ -53,29 +54,30 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
         "data.value": 101,
         "data.value.element": 102,
     });
-    let schema = StructType::try_new(vec![StructField::nullable(
-        "data",
-        MapType::new(
-            DataType::INTEGER,
-            ArrayType::new(DataType::INTEGER, true),
-            true,
-        ),
-    )
-    .with_metadata([
-        (
-            ColumnMetadataKey::ColumnMappingId.as_ref(),
-            MetadataValue::from(1),
-        ),
-        (
-            ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
-            MetadataValue::from("col-1"),
-        ),
-        (
-            ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
-            MetadataValue::Other(nested_ids_legacy),
-        ),
-    ])])
-    .unwrap();
+    let schema = schema! {
+        (StructField::nullable(
+            "data",
+            MapType::new(
+                DataType::INTEGER,
+                ArrayType::new(DataType::INTEGER, true),
+                true,
+            ),
+        )
+        .with_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::from(1),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::from("col-1"),
+            ),
+            (
+                ColumnMetadataKey::ParquetFieldNestedIds.as_ref(),
+                MetadataValue::Other(nested_ids_legacy),
+            ),
+        ])),
+    };
     let schema_string = serde_json::to_string(&schema).unwrap();
 
     let commit = [
@@ -356,57 +358,43 @@ fn make_default_engine_and_store() -> (Arc<InMemory>, Arc<DefaultEngine<TokioBac
 }
 
 fn simple_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("name", DataType::STRING),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "name": STRING,
+    }
 }
 
 /// Schema covering every Delta types(primitive, struct, map, array, variant)
 /// Including a deeply nested map<list<int>, struct<inner_map: map<list<int>, int>, n: int>> column.
 /// `region` is the partition column.
 fn nested_schema_with_all_delta_types() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("region", DataType::STRING),
-            StructField::nullable("int_col", DataType::INTEGER),
-            StructField::nullable("bool_col", DataType::BOOLEAN),
-            StructField::nullable("byte_col", DataType::BYTE),
-            StructField::nullable("short_col", DataType::SHORT),
-            StructField::nullable("long_col", DataType::LONG),
-            StructField::nullable("float_col", DataType::FLOAT),
-            StructField::nullable("double_col", DataType::DOUBLE),
-            StructField::nullable("decimal_col", DataType::decimal(10, 2).unwrap()),
-            StructField::nullable("string_col", DataType::STRING),
-            StructField::nullable("binary_col", DataType::BINARY),
-            StructField::nullable("date_col", DataType::DATE),
-            StructField::nullable("timestamp_col", DataType::TIMESTAMP),
-            StructField::nullable("timestamp_ntz_col", DataType::TIMESTAMP_NTZ),
-            StructField::nullable("variant_col", DataType::unshredded_variant()),
-            StructField::nullable("complex", complex_nested_data_type()),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "region": STRING,
+        nullable "int_col": INTEGER,
+        nullable "bool_col": BOOLEAN,
+        nullable "byte_col": BYTE,
+        nullable "short_col": SHORT,
+        nullable "long_col": LONG,
+        nullable "float_col": FLOAT,
+        nullable "double_col": DOUBLE,
+        nullable "decimal_col": (DataType::decimal(10, 2).unwrap()),
+        nullable "string_col": STRING,
+        nullable "binary_col": BINARY,
+        nullable "date_col": DATE,
+        nullable "timestamp_col": TIMESTAMP,
+        nullable "timestamp_ntz_col": TIMESTAMP_NTZ,
+        nullable "variant_col": (DataType::unshredded_variant()),
+        nullable "complex": (complex_nested_data_type()),
+    }
 }
 
 /// `map<list<int>, struct<inner_map: map<list<int>, int>, n: int>>`. A deeply nested
 /// type used to validate field-id propagation through every level of map/list/struct.
 fn complex_nested_data_type() -> DataType {
-    let inner_struct = StructType::try_new(vec![
-        StructField::nullable(
-            "inner_map",
-            MapType::new(
-                ArrayType::new(DataType::INTEGER, true),
-                DataType::INTEGER,
-                true,
-            ),
-        ),
-        StructField::nullable("n", DataType::INTEGER),
-    ])
-    .unwrap();
+    let inner_struct = schema! {
+        nullable "inner_map": { [ nullable INTEGER ] => nullable INTEGER },
+        nullable "n": INTEGER,
+    };
     DataType::from(MapType::new(
         ArrayType::new(DataType::INTEGER, true),
         inner_struct,

--- a/kernel/tests/integration/features/interval.rs
+++ b/kernel/tests/integration/features/interval.rs
@@ -1,8 +1,6 @@
 //! Reader-side behavior for ANSI interval columns.
 
-use std::sync::Arc;
-
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType};
 use delta_kernel::Snapshot;
 use test_utils::{create_table, engine_store_setup};
 
@@ -14,9 +12,7 @@ async fn test_build_scan_over_interval_table(
     #[case] name: &str,
     #[case] interval: DataType,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "iv", interval,
-    )])?);
+    let schema = schema_ref! { nullable "iv": (interval) };
     let (store, engine, table_location) = engine_store_setup(name, None);
     let table_url = create_table(store, table_location, schema, &[], true, vec![], vec![]).await?;
 

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -10,7 +10,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::to_json_bytes;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt};
-use delta_kernel::schema::{DataType, MetadataColumnSpec, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, MetadataColumnSpec, SchemaRef};
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Error, Snapshot};
 use itertools::Itertools;
@@ -133,10 +133,7 @@ async fn setup_number_table_with_features(
     Arc<DefaultEngine<TokioBackgroundExecutor>>,
     Arc<DynObjectStore>,
 )> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "number",
-        DataType::INTEGER,
-    )])?);
+    let schema = schema_ref! { nullable "number": INTEGER };
     let (table_url, engine, store) = create_row_tracking_table_with_features(
         tmp_dir,
         name,
@@ -443,10 +440,10 @@ async fn test_row_tracking_three_consecutive_transactions() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "name": STRING,
+    };
 
     let (table_url, engine, store) =
         create_row_tracking_table(&tmp_test_dir, "test_three_transactions", schema.clone()).await?;
@@ -768,10 +765,7 @@ async fn test_no_row_tracking_fields_without_feature() -> DeltaResult<()> {
     // Setup
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_test_dir = tempdir()?;
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "number",
-        DataType::INTEGER,
-    )])?);
+    let schema = schema_ref! { nullable "number": INTEGER };
 
     // Create a table without row tracking
     let tmp_test_dir_url = Url::from_directory_path(tmp_test_dir.path())

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -11,7 +11,7 @@ use delta_kernel::engine::arrow_conversion::TryFromKernel;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::path::ParsedLogPath;
-use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, SchemaRef};
 use delta_kernel::snapshot::{ChecksumWriteResult, IncrementalReplay, Snapshot, SnapshotRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -57,10 +57,10 @@ async fn test_get_file_stats_from_crc() -> DeltaResult<()> {
 async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("value", DataType::STRING, true),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
@@ -1813,10 +1813,10 @@ const LARGE_FILE_ROW_COUNT: i32 = (FIRST_BIN_BOUNDARY * 2 / APPROX_BYTES_PER_ROW
 #[tokio::test]
 async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResult<()> {
     let (_temp_dir, table_path, engine) = test_table_setup()?;
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("data", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "data": STRING,
+    };
 
     // ===== v0: empty table =====
     let committed = create_table(&table_path, schema, "test_engine")

--- a/kernel/tests/integration/log/empty_log_files.rs
+++ b/kernel/tests/integration/log/empty_log_files.rs
@@ -6,19 +6,14 @@
 //! - 0-byte checkpoint files are skipped, falling back to an older checkpoint
 //! - 0-byte CRC files are skipped (CRC is optional)
 
-use std::sync::Arc;
-
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, SchemaRef};
 use delta_kernel::Snapshot;
 use test_utils::{add_commit, compacted_log_path_for_versions, create_table, engine_store_setup};
 
-fn simple_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)])
-            .expect("valid schema"),
-    )
+fn simple_schema() -> SchemaRef {
+    schema_ref! { nullable "id": INTEGER }
 }
 
 fn commit_with_add(file_name: &str, num_records: i64) -> String {

--- a/kernel/tests/integration/log/snapshot_build.rs
+++ b/kernel/tests/integration/log/snapshot_build.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::{ArrayRef, Int32Array};
 use delta_kernel::committer::{Committer, FileSystemCommitter};
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema, schema_ref};
 use delta_kernel::snapshot::{
     CheckpointWriteResult, ChecksumWriteResult, IncrementalReplay, SnapshotBuilder,
 };
@@ -106,10 +106,8 @@ async fn setup_multi_version_table<E: TaskExecutor>(
 async fn deeply_nested_schema_snapshot_load_returns_schema_error(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let deeply_nested_schema = (0..42).fold(
-        StructType::new_unchecked([StructField::nullable("leaf", DataType::INTEGER)]),
-        |schema, depth| {
-            StructType::new_unchecked([StructField::nullable(format!("level_{depth}"), schema)])
-        },
+        schema! { nullable "leaf": INTEGER },
+        |nested, depth| schema! { nullable (format!("level_{depth}")): (nested) },
     );
     let (store, engine, table_url) = engine_store_setup("deeply_nested_schema", None);
     let commit = [

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -15,7 +15,7 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryFromKernel;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema, schema_ref, StructType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
 use delta_kernel::transaction::CommitResult;
@@ -879,13 +879,12 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
         ]
     }
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "info",
-            DataType::try_struct_type([StructField::nullable("name", DataType::STRING)])?,
-        ),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "info": {
+            nullable "name": STRING,
+        },
+    };
 
     let _ = create_table(table_path, schema.clone(), "Test/1.0")
         .with_table_properties([
@@ -1121,11 +1120,11 @@ async fn create_partitioned_stats_table<E: TaskExecutor>(
     table_url: &url::Url,
     engine: &Arc<test_utils::delta_kernel_default_engine::DefaultEngine<E>>,
 ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-        StructField::nullable("part_key", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "name": STRING,
+        nullable "part_key": STRING,
+    };
 
     let _ = create_table(table_path, schema.clone(), "Test/1.0")
         .with_table_properties([
@@ -1136,10 +1135,10 @@ async fn create_partitioned_stats_table<E: TaskExecutor>(
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .commit(engine.as_ref())?;
 
-    let data_schema = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-    ])?;
+    let data_schema = schema! {
+        nullable "id": LONG,
+        nullable "name": STRING,
+    };
     let arrow_schema = Arc::new(ArrowSchema::try_from_kernel(&data_schema)?);
 
     let batch1 = RecordBatch::try_new(
@@ -1567,14 +1566,11 @@ enum CrossFeature {
 /// region: string`. The `region` column is used as the partition column in the
 /// `Partitioned` variant; `id` is the clustering column in the `Clustered` variant.
 fn cross_feature_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-            StructField::nullable("region", DataType::STRING),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+        nullable "region": STRING,
+    }
 }
 
 /// Creates a V2 table for the given `features` and writes 3 commits totaling 6 rows
@@ -1628,10 +1624,11 @@ async fn build_v2_table_with_feature<E: TaskExecutor>(
     // the partition value is supplied separately in `partition_values`.
     let partitioned = features.contains(&CrossFeature::Partitioned);
     let data_arrow_schema = if partitioned {
-        Arc::new(ArrowSchema::try_from_kernel(&StructType::try_new(vec![
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::nullable("value", DataType::STRING),
-        ])?)?)
+        let data_schema = schema! {
+            nullable "id": INTEGER,
+            nullable "value": STRING,
+        };
+        Arc::new(ArrowSchema::try_from_kernel(&data_schema)?)
     } else {
         Arc::new(ArrowSchema::try_from_kernel(schema.as_ref())?)
     };

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -9,7 +9,7 @@ use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::metrics::{MetricEvent, MetricsReporter, TableType, TransactionCommitSuccess};
 use delta_kernel::object_store::local::LocalFileSystem;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, StructField};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Snapshot};
@@ -305,10 +305,10 @@ async fn commit_dv_update_reports_updated_file_count_not_batch_count(
     // Three files get a new deletion vector in a single update_deletion_vectors call.
     // num_dv_updates must be the count of updated FILES (3), not the number of scan-metadata
     // batches they arrive in -- a single batch carrying all three would otherwise report 1.
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
     let file_names = &["file0.parquet", "file1.parquet", "file2.parquet"];
     let (_store, engine, table_url, file_paths) =
         create_dv_table_with_files("dv_metrics_table", schema, &[], file_names).await?;
@@ -348,10 +348,10 @@ async fn commit_dv_update_accumulates_file_count_across_calls(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // num_dv_updates must accumulate (`+=`) across multiple update_deletion_vectors calls on one
     // transaction: two calls updating one file each must report 2, not the last call's 1.
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
     let file_names = &["file0.parquet", "file1.parquet"];
     let (_store, engine, table_url, file_paths) =
         create_dv_table_with_files("dv_metrics_multi_call_table", schema, &[], file_names).await?;

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use delta_kernel::arrow::array::Int32Array;
 use delta_kernel::committer::FileSystemCommitter;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, SchemaRef};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{DeltaResult, Snapshot};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
@@ -57,11 +57,8 @@ fn measuring_engine(
 }
 
 /// Build a minimal single-column INTEGER schema for test tables.
-fn simple_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)])
-            .expect("valid schema"),
-    )
+fn simple_schema() -> SchemaRef {
+    schema_ref! { nullable "id": INTEGER }
 }
 
 /// Insert `count` rows (starting from `start_val`) into an existing table, using

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -26,7 +26,7 @@ use delta_kernel::parquet::file::properties::{EnabledStatistics, WriterPropertie
 use delta_kernel::path::ParsedLogPath;
 use delta_kernel::scan::state::{transform_to_logical, ScanFile};
 use delta_kernel::scan::{Scan, StatsOptions};
-use delta_kernel::schema::{DataType, MetadataColumnSpec, Schema, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, MetadataColumnSpec, Schema, StructField};
 use delta_kernel::{Engine, FileMeta, Snapshot};
 use itertools::Itertools;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
@@ -1805,11 +1805,11 @@ async fn test_row_index_metadata_column() -> Result<(), Box<dyn std::error::Erro
     let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
 
     // Create a schema that includes a row index metadata column
-    let schema = Arc::new(StructType::try_new([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::create_metadata_column("row_index", MetadataColumnSpec::RowIndex),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        (StructField::create_metadata_column("row_index", MetadataColumnSpec::RowIndex)),
+        nullable "value": STRING,
+    };
 
     let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
     let scan = snapshot.scan_builder().with_schema(schema).build()?;
@@ -1898,11 +1898,11 @@ async fn test_file_path_metadata_column() -> Result<(), Box<dyn std::error::Erro
     let engine = Arc::new(DefaultEngineBuilder::new(storage.clone()).build());
 
     // Create a schema that includes the file path metadata column
-    let schema = Arc::new(StructType::try_new([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+        nullable "value": STRING,
+    };
 
     let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
     let scan = snapshot.scan_builder().with_schema(schema).build()?;
@@ -2006,10 +2006,10 @@ async fn test_unsupported_metadata_columns() -> Result<(), Box<dyn std::error::E
 
     for (column_name, metadata_spec, error_text) in test_cases {
         let snapshot = Snapshot::builder_for(table_root).build(engine.as_ref())?;
-        let schema = Arc::new(StructType::try_new([
-            StructField::nullable("id", DataType::INTEGER),
-            StructField::create_metadata_column(column_name, metadata_spec),
-        ])?);
+        let schema = schema_ref! {
+            nullable "id": INTEGER,
+            (StructField::create_metadata_column(column_name, metadata_spec)),
+        };
 
         let scan_err = snapshot
             .scan_builder()

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -14,7 +14,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::{schema, schema_ref};
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -195,10 +195,10 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
 
     // create a simple partitioned table: one int column named 'number', partitioned by string
     // column named 'partition'
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("number", DataType::INTEGER),
-        StructField::nullable("partition", DataType::STRING),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "number": INTEGER,
+        nullable "partition": STRING,
+    };
     let data_schema = schema_ref! { nullable "number": INTEGER };
 
     for (table_url, engine, store, table_name) in
@@ -476,11 +476,11 @@ async fn commit_rejects_add_with_invalid_partition_keys(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("d", DataType::INTEGER),
-        StructField::nullable("p1", DataType::STRING),
-        StructField::nullable("p2", DataType::INTEGER),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "d": INTEGER,
+        nullable "p1": STRING,
+        nullable "p2": INTEGER,
+    };
     let (_tmp_dir, table_path, engine) = test_utils::test_table_setup_mt()?;
     let mut builder = create_table(&table_path, table_schema, "test/1.0")
         .with_data_layout(DataLayout::partitioned(["p1", "p2"]));
@@ -492,10 +492,8 @@ async fn commit_rejects_add_with_invalid_partition_keys(
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
 
-    let data_schema: Arc<ArrowSchema> = Arc::new(
-        (&StructType::try_new(vec![StructField::nullable("d", DataType::INTEGER)])?)
-            .try_into_arrow()?,
-    );
+    let data_schema = schema! { nullable "d": INTEGER };
+    let data_schema: Arc<ArrowSchema> = Arc::new((&data_schema).try_into_arrow()?);
     let make_add = |txn: &Transaction, p1: &str, p2: i32| {
         let wc = txn.partitioned_write_context(HashMap::from([
             ("p1".to_string(), Scalar::String(p1.into())),

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -14,8 +14,8 @@ use delta_kernel::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt as _}
 use delta_kernel::expressions::{ColumnName, Scalar};
 use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use delta_kernel::schema::{
-    schema_ref, ArrayType, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField,
-    StructType,
+    schema, schema_ref, ArrayType, ColumnMetadataKey, DataType, MetadataValue, SchemaRef,
+    StructField, StructType,
 };
 use delta_kernel::table_features::{
     get_any_level_column_physical_name, ColumnMappingMode, TableFeature,
@@ -166,7 +166,7 @@ fn test_create_table_rejects_col_defaults() -> DeltaResult<()> {
 
 #[test]
 fn test_schema_with_column_defaults_errors_on_unknown_column() {
-    let schema = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+    let schema = schema! { nullable "c": INTEGER };
 
     let err = schema_with_column_defaults(&schema, HashMap::from([("does_not_exist", "1")]))
         .expect_err("unknown column must produce an error")
@@ -179,7 +179,7 @@ fn test_schema_with_column_defaults_errors_on_unknown_column() {
 
 #[test]
 fn test_schema_with_column_defaults_reports_all_unknown_columns() {
-    let schema = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+    let schema = schema! { nullable "c": INTEGER };
 
     let err =
         schema_with_column_defaults(&schema, HashMap::from([("ghost1", "1"), ("ghost2", "2")]))
@@ -191,7 +191,7 @@ fn test_schema_with_column_defaults_reports_all_unknown_columns() {
 
 #[test]
 fn test_schema_with_column_defaults_overwrites_existing_default() {
-    let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)]).unwrap();
+    let base = schema! { nullable "c": INTEGER };
     let with_first = schema_with_column_defaults(&base, HashMap::from([("c", "1")])).unwrap();
     let with_second =
         schema_with_column_defaults(&with_first, HashMap::from([("c", "99")])).unwrap();
@@ -207,10 +207,10 @@ fn test_schema_with_column_defaults_overwrites_existing_default() {
 #[tokio::test]
 async fn test_blind_append_to_column_defaults_table_is_supported(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "name": STRING,
+    };
 
     let (store, engine, table_location) = engine_store_setup("test_table_col_defaults", None);
     // Use the JSON helper instead of the kernel `create_table` builder because the
@@ -264,10 +264,10 @@ async fn write_context_acknowledgement_depends_on_column_defaults(
     #[case] partition_columns: &[&str],
     #[values(false, true)] has_default: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![
-        StructField::nullable("c", DataType::INTEGER),
-        StructField::nullable("p", DataType::INTEGER),
-    ])?;
+    let base = schema! {
+        nullable "c": INTEGER,
+        nullable "p": INTEGER,
+    };
     let schema = if has_default {
         schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?
     } else {
@@ -333,7 +333,7 @@ async fn assert_materialized_column_default_round_trips(
     } else {
         &[]
     };
-    let base = StructType::try_new(vec![StructField::nullable("c", data_type.clone())])?;
+    let base = schema! { nullable "c": (data_type.clone()) };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
     let writer_features = [&["allowColumnDefaults"], extra_features].concat();
@@ -427,12 +427,12 @@ async fn test_transaction_top_level_column_defaults_excludes_nested_defaults(
 
     // `a`: no default, `b`: kernel-parsable default, `c`: non-kernel-parsable default,
     // `s.inner`: nested default that the top-level API must not return.
-    let base = StructType::try_new(vec![
-        StructField::nullable("a", DataType::INTEGER),
-        StructField::nullable("b", DataType::INTEGER),
-        StructField::nullable("c", DataType::TIMESTAMP),
-        StructField::nullable("s", DataType::try_struct_type([nested_default])?),
-    ])?;
+    let base = schema! {
+        nullable "a": INTEGER,
+        nullable "b": INTEGER,
+        nullable "c": TIMESTAMP,
+        nullable "s": { (nested_default) },
+    };
     let schema = schema_with_column_defaults(
         &base,
         HashMap::from([("b", "1337"), ("c", "current_timestamp()")]),
@@ -498,7 +498,7 @@ async fn test_load_and_write_tolerate_v3_unverifiable_default(
     #[case] default_sql: &str,
     #[case] warning_text: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![StructField::nullable("c", field_type)])?;
+    let base = schema! { nullable "c": (field_type) };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
     let (engine, table_url) = setup_unpartitioned_table(
@@ -530,7 +530,7 @@ async fn test_load_rejects_non_string_column_default() -> Result<(), Box<dyn std
         ColumnMetadataKey::CurrentDefault.as_ref().to_string(),
         MetadataValue::Number(7),
     )]);
-    let schema = Arc::new(StructType::try_new(vec![field])?);
+    let schema = schema_ref! { (field) };
 
     let (engine, table_url) = setup_unpartitioned_table(
         "test_load_rejects_non_string_default",
@@ -552,7 +552,7 @@ async fn test_load_rejects_non_string_column_default() -> Result<(), Box<dyn std
 /// feature) is tolerated: the snapshot loads and a write context builds without error.
 #[tokio::test]
 async fn test_load_and_write_allow_orphan_default() -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![StructField::nullable("c", DataType::INTEGER)])?;
+    let base = schema! { nullable "c": INTEGER };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
 
     let (engine, table_url) =
@@ -582,7 +582,7 @@ async fn test_variant_column_default_validation_at_snapshot_load(
     #[case] expected_error: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let variant_type = DataType::unshredded_variant();
-    let base = StructType::try_new(vec![StructField::nullable("v", variant_type)])?;
+    let base = schema! { nullable "v": (variant_type) };
     let schema = schema_with_column_defaults(&base, HashMap::from([("v", default_sql)]))?;
 
     let (store, engine, table_location) =
@@ -638,7 +638,7 @@ async fn test_load_tolerates_unmaterializable_default(
     #[case] data_type: DataType,
     #[case] default_sql: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![StructField::nullable("c", data_type)])?;
+    let base = schema! { nullable "c": (data_type) };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", default_sql)]))?;
 
     let (engine, table_url) = setup_unpartitioned_table(
@@ -670,7 +670,7 @@ fn test_column_default_composes_with_deletion_vectors() -> Result<(), Box<dyn st
     let table_path = temp_dir.path().join("table-with-dv-and-column-default");
     copy_directory(&source_path, &table_path)?;
 
-    let base = StructType::try_new(vec![StructField::nullable("value", DataType::INTEGER)])?;
+    let base = schema! { nullable "value": INTEGER };
     let schema = schema_with_column_defaults(&base, HashMap::from([("value", "42")]))?;
     add_column_defaults_feature_commit(&table_path, 2, Some(schema.as_ref()))?;
 
@@ -696,10 +696,10 @@ fn test_column_default_composes_with_deletion_vectors() -> Result<(), Box<dyn st
 async fn test_defaulted_clustering_column_round_trips_with_stats(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
-    let base = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("c", DataType::INTEGER),
-    ])?;
+    let base = schema! {
+        nullable "id": LONG,
+        nullable "c": INTEGER,
+    };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
 
     kernel_create_table(&table_path, schema.clone(), "Test/1.0")
@@ -743,11 +743,11 @@ async fn test_defaulted_clustering_column_round_trips_with_stats(
 async fn test_column_default_round_trips_with_column_mapping_and_checkpoint(
     #[case] column_mapping_mode: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("c", DataType::INTEGER),
-        StructField::nullable("p", DataType::INTEGER),
-    ])?;
+    let base = schema! {
+        nullable "id": LONG,
+        nullable "c": INTEGER,
+        nullable "p": INTEGER,
+    };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42"), ("p", "7")]))?;
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     let mut table_properties = vec![("delta.checkpoint.writeStatsAsStruct", "true")];
@@ -782,10 +782,10 @@ async fn test_column_default_round_trips_with_column_mapping_and_checkpoint(
     let data_column = physical_name("c");
     let partition_column = physical_name("p");
 
-    let data_schema = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("c", DataType::INTEGER),
-    ])?;
+    let data_schema = schema! {
+        nullable "id": LONG,
+        nullable "c": INTEGER,
+    };
     let data_columns: Vec<ArrayRef> = vec![
         Arc::new(Int64Array::from(vec![1, 2, 3])),
         Arc::new(Int32Array::from(vec![42, 42, 42])),
@@ -861,10 +861,10 @@ async fn test_column_default_round_trips_with_column_mapping_and_checkpoint(
 #[tokio::test]
 async fn test_partition_column_default_round_trips_on_read(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let base = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("p", DataType::INTEGER),
-    ])?;
+    let base = schema! {
+        nullable "id": LONG,
+        nullable "p": INTEGER,
+    };
     let schema = schema_with_column_defaults(&base, HashMap::from([("p", "42")]))?;
 
     let (store, engine, table_location) =
@@ -882,7 +882,7 @@ async fn test_partition_column_default_round_trips_on_read(
     let engine = Arc::new(engine);
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
 
-    let data_schema = StructType::try_new(vec![StructField::nullable("id", DataType::LONG)])?;
+    let data_schema = schema! { nullable "id": LONG };
     let data = RecordBatch::try_new(
         Arc::new((&data_schema).try_into_arrow()?),
         vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
@@ -913,10 +913,10 @@ async fn test_partition_column_default_round_trips_on_read(
 #[tokio::test(flavor = "multi_thread")]
 async fn test_column_default_with_iceberg_compat_v3_e2e() -> Result<(), Box<dyn std::error::Error>>
 {
-    let base = StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("c", DataType::INTEGER),
-    ])?;
+    let base = schema! {
+        nullable "id": LONG,
+        nullable "c": INTEGER,
+    };
     let schema = schema_with_column_defaults(&base, HashMap::from([("c", "42")]))?;
 
     let (store, engine, table_location) = engine_store_setup("test_v3_col_default_e2e", None);

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -16,7 +16,7 @@ use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
 use delta_kernel::scan::StatsOptions;
-use delta_kernel::schema::{schema_ref, MetadataValue, StructType};
+use delta_kernel::schema::{schema, schema_ref, DataType, MetadataValue, StructField};
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{Engine, FileMeta, Snapshot};
@@ -499,20 +499,16 @@ async fn test_read_and_append_tolerates_stale_column_mapping_when_disabled(
 
     // A `value` column carrying a stale physicalName + id, with no columnMapping feature in the
     // protocol and mode absent (so it resolves to None).
-    let stale_schema = schema_ref! {
+    let stale_schema = schema! {
         nullable "id": INTEGER,
-        nullable "value": INTEGER
-    };
-    let stale_schema = StructType::try_new([
-        stale_schema.field("id").unwrap().clone(),
-        stale_schema.field("value").unwrap().clone().add_metadata([
+        (StructField::nullable("value", DataType::INTEGER).add_metadata([
             ("delta.columnMapping.id", MetadataValue::Number(2)),
             (
                 "delta.columnMapping.physicalName",
                 MetadataValue::String("col-2f8a".to_string()),
             ),
-        ]),
-    ])?;
+        ])),
+    };
     let escaped = serde_json::to_string(&serde_json::to_string(&stale_schema)?)?;
     // Create a v0 commit directly to bypass create_table validation (which would reject the
     // stale annotations on the write path).

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -7,7 +7,7 @@ use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use itertools::Itertools;
 use serde_json::{json, Deserializer};
 use test_utils::{load_and_begin_transaction, set_json_value, setup_test_tables};
@@ -142,11 +142,11 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
                 Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
             ],
         )?;
-        let engine_schema = Arc::new(StructType::new_unchecked(vec![
-            StructField::not_null("myApp", DataType::STRING),
-            StructField::not_null("myVersion", DataType::STRING),
-            StructField::nullable("operation", DataType::STRING),
-        ]));
+        let engine_schema = schema_ref! {
+            not_null "myApp": STRING,
+            not_null "myVersion": STRING,
+            nullable "operation": STRING,
+        };
 
         let txn = load_and_begin_transaction(table_url.clone(), &engine)?
             .with_operation("WRITE".to_string())

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType};
 use test_utils::load_and_begin_transaction;
 
 mod supported {
@@ -45,16 +45,13 @@ mod supported {
         #[case] interval: DataType,
         #[case] column: ArrayRef,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::not_null("id", DataType::LONG),
-            StructField::nullable(
-                "nested",
-                StructType::new_unchecked([
-                    StructField::nullable("iv", interval),
-                    StructField::nullable("label", DataType::STRING),
-                ]),
-            ),
-        ])?);
+        let schema = schema_ref! {
+            not_null "id": LONG,
+            nullable "nested": {
+                nullable "iv": (interval),
+                nullable "label": STRING,
+            },
+        };
 
         let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
         let snapshot = create_table_transaction(&table_path, schema.clone(), "Test/1.0")
@@ -195,10 +192,10 @@ mod supported {
         #[case] property_name: &str,
         #[case] property_value: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let schema = Arc::new(StructType::try_new(vec![
-            StructField::not_null("value", DataType::LONG),
-            StructField::nullable("iv", interval.clone()),
-        ])?);
+        let schema = schema_ref! {
+            not_null "value": LONG,
+            nullable "iv": (interval.clone()),
+        };
         let interval_column: ArrayRef = if interval == DataType::INTERVAL_YEAR_MONTH {
             Arc::new(Int32Array::from(vec![Some(12), None, Some(-6)]))
         } else {

--- a/kernel/tests/integration/write/nested_field_ids.rs
+++ b/kernel/tests/integration/write/nested_field_ids.rs
@@ -8,7 +8,7 @@ use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+    schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 use delta_kernel::{EngineData, ParquetHandler};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
@@ -103,7 +103,10 @@ fn build_kernel_schema(nested_ids_meta_key: &str) -> StructType {
         ],
     );
 
-    StructType::try_new(vec![array_in_map, map_in_list]).unwrap()
+    schema! {
+        (array_in_map),
+        (map_in_list),
+    }
 }
 
 /// Write `record_batch` via the `ParquetHandler::write_parquet_file` trait method to a

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -15,7 +15,7 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
-use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::schema::{schema, schema_ref, DataType, StructType};
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
@@ -156,14 +156,14 @@ async fn test_write_partitioned_interval_roundtrip(
     )]
     cm_mode: ColumnMappingMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("value", DataType::INTEGER),
-        StructField::nullable("period", interval),
-    ])?);
+    let schema = schema_ref! {
+        nullable "value": INTEGER,
+        nullable "period": (interval),
+    };
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let snapshot =
         create_interval_partitioned_table(&table_path, engine.as_ref(), schema, cm_mode, false)?;
-    let data_schema = StructType::try_new([StructField::nullable("value", DataType::INTEGER)])?;
+    let data_schema = schema! { nullable "value": INTEGER };
     let batch = RecordBatch::try_new(
         Arc::new((&data_schema).try_into_arrow()?),
         vec![Arc::new(Int32Array::from(vec![7]))],
@@ -223,16 +223,16 @@ async fn test_materialized_partitioned_interval_roundtrip(
     )]
     cm_mode: ColumnMappingMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("value", DataType::INTEGER),
-        StructField::nullable("period", interval),
-    ])?);
+    let schema = schema_ref! {
+        nullable "value": INTEGER,
+        nullable "period": (interval),
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let snapshot =
         create_interval_partitioned_table(&table_path, engine.as_ref(), schema, cm_mode, true)?;
 
-    let data_schema = StructType::try_new(vec![StructField::nullable("value", DataType::INTEGER)])?;
+    let data_schema = schema! { nullable "value": INTEGER };
     let batch = RecordBatch::try_new(
         Arc::new((&data_schema).try_into_arrow()?),
         vec![Arc::new(Int32Array::from(vec![7]))],
@@ -418,13 +418,10 @@ async fn test_write_partitioned_path_encodes_special_chars(
     cm_mode: ColumnMappingMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ===== Step 1: Create a single-STRING-partition table and write one row. =====
-    let schema = Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("value", DataType::INTEGER),
-            StructField::nullable("p", DataType::STRING),
-        ])
-        .unwrap(),
-    );
+    let schema = schema_ref! {
+        nullable "value": INTEGER,
+        nullable "p": STRING,
+    };
     let (_tmp_dir, table_path, snapshot, engine) = setup_and_write(
         schema,
         &["p"],
@@ -513,25 +510,22 @@ async fn test_write_partitioned_path_encodes_special_chars(
 // ==============================================================================
 
 fn all_types_schema() -> Arc<StructType> {
-    Arc::new(
-        StructType::try_new(vec![
-            StructField::nullable("value", DataType::INTEGER),
-            StructField::nullable("p_string", DataType::STRING),
-            StructField::nullable("p_int", DataType::INTEGER),
-            StructField::nullable("p_long", DataType::LONG),
-            StructField::nullable("p_short", DataType::SHORT),
-            StructField::nullable("p_byte", DataType::BYTE),
-            StructField::nullable("p_float", DataType::FLOAT),
-            StructField::nullable("p_double", DataType::DOUBLE),
-            StructField::nullable("p_boolean", DataType::BOOLEAN),
-            StructField::nullable("p_date", DataType::DATE),
-            StructField::nullable("p_timestamp", DataType::TIMESTAMP),
-            StructField::nullable("p_decimal", DataType::decimal(10, 2).unwrap()),
-            StructField::nullable("p_binary", DataType::BINARY),
-            StructField::nullable("p_timestamp_ntz", DataType::TIMESTAMP_NTZ),
-        ])
-        .unwrap(),
-    )
+    schema_ref! {
+        nullable "value": INTEGER,
+        nullable "p_string": STRING,
+        nullable "p_int": INTEGER,
+        nullable "p_long": LONG,
+        nullable "p_short": SHORT,
+        nullable "p_byte": BYTE,
+        nullable "p_float": FLOAT,
+        nullable "p_double": DOUBLE,
+        nullable "p_boolean": BOOLEAN,
+        nullable "p_date": DATE,
+        nullable "p_timestamp": TIMESTAMP,
+        nullable "p_decimal": (DataType::decimal(10, 2).unwrap()),
+        nullable "p_binary": BINARY,
+        nullable "p_timestamp_ntz": TIMESTAMP_NTZ,
+    }
 }
 
 const PARTITION_COLS: &[&str] = &[
@@ -995,10 +989,10 @@ async fn test_materialized_partition_columns_excluded_from_stats(
     let _ = tracing_subscriber::fmt::try_init();
 
     let partition_col = "partition";
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("number", DataType::INTEGER),
-        StructField::nullable(partition_col, DataType::STRING),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "number": INTEGER,
+        nullable (partition_col): STRING,
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let _ = create_table(&table_path, table_schema.clone(), "test/1.0")
@@ -1011,10 +1005,7 @@ async fn test_materialized_partition_columns_excluded_from_stats(
         .with_engine_info("default engine");
 
     // Data batch must not contain the partition column.
-    let data_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "number",
-        DataType::INTEGER,
-    )])?);
+    let data_schema = schema_ref! { nullable "number": INTEGER };
     let arrow_schema = Arc::new(data_schema.as_ref().try_into_arrow()?);
     let batch = RecordBatch::try_new(
         arrow_schema,
@@ -1070,12 +1061,12 @@ async fn test_materialize_partition_columns_e2e(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cm = cm_mode_str(cm_mode);
     // Partition columns p1, p2 sit in the middle of the data columns.
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("d1", DataType::INTEGER),
-        StructField::nullable("p1", DataType::STRING),
-        StructField::nullable("p2", DataType::INTEGER),
-        StructField::nullable("d2", DataType::INTEGER),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "d1": INTEGER,
+        nullable "p1": STRING,
+        nullable "p2": INTEGER,
+        nullable "d2": INTEGER,
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let _ = create_table(&table_path, table_schema, "test/1.0")
@@ -1089,10 +1080,10 @@ async fn test_materialize_partition_columns_e2e(
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     // Data schema excludes partition columns.
-    let kernel_data_schema = StructType::try_new(vec![
-        StructField::nullable("d1", DataType::INTEGER),
-        StructField::nullable("d2", DataType::INTEGER),
-    ])?;
+    let kernel_data_schema = schema! {
+        nullable "d1": INTEGER,
+        nullable "d2": INTEGER,
+    };
     let arrow_data_schema: Arc<ArrowSchema> = Arc::new((&kernel_data_schema).try_into_arrow()?);
     let make_batch = |d1: Vec<i32>, d2: Vec<i32>| {
         RecordBatch::try_new(
@@ -1198,7 +1189,7 @@ async fn test_materialize_all_primitive_partition_types() -> Result<(), Box<dyn 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     // Data schema excludes partition columns.
-    let data_schema = StructType::try_new(vec![StructField::nullable("value", DataType::INTEGER)])?;
+    let data_schema = schema! { nullable "value": INTEGER };
     let batch = RecordBatch::try_new(
         Arc::new((&data_schema).try_into_arrow()?),
         vec![normal_arrow_columns()[0].clone()],
@@ -1242,10 +1233,10 @@ async fn test_input_data_with_partition_column_errors(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cm = cm_mode_str(cm_mode);
     let partition_col = "partition";
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("number", DataType::INTEGER),
-        StructField::nullable(partition_col, DataType::STRING),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "number": INTEGER,
+        nullable (partition_col): STRING,
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let mut properties = vec![("delta.columnMapping.mode", cm)];
@@ -1339,10 +1330,10 @@ async fn test_partition_null_validation(
     let (value, expected_err) = case;
 
     // Schema: a nullable data column + a NOT NULL string partition column.
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("value", DataType::INTEGER),
-        StructField::not_null("p", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "value": INTEGER,
+        not_null "p": STRING,
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let mut properties = vec![("delta.columnMapping.mode", cm_mode_str(cm_mode))];
@@ -1394,11 +1385,11 @@ async fn test_partition_null_validation_mixed_nullability(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("value", DataType::INTEGER),
-        StructField::not_null("p_required", DataType::STRING),
-        StructField::nullable("p_optional", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "value": INTEGER,
+        not_null "p_required": STRING,
+        nullable "p_optional": STRING,
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup_mt()?;
     let snapshot = create_partitioned_table(

--- a/kernel/tests/integration/write/post_commit.rs
+++ b/kernel/tests/integration/write/post_commit.rs
@@ -8,7 +8,7 @@ use delta_kernel::arrow::array::{Int32Array, RecordBatch};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::Scalar;
-use delta_kernel::schema::{schema_ref, DataType, StructField, StructType};
+use delta_kernel::schema::schema_ref;
 use delta_kernel::transaction::create_table::create_table as create_table_txn;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Snapshot};
@@ -82,10 +82,10 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
 #[tokio::test]
 async fn test_write_parquet_succeed_with_logical_partition_names(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("letter", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "letter": STRING,
+    };
 
     for (table_url, engine, _store, _table_name) in setup_test_tables(
         schema.clone(),

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -25,7 +25,7 @@ use delta_kernel::expressions::{
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::{scan_row_schema, StatsOptions};
-use delta_kernel::schema::{schema_ref, DataType, MapType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, MapType};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::CommitResult;
 use delta_kernel::{DeltaResult, Engine, Error, Expression as Expr, Predicate as Pred, Snapshot};
@@ -1052,10 +1052,10 @@ async fn test_update_deletion_vectors_rejects_corrupted_scan_files(
 ) -> Result<(), Box<dyn std::error::Error>> {
     const BATCH_COUNT: usize = 3;
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("part", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "part": STRING,
+    };
     let (_store, engine, table_url, file_paths) = create_dv_table_with_files(
         "test_table",
         schema,
@@ -1217,10 +1217,10 @@ async fn test_update_deletion_vectors_multiple_files(
     // in a single call, creating proper Remove and Add actions for each file.
     let _ = tracing_subscriber::fmt::try_init();
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
 
     // Setup: Create table with 3 files
     let file_names = &["file0.parquet", "file1.parquet", "file2.parquet"];
@@ -1349,10 +1349,10 @@ async fn test_update_deletion_vectors_respects_selection_vector(
     #[case] target_indexes: &[usize],
     #[case] expect_mismatch: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("value", DataType::STRING),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "value": STRING,
+    };
 
     let file_names = &[
         "file0.parquet",
@@ -1945,10 +1945,10 @@ async fn test_remove_files_partitioned_with_parsed_columns(
     let _ = tracing_subscriber::fmt::try_init();
 
     let partition_col = "country";
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("country", DataType::STRING),
-    ])?);
+    let table_schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "country": STRING,
+    };
     let data_schema = schema_ref! { nullable "id": INTEGER };
 
     // Local directory backing: `read_actions_from_commit` reads commit JSON off disk

--- a/kernel/tests/integration/write/stats.rs
+++ b/kernel/tests/integration/write/stats.rs
@@ -12,7 +12,7 @@ use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowS
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::{col, lit, ColumnName};
-use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, StructType};
 use delta_kernel::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
 use delta_kernel::{Predicate as Pred, Snapshot};
 use test_utils::{
@@ -131,15 +131,12 @@ async fn test_write_stats_for_complex_type_columns(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable("tags", ArrayType::new(DataType::STRING, true)),
-        StructField::nullable(
-            "props",
-            MapType::new(DataType::STRING, DataType::LONG, true),
-        ),
-        StructField::nullable("v", DataType::unshredded_variant()),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "tags": [ nullable STRING ],
+        nullable "props": { STRING => nullable LONG },
+        nullable "v": (DataType::unshredded_variant()),
+    };
 
     let mode_str = match cm_mode {
         ColumnMappingMode::None => "none",
@@ -278,20 +275,14 @@ async fn test_write_stats_nested_complex_types_respect_column_limit(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("id", DataType::LONG),
-        StructField::nullable(
-            "data",
-            DataType::try_struct_type(vec![
-                StructField::nullable("name", DataType::STRING),
-                StructField::nullable("tags", ArrayType::new(DataType::STRING, true)),
-                StructField::nullable(
-                    "props",
-                    MapType::new(DataType::STRING, DataType::LONG, true),
-                ),
-            ])?,
-        ),
-    ])?);
+    let schema = schema_ref! {
+        nullable "id": LONG,
+        nullable "data": {
+            nullable "name": STRING,
+            nullable "tags": [ nullable STRING ],
+            nullable "props": { STRING => nullable LONG },
+        },
+    };
 
     let (_tmp_dir, table_path, engine) = test_table_setup()?;
     let table_url = Url::from_directory_path(&table_path).unwrap();

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -15,7 +15,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::{Error as KernelError, Snapshot};
 use itertools::Itertools;
@@ -649,112 +649,69 @@ async fn try_write_with_void_schema(schema: SchemaRef) -> KernelError {
 
 #[rstest]
 #[case::void_array_element(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "arr",
-            ArrayType::new(DataType::VOID, true),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "arr": [ nullable VOID ],
+    },
     "array element type"
 )]
 #[case::void_map_value(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "m",
-            MapType::new(DataType::STRING, DataType::VOID, true),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "m": { STRING => nullable VOID },
+    },
     "map value type"
 )]
 #[case::void_map_key(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "m",
-            MapType::new(DataType::VOID, DataType::STRING, true),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "m": { VOID => nullable STRING },
+    },
     "map key type"
 )]
 #[case::void_in_struct_in_array(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "arr",
-            ArrayType::new(
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::VOID),
-                ]),
-                true,
-            ),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "arr": [ nullable {
+            nullable "a": INTEGER,
+            nullable "b": VOID,
+        } ],
+    },
     "Void type is not allowed inside"
 )]
 #[case::void_in_struct_in_map_value(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "m",
-            MapType::new(
-                DataType::STRING,
-                StructType::new_unchecked([
-                    StructField::nullable("a", DataType::INTEGER),
-                    StructField::nullable("b", DataType::VOID),
-                ]),
-                true,
-            ),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "m": { STRING => nullable {
+            nullable "a": INTEGER,
+            nullable "b": VOID,
+        } },
+    },
     "Void type is not allowed inside"
 )]
 #[case::all_void_table(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", DataType::VOID),
-        StructField::nullable("b", DataType::VOID),
-    ])),
+    schema_ref! { nullable "a": VOID, nullable "b": VOID },
     "at least one non-void column"
 )]
 #[case::all_void_struct(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("x", DataType::VOID),
-                StructField::nullable("y", DataType::VOID),
-            ]),
-        ),
-    ])),
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "s": { nullable "x": VOID, nullable "y": VOID },
+    },
     "contains no non-void fields"
 )]
 // A zero-field top-level schema is an empty schema, rejected by the empty-schema
 // write gate (it has no columns at all, void or otherwise) rather than by void validation.
 #[case::empty_struct_top_level(
-    Arc::new(StructType::new_unchecked(Vec::<StructField>::new())),
+    schema_ref! {},
     "empty schema"
 )]
 #[case::nested_empty_struct(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "s",
-            StructType::new_unchecked(Vec::<StructField>::new()),
-        ),
-    ])),
+    schema_ref! { nullable "id": INTEGER, nullable "s": {} },
     "contains no non-void fields"
 )]
 #[case::empty_struct_in_array(
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "arr",
-            ArrayType::new(StructType::new_unchecked(Vec::<StructField>::new()), true),
-        ),
-    ])),
+    schema_ref! { nullable "id": INTEGER, nullable "arr": [ nullable {} ] },
     "struct nested in Array or Map must contain at least one non-void field"
 )]
 #[tokio::test]
@@ -780,30 +737,21 @@ async fn write_rejects_invalid_void_placement(
     "void_fail_fast_unpartitioned_array",
     vec![],
     HashMap::new(),
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("arr", ArrayType::new(DataType::VOID, true)),
-    ])),
+    schema_ref! { nullable "id": INTEGER, nullable "arr": [ nullable VOID ] },
     "array element type",
 )]
 #[case::partitioned_void_array(
     "void_fail_fast_partitioned_array",
     vec!["id"],
     HashMap::from([("id".to_string(), Scalar::Integer(1))]),
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("arr", ArrayType::new(DataType::VOID, true)),
-    ])),
+    schema_ref! { nullable "id": INTEGER, nullable "arr": [ nullable VOID ] },
     "array element type",
 )]
 #[case::unpartitioned_all_void(
     "void_fail_fast_unpartitioned_all_void",
     vec![],
     HashMap::new(),
-    Arc::new(StructType::new_unchecked([
-        StructField::nullable("a", DataType::VOID),
-        StructField::nullable("b", DataType::VOID),
-    ])),
+    schema_ref! { nullable "a": VOID, nullable "b": VOID },
     "at least one non-void column",
 )]
 #[tokio::test]
@@ -850,11 +798,11 @@ async fn write_context_creation_fails_fast_on_invalid_void_schema(
 #[tokio::test]
 async fn write_context_excludes_void_from_physical_schema() -> Result<(), Box<dyn std::error::Error>>
 {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("v", DataType::VOID),
-        StructField::nullable("name", DataType::STRING),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "v": VOID,
+        nullable "name": STRING,
+    };
     let (store, engine, table_location) = engine_store_setup("void_physical_test", None);
     let table_url = create_table(store, table_location, schema, &[], false, vec![], vec![]).await?;
     let engine = Arc::new(engine);
@@ -886,10 +834,10 @@ async fn write_context_excludes_void_from_physical_schema() -> Result<(), Box<dy
 #[tokio::test]
 async fn metadata_only_commit_with_void_in_array_succeeds() -> Result<(), Box<dyn std::error::Error>>
 {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable("arr", ArrayType::new(DataType::VOID, true)),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "arr": [ nullable VOID ],
+    };
     let (store, engine, table_location) = engine_store_setup("void_metadata_test", None);
     let table_url = create_table(store, table_location, schema, &[], false, vec![], vec![]).await?;
     let engine = Arc::new(engine);
@@ -913,16 +861,13 @@ async fn metadata_only_commit_with_void_in_array_succeeds() -> Result<(), Box<dy
 #[tokio::test]
 async fn write_context_excludes_nested_void_from_physical_schema(
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-            ]),
-        ),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "s": {
+            nullable "a": INTEGER,
+            nullable "b": VOID,
+        },
+    };
     let (store, engine, table_location) = engine_store_setup("void_nested_physical_test", None);
     let table_url = create_table(store, table_location, schema, &[], false, vec![], vec![]).await?;
     let engine = Arc::new(engine);
@@ -967,16 +912,13 @@ async fn write_context_excludes_nested_void_from_physical_schema(
 // matching the physical schema which has void stripped recursively.
 #[tokio::test]
 async fn write_transform_drops_nested_void_fields() -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::new_unchecked([
-        StructField::nullable("id", DataType::INTEGER),
-        StructField::nullable(
-            "s",
-            StructType::new_unchecked([
-                StructField::nullable("a", DataType::INTEGER),
-                StructField::nullable("b", DataType::VOID),
-            ]),
-        ),
-    ]));
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+        nullable "s": {
+            nullable "a": INTEGER,
+            nullable "b": VOID,
+        },
+    };
     let (store, engine, table_location) = engine_store_setup("void_nested_transform_test", None);
     let table_url = create_table(store, table_location, schema, &[], false, vec![], vec![]).await?;
     let engine = Arc::new(engine);

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -15,7 +15,7 @@ use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
-use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField};
 use delta_kernel::transaction::create_table::create_table as kernel_create_table;
 use delta_kernel::{Error as KernelError, Snapshot};
 use itertools::Itertools;
@@ -34,10 +34,7 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
     // create a table with TIMESTAMP_NTZ column
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "ts_ntz",
-        DataType::TIMESTAMP_NTZ,
-    )])?);
+    let schema = schema_ref! { nullable "ts_ntz": TIMESTAMP_NTZ };
 
     let (store, engine, table_location) = engine_store_setup("test_table_timestamp_ntz", None);
     let table_url = create_table(
@@ -124,10 +121,7 @@ async fn test_append_timestamp_stats_are_millisecond_truncated(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
 
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "ts",
-        DataType::TIMESTAMP,
-    )])?);
+    let schema = schema_ref! { nullable "ts": TIMESTAMP };
 
     let (store, engine, table_location) = engine_store_setup("test_table_timestamp_stats", None);
     let table_url = create_table(
@@ -205,18 +199,14 @@ async fn test_append_variant(
     }
 
     // create a table with VARIANT column
-    let table_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("v", DataType::unshredded_variant()),
-        StructField::nullable("i", DataType::INTEGER),
-        StructField::nullable(
-            "nested",
-            // We flip the value and metadata fields in the actual parquet file for the test
-            StructType::try_new(vec![StructField::nullable(
-                "nested_v",
-                unshredded_variant_schema_flipped(),
-            )])?,
-        ),
-    ])?);
+    // We flip the value and metadata fields in the actual parquet file for the test.
+    let table_schema = schema_ref! {
+        nullable "v": unshredded_variant(),
+        nullable "i": INTEGER,
+        nullable "nested": {
+            nullable "nested_v": (unshredded_variant_schema_flipped()),
+        },
+    };
 
     let write_schema = table_schema.clone();
 
@@ -360,18 +350,13 @@ async fn test_append_variant(
     assert!(parsed_commits[1].get("add").is_some());
 
     // The scanned data will match the logical schema, not the physical one
-    let expected_schema = Arc::new(StructType::try_new(vec![
-        StructField::nullable("v", DataType::unshredded_variant()),
-        StructField::nullable("i", DataType::INTEGER),
-        StructField::nullable(
-            "nested",
-            StructType::try_new(vec![StructField::nullable(
-                "nested_v",
-                DataType::unshredded_variant(),
-            )])
-            .unwrap(),
-        ),
-    ])?);
+    let expected_schema = schema_ref! {
+        nullable "v": unshredded_variant(),
+        nullable "i": INTEGER,
+        nullable "nested": {
+            nullable "nested_v": unshredded_variant(),
+        },
+    };
 
     // During the read, the flipped fields should be reordered into metadata, value.
     let variant_nested_v_array_expected = Arc::new(StructArray::try_new(
@@ -409,22 +394,18 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
 
     // setup tracing
     let _ = tracing_subscriber::fmt::try_init();
-    let table_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "v",
-        DataType::unshredded_variant(),
-    )])?);
+    let table_schema = schema_ref! { nullable "v": unshredded_variant() };
 
     // The table will be attempted to be written in this form but be read into
     // STRUCT<metadata: BINARY, value: BINARY>. The read should fail because the default engine
     // currently does not support shredded reads.
-    let shredded_write_schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "v",
-        DataType::try_struct_type([
-            StructField::new("metadata", DataType::BINARY, true),
-            StructField::new("value", DataType::BINARY, true),
-            StructField::new("typed_value", DataType::INTEGER, true),
-        ])?,
-    )])?);
+    let shredded_write_schema = schema_ref! {
+        nullable "v": {
+            nullable "metadata": BINARY,
+            nullable "value": BINARY,
+            nullable "typed_value": INTEGER,
+        },
+    };
 
     let tmp_test_dir = tempdir()?;
     let tmp_test_dir_url = Url::from_directory_path(tmp_test_dir.path()).unwrap();
@@ -562,10 +543,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
     let _ = tracing_subscriber::fmt::try_init();
 
     // Create a table with a NOT NULL column.
-    let schema = Arc::new(StructType::try_new(vec![StructField::not_null(
-        "c",
-        data_type.clone(),
-    )])?);
+    let schema = schema_ref! { not_null "c": (data_type.clone()) };
     let (_tmp_dir, table_path, engine) = test_table_setup()?;
     let _ = kernel_create_table(&table_path, schema.clone(), "test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
@@ -613,14 +591,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
     Ok(())
 }
 
-// ---- Void type write-time validation tests ----
-//
-// The rstest cases below use `StructType::new_unchecked` for convenience; `StructType::try_new`
-// would also accept them, since it validates structural properties (field-name uniqueness,
-// metadata-column rules) and does not reject void placements. The validator
-// (`validate_schema_for_write`) is the kernel-internal write-time rejection point for void in
-// `Array`/`Map` and all-void structs, and it also protects schemas loaded from existing table
-// metadata (JSON-deserialized from the log) and any `new_unchecked` paths.
+// === Void type write-time validation tests ===
 
 /// Helper to create a table with a given schema and attempt a commit with dummy add_files.
 /// Returns the commit error (panics if commit succeeds).

--- a/test-utils/src/column_mapping_fixtures.rs
+++ b/test-utils/src/column_mapping_fixtures.rs
@@ -1,26 +1,34 @@
 //! Schema fixtures for column mappings.
 use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+    schema, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
 };
 
 pub fn same_leaf_phy_name_under_different_parents() -> StructType {
-    let parent1_children = StructType::new_unchecked([cm_field("a", 2, "x", DataType::INTEGER)]);
-    let parent2_children = StructType::new_unchecked([cm_field("a", 4, "x", DataType::INTEGER)]);
-    StructType::new_unchecked([
-        cm_field("outer1", 1, "outer1", parent1_children),
-        cm_field("outer2", 3, "outer2", parent2_children),
-    ])
+    let parent1_children = schema! {
+        (cm_field("a", 2, "x", DataType::INTEGER)),
+    };
+    let parent2_children = schema! {
+        (cm_field("a", 4, "x", DataType::INTEGER)),
+    };
+    schema! {
+        (cm_field("outer1", 1, "outer1", parent1_children)),
+        (cm_field("outer2", 3, "outer2", parent2_children)),
+    }
 }
 
 pub fn nested_field_with_same_phy_path() -> StructType {
-    let innermost = StructType::new_unchecked([
-        cm_field("a", 3, "x", DataType::INTEGER),
-        cm_field("b", 4, "x", DataType::INTEGER),
-    ]);
+    let innermost = schema! {
+        (cm_field("a", 3, "x", DataType::INTEGER)),
+        (cm_field("b", 4, "x", DataType::INTEGER)),
+    };
     let arr_of_struct = ArrayType::new(innermost, true);
     let map_to_arr = MapType::new(DataType::STRING, arr_of_struct, true);
-    let inner_struct = StructType::new_unchecked([cm_field("inner", 2, "inner", map_to_arr)]);
-    StructType::new_unchecked([cm_field("outer", 1, "outer", inner_struct)])
+    let inner_struct = schema! {
+        (cm_field("inner", 2, "inner", map_to_arr)),
+    };
+    schema! {
+        (cm_field("outer", 1, "outer", inner_struct)),
+    }
 }
 
 /// `StructField` carrying both `delta.columnMapping.id` and `delta.columnMapping.physicalName`.

--- a/test-utils/src/engine_contract.rs
+++ b/test-utils/src/engine_contract.rs
@@ -20,8 +20,8 @@ use delta_kernel::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
 use delta_kernel::parquet::arrow::{ARROW_SCHEMA_META_KEY, PARQUET_FIELD_ID_META_KEY};
 use delta_kernel::schema::{
-    ColumnMetadataKey, DataType, MetadataColumnSpec, PrimitiveType, SchemaRef, StructField,
-    StructType,
+    schema_ref, ColumnMetadataKey, DataType, MetadataColumnSpec, PrimitiveType, SchemaRef,
+    StructField, StructType,
 };
 use delta_kernel::{DeltaResult, Engine, EngineData, FileMeta, JsonHandler, ParquetHandler};
 use itertools::Itertools;
@@ -78,13 +78,10 @@ pub fn test_json_handler_file_path_contract(handler: &dyn JsonHandler) {
     let (_temp, file_meta) = make_temp_json_file(&[r#"{"x": 1}"#, r#"{"x": 2}"#]);
     let expected_url = file_meta.location.to_string();
 
-    let schema = Arc::new(
-        StructType::try_new([
-            StructField::not_null("x", DataType::INTEGER),
-            StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath),
-        ])
-        .unwrap(),
-    );
+    let schema = schema_ref! {
+        not_null "x": INTEGER,
+        (StructField::create_metadata_column("_file", MetadataColumnSpec::FilePath)),
+    };
 
     let engine_data = handler
         .read_json_files(&[file_meta], schema, None)

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -196,7 +196,7 @@ use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
 use delta_kernel::parquet::file::properties::WriterProperties;
 use delta_kernel::scan::Scan;
 use delta_kernel::schema::{
-    schema_ref, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
+    schema_ref, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructType,
 };
 use delta_kernel::table_features::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 use delta_kernel::transaction::{CommitResult, Transaction};
@@ -1184,20 +1184,17 @@ pub fn set_json_value(
 /// `[row_number: long, name: string, score: double, address: {street: string, city: string}, tag:
 /// string, value: int]`
 pub fn nested_schema() -> Result<SchemaRef, Box<dyn std::error::Error>> {
-    Ok(Arc::new(StructType::try_new(vec![
-        StructField::nullable("row_number", DataType::LONG),
-        StructField::nullable("name", DataType::STRING),
-        StructField::nullable("score", DataType::DOUBLE),
-        StructField::nullable(
-            "address",
-            StructType::try_new(vec![
-                StructField::nullable("street", DataType::STRING),
-                StructField::nullable("city", DataType::STRING),
-            ])?,
-        ),
-        StructField::nullable("tag", DataType::STRING),
-        StructField::nullable("value", DataType::INTEGER),
-    ])?))
+    Ok(schema_ref! {
+        nullable "row_number": LONG,
+        nullable "name": STRING,
+        nullable "score": DOUBLE,
+        nullable "address": {
+            nullable "street": STRING,
+            nullable "city": STRING,
+        },
+        nullable "tag": STRING,
+        nullable "value": INTEGER,
+    })
 }
 
 /// Returns two [`RecordBatch`]es with hardcoded test data matching [`nested_schema`].

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -196,7 +196,7 @@ use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
 use delta_kernel::parquet::file::properties::WriterProperties;
 use delta_kernel::scan::Scan;
 use delta_kernel::schema::{
-    ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
+    schema_ref, ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
 };
 use delta_kernel::table_features::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 use delta_kernel::transaction::{CommitResult, Transaction};
@@ -1269,32 +1269,30 @@ pub fn nested_batches() -> Result<Vec<RecordBatch>, Box<dyn std::error::Error>> 
 
 /// Schema with one column of the given type: `(id INT, col <dtype>)`.
 pub fn schema_with_type(dtype: DataType) -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("col", dtype, true),
-    ]))
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "col": (dtype),
+    }
 }
 
 /// Schema with the given type nested inside a struct:
 /// `(id INT, nested STRUCT<inner <dtype>>)`.
 pub fn nested_schema_with_type(dtype: DataType) -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new(
-            "nested",
-            StructType::new_unchecked(vec![StructField::new("inner", dtype, true)]),
-            true,
-        ),
-    ]))
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "nested": {
+            nullable "inner": (dtype),
+        },
+    }
 }
 
 /// Schema with two columns of the given type: `(id INT, col1 <dtype>, col2 <dtype>)`.
 pub fn multi_schema_with_type(dtype: DataType) -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::new("id", DataType::INTEGER, true),
-        StructField::new("col1", dtype.clone(), true),
-        StructField::new("col2", dtype, true),
-    ]))
+    schema_ref! {
+        nullable "id": INTEGER,
+        nullable "col1": (dtype.clone()),
+        nullable "col2": (dtype),
+    }
 }
 
 pub fn top_level_ntz_schema() -> SchemaRef {

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1881,7 +1881,6 @@ pub(crate) fn default_schema() -> SchemaRef {
 mod tests {
     use delta_kernel::object_store::path::Path;
     use delta_kernel::object_store::ObjectStore;
-    use delta_kernel::schema::StructField;
     use rstest::rstest;
 
     use super::*;
@@ -2366,11 +2365,12 @@ mod tests {
 
     #[test]
     fn test_nested_struct_schema_round_trip() -> DeltaResult<()> {
-        let inner = DataType::try_struct_type([StructField::nullable("a", DataType::LONG)])?;
-        let schema: SchemaRef = Arc::new(StructType::try_new([
-            StructField::nullable("id", DataType::LONG),
-            StructField::nullable("inner", inner),
-        ])?);
+        let schema = schema_ref! {
+            nullable "id": LONG,
+            nullable "inner": {
+                nullable "a": LONG,
+            },
+        };
         let table = TestTableBuilder::new()
             .with_schema(schema.clone())
             .build()?;

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -68,7 +68,7 @@ use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{DynObjectStore, Error as ObjectStoreError, ObjectStoreExt as _};
-use delta_kernel::schema::{DataType, PrimitiveType, SchemaRef, StructField, StructType};
+use delta_kernel::schema::{schema_ref, DataType, PrimitiveType, SchemaRef, StructType};
 use delta_kernel::snapshot::ChecksumWriteResult;
 use delta_kernel::table_features::TableFeature;
 use delta_kernel::transaction::create_table::create_table;
@@ -988,24 +988,24 @@ impl fmt::Display for DataLayoutConfig {
 ///
 /// All columns are nullable. Follow-up: add non-nullable variants to test NOT NULL handling.
 pub fn partitioned_schema() -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
+    schema_ref! {
         // Partition-candidate columns (all valid partition types, matches write::partitioned)
-        StructField::new("part_bool", DataType::BOOLEAN, true),
-        StructField::new("part_byte", DataType::BYTE, true),
-        StructField::new("part_short", DataType::SHORT, true),
-        StructField::new("part_int", DataType::INTEGER, true),
-        StructField::new("part_long", DataType::LONG, true),
-        StructField::new("part_float", DataType::FLOAT, true),
-        StructField::new("part_double", DataType::DOUBLE, true),
-        StructField::new("part_string", DataType::STRING, true),
-        StructField::new("part_binary", DataType::BINARY, true),
-        StructField::new("part_date", DataType::DATE, true),
-        StructField::new("part_ts", DataType::TIMESTAMP, true),
-        StructField::new("part_ts_ntz", DataType::TIMESTAMP_NTZ, true),
-        StructField::new("part_decimal", DataType::decimal(10, 2).unwrap(), true),
+        nullable "part_bool": BOOLEAN,
+        nullable "part_byte": BYTE,
+        nullable "part_short": SHORT,
+        nullable "part_int": INTEGER,
+        nullable "part_long": LONG,
+        nullable "part_float": FLOAT,
+        nullable "part_double": DOUBLE,
+        nullable "part_string": STRING,
+        nullable "part_binary": BINARY,
+        nullable "part_date": DATE,
+        nullable "part_ts": TIMESTAMP,
+        nullable "part_ts_ntz": TIMESTAMP_NTZ,
+        nullable "part_decimal": (DataType::decimal(10, 2).unwrap()),
         // Non-partition data column (required: at least one non-partition column)
-        StructField::new("value", DataType::INTEGER, true),
-    ]))
+        nullable "value": INTEGER,
+    }
 }
 
 /// Schema with all stats-eligible primitive types for clustering. Boolean and Binary are
@@ -1014,22 +1014,22 @@ pub fn partitioned_schema() -> SchemaRef {
 ///
 /// All columns are nullable. Follow-up: add non-nullable variants to test NOT NULL handling.
 pub fn clustered_schema() -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
+    schema_ref! {
         // Clustering-eligible columns (stats-eligible primitive types)
-        StructField::new("clust_byte", DataType::BYTE, true),
-        StructField::new("clust_short", DataType::SHORT, true),
-        StructField::new("clust_int", DataType::INTEGER, true),
-        StructField::new("clust_long", DataType::LONG, true),
-        StructField::new("clust_float", DataType::FLOAT, true),
-        StructField::new("clust_double", DataType::DOUBLE, true),
-        StructField::new("clust_string", DataType::STRING, true),
-        StructField::new("clust_date", DataType::DATE, true),
-        StructField::new("clust_ts", DataType::TIMESTAMP, true),
-        StructField::new("clust_ts_ntz", DataType::TIMESTAMP_NTZ, true),
-        StructField::new("clust_decimal", DataType::decimal(10, 2).unwrap(), true),
+        nullable "clust_byte": BYTE,
+        nullable "clust_short": SHORT,
+        nullable "clust_int": INTEGER,
+        nullable "clust_long": LONG,
+        nullable "clust_float": FLOAT,
+        nullable "clust_double": DOUBLE,
+        nullable "clust_string": STRING,
+        nullable "clust_date": DATE,
+        nullable "clust_ts": TIMESTAMP,
+        nullable "clust_ts_ntz": TIMESTAMP_NTZ,
+        nullable "clust_decimal": (DataType::decimal(10, 2).unwrap()),
         // Non-clustering data column
-        StructField::new("value", DataType::INTEGER, true),
-    ]))
+        nullable "value": INTEGER,
+    }
 }
 
 // Canonical sweep rows for the DataLayoutConfig axis.
@@ -1856,36 +1856,32 @@ fn scalar_for_type(data_type: &DataType, seed: usize) -> Scalar {
 /// Default schema with all Delta primitive types including TimestampNtz
 /// and a nested column type.
 pub(crate) fn default_schema() -> SchemaRef {
-    Arc::new(StructType::new_unchecked(vec![
-        StructField::new("bool_col", DataType::BOOLEAN, true),
-        StructField::new("byte_col", DataType::BYTE, true),
-        StructField::new("short_col", DataType::SHORT, true),
-        StructField::new("int_col", DataType::INTEGER, true),
-        StructField::new("long_col", DataType::LONG, true),
-        StructField::new("float_col", DataType::FLOAT, true),
-        StructField::new("double_col", DataType::DOUBLE, true),
-        StructField::new("string_col", DataType::STRING, true),
-        StructField::new("binary_col", DataType::BINARY, true),
-        StructField::new("date_col", DataType::DATE, true),
-        StructField::new("ts_col", DataType::TIMESTAMP, true),
-        StructField::new("ts_ntz_col", DataType::TIMESTAMP_NTZ, true),
-        StructField::new("decimal_col", DataType::decimal(10, 2).unwrap(), true),
-        StructField::new(
-            "nested_col",
-            DataType::try_struct_type([
-                StructField::nullable("a", DataType::LONG),
-                StructField::nullable("b", DataType::STRING),
-            ])
-            .unwrap(),
-            true,
-        ),
-    ]))
+    schema_ref! {
+        nullable "bool_col": BOOLEAN,
+        nullable "byte_col": BYTE,
+        nullable "short_col": SHORT,
+        nullable "int_col": INTEGER,
+        nullable "long_col": LONG,
+        nullable "float_col": FLOAT,
+        nullable "double_col": DOUBLE,
+        nullable "string_col": STRING,
+        nullable "binary_col": BINARY,
+        nullable "date_col": DATE,
+        nullable "ts_col": TIMESTAMP,
+        nullable "ts_ntz_col": TIMESTAMP_NTZ,
+        nullable "decimal_col": (DataType::decimal(10, 2).unwrap()),
+        nullable "nested_col": {
+            nullable "a": LONG,
+            nullable "b": STRING,
+        },
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use delta_kernel::object_store::path::Path;
     use delta_kernel::object_store::ObjectStore;
+    use delta_kernel::schema::StructField;
     use rstest::rstest;
 
     use super::*;

--- a/workloads/src/predicate_parser.rs
+++ b/workloads/src/predicate_parser.rs
@@ -428,78 +428,57 @@ fn between_to_pred(
 mod tests {
     use delta_kernel::expressions::col;
     use delta_kernel::expressions::Scalar::*;
-    use delta_kernel::schema::{MapType, Schema, StructField, StructType};
+    use delta_kernel::schema::{schema, Schema};
     use rstest::rstest;
 
     use super::*;
 
     /// Test schema with columns for all test cases.
     fn test_schema() -> Schema {
-        Schema::new_unchecked(vec![
-            // Columns matching upstream tests
-            StructField::new("id", DataType::LONG, true),
-            StructField::new("a", DataType::LONG, true),
-            StructField::new("b", DataType::LONG, true),
-            StructField::new("c", DataType::LONG, true),
-            StructField::new("name", DataType::STRING, true),
-            StructField::new("value", DataType::LONG, true),
-            StructField::new("flag", DataType::BOOLEAN, true),
-            StructField::new("partCol", DataType::LONG, true),
-            StructField::new("version_tag", DataType::STRING, true),
-            // Double columns for literal_types tests
-            StructField::new("c3", DataType::DOUBLE, true),
-            StructField::new("c4", DataType::DOUBLE, true),
-            StructField::new("val", DataType::DOUBLE, true),
-            StructField::new("cc9", DataType::BOOLEAN, true),
-            StructField::new("long_val", DataType::LONG, true),
-            // Columns for unsupported predicate tests (these trigger other errors first)
-            StructField::new("fruit", DataType::STRING, true),
-            StructField::new("cc8", DataType::STRING, true),
-            StructField::new("s", DataType::STRING, true),
-            StructField::new("time_col", DataType::TIMESTAMP, true),
-            StructField::new("items", ArrayType::new(DataType::LONG, true), true),
-            // Nested struct for upstream tests
-            StructField::new(
-                "null_v_struct",
-                StructType::new_unchecked(vec![StructField::new("v", DataType::LONG, true)]),
-                true,
-            ),
-            // Nested structs for nested_columns tests (a.b, a.b.c, b.c.f.i, data.value)
-            StructField::new(
-                "data",
-                StructType::new_unchecked(vec![StructField::new("value", DataType::LONG, true)]),
-                true,
-            ),
-            // Additional typed columns for type-checking tests
-            StructField::new("int_col", DataType::INTEGER, true),
-            StructField::new("str_col", DataType::STRING, true),
-            StructField::new("long_col", DataType::LONG, true),
-            StructField::new("double_col", DataType::DOUBLE, true),
-            StructField::new("short_col", DataType::SHORT, true),
-            StructField::new("byte_col", DataType::BYTE, true),
-            StructField::new("float_col", DataType::FLOAT, true),
-            StructField::new("bool_col", DataType::BOOLEAN, true),
-            StructField::new("date_col", DataType::DATE, true),
-            StructField::new("ts_col", DataType::TIMESTAMP, true),
-            StructField::new("ts_ntz_col", DataType::TIMESTAMP_NTZ, true),
-            // Struct type for nested tests
-            StructField::new(
-                "struct_col",
-                StructType::new_unchecked(vec![
-                    StructField::new("inner_int", DataType::INTEGER, true),
-                    StructField::new("inner_str", DataType::STRING, true),
-                ]),
-                true,
-            ),
-            // Array type
-            StructField::new("array_col", ArrayType::new(DataType::LONG, true), true),
-            // Map type
-            StructField::new(
-                "map_col",
-                MapType::new(DataType::STRING, DataType::LONG, true),
-                true,
-            ),
-        ])
+        schema! {
+            nullable "id": LONG,
+            nullable "a": LONG,
+            nullable "b": LONG,
+            nullable "c": LONG,
+            nullable "name": STRING,
+            nullable "value": LONG,
+            nullable "flag": BOOLEAN,
+            nullable "partCol": LONG,
+            nullable "version_tag": STRING,
+            nullable "c3": DOUBLE,
+            nullable "c4": DOUBLE,
+            nullable "val": DOUBLE,
+            nullable "cc9": BOOLEAN,
+            nullable "long_val": LONG,
+            nullable "fruit": STRING,
+            nullable "cc8": STRING,
+            nullable "s": STRING,
+            nullable "time_col": TIMESTAMP,
+            nullable "items": [ nullable LONG ],
+            nullable "null_v_struct": {
+                nullable "v": LONG,
+            },
+            nullable "data": {
+                nullable "value": LONG,
+            },
+            nullable "int_col": INTEGER,
+            nullable "str_col": STRING,
+            nullable "long_col": LONG,
+            nullable "double_col": DOUBLE,
+            nullable "short_col": SHORT,
+            nullable "byte_col": BYTE,
+            nullable "float_col": FLOAT,
+            nullable "bool_col": BOOLEAN,
+            nullable "date_col": DATE,
+            nullable "ts_col": TIMESTAMP,
+            nullable "ts_ntz_col": TIMESTAMP_NTZ,
+            nullable "struct_col": {
+                nullable "inner_int": INTEGER,
+                nullable "inner_str": STRING,
+            },
+            nullable "array_col": [ nullable LONG ],
+            nullable "map_col": { STRING => nullable LONG },
+        }
     }
 
     // Helper to build an IN predicate: `col IN (scalars...)`


### PR DESCRIPTION
## What changes are proposed in this pull request?

Many inline schemas still used direct `StructType` construction for static fields. Replace them with `schema!`, `schema_ref!`, `lazy_schema_ref!`, or `try_schema!` as appropriate. Use schema macros for declarative shapes, including interpolated runtime values. Keep direct construction for fully data-dependent field collections.

This makes static schema declarations shorter and consistent without changing their shape.

CI note: The unused-code annotations come from the isolated no-default-features check added in #3124. They already exist on the base commit; this refactor introduces none and removes three.

## How was this change tested?

Refactor only. Existing CI and tests.
