### PR TITLE
fix: silence no-default internal dead-code warnings

### DIFF
--- a/kernel/src/clustering.rs
+++ b/kernel/src/clustering.rs
@@ -49,6 +49,7 @@ pub(crate) const CLUSTERING_DOMAIN_NAME: &str = "delta.clustering";
 /// Callers needing to correlate a clustering column with per-file statistics must use
 /// [`physical_column`]: stats are keyed on physical names.
 #[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 #[internal_api]
 pub(crate) struct ClusteringColumnInfo {
     /// The physical column reference as stored in the `delta.clustering` domain.

--- a/kernel/src/column_trie.rs
+++ b/kernel/src/column_trie.rs
@@ -94,6 +94,7 @@ impl<'col> ColumnTrie<'col> {
     /// - `["a"]` -> false (not terminal)
     ///
     /// [`contains_prefix_of`]: Self::contains_prefix_of
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     #[internal_api]
     pub(crate) fn is_terminal(&self, path: &[String]) -> bool {
         let mut node = self;

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -2013,6 +2013,7 @@ impl PrimitiveType {
     }
 
     /// Returns whether this is one of the ANSI interval primitive types.
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     #[internal_api]
     pub(crate) fn is_interval(&self) -> bool {
         matches!(self, Self::IntervalYearMonth | Self::IntervalDayTime)

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -551,6 +551,7 @@ impl Snapshot {
     ///
     /// Returns an error if the clustering domain metadata is malformed, or if a physical
     /// column name cannot be resolved to a logical name in the schema.
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     #[internal_api]
     pub(crate) fn get_clustering_column_infos(
         &self,

--- a/kernel/src/table_changes/mod.rs
+++ b/kernel/src/table_changes/mod.rs
@@ -66,12 +66,14 @@ mod scan_file;
 #[cfg(test)]
 mod test_utils;
 
+#[cfg_attr(not(feature = "internal-api"), allow(unused_imports))]
 #[internal_api]
 pub(crate) use scan_file::{TableChangesFileAction, TableChangesScanFile};
 
 /// Selects the history represented by [`TableChanges::scan_file_listing`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 #[internal_api]
 pub(crate) enum TableChangesListingMode {
     /// Preserves each commit's file actions.

--- a/kernel/src/table_features/column_mapping.rs
+++ b/kernel/src/table_features/column_mapping.rs
@@ -879,6 +879,7 @@ pub(crate) fn get_any_level_column_physical_name(
 ///
 /// Walks the schema once, matching each path component by `physical_name(mode)`, and returns the
 /// resolved logical [`ColumnName`] together with the data type of the final (leaf) field.
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 pub(crate) fn physical_to_logical_column_name_and_type(
     logical_schema: &StructType,
     physical_col: &ColumnName,

--- a/kernel/src/transaction/stats_verifier.rs
+++ b/kernel/src/transaction/stats_verifier.rs
@@ -20,12 +20,14 @@ use crate::DeltaResult;
 /// For each required column, validates that `nullCount` is present (non-null) and that
 /// `minValues` and `maxValues` are present unless the column is all-null
 /// (`nullCount == numRecords`).
+#[cfg_attr(not(feature = "internal-api"), allow(unreachable_pub))]
 pub struct StatsColumnVerifier {
     required_columns: Vec<(ColumnName, DataType)>,
 }
 
 impl StatsColumnVerifier {
     /// Create a new verifier that checks statistics for the given required columns and types.
+    #[cfg_attr(not(feature = "internal-api"), allow(unreachable_pub))]
     pub fn new(required_columns: Vec<(ColumnName, DataType)>) -> Self {
         Self { required_columns }
     }
@@ -34,6 +36,7 @@ impl StatsColumnVerifier {
     ///
     /// For each required column, extracts all three stat columns (nullCount, minValues,
     /// maxValues) in a single `visit_rows` call per batch.
+    #[cfg_attr(not(feature = "internal-api"), allow(unreachable_pub))]
     pub fn verify(&self, add_files: &[Box<dyn crate::EngineData>]) -> DeltaResult<()> {
         if self.required_columns.is_empty() {
             return Ok(());
@@ -297,6 +300,7 @@ impl RowVisitor for ColumnStatsValidator<'_> {
 
 /// Verify that every `add` action has `stats.numRecords` populated. Short-circuits on the first
 /// violation and returns an error containing the `add.path`.
+#[cfg_attr(not(feature = "internal-api"), allow(unreachable_pub))]
 pub fn verify_num_records_present(add_files: &[Box<dyn crate::EngineData>]) -> DeltaResult<()> {
     let column_names = vec![column_name!("path"), column_name!("stats", NUM_RECORDS)];
     let mut first_missing: Option<String> = None;

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -558,6 +558,7 @@ struct DvUpdateEntry {
 
 impl DvUpdateEntry {
     /// The (null DV, null stats) entry for rows that are not getting a DV update.
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     fn null() -> Self {
         static NULL_DV: LazyLock<Scalar> =
             LazyLock::new(|| Scalar::null(DeletionVectorDescriptor::to_schema()));

--- a/kernel/src/utils.rs
+++ b/kernel/src/utils.rs
@@ -161,6 +161,7 @@ pub(crate) trait FoldWithOption: Sized {
 
     /// Fallible [`fold_with`](Self::fold_with): applies `Result`-returning `f` to `self` if `opt`
     /// is [`Some`], otherwise returns `self` unchanged (wrapped in `Ok`).
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     fn try_fold_with<U, E>(
         self,
         opt: Option<U>,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds targeted `#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]` annotations to internal helper items that are intentionally unused in the no-default-features kernel lint build, but are used when `internal-api` or feature-dependent crates are compiled.

This follows the existing pattern already used for internal-only code paths in the repo and fixes the warnings reported after #3124.

Why this is safe: this is lint-only. `allow(dead_code)` does not change item visibility, signatures, cfg inclusion, generated code, or runtime behavior. The attributes apply only when `internal-api` is disabled; builds with `internal-api` keep normal dead-code linting for these items.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo clippy --no-default-features --package delta_kernel --package delta_kernel_ffi --package delta_kernel_derive --package delta_kernel_ffi_macros -- -D warnings`
- `cargo check -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc`
- `cargo clippy -p delta_kernel --no-default-features --features declarative-plans,vendored-protoc --tests -- -D warnings`
- Pre-commit hook passed: formatting, clippy, tests, and coverage
