### PR TITLE
fix: check read/write support before writing checkpoint/checksum

### DIFF
--- a/kernel/src/checkpoint/mod.rs
+++ b/kernel/src/checkpoint/mod.rs
@@ -383,6 +383,10 @@ impl RetentionCalculator for CheckpointWriter {
 impl CheckpointWriter {
     /// Creates a new [`CheckpointWriter`] for the given snapshot.
     pub(crate) fn try_new(snapshot: SnapshotRef, engine: &dyn Engine) -> DeltaResult<Self> {
+        snapshot
+            .table_configuration()
+            .ensure_read_write_supported()?;
+
         // We disallow checkpointing if the Snapshot is not published. If we didn't, this could
         // create gaps in the version history, thereby breaking old readers.
         snapshot.log_segment().validate_published()?;

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -908,6 +908,10 @@ impl Snapshot {
     ///
     /// See the [`crate::checkpoint`] module documentation for more details on checkpoint types
     /// and the overall checkpoint process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Kernel does not support reading or writing the table's protocol.
     pub fn create_checkpoint_writer(
         self: Arc<Self>,
         engine: &dyn Engine,
@@ -954,6 +958,7 @@ impl Snapshot {
     ///
     /// # Errors
     ///
+    /// - If Kernel does not support reading or writing the table's protocol.
     /// - [`Error::ChecksumWriteUnsupported`] if no CRC can be resolved for this version, if the
     ///   resolved CRC's `file_stats_state` is `Indeterminate` (a non-incremental operation like
     ///   ANALYZE STATS, or a file action with a missing size; recoverable with a full state
@@ -981,6 +986,8 @@ impl Snapshot {
             );
             return Ok((ChecksumWriteResult::AlreadyExists, Arc::clone(self)));
         }
+
+        self.table_configuration().ensure_read_write_supported()?;
 
         let crc = self.resolve_crc_for_write(engine)?;
 
@@ -1100,6 +1107,7 @@ impl Snapshot {
     ///   write sidecar files.
     ///
     /// # Errors
+    /// - If Kernel does not support reading or writing the table.
     /// - If `CheckpointSpec::V2` is used but the table does not support the `v2Checkpoint` feature.
     /// - If `CheckpointSpec::V1` is used but the table supports `v2Checkpoint` feature. Note: the
     ///   Delta protocol permits writing V1 checkpoints to such tables; this is a kernel limitation.

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -911,7 +911,7 @@ impl Snapshot {
     ///
     /// # Errors
     ///
-    /// Returns an error if Kernel does not support reading or writing the table's protocol.
+    /// Returns an error if Kernel does not support reading or writing the table.
     pub fn create_checkpoint_writer(
         self: Arc<Self>,
         engine: &dyn Engine,
@@ -958,7 +958,7 @@ impl Snapshot {
     ///
     /// # Errors
     ///
-    /// - If Kernel does not support reading or writing the table's protocol.
+    /// - If Kernel does not support reading or writing the table.
     /// - [`Error::ChecksumWriteUnsupported`] if no CRC can be resolved for this version, if the
     ///   resolved CRC's `file_stats_state` is `Indeterminate` (a non-incremental operation like
     ///   ANALYZE STATS, or a file action with a missing size; recoverable with a full state

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -911,7 +911,8 @@ impl Snapshot {
     ///
     /// # Errors
     ///
-    /// Returns an error if Kernel does not support reading or writing the table.
+    /// Returns an error if Kernel does not support reading or writing the table, or if the
+    /// snapshot is not published.
     pub fn create_checkpoint_writer(
         self: Arc<Self>,
         engine: &dyn Engine,

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -711,6 +711,12 @@ impl TableConfiguration {
         }
     }
 
+    /// Ensures Kernel supports both scanning and writing this table.
+    pub(crate) fn ensure_read_write_supported(&self) -> DeltaResult<()> {
+        self.ensure_operation_supported(Operation::Scan)?;
+        self.ensure_operation_supported(Operation::Write)
+    }
+
     /// Internal helper for read operations (Scan, Cdf)
     fn ensure_read_supported(&self, operation: Operation) -> DeltaResult<()> {
         check_reader_version_range(&self.protocol)?;

--- a/kernel/tests/integration/features/maintenance_ops.rs
+++ b/kernel/tests/integration/features/maintenance_ops.rs
@@ -188,7 +188,7 @@ async fn test_checkpoint_already_exists(#[case] v2_checkpoint: bool) -> DeltaRes
     }))
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn maintenance_writes_reject_unsupported_table_features(
+async fn checkpoint_crc_writes_reject_unsupported_table_features(
     #[case] reader_features: &[&str],
     #[case] writer_features: &[&str],
     #[case] checkpoint_spec: Option<CheckpointSpec>,

--- a/kernel/tests/integration/features/maintenance_ops.rs
+++ b/kernel/tests/integration/features/maintenance_ops.rs
@@ -1,5 +1,6 @@
 //! Integration tests for table maintenance operations (checkpoint, checksum).
 
+use delta_kernel::checkpoint::{CheckpointSpec, V2CheckpointConfig};
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::schema_ref;
@@ -110,12 +111,87 @@ async fn test_checkpoint_already_exists(#[case] v2_checkpoint: bool) -> DeltaRes
 }
 
 #[rstest]
-#[case::reader_writer(&["futureFeature"], &["futureFeature"])]
-#[case::writer_only(&[], &["futureFeature"])]
+#[case::unknown_reader_writer_no_spec(&["futureFeature"], &["futureFeature"], None)]
+#[case::unknown_reader_writer_v1(
+    &["futureFeature"],
+    &["futureFeature"],
+    Some(CheckpointSpec::V1)
+)]
+#[case::unknown_reader_writer_v2(
+    &["v2Checkpoint", "futureFeature"],
+    &["v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::NoSidecar))
+)]
+#[case::unknown_reader_writer_v2_sidecar(
+    &["v2Checkpoint", "futureFeature"],
+    &["v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+        file_actions_per_sidecar_hint: None,
+    }))
+)]
+#[case::unknown_writer_only_no_spec(&[], &["futureFeature"], None)]
+#[case::unknown_writer_only_v1(&[], &["futureFeature"], Some(CheckpointSpec::V1))]
+#[case::unknown_writer_only_v2(
+    &["v2Checkpoint"],
+    &["v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::NoSidecar))
+)]
+#[case::unknown_writer_only_v2_sidecar(
+    &["v2Checkpoint"],
+    &["v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+        file_actions_per_sidecar_hint: None,
+    }))
+)]
+#[case::mixed_reader_writer_no_spec(
+    &["deletionVectors", "futureFeature"],
+    &["deletionVectors", "futureFeature"],
+    None
+)]
+#[case::mixed_reader_writer_v1(
+    &["deletionVectors", "futureFeature"],
+    &["deletionVectors", "futureFeature"],
+    Some(CheckpointSpec::V1)
+)]
+#[case::mixed_reader_writer_v2(
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::NoSidecar))
+)]
+#[case::mixed_reader_writer_v2_sidecar(
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+        file_actions_per_sidecar_hint: None,
+    }))
+)]
+#[case::mixed_writer_only_no_spec(
+    &["deletionVectors"],
+    &["deletionVectors", "futureFeature"],
+    None
+)]
+#[case::mixed_writer_only_v1(
+    &["deletionVectors"],
+    &["deletionVectors", "futureFeature"],
+    Some(CheckpointSpec::V1)
+)]
+#[case::mixed_writer_only_v2(
+    &["deletionVectors", "v2Checkpoint"],
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::NoSidecar))
+)]
+#[case::mixed_writer_only_v2_sidecar(
+    &["deletionVectors", "v2Checkpoint"],
+    &["deletionVectors", "v2Checkpoint", "futureFeature"],
+    Some(CheckpointSpec::V2(V2CheckpointConfig::WithSidecar {
+        file_actions_per_sidecar_hint: None,
+    }))
+)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn maintenance_writes_reject_unsupported_table_features(
     #[case] reader_features: &[&str],
     #[case] writer_features: &[&str],
+    #[case] checkpoint_spec: Option<CheckpointSpec>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     let table_url = Url::from_directory_path(&table_path).unwrap();
@@ -155,7 +231,9 @@ async fn maintenance_writes_reject_unsupported_table_features(
     add_commit(table_url.as_str(), &store, 0, commit).await?;
 
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    let checkpoint_result = snapshot.checkpoint(engine.as_ref(), None).map(|_| ());
+    let checkpoint_result = snapshot
+        .checkpoint(engine.as_ref(), checkpoint_spec.as_ref())
+        .map(|_| ());
     assert_result_error_with_message(checkpoint_result, "futureFeature");
 
     let checksum_result = snapshot.write_checksum(engine.as_ref()).map(|_| ());

--- a/kernel/tests/integration/features/maintenance_ops.rs
+++ b/kernel/tests/integration/features/maintenance_ops.rs
@@ -1,12 +1,15 @@
 //! Integration tests for table maintenance operations (checkpoint, checksum).
 
 use delta_kernel::committer::FileSystemCommitter;
+use delta_kernel::object_store::local::LocalFileSystem;
 use delta_kernel::schema::schema_ref;
 use delta_kernel::snapshot::{CheckpointWriteResult, ChecksumWriteResult};
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::{DeltaResult, Snapshot};
 use rstest::rstest;
-use test_utils::test_table_setup_mt;
+use serde_json::json;
+use test_utils::{add_commit, assert_result_error_with_message, test_table_setup_mt};
+use url::Url;
 
 #[rstest]
 #[case::v1_checkpoint(false)]
@@ -102,6 +105,61 @@ async fn test_checkpoint_already_exists(#[case] v2_checkpoint: bool) -> DeltaRes
     );
     let (result, _) = fresh.checkpoint(engine.as_ref(), None)?;
     assert_eq!(result, CheckpointWriteResult::AlreadyExists);
+
+    Ok(())
+}
+
+#[rstest]
+#[case::reader_writer(&["futureFeature"], &["futureFeature"])]
+#[case::writer_only(&[], &["futureFeature"])]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn maintenance_writes_reject_unsupported_table_features(
+    #[case] reader_features: &[&str],
+    #[case] writer_features: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
+    let table_url = Url::from_directory_path(&table_path).unwrap();
+    let store = LocalFileSystem::new();
+    let schema_string = json!({
+        "type": "struct",
+        "fields": [{
+            "name": "id",
+            "type": "integer",
+            "nullable": true,
+            "metadata": {},
+        }],
+    })
+    .to_string();
+    let commit = [
+        json!({
+            "protocol": {
+                "minReaderVersion": 3,
+                "minWriterVersion": 7,
+                "readerFeatures": reader_features,
+                "writerFeatures": writer_features,
+            }
+        }),
+        json!({
+            "metaData": {
+                "id": "maintenance-feature-validation",
+                "format": { "provider": "parquet", "options": {} },
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {},
+                "createdTime": 1_700_000_000_000i64,
+            }
+        }),
+    ]
+    .map(|action| action.to_string())
+    .join("\n");
+    add_commit(table_url.as_str(), &store, 0, commit).await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let checkpoint_result = snapshot.checkpoint(engine.as_ref(), None).map(|_| ());
+    assert_result_error_with_message(checkpoint_result, "futureFeature");
+
+    let checksum_result = snapshot.write_checksum(engine.as_ref()).map(|_| ());
+    assert_result_error_with_message(checksum_result, "futureFeature");
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Check read and write support before writing a checkpoint or checksum. This prevents Kernel
from emitting checkpoint or checksum state for table features it does not understand.

### This PR affects the following public APIs

`Snapshot::create_checkpoint_writer`, `Snapshot::checkpoint`, and `Snapshot::write_checksum`
now reject tables whose reader or writer features Kernel does not support.

## How was this change tested?

Added integration tests verifying that checkpoint and checksum writes reject unknown reader or
writer features across V1 and V2 checkpoint configurations.