### PR TITLE
feat: nested add-column paths and schema evolution API

### DIFF
--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -54,6 +54,18 @@ pub(crate) enum SchemaOperation {
     SetNullable { column: ColumnName },
 }
 
+impl SchemaOperation {
+    #[internal_api]
+    pub(crate) fn add_column(field: StructField, path: Vec<PathSegment>) -> SchemaOperation {
+        SchemaOperation::AddColumn { path, field }
+    }
+
+    #[internal_api]
+    pub(crate) fn set_nullable(column: ColumnName) -> SchemaOperation {
+        SchemaOperation::SetNullable { column }
+    }
+}
+
 fn add_field(parent: &mut StructType, field: StructField) -> DeltaResult<()> {
     let lowered = field.name().to_lowercase();
     if parent

--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -318,16 +318,12 @@ pub(crate) fn evolve_table_config(
         .clone()
         .with_schema(evolved_schema.clone())?
         .fold_with(new_max_column_id, |evolved_metadata, id| {
-            evolved_metadata
-                .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+            evolved_metadata.with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
         });
 
     // Validates the evolved metadata against the protocol.
-    let evolved_table_config = TableConfiguration::try_new_with_schema(
-        table_config,
-        evolved_metadata,
-        evolved_schema,
-    )?;
+    let evolved_table_config =
+        TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)?;
     Ok(evolved_table_config)
 }
 

--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -274,6 +274,10 @@ pub(crate) fn evolve_table_config(
     let schema = Arc::unwrap_or_clone(table_config.logical_schema());
     let column_mapping_mode = table_config.column_mapping_mode();
     let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+    // Whether the pre-alter schema already carried column-mapping metadata -- the only fact the
+    // strip below needs from it. Captured as a bool (not a clone) before
+    // `apply_schema_operations` consumes `schema` by value. Short-circuits outside
+    // `None` mode, where no strip fires.
     let current_has_cm = column_mapping_mode == ColumnMappingMode::None
         && schema_has_column_mapping_metadata(&schema);
     let SchemaEvolutionResult {
@@ -285,20 +289,33 @@ pub(crate) fn evolve_table_config(
         column_mapping_mode,
         current_max_column_id,
     )?;
+
+    // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
+    // that was clean before it, strip them; residual annotations already present on the
+    // table are left in place (see `strip_stray_column_mapping_metadata`).
     let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
         strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
             .map_or(evolved_schema, Arc::new)
     } else {
         evolved_schema
     };
+
     let evolved_metadata = table_config
         .metadata()
         .clone()
         .with_schema(evolved_schema.clone())?
-        .fold_with(new_max_column_id, |metadata, id| {
-            metadata.with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+        .fold_with(new_max_column_id, |evolved_metadata, id| {
+            evolved_metadata
+                .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
         });
-    TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)
+
+    // Validates the evolved metadata against the protocol.
+    let evolved_table_config = TableConfiguration::try_new_with_schema(
+        table_config,
+        evolved_metadata,
+        evolved_schema,
+    )?;
+    Ok(evolved_table_config)
 }
 
 #[cfg(test)]

--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -56,11 +56,13 @@ pub(crate) enum SchemaOperation {
 
 impl SchemaOperation {
     #[internal_api]
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     pub(crate) fn add_column(field: StructField, path: Vec<PathSegment>) -> SchemaOperation {
         SchemaOperation::AddColumn { path, field }
     }
 
     #[internal_api]
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     pub(crate) fn set_nullable(column: ColumnName) -> SchemaOperation {
         SchemaOperation::SetNullable { column }
     }

--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -23,9 +23,12 @@ use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
 /// One segment in a path to a nested schema field.
-#[internal_api]
+/// This kernel also uses ColumnName as a path to a nested field,
+/// however this has the limitation of not concretely identifying
+/// recursion into arrays and maps (MapKey, MapValue).
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[internal_api]
 pub(crate) enum PathSegment {
     Field(String),
     ArrayElement,
@@ -83,8 +86,8 @@ fn to_path_segments(path: &[String]) -> Vec<PathSegment> {
         .collect::<Vec<_>>()
 }
 
-// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
-// case-insensitively; explicit segments select array elements and map keys or values.
+/// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
+/// case-insensitively; can recurse into arrays and maps via explicit `PathSegment`s.
 fn modify_field_at_path(
     data_type: &mut DataType,
     path: &[PathSegment],
@@ -173,8 +176,37 @@ pub(crate) fn apply_schema_operations(
 
     for op in operations {
         let mut root = DataType::from(schema);
-        let add_column = match op {
-            SchemaOperation::AddColumn { path, field } => Some((path, field)),
+        match op {
+            SchemaOperation::AddColumn { path, field } => {
+                if field.is_metadata_column() {
+                    return Err(Error::schema(format!(
+                        "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                        field.name()
+                    )));
+                }
+                if !matches!(field.data_type, DataType::Primitive(_)) {
+                    StructType::ensure_no_metadata_columns_in_field(&field)?;
+                }
+                if !field.is_nullable() {
+                    return Err(Error::schema(format!(
+                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                         because existing data files do not contain this column.",
+                        field.name()
+                    )));
+                }
+                let field = if cm_enabled {
+                    let id = max_id.as_mut().ok_or_else(|| {
+                        Error::invalid_protocol(
+                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                             is not set in table properties",
+                        )
+                    })?;
+                    try_assign_flat_column_mapping_info(&field, id)?
+                } else {
+                    field
+                };
+                modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
+            }
             SchemaOperation::SetNullable { column } => {
                 let (leaf, parent) = column
                     .path()
@@ -187,39 +219,7 @@ pub(crate) fn apply_schema_operations(
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
-                None
             }
-        };
-
-        if let Some((path, field)) = add_column {
-            if field.is_metadata_column() {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': metadata columns are not allowed in a table schema",
-                    field.name()
-                )));
-            }
-            if !matches!(field.data_type, DataType::Primitive(_)) {
-                StructType::ensure_no_metadata_columns_in_field(&field)?;
-            }
-            if !field.is_nullable() {
-                return Err(Error::schema(format!(
-                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                     because existing data files do not contain this column.",
-                    field.name()
-                )));
-            }
-            let field = if cm_enabled {
-                let id = max_id.as_mut().ok_or_else(|| {
-                    Error::invalid_protocol(
-                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                         is not set in table properties",
-                    )
-                })?;
-                try_assign_flat_column_mapping_info(&field, id)?
-            } else {
-                field
-            };
-            modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
         }
 
         let DataType::Struct(updated_schema) = root else {

--- a/kernel/src/schema/changes.rs
+++ b/kernel/src/schema/changes.rs
@@ -14,7 +14,7 @@ use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    find_max_column_id_in_schema, schema_has_column_mapping_metadata,
+    drop_column_mapping_metadata, find_max_column_id_in_schema, schema_has_column_mapping_metadata,
     strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
     validate_column_mapping_id, ColumnMappingMode,
 };
@@ -208,6 +208,17 @@ pub(crate) fn apply_schema_operations(
                         field.name()
                     )));
                 }
+                // New columns must receive fresh identities rather than reusing caller-supplied
+                // identities that may refer to previously dropped columns.
+                let field_schema = StructType::new_unchecked([field]);
+                let field = drop_column_mapping_metadata(&field_schema)
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| {
+                        Error::internal_error(
+                            "column mapping metadata removal returned an empty schema",
+                        )
+                    })?;
                 let field = if cm_enabled {
                     let id = max_id.as_mut().ok_or_else(|| {
                         Error::invalid_protocol(
@@ -861,38 +872,34 @@ mod tests {
         f
     }
 
-    /// CM-enabled: a connector may pre-populate `delta.columnMapping.id` on the new column,
-    /// even at nested depth. The id is preserved and the missing `physicalName` is filled in,
-    /// matching delta-spark's `assignColumnIdAndPhysicalName`.
     #[rstest]
     #[case::top_level(field_with_id_only("tainted", DataType::STRING, 99))]
     #[case::nested_in_struct(StructField::nullable(
         "outer",
         StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
     ))]
-    fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
+    fn add_column_replaces_supplied_column_mapping_ids(#[case] field: StructField) {
         let ops = vec![SchemaOperation::AddColumn {
             path: vec![],
             field,
         }];
-        let result = apply_schema_operations(
-            simple_schema(),
-            ops,
-            ColumnMappingMode::Name,
-            Some(2), // current_max_column_id
-        )
-        .unwrap();
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(2))
+                .unwrap();
 
-        // The preserved id=99 must surface as the schema's max, even though the persisted
-        // maxColumnId was only 2 going in.
-        assert_eq!(find_max_column_id_in_schema(&result.schema), Some(99));
-        assert_eq!(result.new_max_column_id, Some(99));
+        let ids = result
+            .schema
+            .fields()
+            .last()
+            .expect("added field")
+            .collect_column_mapping_ids();
+        assert!(!ids.contains(&99));
+        assert!(ids.iter().all(|id| *id > 2));
+        assert_eq!(result.new_max_column_id, ids.iter().max().copied());
     }
 
-    /// CM-enabled, only `physicalName` provided: id is allocated as `max_id + 1` and the
-    /// physical name is preserved.
     #[test]
-    fn add_column_with_only_physical_name_allocates_id() {
+    fn add_column_replaces_supplied_physical_name_and_allocates_id() {
         let mut field = StructField::nullable("named", DataType::STRING);
         field.metadata.insert(
             ColumnMetadataKey::ColumnMappingPhysicalName
@@ -909,10 +916,8 @@ mod tests {
                 .unwrap();
         let added = result.schema.field("named").unwrap();
         assert_eq!(get_cm_id(added), 8);
-        assert_eq!(
-            added.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName),
-            Some(&MetadataValue::String("user-supplied-name".to_string()))
-        );
+        assert_ne!(get_physical_name(added), "user-supplied-name");
+        assert!(get_physical_name(added).starts_with("col-"));
         assert_eq!(result.new_max_column_id, Some(8));
     }
 
@@ -942,9 +947,8 @@ mod tests {
         );
     }
 
-    /// CM-enabled, wrong-typed `delta.columnMapping.id` annotation: error.
     #[test]
-    fn add_column_with_wrong_typed_id_is_rejected() {
+    fn add_column_replaces_non_numeric_column_mapping_id() {
         let mut field = StructField::nullable("bad", DataType::STRING);
         field.metadata.insert(
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
@@ -954,18 +958,12 @@ mod tests {
             path: vec![],
             field,
         }];
-        let err = apply_schema_operations(
-            simple_schema(),
-            ops,
-            ColumnMappingMode::Name,
-            Some(2), // current_max_column_id
-        )
-        .unwrap_err()
-        .to_string();
-        assert!(
-            err.contains("non-numeric") && err.contains("delta.columnMapping.id"),
-            "error should name the wrong-typed id annotation, got: {err}"
-        );
+        let result =
+            apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(2))
+                .unwrap();
+        let added = result.schema.field("bad").unwrap();
+        assert_eq!(get_cm_id(added), 3);
+        assert_eq!(result.new_max_column_id, Some(3));
     }
 
     /// If the persisted `maxColumnId` is stale (smaller than the actual max ID present in

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -24,8 +24,8 @@ use crate::table_features::{
     StaleAnnotationPolicy,
 };
 use crate::transforms::{transform_output_type, SchemaTransform};
-use crate::utils::require;
-use crate::{CollectInto, DeltaResult, Error};
+use crate::utils::{require, CollectInto};
+use crate::{DeltaResult, Error};
 
 pub(crate) mod column_default;
 pub use column_default::ColumnDefault;

--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -30,6 +30,7 @@ use crate::{CollectInto, DeltaResult, Error};
 pub(crate) mod column_default;
 pub use column_default::ColumnDefault;
 pub(crate) use column_default::{try_collect_column_defaults, validate_column_defaults_metadata};
+pub(crate) mod changes;
 pub(crate) mod compare;
 #[cfg(feature = "schema-diff")]
 pub(crate) mod diff;

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -6,7 +6,7 @@ pub use column_mapping::ColumnMappingMode;
 #[internal_api]
 pub(crate) use column_mapping::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 pub(crate) use column_mapping::{
-    column_mapping_mode, get_column_mapping_mode_from_properties,
+    column_mapping_mode, drop_column_mapping_metadata, get_column_mapping_mode_from_properties,
     physical_to_logical_column_name_and_type, schema_has_column_mapping_metadata,
     strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
     validate_and_extract_column_mapping_annotations, validate_column_mapping_id,

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -28,6 +28,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use delta_kernel_derive::internal_api;
+
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
 use crate::schema::changes::{
@@ -135,7 +136,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         });
         self.transition()
     }
-    
+
     /// Change a column's nullability from NOT NULL to nullable. If the column is already
     /// nullable, the op is a no-op but still generates a commit.
     ///
@@ -145,7 +146,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
-    
+
     /// Add a new column at an explicit schema path.
     ///
     /// `path` identifies the struct that will contain `field`. An empty path targets the table's
@@ -163,7 +164,6 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::AddColumn { path, field });
         self.transition()
     }
