### PR TITLE
fix: honor allow_null_container_values in IntoStructData

### DIFF
--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -467,8 +467,23 @@ pub fn into_struct_data_derive(input: proc_macro::TokenStream) -> proc_macro::To
         Ok(fields) => fields,
         Err(e) => return e.to_compile_error().into(),
     };
-    let (field_idents, field_types): (Vec<_>, Vec<_>) =
-        fields.into_iter().map(|f| (&f.ident, &f.ty)).unzip();
+    let field_types: Vec<_> = fields.iter().map(|f| &f.ty).collect();
+    // Match `ToSchema`: an `#[allow_null_container_values]` field's value must be value-nullable
+    // too.
+    let field_values: Vec<_> = fields
+        .iter()
+        .map(|f| {
+            let ident = &f.ident;
+            if has_named_attr(&f.attrs, "allow_null_container_values") {
+                quote! {
+                    delta_kernel::expressions::Scalar::from(value.#ident)
+                        .with_nullable_container_values()
+                }
+            } else {
+                quote! { value.#ident.into() }
+            }
+        })
+        .collect();
 
     let expanded = quote! {
         #[automatically_derived]
@@ -480,7 +495,7 @@ pub fn into_struct_data_derive(input: proc_macro::TokenStream) -> proc_macro::To
             fn from(value: #struct_name) -> Self {
                 Self::from_values_unchecked(
                     <#struct_name as delta_kernel::schema::ToSchema>::to_schema(),
-                    vec![ #(value.#field_idents.into()),* ],
+                    vec![ #(#field_values),* ],
                 )
             }
         }

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -467,23 +467,21 @@ pub fn into_struct_data_derive(input: proc_macro::TokenStream) -> proc_macro::To
         Ok(fields) => fields,
         Err(e) => return e.to_compile_error().into(),
     };
-    let field_types: Vec<_> = fields.iter().map(|f| &f.ty).collect();
-    // Match `ToSchema`: an `#[allow_null_container_values]` field's value must be value-nullable
-    // too.
-    let field_values: Vec<_> = fields
+
+    let (field_types, field_values): (Vec<_>, Vec<_>) = fields
         .iter()
-        .map(|f| {
-            let ident = &f.ident;
-            if has_named_attr(&f.attrs, "allow_null_container_values") {
+        .map(|f: &&Field| {
+            let ident: &Option<Ident> = &f.ident;
+            let value: TokenStream = if has_named_attr(&f.attrs, "allow_null_container_values") {
                 quote! {
-                    delta_kernel::expressions::Scalar::from(value.#ident)
-                        .with_nullable_container_values()
+                    delta_kernel::expressions::Scalar::from(value.#ident).with_nullable_container_values()
                 }
             } else {
-                quote! { value.#ident.into() }
-            }
+                quote! { value.#ident.into()}
+            };
+            (&f.ty, value)
         })
-        .collect();
+        .unzip();
 
     let expanded = quote! {
         #[automatically_derived]

--- a/derive-macros/src/lib.rs
+++ b/derive-macros/src/lib.rs
@@ -689,6 +689,23 @@ mod tests {
         Ok(tokens.to_string())
     }
 
+    #[rstest]
+    #[case::enum_input("enum E { A }")]
+    #[case::tuple_struct("struct S(i32);")]
+    #[case::unit_struct("struct S;")]
+    fn schema_fields_rejects_non_named_structs(#[case] input: &str) {
+        let input = syn::parse_str::<DeriveInput>(input).unwrap();
+        // This is the exact `Err` the `IntoStructData` derive forwards via
+        // `e.to_compile_error().into()`.
+        let err = schema_fields(&input.data, "IntoStructData", input.ident.span()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("IntoStructData can only be derived for structs with named fields"),
+            "found: {err}"
+        );
+        assert!(err.to_compile_error().to_string().contains("compile_error"));
+    }
+
     #[test]
     fn test_valid_field_id_parsing() {
         let input = r#"

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -402,6 +402,24 @@ impl Scalar {
         Self::Null(data_type.into())
     }
 
+    /// Set a map scalar's `value_contains_null` to true, so a value built for an
+    /// `#[allow_null_container_values]` field matches the value-nullable type `ToSchema` declares.
+    /// Non-map scalars are returned unchanged.
+    #[internal_api]
+    pub(crate) fn with_nullable_container_values(self) -> Self {
+        match self {
+            Self::Map(mut data) => {
+                data.data_type.value_contains_null = true;
+                Self::Map(data)
+            }
+            Self::Null(DataType::Map(mut map_type)) => {
+                map_type.value_contains_null = true;
+                Self::Null(DataType::Map(map_type))
+            }
+            other => other,
+        }
+    }
+
     /// Constructs a Decimal value from raw parts
     pub fn decimal(bits: impl Into<i128>, precision: u8, scale: u8) -> DeltaResult<Self> {
         let dtype = DecimalType::try_new(precision, scale)?;
@@ -2239,6 +2257,29 @@ mod tests {
         values.swap(0, 2);
         let reordered = StructData::try_new(fields, values).unwrap();
         assert_eq!(Person::try_from(reordered).unwrap(), person);
+    }
+
+    #[rstest]
+    #[case::present(Some(HashMap::from([("k".to_string(), "v".to_string())])))]
+    #[case::absent(None)]
+    fn into_struct_data_marks_allow_null_container_values_map_as_value_nullable(
+        #[case] tags: Option<HashMap<String, String>>,
+    ) {
+        #[derive(ToSchema, IntoStructData)]
+        struct HasNullableMap {
+            #[allow_null_container_values]
+            tags: Option<HashMap<String, String>>,
+        }
+
+        let Scalar::Struct(data) = Scalar::from(HasNullableMap { tags }) else {
+            unreachable!()
+        };
+
+        // The value's map type matches the schema field's (both value-nullable), so the struct is
+        // self-consistent and `try_new` accepts it.
+        assert_eq!(&data.values()[0].data_type(), data.fields()[0].data_type());
+        let (fields, values) = data.into_parts();
+        StructData::try_new(fields, values).unwrap();
     }
 
     #[test]

--- a/kernel/src/expressions/scalars.rs
+++ b/kernel/src/expressions/scalars.rs
@@ -2282,6 +2282,14 @@ mod tests {
         StructData::try_new(fields, values).unwrap();
     }
 
+    #[rstest]
+    #[case::integer(Scalar::from(1i32))]
+    #[case::string(Scalar::from("s"))]
+    #[case::null_integer(Scalar::Null(DataType::INTEGER))]
+    fn with_nullable_container_values_leaves_non_map_scalars_unchanged(#[case] scalar: Scalar) {
+        assert_eq!(scalar.clone().with_nullable_container_values(), scalar);
+    }
+
     #[test]
     fn derived_struct_conversion_builds_nested_error_path_while_unwinding() {
         let address = StructData::from_values_unchecked(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes IntoStructData to honor allow_null_container_values for Maps. Currently, it's marked as always false. This actually marks the map values as nullable similar to `ToSchema`. This has the effect of StructData values and field types being consistent, which is important for handling metadata fields like `tags` where technically null map values are allowed.

## How was this change tested?
Added test