### PR TITLE
ci: clean up no-default check aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,8 +188,6 @@ jobs:
       - name: lint without default features - packages which depend on kernel with features enabled
         run: cargo clippy-no-default-kernel-dependents
       - name: check without default features - kernel
-        env:
-          RUSTFLAGS: --cap-lints=warn
         run: cargo check-no-default-kernel
       - name: check without default features - default engine
         run: cargo check-no-default-engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,11 @@ cargo +nightly fmt \
   && cargo clippy --workspace --benches --tests --all-features -- -D warnings \
   && cargo doc --workspace --all-features --no-deps
 
-# Workspace no-default-features lint for crates that depend on kernel's Arrow APIs
-cargo clippy --workspace --no-default-features --features arrow \
-  --exclude delta_kernel --exclude delta_kernel_ffi --exclude delta_kernel_derive --exclude delta_kernel_ffi_macros -- -D warnings
+# Split no-default-features CI checks (cargo aliases from .cargo/config.toml)
+cargo clippy-no-default-kernel-dependents
+cargo check-no-default-kernel
+cargo check-no-default-engine
+cargo clippy-no-default-kernel-leaves
 
 # Quick pre-push check (mimics CI)
 cargo +nightly fmt \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ cargo test --all-features
 This will build the kernel, run all unit tests, fetch the [Delta Acceptance Tests][dat] data and run
 the acceptance tests against it.
 
+CI also checks no-default-features builds in smaller pieces so that dependent crates do not
+accidentally enable kernel features. To run the same checks locally, use:
+
+```sh
+cargo clippy-no-default-kernel-dependents
+cargo check-no-default-kernel
+cargo check-no-default-engine
+cargo clippy-no-default-kernel-leaves
+```
+
 In general, you will want to depend on `delta-kernel-rs` by adding it as a dependency to your
 `Cargo.toml`, (that is, for rust projects using cargo) for other projects please see the [FFI]
 module. The core kernel includes facilities for reading and writing delta tables, and allows the

--- a/kernel/src/actions/visitors.rs
+++ b/kernel/src/actions/visitors.rs
@@ -105,6 +105,7 @@ pub(crate) struct AddVisitor {
     pub(crate) adds: Vec<Add>,
 }
 
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 impl AddVisitor {
     #[internal_api]
     fn visit_add<'a>(
@@ -178,6 +179,7 @@ pub(crate) struct RemoveVisitor {
     pub(crate) removes: Vec<Remove>,
 }
 
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 impl RemoveVisitor {
     #[internal_api]
     pub(crate) fn visit_remove<'a>(
@@ -254,6 +256,7 @@ pub(crate) struct CdcVisitor {
     pub(crate) cdcs: Vec<Cdc>,
 }
 
+#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
 impl CdcVisitor {
     #[internal_api]
     pub(crate) fn visit_cdc<'a>(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use the cargo aliases for the split no-default-features CI checks, document them in `README.md`
and `CLAUDE.md`, and remove the `RUSTFLAGS='--cap-lints=warn'` workaround from the kernel-only
check.

This also adds targeted `#[cfg_attr(not(feature = "internal-api"), allow(dead_code))]`
annotations for the action visitor helper impls that are intentionally unused in the
no-default-features kernel build shape.

Why this is safe: the new annotations are lint-only. They do not change item visibility,
signatures, cfg inclusion, generated code, or runtime behavior. They apply only when
`internal-api` is disabled; internal-api builds keep normal dead-code linting for these helpers.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo check-no-default-kernel`
- `RUSTFLAGS='-D warnings' cargo check-no-default-kernel`
- `git diff --check`
