### PR TITLE
refactor!: Use lit, define and use null_lit, remove redundant helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,10 @@ Keep this list updated when new protocol features are added to kernel.
     `DataType::Array(Box::new(ArrayType::new(...)))`.
 - Prefer the `DeltaResultIterator<'a, T>` / `DeltaResultIteratorStatic<T>` aliases over
   hand-rolled `Box<dyn Iterator<Item = DeltaResult<T>> + Send (+ 'a)>`.
+- Prefer the `lit` / `null_lit` constructors over `Expression::literal(...)` / `lit(Scalar::Null(...))`
+  when building expressions inline. They take `impl Into<Scalar>` and `impl Into<DataType>`,
+  respectively. Prefer `Predicate::TRUE` / `FALSE` / `NULL` for predicates whose value is statically
+  known, reserving `Predicate::literal(b)` for runtime `bool` values.
 - Prefer the `col!` macro and `lit(value)` constructor over `Expression::column(...)` /
   `Expression::literal(...)` when building expressions inline. `col!` uses the same
   compile-time segment rules as `column_name!` (string literals split on `.`; constants are

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -17,7 +17,8 @@ use datafusion::logical_expr::{
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::parse_json;
-use delta_kernel::expressions::{null_lit, BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
+use delta_kernel::expressions::{
+    null_lit, BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
     ParseJsonExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
 };

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -17,8 +17,7 @@ use datafusion::logical_expr::{
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine::parse_json;
-use delta_kernel::expressions::{
-    BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
+use delta_kernel::expressions::{null_lit, BinaryExpression, BinaryExpressionOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, ExpressionRef, ExpressionStructPatch, MapToStructExpression,
     ParseJsonExpression, UnaryExpressionOp, VariadicExpression, VariadicExpressionOp,
 };
@@ -537,7 +536,7 @@ mod tests {
     #[case::i64(lit(42i64), "Int64(42)")]
     #[case::string(lit("abc"), "Utf8(\"abc\")")]
     #[case::boolean(lit(true), "Boolean(true)")]
-    #[case::null(KernelExpr::null_literal(DataType::LONG), "Int64(NULL)")]
+    #[case::null(null_lit(DataType::LONG), "Int64(NULL)")]
     fn literal_lowers_to_scalar(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -5,7 +5,8 @@ use datafusion::functions_nested::expr_fn::array_has;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
-use delta_kernel::expressions::{null_lit, ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
+use delta_kernel::expressions::{
+    null_lit, ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
     BinaryPredicateOp as KernelBinaryPredicateOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
     JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -5,8 +5,7 @@ use datafusion::functions_nested::expr_fn::array_has;
 use datafusion::logical_expr::expr::InList;
 use datafusion::logical_expr::utils::{conjunction, disjunction};
 use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
-use delta_kernel::expressions::{
-    ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
+use delta_kernel::expressions::{null_lit, ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
     BinaryPredicateOp as KernelBinaryPredicateOp, ColumnName as KernelColumnName,
     Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
     JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,
@@ -258,7 +257,7 @@ mod tests {
         let elements: Vec<KernelScalar> = values.into_iter().map(KernelScalar::Long).collect();
         let array =
             KernelArrayData::try_new(ArrayType::new(DataType::LONG, false), elements).unwrap();
-        KernelExpr::literal(KernelScalar::Array(array))
+        lit(KernelScalar::Array(array))
     }
 
     /// A literal `Scalar::Array` of longs where `None` becomes a null element.
@@ -272,7 +271,7 @@ mod tests {
             .collect();
         let array =
             KernelArrayData::try_new(ArrayType::new(DataType::LONG, true), elements).unwrap();
-        KernelExpr::literal(KernelScalar::Array(array))
+        lit(KernelScalar::Array(array))
     }
 
     // === Tests ===
@@ -307,7 +306,7 @@ mod tests {
     #[case::null_needle_in_list(
         KernelPred::binary(
             KernelBinaryPredicateOp::In,
-            KernelExpr::null_literal(DataType::LONG),
+            null_lit(DataType::LONG),
             long_array([1, 2]),
         ),
         "Int64(NULL) IN ([Int64(1), Int64(2)]) IS TRUE"
@@ -408,8 +407,8 @@ mod tests {
         let in_pred = KernelPred::binary(
             KernelBinaryPredicateOp::In,
             match needle {
-                Some(n) => KernelExpr::literal(n),
-                None => KernelExpr::null_literal(DataType::LONG),
+                Some(n) => lit(n),
+                None => null_lit(DataType::LONG),
             },
             nullable_long_array(elements.to_vec()),
         );
@@ -437,8 +436,8 @@ mod tests {
         let in_pred = KernelPred::binary(
             KernelBinaryPredicateOp::In,
             match needle {
-                Some(n) => KernelExpr::literal(n),
-                None => KernelExpr::null_literal(DataType::LONG),
+                Some(n) => lit(n),
+                None => null_lit(DataType::LONG),
             },
             col!("list"),
         );

--- a/datafusion-executor/src/scalar.rs
+++ b/datafusion-executor/src/scalar.rs
@@ -277,7 +277,7 @@ mod tests {
             StructField::not_null("b", KernelDataType::STRING),
         ])
         .unwrap();
-        let value = to_df_scalar(&KernelScalar::Null(struct_type.into())).unwrap();
+        let value = to_df_scalar(&KernelScalar::null(struct_type)).unwrap();
         assert!(matches!(value, DFScalarValue::Struct(_)), "got {value:?}");
         assert!(value.is_null(), "expected a null struct, got {value:?}");
     }

--- a/ffi/src/engine_funcs.rs
+++ b/ffi/src/engine_funcs.rs
@@ -228,8 +228,8 @@ fn evaluate_expression_impl(
 mod tests {
     use std::sync::Arc;
 
+    use delta_kernel::expressions::lit;
     use delta_kernel::schema::{DataType, StructField, StructType};
-    use delta_kernel::Expression;
 
     use super::{free_expression_evaluator, new_expression_evaluator};
     use crate::ffi_test_utils::ok_or_panic;
@@ -243,7 +243,7 @@ mod tests {
         let in_schema = Arc::new(
             StructType::try_new(vec![StructField::new("a", DataType::LONG, true)]).unwrap(),
         );
-        let expr = Expression::literal(1);
+        let expr = lit(1);
         let output_type: Handle<SharedSchema> = in_schema.clone().into();
         let in_schema_handle: Handle<SharedSchema> = in_schema.into();
         unsafe {

--- a/ffi/src/expressions/arrow_eval.rs
+++ b/ffi/src/expressions/arrow_eval.rs
@@ -20,7 +20,7 @@ use delta_kernel::engine::arrow_expression::evaluate_expression::evaluate_expres
 use delta_kernel::engine::arrow_expression::opaque::{
     ArrowOpaquePredicate as _, ArrowOpaquePredicateOp,
 };
-use delta_kernel::expressions::{Expression, ExpressionRef, Scalar, ScalarExpressionEvaluator};
+use delta_kernel::expressions::{null_lit, Expression, ExpressionRef, ScalarExpressionEvaluator};
 use delta_kernel::kernel_predicates::{
     DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
     IndirectDataSkippingPredicateEvaluator, KernelPredicateEvaluator,
@@ -177,7 +177,7 @@ fn rewrite_stat_arg(
     arg: &Expression,
     type_hint: Option<&DataType>,
 ) -> Option<Expression> {
-    let null_long = || Expression::literal(Scalar::Null(DataType::LONG));
+    let null_long = || null_lit(DataType::LONG);
     match arg {
         Expression::Column(col) => {
             // The two column kinds go through the same call: a partition column resolves to its
@@ -1010,7 +1010,7 @@ mod tests {
                     Ordering::Greater => BinaryPredicateOp::GreaterThan,
                     Ordering::Equal => BinaryPredicateOp::Equal,
                 };
-                let pred = Predicate::binary(base_op, col, Expression::literal(val.clone()));
+                let pred = Predicate::binary(base_op, col, lit(val.clone()));
                 Some(if inverted { Predicate::not(pred) } else { pred })
             }
         }
@@ -1141,12 +1141,9 @@ mod tests {
             assert_eq!(fields.len(), 4);
             assert_eq!(*fields[0], stats_col("minValues", &column_name!("col")));
             assert_eq!(*fields[1], stats_col("maxValues", &column_name!("col")));
-            assert_eq!(
-                *fields[2],
-                Expression::literal(Scalar::Null(DataType::LONG))
-            );
+            assert_eq!(*fields[2], null_lit(DataType::LONG));
             assert_eq!(*fields[3], stats_col_numrecords());
-            assert_eq!(opaque.exprs[1], Expression::literal("foo"));
+            assert_eq!(opaque.exprs[1], lit("foo"));
         }
 
         /// A data column with no sibling literal gives no type hint, so min/max stats can't be
@@ -1161,13 +1158,13 @@ mod tests {
         #[test]
         fn passes_literals_through_unchanged() {
             let op = op_with_callbacks("OP");
-            let args = [Expression::literal("foo")];
+            let args = [lit("foo")];
             let pred = rewrite(&op, &args, &rewriter(), false).expect("rewrite should succeed");
             let Predicate::Opaque(opaque) = pred else {
                 panic!("expected Opaque");
             };
             assert_eq!(opaque.exprs.len(), 1, "arity preserved");
-            assert_eq!(opaque.exprs[0], Expression::literal("foo"));
+            assert_eq!(opaque.exprs[0], lit("foo"));
         }
 
         #[test]
@@ -1216,18 +1213,9 @@ mod tests {
             let Expression::Struct(fields, _) = &opaque.exprs[0] else {
                 panic!("expected Struct arg");
             };
-            assert_eq!(
-                *fields[0],
-                Expression::literal(Scalar::Null(DataType::LONG))
-            );
-            assert_eq!(
-                *fields[1],
-                Expression::literal(Scalar::Null(DataType::LONG))
-            );
-            assert_eq!(
-                *fields[2],
-                Expression::literal(Scalar::Null(DataType::LONG))
-            );
+            assert_eq!(*fields[0], null_lit(DataType::LONG));
+            assert_eq!(*fields[1], null_lit(DataType::LONG));
+            assert_eq!(*fields[2], null_lit(DataType::LONG));
             assert_eq!(*fields[3], stats_col_numrecords());
         }
 

--- a/ffi/src/expressions/engine_visitor.rs
+++ b/ffi/src/expressions/engine_visitor.rs
@@ -754,7 +754,7 @@ fn visit_predicate_internal(predicate: &Predicate, visitor: &mut EngineExpressio
 
 #[cfg(test)]
 mod tests {
-    use delta_kernel::expressions::{Expression, Scalar};
+    use delta_kernel::expressions::{lit, Expression, Scalar};
     use rstest::rstest;
 
     use super::*;
@@ -887,35 +887,35 @@ mod tests {
 
     #[rstest]
     #[case(
-        Expression::literal(Scalar::IntervalYearMonth(26)),
+        lit(Scalar::IntervalYearMonth(26)),
         LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: 26 }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalDayTime(987_654)),
+        lit(Scalar::IntervalDayTime(987_654)),
         LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: 987_654 }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalYearMonth(-13)),
+        lit(Scalar::IntervalYearMonth(-13)),
         LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: -13 }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalYearMonth(i32::MIN)),
+        lit(Scalar::IntervalYearMonth(i32::MIN)),
         LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: i32::MIN }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalYearMonth(i32::MAX)),
+        lit(Scalar::IntervalYearMonth(i32::MAX)),
         LiteralEvent::IntervalYearMonth { sibling_list_id: 0, value: i32::MAX }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalDayTime(-86_400_000_000)),
+        lit(Scalar::IntervalDayTime(-86_400_000_000)),
         LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: -86_400_000_000 }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalDayTime(i64::MIN)),
+        lit(Scalar::IntervalDayTime(i64::MIN)),
         LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: i64::MIN }
     )]
     #[case(
-        Expression::literal(Scalar::IntervalDayTime(i64::MAX)),
+        lit(Scalar::IntervalDayTime(i64::MAX)),
         LiteralEvent::IntervalDayTime { sibling_list_id: 0, value: i64::MAX }
     )]
     fn visit_expression_uses_interval_literal_callbacks(

--- a/ffi/src/expressions/kernel_visitor.rs
+++ b/ffi/src/expressions/kernel_visitor.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 #[cfg(feature = "default-engine-base")]
 use delta_kernel::engine::arrow_expression::opaque::ArrowOpaquePredicate;
 use delta_kernel::expressions::{
-    BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression, JunctionPredicateOp, Predicate,
-    Scalar, UnaryPredicateOp,
+    lit, null_lit, BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression,
+    JunctionPredicateOp, Predicate, Scalar, UnaryPredicateOp,
 };
 use delta_kernel::schema::{DataType, PrimitiveType};
 use delta_kernel::DeltaResult;
@@ -275,7 +275,7 @@ fn visit_expression_literal_string_impl(
     state: &mut KernelExpressionVisitorState,
     value: DeltaResult<String>,
 ) -> DeltaResult<usize> {
-    Ok(wrap_expression(state, Expression::literal(value?)))
+    Ok(wrap_expression(state, lit(value?)))
 }
 
 // We need to get parse.expand working to be able to macro everything below, see issue #255
@@ -284,7 +284,7 @@ pub extern "C" fn visit_expression_literal_int(
     state: &mut KernelExpressionVisitorState,
     value: i32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -292,7 +292,7 @@ pub extern "C" fn visit_expression_literal_long(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -300,7 +300,7 @@ pub extern "C" fn visit_expression_literal_short(
     state: &mut KernelExpressionVisitorState,
     value: i16,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -308,7 +308,7 @@ pub extern "C" fn visit_expression_literal_byte(
     state: &mut KernelExpressionVisitorState,
     value: i8,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -316,7 +316,7 @@ pub extern "C" fn visit_expression_literal_float(
     state: &mut KernelExpressionVisitorState,
     value: f32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -324,7 +324,7 @@ pub extern "C" fn visit_expression_literal_double(
     state: &mut KernelExpressionVisitorState,
     value: f64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 #[no_mangle]
@@ -332,7 +332,7 @@ pub extern "C" fn visit_expression_literal_bool(
     state: &mut KernelExpressionVisitorState,
     value: bool,
 ) -> usize {
-    wrap_expression(state, Expression::literal(value))
+    wrap_expression(state, lit(value))
 }
 
 /// visit a date literal expression 'value' (i32 representing days since unix epoch)
@@ -341,7 +341,7 @@ pub extern "C" fn visit_expression_literal_date(
     state: &mut KernelExpressionVisitorState,
     value: i32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(Scalar::Date(value)))
+    wrap_expression(state, lit(Scalar::Date(value)))
 }
 
 /// visit a timestamp literal expression 'value' (i64 representing microseconds since unix epoch)
@@ -350,7 +350,7 @@ pub extern "C" fn visit_expression_literal_timestamp(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(Scalar::Timestamp(value)))
+    wrap_expression(state, lit(Scalar::Timestamp(value)))
 }
 
 /// visit a timestamp_ntz literal expression 'value' (i64 representing microseconds since unix
@@ -360,7 +360,7 @@ pub extern "C" fn visit_expression_literal_timestamp_ntz(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(Scalar::TimestampNtz(value)))
+    wrap_expression(state, lit(Scalar::TimestampNtz(value)))
 }
 
 /// Visit an interval year-month literal (signed month count).
@@ -369,7 +369,7 @@ pub extern "C" fn visit_expression_literal_interval_year_month(
     state: &mut KernelExpressionVisitorState,
     value: i32,
 ) -> usize {
-    wrap_expression(state, Expression::literal(Scalar::IntervalYearMonth(value)))
+    wrap_expression(state, lit(Scalar::IntervalYearMonth(value)))
 }
 
 /// Visit an interval day-time literal (signed microsecond count).
@@ -378,7 +378,7 @@ pub extern "C" fn visit_expression_literal_interval_day_time(
     state: &mut KernelExpressionVisitorState,
     value: i64,
 ) -> usize {
-    wrap_expression(state, Expression::literal(Scalar::IntervalDayTime(value)))
+    wrap_expression(state, lit(Scalar::IntervalDayTime(value)))
 }
 
 /// visit a binary literal expression
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn visit_expression_literal_binary(
     len: usize,
 ) -> usize {
     let bytes = std::slice::from_raw_parts(value, len);
-    wrap_expression(state, Expression::literal(Scalar::Binary(bytes.to_vec())))
+    wrap_expression(state, lit(bytes))
 }
 
 /// visit a decimal literal expression
@@ -424,7 +424,7 @@ fn visit_expression_literal_decimal_impl(
     // Reconstruct the i128 from two u64 parts
     let value = ((value_hi as i128) << 64) | (value_lo as i128);
     let decimal = Scalar::decimal(value, precision, scale)?;
-    Ok(wrap_expression(state, Expression::literal(decimal)))
+    Ok(wrap_expression(state, lit(decimal)))
 }
 
 /// Type tag for null literal construction via FFI. Identifies the data type of a typed null.
@@ -617,10 +617,7 @@ fn visit_expression_literal_null_impl(
 ) -> DeltaResult<usize> {
     let tag = NullTypeTag::try_from(type_tag)?;
     let data_type = tag.to_data_type(precision, scale)?;
-    Ok(wrap_expression(
-        state,
-        Expression::literal(Scalar::Null(data_type)),
-    ))
+    Ok(wrap_expression(state, null_lit(data_type)))
 }
 
 #[no_mangle]
@@ -841,7 +838,7 @@ fn visit_predicate_opaque_with_eval_impl(
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
-    use delta_kernel::expressions::{col, lit, Expression, Scalar};
+    use delta_kernel::expressions::{col, lit, Scalar};
     use delta_kernel::schema::{ArrayType, DataType, MapType, StructField, StructType};
     use rstest::rstest;
 
@@ -1049,7 +1046,7 @@ mod tests {
         let id =
             visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
-        assert_eq!(expr, Expression::literal(Scalar::Null(data_type)),);
+        assert_eq!(expr, null_lit(data_type),);
     }
 
     #[test]
@@ -1061,7 +1058,7 @@ mod tests {
         let id =
             visit_expression_literal_null_impl(&mut state, tag as u8, precision, scale).unwrap();
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
-        assert_eq!(expr, Expression::literal(Scalar::Null(dt)));
+        assert_eq!(expr, null_lit(dt));
     }
 
     #[rstest]
@@ -1085,7 +1082,7 @@ mod tests {
             _ => unreachable!(),
         };
         let expr = unwrap_kernel_expression(&mut state, id).unwrap();
-        assert_eq!(expr, Expression::literal(expected));
+        assert_eq!(expr, lit(expected));
     }
 
     // ============================================================================
@@ -1140,8 +1137,8 @@ mod tests {
     }
 
     fn make_two_literal_ids(state: &mut KernelExpressionVisitorState) -> (usize, usize) {
-        let a = wrap_expression(state, Expression::literal(1i32));
-        let b = wrap_expression(state, Expression::literal(2i32));
+        let a = wrap_expression(state, lit(1i32));
+        let b = wrap_expression(state, lit(2i32));
         (a, b)
     }
 

--- a/ffi/src/test_ffi.rs
+++ b/ffi/src/test_ffi.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use delta_kernel::expressions::{
-    col, column_name, column_pred, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
+    col, column_name, column_pred, lit, null_lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
     Expression as Expr, ExpressionStructPatchBuilder, MapData, OpaqueExpressionOp,
     OpaquePredicateOp, Predicate as Pred, Scalar, ScalarExpressionEvaluator, StructData,
 };
@@ -129,41 +129,38 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
 
     let mut sub_exprs = vec![
         col!("col"),
-        Expr::literal(i8::MAX),
-        Expr::literal(i8::MIN),
-        Expr::literal(f32::MAX),
-        Expr::literal(f32::MIN),
-        Expr::literal(f64::MAX),
-        Expr::literal(f64::MIN),
-        Expr::literal(i32::MAX),
-        Expr::literal(i32::MIN),
-        Expr::literal(i64::MAX),
-        Expr::literal(i64::MIN),
-        Expr::literal("hello expressions"),
-        Expr::literal(true),
-        Expr::literal(false),
-        Scalar::Timestamp(50).into(),
-        Scalar::TimestampNtz(100).into(),
-        Scalar::Date(32).into(),
-        Scalar::Binary(0x0000deadbeefcafeu64.to_be_bytes().to_vec()).into(),
+        lit(i8::MAX),
+        lit(i8::MIN),
+        lit(f32::MAX),
+        lit(f32::MIN),
+        lit(f64::MAX),
+        lit(f64::MIN),
+        lit(i32::MAX),
+        lit(i32::MIN),
+        lit(i64::MAX),
+        lit(i64::MIN),
+        lit("hello expressions"),
+        lit(true),
+        lit(false),
+        lit(Scalar::Timestamp(50)),
+        lit(Scalar::TimestampNtz(100)),
+        lit(Scalar::Date(32)),
+        lit(0x0000deadbeefcafeu64.to_be_bytes().to_vec()),
         // Both the most and least significant u64 of the Decimal value will be 1
-        Scalar::decimal((1i128 << 64) + 1, 20, 3).unwrap().into(),
-        Expr::null_literal(DataType::SHORT),
-        Scalar::Struct(top_level_struct).into(),
+        lit(Scalar::decimal((1i128 << 64) + 1, 20, 3).unwrap()),
+        null_lit(DataType::SHORT),
+        lit(top_level_struct),
         Expr::struct_patch(top_level_patch).unwrap(),
         Expr::struct_patch(ExpressionStructPatchBuilder::new()).unwrap(),
         Expr::struct_patch(empty_nested_patch).unwrap(),
-        Scalar::Array(array_data).into(),
-        Scalar::Map(map_data).into(),
-        Expr::struct_from([Expr::literal(5_i32), Expr::literal(20_i64)]),
-        Expr::opaque(
-            OpaqueTestOp("foo".to_string()),
-            vec![Expr::literal(42), Expr::literal(1.111)],
-        ),
+        lit(array_data),
+        lit(map_data),
+        Expr::struct_from([lit(5_i32), lit(20_i64)]),
+        Expr::opaque(OpaqueTestOp("foo".to_string()), vec![lit(42), lit(1.111)]),
         Expr::unknown("mystery"),
         Expr::map_to_struct(col!("pv")),
         Expr::coalesce([col!("col"), lit(0_i32)]),
-        Expr::array([Expr::literal(1_i32), Expr::literal(2_i32)]),
+        Expr::array([lit(1_i32), lit(2_i32)]),
     ];
     sub_exprs.extend(
         [
@@ -173,7 +170,7 @@ pub unsafe extern "C" fn get_testing_kernel_expression() -> Handle<SharedExpress
             BinaryExpressionOp::Minus,
         ]
         .into_iter()
-        .map(|op| Expr::binary(op, Expr::literal(0), Expr::literal(0))),
+        .map(|op| Expr::binary(op, lit(0), lit(0))),
     );
 
     Arc::new(Expr::struct_from(sub_exprs)).into()
@@ -200,23 +197,17 @@ pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicat
         Pred::FALSE,
         Pred::binary(
             BinaryPredicateOp::In,
-            Expr::literal(10),
+            lit(10),
             Scalar::Array(array_data.clone()),
         ),
         Pred::not(Pred::binary(
             BinaryPredicateOp::In,
-            Expr::literal(10),
+            lit(10),
             Scalar::Array(array_data),
         )),
-        Pred::or_from(vec![
-            Pred::eq(Expr::literal(5), Expr::literal(10)),
-            Pred::ne(Expr::literal(20), Expr::literal(10)),
-        ]),
+        Pred::or_from(vec![Pred::eq(lit(5), lit(10)), Pred::ne(lit(20), lit(10))]),
         Pred::is_not_null(col!("col")),
-        Pred::opaque(
-            OpaqueTestOp("bar".to_string()),
-            vec![Expr::literal(42), Expr::literal(1.111)],
-        ),
+        Pred::opaque(OpaqueTestOp("bar".to_string()), vec![lit(42), lit(1.111)]),
         Pred::unknown("intrigue"),
     ];
     sub_exprs.extend(
@@ -230,7 +221,7 @@ pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicat
             Pred::distinct,
         ]
         .into_iter()
-        .map(|op_fn| op_fn(Expr::literal(0), Expr::literal(0))),
+        .map(|op_fn| op_fn(lit(0), lit(0))),
     );
 
     Arc::new(Pred::and_from(sub_exprs)).into()
@@ -245,44 +236,24 @@ pub unsafe extern "C" fn get_testing_kernel_predicate() -> Handle<SharedPredicat
 pub unsafe extern "C" fn get_simple_testing_kernel_expression() -> Handle<SharedExpression> {
     let sub_exprs = vec![
         col!("simple_col"),
-        Expr::literal(42i32),
-        Expr::literal(100i64),
-        Expr::literal(2.5f64), // Using 2.5 to avoid clippy::approx_constant warning
-        Expr::literal(true),
-        Expr::literal(false),
-        Expr::literal("test string"),
-        Scalar::Date(19000).into(),
-        Scalar::Timestamp(1234567890).into(),
-        Scalar::TimestampNtz(9876543210).into(),
-        Scalar::IntervalYearMonth(-13).into(),
-        Scalar::IntervalDayTime(9_876_543_210).into(),
-        Expr::null_literal(DataType::INTEGER),
-        Expr::null_literal(DataType::decimal(10, 5).unwrap()),
-        Expr::binary(
-            BinaryExpressionOp::Plus,
-            Expr::literal(10),
-            Expr::literal(20),
-        ),
-        Expr::binary(
-            BinaryExpressionOp::Minus,
-            Expr::literal(50),
-            Expr::literal(30),
-        ),
-        Expr::binary(
-            BinaryExpressionOp::Multiply,
-            Expr::literal(5),
-            Expr::literal(6),
-        ),
-        Expr::binary(
-            BinaryExpressionOp::Divide,
-            Expr::literal(100),
-            Expr::literal(4),
-        ),
-        Expr::struct_from([
-            Expr::literal(1_i32),
-            Expr::literal(2_i64),
-            Expr::literal(3.0_f64),
-        ]),
+        lit(42i32),
+        lit(100i64),
+        lit(2.5f64), // Using 2.5 to avoid clippy::approx_constant warning
+        lit(true),
+        lit(false),
+        lit("test string"),
+        lit(Scalar::Date(19000)),
+        lit(Scalar::Timestamp(1234567890)),
+        lit(Scalar::TimestampNtz(9876543210)),
+        lit(Scalar::IntervalYearMonth(-13)),
+        lit(Scalar::IntervalDayTime(9_876_543_210)),
+        null_lit(DataType::INTEGER),
+        null_lit(DataType::decimal(10, 5).unwrap()),
+        Expr::binary(BinaryExpressionOp::Plus, lit(10), lit(20)),
+        Expr::binary(BinaryExpressionOp::Minus, lit(50), lit(30)),
+        Expr::binary(BinaryExpressionOp::Multiply, lit(5), lit(6)),
+        Expr::binary(BinaryExpressionOp::Divide, lit(100), lit(4)),
+        Expr::struct_from([lit(1_i32), lit(2_i64), lit(3.0_f64)]),
         Expr::map_to_struct(col!("partitionValues")),
     ];
     Arc::new(Expr::struct_from(sub_exprs)).into()
@@ -299,20 +270,17 @@ pub unsafe extern "C" fn get_simple_testing_kernel_predicate() -> Handle<SharedP
         column_pred!("pred_col"),
         Pred::TRUE,
         Pred::FALSE,
-        Pred::eq(Expr::literal(10), Expr::literal(10)),
-        Pred::ne(Expr::literal(5), Expr::literal(10)),
-        Pred::lt(Expr::literal(5), Expr::literal(10)),
-        Pred::le(Expr::literal(10), Expr::literal(10)),
-        Pred::gt(Expr::literal(20), Expr::literal(10)),
-        Pred::ge(Expr::literal(10), Expr::literal(10)),
-        Pred::distinct(Expr::literal(1), Expr::literal(2)),
+        Pred::eq(lit(10), lit(10)),
+        Pred::ne(lit(5), lit(10)),
+        Pred::lt(lit(5), lit(10)),
+        Pred::le(lit(10), lit(10)),
+        Pred::gt(lit(20), lit(10)),
+        Pred::ge(lit(10), lit(10)),
+        Pred::distinct(lit(1), lit(2)),
         Pred::is_null(col!("nullable_col")),
         Pred::is_not_null(col!("nonnull_col")),
         Pred::not(Pred::FALSE),
-        Pred::or_from(vec![
-            Pred::eq(Expr::literal(1), Expr::literal(1)),
-            Pred::eq(Expr::literal(2), Expr::literal(2)),
-        ]),
+        Pred::or_from(vec![Pred::eq(lit(1), lit(1)), Pred::eq(lit(2), lit(2))]),
     ];
     Arc::new(Pred::and_from(sub_preds)).into()
 }

--- a/kernel/src/checkpoint/sidecar/mod.rs
+++ b/kernel/src/checkpoint/sidecar/mod.rs
@@ -6,7 +6,7 @@ use crate::action_reconciliation::ActionReconciliationIterator;
 use crate::actions::{ADD_NAME, REMOVE_NAME, SIDECAR_NAME};
 use crate::engine_data::filter_by_predicate;
 use crate::expressions::{
-    col, lit, Expression, ExpressionStructPatchBuilder, Predicate, Scalar, StructData,
+    col, null_lit, Expression, ExpressionStructPatchBuilder, Predicate, Scalar, StructData,
 };
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::{
@@ -203,11 +203,8 @@ impl SidecarSplitter {
             checkpoint_data_schema.clone(),
             Arc::new(Expression::struct_patch(
                 ExpressionStructPatchBuilder::new()
-                    .replace(ADD_NAME, lit(Scalar::Null(add_field.data_type.clone())))
-                    .replace(
-                        REMOVE_NAME,
-                        lit(Scalar::Null(remove_field.data_type.clone())),
-                    ),
+                    .replace(ADD_NAME, null_lit(add_field.data_type.clone()))
+                    .replace(REMOVE_NAME, null_lit(remove_field.data_type.clone())),
             )?),
             checkpoint_data_schema.clone().into(),
         )?;

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -1128,7 +1128,7 @@ mod tests {
         DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
     };
     use crate::expressions::{
-        col, column_expr_ref, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
+        col, column_expr_ref, lit, null_lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp,
         Expression as Expr, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData,
         Predicate as Pred, StructData,
     };
@@ -1853,11 +1853,11 @@ mod tests {
         let batch = create_test_batch();
 
         // Valid: literal matches expected type
-        let result = evaluate_expression(&Expr::literal(42), &batch, Some(&DataType::INTEGER));
+        let result = evaluate_expression(&lit(42), &batch, Some(&DataType::INTEGER));
         assert!(result.is_ok());
 
         // Error: literal type mismatch
-        let result = evaluate_expression(&Expr::literal(42), &batch, Some(&DataType::STRING));
+        let result = evaluate_expression(&lit(42), &batch, Some(&DataType::STRING));
         assert_result_error_with_message(result, "Incorrect datatype");
     }
 
@@ -1969,7 +1969,7 @@ mod tests {
         let (literal_source, column_source, batch) = in_element_sources(elements);
         let needle = match needle {
             Some(n) => lit(n),
-            None => Expr::null_literal(DataType::INTEGER),
+            None => null_lit(DataType::INTEGER),
         };
         for elements in [literal_source, column_source] {
             let pred = Pred::binary(BinaryPredicateOp::In, needle.clone(), elements);
@@ -3476,7 +3476,7 @@ mod tests {
     // the Arrow Debug formatter for `DataType` since that may change.
     #[case::input_type_mismatch(
         create_test_batch(),
-        Expr::array([Expr::literal(1_i32), Expr::literal(2_i32), Expr::literal("text")]),
+        Expr::array([lit(1_i32), lit(2_i32), lit("text")]),
         None,
         "input 2",
     )]

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -144,17 +144,17 @@ fn test_in_predicate_with_list_view_column() {
 #[case::utf8view(
     Arc::new(StringViewArray::from(vec![None, Some("apple"), Some("hello"), Some("zebra")])) as ArrayRef,
     DataType::Utf8View,
-    Expr::literal("hello"),
+    lit("hello"),
 )]
 #[case::large_utf8(
     Arc::new(GenericStringArray::<i64>::from(vec![None, Some("apple"), Some("hello"), Some("zebra")])) as ArrayRef,
     DataType::LargeUtf8,
-    Expr::literal("hello"),
+    lit("hello"),
 )]
 #[case::binary_view(
     Arc::new(BinaryViewArray::from(vec![None, Some(b"apple".as_ref()), Some(b"hello"), Some(b"zebra")])) as ArrayRef,
     DataType::BinaryView,
-    Expr::literal(b"hello".as_ref()),
+    lit(b"hello".as_ref()),
 )]
 fn test_binary_predicate_with_view_types(
     #[case] array: ArrayRef,
@@ -228,7 +228,7 @@ fn test_literal_type_array() {
 
     let not_in_op = Pred::not(Pred::binary(
         BinaryPredicateOp::In,
-        Expr::literal(5),
+        lit(5),
         Scalar::Array(
             ArrayData::try_new(
                 ArrayType::new(KernelDataType::INTEGER, false),
@@ -465,23 +465,23 @@ fn test_binary_op_scalar() {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
     let column = col!("a");
 
-    let expression = column.clone().add(Expr::literal(1));
+    let expression = column.clone().add(lit(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![2, 3, 4]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().sub(Expr::literal(1));
+    let expression = column.clone().sub(lit(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![0, 1, 2]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    let expression = column.clone().mul(Expr::literal(2));
+    let expression = column.clone().mul(lit(2));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
     // TODO handle type casting
-    let expression = column.div(Expr::literal(1));
+    let expression = column.div(lit(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
     let expected = Arc::new(Int32Array::from(vec![1, 2, 3]));
     assert_eq!(results.as_ref(), expected.as_ref())
@@ -525,32 +525,32 @@ fn test_binary_cmp() {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(values)]).unwrap();
     let column = col!("a");
 
-    let predicate_lt = column.clone().lt(Expr::literal(2));
+    let predicate_lt = column.clone().lt(lit(2));
     let results = evaluate_predicate(&predicate_lt, &batch, false).unwrap();
     let expected_lt = BooleanArray::from(vec![true, false, false]);
     assert_eq!(results, expected_lt);
 
-    let predicate_le = column.clone().le(Expr::literal(2));
+    let predicate_le = column.clone().le(lit(2));
     let results = evaluate_predicate(&predicate_le, &batch, false).unwrap();
     let expected_le = BooleanArray::from(vec![true, true, false]);
     assert_eq!(results, expected_le);
 
-    let predicate_gt = column.clone().gt(Expr::literal(2));
+    let predicate_gt = column.clone().gt(lit(2));
     let results = evaluate_predicate(&predicate_gt, &batch, false).unwrap();
     let expected_gt = BooleanArray::from(vec![false, false, true]);
     assert_eq!(results, expected_gt);
 
-    let predicate_ge = column.clone().ge(Expr::literal(2));
+    let predicate_ge = column.clone().ge(lit(2));
     let results = evaluate_predicate(&predicate_ge, &batch, false).unwrap();
     let expected_ge = BooleanArray::from(vec![false, true, true]);
     assert_eq!(results, expected_ge);
 
-    let predicate_eq = column.clone().eq(Expr::literal(2));
+    let predicate_eq = column.clone().eq(lit(2));
     let results = evaluate_predicate(&predicate_eq, &batch, false).unwrap();
     let expected_eq = BooleanArray::from(vec![false, true, false]);
     assert_eq!(results, expected_eq);
 
-    let predicate_ne = column.clone().ne(Expr::literal(2));
+    let predicate_ne = column.clone().ne(lit(2));
     let results = evaluate_predicate(&predicate_ne, &batch, false).unwrap();
     let expected_ne = BooleanArray::from(vec![true, false, true]);
     assert_eq!(results, expected_ne);

--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -517,7 +517,7 @@ mod tests {
     }
 
     fn null_dv() -> Scalar {
-        Scalar::Null(DataType::from(DeletionVectorDescriptor::to_schema()))
+        Scalar::null(DeletionVectorDescriptor::to_schema())
     }
 
     fn present_dv() -> Scalar {

--- a/kernel/src/expressions/literal_expression_transform.rs
+++ b/kernel/src/expressions/literal_expression_transform.rs
@@ -3,7 +3,7 @@
 
 use std::ops::Deref as _;
 
-use crate::expressions::{Expression, Scalar};
+use crate::expressions::{null_lit, Expression, Scalar};
 use crate::schema::{ArrayType, DataType, MapType, PrimitiveType, StructType};
 use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::DeltaResult;
@@ -126,7 +126,7 @@ impl<'a, T: Iterator<Item = &'a Scalar>> SchemaTransform<'a> for LiteralExpressi
                     "NULL value for non-nullable struct field with non-NULL siblings".to_string(),
                 ));
             }
-            Expression::null_literal(struct_type.clone().into())
+            null_lit(struct_type.clone())
         } else {
             Expression::struct_from(field_exprs)
         };
@@ -156,7 +156,7 @@ mod tests {
     use Expression as Expr;
 
     use super::*;
-    use crate::expressions::{ArrayData, MapData};
+    use crate::expressions::{lit, ArrayData, MapData};
     use crate::schema::{schema_ref, SchemaRef, StructField, StructType};
     use crate::DataType as DeltaDataTypes;
 
@@ -178,11 +178,11 @@ mod tests {
         let values = &[Scalar::Null(DeltaDataTypes::INTEGER)];
 
         let schema = schema_ref! { not_null "col_1": INTEGER };
-        let expected = Expr::null_literal(schema.clone().into());
+        let expected = null_lit(schema.clone());
         assert_single_row_transform(values, schema, Ok(expected));
 
         let schema = schema_ref! { nullable "col_1": INTEGER };
-        let expected = Expr::struct_from(vec![Expr::null_literal(DeltaDataTypes::INTEGER)]);
+        let expected = Expr::struct_from(vec![null_lit(DeltaDataTypes::INTEGER)]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
 
@@ -231,8 +231,8 @@ mod tests {
             },
         };
         let expected = Expr::struct_from(vec![
-            Expr::struct_from(vec![Expr::literal(1), Expr::literal(2)]),
-            Expr::struct_from(vec![Expr::literal(3), Expr::literal(4)]),
+            Expr::struct_from(vec![lit(1), lit(2)]),
+            Expr::struct_from(vec![lit(3), lit(4)]),
         ]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
@@ -251,10 +251,7 @@ mod tests {
             StructField::nullable("map", map_type),
             StructField::nullable("array", array_type),
         ]));
-        let expected = Expr::struct_from(vec![
-            Expr::literal(Scalar::Map(map_data)),
-            Expr::literal(Scalar::Array(array_data)),
-        ]);
+        let expected = Expr::struct_from(vec![lit(map_data), lit(array_data)]);
         assert_single_row_transform(values, schema, Ok(expected));
     }
 
@@ -295,15 +292,13 @@ mod tests {
 
         let expected_result = match expected {
             Expected::Noop => {
-                let nested_struct = Expr::struct_from(vec![
-                    Expr::literal(values[0].clone()),
-                    Expr::literal(values[1].clone()),
-                ]);
+                let nested_struct =
+                    Expr::struct_from(vec![lit(values[0].clone()), lit(values[1].clone())]);
                 Ok(Expr::struct_from([nested_struct]))
             }
-            Expected::Null => Ok(Expr::null_literal(schema.clone().into())),
+            Expected::Null => Ok(null_lit(schema.clone())),
             Expected::NullStruct => {
-                let nested_null = Expr::null_literal(field_x.data_type().clone());
+                let nested_null = null_lit(field_x.data_type().clone());
                 Ok(Expr::struct_from([nested_null]))
             }
             Expected::Error => Err(()),

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -47,6 +47,24 @@ pub fn lit(value: impl Into<Scalar>) -> Expression {
     Expression::literal(value)
 }
 
+/// Build a typed NULL [`Expression::Literal`].
+///
+/// Prefer this over `lit(Scalar::Null(...))`. Accepts anything convertible into a [`DataType`]
+/// (including container types like [`StructType`](crate::schema::StructType)), so callers can
+/// skip an explicit `DataType::from(...)` wrapper.
+///
+/// ```
+/// # use delta_kernel::expressions::{lit, null_lit, Scalar};
+/// # use delta_kernel::schema::DataType;
+/// assert_eq!(
+///     lit(Scalar::Null(DataType::LONG)),
+///     null_lit(DataType::LONG),
+/// );
+/// ```
+pub fn null_lit(data_type: impl Into<DataType>) -> Expression {
+    Expression::Literal(Scalar::null(data_type))
+}
+
 /// A [`StructPatchBuilder`](crate::struct_patch::StructPatchBuilder) whose emitted items are
 /// expressions, lowered into an [`ExpressionStructPatch`] that can be embedded in an
 /// [`Expression`].
@@ -701,11 +719,6 @@ impl Expression {
         Self::Literal(value.into())
     }
 
-    /// Creates a NULL literal expression
-    pub const fn null_literal(data_type: DataType) -> Self {
-        Self::Literal(Scalar::Null(data_type))
-    }
-
     /// Wraps a predicate as a boolean-valued expression
     pub fn from_pred(value: Predicate) -> Self {
         match value {
@@ -872,12 +885,13 @@ impl Expression {
 }
 
 impl Predicate {
-    /// Literal boolean true
+    /// Literal boolean true.
     pub const TRUE: Self = Self::literal(true);
-    /// Literal boolean false
+    /// Literal boolean false.
     pub const FALSE: Self = Self::literal(false);
-    /// NULL boolean literal
-    pub const NULL: Self = Self::null_literal();
+    /// NULL boolean literal.
+    pub const NULL: Self =
+        Self::BooleanExpression(Expression::Literal(Scalar::Null(DataType::BOOLEAN)));
 
     /// Returns a set of columns referenced by this predicate.
     pub fn references(&self) -> HashSet<&ColumnName> {
@@ -891,14 +905,11 @@ impl Predicate {
         Self::from_expr(ColumnName::new(field_names))
     }
 
-    /// Create a new literal boolean value. See also [`Self::TRUE`] and [`Self::FALSE`].
+    /// Create a boolean literal predicate from a runtime `bool`.
+    ///
+    /// Prefer [`Self::TRUE`] / [`Self::FALSE`] when the value is statically known.
     pub const fn literal(value: bool) -> Self {
         Self::BooleanExpression(Expression::Literal(Scalar::Boolean(value)))
-    }
-
-    /// Creates a NULL literal boolean value. Prefer [`Self::NULL`].
-    pub const fn null_literal() -> Self {
-        Self::BooleanExpression(Expression::Literal(Scalar::Null(DataType::BOOLEAN)))
     }
 
     /// Converts a boolean-valued expression into a predicate
@@ -1011,8 +1022,8 @@ impl Predicate {
         let mut preds: Vec<_> = preds.into_iter().collect();
         match preds.len() {
             0 => match op {
-                JunctionPredicateOp::And => Self::literal(true),
-                JunctionPredicateOp::Or => Self::literal(false),
+                JunctionPredicateOp::And => Self::TRUE,
+                JunctionPredicateOp::Or => Self::FALSE,
             },
             // A junction of one predicate is just that predicate.
             1 => preds.remove(0),
@@ -1341,8 +1352,8 @@ mod tests {
         use super::assert_roundtrip;
         use crate::expressions::scalars::{ArrayData, DecimalData, MapData, StructData};
         use crate::expressions::{
-            col, column_name, lit, BinaryExpressionOp, BinaryPredicateOp, ColumnName, Expression,
-            ExpressionStructPatchBuilder, Predicate, Scalar, UnaryExpressionOp,
+            col, column_name, lit, null_lit, BinaryExpressionOp, BinaryPredicateOp, ColumnName,
+            Expression, ExpressionStructPatchBuilder, Predicate, Scalar, UnaryExpressionOp,
         };
         use crate::schema::{ArrayType, DataType, DecimalType, MapType, StructField};
         use crate::unit_test_utils::assert_result_error_with_message;
@@ -1354,22 +1365,22 @@ mod tests {
             // Test all primitive scalar types that have proper PartialEq
             let cases: Vec<Expression> = vec![
                 // Numeric types
-                Expression::literal(42i32),         // Integer
-                Expression::literal(9999999999i64), // Long
-                Expression::literal(123i16),        // Short
-                Expression::literal(42i8),          // Byte
-                Expression::literal(1.12345677_32), // Float
-                Expression::literal(1.12345667_64), // Double
+                lit(42i32),         // Integer
+                lit(9999999999i64), // Long
+                lit(123i16),        // Short
+                lit(42i8),          // Byte
+                lit(1.12345677_32), // Float
+                lit(1.12345667_64), // Double
                 // String and Boolean
-                Expression::literal("hello world"),
-                Expression::literal(true),
-                Expression::literal(false),
+                lit("hello world"),
+                lit(true),
+                lit(false),
                 // Temporal types
                 Expression::Literal(Scalar::Timestamp(1234567890000000)),
                 Expression::Literal(Scalar::TimestampNtz(1234567890000000)),
                 Expression::Literal(Scalar::Date(19000)),
                 // Binary
-                Expression::Literal(Scalar::Binary(vec![1, 2, 3, 4, 5])),
+                lit(vec![1u8, 2, 3, 4, 5]),
                 // Decimal
                 Expression::Literal(Scalar::Decimal(
                     DecimalData::try_new(12345i128, DecimalType::try_new(10, 2).unwrap()).unwrap(),
@@ -1386,9 +1397,9 @@ mod tests {
             // Test complex scalar types that need JSON comparison (partial_cmp returns None)
             let cases: Vec<Expression> = vec![
                 // Null with different types
-                Expression::null_literal(DataType::INTEGER),
-                Expression::null_literal(DataType::STRING),
-                Expression::null_literal(DataType::BOOLEAN),
+                null_lit(DataType::INTEGER),
+                null_lit(DataType::STRING),
+                null_lit(DataType::BOOLEAN),
                 // Array
                 Expression::Literal(Scalar::Array(
                     ArrayData::try_new(
@@ -1731,7 +1742,7 @@ mod tests {
                 }
             }
 
-            let expr = Expression::opaque(TestOpaqueExprOp, [Expression::literal(1)]);
+            let expr = Expression::opaque(TestOpaqueExprOp, [lit(1)]);
             let result = serde_json::to_string(&expr);
             assert_result_error_with_message(result, "Cannot serialize an Opaque Expression");
         }
@@ -1779,7 +1790,7 @@ mod tests {
                 }
             }
 
-            let pred = Predicate::opaque(TestOpaquePredOp, [Expression::literal(1)]);
+            let pred = Predicate::opaque(TestOpaquePredOp, [lit(1)]);
             let result = serde_json::to_string(&pred);
             assert_result_error_with_message(result, "Cannot serialize an Opaque Predicate");
         }

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -705,6 +705,12 @@ impl From<&[u8]> for Scalar {
     }
 }
 
+impl From<Vec<u8>> for Scalar {
+    fn from(b: Vec<u8>) -> Self {
+        Self::Binary(b)
+    }
+}
+
 impl From<bytes::Bytes> for Scalar {
     fn from(b: bytes::Bytes) -> Self {
         Self::Binary(b.into())
@@ -1839,6 +1845,13 @@ mod tests {
         } else {
             panic!("Expected Binary scalar");
         }
+
+        // Owned Vec moves into Binary without reallocation via slice.
+        let owned = vec![9u8, 8, 7];
+        let from_vec: Scalar = owned.into();
+        assert_eq!(from_vec, Scalar::Binary(vec![9, 8, 7]));
+        let from_slice: Scalar = [9u8, 8, 7].as_slice().into();
+        assert_eq!(from_slice, Scalar::Binary(vec![9, 8, 7]));
 
         // Test with empty bytes
         let empty_bytes = bytes::Bytes::new();

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -12,7 +12,7 @@
 //! Delta metadata contains today. If the supported SQL surface grows, options include moving
 //! parsing behind the [`Engine`](crate::Engine) trait or adopting an existing SQL parser library.
 
-use crate::expressions::{Expression, Scalar};
+use crate::expressions::{lit, null_lit, Expression, Scalar};
 use crate::schema::{DataType, PrimitiveType};
 use crate::{DeltaResult, Error};
 
@@ -32,7 +32,7 @@ mod token;
 ///
 /// The SQL comes from table metadata. A column declared `c DATE DEFAULT DATE '2024-01-01'` stores
 /// the string `DATE '2024-01-01'` as its default, and `parse_sql("DATE '2024-01-01'", &DATE)`
-/// parses it into `Expression::literal(Scalar::Date(..))`. The bare form `'2024-01-01'` is
+/// parses it into `lit(Scalar::Date(..))`. The bare form `'2024-01-01'` is
 /// equivalent; the `DATE` keyword is optional.
 ///
 /// # Errors
@@ -46,7 +46,7 @@ pub(crate) fn parse_sql(sql: &str, data_type: &DataType) -> DeltaResult<Expressi
     }
     // NULL is valid for any data type, including non-primitive ones.
     if trimmed.eq_ignore_ascii_case("null") {
-        return Ok(Expression::literal(Scalar::Null(data_type.clone())));
+        return Ok(null_lit(data_type.clone()));
     }
     // TODO(#2630): support SQL function calls (e.g. `current_date()`) when column defaults
     // need them.
@@ -76,7 +76,7 @@ fn parse_literal(trimmed: &str, data_type: &DataType, sql: &str) -> DeltaResult<
         }
         _ => primitive.parse_scalar(trimmed)?,
     };
-    Ok(Expression::literal(scalar))
+    Ok(lit(scalar))
 }
 
 /// Build a `Scalar::String` from a single-quoted body via [`unquote_string`] (e.g. `'it''s'` ->
@@ -408,7 +408,7 @@ mod tests {
     )]
     fn parses_basic_literals(#[case] sql: &str, #[case] ty: DataType, #[case] expected: Scalar) {
         let got = parse_sql(sql, &ty).unwrap();
-        assert_eq!(got, Expression::literal(expected));
+        assert_eq!(got, lit(expected));
     }
 
     #[rstest]
@@ -420,7 +420,7 @@ mod tests {
     #[case("DATE ' 2024-01-01 '", date_days(2024, 1, 1))]
     fn parses_date_literals(#[case] sql: &str, #[case] expected_days: i32) {
         let got = parse_sql(sql, &DataType::DATE).unwrap();
-        assert_eq!(got, Expression::literal(Scalar::Date(expected_days)));
+        assert_eq!(got, lit(Scalar::Date(expected_days)));
     }
 
     #[rstest]
@@ -431,10 +431,7 @@ mod tests {
     #[case("' 2024-01-01 12:34:56 '", "2024-01-01 12:34:56")] // body is trimmed, matching Spark
     fn parses_zoneless_timestamp_ntz_literals(#[case] sql: &str, #[case] equivalent: &str) {
         let got = parse_sql(sql, &DataType::TIMESTAMP_NTZ).unwrap();
-        assert_eq!(
-            got,
-            Expression::literal(Scalar::TimestampNtz(ts_micros(equivalent)))
-        );
+        assert_eq!(got, lit(Scalar::TimestampNtz(ts_micros(equivalent))));
     }
 
     #[rstest]
@@ -513,10 +510,7 @@ mod tests {
     #[case("TIMESTAMP_LTZ'1970-01-01T00:00:00.123Z'", "1970-01-01 00:00:00.123")] // butted against quote
     fn iso_8601_form_accepted_only_for_timestamp(#[case] sql: &str, #[case] equivalent: &str) {
         let got = parse_sql(sql, &DataType::TIMESTAMP).unwrap();
-        assert_eq!(
-            got,
-            Expression::literal(Scalar::Timestamp(ts_micros(equivalent)))
-        );
+        assert_eq!(got, lit(Scalar::Timestamp(ts_micros(equivalent))));
         parse_sql(sql, &DataType::TIMESTAMP_NTZ).unwrap_err();
     }
 
@@ -527,7 +521,7 @@ mod tests {
     #[case("x'01ff'", vec![0x01, 0xff])]
     fn parses_binary_literals(#[case] sql: &str, #[case] expected: Vec<u8>) {
         let got = parse_sql(sql, &DataType::BINARY).unwrap();
-        assert_eq!(got, Expression::literal(Scalar::Binary(expected)));
+        assert_eq!(got, lit(expected));
     }
 
     #[rstest]
@@ -538,10 +532,10 @@ mod tests {
     #[case(DataType::BINARY)]
     fn null_is_accepted_for_any_primitive(#[case] ty: DataType) {
         let got = parse_sql("NULL", &ty).unwrap();
-        assert_eq!(got, Expression::literal(Scalar::Null(ty.clone())));
+        assert_eq!(got, null_lit(ty.clone()));
         // also case-insensitive
         let got_lower = parse_sql(" null ", &ty).unwrap();
-        assert_eq!(got_lower, Expression::literal(Scalar::Null(ty)));
+        assert_eq!(got_lower, null_lit(ty));
     }
 
     /// As the parser grows new capabilities (typed numeric suffixes, CAST, foldable
@@ -694,7 +688,7 @@ mod tests {
     fn float_exponent_literal_double_rounds_to_match_spark() {
         let got = parse_sql("7.038531E-26", &DataType::FLOAT).unwrap();
         let spark = "7.038531E-26".parse::<f64>().unwrap() as f32;
-        assert_eq!(got, Expression::literal(Scalar::Float(spark)));
+        assert_eq!(got, lit(spark));
         assert_eq!(spark.to_bits(), 0x15ae_43fe);
         // The value a direct decimal->f32 parse (single rounding) would have produced -- 1 ULP off.
         assert_ne!(
@@ -799,6 +793,6 @@ mod tests {
     #[case::map_target(map_ty())]
     fn null_is_accepted_for_non_primitive_target(#[case] ty: DataType) {
         let got = parse_sql("NULL", &ty).unwrap();
-        assert_eq!(got, Expression::literal(Scalar::Null(ty)));
+        assert_eq!(got, null_lit(ty));
     }
 }

--- a/kernel/src/kernel_predicates/tests.rs
+++ b/kernel/src/kernel_predicates/tests.rs
@@ -265,22 +265,22 @@ fn test_default_scalar_arithmetic() {
     let filter = DefaultKernelPredicateEvaluator::from(Scalar::from(1));
     for ((l, r), (add, sub, mul, div)) in left.iter().zip(right).zip(expected) {
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) + Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) + lit(r.clone()))),
             Some(add),
             "add({l:?}, {r:?})"
         );
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) - Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) - lit(r.clone()))),
             Some(sub),
             "sub({l:?}, {r:?})"
         );
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) * Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) * lit(r.clone()))),
             Some(mul),
             "mul({l:?}, {r:?})"
         );
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) / Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) / lit(r.clone()))),
             Some(div),
             "div({l:?}, {r:?})"
         );
@@ -288,27 +288,27 @@ fn test_default_scalar_arithmetic() {
 
     // Invalid type combinations
     expect_eq!(
-        filter.eval_expr(&(Expr::literal("hi") + Expr::literal("ho"))),
+        filter.eval_expr(&(lit("hi") + lit("ho"))),
         None,
         "add(string, string)"
     );
     expect_eq!(
-        filter.eval_expr(&(Expr::literal(1i8) + Expr::literal(1i64))),
+        filter.eval_expr(&(lit(1i8) + lit(1i64))),
         None,
         "add(byte, long)"
     );
     expect_eq!(
-        filter.eval_expr(&(Expr::literal(1i8) - Expr::literal(1i64))),
+        filter.eval_expr(&(lit(1i8) - lit(1i64))),
         None,
         "sub(byte, long)"
     );
     expect_eq!(
-        filter.eval_expr(&(Expr::literal(1i8) * Expr::literal(1i64))),
+        filter.eval_expr(&(lit(1i8) * lit(1i64))),
         None,
         "mul(byte, long)"
     );
     expect_eq!(
-        filter.eval_expr(&(Expr::literal(1i8) / Expr::literal(1i64))),
+        filter.eval_expr(&(lit(1i8) / lit(1i64))),
         None,
         "div(byte, long)"
     );
@@ -322,7 +322,7 @@ fn test_default_scalar_arithmetic() {
     ];
     for (l, r) in args {
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) + Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) + lit(r.clone()))),
             None,
             "add({l:?}, {r:?})"
         );
@@ -337,7 +337,7 @@ fn test_default_scalar_arithmetic() {
     ];
     for (l, r) in args {
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) - Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) - lit(r.clone()))),
             None,
             "sub({l:?}, {r:?})"
         );
@@ -352,7 +352,7 @@ fn test_default_scalar_arithmetic() {
     ];
     for arg in args {
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(arg.clone()) * Expr::literal(arg.clone()))),
+            filter.eval_expr(&(lit(arg.clone()) * lit(arg.clone()))),
             None,
             "mul({arg:?}, {arg:?})"
         );
@@ -367,7 +367,7 @@ fn test_default_scalar_arithmetic() {
     ];
     for (l, r) in args {
         expect_eq!(
-            filter.eval_expr(&(Expr::literal(l.clone()) / Expr::literal(r.clone()))),
+            filter.eval_expr(&(lit(l.clone()) / lit(r.clone()))),
             None,
             "div({l:?}, {r:?})"
         );
@@ -543,7 +543,7 @@ fn test_eval_is_null() {
         "x IS NULL"
     );
 
-    let expr = Expr::literal(1);
+    let expr = lit(1);
     expect_eq!(
         filter.eval_pred_unary(IsNull, &expr, true),
         Some(true),

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -715,7 +715,7 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator<'_> {
         } else {
             let safe_to_skip = match inverted {
                 true => self.get_rowcount_stat()?, // all-null
-                false => Expr::literal(0i64),      // no-null
+                false => lit(0i64),                // no-null
             };
             Some(Pred::ne(self.get_nullcount_stat(col)?, safe_to_skip))
         }
@@ -895,7 +895,7 @@ impl DataSkippingPredicateEvaluator for CheckpointDataSkippingPredicateCreator<'
             return None; // IS NOT NULL: column vs column, can't prune (#1873)
         }
         let nullcount = self.get_nullcount_stat(col)?;
-        let comparison = Pred::ne(nullcount.clone(), Expr::literal(0i64));
+        let comparison = Pred::ne(nullcount.clone(), lit(0i64));
         Some(Pred::or(Pred::is_null(nullcount), comparison))
     }
 

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -1178,7 +1178,7 @@ fn test_interval_partition_columns_are_not_pruning_columns(
         column_expr_ref!("stats_parsed"),
         Some(&partition_schema),
         column_expr_ref!("partitionValues_parsed"),
-        Arc::new(Expr::literal(true)),
+        Arc::new(lit(true)),
     )
     .unwrap();
 

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -12,7 +12,7 @@ use super::{PhysicalPredicate, ScanMetadata, COMMIT_READ_SCHEMA};
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::engine_data::{EngineData, GetData, RowVisitor, TypedGetData as _};
 use crate::expressions::{
-    col, column_expr_ref, column_name, ColumnName, Expression, ExpressionRef, Predicate,
+    col, column_expr_ref, column_name, null_lit, ColumnName, Expression, ExpressionRef, Predicate,
     PredicateRef, UnaryExpressionOp,
 };
 use crate::log_replay::deduplicator::{CheckpointDeduplicator, Deduplicator, FileActionInfo};
@@ -22,7 +22,6 @@ use crate::log_replay::{
 };
 use crate::log_segment::CheckpointReadInfo;
 use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
-use crate::scan::Scalar;
 use crate::schema::{
     schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
@@ -830,7 +829,7 @@ fn get_add_transform_expr(
     has_partition_values_parsed: bool,
 ) -> ExpressionRef {
     let stats_expr = if skip_stats {
-        Arc::new(Expression::Literal(Scalar::Null(DataType::STRING)))
+        Arc::new(null_lit(DataType::STRING))
     } else if has_stats_parsed && synthesize_json {
         // Checkpoint may lack JSON stats when writeStatsAsJson=false. Fall back to
         // serializing stats_parsed so ScanFile.stats is populated either way.
@@ -840,7 +839,7 @@ fn get_add_transform_expr(
         ]))
     } else if has_stats_parsed {
         // The compatible checkpoint projection can omit add.stats when JSON output is disabled.
-        Arc::new(Expression::Literal(Scalar::Null(DataType::STRING)))
+        Arc::new(null_lit(DataType::STRING))
     } else {
         column_expr_ref!("add.stats")
     };
@@ -1156,8 +1155,8 @@ mod tests {
     use crate::actions::get_commit_schema;
     use crate::engine::sync::SyncEngine;
     use crate::expressions::{
-        col, column_name, lit, BinaryExpressionOp, Expression, OpaquePredicateOp, Predicate,
-        Scalar, ScalarExpressionEvaluator, UnaryExpressionOp,
+        col, column_name, lit, null_lit, BinaryExpressionOp, Expression, OpaquePredicateOp,
+        Predicate, Scalar, ScalarExpressionEvaluator, UnaryExpressionOp,
     };
     use crate::kernel_predicates::{
         DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -2068,7 +2067,7 @@ mod tests {
         };
         assert_eq!(
             fields[3].as_ref(),
-            &Expression::Literal(Scalar::Null(DataType::STRING)),
+            &null_lit(DataType::STRING),
             "structured-only checkpoint stats output must be a typed NULL"
         );
     }

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -20,7 +20,7 @@ use crate::cancellation::{CancellableIterator, CancellationTokenRef};
 #[cfg(feature = "declarative-plans")]
 use crate::checkpoint::CheckpointShape;
 use crate::engine_data::FilteredEngineData;
-use crate::expressions::{column_name, ColumnName, ExpressionRef, Predicate, PredicateRef, Scalar};
+use crate::expressions::{column_name, ColumnName, ExpressionRef, Predicate, PredicateRef};
 use crate::kernel_predicates::{
     DefaultKernelPredicateEvaluator, EmptyColumnResolver, KernelPredicateEvaluator as _,
 };

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -17,7 +17,8 @@ use crate::actions::{
 };
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
-    col, column_name, joined_column_expr, ColumnName, Expression as Expr, ExpressionRef, Predicate,
+    col, column_name, joined_column_expr, lit, null_lit, ColumnName, Expression as Expr,
+    ExpressionRef, Predicate,
 };
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
@@ -369,7 +370,7 @@ fn sidecar_actions(
                 col!(SIDECAR_NAME, FILE_PATH),
                 col!(SIDECAR_NAME, SIDECAR_SIZE),
                 col!(SIDECAR_NAME, SIDECAR_FILE_MOD),
-                Expr::null_literal(DeletionVectorDescriptor::to_schema().into()),
+                null_lit(DeletionVectorDescriptor::to_schema()),
                 col!(VERSION),
             ]),
             SIDECAR_FILE_META_SCHEMA.clone(),
@@ -562,7 +563,7 @@ fn stats_skipping_predicate(state: &StateInfo) -> Option<Predicate> {
         &state.physical_stats_columns,
     )?;
     // A null skipping verdict means the available metadata cannot prove the file is skippable.
-    let skipping = Predicate::distinct(skipping, Expr::literal(false));
+    let skipping = Predicate::distinct(skipping, lit(false));
     let mut prefixer = MetadataSkippingColumnPrefixer;
     Some(prefixer.transform_pred(&skipping).into_owned())
 }
@@ -580,7 +581,6 @@ mod tests {
     use crate::arrow::array::{StringArray, StructArray};
     use crate::engine::arrow_data::EngineDataArrowExt as _;
     use crate::engine::sync::SyncEngine;
-    use crate::expressions::lit;
     use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
     use crate::object_store::memory::InMemory;
@@ -893,7 +893,7 @@ mod tests {
         let segment = log_segment(log_root(), &[], None);
         let scan = mock_snapshot(segment)?
             .scan_builder()
-            .with_predicate(Arc::new(Predicate::literal(false)))
+            .with_predicate(Arc::new(Predicate::FALSE))
             .build()?;
         assert_eq!(
             scan.state_info.physical_predicate,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -20,7 +20,7 @@ use crate::engine::parquet_row_group_skipping::ParquetRowGroupSkipping;
 use crate::engine::sync::SyncEngine;
 use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::{
-    col, column_name, column_pred, lit, Expression as Expr, Predicate as Pred,
+    col, column_name, column_pred, lit, Expression as Expr, Predicate as Pred, Scalar,
 };
 use crate::object_store::memory::InMemory;
 use crate::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -50,9 +50,9 @@ fn test_static_skipping() {
         (true, Pred::and(column_pred!("a"), Pred::FALSE)),
         (false, Pred::or(column_pred!("a"), Pred::TRUE)),
         (false, Pred::or(column_pred!("a"), Pred::FALSE)),
-        (false, Pred::lt(col!("a"), Expr::literal(10))),
-        (false, Pred::lt(Expr::literal(10), Expr::literal(100))),
-        (true, Pred::gt(Expr::literal(10), Expr::literal(100))),
+        (false, Pred::lt(col!("a"), lit(10))),
+        (false, Pred::lt(lit(10), lit(100))),
+        (true, Pred::gt(lit(10), lit(100))),
         (false, Pred::and(Pred::NULL, column_pred!("a"))), // NULL is unknown, not false
     ];
     for (should_skip, predicate) in test_cases {

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -399,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_get_transform_expr_static_transforms() {
-        let expr = Arc::new(Expression::literal(42));
+        let expr = Arc::new(lit(42));
         let transform_spec = vec![
             FieldTransformSpec::StaticInsert {
                 insert_after: Some("col1".to_string()),

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::Transaction;
 use crate::actions::{CommitInfo, COMMIT_INFO_NAME, LOG_COMMIT_INFO_SCHEMA};
-use crate::expressions::{MapData, Scalar};
+use crate::expressions::{lit, MapData, Scalar};
 use crate::schema::{schema_ref, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
@@ -16,44 +16,27 @@ fn commit_info_literal_exprs(
 ) -> Result<Vec<(&'static str, ExpressionRef)>, Error> {
     let op_params_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
     let literal_exprs = vec![
-        (
-            "timestamp",
-            Arc::new(Expression::literal(commit_info.timestamp)),
-        ),
+        ("timestamp", Arc::new(lit(commit_info.timestamp))),
         (
             "inCommitTimestamp",
-            Arc::new(Expression::literal(commit_info.in_commit_timestamp)),
+            Arc::new(lit(commit_info.in_commit_timestamp)),
         ),
-        (
-            "operation",
-            Arc::new(Expression::literal(commit_info.operation)),
-        ),
+        ("operation", Arc::new(lit(commit_info.operation))),
         (
             "operationParameters",
-            Arc::new(Expression::literal(
-                match commit_info.operation_parameters {
-                    Some(map) => Scalar::Map(MapData::try_new(
-                        op_params_map_type,
-                        map.into_iter()
-                            .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
-                    )?),
-                    None => Scalar::null(op_params_map_type),
-                },
-            )),
+            Arc::new(lit(match commit_info.operation_parameters {
+                Some(map) => Scalar::Map(MapData::try_new(
+                    op_params_map_type,
+                    map.into_iter()
+                        .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
+                )?),
+                None => Scalar::null(op_params_map_type),
+            })),
         ),
-        (
-            "kernelVersion",
-            Arc::new(Expression::literal(commit_info.kernel_version)),
-        ),
-        (
-            "isBlindAppend",
-            Arc::new(Expression::literal(commit_info.is_blind_append)),
-        ),
-        (
-            "engineInfo",
-            Arc::new(Expression::literal(commit_info.engine_info)),
-        ),
-        ("txnId", Arc::new(Expression::literal(commit_info.txn_id))),
+        ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
+        ("isBlindAppend", Arc::new(lit(commit_info.is_blind_append))),
+        ("engineInfo", Arc::new(lit(commit_info.engine_info))),
+        ("txnId", Arc::new(lit(commit_info.txn_id))),
     ];
     let expected_expr_len = CommitInfo::to_schema().fields().len();
     if literal_exprs.len() != expected_expr_len {

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::Transaction;
 use crate::actions::{CommitInfo, COMMIT_INFO_NAME, LOG_COMMIT_INFO_SCHEMA};
-use crate::expressions::{lit, MapData, Scalar};
+use crate::expressions::{lit, null_lit, MapData, Scalar};
 use crate::schema::{schema_ref, MapType, ToSchema};
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, IntoEngineData};
@@ -24,14 +24,14 @@ fn commit_info_literal_exprs(
         ("operation", Arc::new(lit(commit_info.operation))),
         (
             "operationParameters",
-            Arc::new(lit(match commit_info.operation_parameters {
-                Some(map) => Scalar::Map(MapData::try_new(
+            Arc::new(match commit_info.operation_parameters {
+                Some(map) => lit(MapData::try_new(
                     op_params_map_type,
                     map.into_iter()
                         .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
                 )?),
-                None => Scalar::null(op_params_map_type),
-            })),
+                None => null_lit(op_params_map_type),
+            }),
         ),
         ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
         ("isBlindAppend", Arc::new(lit(commit_info.is_blind_append))),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -571,7 +571,7 @@ impl DvUpdateEntry {
     /// The (null DV, null stats) entry for rows that are not getting a DV update.
     fn null() -> Self {
         static NULL_DV: LazyLock<Scalar> =
-            LazyLock::new(|| Scalar::Null(DataType::from(DeletionVectorDescriptor::to_schema())));
+            LazyLock::new(|| Scalar::null(DeletionVectorDescriptor::to_schema()));
         static NULL_STATS: LazyLock<Scalar> = LazyLock::new(|| Scalar::Null(DataType::STRING));
         Self {
             deletion_vector: NULL_DV.clone(),

--- a/kernel/src/transaction/write_context.rs
+++ b/kernel/src/transaction/write_context.rs
@@ -298,7 +298,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::expressions::Expression;
+    use crate::expressions::lit;
     use crate::schema::schema_ref;
 
     fn make_write_context(
@@ -322,7 +322,7 @@ mod tests {
         });
         WriteContext {
             shared,
-            logical_to_physical: Arc::new(Expression::literal(true)),
+            logical_to_physical: Arc::new(lit(true)),
             physical_partition_values: partition_values,
         }
     }

--- a/kernel/src/transforms/expression.rs
+++ b/kernel/src/transforms/expression.rs
@@ -691,14 +691,14 @@ mod tests {
             }
 
             // Check that other expressions are unchanged
-            assert_eq!(result_expr.exprs[0], Expr::literal(1));
+            assert_eq!(result_expr.exprs[0], lit(1));
             if let Expr::Column(col) = &result_expr.exprs[2] {
                 assert_eq!(col.len(), 1);
                 assert_eq!(col[0], "unchanged_col");
             } else {
                 panic!("Expected column expression");
             }
-            assert_eq!(result_expr.exprs[3], Expr::literal("test"));
+            assert_eq!(result_expr.exprs[3], lit("test"));
         }
     }
 
@@ -822,7 +822,7 @@ mod tests {
                 panic!("Expected unchanged column");
             }
 
-            assert_eq!(result_expr.exprs[1], Expr::literal(10)); // 5 * 2
+            assert_eq!(result_expr.exprs[1], lit(10)); // 5 * 2
 
             if let Expr::Column(col) = &result_expr.exprs[2] {
                 assert_eq!(col.len(), 1);
@@ -831,7 +831,7 @@ mod tests {
                 panic!("Expected transformed column");
             }
 
-            assert_eq!(result_expr.exprs[3], Expr::literal("keep"));
+            assert_eq!(result_expr.exprs[3], lit("keep"));
         }
     }
 

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -15,8 +15,8 @@ use delta_kernel::arrow::datatypes::{
 use delta_kernel::engine::arrow_conversion::TryFromKernel as _;
 use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
 use delta_kernel::expressions::{
-    col, column_pred, lit, Expression as Expr, ExpressionRef, Predicate as Pred, PredicateRef,
-    Scalar,
+    col, column_pred, lit, null_lit, Expression as Expr, ExpressionRef, Predicate as Pred,
+    PredicateRef, Scalar,
 };
 use delta_kernel::log_segment::LogSegment;
 use delta_kernel::object_store::memory::InMemory;
@@ -1378,7 +1378,7 @@ fn not_and_or_predicates(
     table_for_numbers(vec![1, 2, 4, 5, 6])
 )]
 #[case::distinct_null(
-    col!("number").distinct(Expr::null_literal(DataType::LONG)),
+    col!("number").distinct(null_lit(DataType::LONG)),
     table_for_numbers(vec![1, 2, 3, 4, 5, 6])
 )]
 #[case::not_distinct_value(
@@ -1386,7 +1386,7 @@ fn not_and_or_predicates(
     table_for_numbers(vec![3])
 )]
 #[case::not_distinct_null(
-    Pred::not(col!("number").distinct(Expr::null_literal(DataType::LONG))),
+    Pred::not(col!("number").distinct(null_lit(DataType::LONG))),
     table_for_numbers(vec![])
 )]
 #[case::gt_empty_struct(

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -18,7 +18,9 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::engine_data::FilteredEngineData;
-use delta_kernel::expressions::{col, lit, ExpressionStructPatchBuilder, MapData, Scalar};
+use delta_kernel::expressions::{
+    col, lit, null_lit, ExpressionStructPatchBuilder, MapData, Scalar,
+};
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::{scan_row_schema, StatsOptions};
@@ -1429,7 +1431,7 @@ fn with_missing_extended_metadata_fields(
     let (data, selection_vector) = scan_files.into_parts();
     let map_type = MapType::new(DataType::STRING, DataType::STRING, true);
     let tags = if missing_fields.contains(&ExtendedMetadataField::Tags) {
-        Scalar::Null(DataType::from(map_type.clone()))
+        Scalar::null(map_type.clone())
     } else {
         Scalar::Map(MapData::try_new(map_type.clone(), [("key", "value")])?)
     };
@@ -1437,11 +1439,11 @@ fn with_missing_extended_metadata_fields(
         ExpressionStructPatchBuilder::new().replace_at(["fileConstantValues"], "tags", lit(tags));
     for field in missing_fields {
         patch = match field {
-            ExtendedMetadataField::Size => patch.replace("size", lit(Scalar::Null(DataType::LONG))),
+            ExtendedMetadataField::Size => patch.replace("size", null_lit(DataType::LONG)),
             ExtendedMetadataField::PartitionValues => patch.replace_at(
                 ["fileConstantValues"],
                 field.name(),
-                lit(Scalar::Null(DataType::from(map_type.clone()))),
+                null_lit(map_type.clone()),
             ),
             ExtendedMetadataField::Tags => patch,
         };

--- a/workloads/src/predicate_parser.rs
+++ b/workloads/src/predicate_parser.rs
@@ -44,8 +44,8 @@ use std::borrow::Cow;
 // - K-prefix: Kernel types (KExpr, KPred, KBinOp, KPredOp)
 // - P-prefix: Parser/sqlparser types (PExpr, PBinOp, PUnaryOp, PVal)
 use delta_kernel::expressions::{
-    ArrayData, BinaryExpressionOp as KBinOp, BinaryPredicateOp as KPredOp, ColumnName,
-    Expression as KExpr, Predicate as KPred, Scalar,
+    lit, null_lit, ArrayData, BinaryExpressionOp as KBinOp, BinaryPredicateOp as KPredOp,
+    ColumnName, Expression as KExpr, Predicate as KPred, Scalar,
 };
 use delta_kernel::schema::{ArrayType, DataType, PrimitiveType, Schema};
 use itertools::Itertools as _;
@@ -129,7 +129,7 @@ fn synthesize_expr(schema: &Schema, expr: &PExpr) -> Option<(KExpr, DataType)> {
             Some((expr, ty))
         }
         PExpr::Value(v) => match &v.value {
-            PVal::Boolean(b) => Some((Scalar::Boolean(*b).into(), DataType::BOOLEAN)),
+            PVal::Boolean(b) => Some((lit(*b), DataType::BOOLEAN)),
             _ => None, // Numeric, string, null need type context
         },
         // Typed literals need type context from the other side of comparison
@@ -189,7 +189,7 @@ fn check_expr(
                     format!("Typed literal cannot be used for type: {expected_ty:?}").into(),
                 );
             };
-            Ok(prim.parse_scalar(s).map_err(|e| e.to_string())?.into())
+            Ok(lit(prim.parse_scalar(s).map_err(|e| e.to_string())?))
         }
         PExpr::Nested(inner) => check_expr(schema, expected_ty, inner),
         _ => {
@@ -225,20 +225,20 @@ fn check_literal(
         ) => {
             let raw = format!("{}{n}", if is_negative { "-" } else { "" });
             let scalar = prim.parse_scalar(&raw).map_err(|e| e.to_string())?;
-            Ok(scalar.into())
+            Ok(lit(scalar))
         }
 
         // String literals - use parse_scalar (handles String, Date, Timestamp, etc.)
         (DataType::Primitive(prim), PVal::SingleQuotedString(s) | PVal::DoubleQuotedString(s)) => {
             let scalar = prim.parse_scalar(s).map_err(|e| e.to_string())?;
-            Ok(scalar.into())
+            Ok(lit(scalar))
         }
 
         // Boolean literals
-        (DataType::Primitive(Boolean), PVal::Boolean(b)) => Ok(Scalar::Boolean(*b).into()),
+        (DataType::Primitive(Boolean), PVal::Boolean(b)) => Ok(lit(*b)),
 
         // NULL can be any type
-        (ty, PVal::Null) => Ok(Scalar::Null(ty.clone()).into()),
+        (ty, PVal::Null) => Ok(null_lit(ty.clone())),
 
         // Type mismatches
         (expected, actual) => Err(format!(
@@ -402,11 +402,7 @@ fn in_list_to_pred(
     // Check if any scalar is null to determine array nullability
     let contains_null = scalars.iter().any(|s| s.is_null());
     let array_data = ArrayData::try_new(ArrayType::new(col_ty, contains_null), scalars)?;
-    let pred = KPred::binary(
-        KPredOp::In,
-        col_expr,
-        KExpr::literal(Scalar::Array(array_data)),
-    );
+    let pred = KPred::binary(KPredOp::In, col_expr, lit(array_data));
     Ok(if negated { KPred::not(pred) } else { pred })
 }
 
@@ -514,7 +510,7 @@ mod tests {
             .map(|s| s.data_type())
             .unwrap_or(DataType::LONG);
         let array = ArrayData::try_new(ArrayType::new(element_type, false), scalars).unwrap();
-        KPred::binary(KPredOp::In, col, KExpr::literal(Array(array)))
+        KPred::binary(KPredOp::In, col, lit(Array(array)))
     }
 
     // -- Comparisons --
@@ -850,11 +846,7 @@ mod tests {
             vec![Long(1), Long(2), Null(DataType::LONG)],
         )
         .unwrap();
-        let expected = KPred::binary(
-            KPredOp::In,
-            col!("a"),
-            KExpr::literal(Scalar::Array(expected_array)),
-        );
+        let expected = KPred::binary(KPredOp::In, col!("a"), lit(expected_array));
         assert_eq!(pred, expected);
     }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Define a new `null_lit` helper for creating NULL literals of a given data type.

Sweep the code base to simplify literal and scalar creation, and remove some helpers that are no longer helpful.

### This PR affects the following public APIs

Removed `Expression::literal` (use `lit`) instead
Removed `Expression::null_literal` (use the new `null_lit` helper instead)
Removed `Predicate::null_literal` (use `Predicate::NULL` instead)

## How was this change tested?

Refactor. Compilation and unit tests.