### PR TITLE
feat: forward UC protocol metadata through FFI

### DIFF
--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -612,6 +612,31 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_version_non_zero_omits_unchanged_protocol_and_metadata() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
+        let commit_metadata = catalog_managed_commit_metadata(table_root.clone(), 1);
+        let engine = DefaultEngine::builder(Arc::new(LocalFileSystem::new())).build();
+        fs::create_dir_all(tmp_dir.path().join("_delta_log/_staged_commits")).unwrap();
+
+        let client = Arc::new(CapturingUpdateTableClient::default());
+        let committer = UCCommitter::new(
+            client.clone(),
+            "test-table-id",
+            TableIdentifier::new("test_catalog", "test_schema", "test_table"),
+        );
+        let result = committer
+            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
+            .unwrap();
+        assert!(matches!(result, CommitResponse::Committed { .. }));
+
+        let request = client.request.lock().unwrap().clone().unwrap();
+        assert!(request.staged_commit().is_some());
+        assert_eq!(request.protocol(), None);
+        assert_eq!(request.metadata(), None);
+    }
+
     #[test]
     fn commit_version_non_zero_rejects_clustering_change() {
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/delta-kernel-unity-catalog/src/committer.rs
+++ b/delta-kernel-unity-catalog/src/committer.rs
@@ -112,17 +112,10 @@ impl<C: UpdateTableClient> UCCommitter<C> {
         Ok(())
     }
 
-    /// Validates that this commit does not include ALTER TABLE changes (protocol, metadata,
-    /// or clustering column changes).
-    fn validate_no_alter_table_changes(commit_metadata: &CommitMetadata) -> DeltaResult<()> {
-        require!(
-            !commit_metadata.has_protocol_change(),
-            errors::alter_table_unsupported("protocol")
-        );
-        require!(
-            !commit_metadata.has_metadata_change(),
-            errors::alter_table_unsupported("metadata")
-        );
+    /// Validates that this commit does not include unsupported ALTER TABLE changes.
+    fn validate_no_unsupported_alter_table_changes(
+        commit_metadata: &CommitMetadata,
+    ) -> DeltaResult<()> {
         require!(
             !commit_metadata.has_domain_metadata_change(CLUSTERING_DOMAIN_NAME),
             errors::alter_table_unsupported("clustering columns")
@@ -183,7 +176,7 @@ impl<C: UpdateTableClient> UCCommitter<C> {
             "commit_version_non_zero called with version 0"
         );
         self.validate_catalog_managed_state(&commit_metadata)?;
-        Self::validate_no_alter_table_changes(&commit_metadata)?;
+        Self::validate_no_unsupported_alter_table_changes(&commit_metadata)?;
         let staged_commit_path = commit_metadata.staged_commit_path()?;
         engine
             .json_handler()
@@ -201,6 +194,24 @@ impl<C: UpdateTableClient> UCCommitter<C> {
                 file_modification_timestamp: committed.last_modified,
             },
         }];
+        if let Some(protocol) = commit_metadata.new_protocol() {
+            updates.push(DeltaTableUpdate::UpdateProtocol {
+                protocol: serde_json::to_value(protocol).map_err(|e| {
+                    DeltaError::generic(format!(
+                        "failed to serialize protocol for UC update_table: {e}"
+                    ))
+                })?,
+            });
+        }
+        if let Some(metadata) = commit_metadata.new_metadata() {
+            updates.push(DeltaTableUpdate::UpdateMetadata {
+                metadata: serde_json::to_value(metadata).map_err(|e| {
+                    DeltaError::generic(format!(
+                        "failed to serialize metadata for UC update_table: {e}"
+                    ))
+                })?,
+            });
+        }
         if let Some(max_pub) = commit_metadata.max_published_version() {
             updates.push(DeltaTableUpdate::SetLatestBackfilledVersion {
                 latest_published_version: u64_to_wire_i64(max_pub, "max published version")?,
@@ -313,6 +324,7 @@ fn staged_commit_file_name(path: &url::Url) -> DeltaResult<String> {
 mod tests {
     use std::collections::HashMap;
     use std::fs;
+    use std::sync::Mutex;
 
     use delta_kernel::arrow::array::{Array, RecordBatch, StringArray};
     use delta_kernel::committer::{CatalogCommit, CommitMetadata};
@@ -329,6 +341,22 @@ mod tests {
     impl UpdateTableClient for MockUpdateTableClient {
         async fn update_table(&self, _: &TableIdentifier, _: UpdateTableRequest) -> Result<()> {
             unimplemented!()
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingUpdateTableClient {
+        request: Mutex<Option<UpdateTableRequest>>,
+    }
+
+    impl UpdateTableClient for CapturingUpdateTableClient {
+        async fn update_table(
+            &self,
+            _: &TableIdentifier,
+            request: UpdateTableRequest,
+        ) -> Result<()> {
+            *self.request.lock().unwrap() = Some(request);
+            Ok(())
         }
     }
 
@@ -539,35 +567,48 @@ mod tests {
         );
     }
 
-    #[test]
-    fn commit_version_non_zero_rejects_protocol_change() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn commit_version_non_zero_forwards_protocol_and_metadata_changes() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
-        let commit_metadata = catalog_managed_commit_metadata(table_root, 1).with_protocol_change();
+        let commit_metadata = catalog_managed_commit_metadata(table_root.clone(), 1)
+            .with_protocol_change()
+            .with_metadata_change();
         let engine = DefaultEngine::builder(Arc::new(LocalFileSystem::new())).build();
+        fs::create_dir_all(tmp_dir.path().join("_delta_log/_staged_commits")).unwrap();
 
-        let err = test_committer()
-            .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("table protocol"),
-            "expected protocol change error, got: {err}"
+        let client = Arc::new(CapturingUpdateTableClient::default());
+        let committer = UCCommitter::new(
+            client.clone(),
+            "test-table-id",
+            TableIdentifier::new("test_catalog", "test_schema", "test_table"),
         );
-    }
-
-    #[test]
-    fn commit_version_non_zero_rejects_metadata_change() {
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let table_root = url::Url::from_directory_path(tmp_dir.path()).unwrap();
-        let commit_metadata = catalog_managed_commit_metadata(table_root, 1).with_metadata_change();
-        let engine = DefaultEngine::builder(Arc::new(LocalFileSystem::new())).build();
-
-        let err = test_committer()
+        let result = committer
             .commit(&engine, Box::new(std::iter::empty()), commit_metadata)
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("table metadata"),
-            "expected metadata change error, got: {err}"
+            .unwrap();
+        assert!(matches!(result, CommitResponse::Committed { .. }));
+
+        let request = client.request.lock().unwrap().clone().unwrap();
+        let protocol = request.protocol().expect("missing protocol update");
+        assert_eq!(protocol["minReaderVersion"], 3);
+        assert_eq!(protocol["minWriterVersion"], 7);
+        assert_eq!(
+            protocol["readerFeatures"],
+            serde_json::json!(["catalogManaged", "vacuumProtocolCheck"])
+        );
+        assert_eq!(
+            protocol["writerFeatures"],
+            serde_json::json!(["catalogManaged", "inCommitTimestamp", "vacuumProtocolCheck"])
+        );
+
+        let metadata = request.metadata().expect("missing metadata update");
+        assert_eq!(
+            metadata["configuration"]["io.unitycatalog.tableId"],
+            "test-table-id"
+        );
+        assert_eq!(
+            metadata["configuration"]["delta.enableInCommitTimestamps"],
+            "true"
         );
     }
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 bytes = "1.10"
 prost = { version = "0.13", optional = true }
+serde_json = { version = "1.0.142", optional = true }
 tracing = "0.1"
 tracing-core = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true, features = [ "json" ] }
@@ -53,7 +54,7 @@ rstest = "0.23"
 default = ["default-engine-rustls", "arrow"]
 default-engine-native-tls = ["delta_kernel/default-engine-base", "dep:delta_kernel_default_engine", "delta_kernel_default_engine/native-tls", "default-engine-base"]
 default-engine-rustls = ["delta_kernel/default-engine-base", "dep:delta_kernel_default_engine", "delta_kernel_default_engine/rustls", "default-engine-base"]
-delta-kernel-unity-catalog = [ "dep:delta-kernel-unity-catalog", "dep:unity-catalog-delta-client-api" ]
+delta-kernel-unity-catalog = [ "dep:delta-kernel-unity-catalog", "dep:unity-catalog-delta-client-api", "dep:serde_json" ]
 arrow = ["arrow-59"]
 arrow-59 = ["delta_kernel/arrow-59"]
 arrow-58 = ["delta_kernel/arrow-58"]

--- a/ffi/src/delta_kernel_unity_catalog.rs
+++ b/ffi/src/delta_kernel_unity_catalog.rs
@@ -1,9 +1,10 @@
-//! FFI hooks that enable constructing a UpdateTableClient.
+//! FFI hooks that enable constructing a Unity Catalog committer.
 
 use std::sync::Arc;
 
 use delta_kernel::actions::{Metadata, Protocol};
 use delta_kernel::committer::Committer;
+use delta_kernel::snapshot::Snapshot;
 use delta_kernel::DeltaResult;
 use delta_kernel_default_engine::executor::tokio::{
     TokioBackgroundExecutor, TokioMultiThreadExecutor,
@@ -12,7 +13,7 @@ use delta_kernel_default_engine::DefaultEngine;
 use delta_kernel_ffi::handle::Handle;
 use delta_kernel_ffi::{kernel_string_slice, KernelStringSlice, OptionalValue, TryFromStringSlice};
 use delta_kernel_ffi_macros::handle_descriptor;
-use delta_kernel_unity_catalog::UCCommitter;
+use delta_kernel_unity_catalog::{build_uc_create_table_request, UCCommitter};
 use tracing::debug;
 use unity_catalog_delta_client_api::{
     Result as ApiResult, TableIdentifier, UpdateTableClient,
@@ -33,8 +34,7 @@ pub struct Commit {
     pub file_modification_timestamp: i64,
 }
 
-/// Request to commit a new version to the table. It must include either a `commit_info` or
-/// `latest_backfilled_version`.
+/// Request passed to the commit callback.
 #[repr(C)]
 pub struct CommitRequest {
     pub table_id: KernelStringSlice,
@@ -46,6 +46,20 @@ pub struct CommitRequest {
     pub protocol: OptionalValue<Handle<SharedProtocol>>,
 }
 
+/// Request passed to the create-table callback.
+///
+/// `request_json` is a serialized
+/// [`unity_catalog_delta_client_api::CreateTableRequest`] built from the committed version 0
+/// snapshot.
+#[repr(C)]
+pub struct CreateTableRequest {
+    pub table_id: KernelStringSlice,
+    pub catalog: KernelStringSlice,
+    pub schema: KernelStringSlice,
+    pub table_name: KernelStringSlice,
+    pub request_json: KernelStringSlice,
+}
+
 /// The callback that will be called when the client wants to commit. Return `None` on success, or
 /// `Some(error)` if an error occurred.
 // Note, it doesn't make sense to return an ExternResult here because that can't hold the string
@@ -55,9 +69,19 @@ pub type CCommit = extern "C" fn(
     request: CommitRequest,
 ) -> OptionalValue<Handle<ExclusiveRustString>>;
 
-pub struct FfiUCCommitClient {
+/// The callback that will be called after a successful version 0 table-creation commit.
+///
+/// Return `None` on success, or `Some(error)` if an error occurred.
+pub type CCreateTable = extern "C" fn(
     context: NullableCvoid,
+    request: CreateTableRequest,
+) -> OptionalValue<Handle<ExclusiveRustString>>;
+
+pub struct FfiUCCommitClient {
+    commit_context: NullableCvoid,
     commit_callback: CCommit,
+    create_table_context: NullableCvoid,
+    create_table_callback: Option<CCreateTable>,
 }
 
 // NullableCvoid is NOT `Send` by itself. Here we declare our struct to be Send as it's up to the
@@ -109,12 +133,8 @@ impl UpdateTableClient for FfiUCCommitClient {
             })?
             .map(|protocol| Arc::new(protocol).into());
 
-        // there is a subtle issue here where we need to ensure that the string we use to refer to
-        // the commit_info.file_name stays in scope until _after_ the callback returns, so that the
-        // KernelStringSlice remains valid. This means we can't get clever with
-        // request.commit_info.map to build an Option<Commit>. Rather we just use a closure to hold
-        // the common code and call it from a scope where the string remains valid until after the
-        // closure finishes
+        // Keep file_name alive until the callback returns. The KernelStringSlice in Commit borrows
+        // from it, so the AddCommit path needs its own scope.
         let send_request = |commit_info| -> ApiResult<()> {
             let c_commit_request = CommitRequest {
                 table_id: kernel_string_slice!(table_id),
@@ -124,7 +144,7 @@ impl UpdateTableClient for FfiUCCommitClient {
                 protocol: protocol.into(),
             };
 
-            match (self.commit_callback)(self.context, c_commit_request) {
+            match (self.commit_callback)(self.commit_context, c_commit_request) {
                 OptionalValue::Some(e) => {
                     let boxed_str = unsafe { e.into_inner() }; // get the string back into Box<String>
                     let s: String = *boxed_str; // move back onto the stack
@@ -169,8 +189,36 @@ pub unsafe extern "C" fn get_uc_commit_client(
     commit_callback: CCommit,
 ) -> Handle<SharedFfiUCCommitClient> {
     Arc::new(FfiUCCommitClient {
-        context,
+        commit_context: context,
         commit_callback,
+        create_table_context: None,
+        create_table_callback: None,
+    })
+    .into()
+}
+
+/// Get a commit client that will call the passed callbacks when it wants to make a commit or
+/// finalize table creation. The matching context will be passed back to each callback when called.
+///
+/// IMPORTANT: The pointers passed for the contexts MUST be thread-safe (i.e. be able to be sent
+/// between threads safely) and MUST remain valid for as long as the client is used. It is valid to
+/// pass NULL as either context.
+///
+/// # Safety
+///
+///  Caller is responsible for passing valid pointers for the callbacks and valid context pointers.
+#[no_mangle]
+pub unsafe extern "C" fn get_uc_commit_client_with_create_table(
+    commit_context: NullableCvoid,
+    commit_callback: CCommit,
+    create_table_context: NullableCvoid,
+    create_table_callback: CCreateTable,
+) -> Handle<SharedFfiUCCommitClient> {
+    Arc::new(FfiUCCommitClient {
+        commit_context,
+        commit_callback,
+        create_table_context,
+        create_table_callback: Some(create_table_callback),
     })
     .into()
 }
@@ -186,11 +234,57 @@ pub unsafe extern "C" fn free_uc_commit_client(commit_client: Handle<SharedFfiUC
 
 // we need our own struct here because we want to override the calls to enter the tokio runtime
 // before calling into the standard committer
-struct FfiUCCommitter<C: UpdateTableClient> {
-    inner: UCCommitter<C>,
+struct FfiUCCommitter {
+    inner: UCCommitter<FfiUCCommitClient>,
+    client: Arc<FfiUCCommitClient>,
+    table_id: String,
+    table: TableIdentifier,
 }
 
-impl<C: UpdateTableClient + 'static> Committer for FfiUCCommitter<C> {
+impl FfiUCCommitter {
+    fn call_create_table_callback(
+        &self,
+        engine: &dyn delta_kernel::Engine,
+        table_root: &str,
+    ) -> DeltaResult<()> {
+        let Some(create_table_callback) = self.client.create_table_callback else {
+            return Ok(());
+        };
+
+        let snapshot = Snapshot::builder_for(table_root)
+            .at_version(0)
+            .with_max_catalog_version(0)
+            .build(engine)?;
+        let create_request = build_uc_create_table_request(&snapshot, engine, &self.table.table)?;
+        let request_json = serde_json::to_string(&create_request).map_err(|e| {
+            delta_kernel::Error::generic(format!(
+                "failed to serialize UC create_table request: {e}"
+            ))
+        })?;
+        let table_id = self.table_id.clone();
+        let catalog = self.table.catalog.clone();
+        let schema = self.table.schema.clone();
+        let table_name = self.table.table.clone();
+
+        let c_create_request = CreateTableRequest {
+            table_id: kernel_string_slice!(table_id),
+            catalog: kernel_string_slice!(catalog),
+            schema: kernel_string_slice!(schema),
+            table_name: kernel_string_slice!(table_name),
+            request_json: kernel_string_slice!(request_json),
+        };
+        match (create_table_callback)(self.client.create_table_context, c_create_request) {
+            OptionalValue::Some(e) => {
+                let boxed_str = unsafe { e.into_inner() };
+                let s: String = *boxed_str;
+                Err(delta_kernel::Error::generic(s))
+            }
+            OptionalValue::None => Ok(()),
+        }
+    }
+}
+
+impl Committer for FfiUCCommitter {
     fn commit(
         &self,
         engine: &dyn delta_kernel::Engine,
@@ -199,6 +293,9 @@ impl<C: UpdateTableClient + 'static> Committer for FfiUCCommitter<C> {
         >,
         commit_metadata: delta_kernel::committer::CommitMetadata,
     ) -> DeltaResult<delta_kernel::committer::CommitResponse> {
+        let is_create_table = commit_metadata.version() == 0;
+        let table_root = commit_metadata.table_root().to_string();
+
         // We hold this guard until the end of the function so we stay in the tokio context until
         // we're done
         let _guard = engine
@@ -216,7 +313,13 @@ impl<C: UpdateTableClient + 'static> Committer for FfiUCCommitter<C> {
                     "FFIUCCommitter can only be used with the default engine",
                 )
             })?;
-        self.inner.commit(engine, actions, commit_metadata)
+        let response = self.inner.commit(engine, actions, commit_metadata)?;
+        if is_create_table {
+            if let delta_kernel::committer::CommitResponse::Committed { .. } = &response {
+                self.call_create_table_callback(engine, &table_root)?;
+            }
+        }
+        Ok(response)
     }
 
     fn is_catalog_committer(&self) -> bool {
@@ -264,12 +367,12 @@ fn get_uc_committer_impl(
     let catalog_str: String = unsafe { TryFromStringSlice::try_from_slice(&catalog) }?;
     let schema_str: String = unsafe { TryFromStringSlice::try_from_slice(&schema) }?;
     let table_name_str: String = unsafe { TryFromStringSlice::try_from_slice(&table_name) }?;
+    let table = TableIdentifier::new(catalog_str, schema_str, table_name_str);
     let committer: Box<dyn Committer> = Box::new(FfiUCCommitter {
-        inner: UCCommitter::new(
-            client,
-            table_id_str,
-            TableIdentifier::new(catalog_str, schema_str, table_name_str),
-        ),
+        inner: UCCommitter::new(client.clone(), table_id_str.clone(), table.clone()),
+        client,
+        table_id: table_id_str,
+        table,
     });
     Ok(committer.into())
 }
@@ -295,6 +398,11 @@ pub(crate) mod tests {
     use std::ptr::NonNull;
     use std::sync::Arc;
 
+    use delta_kernel::object_store::memory::InMemory;
+    use delta_kernel::schema::schema_ref;
+    use delta_kernel::transaction::create_table::create_table;
+    use delta_kernel_default_engine::DefaultEngineBuilder;
+    use delta_kernel_unity_catalog::get_required_properties_for_disk;
     use unity_catalog_delta_client_api::{
         Commit as ClientCommit, DeltaTableRequirement as ApiRequirement,
         DeltaTableUpdate as ApiUpdate, Error as ApiError,
@@ -329,19 +437,42 @@ pub(crate) mod tests {
         pub(crate) commit_called: bool,
         pub(crate) last_commit_table_id: Option<String>,
         pub(crate) last_staged_filename: Option<String>,
+        pub(crate) last_latest_backfilled_version: Option<i64>,
         pub(crate) last_metadata: Option<MetadataVisitState>,
         pub(crate) last_protocol: Option<ProtocolVisitState>,
+        pub(crate) create_table_called: bool,
+        pub(crate) last_create_table_id: Option<String>,
+        pub(crate) last_create_catalog: Option<String>,
+        pub(crate) last_create_schema: Option<String>,
+        pub(crate) last_create_table_name: Option<String>,
+        pub(crate) last_create_request_json: Option<String>,
         pub(crate) should_fail_commit: bool,
+        pub(crate) should_fail_create_table: bool,
     }
 
     pub(crate) fn get_test_context(should_fail_commit: bool) -> NullableCvoid {
+        get_test_context_with_create_table_failure(should_fail_commit, false)
+    }
+
+    pub(crate) fn get_test_context_with_create_table_failure(
+        should_fail_commit: bool,
+        should_fail_create_table: bool,
+    ) -> NullableCvoid {
         let context = Box::new(TestContext {
             commit_called: false,
             last_commit_table_id: None,
             last_staged_filename: None,
+            last_latest_backfilled_version: None,
             last_metadata: None,
             last_protocol: None,
+            create_table_called: false,
+            last_create_table_id: None,
+            last_create_catalog: None,
+            last_create_schema: None,
+            last_create_table_name: None,
+            last_create_request_json: None,
             should_fail_commit,
+            should_fail_create_table,
         });
         NonNull::new(Box::into_raw(context) as *mut c_void)
     }
@@ -443,6 +574,10 @@ pub(crate) mod tests {
             };
             context.last_staged_filename = Some(file_name);
         }
+        context.last_latest_backfilled_version = match request.latest_backfilled_version {
+            OptionalValue::Some(version) => Some(version),
+            OptionalValue::None => None,
+        };
         if let OptionalValue::Some(protocol) = request.protocol {
             context.last_protocol = Some(collect_protocol(protocol));
         }
@@ -464,11 +599,57 @@ pub(crate) mod tests {
         }
     }
 
+    #[no_mangle]
+    extern "C" fn test_create_table_callback(
+        context: NullableCvoid,
+        request: CreateTableRequest,
+    ) -> OptionalValue<Handle<ExclusiveRustString>> {
+        let context = cast_test_context(context).unwrap();
+        let string_from_slice =
+            |slice| unsafe { crate::TryFromStringSlice::try_from_slice(&slice).unwrap() };
+
+        context.create_table_called = true;
+        context.last_create_table_id = Some(string_from_slice(request.table_id));
+        context.last_create_catalog = Some(string_from_slice(request.catalog));
+        context.last_create_schema = Some(string_from_slice(request.schema));
+        context.last_create_table_name = Some(string_from_slice(request.table_name));
+        context.last_create_request_json = Some(string_from_slice(request.request_json));
+
+        if context.should_fail_create_table {
+            let error_msg = "Test create-table failure";
+            let error_str = unsafe {
+                ok_or_panic(allocate_kernel_string(
+                    kernel_string_slice!(error_msg),
+                    allocate_err,
+                ))
+            };
+            OptionalValue::Some(error_str)
+        } else {
+            OptionalValue::None
+        }
+    }
+
     #[test]
     fn test_get_uc_commit_client() {
         let client = unsafe { get_uc_commit_client(None, test_commit_callback) };
 
         let _client_ref: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+        unsafe { free_uc_commit_client(client) };
+    }
+
+    #[test]
+    fn test_get_uc_commit_client_with_create_table() {
+        let client = unsafe {
+            get_uc_commit_client_with_create_table(
+                None,
+                test_commit_callback,
+                None,
+                test_create_table_callback,
+            )
+        };
+
+        let client_ref: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+        assert!(client_ref.create_table_callback.is_some());
         unsafe { free_uc_commit_client(client) };
     }
 
@@ -549,6 +730,41 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn test_ffi_uc_commit_client_commit_without_staged_commit() {
+        let context = get_test_context(false);
+        let client = unsafe { get_uc_commit_client(context, test_commit_callback) };
+        let client_arc: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+
+        let request = ClientUpdateTableRequest::new(
+            vec![ApiRequirement::AssertTableUuid {
+                uuid: "test_table_id".to_string(),
+            }],
+            vec![ApiUpdate::SetLatestBackfilledVersion {
+                latest_published_version: 9,
+            }],
+        )
+        .unwrap();
+
+        let target = TableIdentifier::new("test_catalog", "test_schema", "test_table");
+        let result: ApiResult<()> = client_arc.update_table(&target, request).await;
+
+        assert!(result.is_ok());
+
+        let context = recover_test_context(context).unwrap();
+        assert!(context.commit_called);
+        assert_eq!(
+            context.last_commit_table_id.as_deref(),
+            Some("test_table_id")
+        );
+        assert_eq!(context.last_latest_backfilled_version, Some(9));
+        assert_eq!(context.last_staged_filename, None);
+        assert_eq!(context.last_protocol, None);
+        assert_eq!(context.last_metadata, None);
+
+        unsafe { free_uc_commit_client(client) };
+    }
+
+    #[tokio::test]
     async fn test_ffi_uc_commit_client_commit_failure() {
         let context = get_test_context(true);
 
@@ -590,6 +806,68 @@ pub(crate) mod tests {
         unsafe { free_uc_commit_client(client) };
     }
 
+    #[tokio::test]
+    async fn test_ffi_uc_commit_client_rejects_invalid_protocol_update() {
+        let context = get_test_context(false);
+        let client = unsafe { get_uc_commit_client(context, test_commit_callback) };
+        let client_arc: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+
+        let request = ClientUpdateTableRequest::new(
+            vec![ApiRequirement::AssertTableUuid {
+                uuid: "test_table_id".to_string(),
+            }],
+            vec![ApiUpdate::UpdateProtocol {
+                protocol: serde_json::json!({"minReaderVersion": "bad"}),
+            }],
+        )
+        .unwrap();
+
+        let target = TableIdentifier::new("test_catalog", "test_schema", "test_table");
+        let error = client_arc.update_table(&target, request).await.unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to decode protocol update"),
+            "expected protocol decode error, got: {error}"
+        );
+        let context = recover_test_context(context).unwrap();
+        assert!(!context.commit_called);
+
+        unsafe { free_uc_commit_client(client) };
+    }
+
+    #[tokio::test]
+    async fn test_ffi_uc_commit_client_rejects_invalid_metadata_update() {
+        let context = get_test_context(false);
+        let client = unsafe { get_uc_commit_client(context, test_commit_callback) };
+        let client_arc: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+
+        let request = ClientUpdateTableRequest::new(
+            vec![ApiRequirement::AssertTableUuid {
+                uuid: "test_table_id".to_string(),
+            }],
+            vec![ApiUpdate::UpdateMetadata {
+                metadata: serde_json::json!({"id": "test-id"}),
+            }],
+        )
+        .unwrap();
+
+        let target = TableIdentifier::new("test_catalog", "test_schema", "test_table");
+        let error = client_arc.update_table(&target, request).await.unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to decode metadata update"),
+            "expected metadata decode error, got: {error}"
+        );
+        let context = recover_test_context(context).unwrap();
+        assert!(!context.commit_called);
+
+        unsafe { free_uc_commit_client(client) };
+    }
+
     #[test]
     fn test_get_uc_committer() {
         let client = unsafe { get_uc_commit_client(None, test_commit_callback) };
@@ -613,5 +891,106 @@ pub(crate) mod tests {
             free_uc_commit_client(client);
             free_uc_committer(committer);
         }
+    }
+
+    #[tokio::test]
+    async fn test_ffi_uc_committer_invokes_create_table_callback_after_version_0_commit() {
+        let context = get_test_context(false);
+        let client = unsafe {
+            get_uc_commit_client_with_create_table(
+                context,
+                test_commit_callback,
+                context,
+                test_create_table_callback,
+            )
+        };
+        let client_arc: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+        let table_id = "test-table-id";
+        let table = TableIdentifier::new("test_catalog", "test_schema", "test_table");
+        let committer: Box<dyn Committer> = Box::new(FfiUCCommitter {
+            inner: UCCommitter::new(client_arc.clone(), table_id, table.clone()),
+            client: client_arc,
+            table_id: table_id.to_string(),
+            table,
+        });
+
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage).build();
+        let table_path = "memory:///ffi_uc_create_success/";
+        let schema = schema_ref! { nullable "id": INTEGER };
+        let disk_props = get_required_properties_for_disk(table_id);
+
+        create_table(table_path, schema, "Test/1.0")
+            .with_table_properties(disk_props)
+            .build(&engine, committer)
+            .unwrap()
+            .commit(&engine)
+            .unwrap()
+            .unwrap_committed();
+
+        let context = recover_test_context(context).unwrap();
+        assert!(!context.commit_called);
+        assert!(context.create_table_called);
+        assert_eq!(context.last_create_table_id.as_deref(), Some(table_id));
+        assert_eq!(context.last_create_catalog.as_deref(), Some("test_catalog"));
+        assert_eq!(context.last_create_schema.as_deref(), Some("test_schema"));
+        assert_eq!(
+            context.last_create_table_name.as_deref(),
+            Some("test_table")
+        );
+
+        let request_json = context.last_create_request_json.unwrap();
+        let request: serde_json::Value = serde_json::from_str(&request_json).unwrap();
+        assert_eq!(request["name"], "test_table");
+        assert_eq!(request["location"], table_path);
+        assert!(request["last-commit-timestamp-ms"].is_i64());
+        assert_eq!(request["properties"]["io.unitycatalog.tableId"], table_id);
+
+        unsafe { free_uc_commit_client(client) };
+    }
+
+    #[tokio::test]
+    async fn test_ffi_uc_committer_propagates_create_table_callback_failure() {
+        let context = get_test_context_with_create_table_failure(false, true);
+        let client = unsafe {
+            get_uc_commit_client_with_create_table(
+                context,
+                test_commit_callback,
+                context,
+                test_create_table_callback,
+            )
+        };
+        let client_arc: Arc<FfiUCCommitClient> = unsafe { client.clone_as_arc() };
+        let table_id = "test-table-id";
+        let table = TableIdentifier::new("test_catalog", "test_schema", "test_table");
+        let committer: Box<dyn Committer> = Box::new(FfiUCCommitter {
+            inner: UCCommitter::new(client_arc.clone(), table_id, table.clone()),
+            client: client_arc,
+            table_id: table_id.to_string(),
+            table,
+        });
+
+        let storage = Arc::new(InMemory::new());
+        let engine = DefaultEngineBuilder::new(storage).build();
+        let table_path = "memory:///ffi_uc_create_failure/";
+        let schema = schema_ref! { nullable "id": INTEGER };
+        let disk_props = get_required_properties_for_disk(table_id);
+
+        let error = create_table(table_path, schema, "Test/1.0")
+            .with_table_properties(disk_props)
+            .build(&engine, committer)
+            .unwrap()
+            .commit(&engine)
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("Test create-table failure"),
+            "expected create-table callback error, got: {error}"
+        );
+
+        let context = recover_test_context(context).unwrap();
+        assert!(context.create_table_called);
+
+        unsafe { free_uc_commit_client(client) };
     }
 }

--- a/ffi/src/delta_kernel_unity_catalog.rs
+++ b/ffi/src/delta_kernel_unity_catalog.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use delta_kernel::actions::{Metadata, Protocol};
 use delta_kernel::committer::Committer;
 use delta_kernel::DeltaResult;
 use delta_kernel_default_engine::executor::tokio::{
@@ -20,7 +21,7 @@ use unity_catalog_delta_client_api::{
 
 use crate::error::{AllocateErrorFn, ExternResult, IntoExternResult as _};
 use crate::transaction::MutableCommitter;
-use crate::{ExclusiveRustString, NullableCvoid};
+use crate::{ExclusiveRustString, NullableCvoid, SharedMetadata, SharedProtocol};
 
 /// Data representing a commit.
 #[repr(C)]
@@ -39,10 +40,10 @@ pub struct CommitRequest {
     pub table_id: KernelStringSlice,
     pub commit_info: OptionalValue<Commit>,
     pub latest_backfilled_version: OptionalValue<i64>,
-    /// json serialized version of the metadata
-    pub metadata: OptionalValue<KernelStringSlice>,
-    /// json serialized version of the protocol
-    pub protocol: OptionalValue<KernelStringSlice>,
+    /// New table metadata. The callback owns this handle and must free it with `free_metadata`.
+    pub metadata: OptionalValue<Handle<SharedMetadata>>,
+    /// New table protocol. The callback owns this handle and must free it with `free_protocol`.
+    pub protocol: OptionalValue<Handle<SharedProtocol>>,
 }
 
 /// The callback that will be called when the client wants to commit. Return `None` on success, or
@@ -85,6 +86,28 @@ impl UpdateTableClient for FfiUCCommitClient {
 
         let latest_backfilled_version = request.latest_backfilled_version();
         let add_commit = request.staged_commit().cloned();
+        let metadata = request
+            .metadata()
+            .cloned()
+            .map(serde_json::from_value::<Metadata>)
+            .transpose()
+            .map_err(|e| {
+                unity_catalog_delta_client_api::Error::Generic(format!(
+                    "failed to decode metadata update for FFI UC commit client: {e}"
+                ))
+            })?
+            .map(|metadata| Arc::new(metadata).into());
+        let protocol = request
+            .protocol()
+            .cloned()
+            .map(serde_json::from_value::<Protocol>)
+            .transpose()
+            .map_err(|e| {
+                unity_catalog_delta_client_api::Error::Generic(format!(
+                    "failed to decode protocol update for FFI UC commit client: {e}"
+                ))
+            })?
+            .map(|protocol| Arc::new(protocol).into());
 
         // there is a subtle issue here where we need to ensure that the string we use to refer to
         // the commit_info.file_name stays in scope until _after_ the callback returns, so that the
@@ -97,8 +120,8 @@ impl UpdateTableClient for FfiUCCommitClient {
                 table_id: kernel_string_slice!(table_id),
                 commit_info,
                 latest_backfilled_version: latest_backfilled_version.into(),
-                metadata: None.into(),
-                protocol: None.into(),
+                metadata: metadata.into(),
+                protocol: protocol.into(),
             };
 
             match (self.commit_callback)(self.context, c_commit_request) {
@@ -279,12 +302,35 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::ffi_test_utils::{allocate_err, ok_or_panic};
-    use crate::{allocate_kernel_string, kernel_string_slice, OptionalValue};
+    use crate::{
+        allocate_kernel_string, free_metadata, free_protocol, kernel_string_slice, visit_metadata,
+        visit_protocol, OptionalValue,
+    };
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    pub(crate) struct ProtocolVisitState {
+        min_reader: i32,
+        min_writer: i32,
+        reader_features: Vec<String>,
+        writer_features: Vec<String>,
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    pub(crate) struct MetadataVisitState {
+        id: Option<String>,
+        name: Option<String>,
+        description: Option<String>,
+        format_provider: Option<String>,
+        has_created_time: bool,
+        created_time_ms: i64,
+    }
 
     pub(crate) struct TestContext {
         pub(crate) commit_called: bool,
         pub(crate) last_commit_table_id: Option<String>,
         pub(crate) last_staged_filename: Option<String>,
+        pub(crate) last_metadata: Option<MetadataVisitState>,
+        pub(crate) last_protocol: Option<ProtocolVisitState>,
         pub(crate) should_fail_commit: bool,
     }
 
@@ -293,6 +339,8 @@ pub(crate) mod tests {
             commit_called: false,
             last_commit_table_id: None,
             last_staged_filename: None,
+            last_metadata: None,
+            last_protocol: None,
             should_fail_commit,
         });
         NonNull::new(Box::into_raw(context) as *mut c_void)
@@ -307,6 +355,75 @@ pub(crate) mod tests {
     // get the context without taking ownership
     pub(crate) fn cast_test_context<'a>(context: NullableCvoid) -> Option<&'a mut TestContext> {
         context.map(|ptr| unsafe { &mut *(ptr.as_ptr() as *mut TestContext) })
+    }
+
+    extern "C" fn protocol_version_cb(context: NullableCvoid, min_reader: i32, min_writer: i32) {
+        let state = unsafe { &mut *(context.unwrap().as_ptr() as *mut ProtocolVisitState) };
+        state.min_reader = min_reader;
+        state.min_writer = min_writer;
+    }
+
+    extern "C" fn protocol_feature_cb(
+        context: NullableCvoid,
+        is_reader: bool,
+        feature: KernelStringSlice,
+    ) {
+        let state = unsafe { &mut *(context.unwrap().as_ptr() as *mut ProtocolVisitState) };
+        let feature = unsafe { crate::TryFromStringSlice::try_from_slice(&feature).unwrap() };
+        if is_reader {
+            state.reader_features.push(feature);
+        } else {
+            state.writer_features.push(feature);
+        }
+    }
+
+    extern "C" fn metadata_visit_cb(
+        context: NullableCvoid,
+        id: KernelStringSlice,
+        name: OptionalValue<KernelStringSlice>,
+        description: OptionalValue<KernelStringSlice>,
+        format_provider: KernelStringSlice,
+        has_created_time: bool,
+        created_time_ms: i64,
+    ) {
+        let state = unsafe { &mut *(context.unwrap().as_ptr() as *mut MetadataVisitState) };
+        let string_from_slice =
+            |slice| unsafe { crate::TryFromStringSlice::try_from_slice(&slice).unwrap() };
+        state.id = Some(string_from_slice(id));
+        state.name = match name {
+            OptionalValue::Some(name) => Some(string_from_slice(name)),
+            OptionalValue::None => None,
+        };
+        state.description = match description {
+            OptionalValue::Some(description) => Some(string_from_slice(description)),
+            OptionalValue::None => None,
+        };
+        state.format_provider = Some(string_from_slice(format_provider));
+        state.has_created_time = has_created_time;
+        state.created_time_ms = created_time_ms;
+    }
+
+    fn collect_protocol(protocol: Handle<SharedProtocol>) -> ProtocolVisitState {
+        let mut state = ProtocolVisitState::default();
+        let context = NonNull::new(&mut state as *mut ProtocolVisitState as *mut c_void);
+        unsafe {
+            visit_protocol(
+                protocol.shallow_copy(),
+                context,
+                protocol_version_cb,
+                protocol_feature_cb,
+            )
+        };
+        unsafe { free_protocol(protocol) };
+        state
+    }
+
+    fn collect_metadata(metadata: Handle<SharedMetadata>) -> MetadataVisitState {
+        let mut state = MetadataVisitState::default();
+        let context = NonNull::new(&mut state as *mut MetadataVisitState as *mut c_void);
+        unsafe { visit_metadata(metadata.shallow_copy(), context, metadata_visit_cb) };
+        unsafe { free_metadata(metadata) };
+        state
     }
 
     #[no_mangle]
@@ -325,6 +442,12 @@ pub(crate) mod tests {
                 crate::TryFromStringSlice::try_from_slice(&commit_info.file_name).unwrap()
             };
             context.last_staged_filename = Some(file_name);
+        }
+        if let OptionalValue::Some(protocol) = request.protocol {
+            context.last_protocol = Some(collect_protocol(protocol));
+        }
+        if let OptionalValue::Some(metadata) = request.metadata {
+            context.last_metadata = Some(collect_metadata(metadata));
         }
         context.last_commit_table_id = Some(table_id.clone());
         if context.should_fail_commit {
@@ -361,15 +484,35 @@ pub(crate) mod tests {
             vec![ApiRequirement::AssertTableUuid {
                 uuid: "test_table_id".to_string(),
             }],
-            vec![ApiUpdate::AddCommit {
-                commit: ClientCommit {
-                    version: 10,
-                    timestamp: 2000000000,
-                    file_name: "_staged_commits/00000000000000000010.uuid.json".to_string(),
-                    file_size: 1024,
-                    file_modification_timestamp: 2000000100,
+            vec![
+                ApiUpdate::AddCommit {
+                    commit: ClientCommit {
+                        version: 10,
+                        timestamp: 2000000000,
+                        file_name: "_staged_commits/00000000000000000010.uuid.json".to_string(),
+                        file_size: 1024,
+                        file_modification_timestamp: 2000000100,
+                    },
                 },
-            }],
+                ApiUpdate::UpdateProtocol {
+                    protocol: serde_json::json!({
+                        "minReaderVersion": 3,
+                        "minWriterVersion": 7,
+                        "readerFeatures": ["catalogManaged"],
+                        "writerFeatures": ["catalogManaged", "inCommitTimestamp"],
+                    }),
+                },
+                ApiUpdate::UpdateMetadata {
+                    metadata: serde_json::json!({
+                        "id": "test-id",
+                        "format": {"provider": "parquet", "options": {}},
+                        "schemaString": "{\"type\":\"struct\",\"fields\":[]}",
+                        "partitionColumns": [],
+                        "createdTime": 1234567890,
+                        "configuration": {"delta.enableInCommitTimestamps": "true"},
+                    }),
+                },
+            ],
         )
         .unwrap();
 
@@ -387,6 +530,20 @@ pub(crate) mod tests {
             context.last_staged_filename.unwrap(),
             "_staged_commits/00000000000000000010.uuid.json"
         );
+
+        let protocol = context.last_protocol.unwrap();
+        assert_eq!(protocol.min_reader, 3);
+        assert_eq!(protocol.min_writer, 7);
+        assert_eq!(protocol.reader_features, vec!["catalogManaged"]);
+        assert_eq!(
+            protocol.writer_features,
+            vec!["catalogManaged", "inCommitTimestamp"]
+        );
+
+        let metadata = context.last_metadata.unwrap();
+        assert_eq!(metadata.id.as_deref(), Some("test-id"));
+        assert_eq!(metadata.format_provider.as_deref(), Some("parquet"));
+        assert_eq!(metadata.created_time_ms, 1234567890);
 
         unsafe { free_uc_commit_client(client) };
     }

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -365,20 +365,6 @@ impl From<EngineExecError> for Error {
     }
 }
 
-#[cfg(test)]
-mod error_code_tests {
-    use super::*;
-
-    #[test]
-    fn row_tracking_change_feed_error_has_stable_ffi_mapping() {
-        assert_eq!(
-            KernelError::from(Error::RowTrackingChangeFeedUnsupported(7)),
-            KernelError::RowTrackingChangeFeedUnsupported
-        );
-        assert_eq!(KernelError::RowTrackingChangeFeedUnsupported as i32, 44);
-    }
-}
-
 #[cfg(all(test, feature = "declarative-plans"))]
 mod tests {
     use rstest::rstest;
@@ -414,5 +400,19 @@ mod tests {
     ) {
         let err: Error = exec_error(etype, "boom").into();
         assert_eq!(err.to_string(), expected);
+    }
+}
+
+#[cfg(test)]
+mod error_code_tests {
+    use super::*;
+
+    #[test]
+    fn row_tracking_change_feed_error_has_stable_ffi_mapping() {
+        assert_eq!(
+            KernelError::from(Error::RowTrackingChangeFeedUnsupported(7)),
+            KernelError::RowTrackingChangeFeedUnsupported
+        );
+        assert_eq!(KernelError::RowTrackingChangeFeedUnsupported as i32, 44);
     }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1827,6 +1827,38 @@ pub unsafe extern "C" fn visit_metadata_configuration_from_metadata(
     });
 }
 
+/// Visit the schema string for the specified metadata handle.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid metadata handle, a valid `context` as an opaque
+/// pointer passed to the `visitor` invocation, and a valid `visitor` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_metadata_schema_string(
+    metadata: Handle<SharedMetadata>,
+    context: NullableCvoid,
+    visitor: extern "C" fn(context: NullableCvoid, schema_string: KernelStringSlice),
+) {
+    let metadata = unsafe { metadata.as_ref() };
+    let schema_string = metadata.schema_string();
+    visitor(context, kernel_string_slice!(schema_string));
+}
+
+/// Get an iterator over the partition columns for the specified metadata handle.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid metadata handle and freeing the returned iterator
+/// with [`free_string_slice_data`].
+#[no_mangle]
+pub unsafe extern "C" fn metadata_partition_columns(
+    metadata: Handle<SharedMetadata>,
+) -> Handle<StringSliceIterator> {
+    let metadata = unsafe { metadata.as_ref() };
+    let iter: Box<StringIter> = Box::new(metadata.partition_columns().to_vec().into_iter());
+    iter.into()
+}
+
 // === Snapshot-level computed property FFI ===
 
 type StringIter = dyn Iterator<Item = String> + Send;
@@ -1938,8 +1970,8 @@ mod tests {
     use test_utils::{
         actions_to_string, actions_to_string_catalog_managed, actions_to_string_partitioned,
         actions_to_string_with_metadata, add_commit, add_staged_commit, create_table, TestAction,
-        METADATA, METADATA_WITH_FEATURES, METADATA_WITH_TABLE_PROPERTIES,
-        TEST_ICT_ENABLEMENT_TIMESTAMP,
+        METADATA, METADATA_WITH_FEATURES, METADATA_WITH_PARTITION_COLS,
+        METADATA_WITH_TABLE_PROPERTIES, TEST_ICT_ENABLEMENT_TIMESTAMP,
     };
     use url::Url;
 
@@ -2428,13 +2460,20 @@ mod tests {
         HashMap::from([
             (String::from("delta.appendOnly"), String::from("true")),
             (String::from("custom.key"), String::from("custom_value")),
-        ])
+        ]),
+        Vec::<String>::new()
     )]
-    #[case(METADATA, HashMap::new())]
+    #[case(METADATA, HashMap::new(), Vec::<String>::new())]
+    #[case(
+        METADATA_WITH_PARTITION_COLS,
+        HashMap::new(),
+        vec![String::from("val")]
+    )]
     #[tokio::test]
     async fn test_visit_metadata_configuration(
         #[case] metadata: &str,
         #[case] expected: HashMap<String, String>,
+        #[case] expected_partition_columns: Vec<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let table_root = "memory:///";
         let storage = Arc::new(InMemory::new());
@@ -2464,6 +2503,12 @@ mod tests {
             map.insert(k, v);
         }
 
+        extern "C" fn collect_string(engine_context: NullableCvoid, value: KernelStringSlice) {
+            let value_out =
+                unsafe { &mut *(engine_context.unwrap().as_ptr() as *mut Option<String>) };
+            *value_out = Some(unsafe { String::try_from_slice(&value) }.unwrap());
+        }
+
         let mut collected: HashMap<String, String> = HashMap::new();
         let ctx = NonNull::new(&mut collected as *mut _ as *mut c_void);
         unsafe { visit_metadata_configuration(snap.shallow_copy(), ctx, collect_property) };
@@ -2482,6 +2527,28 @@ mod tests {
         };
 
         assert_eq!(collected_from_metadata, expected);
+
+        let mut schema_string: Option<String> = None;
+        let ctx = NonNull::new(&mut schema_string as *mut _ as *mut c_void);
+        unsafe { visit_metadata_schema_string(metadata.shallow_copy(), ctx, collect_string) };
+        let schema_string = schema_string.unwrap();
+        assert!(schema_string.contains(r#""name":"id""#));
+        assert!(schema_string.contains(r#""name":"val""#));
+
+        let partition_iter = unsafe { metadata_partition_columns(metadata.shallow_copy()) };
+        let mut partition_columns = Vec::new();
+        let mut partition_value: Option<String> = None;
+        while unsafe {
+            string_slice_next(
+                partition_iter.shallow_copy(),
+                NonNull::new(&mut partition_value as *mut _ as *mut c_void),
+                collect_string,
+            )
+        } {
+            partition_columns.push(partition_value.take().unwrap());
+        }
+        unsafe { free_string_slice_data(partition_iter) };
+        assert_eq!(partition_columns, expected_partition_columns);
 
         unsafe { free_metadata(metadata) };
         unsafe { free_snapshot(snap) }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1800,6 +1800,33 @@ pub unsafe extern "C" fn visit_metadata(
     );
 }
 
+/// Visit each metadata configuration (key/value pair) for the specified metadata handle by
+/// invoking the provided `visitor` callback once per entry.
+///
+/// # Safety
+///
+/// Caller is responsible for passing a valid metadata handle, a valid `context` as an opaque
+/// pointer passed to each `visitor` invocation, and a valid `visitor` function pointer.
+#[no_mangle]
+pub unsafe extern "C" fn visit_metadata_configuration_from_metadata(
+    metadata: Handle<SharedMetadata>,
+    context: NullableCvoid,
+    visitor: extern "C" fn(
+        context: NullableCvoid,
+        key: KernelStringSlice,
+        value: KernelStringSlice,
+    ),
+) {
+    let metadata = unsafe { metadata.as_ref() };
+    metadata.configuration().iter().for_each(|(key, value)| {
+        visitor(
+            context,
+            kernel_string_slice!(key),
+            kernel_string_slice!(value),
+        );
+    });
+}
+
 // === Snapshot-level computed property FFI ===
 
 type StringIter = dyn Iterator<Item = String> + Send;
@@ -2443,6 +2470,20 @@ mod tests {
 
         assert_eq!(collected, expected);
 
+        let metadata = unsafe { snapshot_get_metadata(snap.shallow_copy()) };
+        let mut collected_from_metadata: HashMap<String, String> = HashMap::new();
+        let ctx = NonNull::new(&mut collected_from_metadata as *mut _ as *mut c_void);
+        unsafe {
+            visit_metadata_configuration_from_metadata(
+                metadata.shallow_copy(),
+                ctx,
+                collect_property,
+            )
+        };
+
+        assert_eq!(collected_from_metadata, expected);
+
+        unsafe { free_metadata(metadata) };
         unsafe { free_snapshot(snap) }
         unsafe { free_engine(engine) }
         Ok(())

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -296,9 +296,8 @@ impl CommitMetadata {
         ))
     }
 
-    /// Marks this `CommitMetadata` as having a protocol change. Test-only.
-    ///
-    /// that changes the protocol.
+    /// Copies the effective protocol into `new_protocol` to simulate a protocol-changing commit.
+    /// Test-only.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn with_protocol_change(mut self) -> Self {
         let protocol = self.effective_protocol().ok().cloned();
@@ -306,10 +305,8 @@ impl CommitMetadata {
         self
     }
 
-    /// Marks this `CommitMetadata` as having a metadata change. Test-only.
-    ///
-    /// Copies the existing metadata into the `new_metadata` field to simulate an ALTER TABLE
-    /// that changes the metadata.
+    /// Copies the effective metadata into `new_metadata` to simulate a metadata-changing commit.
+    /// Test-only.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn with_metadata_change(mut self) -> Self {
         let metadata = self.effective_metadata().ok().cloned();
@@ -319,8 +316,7 @@ impl CommitMetadata {
 
     /// Adds a domain metadata change for the given domain name. Test-only.
     ///
-    /// Creates a synthetic domain metadata entry to simulate a domain metadata change
-    /// (e.g. clustering column change via ALTER TABLE CLUSTER BY).
+    /// Creates a synthetic domain metadata entry to simulate a domain metadata change.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn with_domain_change(mut self, domain: &str) -> Self {
         self.domain_metadata_changes

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -238,9 +238,23 @@ impl CommitMetadata {
         self.protocol_metadata.new_protocol.is_some()
     }
 
+    /// The new protocol in this commit, when the commit has one.
+    ///
+    /// A commit with no protocol change returns `None`.
+    pub fn new_protocol(&self) -> Option<&Protocol> {
+        self.protocol_metadata.new_protocol.as_ref()
+    }
+
     /// Returns `true` if this commit changes the table's metadata.
     pub fn has_metadata_change(&self) -> bool {
         self.protocol_metadata.new_metadata.is_some()
+    }
+
+    /// The new table metadata in this commit, when the commit has one.
+    ///
+    /// A commit with no metadata change returns `None`.
+    pub fn new_metadata(&self) -> Option<&Metadata> {
+        self.protocol_metadata.new_metadata.as_ref()
     }
 
     /// Returns `true` if this commit includes a domain metadata change for the given domain name.

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -57,6 +57,10 @@ pub enum DeltaTableRequirement {
 pub enum DeltaTableUpdate {
     /// Register a new staged commit with the catalog.
     AddCommit { commit: Commit },
+    /// Update the table's Delta protocol.
+    UpdateProtocol { protocol: serde_json::Value },
+    /// Update the table's Delta metadata.
+    UpdateMetadata { metadata: serde_json::Value },
     /// Inform the catalog of the latest published version.
     SetLatestBackfilledVersion {
         #[serde(rename = "latest-published-version")]
@@ -145,6 +149,18 @@ impl UpdateTableRequest {
                     .to_string(),
             ));
         }
+        if num_updates(|u| matches!(u, DeltaTableUpdate::UpdateProtocol { .. })) > 1 {
+            return Err(crate::error::Error::Generic(
+                "update_table request must not contain more than one UpdateProtocol update"
+                    .to_string(),
+            ));
+        }
+        if num_updates(|u| matches!(u, DeltaTableUpdate::UpdateMetadata { .. })) > 1 {
+            return Err(crate::error::Error::Generic(
+                "update_table request must not contain more than one UpdateMetadata update"
+                    .to_string(),
+            ));
+        }
         Ok(Self {
             requirements,
             updates,
@@ -174,6 +190,22 @@ impl UpdateTableRequest {
             DeltaTableUpdate::SetLatestBackfilledVersion {
                 latest_published_version,
             } => Some(*latest_published_version),
+            _ => None,
+        })
+    }
+
+    /// The protocol update payload in this request, if present.
+    pub fn protocol(&self) -> Option<&serde_json::Value> {
+        self.updates.iter().find_map(|u| match u {
+            DeltaTableUpdate::UpdateProtocol { protocol } => Some(protocol),
+            _ => None,
+        })
+    }
+
+    /// The metadata update payload in this request, if present.
+    pub fn metadata(&self) -> Option<&serde_json::Value> {
+        self.updates.iter().find_map(|u| match u {
+            DeltaTableUpdate::UpdateMetadata { metadata } => Some(metadata),
             _ => None,
         })
     }
@@ -472,6 +504,27 @@ mod tests {
     }
 
     #[test]
+    fn update_protocol_wire_shape() {
+        let v = serde_json::to_value(DeltaTableUpdate::UpdateProtocol {
+            protocol: serde_json::json!({"minReaderVersion": 3, "minWriterVersion": 7}),
+        })
+        .unwrap();
+        assert_eq!(v["action"], "update-protocol");
+        assert_eq!(v["protocol"]["minReaderVersion"], 3);
+        assert_eq!(v["protocol"]["minWriterVersion"], 7);
+    }
+
+    #[test]
+    fn update_metadata_wire_shape() {
+        let v = serde_json::to_value(DeltaTableUpdate::UpdateMetadata {
+            metadata: serde_json::json!({"id": "test-id"}),
+        })
+        .unwrap();
+        assert_eq!(v["action"], "update-metadata");
+        assert_eq!(v["metadata"]["id"], "test-id");
+    }
+
+    #[test]
     fn requirement_assert_table_uuid_wire_shape() {
         let v = serde_json::to_value(DeltaTableRequirement::AssertTableUuid {
             uuid: "abc".to_string(),
@@ -598,12 +651,50 @@ mod tests {
             "more than one AddCommit must be rejected"
         );
 
+        assert!(
+            UpdateTableRequest::new(
+                vec![],
+                vec![
+                    DeltaTableUpdate::UpdateProtocol {
+                        protocol: serde_json::json!({"minReaderVersion": 1}),
+                    },
+                    DeltaTableUpdate::UpdateProtocol {
+                        protocol: serde_json::json!({"minReaderVersion": 2}),
+                    },
+                ],
+            )
+            .is_err(),
+            "more than one UpdateProtocol must be rejected"
+        );
+
+        assert!(
+            UpdateTableRequest::new(
+                vec![],
+                vec![
+                    DeltaTableUpdate::UpdateMetadata {
+                        metadata: serde_json::json!({"id": "a"}),
+                    },
+                    DeltaTableUpdate::UpdateMetadata {
+                        metadata: serde_json::json!({"id": "b"}),
+                    },
+                ],
+            )
+            .is_err(),
+            "more than one UpdateMetadata must be rejected"
+        );
+
         // A single AddCommit alongside the other singletons is accepted.
         assert!(UpdateTableRequest::new(
             vec![],
             vec![
                 DeltaTableUpdate::AddCommit {
                     commit: sample_commit(),
+                },
+                DeltaTableUpdate::UpdateProtocol {
+                    protocol: serde_json::json!({"minReaderVersion": 3}),
+                },
+                DeltaTableUpdate::UpdateMetadata {
+                    metadata: serde_json::json!({"id": "test-id"}),
                 },
                 DeltaTableUpdate::SetLatestBackfilledVersion {
                     latest_published_version: 3,
@@ -635,6 +726,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(req.staged_commit(), None);
+    }
+
+    #[test]
+    fn protocol_and_metadata_return_payloads_when_present() {
+        let protocol = serde_json::json!({"minReaderVersion": 3});
+        let metadata = serde_json::json!({"id": "test-id"});
+        let req = UpdateTableRequest::new(
+            vec![],
+            vec![
+                DeltaTableUpdate::UpdateProtocol {
+                    protocol: protocol.clone(),
+                },
+                DeltaTableUpdate::UpdateMetadata {
+                    metadata: metadata.clone(),
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(req.protocol(), Some(&protocol));
+        assert_eq!(req.metadata(), Some(&metadata));
     }
 
     #[test]

--- a/unity-catalog-delta-client-api/src/models.rs
+++ b/unity-catalog-delta-client-api/src/models.rs
@@ -113,8 +113,7 @@ impl UpdateTableRequest {
     /// # Errors
     ///
     /// Returns an error if a singleton entry appears more than once. The UC `updateTable` endpoint
-    /// accepts at most one each of `AssertTableUuid`, `AssertEtag`, `AddCommit`, and
-    /// `SetLatestBackfilledVersion`.
+    /// accepts at most one of each requirement or update type.
     pub fn new(
         requirements: Vec<DeltaTableRequirement>,
         updates: Vec<DeltaTableUpdate>,


### PR DESCRIPTION
## What changes are proposed in this pull request?

The UC commit-client bridge now forwards protocol and metadata changes instead of dropping them.

### This PR affects the following public APIs

- Adds `update-protocol` and `update-metadata` variants to the UC client API `UpdateTableRequest`.
- Adds `CommitMetadata::new_protocol()` and `CommitMetadata::new_metadata()` so catalog committers can read the actual actions, not just detect that they changed.
- Changes the FFI `CommitRequest` p&m fields to optional `Handle<SharedProtocol>` / `Handle<SharedMetadata>` values. The callback owns those handles and must free them.
- Adds `visit_metadata_configuration_from_metadata` so callbacks can build a complete Java metadata object from a metadata handle.

The REST client still serializes p&m in the UC request body. The FFI callback does not pass them as JSON strings: Java's UC client expects `AbstractMetadata` / `AbstractProtocol`, and its REST client reads those getters to build the UC payload. Passing strings through FFI would just move Delta-action JSON parsing into Java.

Clustering domain metadata changes stay rejected.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo nextest run -p unity-catalog-delta-client-api`
- `cargo nextest run -p delta-kernel-unity-catalog`
- `cargo nextest run -p delta_kernel_ffi --features delta-kernel-unity-catalog delta_kernel_unity_catalog::tests`
- `cargo nextest run -p delta_kernel_ffi --features delta-kernel-unity-catalog test_visit_metadata_configuration`
- `cargo clippy -p delta_kernel_ffi --features delta-kernel-unity-catalog --tests -- -D warnings`
- `cargo clippy -p delta-kernel-unity-catalog --tests -- -D warnings`
- `cargo clippy -p delta_kernel --lib --features internal-api -- -D warnings`
- Pre-commit hook on amend: fmt check, clippy, `cargo test`, and coverage generation.
