### PR TITLE
feat: re-export UC wire models from unity-catalog-delta-rest-client

### DIFF
--- a/unity-catalog-delta-rest-client/src/lib.rs
+++ b/unity-catalog-delta-rest-client/src/lib.rs
@@ -32,3 +32,7 @@ mod tests;
 pub use clients::{UCClient, UCUpdateTableRestClient};
 pub use config::{ClientConfig, ClientConfigBuilder};
 pub use error::{Error, Result};
+pub use unity_catalog_delta_client_api as api;
+pub use unity_catalog_delta_client_api::credentials::*;
+pub use unity_catalog_delta_client_api::models::*;
+pub use unity_catalog_delta_client_api::UpdateTableClient;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Consumers depending on the UC REST client had to also add unity-catalog-delta-client-api to name the request/response types. This change re-exports the api crate's wire models, credential types, and the UpdateTableClient trait at the UC REST client crate root.

Testing: existing tests should suffice.