-
 }
 
 impl AlterTableTransactionBuilder<Modifying> {

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -134,8 +134,9 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
 
     /// Add a new column at an explicit schema path.
     ///
-    /// The final path segment must be [`PathSegment::Field`] and must match `field.name()`.
-    /// Preceding segments may traverse nested structs, array elements, map keys, and map values.
+    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
+    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
+    /// values.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column_at(

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -39,7 +39,7 @@ use crate::table_features::{
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
 use crate::transaction::schema_evolution::{
-    apply_schema_operations, SchemaEvolutionResult, SchemaOperation,
+    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
 };
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
@@ -129,6 +129,22 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
         self.operations.push(SchemaOperation::AddColumn { field });
+        self.transition()
+    }
+
+    /// Add a new column at an explicit schema path.
+    ///
+    /// The final path segment must be [`PathSegment::Field`] and must match `field.name()`.
+    /// Preceding segments may traverse nested structs, array elements, map keys, and map values.
+    ///
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    pub fn add_column_at(
+        mut self,
+        path: Vec<PathSegment>,
+        field: StructField,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations
+            .push(SchemaOperation::AddColumnAt { path, field });
         self.transition()
     }
 

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -117,8 +117,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// The field must not already exist in the schema (case-insensitive). The field must be
     /// nullable because existing data files do not contain this column and will read NULL for it.
-    /// `field` and any of its nested fields must not carry `delta.columnMapping.id` or
-    /// `delta.columnMapping.physicalName` annotations.
+    /// Any caller-supplied column mapping annotations are replaced with fresh identities.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
@@ -144,6 +143,10 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     /// `path` identifies the struct that will contain `field`. An empty path targets the table's
     /// root schema; path segments may traverse nested structs, array elements, map keys, and map
     /// values.
+    ///
+    /// The added field must be nullable, must not be a metadata column, and must not collide
+    /// case-insensitively with a sibling in the target struct. Any caller-supplied column mapping
+    /// annotations are replaced with fresh identities.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     #[internal_api]

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -27,8 +27,12 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
+use crate::schema::changes::{
+    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
+};
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
 use crate::table_configuration::TableConfiguration;
@@ -38,9 +42,6 @@ use crate::table_features::{
 };
 use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
 use crate::transaction::alter_table::AlterTableTransaction;
-use crate::transaction::schema_evolution::{
-    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
-};
 use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
 
@@ -134,24 +135,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         });
         self.transition()
     }
-
-    /// Add a new column at an explicit schema path.
-    ///
-    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
-    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
-    /// values.
-    ///
-    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
-    pub fn add_column_at(
-        mut self,
-        path: Vec<PathSegment>,
-        field: StructField,
-    ) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations
-            .push(SchemaOperation::AddColumn { path, field });
-        self.transition()
-    }
-
+    
     /// Change a column's nullability from NOT NULL to nullable. If the column is already
     /// nullable, the op is a no-op but still generates a commit.
     ///
@@ -161,6 +145,25 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
             .push(SchemaOperation::SetNullable { column });
         self.transition()
     }
