### PR TITLE
refactor: use explicit StructField nullability constructors

### DIFF
--- a/default-engine/src/parquet.rs
+++ b/default-engine/src/parquet.rs
@@ -1659,12 +1659,12 @@ mod tests {
 
         // Create kernel schema with DIFFERENT names but SAME field IDs
         let kernel_schema = schema_ref! {
-            (StructField::new("user_id", delta_kernel::schema::DataType::LONG, false)
+            (StructField::not_null("user_id", delta_kernel::schema::DataType::LONG)
                     .with_metadata([(
                         ColumnMetadataKey::ParquetFieldId.as_ref(),
                         MetadataValue::Number(1),
                     )])),
-            (StructField::new("user_name", delta_kernel::schema::DataType::STRING, false)
+            (StructField::not_null("user_name", delta_kernel::schema::DataType::STRING)
                     .with_metadata([(
                         ColumnMetadataKey::ParquetFieldId.as_ref(),
                         MetadataValue::Number(2),

--- a/docs/user-guide/src/concepts/schema_and_types.md
+++ b/docs/user-guide/src/concepts/schema_and_types.md
@@ -191,7 +191,7 @@ let id = StructField::not_null("id", DataType::LONG);
 let name = StructField::nullable("name", DataType::STRING);
 
 // Field with explicit nullability
-let score = StructField::new("score", DataType::DOUBLE, true);
+let score = StructField::nullable("score", DataType::DOUBLE);
 ```
 
 ### Field metadata

--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -365,7 +365,7 @@ mod tests {
     #[case::ten(10)]
     fn test_validate_clustering_column_count(#[case] num_columns: usize) {
         let schema = schema! {
-            ..((0..num_columns).map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, false)))
+            ..((0..num_columns).map(|i| StructField::not_null(format!("col{i}"), DataType::INTEGER)))
         };
 
         let columns: Vec<ColumnName> = (0..num_columns)

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -551,7 +551,7 @@ mod apply_schema_validation_tests {
     fn test_apply_schema_transforms_parquet_field_id_metadata() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
         let target_schema = schema! {
-            (StructField::new("a", DataType::INTEGER, false)
+            (StructField::not_null("a", DataType::INTEGER)
                 .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
         };
 
@@ -588,7 +588,7 @@ mod apply_schema_validation_tests {
     fn test_apply_schema_matching_field_ids_succeed() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
         let target_schema = schema! {
-            (StructField::new("a", DataType::INTEGER, false)
+            (StructField::not_null("a", DataType::INTEGER)
                 .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
         };
 
@@ -611,7 +611,7 @@ mod apply_schema_validation_tests {
     fn test_apply_schema_conflicting_field_ids_fail() {
         let field_id_key = ColumnMetadataKey::ParquetFieldId.as_ref();
         let target_schema = schema! {
-            (StructField::new("a", DataType::INTEGER, false)
+            (StructField::not_null("a", DataType::INTEGER)
                 .with_metadata([(field_id_key.to_string(), MetadataValue::Number(42))])),
         };
 

--- a/kernel/src/partition/serialization.rs
+++ b/kernel/src/partition/serialization.rs
@@ -617,7 +617,7 @@ mod tests {
     #[test]
     fn test_non_null_struct_returns_error() {
         let data = StructData::try_new(
-            vec![StructField::new("x", DataType::INTEGER, true)],
+            vec![StructField::nullable("x", DataType::INTEGER)],
             vec![Scalar::Integer(1)],
         )
         .unwrap();

--- a/kernel/src/schema/compare.rs
+++ b/kernel/src/schema/compare.rs
@@ -7,13 +7,13 @@
 //!  # use delta_kernel::schema::StructField;
 //!  # use delta_kernel::schema::DataType;
 //!  let schema = StructType::try_new([
-//!     StructField::new("id", DataType::LONG, false),
-//!     StructField::new("value", DataType::STRING, true),
+//!     StructField::not_null("id", DataType::LONG),
+//!     StructField::nullable("value", DataType::STRING),
 //!  ])?;
 //!  let read_schema = StructType::try_new([
-//!     StructField::new("id", DataType::LONG, true),
-//!     StructField::new("value", DataType::STRING, true),
-//!     StructField::new("year", DataType::INTEGER, true),
+//!     StructField::nullable("id", DataType::LONG),
+//!     StructField::nullable("value", DataType::STRING),
+//!     StructField::nullable("year", DataType::INTEGER),
 //!  ])?;
 //!  // Schemas are compatible since the `read_schema` adds a nullable column `year`
 //!  assert!(schema.can_read_as(&read_schema).is_ok());
@@ -414,15 +414,15 @@ mod tests {
     #[test]
     fn duplicate_field_modulo_case() {
         let existing_schema = schema! {
-            (StructField::new("id", DataType::LONG, false)),
-            (StructField::new("Id", DataType::LONG, false)),
+            (StructField::not_null("id", DataType::LONG)),
+            (StructField::not_null("Id", DataType::LONG)),
             not_null "name": STRING,
             nullable "age": INTEGER,
         };
 
         let read_schema = schema! {
-            (StructField::new("id", DataType::LONG, false)),
-            (StructField::new("Id", DataType::LONG, false)),
+            (StructField::not_null("id", DataType::LONG)),
+            (StructField::not_null("Id", DataType::LONG)),
             not_null "name": STRING,
             nullable "age": INTEGER,
         };

--- a/kernel/src/schema/diff.rs
+++ b/kernel/src/schema/diff.rs
@@ -855,7 +855,7 @@ mod tests {
     fn test_physical_name_validation() {
         // Test: Physical names present and unchanged - valid schema evolution (just a rename)
         let before = schema! {
-            (StructField::new("name", DataType::STRING, false).add_metadata([
+            (StructField::not_null("name", DataType::STRING).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
@@ -864,7 +864,7 @@ mod tests {
             ])),
         };
         let after = schema! {
-            (StructField::new("full_name", DataType::STRING, false).add_metadata([
+            (StructField::not_null("full_name", DataType::STRING).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
@@ -885,7 +885,7 @@ mod tests {
 
         // Test: Physical name changed - INVALID (returns error)
         let before = schema! {
-            (StructField::new("name", DataType::STRING, false).add_metadata([
+            (StructField::not_null("name", DataType::STRING).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
@@ -894,7 +894,7 @@ mod tests {
             ])),
         };
         let after = schema! {
-            (StructField::new("name", DataType::STRING, false).add_metadata([
+            (StructField::not_null("name", DataType::STRING).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
@@ -911,7 +911,7 @@ mod tests {
 
         // Test: Missing physical name in one schema - INVALID (returns error)
         let before = schema! {
-            (StructField::new("name", DataType::STRING, false).add_metadata([
+            (StructField::not_null("name", DataType::STRING).add_metadata([
                 ("delta.columnMapping.id", MetadataValue::Number(1)),
                 (
                     "delta.columnMapping.physicalName",
@@ -920,7 +920,7 @@ mod tests {
             ])),
         };
         let after = schema! {
-            (StructField::new("name", DataType::STRING, false)
+            (StructField::not_null("name", DataType::STRING)
                 .add_metadata([("delta.columnMapping.id", MetadataValue::Number(1))])),
         };
 

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -1432,8 +1432,8 @@ impl<'a> IntoIterator for &'a StructType {
 /// use delta_kernel::schema::{StructType, StructField, DataType};
 ///
 /// let fields = vec![
-///     StructField::new("name", DataType::STRING, false),
-///     StructField::new("age", DataType::INTEGER, true),
+///     StructField::not_null("name", DataType::STRING),
+///     StructField::nullable("age", DataType::INTEGER),
 /// ];
 /// let struct_type = StructType::try_new(fields)?;
 ///
@@ -1505,8 +1505,8 @@ impl DoubleEndedIterator for StructFieldIntoIter {
 /// use delta_kernel::schema::{StructType, StructField, DataType};
 ///
 /// let fields = vec![
-///     StructField::new("name", DataType::STRING, false),
-///     StructField::new("age", DataType::INTEGER, true),
+///     StructField::not_null("name", DataType::STRING),
+///     StructField::nullable("age", DataType::INTEGER),
 /// ];
 /// let struct_type = StructType::try_new(fields)?;
 ///
@@ -3710,9 +3710,9 @@ mod tests {
     #[test]
     fn test_struct_type_iterator_basic() {
         let fields = vec![
-            StructField::new("field1", DataType::STRING, true),
-            StructField::new("field2", DataType::INTEGER, false),
-            StructField::new("field3", DataType::BOOLEAN, true),
+            StructField::nullable("field1", DataType::STRING),
+            StructField::not_null("field2", DataType::INTEGER),
+            StructField::nullable("field3", DataType::BOOLEAN),
         ];
         let struct_type = StructType::new_unchecked(fields.clone());
 
@@ -3727,8 +3727,8 @@ mod tests {
     #[test]
     fn test_struct_type_into_iterator_owned() {
         let fields = vec![
-            StructField::new("a", DataType::STRING, true),
-            StructField::new("b", DataType::INTEGER, false),
+            StructField::nullable("a", DataType::STRING),
+            StructField::not_null("b", DataType::INTEGER),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3743,9 +3743,9 @@ mod tests {
     #[test]
     fn test_struct_type_into_iterator_references() {
         let fields = vec![
-            StructField::new("x", DataType::DOUBLE, true),
-            StructField::new("y", DataType::FLOAT, false),
-            StructField::new("z", DataType::LONG, true),
+            StructField::nullable("x", DataType::DOUBLE),
+            StructField::not_null("y", DataType::FLOAT),
+            StructField::nullable("z", DataType::LONG),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3763,10 +3763,10 @@ mod tests {
     #[test]
     fn test_iterator_exact_size() {
         let fields = vec![
-            StructField::new("field1", DataType::STRING, true),
-            StructField::new("field2", DataType::INTEGER, false),
-            StructField::new("field3", DataType::BOOLEAN, true),
-            StructField::new("field4", DataType::DATE, true),
+            StructField::nullable("field1", DataType::STRING),
+            StructField::not_null("field2", DataType::INTEGER),
+            StructField::nullable("field3", DataType::BOOLEAN),
+            StructField::nullable("field4", DataType::DATE),
         ];
 
         // Test ExactSizeIterator for reference iterator
@@ -3787,7 +3787,7 @@ mod tests {
 
     #[test]
     fn test_iterator_with_metadata() {
-        let field_with_metadata = StructField::new("test_field", DataType::STRING, true)
+        let field_with_metadata = StructField::nullable("test_field", DataType::STRING)
             .with_metadata([("key1", MetadataValue::String("value1".to_string()))]);
 
         let struct_type = StructType::new_unchecked([field_with_metadata]);
@@ -3824,9 +3824,9 @@ mod tests {
     #[test]
     fn test_iterator_order_preservation() {
         let fields = vec![
-            StructField::new("zebra", DataType::STRING, true),
-            StructField::new("apple", DataType::INTEGER, false),
-            StructField::new("banana", DataType::BOOLEAN, true),
+            StructField::nullable("zebra", DataType::STRING),
+            StructField::not_null("apple", DataType::INTEGER),
+            StructField::nullable("banana", DataType::BOOLEAN),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3846,8 +3846,8 @@ mod tests {
     #[test]
     fn test_iterator_collect() {
         let original_fields = vec![
-            StructField::new("field1", DataType::STRING, true),
-            StructField::new("field2", DataType::INTEGER, false),
+            StructField::nullable("field1", DataType::STRING),
+            StructField::not_null("field2", DataType::INTEGER),
         ];
         let struct_type = StructType::new_unchecked(original_fields.clone());
 
@@ -3867,10 +3867,10 @@ mod tests {
     #[test]
     fn test_iterator_functional_methods() {
         let fields = vec![
-            StructField::new("nullable_string", DataType::STRING, true),
-            StructField::new("required_int", DataType::INTEGER, false),
-            StructField::new("nullable_bool", DataType::BOOLEAN, true),
-            StructField::new("required_long", DataType::LONG, false),
+            StructField::nullable("nullable_string", DataType::STRING),
+            StructField::not_null("required_int", DataType::INTEGER),
+            StructField::nullable("nullable_bool", DataType::BOOLEAN),
+            StructField::not_null("required_long", DataType::LONG),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3901,10 +3901,10 @@ mod tests {
     #[test]
     fn test_double_ended_iterator_ref() {
         let fields = vec![
-            StructField::new("first", DataType::STRING, true),
-            StructField::new("second", DataType::INTEGER, false),
-            StructField::new("third", DataType::BOOLEAN, true),
-            StructField::new("fourth", DataType::LONG, false),
+            StructField::nullable("first", DataType::STRING),
+            StructField::not_null("second", DataType::INTEGER),
+            StructField::nullable("third", DataType::BOOLEAN),
+            StructField::not_null("fourth", DataType::LONG),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3927,9 +3927,9 @@ mod tests {
     #[test]
     fn test_double_ended_iterator_owned() {
         let fields = vec![
-            StructField::new("alpha", DataType::STRING, true),
-            StructField::new("beta", DataType::INTEGER, false),
-            StructField::new("gamma", DataType::BOOLEAN, true),
+            StructField::nullable("alpha", DataType::STRING),
+            StructField::not_null("beta", DataType::INTEGER),
+            StructField::nullable("gamma", DataType::BOOLEAN),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3953,9 +3953,9 @@ mod tests {
     #[test]
     fn test_double_ended_iterator_collect_reverse() {
         let fields = vec![
-            StructField::new("one", DataType::STRING, true),
-            StructField::new("two", DataType::INTEGER, false),
-            StructField::new("three", DataType::BOOLEAN, true),
+            StructField::nullable("one", DataType::STRING),
+            StructField::not_null("two", DataType::INTEGER),
+            StructField::nullable("three", DataType::BOOLEAN),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3970,9 +3970,9 @@ mod tests {
     #[test]
     fn test_double_ended_iterator_with_into_iter_ref() {
         let fields = vec![
-            StructField::new("x", DataType::DOUBLE, true),
-            StructField::new("y", DataType::FLOAT, false),
-            StructField::new("z", DataType::LONG, true),
+            StructField::nullable("x", DataType::DOUBLE),
+            StructField::not_null("y", DataType::FLOAT),
+            StructField::nullable("z", DataType::LONG),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -3992,8 +3992,8 @@ mod tests {
     #[test]
     fn test_fused_iterator_ref() {
         let fields = vec![
-            StructField::new("test1", DataType::STRING, true),
-            StructField::new("test2", DataType::INTEGER, false),
+            StructField::nullable("test1", DataType::STRING),
+            StructField::not_null("test2", DataType::INTEGER),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -4014,8 +4014,8 @@ mod tests {
     #[test]
     fn test_fused_iterator_owned() {
         let fields = vec![
-            StructField::new("item1", DataType::STRING, true),
-            StructField::new("item2", DataType::INTEGER, false),
+            StructField::nullable("item1", DataType::STRING),
+            StructField::not_null("item2", DataType::INTEGER),
         ];
         let struct_type = StructType::new_unchecked(fields);
 
@@ -4035,7 +4035,7 @@ mod tests {
 
     #[test]
     fn test_fused_iterator_with_into_iter_ref() {
-        let fields = vec![StructField::new("field_a", DataType::BOOLEAN, true)];
+        let fields = vec![StructField::nullable("field_a", DataType::BOOLEAN)];
         let struct_type = StructType::new_unchecked(fields);
 
         // Verify that &StructType into_iter implements FusedIterator
@@ -4068,7 +4068,7 @@ mod tests {
 
     #[test]
     fn test_double_ended_iterator_single_element() {
-        let fields = vec![StructField::new("single", DataType::STRING, true)];
+        let fields = vec![StructField::nullable("single", DataType::STRING)];
         let struct_type = StructType::new_unchecked(fields);
 
         // Test DoubleEndedIterator with single element
@@ -4081,7 +4081,7 @@ mod tests {
 
         // Test getting single element from next_back()
         let struct_type =
-            StructType::new_unchecked([StructField::new("single2", DataType::INTEGER, false)]);
+            StructType::new_unchecked([StructField::not_null("single2", DataType::INTEGER)]);
         let mut iter = struct_type.into_iter();
 
         assert_eq!(iter.next_back().unwrap().name, "single2");
@@ -4559,8 +4559,8 @@ mod tests {
     #[test]
     fn test_builder_add_fields() {
         let schema = StructType::builder()
-            .add_field(StructField::new("id", DataType::INTEGER, false))
-            .add_field(StructField::new("name", DataType::STRING, true))
+            .add_field(StructField::not_null("id", DataType::INTEGER))
+            .add_field(StructField::nullable("name", DataType::STRING))
             .build()
             .unwrap();
 
@@ -4574,7 +4574,7 @@ mod tests {
         let base_schema = schema! { not_null "id": INTEGER };
 
         let extended_schema = StructTypeBuilder::from_schema(&base_schema)
-            .add_field(StructField::new("name", DataType::STRING, true))
+            .add_field(StructField::nullable("name", DataType::STRING))
             .build()
             .unwrap();
 

--- a/kernel/src/schema/validation.rs
+++ b/kernel/src/schema/validation.rs
@@ -224,23 +224,21 @@ mod tests {
     }
 
     fn schema_top_level_dup() -> StructType {
-        let inner =
-            StructType::new_unchecked(vec![StructField::new("x", DataType::INTEGER, false)]);
+        let inner = StructType::new_unchecked(vec![StructField::not_null("x", DataType::INTEGER)]);
         StructType::new_unchecked(vec![
-            StructField::new("a", inner, false),
-            StructField::new("A", DataType::STRING, true),
+            StructField::not_null("a", inner),
+            StructField::nullable("A", DataType::STRING),
         ])
     }
 
     fn schema_array_dup() -> StructType {
         let inner = StructType::new_unchecked(vec![
-            StructField::new("x", DataType::INTEGER, false),
-            StructField::new("X", DataType::STRING, true),
+            StructField::not_null("x", DataType::INTEGER),
+            StructField::nullable("X", DataType::STRING),
         ]);
-        StructType::new_unchecked(vec![StructField::new(
+        StructType::new_unchecked(vec![StructField::not_null(
             "arr",
             ArrayType::new(inner, true),
-            false,
         )])
     }
 

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -1298,7 +1298,7 @@ mod tests {
     }
 
     fn make_cm_field(name: &str, id: i64, data_type: impl Into<DataType>) -> StructField {
-        StructField::new(name, data_type, false).with_metadata([
+        StructField::not_null(name, data_type).with_metadata([
             (
                 ColumnMetadataKey::ColumnMappingId.as_ref(),
                 MetadataValue::Number(id),
@@ -2102,7 +2102,7 @@ mod tests {
     #[test]
     fn test_get_any_level_column_physical_name_success() {
         let inner = schema! {
-            (StructField::new("y", DataType::INTEGER, false).add_metadata([
+            (StructField::not_null("y", DataType::INTEGER).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-inner-y".to_string()),
@@ -2115,7 +2115,7 @@ mod tests {
         };
 
         let schema = schema! {
-            (StructField::new("a", inner, true).add_metadata([
+            (StructField::nullable("a", inner).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-outer-a".to_string()),
@@ -2191,7 +2191,7 @@ mod tests {
         #[case] has_id: bool,
         #[case] expected_err: &str,
     ) {
-        let mut inner_field = StructField::new("y", DataType::INTEGER, false);
+        let mut inner_field = StructField::not_null("y", DataType::INTEGER);
         if has_physical_name {
             inner_field = inner_field.add_metadata([(
                 ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
@@ -2209,7 +2209,7 @@ mod tests {
             (inner_field),
         };
         let schema = schema! {
-            (StructField::new("a", inner, true).add_metadata([
+            (StructField::nullable("a", inner).add_metadata([
                 (
                     ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
                     MetadataValue::String("col-outer-a".to_string()),
@@ -2248,7 +2248,7 @@ mod tests {
         #[case] expected: Option<&str>,
     ) {
         let field =
-            StructField::new("a", DataType::INTEGER, true).fold_with(annotation, |field, value| {
+            StructField::nullable("a", DataType::INTEGER).fold_with(annotation, |field, value| {
                 field.add_metadata([(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(), value)])
             });
         let result = expect_physical_name(&field);
@@ -2292,7 +2292,7 @@ mod tests {
 
     #[test]
     fn physical_to_logical_with_name_mapping() {
-        let field = StructField::new("user_id", DataType::INTEGER, false).with_metadata([(
+        let field = StructField::not_null("user_id", DataType::INTEGER).with_metadata([(
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-abc-123".to_string()),
         )]);
@@ -2327,12 +2327,12 @@ mod tests {
 
     #[test]
     fn physical_to_logical_nested_struct_with_mapping() {
-        let inner_field = StructField::new("city", DataType::STRING, true).with_metadata([(
+        let inner_field = StructField::nullable("city", DataType::STRING).with_metadata([(
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-inner-456".to_string()),
         )]);
         let inner_struct = schema! { (inner_field) };
-        let outer_field = StructField::new("address", inner_struct, true).with_metadata([(
+        let outer_field = StructField::nullable("address", inner_struct).with_metadata([(
             "delta.columnMapping.physicalName".to_string(),
             MetadataValue::String("col-outer-123".to_string()),
         )]);

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -765,7 +765,7 @@ impl CreateTableTransactionBuilder {
     /// # use delta_kernel::schema::{StructType, DataType, StructField};
     /// # use std::sync::Arc;
     /// # fn example() -> delta_kernel::DeltaResult<()> {
-    /// # let schema = Arc::new(StructType::try_new(vec![StructField::new("id", DataType::INTEGER, true)])?);
+    /// # let schema = Arc::new(StructType::try_new(vec![StructField::nullable("id", DataType::INTEGER)])?);
     /// let builder = create_table("/path/to/table", schema, "MyApp/1.0")
     ///     .with_table_properties([
     ///         ("myapp.version", "1.0"),
@@ -810,8 +810,8 @@ impl CreateTableTransactionBuilder {
     /// # use std::sync::Arc;
     /// # fn example() -> delta_kernel::DeltaResult<()> {
     /// # let schema = Arc::new(StructType::try_new(vec![
-    /// #     StructField::new("id", DataType::INTEGER, true),
-    /// #     StructField::new("date", DataType::STRING, true),
+    /// #     StructField::nullable("id", DataType::INTEGER),
+    /// #     StructField::nullable("date", DataType::STRING),
     /// # ])?);
     /// // Clustered layout:
     /// let builder = create_table("/path/to/table", schema.clone(), "MyApp/1.0")

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -15,7 +15,7 @@
 //! # fn example(engine: &dyn Engine) -> delta_kernel::DeltaResult<()> {
 //!
 //! let schema = Arc::new(StructType::try_new(vec![
-//!     StructField::new("id", DataType::INTEGER, true),
+//!     StructField::nullable("id", DataType::INTEGER),
 //! ])?);
 //!
 //! let result = create_table("/path/to/table", schema, "MyApp/1.0")
@@ -73,7 +73,7 @@ use crate::DeltaResult;
 /// # fn example(engine: &dyn Engine) -> delta_kernel::DeltaResult<()> {
 ///
 /// let schema = Arc::new(StructType::try_new(vec![
-///     StructField::new("id", DataType::INTEGER, true),
+///     StructField::nullable("id", DataType::INTEGER),
 /// ])?);
 ///
 /// let result = create_table("/path/to/table", schema, "MyApp/1.0")

--- a/kernel/src/unit_test_utils.rs
+++ b/kernel/src/unit_test_utils.rs
@@ -1070,7 +1070,7 @@ pub(crate) mod column_mapping_physical_name_dedup_fixtures {
     }
 
     fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> StructField {
-        StructField::new(name, ty, true).with_metadata([
+        StructField::nullable(name, ty).with_metadata([
             (
                 ColumnMetadataKey::ColumnMappingId.as_ref(),
                 MetadataValue::Number(id),

--- a/kernel/tests/integration/create_table/clustering.rs
+++ b/kernel/tests/integration/create_table/clustering.rs
@@ -144,7 +144,7 @@ async fn test_clustering_stats_columns_within_limit() -> DeltaResult<()> {
 
     // Build schema with 10 columns (cluster on column 5, within default 32 limit)
     let fields: Vec<StructField> = (0..10)
-        .map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, true))
+        .map(|i| StructField::nullable(format!("col{i}"), DataType::INTEGER))
         .collect();
     let schema = Arc::new(StructType::try_new(fields)?);
 
@@ -169,7 +169,7 @@ async fn test_clustering_stats_columns_beyond_limit() -> DeltaResult<()> {
 
     // Build schema with 40 columns (cluster on column 35, beyond default 32 limit)
     let fields: Vec<StructField> = (0..40)
-        .map(|i| StructField::new(format!("col{i}"), DataType::INTEGER, true))
+        .map(|i| StructField::nullable(format!("col{i}"), DataType::INTEGER))
         .collect();
     let schema = Arc::new(StructType::try_new(fields)?);
 

--- a/test-utils/src/column_mapping_fixtures.rs
+++ b/test-utils/src/column_mapping_fixtures.rs
@@ -33,7 +33,7 @@ pub fn nested_field_with_same_phy_path() -> StructType {
 
 /// `StructField` carrying both `delta.columnMapping.id` and `delta.columnMapping.physicalName`.
 pub fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> StructField {
-    StructField::new(name, ty, true).with_metadata([
+    StructField::nullable(name, ty).with_metadata([
         (
             ColumnMetadataKey::ColumnMappingId.as_ref(),
             MetadataValue::Number(id),
@@ -47,7 +47,7 @@ pub fn cm_field(name: &str, id: i64, phys: &str, ty: impl Into<DataType>) -> Str
 
 /// `StructField` carrying only `delta.columnMapping.id` (physical name left to be filled).
 pub fn cm_field_id_only(name: &str, id: i64, ty: impl Into<DataType>) -> StructField {
-    StructField::new(name, ty, true).with_metadata([(
+    StructField::nullable(name, ty).with_metadata([(
         ColumnMetadataKey::ColumnMappingId.as_ref(),
         MetadataValue::Number(id),
     )])
@@ -55,7 +55,7 @@ pub fn cm_field_id_only(name: &str, id: i64, ty: impl Into<DataType>) -> StructF
 
 /// `StructField` carrying only `delta.columnMapping.physicalName` (id left to be allocated).
 pub fn cm_field_physical_name_only(name: &str, phys: &str, ty: impl Into<DataType>) -> StructField {
-    StructField::new(name, ty, true).with_metadata([(
+    StructField::nullable(name, ty).with_metadata([(
         ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
         MetadataValue::String(phys.to_string()),
     )])

--- a/workloads/src/predicate_parser.rs
+++ b/workloads/src/predicate_parser.rs
@@ -89,8 +89,8 @@ fn preprocess_timestamp_ntz(input: &str) -> Cow<'_, str> {
 /// # Example
 /// ```ignore
 /// let schema = Schema::try_new(vec![
-///     StructField::new("id", DataType::LONG, false),
-///     StructField::new("name", DataType::STRING, false),
+///     StructField::not_null("id", DataType::LONG),
+///     StructField::not_null("name", DataType::STRING),
 /// ])?;
 /// let pred = parse_predicate("id < 500 AND name = 'alice'", &schema).unwrap();
 /// ```


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `StructField::nullable` and `StructField::not_null` whenever a field's nullability is a literal boolean. This makes schema definitions easier to read and reserves `StructField::new` for runtime or computed nullability.

The mechanical cleanup covers source code, tests, fixtures, rustdoc examples, and the user guide. Calls with dynamic nullability and the constructor implementations remain unchanged.

## How was this change tested?

- `cargo +nightly fmt -- --check`
- `cargo build --workspace --all-features`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo clippy --workspace --no-default-features --features arrow --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
- `cargo nextest run --workspace --all-features` (13,091 passed; 63 skipped)
