### PR TITLE
feat: allow delta.checkpointPolicy in CREATE TABLE

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -32,7 +32,7 @@ use crate::table_features::{
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
-    CheckpointPolicy, TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
+    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
     CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID,
     COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS,
     DELETED_FILE_RETENTION_DURATION, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
@@ -489,8 +489,10 @@ fn maybe_enable_ict_for_catalog_managed(
 }
 
 fn maybe_enable_v2_checkpoint_for_policy(validated: &mut ValidatedTableProperties) {
-    let is_v2_policy = TableProperties::from(validated.properties.iter()).checkpoint_policy
-        == Some(CheckpointPolicy::V2);
+    let is_v2_policy = validated
+        .properties
+        .get(CHECKPOINT_POLICY)
+        .is_some_and(|v| v == "v2");
     if is_v2_policy {
         add_feature_to_lists(
             TableFeature::V2Checkpoint,

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -32,7 +32,7 @@ use crate::table_features::{
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
-    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
+    CheckpointPolicy, TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
     CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID,
     COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS,
     DELETED_FILE_RETENTION_DURATION, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
@@ -124,8 +124,7 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     DELETED_FILE_RETENTION_DURATION,
     ENABLE_EXPIRED_LOG_CLEANUP,
     CHECKPOINT_INTERVAL,
-    // Checkpoint policy: stored for downstream engines. Kernel chooses the checkpoint format
-    // from the v2Checkpoint feature. Setting checkpointPolicy does not enable v2 checkpoints.
+    // Checkpoint policy: "v2" auto-enables the v2Checkpoint feature.
     CHECKPOINT_POLICY,
 ];
 
@@ -487,6 +486,18 @@ fn maybe_enable_ict_for_catalog_managed(
             .or_insert_with(|| "true".to_string());
     }
     Ok(())
+}
+
+fn maybe_enable_v2_checkpoint_for_policy(validated: &mut ValidatedTableProperties) {
+    let is_v2_policy = TableProperties::from(validated.properties.iter()).checkpoint_policy
+        == Some(CheckpointPolicy::V2);
+    if is_v2_policy {
+        add_feature_to_lists(
+            TableFeature::V2Checkpoint,
+            &mut validated.reader_features,
+            &mut validated.writer_features,
+        );
+    }
 }
 
 /// Witness that all property-flipping passes which must run before column mapping is applied
@@ -933,6 +944,9 @@ impl CreateTableTransactionBuilder {
         // Auto-enable inCommitTimestamp for catalogManaged tables
         maybe_enable_ict_for_catalog_managed(&mut validated)?;
 
+        // Auto-enable v2Checkpoint when checkpointPolicy=v2
+        maybe_enable_v2_checkpoint_for_policy(&mut validated);
+
         // Set materialized row tracking column names when row tracking is enabled.
         maybe_set_materialized_row_tracking_column_name_properties(&mut validated);
 
@@ -1122,7 +1136,6 @@ mod tests {
             ),
             (ENABLE_EXPIRED_LOG_CLEANUP.to_string(), "true".to_string()),
             (CHECKPOINT_INTERVAL.to_string(), "10".to_string()),
-            (CHECKPOINT_POLICY.to_string(), "v2".to_string()),
         ]);
         let validated = validate_extract_table_features_and_properties(properties).unwrap();
         assert_eq!(
@@ -1141,12 +1154,38 @@ mod tests {
             validated.properties.get(CHECKPOINT_INTERVAL),
             Some(&"10".to_string()),
         );
-        assert_eq!(
-            validated.properties.get(CHECKPOINT_POLICY),
-            Some(&"v2".to_string()),
-        );
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());
+    }
+
+    #[rstest::rstest]
+    #[case::v2(&[(CHECKPOINT_POLICY, "v2")], true)]
+    #[case::classic(&[(CHECKPOINT_POLICY, "classic")], false)]
+    fn test_checkpoint_policy_feature_enablement(
+        #[case] properties: &[(&str, &str)],
+        #[case] expect_v2_checkpoint_feature: bool,
+    ) {
+        let properties: HashMap<String, String> = properties
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let mut validated = validate_extract_table_features_and_properties(properties).unwrap();
+
+        maybe_enable_v2_checkpoint_for_policy(&mut validated);
+
+        assert_eq!(
+            validated
+                .reader_features
+                .contains(&TableFeature::V2Checkpoint),
+            expect_v2_checkpoint_feature,
+        );
+        assert_eq!(
+            validated
+                .writer_features
+                .contains(&TableFeature::V2Checkpoint),
+            expect_v2_checkpoint_feature,
+        );
+        assert!(validated.properties.contains_key(CHECKPOINT_POLICY));
     }
 
     #[test]

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -32,7 +32,7 @@ use crate::table_features::{
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
-    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
+    CheckpointPolicy, TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
     CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID,
     COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS,
     DELETED_FILE_RETENTION_DURATION, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
@@ -492,7 +492,8 @@ fn maybe_enable_v2_checkpoint_for_policy(validated: &mut ValidatedTablePropertie
     let is_v2_policy = validated
         .properties
         .get(CHECKPOINT_POLICY)
-        .is_some_and(|v| v == "v2");
+        .and_then(|v| CheckpointPolicy::try_from(v.as_str()).ok())
+        == Some(CheckpointPolicy::V2);
     if is_v2_policy {
         add_feature_to_lists(
             TableFeature::V2Checkpoint,

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -32,15 +32,15 @@ use crate::table_features::{
     SET_TABLE_FEATURE_SUPPORTED_PREFIX, SET_TABLE_FEATURE_SUPPORTED_VALUE,
 };
 use crate::table_properties::{
-    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_WRITE_STATS_AS_JSON,
-    CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID, COLUMN_MAPPING_MODE,
-    DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS, DELETED_FILE_RETENTION_DURATION,
-    DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED, ENABLE_DELETION_VECTORS,
-    ENABLE_EXPIRED_LOG_CLEANUP, ENABLE_ICEBERG_COMPAT_V1, ENABLE_ICEBERG_COMPAT_V2,
-    ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS, ENABLE_ROW_TRACKING,
-    ENABLE_TYPE_WIDENING, LOG_RETENTION_DURATION, MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME,
-    MATERIALIZED_ROW_ID_COLUMN_NAME, PARQUET_FORMAT_VERSION, ROW_TRACKING_SUSPENDED,
-    SET_TRANSACTION_RETENTION_DURATION,
+    TableProperties, APPEND_ONLY, CHECKPOINT_INTERVAL, CHECKPOINT_POLICY,
+    CHECKPOINT_WRITE_STATS_AS_JSON, CHECKPOINT_WRITE_STATS_AS_STRUCT, COLUMN_MAPPING_MAX_COLUMN_ID,
+    COLUMN_MAPPING_MODE, DATA_SKIPPING_NUM_INDEXED_COLS, DATA_SKIPPING_STATS_COLUMNS,
+    DELETED_FILE_RETENTION_DURATION, DELTA_PROPERTY_PREFIX, ENABLE_CHANGE_DATA_FEED,
+    ENABLE_DELETION_VECTORS, ENABLE_EXPIRED_LOG_CLEANUP, ENABLE_ICEBERG_COMPAT_V1,
+    ENABLE_ICEBERG_COMPAT_V2, ENABLE_ICEBERG_COMPAT_V3, ENABLE_IN_COMMIT_TIMESTAMPS,
+    ENABLE_ROW_TRACKING, ENABLE_TYPE_WIDENING, LOG_RETENTION_DURATION,
+    MATERIALIZED_ROW_COMMIT_VERSION_COLUMN_NAME, MATERIALIZED_ROW_ID_COLUMN_NAME,
+    PARQUET_FORMAT_VERSION, ROW_TRACKING_SUSPENDED, SET_TRANSACTION_RETENTION_DURATION,
 };
 use crate::transaction::create_table::CreateTableTransaction;
 use crate::transaction::data_layout::DataLayout;
@@ -124,6 +124,9 @@ const ALLOWED_DELTA_PROPERTIES: &[&str] = &[
     DELETED_FILE_RETENTION_DURATION,
     ENABLE_EXPIRED_LOG_CLEANUP,
     CHECKPOINT_INTERVAL,
+    // Checkpoint policy: stored for downstream engines. Kernel chooses the checkpoint format
+    // from the v2Checkpoint feature. Setting checkpointPolicy does not enable v2 checkpoints.
+    CHECKPOINT_POLICY,
 ];
 
 /// Ensures that no Delta table exists at the given path.
@@ -1119,6 +1122,7 @@ mod tests {
             ),
             (ENABLE_EXPIRED_LOG_CLEANUP.to_string(), "true".to_string()),
             (CHECKPOINT_INTERVAL.to_string(), "10".to_string()),
+            (CHECKPOINT_POLICY.to_string(), "v2".to_string()),
         ]);
         let validated = validate_extract_table_features_and_properties(properties).unwrap();
         assert_eq!(
@@ -1136,6 +1140,10 @@ mod tests {
         assert_eq!(
             validated.properties.get(CHECKPOINT_INTERVAL),
             Some(&"10".to_string()),
+        );
+        assert_eq!(
+            validated.properties.get(CHECKPOINT_POLICY),
+            Some(&"v2".to_string()),
         );
         assert!(validated.reader_features.is_empty());
         assert!(validated.writer_features.is_empty());

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -585,6 +585,45 @@ fn test_create_table_with_feature_signal(
 }
 
 #[rstest]
+#[case::v2("v2", true)]
+#[case::classic("classic", false)]
+fn test_create_table_checkpoint_policy_auto_enables_v2_checkpoint(
+    #[case] policy: &str,
+    #[case] expect_v2_checkpoint: bool,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+
+    let _ = create_table(&table_path, simple_schema()?, "Test/1.0")
+        .with_table_properties([("delta.checkpointPolicy", policy)])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let table_config = snapshot.table_configuration();
+    let protocol = table_config.protocol();
+
+    assert_eq!(
+        table_config.is_feature_supported(&TableFeature::V2Checkpoint),
+        expect_v2_checkpoint,
+        "checkpointPolicy={policy}: v2Checkpoint supported should be {expect_v2_checkpoint}"
+    );
+    assert_eq!(
+        protocol
+            .reader_features()
+            .is_some_and(|f| f.contains(&TableFeature::V2Checkpoint)),
+        expect_v2_checkpoint,
+    );
+    assert_eq!(
+        protocol
+            .writer_features()
+            .is_some_and(|f| f.contains(&TableFeature::V2Checkpoint)),
+        expect_v2_checkpoint,
+    );
+
+    Ok(())
+}
+
+#[rstest]
 fn test_create_table_with_checkpoint_stats_properties(
     #[values(true, false)] write_stats_as_json: bool,
     #[values(true, false)] write_stats_as_struct: bool,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change adds `delta.checkpointPolicy` to the CREATE TABLE `delta.*` allow-list, so it is accepted and stored in table metadata. Kernel selects checkpoint format from the `v2Checkpoint`table feature, so setting `checkpointPolicy` enables no feature and does not change kernel-written checkpoints. This change also auto-enables the `v2Checkpoint` table feature when `delta.checkpointPolicy=V2`.

## How was this change tested?

New UT.
