### PR TITLE
fix: allow incremental CRC replay for streaming updates

### DIFF
--- a/kernel/src/crc/delta.rs
+++ b/kernel/src/crc/delta.rs
@@ -290,6 +290,7 @@ mod tests {
     fn test_incremental_safe_operations() {
         for op in [
             "WRITE",
+            "STREAMING UPDATE",
             "MERGE",
             "UPDATE",
             "DELETE",

--- a/kernel/src/crc/file_stats.rs
+++ b/kernel/src/crc/file_stats.rs
@@ -70,6 +70,7 @@ pub(crate) struct FileStatsDelta {
 
 const INCREMENTAL_SAFE_OPS: &[&str] = &[
     "WRITE",
+    "STREAMING UPDATE",
     "MERGE",
     "UPDATE",
     "DELETE",

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -699,6 +699,7 @@ mod tests {
 
     #[rstest::rstest]
     #[case::safe("WRITE", true)]
+    #[case::streaming_update("STREAMING UPDATE", true)]
     #[case::unsafe_op("ANALYZE STATS", false)]
     fn on_commit_info_classifies_operation(#[case] op: &str, #[case] is_safe: bool) {
         let mut acc = CrcReplayAccumulator::new(None);

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -1045,31 +1045,6 @@ async fn test_adds_and_removes_accumulate() {
     assert_eq!(stats.table_size_bytes(), 700); // c (300) + d (400)
 }
 
-#[tokio::test]
-async fn test_streaming_update_advances_on_disk_file_stats() {
-    let built = CrcReadTest::new()
-        .commit(0, create_table_actions())
-        .crc_with_files(0, protocol_a(), metadata_a(), None, &[100])
-        .commit(
-            1,
-            [
-                commit_info("STREAMING UPDATE", None),
-                remove("a", Some(100)),
-                add("b", 200),
-            ],
-        )
-        .build()
-        .await;
-    let base = built.read_crc_at(0).unwrap();
-
-    let crc = built.incrementally_build_crc(&base).unwrap();
-
-    assert!(crc.file_stats_state().is_complete());
-    let stats = crc.file_stats().unwrap();
-    assert_eq!(stats.num_files(), 1);
-    assert_eq!(stats.table_size_bytes(), 200);
-}
-
 // === Indeterminate trips ===
 
 // Three distinct ways a single commit can lose incremental safety.

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -1045,6 +1045,31 @@ async fn test_adds_and_removes_accumulate() {
     assert_eq!(stats.table_size_bytes(), 700); // c (300) + d (400)
 }
 
+#[tokio::test]
+async fn test_streaming_update_advances_on_disk_file_stats() {
+    let built = CrcReadTest::new()
+        .commit(0, create_table_actions())
+        .crc_with_files(0, protocol_a(), metadata_a(), None, &[100])
+        .commit(
+            1,
+            [
+                commit_info("STREAMING UPDATE", None),
+                remove("a", Some(100)),
+                add("b", 200),
+            ],
+        )
+        .build()
+        .await;
+    let base = built.read_crc_at(0).unwrap();
+
+    let crc = built.incrementally_build_crc(&base).unwrap();
+
+    assert!(crc.file_stats_state().is_complete());
+    let stats = crc.file_stats().unwrap();
+    assert_eq!(stats.num_files(), 1);
+    assert_eq!(stats.table_size_bytes(), 200);
+}
+
 // === Indeterminate trips ===
 
 // Three distinct ways a single commit can lose incremental safety.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Treat `STREAMING UPDATE` commits as safe for incremental file-stat CRC replay. Streaming sink file changes are represented by normal Add and Remove actions; a Remove without a size still degrades file stats to indeterminate.

This lets a snapshot advance an asynchronously written CRC across recent streaming commits instead of unnecessarily losing file-count and byte-size metadata.

## How was this change tested?

Added `STREAMING UPDATE` to the existing operation-classification parameterized test and to the incremental-safe operation matrix.

- `cargo nextest run -p delta_kernel --lib --all-features on_commit_info_classifies_operation`
- `cargo nextest run -p delta_kernel --lib --all-features test_incremental_safe_operations`
- `cargo +nightly fmt --check`