### PR TITLE
docs: update alter table column mapping docs

### DIFF
--- a/docs/user-guide/src/writing/alter_table.md
+++ b/docs/user-guide/src/writing/alter_table.md
@@ -86,15 +86,13 @@ column by including it in the `RecordBatch` they pass to
 |------|-----|
 | The field name must not already exist (case-insensitive) | Delta column names are unique within a struct. |
 | The field must be nullable | Existing files do not contain the new column. They read back `NULL`, which would violate a `NOT NULL` constraint. |
-| The table must not have column mapping enabled | The current implementation supports add-column only on tables without column mapping. |
 | The table must support writes | Tables with unsupported writer features cannot be altered. |
 | The evolved schema must not require protocol features the table does not enable | For example, adding a `TIMESTAMP_NTZ` column to a table without the `timestampNtz` feature fails. |
+| Column mapping tables must be protocol-valid | When column mapping is enabled, Kernel assigns or preserves column-mapping IDs and physical names for the added column and updates `delta.columnMapping.maxColumnId`. |
 
 > [!NOTE]
-> The column-mapping limitation applies to add-column only. If your table uses
-> column mapping (`delta.columnMapping.mode = "name"` or `"id"`), you cannot
-> currently add a column through `alter_table()`. This restriction is expected
-> to be lifted as the alter-table framework grows.
+> `ALTER TABLE` is still rejected on tables with unsupported writer features, and
+> currently on tables with `icebergCompatV3` or `allowColumnDefaults` enabled.
 
 ## Chaining multiple operations
 

--- a/kernel/src/transaction/builder/alter_table.rs
+++ b/kernel/src/transaction/builder/alter_table.rs
@@ -123,8 +123,8 @@ impl<S: Chainable> AlterTableTransactionBuilder<S> {
     ///
     /// The field must not already exist in the schema (case-insensitive). The field must be
     /// nullable because existing data files do not contain this column and will read NULL for it.
-    /// `field` and any of its nested fields must not carry `delta.columnMapping.id` or
-    /// `delta.columnMapping.physicalName` annotations.
+    /// On column-mapping tables, Kernel assigns or preserves column-mapping IDs and physical names
+    /// for the added field.
     ///
     /// These constraints are validated during [`build()`](AlterTableTransactionBuilder::build).
     pub fn add_column(mut self, field: StructField) -> AlterTableTransactionBuilder<Modifying> {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This updates the Alter Table user guide and add_column rustdoc to remove stale wording that said ALTER TABLE ADD COLUMN was unsupported on column-mapping tables.

The docs now describe the current behavior: when column mapping is enabled, Kernel assigns or preserves column-mapping metadata for the added column. ALTER TABLE is still rejected for unsupported writer features and for tables with icebergCompatV3 or allowColumnDefaults enabled.

## How was this change tested?

- cargo +nightly fmt --check
- git diff --check -- docs/user-guide/src/writing/alter_table.md kernel/src/transaction/builder/alter_table.rs