+    
+    /// Add a new column at an explicit schema path.
+    ///
+    /// `path` identifies the struct that will contain `field`. An empty path targets the table's
+    /// root schema; path segments may traverse nested structs, array elements, map keys, and map
+    /// values.
+    ///
+    /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
+    #[internal_api]
+    pub(crate) fn add_column_at(
+        mut self,
+        path: Vec<PathSegment>,
+        field: StructField,
+    ) -> AlterTableTransactionBuilder<Modifying> {
+        self.operations
+            .push(SchemaOperation::AddColumn { path, field });
+        self.transition()
+    }
+
 }
 
 impl AlterTableTransactionBuilder<Modifying> {

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -31,19 +31,11 @@ use delta_kernel_derive::internal_api;
 
 use crate::committer::Committer;
 use crate::expressions::ColumnName;
-use crate::schema::changes::{
-    apply_schema_operations, PathSegment, SchemaEvolutionResult, SchemaOperation,
-};
+use crate::schema::changes::{evolve_table_config, PathSegment, SchemaOperation};
 use crate::schema::StructField;
 use crate::snapshot::SnapshotRef;
-use crate::table_configuration::TableConfiguration;
-use crate::table_features::{
-    schema_has_column_mapping_metadata, strip_stray_column_mapping_metadata, ColumnMappingMode,
-    Operation, TableFeature,
-};
-use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
+use crate::table_features::{Operation, TableFeature};
 use crate::transaction::alter_table::AlterTableTransaction;
-use crate::utils::FoldWithOption as _;
 use crate::{DeltaResult, Engine, Error};
 
 /// Initial state: `build()` is not yet available (at least one operation is required).
@@ -209,50 +201,7 @@ impl AlterTableTransactionBuilder<Modifying> {
         // protocol must also re-check this on the evolved `TableConfiguration`.
         table_config.ensure_operation_supported(Operation::Write)?;
 
-        let schema = Arc::unwrap_or_clone(table_config.logical_schema());
-        let column_mapping_mode = table_config.column_mapping_mode();
-        let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
-        // Whether the pre-alter schema already carried column-mapping metadata -- the only fact the
-        // strip below needs from it. Captured as a bool (not a clone) before
-        // `apply_schema_operations` consumes `schema` by value. Short-circuits outside
-        // `None` mode, where no strip fires.
-        let current_has_cm = column_mapping_mode == ColumnMappingMode::None
-            && schema_has_column_mapping_metadata(&schema);
-        let SchemaEvolutionResult {
-            schema: evolved_schema,
-            new_max_column_id,
-        } = apply_schema_operations(
-            schema,
-            self.operations,
-            column_mapping_mode,
-            current_max_column_id,
-        )?;
-
-        // Only in `None` mode: if this ALTER introduced column-mapping annotations into a table
-        // that was clean before it, strip them; residual annotations already present on the
-        // table are left in place (see `strip_stray_column_mapping_metadata`).
-        let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
-            strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
-                .map_or(evolved_schema, Arc::new)
-        } else {
-            evolved_schema
-        };
-
-        let evolved_metadata = table_config
-            .metadata()
-            .clone()
-            .with_schema(evolved_schema.clone())?
-            .fold_with(new_max_column_id, |evolved_metadata, id| {
-                evolved_metadata
-                    .with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
-            });
-
-        // Validates the evolved metadata against the protocol.
-        let evolved_table_config = TableConfiguration::try_new_with_schema(
-            table_config,
-            evolved_metadata,
-            evolved_schema,
-        )?;
+        let evolved_table_config = evolve_table_config(table_config, self.operations)?;
 
         AlterTableTransaction::try_new_alter_table(
             self.snapshot,

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -128,7 +128,10 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {
-        self.operations.push(SchemaOperation::AddColumn { field });
+        self.operations.push(SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        });
         self.transition()
     }
 
@@ -145,7 +148,7 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
         field: StructField,
     ) -> AlterTableTransactionBuilder<Modifying> {
         self.operations
-            .push(SchemaOperation::AddColumnAt { path, field });
+            .push(SchemaOperation::AddColumn { path, field });
         self.transition()
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -71,8 +71,7 @@ pub(crate) mod alter_table;
 pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
-pub(crate) mod schema_evolution;
-pub use schema_evolution::{PathSegment, SchemaOperation};
+pub use crate::schema::changes::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2259,6 +2259,28 @@ mod tests {
     }
 
     #[test]
+    fn schema_add_whole_struct_column_is_persisted_on_commit() -> DeltaResult<()> {
+        let (engine, txn, _tempdir) = create_existing_table_txn()?;
+        let address_type = StructType::try_new(vec![
+            StructField::nullable("number", DataType::INTEGER),
+            StructField::nullable("street", DataType::STRING),
+        ])?;
+        let snapshot = txn
+            .with_schema_changes(vec![SchemaOperation::add_column(
+                StructField::nullable("address", address_type.clone()),
+                ColumnName::new(Vec::<String>::new()),
+            )])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+
+        let schema = snapshot.schema();
+        let address = schema.field("address").unwrap();
+        assert!(address.is_nullable());
+        assert_eq!(address.data_type(), &DataType::from(address_type));
+        Ok(())
+    }
+
+    #[test]
     fn schema_changes_are_rejected_after_staging_data() -> DeltaResult<()> {
         let (_engine, mut txn, _tempdir) = create_existing_table_txn()?;
         add_dummy_file(&mut txn);

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2184,7 +2184,7 @@ mod tests {
             ])?
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
-        assert!(snapshot.schema().contains("fresh_column"));
+        assert!(snapshot.schema().contains("first_column"));
 
         // A second transaction starts from the committed schema, so its own change must land on
         // top of the first one rather than replacing or re-applying it.
@@ -2197,7 +2197,7 @@ mod tests {
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
 
-        assert!(snapshot.schema().contains("fresh_column"));
+        assert!(snapshot.schema().contains("first_column"));
         assert!(snapshot.schema().contains("second_column"));
         Ok(())
     }

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -213,7 +213,7 @@ pub struct Transaction<S = ExistingTable> {
     effective_table_config: TableConfiguration,
     // Whether to emit a Protocol action. True for CREATE TABLE and ALTER TABLE, false otherwise.
     should_emit_protocol: bool,
-    // Whether to emit a Metadata action. True for CREATE TABLE and ALTER TABLE, false otherwise.
+    // Whether to emit a Metadata action. True when creating or altering table metadata.
     should_emit_metadata: bool,
     committer: Box<dyn Committer>,
     operation: Option<String>,
@@ -2132,6 +2132,13 @@ mod tests {
         Ok(())
     }
 
+    fn fresh_column_operation() -> SchemaOperation {
+        SchemaOperation::add_column(
+            StructField::nullable("fresh_column", DataType::INTEGER),
+            vec![],
+        )
+    }
+
     #[test]
     fn write_context_reflects_updated_effective_table_config(
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -2148,10 +2155,7 @@ mod tests {
             .logical_schema()
             .contains("fresh_column"));
 
-        let txn = txn.with_schema_changes(vec![SchemaOperation::AddColumn {
-            path: vec![],
-            field: StructField::nullable("fresh_column", DataType::INTEGER),
-        }])?;
+        let txn = txn.with_schema_changes(vec![fresh_column_operation()])?;
 
         let updated_write_context = txn.unpartitioned_write_context()?;
         assert!(updated_write_context
@@ -2164,6 +2168,37 @@ mod tests {
             .logical_schema()
             .contains("fresh_column"));
 
+        Ok(())
+    }
+
+    #[test]
+    fn schema_changes_are_applied_once_and_persisted_on_commit() -> DeltaResult<()> {
+        let (engine, txn, _tempdir) = create_existing_table_txn()?;
+
+        let snapshot = txn
+            .with_schema_changes(vec![
+                fresh_column_operation(),
+                SchemaOperation::add_column(
+                    StructField::nullable("second_column", DataType::STRING),
+                    ColumnName::new(Vec::<String>::new()),
+                ),
+            ])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+
+        assert!(snapshot.schema().contains("fresh_column"));
+        assert!(snapshot.schema().contains("second_column"));
+        Ok(())
+    }
+
+    #[test]
+    fn schema_changes_are_rejected_after_staging_data() -> DeltaResult<()> {
+        let (_engine, mut txn, _tempdir) = create_existing_table_txn()?;
+        add_dummy_file(&mut txn);
+
+        let result = txn.with_schema_changes(vec![fresh_column_operation()]);
+
+        assert!(matches!(result, Err(Error::InvalidTransactionState(_))));
         Ok(())
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2149,6 +2149,7 @@ mod tests {
             .contains("fresh_column"));
 
         let txn = txn.with_schema_changes(vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("fresh_column", DataType::INTEGER),
         }])?;
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1796,6 +1796,7 @@ mod tests {
     use url::Url;
 
     use super::*;
+    use super::schema_evolution::SchemaOperation;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::actions::CommitInfo;
     use crate::arrow::array::{

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -71,7 +71,8 @@ pub(crate) mod alter_table;
 pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
-pub use crate::schema::changes::{PathSegment, SchemaOperation};
+#[internal_api]
+pub(crate) use crate::schema::changes::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -72,6 +72,7 @@ pub use alter_table::AlterTableTransaction;
 mod commit_info;
 mod domain_metadata;
 pub(crate) mod schema_evolution;
+pub use schema_evolution::{PathSegment, SchemaOperation};
 #[cfg(feature = "internal-api")]
 pub mod stats_verifier;
 #[cfg(not(feature = "internal-api"))]
@@ -2135,7 +2136,7 @@ mod tests {
     fn write_context_reflects_updated_effective_table_config(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, snapshot) = setup_non_dv_table();
-        let mut txn = snapshot
+        let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
@@ -2147,24 +2148,9 @@ mod tests {
             .logical_schema()
             .contains("fresh_column"));
 
-        let mut evolved_fields: Vec<StructField> = txn
-            .effective_table_config
-            .logical_schema()
-            .fields()
-            .cloned()
-            .collect();
-        evolved_fields.push(StructField::nullable("fresh_column", DataType::INTEGER));
-        let evolved_schema = Arc::new(StructType::new_unchecked(evolved_fields));
-        let evolved_metadata = txn
-            .effective_table_config
-            .metadata()
-            .clone()
-            .with_schema(evolved_schema.clone())?;
-        txn.effective_table_config = TableConfiguration::try_new_with_schema(
-            &txn.effective_table_config,
-            evolved_metadata,
-            evolved_schema,
-        )?;
+        let txn = txn.with_schema_changes(vec![SchemaOperation::AddColumn {
+            field: StructField::nullable("fresh_column", DataType::INTEGER),
+        }])?;
 
         let updated_write_context = txn.unpartitioned_write_context()?;
         assert!(updated_write_context

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2177,17 +2177,84 @@ mod tests {
 
         let snapshot = txn
             .with_schema_changes(vec![
-                fresh_column_operation(),
                 SchemaOperation::add_column(
-                    StructField::nullable("second_column", DataType::STRING),
+                    StructField::nullable("first_column", DataType::INTEGER),
                     ColumnName::new(Vec::<String>::new()),
-                ),
+                )
             ])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+        assert!(snapshot.schema().contains("fresh_column"));
+
+        // A second transaction starts from the committed schema, so its own change must land on
+        // top of the first one rather than replacing or re-applying it.
+        let snapshot = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_schema_changes(vec![SchemaOperation::add_column(
+                StructField::nullable("second_column", DataType::STRING),
+                ColumnName::new(Vec::<String>::new()),
+            )])?
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
 
         assert!(snapshot.schema().contains("fresh_column"));
         assert!(snapshot.schema().contains("second_column"));
+        Ok(())
+    }
+
+    #[test]
+    fn schema_set_nullable_is_persisted_on_commit() -> DeltaResult<()> {
+        let engine: Arc<dyn Engine> =
+            Arc::new(SyncEngine::new_with_store(Arc::new(InMemory::new())));
+        let schema = Arc::new(StructType::try_new(vec![
+            StructField::not_null("id", DataType::INTEGER),
+            StructField::nullable("name", DataType::STRING),
+        ])?);
+        let snapshot = create_table("memory:///set_nullable", schema, "test")
+            .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+        assert!(!snapshot.schema().field("id").unwrap().is_nullable());
+
+        let snapshot = snapshot
+            .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
+            .with_schema_changes(vec![SchemaOperation::set_nullable(column_name!("id"))])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+
+        assert!(snapshot.schema().field("id").unwrap().is_nullable());
+        assert!(snapshot.schema().field("name").unwrap().is_nullable());
+        Ok(())
+    }
+
+    #[test]
+    fn schema_add_struct_then_nested_field_is_persisted_on_commit() -> DeltaResult<()> {
+        let (engine, txn, _tempdir) = create_existing_table_txn()?;
+        let snapshot = txn
+            .with_schema_changes(vec![
+                SchemaOperation::add_column(
+                    StructField::nullable("address", StructType::try_new(vec![])?),
+                    ColumnName::new(Vec::<String>::new()),
+                ),
+                SchemaOperation::add_column(
+                    StructField::nullable("city", DataType::STRING),
+                    column_name!("address"),
+                ),
+            ])?
+            .commit(engine.as_ref())?
+            .unwrap_post_commit_snapshot();
+
+        let schema = snapshot.schema();
+        let address = schema.field("address").unwrap();
+        let DataType::Struct(inner) = address.data_type() else {
+            panic!(
+                "expected address to be a struct, got {:?}",
+                address.data_type()
+            );
+        };
+        let city = inner.field("city").expect("city nested under address");
+        assert_eq!(city.data_type(), &DataType::STRING);
+        assert!(city.is_nullable());
         Ok(())
     }
 

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -1796,7 +1796,6 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use super::schema_evolution::SchemaOperation;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::actions::CommitInfo;
     use crate::arrow::array::{
@@ -2177,12 +2176,10 @@ mod tests {
         let (engine, txn, _tempdir) = create_existing_table_txn()?;
 
         let snapshot = txn
-            .with_schema_changes(vec![
-                SchemaOperation::add_column(
-                    StructField::nullable("first_column", DataType::INTEGER),
-                    ColumnName::new(Vec::<String>::new()),
-                )
-            ])?
+            .with_schema_changes(vec![SchemaOperation::add_column(
+                StructField::nullable("first_column", DataType::INTEGER),
+                vec![],
+            )])?
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
         assert!(snapshot.schema().contains("first_column"));
@@ -2193,7 +2190,7 @@ mod tests {
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_schema_changes(vec![SchemaOperation::add_column(
                 StructField::nullable("second_column", DataType::STRING),
-                ColumnName::new(Vec::<String>::new()),
+                vec![],
             )])?
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();
@@ -2235,11 +2232,11 @@ mod tests {
             .with_schema_changes(vec![
                 SchemaOperation::add_column(
                     StructField::nullable("address", StructType::try_new(vec![])?),
-                    ColumnName::new(Vec::<String>::new()),
+                    vec![],
                 ),
                 SchemaOperation::add_column(
                     StructField::nullable("city", DataType::STRING),
-                    column_name!("address"),
+                    vec![PathSegment::Field("address".to_string())],
                 ),
             ])?
             .commit(engine.as_ref())?
@@ -2269,7 +2266,7 @@ mod tests {
         let snapshot = txn
             .with_schema_changes(vec![SchemaOperation::add_column(
                 StructField::nullable("address", address_type.clone()),
-                ColumnName::new(Vec::<String>::new()),
+                vec![],
             )])?
             .commit(engine.as_ref())?
             .unwrap_post_commit_snapshot();

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -6,6 +6,8 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use delta_kernel_derive::internal_api;
+
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
@@ -21,9 +23,10 @@ use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
 /// One segment in a path to a nested schema field.
+#[internal_api]
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PathSegment {
+pub(crate) enum PathSegment {
     Field(String),
     ArrayElement,
     MapKey,
@@ -33,15 +36,13 @@ pub enum PathSegment {
 /// A schema evolution operation to be applied to a table.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
-pub enum SchemaOperation {
-    /// Add a top-level column.
-    AddColumn { field: StructField },
-
+#[internal_api]
+pub(crate) enum SchemaOperation {
     /// Add a column at an explicit schema path.
     ///
     /// The path identifies the struct that will contain `field`. An empty path adds `field` to the
     /// table's root schema.
-    AddColumnAt {
+    AddColumn {
         path: Vec<PathSegment>,
         field: StructField,
     },
@@ -173,8 +174,7 @@ pub(crate) fn apply_schema_operations(
     for op in operations {
         let mut root = DataType::from(schema);
         let add_column = match op {
-            SchemaOperation::AddColumn { field } => Some((Vec::new(), field)),
-            SchemaOperation::AddColumnAt { path, field } => Some((path, field)),
+            SchemaOperation::AddColumn { path, field } => Some((path, field)),
             SchemaOperation::SetNullable { column } => {
                 let (leaf, parent) = column
                     .path()
@@ -316,7 +316,10 @@ mod tests {
         } else {
             StructField::not_null(name, DataType::STRING)
         };
-        SchemaOperation::AddColumn { field }
+        SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }
     }
 
     // Builds a struct column whose nested leaf field has the given name. Used to prove that
@@ -326,6 +329,7 @@ mod tests {
         let inner =
             StructType::try_new(vec![StructField::nullable(leaf_name, DataType::STRING)]).unwrap();
         SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable(name, inner),
         }
     }
@@ -447,12 +451,13 @@ mod tests {
     )]
     #[case::metadata_column(
         vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::create_metadata_column("row_idx", MetadataColumnSpec::RowIndex),
         }],
         "metadata columns are not allowed"
     )]
     #[case::missing_add_parent(
-        vec![SchemaOperation::AddColumnAt {
+        vec![SchemaOperation::AddColumn {
             path: vec![PathSegment::Field("missing".to_string())],
             field: StructField::nullable("added", DataType::STRING),
         }],
@@ -470,7 +475,7 @@ mod tests {
     #[rstest]
     #[case::single(vec![add_col("email", true)], &["id", "name", "email"])]
     #[case::at_root(
-        vec![SchemaOperation::AddColumnAt {
+        vec![SchemaOperation::AddColumn {
             path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }],
@@ -544,7 +549,7 @@ mod tests {
             StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
         let mut path = vec![PathSegment::Field("container".to_string())];
         path.extend(container_path.iter().cloned());
-        let operation = SchemaOperation::AddColumnAt {
+        let operation = SchemaOperation::AddColumn {
             path,
             field: StructField::nullable("added", DataType::INTEGER),
         };
@@ -631,6 +636,7 @@ mod tests {
     fn chain_add_and_set_nullable_applies_both() {
         let ops = vec![
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("email", DataType::STRING),
             },
             SchemaOperation::SetNullable {
@@ -693,6 +699,7 @@ mod tests {
         #[case] expected_id: i64,
     ) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }];
         let result =
@@ -707,6 +714,7 @@ mod tests {
     #[test]
     fn add_column_without_max_column_id_fails_when_mapping_enabled() {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("email", DataType::STRING),
         }];
         let err = apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, None)
@@ -722,12 +730,15 @@ mod tests {
     fn add_multiple_columns_with_column_mapping_assigns_unique_ids() {
         let ops = vec![
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("a", DataType::STRING),
             },
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("b", DataType::STRING),
             },
             SchemaOperation::AddColumn {
+                path: vec![],
                 field: StructField::nullable("c", DataType::STRING),
             },
         ];
@@ -786,6 +797,7 @@ mod tests {
         #[case] expected_id_count: usize,
     ) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("col", data_type),
         }];
         let result =
@@ -828,7 +840,10 @@ mod tests {
         StructType::try_new(vec![field_with_id_only("inner", DataType::STRING, 99)]).unwrap(),
     ))]
     fn add_column_with_preexisting_cm_metadata_is_preserved_under_cm(#[case] field: StructField) {
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let result = apply_schema_operations(
             simple_schema(),
             ops,
@@ -854,7 +869,10 @@ mod tests {
                 .to_string(),
             MetadataValue::String("user-supplied-name".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let result =
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::Name, Some(7))
                 .unwrap();
@@ -877,6 +895,7 @@ mod tests {
     #[case::negative(-1)]
     fn alter_with_out_of_range_persisted_max_column_id_is_rejected(#[case] seed: i64) {
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("anything", DataType::INTEGER),
         }];
         let err =
@@ -900,7 +919,10 @@ mod tests {
             ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
             MetadataValue::String("not-a-number".to_string()),
         );
-        let ops = vec![SchemaOperation::AddColumn { field }];
+        let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
+            field,
+        }];
         let err = apply_schema_operations(
             simple_schema(),
             ops,
@@ -927,6 +949,7 @@ mod tests {
         );
         let schema = StructType::try_new(vec![existing]).unwrap();
         let ops = vec![SchemaOperation::AddColumn {
+            path: vec![],
             field: StructField::nullable("new", DataType::STRING),
         }];
         // Persisted maxColumnId is stale at 5, but the schema actually contains id=42.

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -32,10 +32,7 @@ pub enum PathSegment {
     MapValue,
 }
 
-/// A schema evolution operation to apply to a table.
-///
-/// Operations are validated and applied in order. Each operation sees the schema state after all
-/// prior operations have been applied.
+/// A schema evolution operation to be applied to a table.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum SchemaOperation {
@@ -119,26 +116,10 @@ fn add_column_at_path(
     match (segment, data_type) {
         // Adding the field to the current struct.
         (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
+            // The path leaf is supposed to be the field we are trying to add.
             if !name.eq_ignore_ascii_case(field.name()) {
                 return Err(Error::schema(format!(
                     "Cannot add column '{}': path leaf '{name}' does not match field name",
-                    field.name()
-                )));
-            }
-            if field.is_metadata_column() {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': metadata columns are not allowed in \
-                     a table schema",
-                    field.name()
-                )));
-            }
-            if !matches!(field.data_type, DataType::Primitive(_)) {
-                StructType::ensure_no_metadata_columns_in_field(&field)?;
-            }
-            if !field.is_nullable() {
-                return Err(Error::schema(format!(
-                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                     because existing data files do not contain this column.",
                     field.name()
                 )));
             }
@@ -263,8 +244,23 @@ pub(crate) fn apply_schema_operations(
             }
         };
 
-        // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
-        // later when the caller builds a new TableConfiguration from the evolved schema.
+        if field.is_metadata_column() {
+            return Err(Error::schema(format!(
+                "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                field.name()
+            )));
+        }
+        if !matches!(field.data_type, DataType::Primitive(_)) {
+            StructType::ensure_no_metadata_columns_in_field(&field)?;
+        }
+        if !field.is_nullable() {
+            return Err(Error::schema(format!(
+                "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                 because existing data files do not contain this column.",
+                field.name()
+            )));
+        }
+
         let mut root = DataType::from(schema);
         add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
         let DataType::Struct(updated_schema) = root else {

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -4,6 +4,7 @@
 //! that validates and applies schema changes to produce an evolved schema.
 
 use std::cmp::Ordering;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 
@@ -11,21 +12,43 @@ use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
 use crate::schema::{DataType, SchemaRef, StructField, StructType};
+use crate::table_configuration::TableConfiguration;
 use crate::table_features::{
-    find_max_column_id_in_schema, try_assign_flat_column_mapping_info, validate_column_mapping_id,
-    ColumnMappingMode,
+    find_max_column_id_in_schema, schema_has_column_mapping_metadata,
+    strip_stray_column_mapping_metadata, try_assign_flat_column_mapping_info,
+    validate_column_mapping_id, ColumnMappingMode,
 };
+use crate::table_properties::COLUMN_MAPPING_MAX_COLUMN_ID;
+use crate::utils::FoldWithOption as _;
 use crate::DeltaResult;
 
-/// A schema evolution operation to be applied during ALTER TABLE.
+/// One segment in a path to a nested schema field.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSegment {
+    Field(String),
+    ArrayElement,
+    MapKey,
+    MapValue,
+}
+
+/// A schema evolution operation to apply to a table.
 ///
-/// Operations are validated and applied in order during
-/// [`apply_schema_operations`]. Each operation sees the schema state after all prior operations
-/// have been applied.
+/// Operations are validated and applied in order. Each operation sees the schema state after all
+/// prior operations have been applied.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
-pub(crate) enum SchemaOperation {
+pub enum SchemaOperation {
     /// Add a top-level column.
     AddColumn { field: StructField },
+
+    /// Add a column at an explicit schema path.
+    ///
+    /// The final segment must be [`PathSegment::Field`] and must match `field.name()`.
+    AddColumnAt {
+        path: Vec<PathSegment>,
+        field: StructField,
+    },
 
     /// Change a column's nullability from NOT NULL to nullable.
     SetNullable { column: ColumnName },
@@ -82,6 +105,97 @@ fn modify_field_at_path(
     modifier(field)
 }
 
+fn add_column_at_path(
+    data_type: &mut DataType,
+    path: &[PathSegment],
+    field: StructField,
+    cm_enabled: bool,
+    max_id: &mut Option<i64>,
+) -> DeltaResult<()> {
+    let (segment, rest) = path
+        .split_first()
+        .ok_or_else(|| Error::schema("Cannot add column: empty column path"))?;
+
+    match (segment, data_type) {
+        // Adding the field to the current struct.
+        (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
+            if !name.eq_ignore_ascii_case(field.name()) {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': path leaf '{name}' does not match field name",
+                    field.name()
+                )));
+            }
+            if field.is_metadata_column() {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': metadata columns are not allowed in \
+                     a table schema",
+                    field.name()
+                )));
+            }
+            if !matches!(field.data_type, DataType::Primitive(_)) {
+                StructType::ensure_no_metadata_columns_in_field(&field)?;
+            }
+            if !field.is_nullable() {
+                return Err(Error::schema(format!(
+                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                     because existing data files do not contain this column.",
+                    field.name()
+                )));
+            }
+            let lowered = field.name().to_lowercase();
+            if parent
+                .fields()
+                .any(|existing| existing.name().to_lowercase() == lowered)
+            {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': a column with that name already exists",
+                    field.name()
+                )));
+            }
+            let field = if cm_enabled {
+                let id = max_id.as_mut().ok_or_else(|| {
+                    Error::invalid_protocol(
+                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                         is not set in table properties",
+                    )
+                })?;
+                try_assign_flat_column_mapping_info(&field, id)?
+            } else {
+                field
+            };
+            parent.field_map_mut().insert(field.name().clone(), field);
+            Ok(())
+        }
+        (PathSegment::Field(name), DataType::Struct(parent)) => {
+            let lowered = name.to_lowercase();
+            let index = parent
+                .fields()
+                .position(|existing| existing.name().to_lowercase() == lowered)
+                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
+            let nested = &mut parent
+                .field_map_mut()
+                .get_index_mut(index)
+                .ok_or_else(|| Error::internal_error("field index became invalid"))?
+                .1
+                .data_type;
+            add_column_at_path(nested, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::ArrayElement, DataType::Array(array)) => {
+            add_column_at_path(&mut array.element_type, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::MapKey, DataType::Map(map)) => {
+            add_column_at_path(&mut map.key_type, rest, field, cm_enabled, max_id)
+        }
+        (PathSegment::MapValue, DataType::Map(map)) => {
+            add_column_at_path(&mut map.value_type, rest, field, cm_enabled, max_id)
+        }
+        (segment, data_type) => Err(Error::schema(format!(
+            "Cannot add column '{}': path segment {segment:?} does not match {data_type}",
+            field.name()
+        ))),
+    }
+}
+
 /// The result of applying schema operations.
 #[derive(Debug)]
 pub(crate) struct SchemaEvolutionResult {
@@ -132,61 +246,11 @@ pub(crate) fn apply_schema_operations(
     };
 
     for op in operations {
-        match op {
-            // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
-            // later when the caller builds a new TableConfiguration from the evolved schema --
-            // the alter is rejected if the table doesn't already have the required feature
-            // enabled. This matches Spark, which also rejects with
-            // `DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT` and requires the user to enable the
-            // feature explicitly before adding such a column.
+        let (path, field) = match op {
             SchemaOperation::AddColumn { field } => {
-                if field.is_metadata_column() {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': metadata columns are not allowed in \
-                         a table schema",
-                        field.name()
-                    )));
-                }
-                if !matches!(field.data_type, DataType::Primitive(_)) {
-                    StructType::ensure_no_metadata_columns_in_field(&field)?;
-                }
-                // Case-insensitive sibling-conflict check (O(N) per AddColumn).
-                let lowered = field.name().to_lowercase();
-                if schema.fields().any(|f| f.name().to_lowercase() == lowered) {
-                    return Err(Error::schema(format!(
-                        "Cannot add column '{}': a column with that name already exists",
-                        field.name()
-                    )));
-                }
-                // Validate field is nullable (Delta protocol requires added columns to be
-                // nullable so existing data files can return NULL for the new column)
-                // NOTE: non-nullable columns depend on invariants feature
-                if !field.is_nullable() {
-                    return Err(Error::schema(format!(
-                        "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                         because existing data files do not contain this column.",
-                        field.name()
-                    )));
-                }
-                let field = if cm_enabled {
-                    let id = max_id.as_mut().ok_or_else(|| {
-                        Error::invalid_protocol(
-                            "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                             is not set in table properties",
-                        )
-                    })?;
-                    // ALTER TABLE doesn't support icebergCompatV3 yet, so the new field never
-                    // gets `delta.columnMapping.nested.ids` here. Tracking issue:
-                    // <https://github.com/delta-io/delta-kernel-rs/issues/2492>
-                    try_assign_flat_column_mapping_info(&field, id)?
-                } else {
-                    // Stray CM metadata on a mapping-disabled table is handled by the AlterTable
-                    // builder, which strips annotations this ALTER newly introduces from the
-                    // evolved schema.
-                    field
-                };
-                schema.field_map_mut().insert(field.name().clone(), field);
+                (vec![PathSegment::Field(field.name().clone())], field)
             }
+            SchemaOperation::AddColumnAt { path, field } => (path, field),
             SchemaOperation::SetNullable { column } => {
                 modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
                     f.nullable = true;
@@ -195,8 +259,20 @@ pub(crate) fn apply_schema_operations(
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
+                continue;
             }
-        }
+        };
+
+        // Protocol feature checks for the field's data type (e.g. `timestampNtz`) happen
+        // later when the caller builds a new TableConfiguration from the evolved schema.
+        let mut root = DataType::from(schema);
+        add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
+        let DataType::Struct(updated_schema) = root else {
+            return Err(Error::internal_error(
+                "schema root changed type while adding a column",
+            ));
+        };
+        schema = *updated_schema;
     }
 
     validate_schema(&schema, column_mapping_mode)?;
@@ -216,6 +292,46 @@ pub(crate) fn apply_schema_operations(
         schema: schema.into(),
         new_max_column_id,
     })
+}
+
+/// Applies schema changes and validates the resulting table configuration.
+///
+/// # Errors
+///
+/// Returns an error when an operation is invalid, the evolved schema violates Delta schema
+/// rules, or the evolved metadata is incompatible with the table protocol.
+pub(crate) fn evolve_table_config(
+    table_config: &TableConfiguration,
+    operations: Vec<SchemaOperation>,
+) -> DeltaResult<TableConfiguration> {
+    let schema = Arc::unwrap_or_clone(table_config.logical_schema());
+    let column_mapping_mode = table_config.column_mapping_mode();
+    let current_max_column_id = table_config.table_properties().column_mapping_max_column_id;
+    let current_has_cm = column_mapping_mode == ColumnMappingMode::None
+        && schema_has_column_mapping_metadata(&schema);
+    let SchemaEvolutionResult {
+        schema: evolved_schema,
+        new_max_column_id,
+    } = apply_schema_operations(
+        schema,
+        operations,
+        column_mapping_mode,
+        current_max_column_id,
+    )?;
+    let evolved_schema = if column_mapping_mode == ColumnMappingMode::None {
+        strip_stray_column_mapping_metadata(current_has_cm, &evolved_schema)
+            .map_or(evolved_schema, Arc::new)
+    } else {
+        evolved_schema
+    };
+    let evolved_metadata = table_config
+        .metadata()
+        .clone()
+        .with_schema(evolved_schema.clone())?
+        .fold_with(new_max_column_id, |metadata, id| {
+            metadata.with_configuration_entry(COLUMN_MAPPING_MAX_COLUMN_ID, id.to_string())
+        });
+    TableConfiguration::try_new_with_schema(table_config, evolved_metadata, evolved_schema)
 }
 
 #[cfg(test)]
@@ -379,6 +495,20 @@ mod tests {
         }],
         "metadata columns are not allowed"
     )]
+    #[case::empty_add_path(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![],
+            field: StructField::nullable("added", DataType::STRING),
+        }],
+        "empty column path"
+    )]
+    #[case::add_path_leaf_mismatch(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![PathSegment::Field("other".to_string())],
+            field: StructField::nullable("added", DataType::STRING),
+        }],
+        "does not match field name"
+    )]
     fn apply_schema_operations_rejects(
         #[case] ops: Vec<SchemaOperation>,
         #[case] error_contains: &str,
@@ -402,6 +532,79 @@ mod tests {
             apply_schema_operations(simple_schema(), ops, ColumnMappingMode::None, None).unwrap();
         let actual: Vec<&str> = result.schema.fields().map(|f| f.name().as_str()).collect();
         assert_eq!(&actual, expected_names);
+    }
+
+    fn struct_with_existing_field() -> StructType {
+        StructType::try_new([StructField::nullable("existing", DataType::STRING)]).unwrap()
+    }
+
+    fn nested_struct_at<'a>(mut data_type: &'a DataType, path: &[PathSegment]) -> &'a StructType {
+        for segment in path {
+            data_type = match (segment, data_type) {
+                (PathSegment::ArrayElement, DataType::Array(array)) => array.element_type(),
+                (PathSegment::MapKey, DataType::Map(map)) => map.key_type(),
+                (PathSegment::MapValue, DataType::Map(map)) => map.value_type(),
+                (segment, data_type) => {
+                    panic!("path segment {segment:?} does not match {data_type}")
+                }
+            };
+        }
+        let DataType::Struct(parent) = data_type else {
+            panic!("path does not resolve to a struct");
+        };
+        parent
+    }
+
+    #[rstest]
+    #[case::struct_parent(
+        DataType::from(struct_with_existing_field()),
+        vec![],
+    )]
+    #[case::array_element(
+        DataType::from(ArrayType::new(struct_with_existing_field(), true)),
+        vec![PathSegment::ArrayElement],
+    )]
+    #[case::map_key(
+        DataType::from(MapType::new(
+            struct_with_existing_field(),
+            DataType::INTEGER,
+            true,
+        )),
+        vec![PathSegment::MapKey],
+    )]
+    #[case::map_value(
+        DataType::from(MapType::new(
+            DataType::INTEGER,
+            struct_with_existing_field(),
+            true,
+        )),
+        vec![PathSegment::MapValue],
+    )]
+    fn add_column_at_traverses_nested_types(
+        #[case] parent_type: DataType,
+        #[case] container_path: Vec<PathSegment>,
+    ) {
+        let schema =
+            StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
+        let mut path = vec![PathSegment::Field("container".to_string())];
+        path.extend(container_path.iter().cloned());
+        path.push(PathSegment::Field("added".to_string()));
+        let operation = SchemaOperation::AddColumnAt {
+            path,
+            field: StructField::nullable("added", DataType::INTEGER),
+        };
+
+        let result =
+            apply_schema_operations(schema, vec![operation], ColumnMappingMode::None, None)
+                .unwrap();
+        let container = result.schema.field("container").unwrap();
+        let parent = nested_struct_at(container.data_type(), &container_path);
+
+        assert!(parent.field("existing").is_some());
+        assert_eq!(
+            parent.field("added"),
+            Some(&StructField::nullable("added", DataType::INTEGER))
+        );
     }
 
     // === apply_schema_operations: SetNullable tests ===

--- a/kernel/src/transaction/schema_evolution.rs
+++ b/kernel/src/transaction/schema_evolution.rs
@@ -6,8 +6,6 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
-use indexmap::IndexMap;
-
 use crate::error::Error;
 use crate::expressions::ColumnName;
 use crate::schema::validation::validate_schema;
@@ -41,7 +39,8 @@ pub enum SchemaOperation {
 
     /// Add a column at an explicit schema path.
     ///
-    /// The final segment must be [`PathSegment::Field`] and must match `field.name()`.
+    /// The path identifies the struct that will contain `field`. An empty path adds `field` to the
+    /// table's root schema.
     AddColumnAt {
         path: Vec<PathSegment>,
         field: StructField,
@@ -51,128 +50,73 @@ pub enum SchemaOperation {
     SetNullable { column: ColumnName },
 }
 
-// Helper to modify a nested column. For each component in `path`, locates the matching field
-// (case-insensitive), then descends into the next nested struct. At the leaf, calls `modifier`
-// to mutate the field in place.
-//
-// `modifier` is expected to mutate the field's nullability, metadata, or `data_type` -- but
-// not its name. Renames need additional handling (IndexMap re-keying + sibling-conflict check)
-// that downstream PRs will introduce alongside the rename caller.
-//
-// Returns an error if a field in the path does not exist or an intermediate field is not a struct.
-//
-// Example:
-//   fields   = [ id: int not null, address: struct { city: string not null, zip: string } ]
-//   path     = ["address", "city"]
-//   modifier = |f| { f.nullable = true; Ok(()) }
-// yields:
-//   [ id: int not null, address: struct { city: string, zip: string } ]
-fn modify_field_at_path(
-    fields: &mut IndexMap<String, StructField>,
-    path: &[String],
-    modifier: &dyn Fn(&mut StructField) -> DeltaResult<()>,
-) -> DeltaResult<()> {
-    let (first, rest) = path
-        .split_first()
-        .ok_or_else(|| Error::generic("empty column path"))?;
-
-    // Delta column names are case-insensitive.
-    let lowered = first.to_lowercase();
-    let idx = fields
-        .iter()
-        .position(|(_, f)| f.name().to_lowercase() == lowered)
-        .ok_or_else(|| Error::generic(format!("field '{first}' does not exist")))?;
-
-    if !rest.is_empty() {
-        let (_, field) = fields
-            .get_index_mut(idx)
-            .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-        let DataType::Struct(inner) = &mut field.data_type else {
-            return Err(Error::generic(format!(
-                "intermediate field '{first}' is not a struct"
-            )));
-        };
-        return modify_field_at_path(inner.field_map_mut(), rest, modifier);
+fn add_field(parent: &mut StructType, field: StructField) -> DeltaResult<()> {
+    let lowered = field.name().to_lowercase();
+    if parent
+        .fields()
+        .any(|existing| existing.name().to_lowercase() == lowered)
+    {
+        return Err(Error::schema(format!(
+            "Cannot add column '{}': a column with that name already exists",
+            field.name()
+        )));
     }
-
-    // === Leaf handling ===
-    let (_, field) = fields
-        .get_index_mut(idx)
-        .ok_or_else(|| Error::internal_error("idx from position() invalid"))?;
-    modifier(field)
+    parent.field_map_mut().insert(field.name().clone(), field);
+    Ok(())
 }
 
-fn add_column_at_path(
+fn set_field_nullable(field: &mut StructType, name: &str) -> DeltaResult<()> {
+    let field = field
+        .field_map_mut()
+        .values_mut()
+        .find(|field| field.name().to_lowercase() == name.to_lowercase())
+        .ok_or_else(|| Error::generic(format!("field '{}' does not exist", name)))?;
+    field.nullable = true;
+    Ok(())
+}
+
+fn to_path_segments(path: &[String]) -> Vec<PathSegment> {
+    path.iter()
+        .cloned()
+        .map(PathSegment::Field)
+        .collect::<Vec<_>>()
+}
+
+// Resolves `path` to a struct and calls `modifier` on it. Field names are matched
+// case-insensitively; explicit segments select array elements and map keys or values.
+fn modify_field_at_path(
     data_type: &mut DataType,
     path: &[PathSegment],
-    field: StructField,
-    cm_enabled: bool,
-    max_id: &mut Option<i64>,
+    modifier: impl FnOnce(&mut StructType) -> DeltaResult<()>,
 ) -> DeltaResult<()> {
-    let (segment, rest) = path
-        .split_first()
-        .ok_or_else(|| Error::schema("Cannot add column: empty column path"))?;
+    let Some((segment, rest)) = path.split_first() else {
+        let DataType::Struct(parent) = data_type else {
+            return Err(Error::generic("path target is not a struct"));
+        };
+        return modifier(parent);
+    };
 
     match (segment, data_type) {
-        // Adding the field to the current struct.
-        (PathSegment::Field(name), DataType::Struct(parent)) if rest.is_empty() => {
-            // The path leaf is supposed to be the field we are trying to add.
-            if !name.eq_ignore_ascii_case(field.name()) {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': path leaf '{name}' does not match field name",
-                    field.name()
-                )));
-            }
-            let lowered = field.name().to_lowercase();
-            if parent
-                .fields()
-                .any(|existing| existing.name().to_lowercase() == lowered)
-            {
-                return Err(Error::schema(format!(
-                    "Cannot add column '{}': a column with that name already exists",
-                    field.name()
-                )));
-            }
-            let field = if cm_enabled {
-                let id = max_id.as_mut().ok_or_else(|| {
-                    Error::invalid_protocol(
-                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
-                         is not set in table properties",
-                    )
-                })?;
-                try_assign_flat_column_mapping_info(&field, id)?
-            } else {
-                field
-            };
-            parent.field_map_mut().insert(field.name().clone(), field);
-            Ok(())
-        }
         (PathSegment::Field(name), DataType::Struct(parent)) => {
             let lowered = name.to_lowercase();
-            let index = parent
-                .fields()
-                .position(|existing| existing.name().to_lowercase() == lowered)
-                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
-            let nested = &mut parent
+            let field = parent
                 .field_map_mut()
-                .get_index_mut(index)
-                .ok_or_else(|| Error::internal_error("field index became invalid"))?
-                .1
-                .data_type;
-            add_column_at_path(nested, rest, field, cm_enabled, max_id)
+                .values_mut()
+                .find(|field| field.name().to_lowercase() == lowered)
+                .ok_or_else(|| Error::schema(format!("field '{name}' does not exist")))?;
+            modify_field_at_path(&mut field.data_type, rest, modifier)
         }
         (PathSegment::ArrayElement, DataType::Array(array)) => {
-            add_column_at_path(&mut array.element_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut array.element_type, rest, modifier)
         }
         (PathSegment::MapKey, DataType::Map(map)) => {
-            add_column_at_path(&mut map.key_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut map.key_type, rest, modifier)
         }
         (PathSegment::MapValue, DataType::Map(map)) => {
-            add_column_at_path(&mut map.value_type, rest, field, cm_enabled, max_id)
+            modify_field_at_path(&mut map.value_type, rest, modifier)
         }
         (segment, data_type) => Err(Error::schema(format!(
-            "Cannot add column '{}': path segment {segment:?} does not match {data_type}",
-            field.name()
+            "path segment {segment:?} does not match {data_type}"
         ))),
     }
 }
@@ -227,45 +171,60 @@ pub(crate) fn apply_schema_operations(
     };
 
     for op in operations {
-        let (path, field) = match op {
-            SchemaOperation::AddColumn { field } => {
-                (vec![PathSegment::Field(field.name().clone())], field)
-            }
-            SchemaOperation::AddColumnAt { path, field } => (path, field),
+        let mut root = DataType::from(schema);
+        let add_column = match op {
+            SchemaOperation::AddColumn { field } => Some((Vec::new(), field)),
+            SchemaOperation::AddColumnAt { path, field } => Some((path, field)),
             SchemaOperation::SetNullable { column } => {
-                modify_field_at_path(schema.field_map_mut(), column.path(), &|f| {
-                    f.nullable = true;
-                    Ok(())
+                let (leaf, parent) = column
+                    .path()
+                    .split_last()
+                    .ok_or_else(|| Error::generic("empty column path"))?;
+                let parent = to_path_segments(parent);
+                modify_field_at_path(&mut root, &parent, |parent| {
+                    set_field_nullable(parent, leaf)
                 })
                 .map_err(|e| {
                     Error::generic(format!("Cannot set nullable on column '{column}': {e}"))
                 })?;
-                continue;
+                None
             }
         };
 
-        if field.is_metadata_column() {
-            return Err(Error::schema(format!(
-                "Cannot add column '{}': metadata columns are not allowed in a table schema",
-                field.name()
-            )));
-        }
-        if !matches!(field.data_type, DataType::Primitive(_)) {
-            StructType::ensure_no_metadata_columns_in_field(&field)?;
-        }
-        if !field.is_nullable() {
-            return Err(Error::schema(format!(
-                "Cannot add non-nullable column '{}'. Added columns must be nullable \
-                 because existing data files do not contain this column.",
-                field.name()
-            )));
+        if let Some((path, field)) = add_column {
+            if field.is_metadata_column() {
+                return Err(Error::schema(format!(
+                    "Cannot add column '{}': metadata columns are not allowed in a table schema",
+                    field.name()
+                )));
+            }
+            if !matches!(field.data_type, DataType::Primitive(_)) {
+                StructType::ensure_no_metadata_columns_in_field(&field)?;
+            }
+            if !field.is_nullable() {
+                return Err(Error::schema(format!(
+                    "Cannot add non-nullable column '{}'. Added columns must be nullable \
+                     because existing data files do not contain this column.",
+                    field.name()
+                )));
+            }
+            let field = if cm_enabled {
+                let id = max_id.as_mut().ok_or_else(|| {
+                    Error::invalid_protocol(
+                        "Column mapping is enabled but delta.columnMapping.maxColumnId \
+                         is not set in table properties",
+                    )
+                })?;
+                try_assign_flat_column_mapping_info(&field, id)?
+            } else {
+                field
+            };
+            modify_field_at_path(&mut root, &path, |parent| add_field(parent, field))?;
         }
 
-        let mut root = DataType::from(schema);
-        add_column_at_path(&mut root, &path, field, cm_enabled, &mut max_id)?;
         let DataType::Struct(updated_schema) = root else {
             return Err(Error::internal_error(
-                "schema root changed type while adding a column",
+                "schema root changed type during schema evolution",
             ));
         };
         schema = *updated_schema;
@@ -388,34 +347,35 @@ mod tests {
 
     // === modify_field_at_path tests ===
 
-    // Convert a StructType into the IndexMap<String, StructField> shape that
-    // `modify_field_at_path` operates on.
-    fn into_field_map(schema: StructType) -> IndexMap<String, StructField> {
-        schema
-            .into_fields()
-            .map(|f| (f.name().clone(), f))
-            .collect()
-    }
-
-    fn set_nullable_modifier(f: &mut StructField) -> DeltaResult<()> {
-        f.nullable = true;
-        Ok(())
-    }
-
     fn modify_field_at_path_test_helper(
         schema: StructType,
         path: &[String],
-    ) -> DeltaResult<IndexMap<String, StructField>> {
-        let mut fields = into_field_map(schema);
-        modify_field_at_path(&mut fields, path, &set_nullable_modifier)?;
-        Ok(fields)
+    ) -> DeltaResult<StructType> {
+        let (leaf, parent) = path
+            .split_last()
+            .ok_or_else(|| Error::generic("empty column path"))?;
+        let parent = parent
+            .iter()
+            .cloned()
+            .map(PathSegment::Field)
+            .collect::<Vec<_>>();
+        let mut root = DataType::from(schema);
+        modify_field_at_path(&mut root, &parent, |parent| {
+            set_field_nullable(parent, leaf)
+        })?;
+        let DataType::Struct(schema) = root else {
+            return Err(Error::internal_error(
+                "schema root changed type while testing path modification",
+            ));
+        };
+        Ok(*schema)
     }
 
     #[test]
     fn modify_top_level_field_sets_nullable() {
         let path = vec!["id".to_string()];
         let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(id.is_nullable());
     }
 
@@ -423,7 +383,7 @@ mod tests {
     fn modify_nested_field_modifies_only_leaf() {
         let path = vec!["address".to_string(), "city".to_string()];
         let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
-        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let addr = result.fields().find(|f| f.name() == "address").unwrap();
         match addr.data_type() {
             DataType::Struct(s) => assert!(s.field("city").unwrap().is_nullable()),
             other => panic!("Expected Struct, got: {other:?}"),
@@ -437,9 +397,9 @@ mod tests {
     fn modify_nested_leaf_preserves_other_fields() {
         let path = vec!["address".to_string(), "city".to_string()];
         let result = modify_field_at_path_test_helper(nested_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(!id.is_nullable());
-        let addr = result.values().find(|f| f.name() == "address").unwrap();
+        let addr = result.fields().find(|f| f.name() == "address").unwrap();
         match addr.data_type() {
             DataType::Struct(s) => assert!(s.field("zip").unwrap().is_nullable()),
             other => panic!("Expected Struct, got: {other:?}"),
@@ -466,7 +426,7 @@ mod tests {
     fn modify_case_insensitive_lookup_finds_field() {
         let path = vec!["ID".to_string()];
         let result = modify_field_at_path_test_helper(simple_schema(), &path).unwrap();
-        let id = result.values().find(|f| f.name() == "id").unwrap();
+        let id = result.fields().find(|f| f.name() == "id").unwrap();
         assert!(id.is_nullable());
     }
 
@@ -491,19 +451,12 @@ mod tests {
         }],
         "metadata columns are not allowed"
     )]
-    #[case::empty_add_path(
+    #[case::missing_add_parent(
         vec![SchemaOperation::AddColumnAt {
-            path: vec![],
+            path: vec![PathSegment::Field("missing".to_string())],
             field: StructField::nullable("added", DataType::STRING),
         }],
-        "empty column path"
-    )]
-    #[case::add_path_leaf_mismatch(
-        vec![SchemaOperation::AddColumnAt {
-            path: vec![PathSegment::Field("other".to_string())],
-            field: StructField::nullable("added", DataType::STRING),
-        }],
-        "does not match field name"
+        "does not exist"
     )]
     fn apply_schema_operations_rejects(
         #[case] ops: Vec<SchemaOperation>,
@@ -516,6 +469,13 @@ mod tests {
 
     #[rstest]
     #[case::single(vec![add_col("email", true)], &["id", "name", "email"])]
+    #[case::at_root(
+        vec![SchemaOperation::AddColumnAt {
+            path: vec![],
+            field: StructField::nullable("email", DataType::STRING),
+        }],
+        &["id", "name", "email"],
+    )]
     #[case::multiple(
         vec![add_col("email", true), add_col("age", true)],
         &["id", "name", "email", "age"]
@@ -584,7 +544,6 @@ mod tests {
             StructType::try_new([StructField::nullable("container", parent_type)]).unwrap();
         let mut path = vec![PathSegment::Field("container".to_string())];
         path.extend(container_path.iter().cloned());
-        path.push(PathSegment::Field("added".to_string()));
         let operation = SchemaOperation::AddColumnAt {
             path,
             field: StructField::nullable("added", DataType::INTEGER),

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 use tracing::instrument;
 
-use super::schema_evolution::{evolve_table_config, SchemaOperation};
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
@@ -32,6 +31,7 @@ use crate::metrics::MetricId;
 use crate::scan::data_skipping::stats_schema::schema_with_all_fields_nullable;
 use crate::scan::log_replay::get_scan_metadata_transform_expr;
 use crate::scan::{restored_add_schema, scan_row_schema};
+use crate::schema::changes::{evolve_table_config, SchemaOperation};
 use crate::schema::{ArrayType, SchemaRef, StructField, StructType, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
@@ -144,7 +144,8 @@ impl Transaction {
     /// Returns an error if the table enables an unsupported schema-evolution feature, `changes` is
     /// empty, data files have already been staged, or an operation produces a schema that is
     /// invalid for the table protocol.
-    pub fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+    #[internal_api]
+    pub(crate) fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
         if self
             .effective_table_config
             .is_feature_enabled(&TableFeature::IcebergCompatV3)

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -142,6 +142,7 @@ impl Transaction {
     /// data-file actions have already been staged, or an operation is invalid for the current schema
     /// or table configuration.
     #[internal_api]
+    #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     pub(crate) fn with_schema_changes(
         mut self,
         changes: Vec<SchemaOperation>,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -138,9 +138,9 @@ impl Transaction {
     ///
     /// # Errors
     ///
-    /// Returns an error if `changes` is empty, Iceberg compatibility or column defaults are enabled,
-    /// data-file actions have already been staged, or an operation is invalid for the current schema
-    /// or table configuration.
+    /// Returns an error if `changes` is empty, Iceberg compatibility or column defaults are
+    /// enabled, data-file actions have already been staged, or an operation is invalid for the
+    /// current schema or table configuration.
     #[internal_api]
     #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]
     pub(crate) fn with_schema_changes(

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, LazyLock};
 use delta_kernel_derive::internal_api;
 use tracing::instrument;
 
+use super::schema_evolution::{evolve_table_config, SchemaOperation};
 use super::Transaction;
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{LOG_ADD_SCHEMA, NUM_RECORDS, TIGHT_BOUNDS};
@@ -36,7 +37,7 @@ use crate::snapshot::SnapshotRef;
 use crate::table_features::{
     iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
 };
-use crate::utils::current_time_ms;
+use crate::utils::{current_time_ms, require};
 use crate::{DataType, DeltaResult, Engine, Expression};
 
 // =============================================================================
@@ -131,6 +132,48 @@ impl Transaction {
     pub fn with_operation(mut self, operation: String) -> Self {
         self.operation = Some(operation);
         self
+    }
+
+    /// Applies schema changes before data files are staged in this transaction.
+    ///
+    /// Changes are applied sequentially and the resulting table configuration is validated before
+    /// this method returns.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the table enables an unsupported schema-evolution feature, `changes` is
+    /// empty, data files have already been staged, or an operation produces a schema that is
+    /// invalid for the table protocol.
+    pub fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::IcebergCompatV3)
+        {
+            return Err(Error::unsupported(
+                "Schema changes are not yet supported on tables with icebergCompatV3 enabled",
+            ));
+        }
+        if self
+            .effective_table_config
+            .is_feature_enabled(&TableFeature::AllowColumnDefaults)
+        {
+            return Err(Error::unsupported(
+                "Schema changes are not yet supported on tables with allowColumnDefaults enabled",
+            ));
+        }
+        require!(
+            !changes.is_empty(),
+            Error::generic("with_schema_changes requires at least one schema operation")
+        );
+        require!(
+            !self.has_data_file_actions(),
+            Error::invalid_transaction_state(
+                "with_schema_changes must be called before staging data files"
+            )
+        );
+        self.effective_table_config = evolve_table_config(&self.effective_table_config, changes)?;
+        self.should_emit_metadata = true;
+        Ok(self)
     }
 
     /// Remove domain metadata from the Delta log.

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -134,16 +134,13 @@ impl Transaction {
         self
     }
 
-    /// Applies schema changes before data files are staged in this transaction.
-    ///
-    /// Changes are applied sequentially and the resulting table configuration is validated before
-    /// this method returns.
+    /// Applies schema changes in order before staging data-file actions.
     ///
     /// # Errors
     ///
-    /// Returns an error if the table enables an unsupported schema-evolution feature, `changes` is
-    /// empty, data files have already been staged, or an operation produces a schema that is
-    /// invalid for the table protocol.
+    /// Returns an error if `changes` is empty, Iceberg compatibility or column defaults are enabled,
+    /// data-file actions have already been staged, or an operation is invalid for the current schema
+    /// or table configuration.
     #[internal_api]
     pub(crate) fn with_schema_changes(
         mut self,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -145,7 +145,10 @@ impl Transaction {
     /// empty, data files have already been staged, or an operation produces a schema that is
     /// invalid for the table protocol.
     #[internal_api]
-    pub(crate) fn with_schema_changes(mut self, changes: Vec<SchemaOperation>) -> DeltaResult<Self> {
+    pub(crate) fn with_schema_changes(
+        mut self,
+        changes: Vec<SchemaOperation>,
+    ) -> DeltaResult<Self> {
         if self
             .effective_table_config
             .is_feature_enabled(&TableFeature::IcebergCompatV3)

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -134,7 +134,7 @@ impl Transaction {
         self
     }
 
-    /// Applies schema changes in order before staging data-file actions.
+    /// Stages schema changes to be applied to be applied in this transaction.
     ///
     /// # Errors
     ///

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -9,13 +9,14 @@ use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::expressions::{column_name, ColumnName, Scalar};
 use delta_kernel::schema::{
-    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef, StructField,
-    StructType,
+    schema_ref, ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, SchemaRef,
+    StructField, StructType,
 };
 use delta_kernel::snapshot::Snapshot;
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
+use delta_kernel::transaction::PathSegment;
 use delta_kernel::DeltaResult;
 use rstest::rstest;
 use test_utils::{
@@ -427,6 +428,231 @@ async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error:
         .downcast_ref::<Int32Array>()
         .expect("b is int");
     assert_eq!(b_col.value(0), 100);
+
+    Ok(())
+}
+
+// ============================================================================
+// Add column at tests
+// ============================================================================
+
+#[rstest]
+#[tokio::test]
+async fn add_column_at_round_trip(
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = schema_ref! {
+        nullable "parent": {
+            nullable "existing": INTEGER,
+        },
+    };
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|mode| vec![("delta.columnMapping.mode", mode)])
+        .unwrap_or_default();
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &properties)?;
+
+    snapshot
+        .alter_table()
+        .add_column_at(
+            vec![PathSegment::Field("parent".to_string())],
+            StructField::nullable("added", DataType::STRING),
+        )
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let reloaded_schema = reloaded.schema();
+    let parent = reloaded_schema.field("parent").expect("parent must exist");
+    let DataType::Struct(parent) = parent.data_type() else {
+        panic!("parent must remain a struct")
+    };
+    assert!(parent.field("existing").is_some());
+
+    let added = parent.field("added").expect("added field must exist");
+    assert_eq!(added.data_type(), &DataType::STRING);
+    assert!(added.is_nullable());
+    assert_eq!(added.column_mapping_id().is_some(), cm_mode.is_some());
+    assert_eq!(
+        added
+            .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+            .is_some(),
+        cm_mode.is_some()
+    );
+
+    Ok(())
+}
+
+/// Nested `add_column_at` on a column-mapped table: commit + reload must persist the nested
+/// field's CM id / physical name and advance `maxColumnId`.
+#[rstest]
+#[tokio::test]
+async fn add_column_at_nested_struct_with_column_mapping(
+    #[values("name", "id")] cm_mode: &str,
+) -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = Arc::new(StructType::try_new(vec![
+        StructField::nullable("id", DataType::INTEGER),
+        StructField::nullable(
+            "address",
+            StructType::try_new(vec![StructField::nullable("city", DataType::STRING)])?,
+        ),
+    ])?);
+    let snapshot = create_table_and_load_snapshot(
+        &table_path,
+        schema,
+        engine.as_ref(),
+        &[("delta.columnMapping.mode", cm_mode)],
+    )?;
+    let original_max = max_column_id(&snapshot).expect("CM table must have maxColumnId");
+
+    snapshot
+        .alter_table()
+        .add_column_at(
+            vec![PathSegment::Field("address".to_string())],
+            StructField::nullable("zip", DataType::STRING),
+        )
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let reloaded_schema = reloaded.schema();
+    let zip = reloaded_schema.field_at_path(&["address".to_string(), "zip".to_string()]);
+    let cm_id = zip
+        .column_mapping_id()
+        .expect("nested field must receive a column mapping id");
+    assert!(
+        cm_id > original_max,
+        "nested field id {cm_id} must exceed original max {original_max}"
+    );
+    match zip
+        .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+        .expect("physical name should be assigned")
+    {
+        MetadataValue::String(s) => assert!(s.starts_with("col-")),
+        other => panic!("expected String, got {other:?}"),
+    }
+    assert_eq!(
+        max_column_id(&reloaded).expect("CM table must have maxColumnId"),
+        cm_id,
+        "table maxColumnId must equal the nested field's assigned id",
+    );
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn add_column_at_containers_round_trip(
+    #[values(None, Some("name"), Some("id"))] cm_mode: Option<&str>,
+) -> DeltaResult<()> {
+    fn target_struct<'a>(schema: &'a StructType, path: &[PathSegment]) -> &'a StructType {
+        let (PathSegment::Field(first), rest) = path.split_first().expect("non-empty path") else {
+            panic!("path must start with a field")
+        };
+        let mut data_type = schema
+            .field(first)
+            .unwrap_or_else(|| panic!("field '{first}' not found"))
+            .data_type();
+        for segment in rest {
+            data_type = match (segment, data_type) {
+                (PathSegment::ArrayElement, DataType::Array(array)) => array.element_type(),
+                (PathSegment::MapKey, DataType::Map(map)) => map.key_type(),
+                (PathSegment::MapValue, DataType::Map(map)) => map.value_type(),
+                (PathSegment::Field(name), DataType::Struct(parent)) => parent
+                    .field(name)
+                    .unwrap_or_else(|| panic!("field '{name}' not found"))
+                    .data_type(),
+                (segment, data_type) => {
+                    panic!("path segment {segment:?} does not match {data_type}")
+                }
+            };
+        }
+        let DataType::Struct(target) = data_type else {
+            panic!("path {path:?} does not resolve to a struct")
+        };
+        target
+    }
+
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = schema_ref! {
+        nullable "items": [ nullable {
+            nullable "existing": STRING,
+        } ],
+        nullable "by_key": {
+            { nullable "existing": STRING } => nullable INTEGER
+        },
+        nullable "by_value": {
+            INTEGER => nullable {
+                nullable "existing": STRING,
+            }
+        },
+    };
+    let properties: Vec<(&str, &str)> = cm_mode
+        .map(|mode| vec![("delta.columnMapping.mode", mode)])
+        .unwrap_or_default();
+    let snapshot =
+        create_table_and_load_snapshot(&table_path, schema, engine.as_ref(), &properties)?;
+
+    snapshot
+        .alter_table()
+        .add_column_at(
+            vec![
+                PathSegment::Field("items".to_string()),
+                PathSegment::ArrayElement,
+            ],
+            StructField::nullable("added", DataType::STRING),
+        )
+        .add_column_at(
+            vec![
+                PathSegment::Field("by_key".to_string()),
+                PathSegment::MapKey,
+            ],
+            StructField::nullable("added", DataType::STRING),
+        )
+        .add_column_at(
+            vec![
+                PathSegment::Field("by_value".to_string()),
+                PathSegment::MapValue,
+            ],
+            StructField::nullable("added", DataType::STRING),
+        )
+        .build(engine.as_ref(), committer())?
+        .commit(engine.as_ref())?
+        .unwrap_committed();
+
+    let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let reloaded_schema = reloaded.schema();
+    for path in [
+        vec![
+            PathSegment::Field("items".to_string()),
+            PathSegment::ArrayElement,
+        ],
+        vec![
+            PathSegment::Field("by_key".to_string()),
+            PathSegment::MapKey,
+        ],
+        vec![
+            PathSegment::Field("by_value".to_string()),
+            PathSegment::MapValue,
+        ],
+    ] {
+        let target = target_struct(reloaded_schema.as_ref(), &path);
+        assert!(target.field("existing").is_some());
+
+        let added = target.field("added").expect("added field must exist");
+        assert_eq!(added.data_type(), &DataType::STRING);
+        assert!(added.is_nullable());
+        assert_eq!(added.column_mapping_id().is_some(), cm_mode.is_some());
+        assert_eq!(
+            added
+                .get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName)
+                .is_some(),
+            cm_mode.is_some()
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds nested additive column paths (`add_column_at` / typed path segments for structs, arrays, and maps) and exposes a schema-evolution API for transactions:

- `Transaction::with_schema_changes` (internal)
- `SchemaOperation` helpers (`add_column`, `set_nullable`)
- Shared `evolve_table_config` used by both ALTER TABLE and `with_schema_changes`

- No breaking public API changes.
- Adds **internal APIs** meant for public rollout: `Transaction::with_schema_changes`, `SchemaOperation`, and `AlterTableTransactionBuilder::add_column_at`.

Note: this is a stacked PR and it includes changes proposed [here](https://github.com/delta-io/delta-kernel-rs/pull/3103). See the [changes meant for this PR](https://github.com/delta-io/delta-kernel-rs/pull/3147/changes/b73ae529cf7b24fdd41c4f5ae0a44c21e24f9dc7..669bbe7c5423d686358ede9b249430b7b568d312) 

## How was this change tested?

- Unit tests in `schema_evolution` (nested path traversal, validation, column mapping).
- Integration tests in `alter_table` (including nested `add_column_at` with column mapping).
- Transaction tests for `with_schema_changes` apply-once / persist-on-commit and reject-after-staging-data.