### PR TITLE
feat: validate path,dvid uniqueness among add/remove files

### DIFF
--- a/delta-kernel-unity-catalog/src/utils/create_table.rs
+++ b/delta-kernel-unity-catalog/src/utils/create_table.rs
@@ -17,7 +17,7 @@
 //! let create_table_txn = kernel::create_table(path, schema, "MyApp/1.0")
 //!     .with_table_properties(disk_props)
 //!     .build(engine, committer);
-//! create_table_txn.commit(engine)?;
+//! create_table_txn.commit(engine, false /* skip_duplicate_validation */)?;
 //!
 //! // Step 3: Finalize table in UC
 //! let snapshot = /* load post-commit snapshot at version 0 */;
@@ -218,7 +218,7 @@ mod tests {
             .with_data_layout(data_layout)
             .build(engine, Box::new(TestCatalogCommitter))
             .unwrap()
-            .commit(engine)
+            .commit(engine, false /* skip_duplicate_validation */)
             .unwrap()
             .unwrap_committed();
         let snapshot = Snapshot::builder_for(table_path)
@@ -349,7 +349,7 @@ mod tests {
             .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
             .with_domain_metadata("myApp.retention".to_string(), r#"{"days":30}"#.to_string())
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap()
             .unwrap_committed();
 
@@ -424,7 +424,7 @@ mod tests {
             .with_table_properties(disk_props)
             .build(&engine, Box::new(TestCatalogCommitter))
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap();
         let v0_snapshot = Snapshot::builder_for(table_path)
             .with_max_catalog_version(0)
@@ -433,7 +433,7 @@ mod tests {
         let result = v0_snapshot
             .transaction(Box::new(TestCatalogCommitter), &engine)
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap();
         assert!(result.is_committed());
 

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -124,7 +124,7 @@ fn commit(
         .clone()
         .transaction(Box::new(uc_committer(update_table_client)), engine)?
         .with_operation("WRITE".to_string())
-        .commit(engine)?
+        .commit(engine, false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot())
 }
 
@@ -191,7 +191,7 @@ async fn test_insert_without_publish_hits_limit() -> Result<(), TestError> {
     let err = snapshot
         .clone()
         .transaction(committer, &engine)?
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap_err();
     assert!(
         matches!(err, delta_kernel::Error::Generic(msg) if msg.contains("Max unpublished commits"))
@@ -264,7 +264,7 @@ async fn test_append_scan_back_and_incremental_read() -> Result<(), TestError> {
     create_table(table_uri.as_str(), schema, "delta-kernel-uc-test")
         .with_table_properties(get_required_properties_for_disk(TABLE_ID))
         .build(engine.as_ref(), Box::new(uc_committer(&client)))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     client.create_table(TABLE_ID)?;
 

--- a/delta-kernel-unity-catalog/tests/integration_live_server.rs
+++ b/delta-kernel-unity-catalog/tests/integration_live_server.rs
@@ -210,7 +210,7 @@ async fn live_create_table() {
         })
         .build(engine.as_ref(), committer)
         .expect("failed to build create-table transaction")
-        .commit(engine.as_ref())
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)
         .expect("failed to commit create-table transaction")
         .unwrap_committed();
 

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -322,8 +322,10 @@ pub unsafe extern "C" fn commit(
     let txn = unsafe { txn.into_inner() };
     let extern_engine = unsafe { engine.as_ref() };
     let engine = extern_engine.engine();
-    commit_result_to_committed_handle(txn.commit(engine.as_ref()))
-        .into_extern_result(&extern_engine)
+    commit_result_to_committed_handle(
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */),
+    )
+    .into_extern_result(&extern_engine)
 }
 
 // ============================================================================
@@ -414,8 +416,10 @@ pub unsafe extern "C" fn create_table_commit(
     let txn = unsafe { txn.into_inner() };
     let extern_engine = unsafe { engine.as_ref() };
     let engine = extern_engine.engine();
-    commit_result_to_committed_handle(txn.commit(engine.as_ref()))
-        .into_extern_result(&extern_engine)
+    commit_result_to_committed_handle(
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */),
+    )
+    .into_extern_result(&extern_engine)
 }
 
 // ============================================================================
@@ -3036,7 +3040,12 @@ mod tests {
             vec![(&data_file_path, parquet_len as i64, 1_000_000, Some(4))],
         )?;
         add_txn.add_files(add_metadata);
-        let _ = add_txn.commit(kernel_engine.as_ref())?.unwrap_committed();
+        let _ = add_txn
+            .commit(
+                kernel_engine.as_ref(),
+                false, /* skip_duplicate_validation */
+            )?
+            .unwrap_committed();
 
         // Build and write a connector-authored DV file deleting rows 1 and 2 (ids 20, 30).
         let mut dv = KernelDeletionVector::new();

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -110,7 +110,7 @@ async fn try_main() -> DeltaResult<()> {
                 "Exceeded maximum 5 retries for committing transaction",
             ));
         }
-        txn = match txn.commit(&engine)? {
+        txn = match txn.commit(&engine, false /* skip_duplicate_validation */)? {
             CommitResult::CommittedTransaction(committed) => break committed,
             CommitResult::ConflictedTransaction(conflicted) => {
                 let conflicting_version = conflicted.conflict_version();
@@ -198,7 +198,7 @@ async fn create_table(table_url: &Url, schema: &SchemaRef, engine: &dyn Engine) 
     let table_path = table_url.as_str();
     let _result = create_delta_table(table_path, schema.clone(), "write-table-example/1.0")
         .build(engine, Box::new(FileSystemCommitter::new()))?
-        .commit(engine)?;
+        .commit(engine, false /* skip_duplicate_validation */)?;
 
     println!("✓ Created Delta table with schema: {schema:#?}");
     Ok(())

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -806,7 +806,7 @@ async fn test_checkpoint_preserves_domain_metadata() -> DeltaResult<()> {
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
         let result = txn
             .with_domain_metadata(domain.to_string(), value.to_string())
-            .commit(&engine)?;
+            .commit(&engine, false /* skip_duplicate_validation */)?;
         assert!(result.is_committed());
         Ok(())
     };
@@ -882,7 +882,7 @@ async fn test_checkpoint_excludes_tombstoned_domain_metadata() -> DeltaResult<()
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
     let result = txn
         .with_domain_metadata("foo".to_string(), "bar".to_string())
-        .commit(&engine)?;
+        .commit(&engine, false /* skip_duplicate_validation */)?;
     assert!(result.is_committed());
 
     // Verify domain exists before removal
@@ -897,7 +897,7 @@ async fn test_checkpoint_excludes_tombstoned_domain_metadata() -> DeltaResult<()
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
     let result = txn
         .with_domain_metadata_removed("foo".to_string())
-        .commit(&engine)?;
+        .commit(&engine, false /* skip_duplicate_validation */)?;
     assert!(result.is_committed());
 
     // Verify domain is gone before checkpoint
@@ -929,7 +929,7 @@ async fn test_checkpoint_skips_last_checkpoint_write_when_hint_version_is_newer(
         "test",
     )
     .build(&engine, Box::new(FileSystemCommitter::new()))?
-    .commit(&engine)?;
+    .commit(&engine, false /* skip_duplicate_validation */)?;
 
     // Version 1
     add_commit(

--- a/kernel/src/committer/filesystem.rs
+++ b/kernel/src/committer/filesystem.rs
@@ -122,7 +122,7 @@ mod tests {
         let err = snapshot
             .transaction(committer, &engine)
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap_err();
         assert!(matches!(
             err,

--- a/kernel/src/log_segment/domain_metadata_replay.rs
+++ b/kernel/src/log_segment/domain_metadata_replay.rs
@@ -169,7 +169,7 @@ mod tests {
         .build(&engine, Box::new(FileSystemCommitter::new()))
         .unwrap()
         .with_domain_metadata("domainC".to_string(), "cfgC".to_string())
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap();
 
         // Commit 1: add domainA and domainB via an existing-table transaction.
@@ -179,7 +179,7 @@ mod tests {
             .unwrap()
             .with_domain_metadata("domainA".to_string(), "cfgA".to_string())
             .with_domain_metadata("domainB".to_string(), "cfgB".to_string())
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap();
 
         let snapshot = Snapshot::builder_for(url).build(&engine).unwrap();
@@ -320,7 +320,7 @@ mod tests {
             .transaction(Box::new(FileSystemCommitter::new()), &engine)
             .unwrap()
             .with_domain_metadata_removed("domainA".to_string())
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap();
         let snapshot = Snapshot::builder_for(table_root).build(&engine).unwrap();
         (engine, snapshot)

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -348,7 +348,7 @@ fn test_scan_builder_accepts_predicate_on_unprojected_data_column() {
     create_table(url, schema, "DefaultEngine")
         .build(&engine, Box::new(FileSystemCommitter::new()))
         .unwrap()
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap()
         .unwrap_committed();
 
@@ -379,7 +379,7 @@ fn test_scan_builder_rejects_predicate_on_projection_only_metadata_column() {
     create_table(url, schema, "DefaultEngine")
         .build(&engine, Box::new(FileSystemCommitter::new()))
         .unwrap()
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap()
         .unwrap_committed();
 

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -2085,7 +2085,7 @@ mod tests {
 
         let _ = create_table_builder
             .build(&engine, Box::new(FileSystemCommitter::new()))?
-            .commit(&engine)?;
+            .commit(&engine, false /* skip_duplicate_validation */)?;
 
         let snapshot = Snapshot::builder_for(&table_path).build(&engine)?;
         let ts = snapshot.get_timestamp(&engine)?;
@@ -2387,7 +2387,7 @@ mod tests {
                 Box::new(crate::committer::FileSystemCommitter::new()),
             )
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap();
         let snapshot = Snapshot::builder_for("memory:///").build(&engine).unwrap();
         let result = snapshot.get_clustering_column_infos(&engine).unwrap();
@@ -2506,7 +2506,7 @@ mod tests {
             create_table("memory:///", schema, "test")
                 .build(&engine, Box::new(FileSystemCommitter::new()))
                 .unwrap()
-                .commit(&engine)
+                .commit(&engine, false /* skip_duplicate_validation */)
                 .unwrap()
                 .unwrap_committed();
             Snapshot::builder_for("memory:///").build(&engine).unwrap()

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -501,7 +501,7 @@ mod tests {
             .with_table_properties([("delta.enableChangeDataFeed", "true")])
             .build(&engine, Box::new(FileSystemCommitter::new()))
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap()
             .unwrap_committed();
 

--- a/kernel/src/transaction/create_table.rs
+++ b/kernel/src/transaction/create_table.rs
@@ -21,7 +21,7 @@
 //! let result = create_table("/path/to/table", schema, "MyApp/1.0")
 //!     .with_table_properties([("myapp.version", "1.0")])
 //!     .build(engine, Box::new(FileSystemCommitter::new()))?
-//!     .commit(engine)?;
+//!     .commit(engine, false /* skip_duplicate_validation */)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -78,7 +78,7 @@ use crate::DeltaResult;
 ///
 /// let result = create_table("/path/to/table", schema, "MyApp/1.0")
 ///     .build(engine, Box::new(FileSystemCommitter::new()))?
-///     .commit(engine)?;
+///     .commit(engine, false /* skip_duplicate_validation */)?;
 /// # Ok(())
 /// # }
 /// ```
@@ -118,7 +118,7 @@ pub type CreateTableTransaction = Transaction<CreateTable>;
 ///     .build(&engine, Box::new(FileSystemCommitter::new()))?;
 ///
 /// // Commit the transaction to create the table
-/// transaction.commit(&engine)?;
+/// transaction.commit(&engine, false /* skip_duplicate_validation */)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -322,6 +322,21 @@ where
     }))
 }
 
+fn selected_row_count(batches: &[FilteredEngineData]) -> usize {
+    batches
+        .iter()
+        .map(|batch| {
+            batch
+                .selection_vector()
+                .iter()
+                .filter(|&&selected| selected)
+                .count()
+                + batch.data().len()
+                - batch.selection_vector().len()
+        })
+        .sum()
+}
+
 // =============================================================================
 // Shared methods available on ALL transaction types
 // =============================================================================
@@ -423,7 +438,17 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        let mut existing_file_actions = write_validation::FileActionTracker::default();
+        let add_file_count = self
+            .add_files_metadata
+            .iter()
+            .map(|batch| batch.len())
+            .sum::<usize>();
+        let remove_file_count = selected_row_count(&self.remove_files_metadata);
+        let dv_update_count = selected_row_count(&self.dv_matched_files);
+        let mut existing_file_actions = write_validation::FileActionTracker::with_capacity(
+            add_file_count + dv_update_count,
+            remove_file_count + dv_update_count,
+        );
         write_validation::StagedDataValidator::staged_add_file(
             self.effective_table_config.physical_partition_columns(),
             &mut existing_file_actions,

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -423,19 +423,20 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        // Validate required fields for addFile.
+        let mut file_actions = write_validation::FileActionTracker::default();
         write_validation::StagedDataValidator::staged_add_file(
             self.effective_table_config.physical_partition_columns(),
+            &mut file_actions,
         )
         .validate(&self.add_files_metadata)?;
 
         write_validation::StagedDataValidator::staged_dv_matched_file(
             self.effective_table_config.physical_partition_columns(),
+            &mut file_actions,
         )?
         .validate_filtered(&self.dv_matched_files)?;
 
-        // Validate required fields for RemoveFile.
-        write_validation::StagedDataValidator::staged_remove_file()
+        write_validation::StagedDataValidator::staged_remove_file(&mut file_actions)?
             .validate_filtered(&self.remove_files_metadata)?;
 
         // Step 1: Generate SetTransaction actions

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -195,7 +195,7 @@ impl SupportsDataFiles for CreateTable {}
 /// // stage table changes (right now only commit info)
 /// txn.commit_info(Box::new(ArrowEngineData::new(engine_commit_info)));
 /// // commit! (consume the transaction)
-/// txn.commit(&engine)?;
+/// txn.commit(&engine, false /* skip_duplicate_validation */)?;
 /// ```
 pub struct Transaction<S = ExistingTable> {
     span: tracing::Span,
@@ -346,6 +346,13 @@ impl<S> Transaction<S> {
     /// - Ok(CommitResult) for either success or a recoverable error (includes the failed
     ///   transaction in case of a conflict so the user can retry, etc.)
     /// - Err(Error) indicates a non-retryable error (e.g. logic/validation error).
+    ///
+    /// Set `skip_duplicate_file_action_validation` only when the caller guarantees that the
+    /// transaction contains no duplicate AddFile or RemoveFile paths and no AddFile and RemoveFile
+    /// pair with the same path and deletion vector ID.
+    ///
+    /// Duplicate validation builds two maps over all file actions. For 10,000 actions, benchmarks
+    /// measured 39% overhead for local commits and 1-4% for object-store commits.
     #[instrument(
         parent = &self.span,
         name = TRANSACTION_COMMIT_SPAN,
@@ -370,7 +377,11 @@ impl<S> Transaction<S> {
         ),
         err
     )]
-    pub fn commit(self, engine: &dyn Engine) -> DeltaResult<CommitResult<S>> {
+    pub fn commit(
+        self,
+        engine: &dyn Engine,
+        skip_duplicate_file_action_validation: bool,
+    ) -> DeltaResult<CommitResult<S>> {
         let commit_start = Instant::now();
 
         // Some table features don't yet support removeFiles. Reject here.
@@ -438,17 +449,21 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        let add_file_count = self
-            .add_files_metadata
-            .iter()
-            .map(|batch| batch.len())
-            .sum::<usize>();
-        let remove_file_count = selected_row_count(&self.remove_files_metadata);
-        let dv_update_count = selected_row_count(&self.dv_matched_files);
-        let mut existing_file_actions = write_validation::FileActionTracker::with_capacity(
-            add_file_count + dv_update_count,
-            remove_file_count + dv_update_count,
-        );
+        let mut existing_file_actions = if skip_duplicate_file_action_validation {
+            write_validation::FileActionTracker::without_duplicate_validation()
+        } else {
+            let add_file_count = self
+                .add_files_metadata
+                .iter()
+                .map(|batch| batch.len())
+                .sum::<usize>();
+            let remove_file_count = selected_row_count(&self.remove_files_metadata);
+            let dv_update_count = selected_row_count(&self.dv_matched_files);
+            write_validation::FileActionTracker::with_capacity(
+                add_file_count + dv_update_count,
+                remove_file_count + dv_update_count,
+            )
+        };
         write_validation::StagedDataValidator::staged_add_file(
             self.effective_table_config.physical_partition_columns(),
             &mut existing_file_actions,
@@ -3066,7 +3081,7 @@ mod tests {
         txn = txn.with_blind_append();
         // No files added — commit should fail with blind append validation
         let err = txn
-            .commit(_engine.as_ref())
+            .commit(_engine.as_ref(), false /* skip_duplicate_validation */)
             .expect_err("Blind append with no adds should fail");
         assert!(
             err.to_string()
@@ -3084,7 +3099,7 @@ mod tests {
         // Blind append with add files should pass validation and proceed to commit.
         // The commit itself may fail due to schema mismatch with the dummy data,
         // but we verify validation (line 415) passes on the Ok path.
-        let result = txn.commit(engine.as_ref());
+        let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */);
         // If it fails, it should NOT be an InvalidTransactionState error
         if let Err(e) = result {
             assert!(
@@ -3105,7 +3120,7 @@ mod tests {
         let (engine, snapshot, _tempdir) = load_test_table("table-without-dv-small")?;
         let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
-        let result = txn.commit(engine.as_ref())?;
+        let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
         assert!(
             matches!(result, CommitResult::RetryableTransaction(_)),
             "Expected RetryableTransaction, got: {result:?}"
@@ -3467,7 +3482,7 @@ mod tests {
         let err = snapshot
             .transaction(committer, &engine)
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap_err();
         assert!(matches!(
             err,
@@ -3488,7 +3503,7 @@ mod tests {
         let err = create_table("memory:///", schema, "test-engine")
             .build(&engine, committer)
             .unwrap()
-            .commit(&engine)
+            .commit(&engine, false /* skip_duplicate_validation */)
             .unwrap_err();
         assert!(matches!(
             err,
@@ -3596,7 +3611,7 @@ mod tests {
         let mut txn = snapshot.transaction(Box::new(committer), &engine)?;
         add_dummy_file(&mut txn);
 
-        let result = txn.commit(&engine)?;
+        let result = txn.commit(&engine, false /* skip_duplicate_validation */)?;
         assert!(
             matches!(result, CommitResult::ConflictedTransaction(_)),
             "Expected ConflictedTransaction from capturing committer"
@@ -3632,7 +3647,7 @@ mod tests {
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
         let mut txn = snapshot.transaction(Box::new(IoErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
-        let result = txn.commit(engine.as_ref())?;
+        let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
         assert!(matches!(result, CommitResult::RetryableTransaction(_)));
         let failure = commit_failure_event(&reporter).expect("commit failure event");
         assert_eq!(failure.reason, CommitFailureReason::RetryableIo);
@@ -3647,7 +3662,9 @@ mod tests {
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
         let mut txn = snapshot.transaction(Box::new(GenericErrorCommitter), engine.as_ref())?;
         add_dummy_file(&mut txn);
-        assert!(txn.commit(engine.as_ref()).is_err());
+        assert!(txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)
+            .is_err());
         let failure = commit_failure_event(&reporter).expect("commit failure event");
         assert_eq!(failure.reason, CommitFailureReason::Error);
         assert_eq!(failure.table_type, TableType::PathBased);

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -423,20 +423,20 @@ impl<S> Transaction<S> {
         // each stats column.
         self.validate_add_files_stats(&self.add_files_metadata)?;
 
-        let mut file_actions = write_validation::FileActionTracker::default();
+        let mut existing_file_actions = write_validation::FileActionTracker::default();
         write_validation::StagedDataValidator::staged_add_file(
             self.effective_table_config.physical_partition_columns(),
-            &mut file_actions,
+            &mut existing_file_actions,
         )
         .validate(&self.add_files_metadata)?;
 
         write_validation::StagedDataValidator::staged_dv_matched_file(
             self.effective_table_config.physical_partition_columns(),
-            &mut file_actions,
+            &mut existing_file_actions,
         )?
         .validate_filtered(&self.dv_matched_files)?;
 
-        write_validation::StagedDataValidator::staged_remove_file(&mut file_actions)?
+        write_validation::StagedDataValidator::staged_remove_file(&mut existing_file_actions)?
             .validate_filtered(&self.remove_files_metadata)?;
 
         // Step 1: Generate SetTransaction actions

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -399,7 +399,7 @@ static INTERMEDIATE_DV_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 });
 
 /// Returns the intermediate schema with deletion vector column appended to scan row schema.
-fn intermediate_dv_schema() -> &'static SchemaRef {
+pub(super) fn intermediate_dv_schema() -> &'static SchemaRef {
     &INTERMEDIATE_DV_SCHEMA
 }
 

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -378,7 +378,7 @@ fn selection_vector_for_matches(num_rows: usize, matched_file_indexes: &[usize])
 /// Column name for temporary column used during deletion vector updates.
 /// This column holds new DV descriptors appended to scan file metadata before transforming to final
 /// add actions.
-static NEW_DELETION_VECTOR_NAME: &str = "newDeletionVector";
+pub(super) static NEW_DELETION_VECTOR_NAME: &str = "newDeletionVector";
 
 /// Column name for the temporary column holding the rewritten `stats` string for a DV update.
 static NEW_STATS_NAME: &str = "newStats";

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -181,7 +181,7 @@ impl Transaction {
     /// }
     ///
     /// // Commit the transaction
-    /// txn.commit(engine.as_ref())?;
+    /// txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -266,7 +266,7 @@ impl Transaction {
     /// // ... populate dv_map with file paths and their new DV descriptors ...
     ///
     /// txn.update_deletion_vectors(dv_map, files.into_iter())?;
-    /// txn.commit(engine)?;
+    /// txn.commit(engine, false /* skip_duplicate_validation */)?;
     /// ```
     #[internal_api]
     #[cfg_attr(not(feature = "internal-api"), allow(dead_code))]

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -88,6 +88,7 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
+    use test_utils::replace_column;
 
     use super::*;
     use crate::arrow::array::Int64Array;
@@ -96,7 +97,7 @@ mod tests {
     use crate::expressions::column_name;
     use crate::unit_test_utils::{
         add_files_with_partition_values, assert_result_error_with_message, nullable_add_file,
-        nullable_add_files, replace_column, set_field_as_null,
+        nullable_add_files, set_field_as_null,
     };
     use crate::EngineData;
 

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -10,26 +10,26 @@ use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
 use crate::{DeltaResult, Error};
 
-/// Column indices, matching the order in [`MANDATORY_ADD_FILE_COLUMNS`].
+/// Column indices, matching the order in [`ADD_FILE_COLUMNS_FOR_VALIDATION`].
 const PATH: usize = 0;
 const PARTITION_VALUES: usize = 1;
 const SIZE: usize = 2;
 const MODIFICATION_TIME: usize = 3;
 
-static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
+static ADD_FILE_COLUMNS_FOR_VALIDATION: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
 impl<'a> StagedDataValidator<'a> {
     /// Creates a validator that validates every staged add-file row.
     pub(crate) fn staged_add_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
-        file_actions: &'a mut FileActionTracker,
+        existing_file_actions: &'a mut FileActionTracker,
     ) -> Self {
         StagedDataValidator::new(
-            &MANDATORY_ADD_FILE_COLUMNS,
-            vec![Box::new(AddFileRequiredFields {
+            &ADD_FILE_COLUMNS_FOR_VALIDATION,
+            vec![Box::new(AddFileFields {
                 physical_partition_columns: physical_partition_columns.into_iter().collect(),
-                file_actions,
+                existing_file_actions,
             })],
         )
     }
@@ -44,12 +44,12 @@ impl<'a> StagedDataValidator<'a> {
 ///
 /// NOTE: Currently, Kernel doesn't require connectors to set dataChange for staged addFile.
 /// TODO(2869): Add intent-based validation for dataChange.
-pub(crate) struct AddFileRequiredFields<'a> {
+struct AddFileFields<'a> {
     physical_partition_columns: HashSet<String>,
-    file_actions: &'a mut FileActionTracker,
+    existing_file_actions: &'a mut FileActionTracker,
 }
 
-impl Validation for AddFileRequiredFields<'_> {
+impl Validation for AddFileFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
@@ -79,7 +79,7 @@ impl Validation for AddFileRequiredFields<'_> {
             path,
             "modificationTime",
         )?;
-        self.file_actions.record_add(path, None)
+        self.existing_file_actions.record_add(path, None)
     }
 }
 
@@ -90,7 +90,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{Int64Array, StringArray};
+    use crate::arrow::array::Int64Array;
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::expressions::column_name;
@@ -117,10 +117,10 @@ mod tests {
     }
 
     /// Guards the invariant that the column-index consts match the leaf order of
-    /// `MANDATORY_ADD_FILE_COLUMNS`.
+    /// `ADD_FILE_COLUMNS_FOR_VALIDATION`.
     #[test]
     fn column_indices_match_schema_order() {
-        let (names, _) = MANDATORY_ADD_FILE_COLUMNS.as_ref();
+        let (names, _) = ADD_FILE_COLUMNS_FOR_VALIDATION.as_ref();
         assert_eq!(names[PATH], column_name!("path"));
         assert_eq!(names[PARTITION_VALUES], column_name!("partitionValues"));
         assert_eq!(names[SIZE], column_name!("size"));
@@ -132,24 +132,34 @@ mod tests {
     }
 
     #[rstest]
-    #[case::same_batch(false)]
-    #[case::different_batches(true)]
-    fn duplicate_add_file_paths_rejected(#[case] different_batches: bool) {
-        let batches = if different_batches {
-            vec![
-                add_files_with_paths(&["same"]),
-                add_files_with_paths(&["same"]),
-            ]
+    #[case::same_batch(false, None)]
+    #[case::different_batches(true, None)]
+    #[case::different_dv_id(false, Some("existing-dv"))]
+    fn duplicate_add_file_paths_rejected(
+        #[case] different_batches: bool,
+        #[case] existing_dv_id: Option<&str>,
+    ) {
+        let batches = if existing_dv_id.is_some() {
+            vec![nullable_add_files(&["same"])]
+        } else if different_batches {
+            vec![nullable_add_files(&["same"]), nullable_add_files(&["same"])]
         } else {
-            vec![add_files_with_paths(&["same", "same"])]
+            vec![nullable_add_files(&["same", "same"])]
         };
         let adds: Vec<Box<dyn EngineData>> = batches
             .into_iter()
             .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
             .collect();
+        let mut existing_file_actions = FileActionTracker::default();
+        if let Some(dv_id) = existing_dv_id {
+            existing_file_actions
+                .record_add("same", Some(dv_id.to_owned()))
+                .expect("first AddFile should be accepted");
+        }
 
         assert_result_error_with_message(
-            validate_add_files(&[] /* physical_partition_columns */, &adds),
+            StagedDataValidator::staged_add_file(std::iter::empty(), &mut existing_file_actions)
+                .validate(&adds),
             "multiple AddFile actions",
         );
     }
@@ -166,10 +176,15 @@ mod tests {
     ) {
         const BATCH_COUNT: usize = 3;
         const ROW_COUNT: usize = 3;
+        const PATHS: [[&str; ROW_COUNT]; BATCH_COUNT] = [
+            ["batch-0-row-0", "batch-0-row-1", "batch-0-row-2"],
+            ["batch-1-row-0", "batch-1-row-1", "batch-1-row-2"],
+            ["batch-2-row-0", "batch-2-row-1", "batch-2-row-2"],
+        ];
 
         let adds: Vec<Box<dyn EngineData>> = (0..BATCH_COUNT)
             .map(|batch_index| {
-                let batch = assign_unique_paths(nullable_add_files(ROW_COUNT), batch_index);
+                let batch = nullable_add_files(&PATHS[batch_index]);
                 let batch = if batch_index == invalid_batch {
                     set_field_as_null(&batch, field, invalid_row)
                 } else {
@@ -221,11 +236,7 @@ mod tests {
         #[case] modification_time: i64,
         #[case] expected_error: Option<&str>,
     ) {
-        let batch = replace_column(
-            &nullable_add_file(),
-            "path",
-            Arc::new(StringArray::from(vec![path])),
-        );
+        let batch = nullable_add_file(path);
         let batch = replace_column(&batch, "size", Arc::new(Int64Array::from(vec![size])));
         let batch = replace_column(
             &batch,
@@ -244,7 +255,10 @@ mod tests {
 
     #[test]
     fn partition_values_exact_match_ok() {
-        let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", Some("b"))]]);
+        let batch = add_files_with_partition_values(
+            &["file-0"],
+            &[&[("p1", Some("a")), ("p2", Some("b"))]],
+        );
         validate_add_files(
             &["p1", "p2"], /* physical_partition_columns */
             &as_engine_data(batch),
@@ -254,7 +268,8 @@ mod tests {
 
     #[test]
     fn partition_value_null_still_counts_as_present() {
-        let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", None)]]);
+        let batch =
+            add_files_with_partition_values(&["file-0"], &[&[("p1", Some("a")), ("p2", None)]]);
         validate_add_files(
             &["p1", "p2"], /* physical_partition_columns */
             &as_engine_data(batch),
@@ -303,6 +318,11 @@ mod tests {
     ) {
         const BATCH_COUNT: usize = 3;
         const ROW_COUNT: usize = 3;
+        const PATHS: [[&str; ROW_COUNT]; BATCH_COUNT] = [
+            ["batch-0-row-0", "batch-0-row-1", "batch-0-row-2"],
+            ["batch-1-row-0", "batch-1-row-1", "batch-1-row-2"],
+            ["batch-2-row-0", "batch-2-row-1", "batch-2-row-2"],
+        ];
 
         let adds: Vec<Box<dyn EngineData>> = (0..BATCH_COUNT)
             .map(|batch_index| {
@@ -310,10 +330,7 @@ mod tests {
                 if batch_index == invalid_batch {
                     partition_values[invalid_row] = invalid_partition_values;
                 }
-                let batch = assign_unique_paths(
-                    add_files_with_partition_values(&partition_values),
-                    batch_index,
-                );
+                let batch = add_files_with_partition_values(&PATHS[batch_index], &partition_values);
                 Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>
             })
             .collect();
@@ -330,7 +347,7 @@ mod tests {
 
     #[test]
     fn unpartitioned_table_rejects_partition_values() {
-        let batch = add_files_with_partition_values(&[&[("stray", Some("x"))]]);
+        let batch = add_files_with_partition_values(&["file-0"], &[&[("stray", Some("x"))]]);
         assert_result_error_with_message(
             validate_add_files(
                 &[], /* physical_partition_columns */
@@ -338,20 +355,5 @@ mod tests {
             ),
             "partitionValues keys",
         );
-    }
-
-    fn assign_unique_paths(batch: RecordBatch, batch_index: usize) -> RecordBatch {
-        let paths: Vec<_> = (0..batch.num_rows())
-            .map(|row_index| format!("batch-{batch_index}-row-{row_index}"))
-            .collect();
-        replace_column(&batch, "path", Arc::new(StringArray::from(paths)))
-    }
-
-    fn add_files_with_paths(paths: &[&str]) -> RecordBatch {
-        replace_column(
-            &nullable_add_files(paths.len()),
-            "path",
-            Arc::new(StringArray::from(paths.to_vec())),
-        )
     }
 }

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use super::utils::{validate_partition_keys, validate_required_field_exist};
-use super::{StagedDataValidator, Validation};
+use super::{FileActionTracker, StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::schema::ColumnNamesAndTypes;
 use crate::transaction::mandatory_add_file_schema;
@@ -19,15 +19,17 @@ const MODIFICATION_TIME: usize = 3;
 static MANDATORY_ADD_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
     LazyLock::new(|| mandatory_add_file_schema().leaves(None));
 
-impl StagedDataValidator {
+impl<'a> StagedDataValidator<'a> {
     /// Creates a validator that validates every staged add-file row.
     pub(crate) fn staged_add_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
+        file_actions: &'a mut FileActionTracker,
     ) -> Self {
         StagedDataValidator::new(
             &MANDATORY_ADD_FILE_COLUMNS,
             vec![Box::new(AddFileRequiredFields {
                 physical_partition_columns: physical_partition_columns.into_iter().collect(),
+                file_actions,
             })],
         )
     }
@@ -42,11 +44,12 @@ impl StagedDataValidator {
 ///
 /// NOTE: Currently, Kernel doesn't require connectors to set dataChange for staged addFile.
 /// TODO(2869): Add intent-based validation for dataChange.
-pub(crate) struct AddFileRequiredFields {
+pub(crate) struct AddFileRequiredFields<'a> {
     physical_partition_columns: HashSet<String>,
+    file_actions: &'a mut FileActionTracker,
 }
 
-impl Validation for AddFileRequiredFields {
+impl Validation for AddFileRequiredFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
@@ -76,8 +79,7 @@ impl Validation for AddFileRequiredFields {
             path,
             "modificationTime",
         )?;
-
-        Ok(())
+        self.file_actions.record_add(path, None)
     }
 }
 
@@ -98,10 +100,16 @@ mod tests {
     };
     use crate::EngineData;
 
-    fn add_file_validator(physical_partition_columns: &[&str]) -> StagedDataValidator {
+    fn validate_add_files(
+        physical_partition_columns: &[&str],
+        adds: &[Box<dyn EngineData>],
+    ) -> DeltaResult<()> {
+        let mut file_actions = FileActionTracker::default();
         StagedDataValidator::staged_add_file(
             physical_partition_columns.iter().map(|s| s.to_string()),
+            &mut file_actions,
         )
+        .validate(adds)
     }
 
     fn as_engine_data(batch: RecordBatch) -> [Box<dyn EngineData>; 1] {
@@ -124,6 +132,29 @@ mod tests {
     }
 
     #[rstest]
+    #[case::same_batch(false)]
+    #[case::different_batches(true)]
+    fn duplicate_add_file_paths_rejected(#[case] different_batches: bool) {
+        let batches = if different_batches {
+            vec![
+                add_files_with_paths(&["same"]),
+                add_files_with_paths(&["same"]),
+            ]
+        } else {
+            vec![add_files_with_paths(&["same", "same"])]
+        };
+        let adds: Vec<Box<dyn EngineData>> = batches
+            .into_iter()
+            .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
+            .collect();
+
+        assert_result_error_with_message(
+            validate_add_files(&[] /* physical_partition_columns */, &adds),
+            "multiple AddFile actions",
+        );
+    }
+
+    #[rstest]
     #[case::path("path")]
     #[case::partition_values("partitionValues")]
     #[case::size("size")]
@@ -138,7 +169,7 @@ mod tests {
 
         let adds: Vec<Box<dyn EngineData>> = (0..BATCH_COUNT)
             .map(|batch_index| {
-                let batch = nullable_add_files(ROW_COUNT);
+                let batch = assign_unique_paths(nullable_add_files(ROW_COUNT), batch_index);
                 let batch = if batch_index == invalid_batch {
                     set_field_as_null(&batch, field, invalid_row)
                 } else {
@@ -148,7 +179,7 @@ mod tests {
             })
             .collect();
         assert_result_error_with_message(
-            add_file_validator(&[] /* physical_partition_columns */).validate(&adds),
+            validate_add_files(&[] /* physical_partition_columns */, &adds),
             &format!("missing required field '{field}'"),
         );
     }
@@ -202,7 +233,7 @@ mod tests {
             Arc::new(Int64Array::from(vec![modification_time])),
         );
         let adds = [Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>];
-        let result = add_file_validator(&[] /* physical_partition_columns */).validate(&adds);
+        let result = validate_add_files(&[] /* physical_partition_columns */, &adds);
 
         if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);
@@ -214,17 +245,21 @@ mod tests {
     #[test]
     fn partition_values_exact_match_ok() {
         let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", Some("b"))]]);
-        add_file_validator(&["p1", "p2"] /* physical_partition_columns */)
-            .validate(&as_engine_data(batch))
-            .unwrap();
+        validate_add_files(
+            &["p1", "p2"], /* physical_partition_columns */
+            &as_engine_data(batch),
+        )
+        .unwrap();
     }
 
     #[test]
     fn partition_value_null_still_counts_as_present() {
         let batch = add_files_with_partition_values(&[&[("p1", Some("a")), ("p2", None)]]);
-        add_file_validator(&["p1", "p2"] /* physical_partition_columns */)
-            .validate(&as_engine_data(batch))
-            .unwrap();
+        validate_add_files(
+            &["p1", "p2"], /* physical_partition_columns */
+            &as_engine_data(batch),
+        )
+        .unwrap();
     }
 
     #[rstest]
@@ -275,12 +310,14 @@ mod tests {
                 if batch_index == invalid_batch {
                     partition_values[invalid_row] = invalid_partition_values;
                 }
-                let batch = add_files_with_partition_values(&partition_values);
+                let batch = assign_unique_paths(
+                    add_files_with_partition_values(&partition_values),
+                    batch_index,
+                );
                 Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>
             })
             .collect();
-        let error = add_file_validator(physical_partition_columns)
-            .validate(&adds)
+        let error = validate_add_files(physical_partition_columns, &adds)
             .expect_err("invalid partition values should be rejected");
         let Error::InvalidPartitionValues(message) = error else {
             panic!("expected InvalidPartitionValues, got {error:?}");
@@ -295,9 +332,26 @@ mod tests {
     fn unpartitioned_table_rejects_partition_values() {
         let batch = add_files_with_partition_values(&[&[("stray", Some("x"))]]);
         assert_result_error_with_message(
-            add_file_validator(&[] /* physical_partition_columns */)
-                .validate(&as_engine_data(batch)),
+            validate_add_files(
+                &[], /* physical_partition_columns */
+                &as_engine_data(batch),
+            ),
             "partitionValues keys",
         );
+    }
+
+    fn assign_unique_paths(batch: RecordBatch, batch_index: usize) -> RecordBatch {
+        let paths: Vec<_> = (0..batch.num_rows())
+            .map(|row_index| format!("batch-{batch_index}-row-{row_index}"))
+            .collect();
+        replace_column(&batch, "path", Arc::new(StringArray::from(paths)))
+    }
+
+    fn add_files_with_paths(paths: &[&str]) -> RecordBatch {
+        replace_column(
+            &nullable_add_files(paths.len()),
+            "path",
+            Arc::new(StringArray::from(paths.to_vec())),
+        )
     }
 }

--- a/kernel/src/transaction/write_validation/addfile.rs
+++ b/kernel/src/transaction/write_validation/addfile.rs
@@ -133,28 +133,25 @@ mod tests {
     }
 
     #[rstest]
-    #[case::same_batch(false, None)]
-    #[case::different_batches(true, None)]
-    #[case::different_dv_id(false, Some("existing-dv"))]
+    #[case::same_batch(&[&["path", "path"][..]], None)]
+    #[case::different_batches(&[&["path"][..], &["path"][..]], None)]
+    #[case::different_dv_id(&[&["path"][..]], Some(("path", "existing-dv")))]
     fn duplicate_add_file_paths_rejected(
-        #[case] different_batches: bool,
-        #[case] existing_dv_id: Option<&str>,
+        #[case] batch_paths: &[&[&str]],
+        #[case] existing_add: Option<(&str, &str)>,
     ) {
-        let batches = if existing_dv_id.is_some() {
-            vec![nullable_add_files(&["same"])]
-        } else if different_batches {
-            vec![nullable_add_files(&["same"]), nullable_add_files(&["same"])]
-        } else {
-            vec![nullable_add_files(&["same", "same"])]
-        };
+        let batches = batch_paths
+            .iter()
+            .map(|paths| nullable_add_files(paths))
+            .collect::<Vec<_>>();
         let adds: Vec<Box<dyn EngineData>> = batches
             .into_iter()
             .map(|batch| Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
             .collect();
         let mut existing_file_actions = FileActionTracker::default();
-        if let Some(dv_id) = existing_dv_id {
+        if let Some((path, dv_id)) = existing_add {
             existing_file_actions
-                .record_add("same", Some(dv_id.to_owned()))
+                .record_add(path, Some(dv_id.to_owned()))
                 .expect("first AddFile should be accepted");
         }
 

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -36,7 +36,7 @@ const OFFSET_NAME: &str = "offset";
 
 static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
     LazyLock::new(|| {
-        let names = vec![
+        let mut names = vec![
             column_name!(PATH_NAME),
             column_name!(SIZE_NAME),
             column_name!(MODIFICATION_TIME_NAME),
@@ -44,13 +44,10 @@ static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesA
             column_name!(DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
             column_name!(DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
             column_name!(DELETION_VECTOR_NAME, OFFSET_NAME),
-            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
-            column_name!(NEW_DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
-            column_name!(NEW_DELETION_VECTOR_NAME, OFFSET_NAME),
         ];
         // Derive types from the canonical scan schema so this projection stays compatible with scan
         // metadata if those field definitions change.
-        let mut types = names[..NEW_DELETION_VECTOR_STORAGE_TYPE]
+        let mut types = names
             .iter()
             .map(|name| {
                 scan_row_schema()
@@ -59,10 +56,13 @@ static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesA
             })
             .collect::<DeltaResult<Vec<_>>>()?;
         // The transaction appends `newDeletionVector` after producing scan metadata, so it is
-        // absent from `scan_row_schema()`. Its leaves have the same types as the existing
-        // deletion vector.
-        let new_deletion_vector_types =
-            types[OLD_DELETION_VECTOR_STORAGE_TYPE..NEW_DELETION_VECTOR_STORAGE_TYPE].to_vec();
+        // absent from `scan_row_schema()`.
+        let new_deletion_vector_types = types[OLD_DELETION_VECTOR_STORAGE_TYPE..].to_vec();
+        names.extend([
+            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, OFFSET_NAME),
+        ]);
         types.extend(new_deletion_vector_types);
         Ok((names, types).into())
     });
@@ -150,6 +150,7 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
+    use test_utils::replace_column;
 
     use super::*;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
@@ -167,7 +168,7 @@ mod tests {
     use crate::schema::ToSchema;
     use crate::unit_test_utils::{
         add_files_with_partition_values, assert_result_error_with_message, nullable_add_files,
-        replace_column, set_field_as_null,
+        set_field_as_null,
     };
 
     fn make_staged_dv_from_addfile(
@@ -262,12 +263,34 @@ mod tests {
     fn duplicate_dv_update_paths_validate_selected_rows(
         #[case] selection_vector: &[bool],
         #[case] expected_error: Option<&str>,
+        #[values(false, true)] multiple_batches: bool,
     ) {
-        let batches = [make_staged_dv_from_addfile(
-            nullable_add_files(&["same", "same"]),
-            &["new-dv-0", "new-dv-1"],
-            selection_vector.to_vec(),
-        )];
+        let batches = if multiple_batches {
+            (0..2)
+                .map(|batch_index| {
+                    let row_selection = selection_vector
+                        .get(batch_index)
+                        .copied()
+                        .into_iter()
+                        .collect();
+                    make_staged_dv_from_addfile(
+                        nullable_add_files(&["same"]),
+                        &[if batch_index == 0 {
+                            "new-dv-0"
+                        } else {
+                            "new-dv-1"
+                        }],
+                        row_selection,
+                    )
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![make_staged_dv_from_addfile(
+                nullable_add_files(&["same", "same"]),
+                &["new-dv-0", "new-dv-1"],
+                selection_vector.to_vec(),
+            )]
+        };
         let mut file_actions = FileActionTracker::default();
         let result =
             StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
@@ -380,11 +403,11 @@ mod tests {
         StructArray::new(
             dv_schema.fields().clone(),
             vec![
-                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef,
-                Arc::new(StringArray::from(dv_paths.to_vec())) as ArrayRef,
-                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef,
-                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef, // storageType
+                Arc::new(StringArray::from(dv_paths.to_vec())) as ArrayRef,    // pathOrInlineDv
+                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef, // offset
+                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,    // sizeInBytes
+                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,    // cardinality
             ],
             None,
         )

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -3,8 +3,10 @@
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
-use super::utils::{validate_partition_keys, validate_required_field_exist};
-use super::{StagedDataValidator, Validation};
+use super::utils::{
+    deletion_vector_unique_id, validate_partition_keys, validate_required_field_exist,
+};
+use super::{FileActionTracker, StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
 use crate::expressions::column_name;
 use crate::scan::log_replay::{
@@ -12,6 +14,7 @@ use crate::scan::log_replay::{
 };
 use crate::scan::scan_row_schema;
 use crate::schema::ColumnNamesAndTypes;
+use crate::transaction::update::NEW_DELETION_VECTOR_NAME;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -19,7 +22,19 @@ const PATH: usize = 0;
 const SIZE: usize = 1;
 const MODIFICATION_TIME: usize = 2;
 const PARTITION_VALUES: usize = 3;
+const DELETION_VECTOR_STORAGE_TYPE: usize = 4;
+const NEW_DELETION_VECTOR_STORAGE_TYPE: usize = 7;
 const MODIFICATION_TIME_NAME: &str = "modificationTime";
+const DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
+    "deletionVector.storageType",
+    "deletionVector.pathOrInlineDv",
+    "deletionVector.offset",
+];
+const NEW_DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
+    "newDeletionVector.storageType",
+    "newDeletionVector.pathOrInlineDv",
+    "newDeletionVector.offset",
+];
 
 static DV_MATCHED_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> = LazyLock::new(|| {
     let names = vec![
@@ -27,10 +42,16 @@ static DV_MATCHED_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> = Laz
         column_name!(SIZE_NAME),
         column_name!(MODIFICATION_TIME_NAME),
         column_name!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME),
+        column_name!("deletionVector.storageType"),
+        column_name!("deletionVector.pathOrInlineDv"),
+        column_name!("deletionVector.offset"),
+        column_name!(NEW_DELETION_VECTOR_NAME, "storageType"),
+        column_name!(NEW_DELETION_VECTOR_NAME, "pathOrInlineDv"),
+        column_name!(NEW_DELETION_VECTOR_NAME, "offset"),
     ];
     // Derive types from the canonical scan schema so this projection stays compatible with scan
     // metadata if those field definitions change.
-    let types = names
+    let mut types = names[..NEW_DELETION_VECTOR_STORAGE_TYPE]
         .iter()
         .map(|name| {
             scan_row_schema()
@@ -38,14 +59,18 @@ static DV_MATCHED_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> = Laz
                 .map(|field| field.data_type().clone())
         })
         .collect::<DeltaResult<Vec<_>>>()?;
+    let new_deletion_vector_types =
+        types[DELETION_VECTOR_STORAGE_TYPE..NEW_DELETION_VECTOR_STORAGE_TYPE].to_vec();
+    types.extend(new_deletion_vector_types);
     Ok((names, types).into())
 });
 
-struct DvMatchedFileRequiredFields {
+struct DvMatchedFileRequiredFields<'a> {
     physical_partition_columns: HashSet<String>,
+    file_actions: &'a mut FileActionTracker,
 }
 
-impl Validation for DvMatchedFileRequiredFields {
+impl Validation for DvMatchedFileRequiredFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, PATH_NAME)?
@@ -78,16 +103,30 @@ impl Validation for DvMatchedFileRequiredFields {
             path,
             MODIFICATION_TIME_NAME,
         )?;
-        Ok(())
+        let old_dv_id = deletion_vector_unique_id(
+            row,
+            getters,
+            DELETION_VECTOR_STORAGE_TYPE,
+            DELETION_VECTOR_COLUMN_NAMES,
+        )?;
+        let new_dv_id = deletion_vector_unique_id(
+            row,
+            getters,
+            NEW_DELETION_VECTOR_STORAGE_TYPE,
+            NEW_DELETION_VECTOR_COLUMN_NAMES,
+        )?;
+        self.file_actions.record_remove(path, old_dv_id)?;
+        self.file_actions.record_add(path, new_dv_id)
     }
 }
 
-impl StagedDataValidator {
+impl<'a> StagedDataValidator<'a> {
     /// Creates a validator for selected rows staged for deletion-vector updates.
     ///
     /// Errors if the required columns are absent from the scan-row schema.
     pub(crate) fn staged_dv_matched_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
+        file_actions: &'a mut FileActionTracker,
     ) -> DeltaResult<Self> {
         let columns = DV_MATCHED_FILE_COLUMNS.as_ref().map_err(|error| {
             Error::internal_error(format!(
@@ -98,6 +137,7 @@ impl StagedDataValidator {
             columns,
             vec![Box::new(DvMatchedFileRequiredFields {
                 physical_partition_columns: physical_partition_columns.into_iter().collect(),
+                file_actions,
             })],
         ))
     }
@@ -110,13 +150,19 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{new_null_array, ArrayRef, Int64Array, StructArray};
-    use crate::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
+    use crate::actions::deletion_vector::DeletionVectorDescriptor;
+    use crate::arrow::array::{
+        new_null_array, Array as _, ArrayRef, Int32Array, Int64Array, StringArray, StructArray,
+    };
+    use crate::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_conversion::TryIntoArrow;
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine_data::FilteredEngineData;
     use crate::expressions::column_name;
+    use crate::schema::ToSchema;
     use crate::unit_test_utils::{
         add_files_with_partition_values, assert_result_error_with_message, nullable_add_files,
         replace_column, set_field_as_null,
@@ -161,8 +207,37 @@ mod tests {
                 _ => new_null_array(field.data_type(), batch.num_rows()),
             })
             .collect();
-        let batch = RecordBatch::try_new(Arc::new(schema), columns)
+        let mut batch = RecordBatch::try_new(Arc::new(schema), columns)
             .expect("staged DV schema and columns should form a valid batch");
+        let dv_schema: ArrowSchema = (&DeletionVectorDescriptor::to_schema())
+            .try_into_arrow()
+            .expect("deletion-vector schema should convert to Arrow");
+        let row_count = batch.num_rows();
+        let new_dv = StructArray::new(
+            dv_schema.fields().clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef,
+                Arc::new(StringArray::from(
+                    (0..row_count)
+                        .map(|row| format!("new-dv-{row}"))
+                        .collect::<Vec<_>>(),
+                )) as ArrayRef,
+                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,
+            ],
+            None,
+        );
+        let mut fields = batch.schema().fields().to_vec();
+        fields.push(Arc::new(ArrowField::new(
+            NEW_DELETION_VECTOR_NAME,
+            new_dv.data_type().clone(),
+            true,
+        )));
+        let mut columns = batch.columns().to_vec();
+        columns.push(Arc::new(new_dv));
+        batch = RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), columns)
+            .expect("new deletion-vector column should append to the scan-row batch");
         FilteredEngineData::try_new(Box::new(ArrowEngineData::new(batch)), selection_vector)
             .expect("selection vector length should match staged DV row count")
     }
@@ -183,6 +258,39 @@ mod tests {
             names[PARTITION_VALUES],
             column_name!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME)
         );
+        assert_eq!(
+            names[DELETION_VECTOR_STORAGE_TYPE],
+            column_name!("deletionVector.storageType")
+        );
+        assert_eq!(
+            names[NEW_DELETION_VECTOR_STORAGE_TYPE],
+            column_name!(NEW_DELETION_VECTOR_NAME, "storageType")
+        );
+        assert_eq!(names.len(), 10);
+    }
+
+    #[rstest]
+    #[case::selected(&[true, true], Some("multiple RemoveFile actions"))]
+    #[case::unselected(&[true, false], None)]
+    fn duplicate_dv_update_paths_validate_selected_rows(
+        #[case] selection_vector: &[bool],
+        #[case] expected_error: Option<&str>,
+    ) {
+        let batches = [make_staged_dv_from_addfile(
+            nullable_add_files(2 /* row_count */),
+            selection_vector.to_vec(),
+        )];
+        let mut file_actions = FileActionTracker::default();
+        let result =
+            StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
+                .expect("DV validator should use the scan-row schema")
+                .validate_filtered(&batches);
+
+        if let Some(expected_error) = expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            result.expect("unselected duplicate DV update should be ignored");
+        }
     }
 
     #[rstest]
@@ -195,7 +303,8 @@ mod tests {
             Arc::new(Int64Array::from(vec![value])),
         );
         let batches = [make_staged_dv_from_addfile(batch, vec![true])];
-        StagedDataValidator::staged_dv_matched_file(std::iter::empty())
+        let mut file_actions = FileActionTracker::default();
+        StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
             .expect("DV validator should use the scan-row schema")
             .validate_filtered(&batches)
             .expect("protocol-valid boundary value should be accepted");
@@ -214,7 +323,7 @@ mod tests {
 
         let batches: Vec<_> = (0..BATCH_COUNT)
             .map(|batch_index| {
-                let batch = nullable_add_files(2 /* row_count */);
+                let batch = assign_unique_paths(nullable_add_files(2 /* row_count */), batch_index);
                 let batch = if batch_index == invalid_batch {
                     set_field_as_null(&batch, field, 1 /* row */)
                 } else {
@@ -223,8 +332,9 @@ mod tests {
                 make_staged_dv_from_addfile(batch, vec![true, true])
             })
             .collect();
+        let mut file_actions = FileActionTracker::default();
         assert_result_error_with_message(
-            StagedDataValidator::staged_dv_matched_file(std::iter::empty())
+            StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
                 .expect("DV validator should use the scan-row schema")
                 .validate_filtered(&batches),
             field,
@@ -243,18 +353,29 @@ mod tests {
             &[("p1", Some("a")), ("p2", Some("b"))],
             &[("p1", Some("a"))],
         ]);
+        let batch = assign_unique_paths(batch, 0 /* batch_index */);
         let batches = [make_staged_dv_from_addfile(
             batch,
             selection_vector.to_vec(),
         )];
-        let result =
-            StagedDataValidator::staged_dv_matched_file(["p1".to_string(), "p2".to_string()])
-                .expect("DV validator should use the scan-row schema")
-                .validate_filtered(&batches);
+        let mut file_actions = FileActionTracker::default();
+        let result = StagedDataValidator::staged_dv_matched_file(
+            ["p1".to_string(), "p2".to_string()],
+            &mut file_actions,
+        )
+        .expect("DV validator should use the scan-row schema")
+        .validate_filtered(&batches);
         if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);
         } else {
             result.expect("unselected invalid row should be ignored");
         }
+    }
+
+    fn assign_unique_paths(batch: RecordBatch, batch_index: usize) -> RecordBatch {
+        let paths: Vec<_> = (0..batch.num_rows())
+            .map(|row_index| format!("batch-{batch_index}-row-{row_index}"))
+            .collect();
+        replace_column(&batch, PATH_NAME, Arc::new(StringArray::from(paths)))
     }
 }

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -22,55 +22,57 @@ const PATH: usize = 0;
 const SIZE: usize = 1;
 const MODIFICATION_TIME: usize = 2;
 const PARTITION_VALUES: usize = 3;
-const DELETION_VECTOR_STORAGE_TYPE: usize = 4;
+const OLD_DELETION_VECTOR_STORAGE_TYPE: usize = 4;
+const OLD_DELETION_VECTOR_PATH_OR_INLINE_DV: usize = 5;
+const OLD_DELETION_VECTOR_OFFSET: usize = 6;
 const NEW_DELETION_VECTOR_STORAGE_TYPE: usize = 7;
+const NEW_DELETION_VECTOR_PATH_OR_INLINE_DV: usize = 8;
+const NEW_DELETION_VECTOR_OFFSET: usize = 9;
 const MODIFICATION_TIME_NAME: &str = "modificationTime";
-const DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
-    "deletionVector.storageType",
-    "deletionVector.pathOrInlineDv",
-    "deletionVector.offset",
-];
-const NEW_DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
-    "newDeletionVector.storageType",
-    "newDeletionVector.pathOrInlineDv",
-    "newDeletionVector.offset",
-];
+const DELETION_VECTOR_NAME: &str = "deletionVector";
+const STORAGE_TYPE_NAME: &str = "storageType";
+const PATH_OR_INLINE_DV_NAME: &str = "pathOrInlineDv";
+const OFFSET_NAME: &str = "offset";
 
-static DV_MATCHED_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> = LazyLock::new(|| {
-    let names = vec![
-        column_name!(PATH_NAME),
-        column_name!(SIZE_NAME),
-        column_name!(MODIFICATION_TIME_NAME),
-        column_name!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME),
-        column_name!("deletionVector.storageType"),
-        column_name!("deletionVector.pathOrInlineDv"),
-        column_name!("deletionVector.offset"),
-        column_name!(NEW_DELETION_VECTOR_NAME, "storageType"),
-        column_name!(NEW_DELETION_VECTOR_NAME, "pathOrInlineDv"),
-        column_name!(NEW_DELETION_VECTOR_NAME, "offset"),
-    ];
-    // Derive types from the canonical scan schema so this projection stays compatible with scan
-    // metadata if those field definitions change.
-    let mut types = names[..NEW_DELETION_VECTOR_STORAGE_TYPE]
-        .iter()
-        .map(|name| {
-            scan_row_schema()
-                .field_at(name)
-                .map(|field| field.data_type().clone())
-        })
-        .collect::<DeltaResult<Vec<_>>>()?;
-    let new_deletion_vector_types =
-        types[DELETION_VECTOR_STORAGE_TYPE..NEW_DELETION_VECTOR_STORAGE_TYPE].to_vec();
-    types.extend(new_deletion_vector_types);
-    Ok((names, types).into())
-});
+static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
+    LazyLock::new(|| {
+        let names = vec![
+            column_name!(PATH_NAME),
+            column_name!(SIZE_NAME),
+            column_name!(MODIFICATION_TIME_NAME),
+            column_name!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME),
+            column_name!(DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
+            column_name!(DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
+            column_name!(DELETION_VECTOR_NAME, OFFSET_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, OFFSET_NAME),
+        ];
+        // Derive types from the canonical scan schema so this projection stays compatible with scan
+        // metadata if those field definitions change.
+        let mut types = names[..NEW_DELETION_VECTOR_STORAGE_TYPE]
+            .iter()
+            .map(|name| {
+                scan_row_schema()
+                    .field_at(name)
+                    .map(|field| field.data_type().clone())
+            })
+            .collect::<DeltaResult<Vec<_>>>()?;
+        // The transaction appends `newDeletionVector` after producing scan metadata, so it is
+        // absent from `scan_row_schema()`. Its leaves have the same types as the existing
+        // deletion vector.
+        let new_deletion_vector_types =
+            types[OLD_DELETION_VECTOR_STORAGE_TYPE..NEW_DELETION_VECTOR_STORAGE_TYPE].to_vec();
+        types.extend(new_deletion_vector_types);
+        Ok((names, types).into())
+    });
 
-struct DvMatchedFileRequiredFields<'a> {
+struct DvMatchedFileFields<'a> {
     physical_partition_columns: HashSet<String>,
-    file_actions: &'a mut FileActionTracker,
+    existing_file_actions: &'a mut FileActionTracker,
 }
 
-impl Validation for DvMatchedFileRequiredFields<'_> {
+impl Validation for DvMatchedFileFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, PATH_NAME)?
@@ -104,19 +106,17 @@ impl Validation for DvMatchedFileRequiredFields<'_> {
             MODIFICATION_TIME_NAME,
         )?;
         let old_dv_id = deletion_vector_unique_id(
-            row,
-            getters,
-            DELETION_VECTOR_STORAGE_TYPE,
-            DELETION_VECTOR_COLUMN_NAMES,
+            getters[OLD_DELETION_VECTOR_STORAGE_TYPE].get_opt(row, STORAGE_TYPE_NAME)?,
+            getters[OLD_DELETION_VECTOR_PATH_OR_INLINE_DV].get_opt(row, PATH_OR_INLINE_DV_NAME)?,
+            getters[OLD_DELETION_VECTOR_OFFSET].get_opt(row, OFFSET_NAME)?,
         )?;
         let new_dv_id = deletion_vector_unique_id(
-            row,
-            getters,
-            NEW_DELETION_VECTOR_STORAGE_TYPE,
-            NEW_DELETION_VECTOR_COLUMN_NAMES,
+            getters[NEW_DELETION_VECTOR_STORAGE_TYPE].get_opt(row, STORAGE_TYPE_NAME)?,
+            getters[NEW_DELETION_VECTOR_PATH_OR_INLINE_DV].get_opt(row, PATH_OR_INLINE_DV_NAME)?,
+            getters[NEW_DELETION_VECTOR_OFFSET].get_opt(row, OFFSET_NAME)?,
         )?;
-        self.file_actions.record_remove(path, old_dv_id)?;
-        self.file_actions.record_add(path, new_dv_id)
+        self.existing_file_actions.record_remove(path, old_dv_id)?;
+        self.existing_file_actions.record_add(path, new_dv_id)
     }
 }
 
@@ -126,18 +126,20 @@ impl<'a> StagedDataValidator<'a> {
     /// Errors if the required columns are absent from the scan-row schema.
     pub(crate) fn staged_dv_matched_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
-        file_actions: &'a mut FileActionTracker,
+        existing_file_actions: &'a mut FileActionTracker,
     ) -> DeltaResult<Self> {
-        let columns = DV_MATCHED_FILE_COLUMNS.as_ref().map_err(|error| {
-            Error::internal_error(format!(
-                "DV validation columns must exist in the scan-row schema: {error}"
-            ))
-        })?;
+        let columns = DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION
+            .as_ref()
+            .map_err(|error| {
+                Error::internal_error(format!(
+                    "DV validation columns must exist in the scan-row schema: {error}"
+                ))
+            })?;
         Ok(StagedDataValidator::new(
             columns,
-            vec![Box::new(DvMatchedFileRequiredFields {
+            vec![Box::new(DvMatchedFileFields {
                 physical_partition_columns: physical_partition_columns.into_iter().collect(),
-                file_actions,
+                existing_file_actions,
             })],
         ))
     }
@@ -170,6 +172,7 @@ mod tests {
 
     fn make_staged_dv_from_addfile(
         batch: RecordBatch,
+        dv_paths: &[&str],
         selection_vector: Vec<bool>,
     ) -> FilteredEngineData {
         let column = |name| {
@@ -209,25 +212,8 @@ mod tests {
             .collect();
         let mut batch = RecordBatch::try_new(Arc::new(schema), columns)
             .expect("staged DV schema and columns should form a valid batch");
-        let dv_schema: ArrowSchema = (&DeletionVectorDescriptor::to_schema())
-            .try_into_arrow()
-            .expect("deletion-vector schema should convert to Arrow");
-        let row_count = batch.num_rows();
-        let new_dv = StructArray::new(
-            dv_schema.fields().clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef,
-                Arc::new(StringArray::from(
-                    (0..row_count)
-                        .map(|row| format!("new-dv-{row}"))
-                        .collect::<Vec<_>>(),
-                )) as ArrayRef,
-                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef,
-                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,
-            ],
-            None,
-        );
+        assert_eq!(batch.num_rows(), dv_paths.len());
+        let new_dv = new_deletion_vector_array(dv_paths);
         let mut fields = batch.schema().fields().to_vec();
         fields.push(Arc::new(ArrowField::new(
             NEW_DELETION_VECTOR_NAME,
@@ -244,7 +230,7 @@ mod tests {
 
     #[test]
     fn column_indices_match_schema_order() {
-        let columns = DV_MATCHED_FILE_COLUMNS
+        let columns = DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION
             .as_ref()
             .expect("DV validation columns should exist in the scan-row schema");
         let (names, _) = columns.as_ref();
@@ -259,25 +245,27 @@ mod tests {
             column_name!(FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME)
         );
         assert_eq!(
-            names[DELETION_VECTOR_STORAGE_TYPE],
-            column_name!("deletionVector.storageType")
+            names[OLD_DELETION_VECTOR_STORAGE_TYPE],
+            column_name!(DELETION_VECTOR_NAME, STORAGE_TYPE_NAME)
         );
         assert_eq!(
             names[NEW_DELETION_VECTOR_STORAGE_TYPE],
-            column_name!(NEW_DELETION_VECTOR_NAME, "storageType")
+            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME)
         );
         assert_eq!(names.len(), 10);
     }
 
     #[rstest]
     #[case::selected(&[true, true], Some("multiple RemoveFile actions"))]
+    #[case::implicitly_selected(&[true], Some("multiple RemoveFile actions"))]
     #[case::unselected(&[true, false], None)]
     fn duplicate_dv_update_paths_validate_selected_rows(
         #[case] selection_vector: &[bool],
         #[case] expected_error: Option<&str>,
     ) {
         let batches = [make_staged_dv_from_addfile(
-            nullable_add_files(2 /* row_count */),
+            nullable_add_files(&["same", "same"]),
+            &["new-dv-0", "new-dv-1"],
             selection_vector.to_vec(),
         )];
         let mut file_actions = FileActionTracker::default();
@@ -298,11 +286,15 @@ mod tests {
     #[case::negative_modification_time("modificationTime", -1)]
     fn valid_boundary_value_is_accepted(#[case] field: &str, #[case] value: i64) {
         let batch = replace_column(
-            &nullable_add_files(1 /* row_count */),
+            &nullable_add_files(&["file-0"]),
             field,
             Arc::new(Int64Array::from(vec![value])),
         );
-        let batches = [make_staged_dv_from_addfile(batch, vec![true])];
+        let batches = [make_staged_dv_from_addfile(
+            batch,
+            &["new-dv-0"],
+            vec![true],
+        )];
         let mut file_actions = FileActionTracker::default();
         StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
             .expect("DV validator should use the scan-row schema")
@@ -320,16 +312,21 @@ mod tests {
         #[values(0, 1, 2)] invalid_batch: usize,
     ) {
         const BATCH_COUNT: usize = 3;
+        const PATHS: [[&str; 2]; BATCH_COUNT] = [
+            ["batch-0-row-0", "batch-0-row-1"],
+            ["batch-1-row-0", "batch-1-row-1"],
+            ["batch-2-row-0", "batch-2-row-1"],
+        ];
 
         let batches: Vec<_> = (0..BATCH_COUNT)
             .map(|batch_index| {
-                let batch = assign_unique_paths(nullable_add_files(2 /* row_count */), batch_index);
+                let batch = nullable_add_files(&PATHS[batch_index]);
                 let batch = if batch_index == invalid_batch {
                     set_field_as_null(&batch, field, 1 /* row */)
                 } else {
                     batch
                 };
-                make_staged_dv_from_addfile(batch, vec![true, true])
+                make_staged_dv_from_addfile(batch, &["new-dv-0", "new-dv-1"], vec![true, true])
             })
             .collect();
         let mut file_actions = FileActionTracker::default();
@@ -349,13 +346,16 @@ mod tests {
         #[case] selection_vector: &[bool],
         #[case] expected_error: Option<&str>,
     ) {
-        let batch = add_files_with_partition_values(&[
-            &[("p1", Some("a")), ("p2", Some("b"))],
-            &[("p1", Some("a"))],
-        ]);
-        let batch = assign_unique_paths(batch, 0 /* batch_index */);
+        let batch = add_files_with_partition_values(
+            &["file-0", "file-1"],
+            &[
+                &[("p1", Some("a")), ("p2", Some("b"))],
+                &[("p1", Some("a"))],
+            ],
+        );
         let batches = [make_staged_dv_from_addfile(
             batch,
+            &["new-dv-0", "new-dv-1"],
             selection_vector.to_vec(),
         )];
         let mut file_actions = FileActionTracker::default();
@@ -372,10 +372,21 @@ mod tests {
         }
     }
 
-    fn assign_unique_paths(batch: RecordBatch, batch_index: usize) -> RecordBatch {
-        let paths: Vec<_> = (0..batch.num_rows())
-            .map(|row_index| format!("batch-{batch_index}-row-{row_index}"))
-            .collect();
-        replace_column(&batch, PATH_NAME, Arc::new(StringArray::from(paths)))
+    fn new_deletion_vector_array(dv_paths: &[&str]) -> StructArray {
+        let dv_schema: ArrowSchema = (&DeletionVectorDescriptor::to_schema())
+            .try_into_arrow()
+            .expect("deletion-vector schema should convert to Arrow");
+        let row_count = dv_paths.len();
+        StructArray::new(
+            dv_schema.fields().clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef,
+                Arc::new(StringArray::from(dv_paths.to_vec())) as ArrayRef,
+                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,
+                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,
+            ],
+            None,
+        )
     }
 }

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -141,13 +141,10 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
-    use test_utils::replace_column;
+    use test_utils::{deletion_vector_array, replace_column};
 
     use super::*;
-    use crate::actions::deletion_vector::DeletionVectorDescriptor;
-    use crate::arrow::array::{
-        new_null_array, Array as _, ArrayRef, Int32Array, Int64Array, StringArray, StructArray,
-    };
+    use crate::arrow::array::{new_null_array, Array as _, ArrayRef, Int64Array, StructArray};
     use crate::arrow::datatypes::{
         DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
     };
@@ -157,7 +154,6 @@ mod tests {
     use crate::engine_data::FilteredEngineData;
     use crate::expressions::column_name;
     use crate::scan::scan_row_schema;
-    use crate::schema::ToSchema;
     use crate::unit_test_utils::{
         add_files_with_partition_values, assert_result_error_with_message, nullable_add_files,
         set_field_as_null,
@@ -206,7 +202,8 @@ mod tests {
         let mut batch = RecordBatch::try_new(Arc::new(schema), columns)
             .expect("staged DV schema and columns should form a valid batch");
         assert_eq!(batch.num_rows(), dv_paths.len());
-        let new_dv = new_deletion_vector_array(dv_paths);
+        let dv_paths = dv_paths.iter().copied().map(Some).collect::<Vec<_>>();
+        let new_dv = deletion_vector_array("i", &dv_paths);
         let mut fields = batch.schema().fields().to_vec();
         fields.push(Arc::new(ArrowField::new(
             NEW_DELETION_VECTOR_NAME,
@@ -385,23 +382,5 @@ mod tests {
         } else {
             result.expect("unselected invalid row should be ignored");
         }
-    }
-
-    fn new_deletion_vector_array(dv_paths: &[&str]) -> StructArray {
-        let dv_schema: ArrowSchema = (&DeletionVectorDescriptor::to_schema())
-            .try_into_arrow()
-            .expect("deletion-vector schema should convert to Arrow");
-        let row_count = dv_paths.len();
-        StructArray::new(
-            dv_schema.fields().clone(),
-            vec![
-                Arc::new(StringArray::from(vec!["i"; row_count])) as ArrayRef, // storageType
-                Arc::new(StringArray::from(dv_paths.to_vec())) as ArrayRef,    // pathOrInlineDv
-                Arc::new(Int32Array::from(vec![None; row_count])) as ArrayRef, // offset
-                Arc::new(Int32Array::from(vec![1; row_count])) as ArrayRef,    // sizeInBytes
-                Arc::new(Int64Array::from(vec![0; row_count])) as ArrayRef,    // cardinality
-            ],
-            None,
-        )
     }
 }

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -263,7 +263,7 @@ mod tests {
                         .into_iter()
                         .collect();
                     make_staged_dv_from_addfile(
-                        nullable_add_files(&["same"]),
+                        nullable_add_files(&["path"]),
                         &[if batch_index == 0 {
                             "new-dv-0"
                         } else {
@@ -275,7 +275,7 @@ mod tests {
                 .collect::<Vec<_>>()
         } else {
             vec![make_staged_dv_from_addfile(
-                nullable_add_files(&["same", "same"]),
+                nullable_add_files(&["path", "path"]),
                 &["new-dv-0", "new-dv-1"],
                 selection_vector.to_vec(),
             )]

--- a/kernel/src/transaction/write_validation/dv.rs
+++ b/kernel/src/transaction/write_validation/dv.rs
@@ -12,9 +12,8 @@ use crate::expressions::column_name;
 use crate::scan::log_replay::{
     FILE_CONSTANT_VALUES_NAME, PARTITION_VALUES_NAME, PATH_NAME, SIZE_NAME,
 };
-use crate::scan::scan_row_schema;
 use crate::schema::ColumnNamesAndTypes;
-use crate::transaction::update::NEW_DELETION_VECTOR_NAME;
+use crate::transaction::update::{intermediate_dv_schema, NEW_DELETION_VECTOR_NAME};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -36,7 +35,7 @@ const OFFSET_NAME: &str = "offset";
 
 static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
     LazyLock::new(|| {
-        let mut names = vec![
+        let names = vec![
             column_name!(PATH_NAME),
             column_name!(SIZE_NAME),
             column_name!(MODIFICATION_TIME_NAME),
@@ -44,26 +43,18 @@ static DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesA
             column_name!(DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
             column_name!(DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
             column_name!(DELETION_VECTOR_NAME, OFFSET_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
+            column_name!(NEW_DELETION_VECTOR_NAME, OFFSET_NAME),
         ];
-        // Derive types from the canonical scan schema so this projection stays compatible with scan
-        // metadata if those field definitions change.
-        let mut types = names
+        let types = names
             .iter()
             .map(|name| {
-                scan_row_schema()
+                intermediate_dv_schema()
                     .field_at(name)
                     .map(|field| field.data_type().clone())
             })
             .collect::<DeltaResult<Vec<_>>>()?;
-        // The transaction appends `newDeletionVector` after producing scan metadata, so it is
-        // absent from `scan_row_schema()`.
-        let new_deletion_vector_types = types[OLD_DELETION_VECTOR_STORAGE_TYPE..].to_vec();
-        names.extend([
-            column_name!(NEW_DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
-            column_name!(NEW_DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
-            column_name!(NEW_DELETION_VECTOR_NAME, OFFSET_NAME),
-        ]);
-        types.extend(new_deletion_vector_types);
         Ok((names, types).into())
     });
 
@@ -123,7 +114,7 @@ impl Validation for DvMatchedFileFields<'_> {
 impl<'a> StagedDataValidator<'a> {
     /// Creates a validator for selected rows staged for deletion-vector updates.
     ///
-    /// Errors if the required columns are absent from the scan-row schema.
+    /// Errors if the required columns are absent from the intermediate DV schema.
     pub(crate) fn staged_dv_matched_file(
         physical_partition_columns: impl IntoIterator<Item = String>,
         existing_file_actions: &'a mut FileActionTracker,
@@ -132,7 +123,7 @@ impl<'a> StagedDataValidator<'a> {
             .as_ref()
             .map_err(|error| {
                 Error::internal_error(format!(
-                    "DV validation columns must exist in the scan-row schema: {error}"
+                    "DV validation columns must exist in the intermediate DV schema: {error}"
                 ))
             })?;
         Ok(StagedDataValidator::new(
@@ -165,6 +156,7 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine_data::FilteredEngineData;
     use crate::expressions::column_name;
+    use crate::scan::scan_row_schema;
     use crate::schema::ToSchema;
     use crate::unit_test_utils::{
         add_files_with_partition_values, assert_result_error_with_message, nullable_add_files,
@@ -233,7 +225,7 @@ mod tests {
     fn column_indices_match_schema_order() {
         let columns = DV_MATCHED_FILE_COLUMNS_FOR_VALIDATION
             .as_ref()
-            .expect("DV validation columns should exist in the scan-row schema");
+            .expect("DV validation columns should exist in the intermediate DV schema");
         let (names, _) = columns.as_ref();
         assert_eq!(names[PATH], column_name!(PATH_NAME));
         assert_eq!(names[SIZE], column_name!(SIZE_NAME));
@@ -294,7 +286,7 @@ mod tests {
         let mut file_actions = FileActionTracker::default();
         let result =
             StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
-                .expect("DV validator should use the scan-row schema")
+                .expect("DV validator should use the intermediate DV schema")
                 .validate_filtered(&batches);
 
         if let Some(expected_error) = expected_error {
@@ -320,7 +312,7 @@ mod tests {
         )];
         let mut file_actions = FileActionTracker::default();
         StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
-            .expect("DV validator should use the scan-row schema")
+            .expect("DV validator should use the intermediate DV schema")
             .validate_filtered(&batches)
             .expect("protocol-valid boundary value should be accepted");
     }
@@ -355,7 +347,7 @@ mod tests {
         let mut file_actions = FileActionTracker::default();
         assert_result_error_with_message(
             StagedDataValidator::staged_dv_matched_file(std::iter::empty(), &mut file_actions)
-                .expect("DV validator should use the scan-row schema")
+                .expect("DV validator should use the intermediate DV schema")
                 .validate_filtered(&batches),
             field,
         );
@@ -386,7 +378,7 @@ mod tests {
             ["p1".to_string(), "p2".to_string()],
             &mut file_actions,
         )
-        .expect("DV validator should use the scan-row schema")
+        .expect("DV validator should use the intermediate DV schema")
         .validate_filtered(&batches);
         if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -149,48 +149,48 @@ mod tests {
     #[rstest]
     #[case::duplicate_add_different_dv(
         &[
-            FileActionCase::new(TestFileAction::Add, "same", Some("dv-1")),
-            FileActionCase::new(TestFileAction::Add, "same", Some("dv-2")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "same", Some("dv-1")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "same", Some("dv-2")),
         ],
         Some("multiple AddFile actions"),
     )]
     #[case::duplicate_remove_different_dv(
         &[
-            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-1")),
-            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-2")),
+            FileActionTrackerTestCase::new(TestFileActionType::Remove, "same", Some("dv-1")),
+            FileActionTrackerTestCase::new(TestFileActionType::Remove, "same", Some("dv-2")),
         ],
         Some("multiple RemoveFile actions"),
     )]
     #[case::add_remove_same_dv(
         &[
-            FileActionCase::new(TestFileAction::Add, "same", Some("dv")),
-            FileActionCase::new(TestFileAction::Remove, "same", Some("dv")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "same", Some("dv")),
+            FileActionTrackerTestCase::new(TestFileActionType::Remove, "same", Some("dv")),
         ],
         Some("same deletion vector ID"),
     )]
     #[case::remove_add_same_dv(
         &[
-            FileActionCase::new(TestFileAction::Remove, "same", None),
-            FileActionCase::new(TestFileAction::Add, "same", None),
+            FileActionTrackerTestCase::new(TestFileActionType::Remove, "same", None),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "same", None),
         ],
         Some("same deletion vector ID"),
     )]
     #[case::add_remove_different_dv(
         &[
-            FileActionCase::new(TestFileAction::Add, "same", Some("dv-1")),
-            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-2")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "same", Some("dv-1")),
+            FileActionTrackerTestCase::new(TestFileActionType::Remove, "same", Some("dv-2")),
         ],
         None,
     )]
     #[case::same_dv_different_paths(
         &[
-            FileActionCase::new(TestFileAction::Add, "first", Some("dv")),
-            FileActionCase::new(TestFileAction::Add, "second", Some("dv")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "first", Some("dv")),
+            FileActionTrackerTestCase::new(TestFileActionType::Add, "second", Some("dv")),
         ],
         None,
     )]
     fn file_action_combinations_accepted_or_rejected(
-        #[case] file_actions: &[FileActionCase],
+        #[case] file_actions: &[FileActionTrackerTestCase],
         #[case] expected_error: Option<&str>,
     ) {
         let mut tracker = FileActionTracker::default();
@@ -206,12 +206,12 @@ mod tests {
     }
 
     #[derive(Clone, Copy)]
-    enum TestFileAction {
+    enum TestFileActionType {
         Add,
         Remove,
     }
 
-    impl TestFileAction {
+    impl TestFileActionType {
         fn record(
             self,
             tracker: &mut FileActionTracker,
@@ -226,15 +226,15 @@ mod tests {
     }
 
     #[derive(Clone, Copy)]
-    struct FileActionCase {
-        action_type: TestFileAction,
+    struct FileActionTrackerTestCase {
+        action_type: TestFileActionType,
         path: &'static str,
         dv_id: Option<&'static str>,
     }
 
-    impl FileActionCase {
+    impl FileActionTrackerTestCase {
         const fn new(
-            action_type: TestFileAction,
+            action_type: TestFileActionType,
             path: &'static str,
             dv_id: Option<&'static str>,
         ) -> Self {

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -2,21 +2,63 @@
 //!
 //! [`Transaction`]: super::Transaction
 
-// TODO(#2869): Add the remaining write-side validations:
-// - No duplicate (path, DvId) in `txn.add_files_metadata`, `txn.remove_files_metadata`,
-//   `txn.dv_matched_files`
-
 mod addfile;
 mod dv;
 mod removefile;
 mod utils;
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 
 use crate::engine_data::{
     FilteredEngineData, FilteredRowVisitor, GetData, RowIndexIterator, RowVisitor,
 };
 use crate::expressions::ColumnName;
 use crate::schema::{ColumnNamesAndTypes, DataType};
-use crate::{DeltaResult, EngineData};
+use crate::utils::require;
+use crate::{DeltaResult, EngineData, Error};
+
+#[derive(Default)]
+pub(super) struct FileActionTracker {
+    add_paths: HashMap<String, Option<String>>,
+    remove_paths: HashMap<String, Option<String>>,
+}
+
+impl FileActionTracker {
+    fn record_add(&mut self, path: &str, dv_id: Option<String>) -> DeltaResult<()> {
+        let Entry::Vacant(entry) = self.add_paths.entry(path.to_owned()) else {
+            return Err(Error::generic(format!(
+                "Transaction contains multiple AddFile actions for path '{path}'"
+            )));
+        };
+        require!(
+            self.remove_paths.get(path) != Some(&dv_id),
+            Error::generic(format!(
+                "Transaction contains AddFile and RemoveFile actions for path '{path}' with the \
+                 same deletion vector ID"
+            ))
+        );
+        entry.insert(dv_id);
+        Ok(())
+    }
+
+    fn record_remove(&mut self, path: &str, dv_id: Option<String>) -> DeltaResult<()> {
+        let Entry::Vacant(entry) = self.remove_paths.entry(path.to_owned()) else {
+            return Err(Error::generic(format!(
+                "Transaction contains multiple RemoveFile actions for path '{path}'"
+            )));
+        };
+        require!(
+            self.add_paths.get(path) != Some(&dv_id),
+            Error::generic(format!(
+                "Transaction contains AddFile and RemoveFile actions for path '{path}' with the \
+                 same deletion vector ID"
+            ))
+        );
+        entry.insert(dv_id);
+        Ok(())
+    }
+}
 
 /// A single row-level validation.
 pub(crate) trait Validation {
@@ -27,15 +69,15 @@ pub(crate) trait Validation {
 ///
 /// Each instance uses one column projection and applies its configured validations to every staged
 /// row. Every [`Validation`] sees the full getter list and reads the columns it needs.
-pub(crate) struct StagedDataValidator {
+pub(crate) struct StagedDataValidator<'a> {
     columns_and_types: &'static ColumnNamesAndTypes,
-    validations: Vec<Box<dyn Validation>>,
+    validations: Vec<Box<dyn Validation + 'a>>,
 }
 
-impl StagedDataValidator {
+impl<'a> StagedDataValidator<'a> {
     pub(crate) fn new(
         columns_and_types: &'static ColumnNamesAndTypes,
-        validations: Vec<Box<dyn Validation>>,
+        validations: Vec<Box<dyn Validation + 'a>>,
     ) -> Self {
         Self {
             columns_and_types,
@@ -59,10 +101,10 @@ impl StagedDataValidator {
         Ok(())
     }
 
-    fn validate_rows<'a>(
+    fn validate_rows<'data>(
         &mut self,
         rows: impl IntoIterator<Item = usize>,
-        getters: &[&'a dyn GetData<'a>],
+        getters: &[&'data dyn GetData<'data>],
     ) -> DeltaResult<()> {
         for row in rows {
             for validation in &mut self.validations {
@@ -73,7 +115,7 @@ impl StagedDataValidator {
     }
 }
 
-impl RowVisitor for StagedDataValidator {
+impl RowVisitor for StagedDataValidator<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         self.columns_and_types.as_ref()
     }
@@ -83,7 +125,7 @@ impl RowVisitor for StagedDataValidator {
     }
 }
 
-impl FilteredRowVisitor for StagedDataValidator {
+impl FilteredRowVisitor for StagedDataValidator<'_> {
     fn selected_column_names_and_types(&self) -> (&'static [ColumnName], &'static [DataType]) {
         self.columns_and_types.as_ref()
     }
@@ -94,5 +136,120 @@ impl FilteredRowVisitor for StagedDataValidator {
         rows: RowIndexIterator<'_>,
     ) -> DeltaResult<()> {
         self.validate_rows(rows, getters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::unit_test_utils::assert_result_error_with_message;
+
+    #[rstest]
+    #[case::duplicate_add_different_dv(FileActionCase {
+        first: TestFileAction::Add,
+        first_path: "same",
+        first_dv_id: Some("dv-1"),
+        second: TestFileAction::Add,
+        second_path: "same",
+        second_dv_id: Some("dv-2"),
+        expected_error: Some("multiple AddFile actions"),
+    })]
+    #[case::duplicate_remove_different_dv(FileActionCase {
+        first: TestFileAction::Remove,
+        first_path: "same",
+        first_dv_id: Some("dv-1"),
+        second: TestFileAction::Remove,
+        second_path: "same",
+        second_dv_id: Some("dv-2"),
+        expected_error: Some("multiple RemoveFile actions"),
+    })]
+    #[case::add_remove_same_dv(FileActionCase {
+        first: TestFileAction::Add,
+        first_path: "same",
+        first_dv_id: Some("dv"),
+        second: TestFileAction::Remove,
+        second_path: "same",
+        second_dv_id: Some("dv"),
+        expected_error: Some("same deletion vector ID"),
+    })]
+    #[case::remove_add_same_dv(FileActionCase {
+        first: TestFileAction::Remove,
+        first_path: "same",
+        first_dv_id: None,
+        second: TestFileAction::Add,
+        second_path: "same",
+        second_dv_id: None,
+        expected_error: Some("same deletion vector ID"),
+    })]
+    #[case::add_remove_different_dv(FileActionCase {
+        first: TestFileAction::Add,
+        first_path: "same",
+        first_dv_id: Some("dv-1"),
+        second: TestFileAction::Remove,
+        second_path: "same",
+        second_dv_id: Some("dv-2"),
+        expected_error: None,
+    })]
+    #[case::same_dv_different_paths(FileActionCase {
+        first: TestFileAction::Add,
+        first_path: "first",
+        first_dv_id: Some("dv"),
+        second: TestFileAction::Add,
+        second_path: "second",
+        second_dv_id: Some("dv"),
+        expected_error: None,
+    })]
+    fn file_action_combinations_accepted_or_rejected(#[case] case: FileActionCase) {
+        let mut tracker = FileActionTracker::default();
+        case.first
+            .record(
+                &mut tracker,
+                case.first_path,
+                case.first_dv_id.map(str::to_owned),
+            )
+            .expect("first file action should be accepted");
+        let result = case.second.record(
+            &mut tracker,
+            case.second_path,
+            case.second_dv_id.map(str::to_owned),
+        );
+
+        if let Some(expected_error) = case.expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            result.expect("valid file-action combination should be accepted");
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum TestFileAction {
+        Add,
+        Remove,
+    }
+
+    impl TestFileAction {
+        fn record(
+            self,
+            tracker: &mut FileActionTracker,
+            path: &str,
+            dv_id: Option<String>,
+        ) -> DeltaResult<()> {
+            match self {
+                Self::Add => tracker.record_add(path, dv_id),
+                Self::Remove => tracker.record_remove(path, dv_id),
+            }
+        }
+    }
+
+    struct FileActionCase {
+        first: TestFileAction,
+        first_path: &'static str,
+        first_dv_id: Option<&'static str>,
+        second: TestFileAction,
+        second_path: &'static str,
+        second_dv_id: Option<&'static str>,
+        expected_error: Option<&'static str>,
     }
 }

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -25,6 +25,13 @@ pub(super) struct FileActionTracker {
 }
 
 impl FileActionTracker {
+    pub(super) fn with_capacity(add_capacity: usize, remove_capacity: usize) -> Self {
+        Self {
+            add_paths: HashMap::with_capacity(add_capacity),
+            remove_paths: HashMap::with_capacity(remove_capacity),
+        }
+    }
+
     fn record_add(&mut self, path: &str, dv_id: Option<String>) -> DeltaResult<()> {
         let Entry::Vacant(entry) = self.add_paths.entry(path.to_owned()) else {
             return Err(Error::generic(format!(

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -147,76 +147,58 @@ mod tests {
     use crate::unit_test_utils::assert_result_error_with_message;
 
     #[rstest]
-    #[case::duplicate_add_different_dv(FileActionCase {
-        first: TestFileAction::Add,
-        first_path: "same",
-        first_dv_id: Some("dv-1"),
-        second: TestFileAction::Add,
-        second_path: "same",
-        second_dv_id: Some("dv-2"),
-        expected_error: Some("multiple AddFile actions"),
-    })]
-    #[case::duplicate_remove_different_dv(FileActionCase {
-        first: TestFileAction::Remove,
-        first_path: "same",
-        first_dv_id: Some("dv-1"),
-        second: TestFileAction::Remove,
-        second_path: "same",
-        second_dv_id: Some("dv-2"),
-        expected_error: Some("multiple RemoveFile actions"),
-    })]
-    #[case::add_remove_same_dv(FileActionCase {
-        first: TestFileAction::Add,
-        first_path: "same",
-        first_dv_id: Some("dv"),
-        second: TestFileAction::Remove,
-        second_path: "same",
-        second_dv_id: Some("dv"),
-        expected_error: Some("same deletion vector ID"),
-    })]
-    #[case::remove_add_same_dv(FileActionCase {
-        first: TestFileAction::Remove,
-        first_path: "same",
-        first_dv_id: None,
-        second: TestFileAction::Add,
-        second_path: "same",
-        second_dv_id: None,
-        expected_error: Some("same deletion vector ID"),
-    })]
-    #[case::add_remove_different_dv(FileActionCase {
-        first: TestFileAction::Add,
-        first_path: "same",
-        first_dv_id: Some("dv-1"),
-        second: TestFileAction::Remove,
-        second_path: "same",
-        second_dv_id: Some("dv-2"),
-        expected_error: None,
-    })]
-    #[case::same_dv_different_paths(FileActionCase {
-        first: TestFileAction::Add,
-        first_path: "first",
-        first_dv_id: Some("dv"),
-        second: TestFileAction::Add,
-        second_path: "second",
-        second_dv_id: Some("dv"),
-        expected_error: None,
-    })]
-    fn file_action_combinations_accepted_or_rejected(#[case] case: FileActionCase) {
+    #[case::duplicate_add_different_dv(
+        &[
+            FileActionCase::new(TestFileAction::Add, "same", Some("dv-1")),
+            FileActionCase::new(TestFileAction::Add, "same", Some("dv-2")),
+        ],
+        Some("multiple AddFile actions"),
+    )]
+    #[case::duplicate_remove_different_dv(
+        &[
+            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-1")),
+            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-2")),
+        ],
+        Some("multiple RemoveFile actions"),
+    )]
+    #[case::add_remove_same_dv(
+        &[
+            FileActionCase::new(TestFileAction::Add, "same", Some("dv")),
+            FileActionCase::new(TestFileAction::Remove, "same", Some("dv")),
+        ],
+        Some("same deletion vector ID"),
+    )]
+    #[case::remove_add_same_dv(
+        &[
+            FileActionCase::new(TestFileAction::Remove, "same", None),
+            FileActionCase::new(TestFileAction::Add, "same", None),
+        ],
+        Some("same deletion vector ID"),
+    )]
+    #[case::add_remove_different_dv(
+        &[
+            FileActionCase::new(TestFileAction::Add, "same", Some("dv-1")),
+            FileActionCase::new(TestFileAction::Remove, "same", Some("dv-2")),
+        ],
+        None,
+    )]
+    #[case::same_dv_different_paths(
+        &[
+            FileActionCase::new(TestFileAction::Add, "first", Some("dv")),
+            FileActionCase::new(TestFileAction::Add, "second", Some("dv")),
+        ],
+        None,
+    )]
+    fn file_action_combinations_accepted_or_rejected(
+        #[case] file_actions: &[FileActionCase],
+        #[case] expected_error: Option<&str>,
+    ) {
         let mut tracker = FileActionTracker::default();
-        case.first
-            .record(
-                &mut tracker,
-                case.first_path,
-                case.first_dv_id.map(str::to_owned),
-            )
-            .expect("first file action should be accepted");
-        let result = case.second.record(
-            &mut tracker,
-            case.second_path,
-            case.second_dv_id.map(str::to_owned),
-        );
+        let result = file_actions
+            .iter()
+            .try_for_each(|file_action| file_action.record(&mut tracker));
 
-        if let Some(expected_error) = case.expected_error {
+        if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);
         } else {
             result.expect("valid file-action combination should be accepted");
@@ -243,13 +225,29 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy)]
     struct FileActionCase {
-        first: TestFileAction,
-        first_path: &'static str,
-        first_dv_id: Option<&'static str>,
-        second: TestFileAction,
-        second_path: &'static str,
-        second_dv_id: Option<&'static str>,
-        expected_error: Option<&'static str>,
+        action_type: TestFileAction,
+        path: &'static str,
+        dv_id: Option<&'static str>,
+    }
+
+    impl FileActionCase {
+        const fn new(
+            action_type: TestFileAction,
+            path: &'static str,
+            dv_id: Option<&'static str>,
+        ) -> Self {
+            Self {
+                action_type,
+                path,
+                dv_id,
+            }
+        }
+
+        fn record(self, tracker: &mut FileActionTracker) -> DeltaResult<()> {
+            self.action_type
+                .record(tracker, self.path, self.dv_id.map(str::to_owned))
+        }
     }
 }

--- a/kernel/src/transaction/write_validation/mod.rs
+++ b/kernel/src/transaction/write_validation/mod.rs
@@ -22,6 +22,7 @@ use crate::{DeltaResult, EngineData, Error};
 pub(super) struct FileActionTracker {
     add_paths: HashMap<String, Option<String>>,
     remove_paths: HashMap<String, Option<String>>,
+    skip_duplicate_validation: bool,
 }
 
 impl FileActionTracker {
@@ -29,10 +30,21 @@ impl FileActionTracker {
         Self {
             add_paths: HashMap::with_capacity(add_capacity),
             remove_paths: HashMap::with_capacity(remove_capacity),
+            skip_duplicate_validation: false,
+        }
+    }
+
+    pub(super) fn without_duplicate_validation() -> Self {
+        Self {
+            skip_duplicate_validation: true,
+            ..Self::default()
         }
     }
 
     fn record_add(&mut self, path: &str, dv_id: Option<String>) -> DeltaResult<()> {
+        if self.skip_duplicate_validation {
+            return Ok(());
+        }
         let Entry::Vacant(entry) = self.add_paths.entry(path.to_owned()) else {
             return Err(Error::generic(format!(
                 "Transaction contains multiple AddFile actions for path '{path}'"
@@ -50,6 +62,9 @@ impl FileActionTracker {
     }
 
     fn record_remove(&mut self, path: &str, dv_id: Option<String>) -> DeltaResult<()> {
+        if self.skip_duplicate_validation {
+            return Ok(());
+        }
         let Entry::Vacant(entry) = self.remove_paths.entry(path.to_owned()) else {
             return Err(Error::generic(format!(
                 "Transaction contains multiple RemoveFile actions for path '{path}'"
@@ -210,6 +225,14 @@ mod tests {
         } else {
             result.expect("valid file-action combination should be accepted");
         }
+    }
+
+    #[test]
+    fn duplicate_validation_can_be_skipped() {
+        let mut tracker = FileActionTracker::without_duplicate_validation();
+
+        tracker.record_add("same", None).unwrap();
+        tracker.record_add("same", None).unwrap();
     }
 
     #[derive(Clone, Copy)]

--- a/kernel/src/transaction/write_validation/removefile.rs
+++ b/kernel/src/transaction/write_validation/removefile.rs
@@ -2,31 +2,58 @@
 
 use std::sync::LazyLock;
 
-use super::utils::validate_required_field_exist;
-use super::{StagedDataValidator, Validation};
+use super::utils::{deletion_vector_unique_id, validate_required_field_exist};
+use super::{FileActionTracker, StagedDataValidator, Validation};
 use crate::engine_data::{GetData, TypedGetData as _};
-use crate::schema::{lazy_schema_ref, ColumnNamesAndTypes, SchemaRef};
+use crate::expressions::column_name;
+use crate::scan::log_replay::{PATH_NAME, SIZE_NAME};
+use crate::scan::scan_row_schema;
+use crate::schema::ColumnNamesAndTypes;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
 /// Column indices, matching the order in [`MANDATORY_REMOVE_FILE_COLUMNS`].
 const PATH: usize = 0;
 const SIZE: usize = 1;
+const DELETION_VECTOR_STORAGE_TYPE: usize = 2;
 
-static MANDATORY_REMOVE_FILE_SCHEMA: LazyLock<SchemaRef> = lazy_schema_ref! {
-    nullable "path": STRING,
-    nullable "size": LONG,
-};
+const DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
+    "deletionVector.storageType",
+    "deletionVector.pathOrInlineDv",
+    "deletionVector.offset",
+];
 
-static MANDATORY_REMOVE_FILE_COLUMNS: LazyLock<ColumnNamesAndTypes> =
-    LazyLock::new(|| MANDATORY_REMOVE_FILE_SCHEMA.leaves(None));
+static MANDATORY_REMOVE_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
+    LazyLock::new(|| {
+        let names = vec![
+            column_name!(PATH_NAME),
+            column_name!(SIZE_NAME),
+            column_name!("deletionVector.storageType"),
+            column_name!("deletionVector.pathOrInlineDv"),
+            column_name!("deletionVector.offset"),
+        ];
+        let types = names
+            .iter()
+            .map(|name| {
+                scan_row_schema()
+                    .field_at(name)
+                    .map(|field| field.data_type().clone())
+            })
+            .collect::<DeltaResult<Vec<_>>>()?;
+        Ok((names, types).into())
+    });
 
-impl StagedDataValidator {
-    pub(crate) fn staged_remove_file() -> Self {
-        StagedDataValidator::new(
-            &MANDATORY_REMOVE_FILE_COLUMNS,
-            vec![Box::new(RemoveFileRequiredFields)],
-        )
+impl<'a> StagedDataValidator<'a> {
+    pub(crate) fn staged_remove_file(file_actions: &'a mut FileActionTracker) -> DeltaResult<Self> {
+        let columns = MANDATORY_REMOVE_FILE_COLUMNS.as_ref().map_err(|error| {
+            Error::internal_error(format!(
+                "RemoveFile validation columns must exist in the scan-row schema: {error}"
+            ))
+        })?;
+        Ok(StagedDataValidator::new(
+            columns,
+            vec![Box::new(RemoveFileRequiredFields { file_actions })],
+        ))
     }
 }
 
@@ -35,9 +62,11 @@ impl StagedDataValidator {
 ///
 /// The protocol defines `size` as optional, but kernel requires it because its `RemoveFile`
 /// actions currently come only from `AddFile` actions, which provide `size`.
-struct RemoveFileRequiredFields;
+struct RemoveFileRequiredFields<'a> {
+    file_actions: &'a mut FileActionTracker,
+}
 
-impl Validation for RemoveFileRequiredFields {
+impl Validation for RemoveFileRequiredFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
@@ -57,7 +86,13 @@ impl Validation for RemoveFileRequiredFields {
                 "RemoveFile for '{path}' has negative size {size}; size must be non-negative"
             ))
         );
-        Ok(())
+        let dv_id = deletion_vector_unique_id(
+            row,
+            getters,
+            DELETION_VECTOR_STORAGE_TYPE,
+            DELETION_VECTOR_COLUMN_NAMES,
+        )?;
+        self.file_actions.record_remove(path, dv_id)
     }
 }
 
@@ -68,7 +103,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{ArrayRef, Int64Array, StringArray};
+    use crate::arrow::array::{new_null_array, ArrayRef, Int64Array, StringArray};
     use crate::arrow::compute::concat_batches;
     use crate::arrow::datatypes::Schema as ArrowSchema;
     use crate::arrow::record_batch::RecordBatch;
@@ -80,10 +115,43 @@ mod tests {
 
     #[test]
     fn column_indices_match_schema_order() {
-        let (names, _) = MANDATORY_REMOVE_FILE_COLUMNS.as_ref();
+        let columns = MANDATORY_REMOVE_FILE_COLUMNS
+            .as_ref()
+            .expect("RemoveFile validation columns should exist in the scan-row schema");
+        let (names, _) = columns.as_ref();
         assert_eq!(names[PATH], ColumnName::new(["path"]));
         assert_eq!(names[SIZE], ColumnName::new(["size"]));
-        assert_eq!(names.len(), 2);
+        assert_eq!(
+            names[DELETION_VECTOR_STORAGE_TYPE],
+            ColumnName::new(["deletionVector", "storageType"])
+        );
+        assert_eq!(names.len(), 5);
+    }
+
+    #[rstest]
+    #[case::selected(&[true, true], Some("multiple RemoveFile actions"))]
+    #[case::unselected(&[true, false], None)]
+    fn duplicate_remove_paths_validate_selected_rows(
+        #[case] selection_vector: &[bool],
+        #[case] expected_error: Option<&str>,
+    ) {
+        let batch = replace_column(
+            &nullable_staged_remove_files(2 /* row_count */),
+            PATH_NAME,
+            Arc::new(StringArray::from(vec!["same", "same"])),
+        );
+        let removes = [FilteredEngineData::try_new(
+            Box::new(ArrowEngineData::new(batch)),
+            selection_vector.to_vec(),
+        )
+        .expect("valid remove-file selection vector")];
+        let result = validate_remove_files(&removes);
+
+        if let Some(expected_error) = expected_error {
+            assert_result_error_with_message(result, expected_error);
+        } else {
+            result.expect("unselected duplicate RemoveFile should be ignored");
+        }
     }
 
     #[rstest]
@@ -170,11 +238,11 @@ mod tests {
         )
         .expect("valid remove-file selection vector");
         let mut removes = vec![
-            all_rows_selected(nullable_staged_remove_file()),
-            all_rows_selected(nullable_staged_remove_file()),
+            all_rows_selected(nullable_staged_remove_file("default-path-0")),
+            all_rows_selected(nullable_staged_remove_file("default-path-1")),
         ];
         removes[case_batch_index] = remove;
-        let result = remove_validator().validate_filtered(&removes);
+        let result = validate_remove_files(&removes);
 
         if let Some(expected_error) = expected_error {
             assert_result_error_with_message(result, expected_error);
@@ -183,24 +251,27 @@ mod tests {
         }
     }
 
-    fn nullable_staged_remove_file() -> RecordBatch {
-        let arrow_schema: ArrowSchema = MANDATORY_REMOVE_FILE_SCHEMA
+    fn nullable_staged_remove_file(path: &str) -> RecordBatch {
+        let arrow_schema: ArrowSchema = scan_row_schema()
             .as_ref()
             .try_into_arrow()
-            .expect("remove-file schema should convert to Arrow");
+            .expect("scan-row schema should convert to Arrow");
+        let columns = arrow_schema
+            .fields()
+            .iter()
+            .map(|field| match field.name().as_str() {
+                "path" => Arc::new(StringArray::from(vec![path])) as ArrayRef,
+                "size" => Arc::new(Int64Array::from(vec![1])) as ArrayRef,
+                _ => new_null_array(field.data_type(), 1 /* length */),
+            })
+            .collect();
 
-        RecordBatch::try_new(
-            Arc::new(arrow_schema),
-            vec![
-                Arc::new(StringArray::from(vec!["dummy"])) as ArrayRef,
-                Arc::new(Int64Array::from(vec![1])) as ArrayRef,
-            ],
-        )
-        .expect("valid staged remove-file batch")
+        RecordBatch::try_new(Arc::new(arrow_schema), columns)
+            .expect("valid staged remove-file batch")
     }
 
     fn nullable_staged_remove_files(row_count: usize) -> RecordBatch {
-        let batch = nullable_staged_remove_file();
+        let batch = nullable_staged_remove_file("dummy");
         concat_batches(&batch.schema(), &vec![batch; row_count])
             .expect("failed to concatenate rows into a multi-row remove-file batch")
     }
@@ -209,7 +280,10 @@ mod tests {
         FilteredEngineData::with_all_rows_selected(Box::new(ArrowEngineData::new(batch)))
     }
 
-    fn remove_validator() -> StagedDataValidator {
-        StagedDataValidator::staged_remove_file()
+    fn validate_remove_files(removes: &[FilteredEngineData]) -> DeltaResult<()> {
+        let mut file_actions = FileActionTracker::default();
+        let result =
+            StagedDataValidator::staged_remove_file(&mut file_actions)?.validate_filtered(removes);
+        result
     }
 }

--- a/kernel/src/transaction/write_validation/removefile.rs
+++ b/kernel/src/transaction/write_validation/removefile.rs
@@ -106,6 +106,7 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
+    use test_utils::replace_column;
 
     use super::*;
     use crate::arrow::array::{
@@ -119,7 +120,7 @@ mod tests {
     use crate::engine::arrow_data::ArrowEngineData;
     use crate::engine_data::FilteredEngineData;
     use crate::expressions::ColumnName;
-    use crate::unit_test_utils::{assert_result_error_with_message, replace_column};
+    use crate::unit_test_utils::assert_result_error_with_message;
 
     #[test]
     fn column_indices_match_schema_order() {

--- a/kernel/src/transaction/write_validation/removefile.rs
+++ b/kernel/src/transaction/write_validation/removefile.rs
@@ -12,25 +12,25 @@ use crate::schema::ColumnNamesAndTypes;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
-/// Column indices, matching the order in [`MANDATORY_REMOVE_FILE_COLUMNS`].
+/// Column indices, matching the order in [`REMOVE_FILE_COLUMNS_FOR_VALIDATION`].
 const PATH: usize = 0;
 const SIZE: usize = 1;
 const DELETION_VECTOR_STORAGE_TYPE: usize = 2;
+const DELETION_VECTOR_PATH_OR_INLINE_DV: usize = 3;
+const DELETION_VECTOR_OFFSET: usize = 4;
+const DELETION_VECTOR_NAME: &str = "deletionVector";
+const STORAGE_TYPE_NAME: &str = "storageType";
+const PATH_OR_INLINE_DV_NAME: &str = "pathOrInlineDv";
+const OFFSET_NAME: &str = "offset";
 
-const DELETION_VECTOR_COLUMN_NAMES: [&str; 3] = [
-    "deletionVector.storageType",
-    "deletionVector.pathOrInlineDv",
-    "deletionVector.offset",
-];
-
-static MANDATORY_REMOVE_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
+static REMOVE_FILE_COLUMNS_FOR_VALIDATION: LazyLock<DeltaResult<ColumnNamesAndTypes>> =
     LazyLock::new(|| {
         let names = vec![
             column_name!(PATH_NAME),
             column_name!(SIZE_NAME),
-            column_name!("deletionVector.storageType"),
-            column_name!("deletionVector.pathOrInlineDv"),
-            column_name!("deletionVector.offset"),
+            column_name!(DELETION_VECTOR_NAME, STORAGE_TYPE_NAME),
+            column_name!(DELETION_VECTOR_NAME, PATH_OR_INLINE_DV_NAME),
+            column_name!(DELETION_VECTOR_NAME, OFFSET_NAME),
         ];
         let types = names
             .iter()
@@ -44,15 +44,21 @@ static MANDATORY_REMOVE_FILE_COLUMNS: LazyLock<DeltaResult<ColumnNamesAndTypes>>
     });
 
 impl<'a> StagedDataValidator<'a> {
-    pub(crate) fn staged_remove_file(file_actions: &'a mut FileActionTracker) -> DeltaResult<Self> {
-        let columns = MANDATORY_REMOVE_FILE_COLUMNS.as_ref().map_err(|error| {
-            Error::internal_error(format!(
-                "RemoveFile validation columns must exist in the scan-row schema: {error}"
-            ))
-        })?;
+    pub(crate) fn staged_remove_file(
+        existing_file_actions: &'a mut FileActionTracker,
+    ) -> DeltaResult<Self> {
+        let columns = REMOVE_FILE_COLUMNS_FOR_VALIDATION
+            .as_ref()
+            .map_err(|error| {
+                Error::internal_error(format!(
+                    "RemoveFile validation columns must exist in the scan-row schema: {error}"
+                ))
+            })?;
         Ok(StagedDataValidator::new(
             columns,
-            vec![Box::new(RemoveFileRequiredFields { file_actions })],
+            vec![Box::new(RemoveFileFields {
+                existing_file_actions,
+            })],
         ))
     }
 }
@@ -62,11 +68,11 @@ impl<'a> StagedDataValidator<'a> {
 ///
 /// The protocol defines `size` as optional, but kernel requires it because its `RemoveFile`
 /// actions currently come only from `AddFile` actions, which provide `size`.
-struct RemoveFileRequiredFields<'a> {
-    file_actions: &'a mut FileActionTracker,
+struct RemoveFileFields<'a> {
+    existing_file_actions: &'a mut FileActionTracker,
 }
 
-impl Validation for RemoveFileRequiredFields<'_> {
+impl Validation for RemoveFileFields<'_> {
     fn validate_row<'a>(&mut self, row: usize, getters: &[&'a dyn GetData<'a>]) -> DeltaResult<()> {
         let path: &str = getters[PATH]
             .get_opt(row, "path")?
@@ -87,12 +93,11 @@ impl Validation for RemoveFileRequiredFields<'_> {
             ))
         );
         let dv_id = deletion_vector_unique_id(
-            row,
-            getters,
-            DELETION_VECTOR_STORAGE_TYPE,
-            DELETION_VECTOR_COLUMN_NAMES,
+            getters[DELETION_VECTOR_STORAGE_TYPE].get_opt(row, STORAGE_TYPE_NAME)?,
+            getters[DELETION_VECTOR_PATH_OR_INLINE_DV].get_opt(row, PATH_OR_INLINE_DV_NAME)?,
+            getters[DELETION_VECTOR_OFFSET].get_opt(row, OFFSET_NAME)?,
         )?;
-        self.file_actions.record_remove(path, dv_id)
+        self.existing_file_actions.record_remove(path, dv_id)
     }
 }
 
@@ -103,9 +108,12 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{new_null_array, ArrayRef, Int64Array, StringArray};
+    use crate::arrow::array::{
+        new_null_array, ArrayRef, Int32Array, Int64Array, StringArray, StructArray,
+    };
+    use crate::arrow::buffer::NullBuffer;
     use crate::arrow::compute::concat_batches;
-    use crate::arrow::datatypes::Schema as ArrowSchema;
+    use crate::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_conversion::TryIntoArrow as _;
     use crate::engine::arrow_data::ArrowEngineData;
@@ -115,7 +123,7 @@ mod tests {
 
     #[test]
     fn column_indices_match_schema_order() {
-        let columns = MANDATORY_REMOVE_FILE_COLUMNS
+        let columns = REMOVE_FILE_COLUMNS_FOR_VALIDATION
             .as_ref()
             .expect("RemoveFile validation columns should exist in the scan-row schema");
         let (names, _) = columns.as_ref();
@@ -123,7 +131,7 @@ mod tests {
         assert_eq!(names[SIZE], ColumnName::new(["size"]));
         assert_eq!(
             names[DELETION_VECTOR_STORAGE_TYPE],
-            ColumnName::new(["deletionVector", "storageType"])
+            ColumnName::new([DELETION_VECTOR_NAME, STORAGE_TYPE_NAME])
         );
         assert_eq!(names.len(), 5);
     }
@@ -135,11 +143,7 @@ mod tests {
         #[case] selection_vector: &[bool],
         #[case] expected_error: Option<&str>,
     ) {
-        let batch = replace_column(
-            &nullable_staged_remove_files(2 /* row_count */),
-            PATH_NAME,
-            Arc::new(StringArray::from(vec!["same", "same"])),
-        );
+        let batch = nullable_staged_remove_files(&["same", "same"], &[Some("dv-1"), Some("dv-2")]);
         let removes = [FilteredEngineData::try_new(
             Box::new(ArrowEngineData::new(batch)),
             selection_vector.to_vec(),
@@ -227,7 +231,10 @@ mod tests {
         #[values(0, 1)] case_batch_index: usize,
     ) {
         let batch = replace_column(
-            &nullable_staged_remove_files(paths.len()),
+            &nullable_staged_remove_files(
+                &["valid-path-0", "valid-path-1", "valid-path-2"],
+                &[None, None, None],
+            ),
             "path",
             Arc::new(StringArray::from(paths.to_vec())),
         );
@@ -238,8 +245,8 @@ mod tests {
         )
         .expect("valid remove-file selection vector");
         let mut removes = vec![
-            all_rows_selected(nullable_staged_remove_file("default-path-0")),
-            all_rows_selected(nullable_staged_remove_file("default-path-1")),
+            all_rows_selected(nullable_staged_remove_file("default-path-0", None)),
+            all_rows_selected(nullable_staged_remove_file("default-path-1", None)),
         ];
         removes[case_batch_index] = remove;
         let result = validate_remove_files(&removes);
@@ -251,7 +258,7 @@ mod tests {
         }
     }
 
-    fn nullable_staged_remove_file(path: &str) -> RecordBatch {
+    fn nullable_staged_remove_file(path: &str, dv_id: Option<&str>) -> RecordBatch {
         let arrow_schema: ArrowSchema = scan_row_schema()
             .as_ref()
             .try_into_arrow()
@@ -262,6 +269,29 @@ mod tests {
             .map(|field| match field.name().as_str() {
                 "path" => Arc::new(StringArray::from(vec![path])) as ArrayRef,
                 "size" => Arc::new(Int64Array::from(vec![1])) as ArrayRef,
+                DELETION_VECTOR_NAME => {
+                    let ArrowDataType::Struct(fields) = field.data_type() else {
+                        panic!("deletionVector should be a struct");
+                    };
+                    let values = fields
+                        .iter()
+                        .map(|field| match field.name().as_str() {
+                            STORAGE_TYPE_NAME => Arc::new(StringArray::from(vec!["i"])) as ArrayRef,
+                            PATH_OR_INLINE_DV_NAME => {
+                                Arc::new(StringArray::from(vec![dv_id.unwrap_or("")])) as ArrayRef
+                            }
+                            OFFSET_NAME => Arc::new(Int32Array::from(vec![None])) as ArrayRef,
+                            "sizeInBytes" => Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                            "cardinality" => Arc::new(Int64Array::from(vec![1])) as ArrayRef,
+                            _ => panic!("unexpected deletionVector field '{}'", field.name()),
+                        })
+                        .collect();
+                    Arc::new(StructArray::new(
+                        fields.clone(),
+                        values,
+                        Some(NullBuffer::from(vec![dv_id.is_some()])),
+                    ))
+                }
                 _ => new_null_array(field.data_type(), 1 /* length */),
             })
             .collect();
@@ -270,10 +300,15 @@ mod tests {
             .expect("valid staged remove-file batch")
     }
 
-    fn nullable_staged_remove_files(row_count: usize) -> RecordBatch {
-        let batch = nullable_staged_remove_file("dummy");
-        concat_batches(&batch.schema(), &vec![batch; row_count])
-            .expect("failed to concatenate rows into a multi-row remove-file batch")
+    fn nullable_staged_remove_files(paths: &[&str], dv_ids: &[Option<&str>]) -> RecordBatch {
+        assert_eq!(paths.len(), dv_ids.len());
+        let batches: Vec<_> = paths
+            .iter()
+            .zip(dv_ids)
+            .map(|(path, dv_id)| nullable_staged_remove_file(path, *dv_id))
+            .collect();
+        concat_batches(&batches[0].schema(), &batches)
+            .expect("failed to concatenate remove-file rows")
     }
 
     fn all_rows_selected(batch: RecordBatch) -> FilteredEngineData {

--- a/kernel/src/transaction/write_validation/removefile.rs
+++ b/kernel/src/transaction/write_validation/removefile.rs
@@ -106,15 +106,12 @@ mod tests {
     use std::sync::Arc;
 
     use rstest::rstest;
-    use test_utils::replace_column;
+    use test_utils::{deletion_vector_array, replace_column};
 
     use super::*;
-    use crate::arrow::array::{
-        new_null_array, ArrayRef, Int32Array, Int64Array, StringArray, StructArray,
-    };
-    use crate::arrow::buffer::NullBuffer;
+    use crate::arrow::array::{new_null_array, ArrayRef, Int64Array, StringArray};
     use crate::arrow::compute::concat_batches;
-    use crate::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
+    use crate::arrow::datatypes::Schema as ArrowSchema;
     use crate::arrow::record_batch::RecordBatch;
     use crate::engine::arrow_conversion::TryIntoArrow as _;
     use crate::engine::arrow_data::ArrowEngineData;
@@ -289,29 +286,7 @@ mod tests {
             .map(|field| match field.name().as_str() {
                 "path" => Arc::new(StringArray::from(vec![path])) as ArrayRef,
                 "size" => Arc::new(Int64Array::from(vec![1])) as ArrayRef,
-                DELETION_VECTOR_NAME => {
-                    let ArrowDataType::Struct(fields) = field.data_type() else {
-                        panic!("deletionVector should be a struct");
-                    };
-                    let values = fields
-                        .iter()
-                        .map(|field| match field.name().as_str() {
-                            STORAGE_TYPE_NAME => Arc::new(StringArray::from(vec!["i"])) as ArrayRef,
-                            PATH_OR_INLINE_DV_NAME => {
-                                Arc::new(StringArray::from(vec![dv_id.unwrap_or("")])) as ArrayRef
-                            }
-                            OFFSET_NAME => Arc::new(Int32Array::from(vec![None])) as ArrayRef,
-                            "sizeInBytes" => Arc::new(Int32Array::from(vec![1])) as ArrayRef,
-                            "cardinality" => Arc::new(Int64Array::from(vec![1])) as ArrayRef,
-                            _ => panic!("unexpected deletionVector field '{}'", field.name()),
-                        })
-                        .collect();
-                    Arc::new(StructArray::new(
-                        fields.clone(),
-                        values,
-                        Some(NullBuffer::from(vec![dv_id.is_some()])),
-                    ))
-                }
+                DELETION_VECTOR_NAME => Arc::new(deletion_vector_array("i", &[dv_id])) as ArrayRef,
                 _ => new_null_array(field.data_type(), 1 /* length */),
             })
             .collect();

--- a/kernel/src/transaction/write_validation/removefile.rs
+++ b/kernel/src/transaction/write_validation/removefile.rs
@@ -143,13 +143,32 @@ mod tests {
     fn duplicate_remove_paths_validate_selected_rows(
         #[case] selection_vector: &[bool],
         #[case] expected_error: Option<&str>,
+        #[values(false, true)] multiple_batches: bool,
     ) {
-        let batch = nullable_staged_remove_files(&["same", "same"], &[Some("dv-1"), Some("dv-2")]);
-        let removes = [FilteredEngineData::try_new(
-            Box::new(ArrowEngineData::new(batch)),
-            selection_vector.to_vec(),
-        )
-        .expect("valid remove-file selection vector")];
+        let removes = if multiple_batches {
+            selection_vector
+                .iter()
+                .zip(["dv-1", "dv-2"])
+                .map(|(&selected, dv_id)| {
+                    FilteredEngineData::try_new(
+                        Box::new(ArrowEngineData::new(nullable_staged_remove_file(
+                            "same",
+                            Some(dv_id),
+                        ))),
+                        vec![selected],
+                    )
+                    .expect("selection vector length should match staged RemoveFile row count")
+                })
+                .collect()
+        } else {
+            let batch =
+                nullable_staged_remove_files(&["same", "same"], &[Some("dv-1"), Some("dv-2")]);
+            vec![FilteredEngineData::try_new(
+                Box::new(ArrowEngineData::new(batch)),
+                selection_vector.to_vec(),
+            )
+            .expect("selection vector length should match staged RemoveFile row count")]
+        };
         let result = validate_remove_files(&removes);
 
         if let Some(expected_error) = expected_error {
@@ -244,7 +263,7 @@ mod tests {
             Box::new(ArrowEngineData::new(batch)),
             selection_vector.to_vec(),
         )
-        .expect("valid remove-file selection vector");
+        .expect("selection vector length should match staged RemoveFile row count");
         let mut removes = vec![
             all_rows_selected(nullable_staged_remove_file("default-path-0", None)),
             all_rows_selected(nullable_staged_remove_file("default-path-1", None)),

--- a/kernel/src/transaction/write_validation/utils.rs
+++ b/kernel/src/transaction/write_validation/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
-use crate::engine_data::MapItem;
+use crate::actions::deletion_vector::DeletionVectorDescriptor;
+use crate::engine_data::{GetData, MapItem, TypedGetData as _};
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -43,4 +44,23 @@ pub(super) fn validate_partition_keys(
         ))
     );
     Ok(())
+}
+
+pub(super) fn deletion_vector_unique_id<'a>(
+    row: usize,
+    getters: &[&'a dyn GetData<'a>],
+    storage_type_column: usize,
+    column_names: [&str; 3],
+) -> DeltaResult<Option<String>> {
+    let storage_type: Option<&str> = getters[storage_type_column].get_opt(row, column_names[0])?;
+    let Some(storage_type) = storage_type else {
+        return Ok(None);
+    };
+    let path_or_inline_dv: &str = getters[storage_type_column + 1].get(row, column_names[1])?;
+    let offset: Option<i32> = getters[storage_type_column + 2].get_opt(row, column_names[2])?;
+    Ok(Some(DeletionVectorDescriptor::unique_id_from_parts(
+        storage_type,
+        path_or_inline_dv,
+        offset,
+    )))
 }

--- a/kernel/src/transaction/write_validation/utils.rs
+++ b/kernel/src/transaction/write_validation/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use crate::actions::deletion_vector::DeletionVectorDescriptor;
-use crate::engine_data::{GetData, MapItem, TypedGetData as _};
+use crate::engine_data::MapItem;
 use crate::utils::require;
 use crate::{DeltaResult, Error};
 
@@ -46,18 +46,17 @@ pub(super) fn validate_partition_keys(
     Ok(())
 }
 
-pub(super) fn deletion_vector_unique_id<'a>(
-    row: usize,
-    getters: &[&'a dyn GetData<'a>],
-    storage_type_column: usize,
-    column_names: [&str; 3],
+pub(super) fn deletion_vector_unique_id(
+    storage_type: Option<&str>,
+    path_or_inline_dv: Option<&str>,
+    offset: Option<i32>,
 ) -> DeltaResult<Option<String>> {
-    let storage_type: Option<&str> = getters[storage_type_column].get_opt(row, column_names[0])?;
     let Some(storage_type) = storage_type else {
         return Ok(None);
     };
-    let path_or_inline_dv: &str = getters[storage_type_column + 1].get(row, column_names[1])?;
-    let offset: Option<i32> = getters[storage_type_column + 2].get_opt(row, column_names[2])?;
+    let path_or_inline_dv = path_or_inline_dv.ok_or_else(|| {
+        Error::missing_data("DeletionVector is missing required field 'pathOrInlineDv'")
+    })?;
     Ok(Some(DeletionVectorDescriptor::unique_id_from_parts(
         storage_type,
         path_or_inline_dv,

--- a/kernel/src/unit_test_utils.rs
+++ b/kernel/src/unit_test_utils.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use tempfile::TempDir;
 use test_utils::{
     copy_directory, delta_path_for_version, load_test_data, modify_add_file_partition_keys,
-    replace_array_row, AddFilePartitionKeyModify,
+    replace_array_row, replace_column, AddFilePartitionKeyModify,
 };
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -218,18 +218,10 @@ pub(crate) fn nullable_add_file(path: &str) -> RecordBatch {
     )
 }
 
-/// Builds valid add-file rows with a fully nullable schema.
+/// Builds valid add-file rows with a fully nullable schema and specific paths.
 pub(crate) fn nullable_add_files(paths: &[&str]) -> RecordBatch {
     let batches: Vec<_> = paths.iter().map(|path| nullable_add_file(path)).collect();
     concat_batches(&batches[0].schema(), &batches).expect("failed to concatenate add-file rows")
-}
-
-pub(crate) fn replace_column(batch: &RecordBatch, field: &str, column: ArrayRef) -> RecordBatch {
-    let schema = batch.schema();
-    let index = schema.index_of(field).expect("field in schema");
-    let mut columns = batch.columns().to_vec();
-    columns[index] = column;
-    RecordBatch::try_new(schema, columns).expect("failed to rebuild batch after replacing a column")
 }
 
 pub(crate) fn set_field_as_null(batch: &RecordBatch, field: &str, row: usize) -> RecordBatch {

--- a/kernel/src/unit_test_utils.rs
+++ b/kernel/src/unit_test_utils.rs
@@ -210,15 +210,18 @@ pub(crate) fn create_valid_add_file_batch(all_nullable: bool) -> RecordBatch {
 }
 
 /// Builds one valid add-file row with a fully nullable schema.
-pub(crate) fn nullable_add_file() -> RecordBatch {
-    create_valid_add_file_batch(true /* all_nullable */)
+pub(crate) fn nullable_add_file(path: &str) -> RecordBatch {
+    replace_column(
+        &create_valid_add_file_batch(true /* all_nullable */),
+        "path",
+        Arc::new(StringArray::from(vec![path])),
+    )
 }
 
-/// Builds `row_count` valid add-file rows with a fully nullable schema.
-pub(crate) fn nullable_add_files(row_count: usize) -> RecordBatch {
-    let batch = nullable_add_file();
-    concat_batches(&batch.schema(), &vec![batch; row_count])
-        .expect("failed to concatenate rows into a multi-row add-file batch")
+/// Builds valid add-file rows with a fully nullable schema.
+pub(crate) fn nullable_add_files(paths: &[&str]) -> RecordBatch {
+    let batches: Vec<_> = paths.iter().map(|path| nullable_add_file(path)).collect();
+    concat_batches(&batches[0].schema(), &batches).expect("failed to concatenate add-file rows")
 }
 
 pub(crate) fn replace_column(batch: &RecordBatch, field: &str, column: ArrayRef) -> RecordBatch {
@@ -241,16 +244,19 @@ pub(crate) fn set_field_as_null(batch: &RecordBatch, field: &str, row: usize) ->
 
 /// Returns nullable add-file rows with `partitionValues` replaced by `partition_values`.
 pub(crate) fn add_files_with_partition_values(
+    paths: &[&str],
     partition_values: &[&[(&str, Option<&str>)]],
 ) -> RecordBatch {
-    let batches: Vec<_> = partition_values
+    assert_eq!(paths.len(), partition_values.len());
+    let batches: Vec<_> = paths
         .iter()
-        .map(|entries| {
+        .zip(partition_values)
+        .map(|(path, entries)| {
             let modifications: Vec<_> = entries
                 .iter()
                 .map(|(key, value)| AddFilePartitionKeyModify::Insert { key, value: *value })
                 .collect();
-            modify_add_file_partition_keys(nullable_add_file(), &modifications)
+            modify_add_file_partition_keys(nullable_add_file(path), &modifications)
         })
         .collect();
     concat_batches(&batches[0].schema(), &batches)

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -243,7 +243,7 @@ pub async fn write_data_and_check_result_and_stats(
     }
 
     // commit!
-    match txn.commit(engine.as_ref())? {
+    match txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)? {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(committed.commit_version(), expected_since_commit as Version);
             assert_eq!(
@@ -432,7 +432,7 @@ pub async fn create_dv_table_with_files(
     };
     txn.add_files(metadata);
 
-    let _ = txn.commit(engine.as_ref())?;
+    let _ = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let paths: Vec<String> = file_paths.iter().map(|&s| s.to_string()).collect();
     Ok((store, engine, table_url, paths))

--- a/kernel/tests/integration/create_table/clustering.rs
+++ b/kernel/tests/integration/create_table/clustering.rs
@@ -69,7 +69,7 @@ async fn test_create_clustered_table(#[case] col_paths: Vec<Vec<&str>>) -> Delta
         );
     }
 
-    let _ = txn.commit(engine.as_ref())?;
+    let _ = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -107,7 +107,7 @@ async fn test_clustering_with_explicit_feature_signal_no_duplicates() -> DeltaRe
         .with_table_properties([("delta.feature.domainMetadata", "supported")])
         .with_data_layout(DataLayout::clustered(["id"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Read back using kernel APIs and verify no duplicate features
     let table_url = delta_kernel::try_parse_uri(&table_path)?;

--- a/kernel/tests/integration/create_table/column_mapping.rs
+++ b/kernel/tests/integration/create_table/column_mapping.rs
@@ -239,7 +239,7 @@ fn test_column_mapping_feature_only_without_mode() -> DeltaResult<()> {
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.columnMapping", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -366,7 +366,7 @@ fn test_create_clustered_table_with_column_mapping(
         .with_table_properties([("delta.columnMapping.mode", "name")])
         .with_data_layout(DataLayout::clustered(clustering_cols.iter().copied()))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Load snapshot (validates column mapping annotations on read)
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -552,7 +552,7 @@ fn test_create_clustered_table_nested_with_column_mapping(
             columns: expected_cols.clone(),
         })
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -612,7 +612,7 @@ fn test_partitioned_table_stores_logical_column_names_with_column_mapping(
         .with_table_properties([("delta.columnMapping.mode", "name")])
         .with_data_layout(DataLayout::partitioned(partition_cols.iter().copied()))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -680,7 +680,8 @@ fn test_create_table_dup_physical_name(
 
     match expected_error_substring {
         None => {
-            let _commit = result?.commit(engine.as_ref())?;
+            let _commit =
+                result?.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
         }
         Some(substr) => {
             let msg = result

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -221,7 +221,7 @@ async fn run_ctas_test(
         }
         let result = builder
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-            .commit(engine.as_ref())?;
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
         match result {
             CommitResult::CommittedTransaction(c) => c
                 .post_commit_snapshot()
@@ -266,7 +266,8 @@ async fn run_ctas_test(
         .await?;
     tgt_txn.add_files(add_meta);
 
-    let commit_result = tgt_txn.commit(engine.as_ref())?;
+    let commit_result =
+        tgt_txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     let tgt_snapshot = match commit_result {
         CommitResult::CommittedTransaction(c) => c
             .post_commit_snapshot()

--- a/kernel/tests/integration/create_table/iceberg_compat.rs
+++ b/kernel/tests/integration/create_table/iceberg_compat.rs
@@ -138,7 +138,7 @@ fn v3_supported_but_not_enabled_skips_cm_and_nested_ids() -> DeltaResult<()> {
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.icebergCompatV3", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     // 1. V3 is in writerFeatures (supported).

--- a/kernel/tests/integration/create_table/ict.rs
+++ b/kernel/tests/integration/create_table/ict.rs
@@ -84,7 +84,7 @@ fn test_create_table_ict(
     let committed = create_table(&table_path, super::simple_schema()?, "Test/1.0")
         .with_table_properties(properties.iter().copied())
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Verify via post-commit snapshot (reads ICT from in-memory CRC delta)

--- a/kernel/tests/integration/create_table/interval.rs
+++ b/kernel/tests/integration/create_table/interval.rs
@@ -89,7 +89,7 @@ mod supported {
         let _ = create_table(&table_path, schema.clone(), "Test/1.0")
             .with_table_properties(cm_properties(cm_mode))
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-            .commit(engine.as_ref())?;
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
         let table_url = delta_kernel::try_parse_uri(&table_path)?;
         let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -62,7 +62,7 @@ async fn test_create_simple_table() -> DeltaResult<()> {
     // Create table using new API
     let _ = create_table(&table_path, schema.clone(), "DeltaKernel-RS/0.17.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Verify table was created
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -120,7 +120,7 @@ async fn test_create_table_with_user_domain_metadata() -> DeltaResult<()> {
 
     let _ = txn
         .with_domain_metadata(domain.to_string(), config.to_string())
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Load snapshot and verify domain metadata was persisted
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -170,7 +170,7 @@ async fn test_create_table_already_exists() -> DeltaResult<()> {
     // Create table first time
     let _ = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Try to create again - should fail at build time (table already exists)
     let result = create_table(&table_path, schema.clone(), "UserManagementService/1.2.0")
@@ -191,7 +191,7 @@ async fn test_create_table_empty_schema_succeeds() -> DeltaResult<()> {
 
     create_table(&table_path, schema, "EmptySchemaApp/0.1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -223,7 +223,7 @@ async fn test_create_table_empty_schema_checkpoint_round_trip(
     }
     builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
@@ -296,7 +296,7 @@ fn test_create_table_with_non_null_columns_auto_enables_invariants(
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let protocol = snapshot.table_configuration().protocol();
@@ -332,7 +332,7 @@ async fn test_create_table_with_invariants_feature_signal_allowed() -> DeltaResu
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.invariants", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let protocol = snapshot.table_configuration().protocol();
@@ -393,7 +393,7 @@ async fn test_create_table_log_actions() -> DeltaResult<()> {
     // Create table
     let _ = create_table(&table_path, schema, engine_info)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Read the actual Delta log file
     let log_file_path = format!("{table_path}/_delta_log/00000000000000000000.json");
@@ -556,7 +556,7 @@ fn test_create_table_with_feature_signal(
     let _ = create_table(&table_path, simple_schema()?, "Test/1.0")
         .with_table_properties([(property_key.as_str(), "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let table_config = snapshot.table_configuration();
@@ -605,7 +605,7 @@ fn test_create_table_with_checkpoint_stats_properties(
             ("delta.checkpoint.writeStatsAsStruct", struct_val.as_str()),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let tp = snapshot.table_properties();
@@ -638,7 +638,7 @@ fn test_create_table_with_enablement_property(
     let _ = create_table(&table_path, simple_schema()?, "Test/1.0")
         .with_table_properties([(property, value.as_str())])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     let table_config = snapshot.table_configuration();
@@ -693,7 +693,7 @@ fn test_create_table_special_char_column_name(#[case] cm_enabled: bool) -> Delta
 
     if cm_enabled {
         let txn = result?;
-        let _ = txn.commit(engine.as_ref())?;
+        let _ = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
         let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
         assert_eq!(snapshot.version(), 0);

--- a/kernel/tests/integration/create_table/partitioned.rs
+++ b/kernel/tests/integration/create_table/partitioned.rs
@@ -23,7 +23,7 @@ fn test_create_table_partitioned_basic(#[case] partition_col: &str) -> DeltaResu
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned([partition_col]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert_eq!(snapshot.version(), 0);
@@ -65,7 +65,7 @@ fn test_create_table_with_materialize_partition_columns_partitioned_and_not(
     }
     let _ = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(

--- a/kernel/tests/integration/create_table/row_tracking.rs
+++ b/kernel/tests/integration/create_table/row_tracking.rs
@@ -103,7 +103,9 @@ async fn test_create_table_with_row_tracking(
         txn.add_files(add_files);
     }
 
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let snapshot = committed
         .post_commit_snapshot()
         .expect("should have snapshot");
@@ -233,7 +235,9 @@ async fn test_create_table_with_multiple_files_and_row_tracking() -> DeltaResult
     txn.add_files(adds1);
     txn.add_files(adds2);
 
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     assert_eq!(committed.commit_version(), 0);
 
     let table_url = Url::from_directory_path(&table_path).expect("valid path");
@@ -272,7 +276,7 @@ fn test_create_table_with_row_tracking_and_clustering() -> DeltaResult<()> {
         .with_table_properties([("delta.enableRowTracking", "true")])
         .with_data_layout(DataLayout::clustered(["id"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let snapshot = committed
@@ -341,7 +345,9 @@ async fn test_create_table_with_row_tracking_and_clustering_and_data() -> DeltaR
         .await?;
     txn.add_files(add_files);
 
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let snapshot = committed
         .post_commit_snapshot()
         .expect("should have snapshot");
@@ -409,7 +415,7 @@ async fn test_feature_signal_create_then_append_assigns_correct_base_row_id() ->
     let _ = create_table(&table_path, super::simple_schema()?, "Test/1.0")
         .with_table_properties([("delta.feature.rowTracking", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = Url::from_directory_path(&table_path).expect("valid path");
 

--- a/kernel/tests/integration/create_table/timestamp_ntz.rs
+++ b/kernel/tests/integration/create_table/timestamp_ntz.rs
@@ -50,7 +50,7 @@ fn test_create_table_with_timestamp_ntz(
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(cm_properties(cm_mode))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -94,7 +94,7 @@ fn test_create_table_no_timestamp_ntz_no_feature() -> DeltaResult<()> {
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -121,7 +121,7 @@ fn test_create_table_timestamp_ntz_and_variant() -> DeltaResult<()> {
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;

--- a/kernel/tests/integration/create_table/variant.rs
+++ b/kernel/tests/integration/create_table/variant.rs
@@ -55,7 +55,7 @@ fn test_create_table_with_variant(
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties(cm_properties(cm_mode))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -101,7 +101,7 @@ fn test_create_table_no_variant_no_feature() -> DeltaResult<()> {
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -707,7 +707,7 @@ async fn scan_with_replace_table_schema_change(
         .with_data_layout(DataLayout::partitioned(["part"]))
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     let store: Arc<delta_kernel::object_store::DynObjectStore> = Arc::new(LocalFileSystem::new());
@@ -966,7 +966,7 @@ async fn partition_pruning_honors_rfc3339_offset_partition_values(
     create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["ts"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // v1: adds in the style of an offset-emitting foreign writer. Pruning never opens data
@@ -1043,7 +1043,7 @@ async fn interval_partition_values_do_not_prune_files(
     let mut snapshot = create_table(&table_path, schema, "Test/1.0")
         .with_data_layout(DataLayout::partitioned(["period"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     let data_schema = StructType::try_new([StructField::nullable("v", DataType::LONG)])?;
     let batch = RecordBatch::try_new(

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -93,7 +93,7 @@ async fn add_columns_lifecycle(
             .alter_table()
             .add_column(StructField::nullable(name, DataType::STRING))
             .build(engine.as_ref(), committer())?
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_committed();
         let post = committed
             .post_commit_snapshot()
@@ -279,7 +279,7 @@ async fn add_complex_type_column(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
@@ -360,7 +360,7 @@ async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error:
         .alter_table()
         .add_column(StructField::nullable("a", DataType::STRING))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v1_snap = v1
         .post_commit_snapshot()
@@ -374,7 +374,7 @@ async fn back_to_back_alters_with_checkpoint() -> Result<(), Box<dyn std::error:
         .alter_table()
         .add_column(StructField::nullable("b", DataType::INTEGER))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v2_snap = v2
         .post_commit_snapshot()
@@ -481,7 +481,7 @@ async fn empty_create_then_add_column(
     v0.alter_table()
         .add_column(StructField::nullable("id", DataType::INTEGER))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let v1 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -583,7 +583,7 @@ async fn set_nullable_succeeds(
         .alter_table()
         .set_nullable(column.clone())
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(table_path).build(engine.as_ref())?;
@@ -629,7 +629,7 @@ async fn set_nullable_on_layout_column_with_checkpoint(
         .with_data_layout(layout)
         .with_table_properties(properties)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v0 = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     assert!(!v0.schema().field(col_name).unwrap().is_nullable());
@@ -672,7 +672,7 @@ async fn set_nullable_on_layout_column_with_checkpoint(
         .alter_table()
         .set_nullable(ColumnName::new([col_name]))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v2_snap = v2
         .post_commit_snapshot()
@@ -759,7 +759,7 @@ async fn chain_add_column_and_set_nullable(
         .add_column(StructField::nullable("email", DataType::STRING))
         .set_nullable(column_name!("id"))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v1_snap = v1
         .post_commit_snapshot()
@@ -770,7 +770,7 @@ async fn chain_add_column_and_set_nullable(
         .add_column(StructField::nullable("age", DataType::INTEGER))
         .set_nullable(column_name!("name"))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let v2_snap = v2
         .post_commit_snapshot()
@@ -854,7 +854,7 @@ async fn add_column_with_stray_cm_metadata_on_non_cm_table_is_stripped(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Reload from disk so we assert on the persisted schemaString, not the in-memory config.
@@ -896,7 +896,7 @@ async fn add_column_strip_is_none_mode_only(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -947,7 +947,7 @@ async fn add_column_with_orphan_default_metadata_succeeds() -> DeltaResult<()> {
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1047,7 +1047,7 @@ async fn add_column_preserves_complete_cm_metadata(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1086,7 +1086,7 @@ async fn add_column_with_only_physical_name_allocates_id(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1124,7 +1124,7 @@ async fn add_column_with_only_id_fills_physical_name(
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1174,7 +1174,7 @@ async fn add_column_with_id_below_max_column_id_succeeds() -> DeltaResult<()> {
         .alter_table()
         .add_column(field)
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let reloaded = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1271,7 +1271,7 @@ async fn add_column_on_stale_table_leaves_schema_untouched(
         .alter_table()
         .add_column(added_field)
         .build(&engine, committer())?
-        .commit(&engine)?
+        .commit(&engine, false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Reload from disk so we assert on the persisted schemaString, not the in-memory config.

--- a/kernel/tests/integration/features/clustering_e2e.rs
+++ b/kernel/tests/integration/features/clustering_e2e.rs
@@ -49,7 +49,7 @@ async fn test_clustered_table_write_and_checkpoint(
             columns: expected_clustering.clone(),
         })
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = if use_fresh_snapshot {
         // Open a fresh snapshot (as if a different process is writing)
@@ -166,7 +166,7 @@ async fn test_clustered_table_write_all_null_clustering_column() {
         })
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .unwrap()
-        .commit(engine.as_ref())
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)
         .unwrap();
 
     let snapshot = create_result

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -217,7 +217,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     )?;
 
     txn.add_files(add_metadata);
-    let commit_result = txn.commit(engine.as_ref())?;
+    let commit_result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     assert!(matches!(
         commit_result,
         CommitResult::CommittedTransaction(_)
@@ -252,7 +252,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     dv_map.insert(data_file_path_1.clone(), dv_descriptor_1);
 
     txn.update_deletion_vectors(dv_map, scan_files.into_iter().map(Ok))?;
-    let commit_result = txn.commit(engine.as_ref())?;
+    let commit_result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     assert!(matches!(
         commit_result,
         CommitResult::CommittedTransaction(_)
@@ -306,7 +306,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
             .into_iter()
             .map(Ok),
     )?;
-    let commit_result = txn.commit(engine.as_ref())?;
+    let commit_result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     assert!(matches!(
         commit_result,
         CommitResult::CommittedTransaction(_)
@@ -427,7 +427,8 @@ async fn test_dv_update_stats_tight_bound(
     let mut dv_map = HashMap::new();
     dv_map.insert(data_file_path.to_string(), dv_descriptor);
     txn.update_deletion_vectors(dv_map, scan_files.into_iter().map(Ok))?;
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // The new AddFile must report tightBounds: false while preserving every other stats field.
     let v2_adds = read_actions_from_commit(&table_url, 2, "add")?;

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -153,7 +153,7 @@ async fn v3_commit_validates_num_records(
         .with_table_properties([("delta.enableIcebergCompatV3", "true")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .unwrap()
-        .commit(engine.as_ref())
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)
         .unwrap();
     let snapshot = Snapshot::builder_for(TABLE_ROOT)
         .build(engine.as_ref())
@@ -173,11 +173,17 @@ async fn v3_commit_validates_num_records(
 
     match expected {
         Ok(expected_version) => {
-            let committed = txn.commit(engine.as_ref()).unwrap().unwrap_committed();
+            let committed = txn
+                .commit(engine.as_ref(), false /* skip_duplicate_validation */)
+                .unwrap()
+                .unwrap_committed();
             assert_eq!(committed.commit_version(), expected_version);
         }
         Err(needle) => {
-            let err = txn.commit(engine.as_ref()).unwrap_err().to_string();
+            let err = txn
+                .commit(engine.as_ref(), false /* skip_duplicate_validation */)
+                .unwrap_err()
+                .to_string();
             assert!(
                 err.contains(needle) && err.contains("part-fake.parquet"),
                 "expected error containing {needle:?} and 'part-fake.parquet', got: {err}",
@@ -258,7 +264,7 @@ async fn v3_e2e_partitioned_writes_with_field_ids(
         .with_data_layout(DataLayout::partitioned(["region"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))
         .unwrap()
-        .commit(engine.as_ref())
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)
         .unwrap();
 
     // === 4 commits (2 outer iters x 2 partitions), checkpoint, 4 more commits ===

--- a/kernel/tests/integration/features/maintenance_ops.rs
+++ b/kernel/tests/integration/features/maintenance_ops.rs
@@ -24,7 +24,7 @@ async fn test_checkpoint_and_checksum_return_updated_snapshots(
     }
     let committed = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
 
@@ -81,7 +81,7 @@ async fn test_checkpoint_already_exists(#[case] v2_checkpoint: bool) -> DeltaRes
     }
     let committed = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
 

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -104,7 +104,7 @@ async fn write_data_to_table(
     }
 
     // Commit the transaction
-    txn.commit(engine.as_ref())
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)
 }
 
 /// Helper function to create a row-tracking table with a single `number: INTEGER` column.
@@ -628,7 +628,9 @@ async fn test_row_tracking_without_adds() -> DeltaResult<()> {
     let txn = load_and_begin_transaction(table_url.clone(), engine.as_ref())?;
 
     // Commit without adding any add files
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     // Fetch and parse the commit
     let commit_url = table_url.join(&format!("_delta_log/{:020}.json", 1))?;
@@ -696,7 +698,7 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     txn2.add_files(metadata2);
 
     // Commit the first transaction - this should succeed
-    let result1 = txn1.commit(engine1.as_ref())?;
+    let result1 = txn1.commit(engine1.as_ref(), false /* skip_duplicate_validation */)?;
     match result1 {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(
@@ -717,7 +719,7 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     }
 
     // Commit the second transaction - this should result in a conflict
-    let result2 = txn2.commit(engine2.as_ref())?;
+    let result2 = txn2.commit(engine2.as_ref(), false /* skip_duplicate_validation */)?;
     match result2 {
         CommitResult::CommittedTransaction(committed) => {
             panic!(
@@ -982,7 +984,8 @@ async fn test_read_row_ids_stable_across_deletion_vector_update(
             .into_iter()
             .map(Ok),
     )?;
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // Every survivor keeps the exact row ID it had before.
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -64,7 +64,7 @@ async fn test_get_file_stats_no_crc() -> DeltaResult<()> {
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -94,7 +94,7 @@ async fn test_get_file_stats_stale_crc_advances_via_safe_commit_serves_stats() -
     // Safe (WRITE) commit with no file actions advances to version 1 (no new CRC written).
     begin_transaction(snapshot, engine.as_ref())?
         .with_operation("WRITE".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // ===== THEN =====
@@ -206,7 +206,7 @@ async fn test_snapshot_loads_when_crc_at_version_is_corrupt() -> DeltaResult<()>
     let schema = schema_ref! { nullable "id": INTEGER };
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Plant a garbage CRC file at the table version.
     let crc_path = _temp_dir.path().join("_delta_log/00000000000000000000.crc");
@@ -267,7 +267,7 @@ async fn test_crc_returns_none_when_no_crc() -> DeltaResult<()> {
 
     let _ = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -292,7 +292,9 @@ fn create_table_and_commit(
         .build(engine, Box::new(FileSystemCommitter::new()))?
         .with_domain_metadata("zip".to_string(), "zap0".to_string());
 
-    Ok(txn.commit(engine)?.unwrap_committed())
+    Ok(txn
+        .commit(engine, false /* skip_duplicate_validation */)?
+        .unwrap_committed())
 }
 
 #[tokio::test]
@@ -342,7 +344,7 @@ async fn test_post_commit_crc_chains_only_if_read_snapshot_has_crc(
     let committed = begin_transaction(read_snapshot, engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // The new post-commit snapshot should only have a CRC if the read snapshot had one.
@@ -423,7 +425,9 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     for sm in scan.scan_metadata(engine.as_ref())? {
         txn.remove_files(sm?.scan_files);
     }
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // ===== THEN: should have CRC at v3 with right file stats =====
     assert_eq!(committed.commit_version(), 3);
@@ -454,7 +458,9 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string()) // <-- set to zap1
         .with_domain_metadata("foo".to_string(), "bar".to_string()); // <-- add foo
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // ===== THEN: should have CRC at v1 with zip -> zap1, foo -> bar =====
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
@@ -467,7 +473,9 @@ async fn test_post_commit_crc_tracks_domain_metadata_changes() -> DeltaResult<()
     let txn = begin_transaction(snapshot_v1.clone(), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata_removed("zip".to_string()); // <-- remove zip
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // ===== THEN: should have CRC at v2 with zip gone, foo still there =====
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
@@ -497,7 +505,7 @@ async fn test_post_commit_crc_non_incremental_op_makes_file_stats_indeterminate(
     // ===== WHEN: Commit a non-incremental operation (ANALYZE STATS) =====
     let committed = begin_transaction(snapshot_v1.clone(), engine.as_ref())?
         .with_operation("ANALYZE STATS".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // ===== THEN: CRC at v2 has indeterminate file stats =====
@@ -597,7 +605,7 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
     }
     let mut snap = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     const CHECKPOINT_OR_CRC_VERSION: i64 = 4;
@@ -637,7 +645,9 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
             .await?;
         txn.add_files(adds);
-        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        snap = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_post_commit_snapshot();
 
         if checkpoint_or_crc_version == Some(v) {
             match root {
@@ -731,7 +741,7 @@ async fn test_disabled_load_retains_stale_crc_as_base() -> DeltaResult<()> {
     let snap0 = Snapshot::builder_for(table_path.clone()).build(engine.as_ref())?;
     begin_transaction(snap0, engine.as_ref())?
         .with_operation("WRITE".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Default Disabled load at v1: the stale CRC@0 is not advanced, but it is retained as a base.
@@ -771,7 +781,7 @@ async fn test_write_checksum_after_checkpoint_with_stale_base_resolves_from_chec
     let snap0 = Snapshot::builder_for(table_path.clone()).build(engine.as_ref())?;
     begin_transaction(snap0, engine.as_ref())?
         .with_operation("WRITE".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Disabled load retains stale CRC@0 as base; checkpoint at v1 carries state forward and drops
@@ -805,7 +815,7 @@ async fn setup_incremental_below_checkpoint_base<E: TaskExecutor>(
     let schema = schema_ref! { nullable "id": INTEGER };
     let mut snap = create_table(table_path, schema, "test_engine")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     for v in 1..=3i32 {
         let arrow_schema = TryFromKernel::try_from_kernel(snap.schema().as_ref())?;
@@ -823,7 +833,9 @@ async fn setup_incremental_below_checkpoint_base<E: TaskExecutor>(
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
             .await?;
         txn.add_files(adds);
-        snap = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        snap = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_post_commit_snapshot();
         if v == 1 {
             snap.write_checksum(engine.as_ref())?;
         }
@@ -907,7 +919,7 @@ async fn test_write_checksum_from_checkpoint_ict_enabled_but_commit_unreadable_p
             ("delta.enableInCommitTimestamps", "true"),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     let snap = insert_data(
         snap,
@@ -945,7 +957,7 @@ async fn test_write_checksum_no_crc_with_non_incremental_tail_returns_unsupporte
     let schema = schema_ref! { nullable "id": INTEGER };
     let snap = create_table(&table_path, schema, "test_engine")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     let snap = insert_data(
         snap,
@@ -958,7 +970,7 @@ async fn test_write_checksum_no_crc_with_non_incremental_tail_returns_unsupporte
     // Non-incremental operation in the tail dooms file stats regardless of the checkpoint.
     begin_transaction(snap, engine.as_ref())?
         .with_operation("ANALYZE STATS".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let fresh = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
@@ -1135,7 +1147,7 @@ async fn test_write_checksum_with_no_dms_writes_empty_list(
     }
     let committed = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let snapshot = committed.post_commit_snapshot().unwrap();
@@ -1187,7 +1199,7 @@ async fn test_get_domain_metadata_with_crc_skips_log_replay() -> DeltaResult<()>
         .with_operation("WRITE".to_string())
         .with_domain_metadata("zip".to_string(), "zap1".to_string())
         .with_domain_metadata("foo".to_string(), "bar".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Asserts domain metadata on any snapshot, regardless of how it was loaded.
@@ -1285,7 +1297,7 @@ async fn test_partial_dm_serves_hits_and_falls_through_for_misses() -> DeltaResu
     let committed = begin_transaction(snapshot_v0.clone(), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_domain_metadata("foo".to_string(), "bar".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
 
@@ -1370,7 +1382,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
     let committed = begin_transaction(snapshot_v0.clone(), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
 
@@ -1414,7 +1426,7 @@ async fn test_set_transaction_crc_tracking_and_fast_path() -> DeltaResult<()> {
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 2)
         .with_transaction_id("other-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
 
@@ -1465,7 +1477,7 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
     let committed = begin_transaction(snapshot_v0.clone(), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("v1-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v1 = committed.post_commit_snapshot().unwrap();
     snapshot_v1.write_checksum(engine.as_ref())?;
@@ -1486,7 +1498,7 @@ async fn test_partial_set_txn_serves_hits_and_falls_through_for_misses() -> Delt
     let committed = begin_transaction(snapshot_v1_reloaded.clone(), engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
 
@@ -1556,7 +1568,7 @@ async fn test_set_txn_expiration_via_crc_fast_path(
     }
     let committed = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // v1: commit a set transaction for "my-app" (lastUpdated = now)
@@ -1564,7 +1576,7 @@ async fn test_set_txn_expiration_via_crc_fast_path(
     let committed = begin_transaction(snapshot_v0, engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Write CRC at v1 so the fast path is used on reload
@@ -1603,7 +1615,7 @@ async fn test_partial_set_txn_expired_hit_returns_none_via_fast_path() -> DeltaR
             "interval 0 seconds",
         )])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // v1: commit my-app=1, write CRC at v1.
@@ -1611,7 +1623,7 @@ async fn test_partial_set_txn_expired_hit_returns_none_via_fast_path() -> DeltaR
     let committed = begin_transaction(snapshot_v0, engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     committed
         .post_commit_snapshot()
@@ -1626,7 +1638,7 @@ async fn test_partial_set_txn_expired_hit_returns_none_via_fast_path() -> DeltaR
     let committed = begin_transaction(snapshot_v1_reloaded, engine.as_ref())?
         .with_operation("WRITE".to_string())
         .with_transaction_id("my-app".to_string(), 2)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot_v2 = committed.post_commit_snapshot().unwrap();
 
@@ -1660,7 +1672,7 @@ async fn test_set_txn_null_last_updated_never_expires_via_log_replay() -> DeltaR
             "interval 0 seconds",
         )])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // v1: raw commit with txn action that omits lastUpdated
@@ -1698,7 +1710,7 @@ async fn test_set_txn_expired_newest_returns_none_not_older_via_log_replay() -> 
     create_table(&table_path, schema, "test_engine")
         .with_table_properties([("delta.setTransactionRetentionDuration", "interval 365 days")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let store = Arc::new(LocalFileSystem::new());
@@ -1821,7 +1833,7 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     // ===== v0: empty table =====
     let committed = create_table(&table_path, schema, "test_engine")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
     let crc_v0 = write_and_verify_crc(snapshot, &table_path, engine.as_ref());
@@ -1898,7 +1910,9 @@ async fn test_file_histogram_tracks_adds_and_removes_across_bins() -> DeltaResul
     for sm in scan.scan_metadata(engine.as_ref())? {
         txn.remove_files(sm?.scan_files);
     }
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap();
 
     // Delete physical parquet files so disk ground truth reflects the empty table
@@ -2036,7 +2050,7 @@ async fn test_file_histogram_with_bin_type_and_operation_type(
     } else {
         let committed = begin_transaction(fresh_v1, engine.as_ref())?
             .with_operation("ANALYZE STATS".to_string())
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_committed();
         assert_eq!(committed.commit_version(), 2);
         committed.post_commit_snapshot().unwrap().clone()
@@ -2121,7 +2135,9 @@ async fn commit_data<E: TaskExecutor>(
         .write_parquet(&ArrowEngineData::new(batch), &write_context)
         .await?;
     txn.add_files(adds);
-    Ok(txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot())
+    Ok(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_post_commit_snapshot())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -2162,7 +2178,7 @@ async fn test_stale_crc_fresh_build_advance_matrix(
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .with_domain_metadata("domain_at_create".to_string(), "value_0".to_string())
         .with_transaction_id("app_at_create".to_string(), 0)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // === Step 2: Commits up to CHECKPOINT_VERSION, followed by a checkpoint. ===
@@ -2304,7 +2320,7 @@ async fn test_stale_crc_fresh_build_non_incremental_op_trips_indeterminate() -> 
     // ===== WHEN: a non-incremental operation (ANALYZE STATS) commits at v2 =====
     begin_transaction(snap, engine.as_ref())?
         .with_operation("ANALYZE STATS".to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // ===== THEN: advancing the stale CRC trips file stats to Indeterminate, so they are not
@@ -2428,7 +2444,7 @@ async fn setup_stale_crc_dm_table<E: TaskExecutor>(
     let mut snap = create_table(table_path, schema, "test_engine")
         .with_table_properties([("delta.feature.domainMetadata", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     for v in 1..=20i64 {
@@ -2583,7 +2599,7 @@ async fn setup_stale_crc_txn_table<E: TaskExecutor>(
     let schema = schema_ref! { nullable "id": INTEGER };
     let mut snap = create_table(table_path, schema, "test_engine")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     for v in 1..=20i64 {

--- a/kernel/tests/integration/log/history_manager.rs
+++ b/kernel/tests/integration/log/history_manager.rs
@@ -73,14 +73,14 @@ fn test_at_timestamp_resolves_to_intermediate_version() -> DeltaResult<()> {
     let schema = get_simple_int_schema();
     let mut snap = create_table(&table_path, schema, "AtTimestampTest/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // v1..=4: noop commits (each writes a metaData-free, add-free commit JSON).
     for _ in 1..=4 {
         snap = test_utils::begin_transaction(snap.clone(), engine.as_ref())?
             .with_engine_info("AtTimestampTest")
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_post_commit_snapshot();
     }
 

--- a/kernel/tests/integration/log/snapshot_build.rs
+++ b/kernel/tests/integration/log/snapshot_build.rs
@@ -87,7 +87,7 @@ async fn setup_multi_version_table<E: TaskExecutor>(
     };
     let create_snapshot = builder
         .build(engine.as_ref(), kind.committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // The create-table snapshot is built as latest (version 0 is necessarily the latest).

--- a/kernel/tests/integration/log/v2_checkpoints.rs
+++ b/kernel/tests/integration/log/v2_checkpoints.rs
@@ -266,7 +266,7 @@ async fn test_v2_checkpoint_parquet_write() -> DeltaResult<()> {
     let _ = create_table(&table_path, schema.clone(), "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Commit an add action via the transaction API so the checkpoint has action batches
     let snapshot0 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
@@ -360,7 +360,7 @@ async fn test_v2_checkpoint_with_sidecars() -> DeltaResult<()> {
 
     let post_ckpt_snapshot = begin_transaction(post_ckpt_snapshot, engine.as_ref())?
         .with_domain_metadata("app.settings".to_string(), r#"{"version":3}"#.to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // === Step 4: Validate `_last_checkpoint` (version, size, sizeInBytes, numOfAddFiles) ===
@@ -772,7 +772,7 @@ async fn test_checkpoint_spec_rejected(
     }
     let _ = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
 
@@ -800,7 +800,7 @@ async fn test_v2_sidecar_checkpoint_with_no_file_actions() -> DeltaResult<()> {
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
     let version = snapshot.version();
@@ -893,7 +893,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
             ("delta.feature.domainMetadata", "supported"),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // Insert 8 files (one per commit) -> ids 1..=8
     let mut snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
@@ -914,7 +914,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
             "app.feature_flags".to_string(),
             r#"{"dark_mode":true}"#.to_string(),
         )
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // Another domain metadata commit -- updates "app.settings" to verify reconciliation
@@ -925,7 +925,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
             r#"{"tracking":false}"#.to_string(),
         )
         .with_domain_metadata("app.settings".to_string(), r#"{"version":2}"#.to_string())
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // SetTransaction commits -- exercise `txn` actions in checkpoint. Two distinct app_ids
@@ -933,7 +933,7 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     for (app_id, version) in [("app1", 1i64), ("app2", 5), ("app1", 3)] {
         snapshot = begin_transaction(snapshot, engine.as_ref())?
             .with_transaction_id(app_id.to_string(), version)
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_post_commit_snapshot();
     }
 
@@ -945,7 +945,9 @@ async fn v2_table_with_domain_metadata_and_txn<E: TaskExecutor>(
     for sm in scan.scan_metadata(engine.as_ref())? {
         txn.remove_files(sm?.scan_files);
     }
-    snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+    snapshot = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_post_commit_snapshot();
 
     // Insert 8 fresh files (one per commit) -> ids 9..=16
     let names = [
@@ -1134,7 +1136,7 @@ async fn create_partitioned_stats_table<E: TaskExecutor>(
         ])
         .with_data_layout(DataLayout::partitioned(["part_key"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let data_schema = StructType::try_new(vec![
         StructField::nullable("id", DataType::LONG),
@@ -1420,7 +1422,7 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
             ("delta.enableRowTracking", "true"),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // === Step 2: Append one batch. ===
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
@@ -1455,7 +1457,9 @@ async fn test_v2_sidecar_preserves_dv_and_row_tracking_on_add(
         HashMap::from([(path, dv.clone())]),
         scan_files.into_iter().map(Ok),
     )?;
-    let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+    let snapshot = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_post_commit_snapshot();
 
     // === Step 4: Write a V2 sidecar checkpoint. ===
     snapshot.checkpoint(
@@ -1512,7 +1516,7 @@ async fn test_v2_sidecar_default_hint_splits_at_50k() -> Result<(), Box<dyn std:
     let _ = create_table(&table_path, get_simple_schema(), "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // === Step 2: Run 60 commits of 1_000 synthetic adds each (60_000 total). ===
     let mut snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
@@ -1528,7 +1532,9 @@ async fn test_v2_sidecar_default_hint_splits_at_50k() -> Result<(), Box<dyn std:
             .map(|p| (p.as_str(), 100, 0, Some(1)))
             .collect();
         txn.add_files(create_add_files_metadata(&add_files_schema, files)?);
-        snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        snapshot = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_post_commit_snapshot();
     }
 
     // === Step 3: Sidecar checkpoint with default hint (None -> 50_000). ===
@@ -1622,7 +1628,7 @@ async fn build_v2_table_with_feature<E: TaskExecutor>(
     }
     let _ = builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     // For partitioned tables, the data batches must NOT include the partition column --
     // the partition value is supplied separately in `partition_values`.
@@ -1675,7 +1681,7 @@ async fn snapshot_selects_uuid_checkpoint_over_classic_at_one_version() -> Delta
     let _ = create_table(&table_path, schema, "Test/1.0")
         .with_table_properties([("delta.feature.v2Checkpoint", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot0 = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let snapshot = insert_data(

--- a/kernel/tests/integration/metrics/commit.rs
+++ b/kernel/tests/integration/metrics/commit.rs
@@ -55,7 +55,10 @@ fn setup_empty_table() -> DeltaResult<(tempfile::TempDir, Url)> {
     let table_url = delta_kernel::try_parse_uri(&table_path)?;
     create_table(&table_path, simple_schema(), "Test/1.0")
         .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(setup_engine.as_ref())?
+        .commit(
+            setup_engine.as_ref(),
+            false, /* skip_duplicate_validation */
+        )?
         .unwrap_committed();
     Ok((temp_dir, table_url))
 }
@@ -132,7 +135,8 @@ async fn commit_reports_added_file_count_not_batch_count() -> DeltaResult<()> {
             .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
         txn.add_files(metadata);
     }
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     let success = reporter.take_success();
     assert_eq!(success.num_add_files, 4);
@@ -150,7 +154,10 @@ async fn commit_success_carries_correlation_id() -> DeltaResult<()> {
     create_table(&table_path, simple_schema(), "Test/1.0")
         .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
         .with_correlation_id("commit-req-1")
-        .commit(setup_engine.as_ref())?
+        .commit(
+            setup_engine.as_ref(),
+            false, /* skip_duplicate_validation */
+        )?
         .unwrap_committed();
 
     let success = reporter.take_success();
@@ -181,7 +188,7 @@ async fn create_table_builder_carries_correlation_id(
     }
     builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let success = reporter.take_success();
@@ -206,7 +213,7 @@ async fn alter_table_builder_carries_correlation_id(
     let (_temp_dir, table_path, engine) = test_table_setup_mt()?;
     create_table(&table_path, simple_schema(), "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Install the reporter after the create commit so the captured event is the alter commit.
@@ -223,7 +230,7 @@ async fn alter_table_builder_carries_correlation_id(
     builder
         .add_column(StructField::nullable("extra", DataType::STRING))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     let success = reporter.take_success();
@@ -336,7 +343,8 @@ async fn commit_dv_update_reports_updated_file_count_not_batch_count(
     let mut scan_files = get_scan_files(snapshot, engine.as_ref())?;
     let dv_map = sequential_dv_descriptors(&file_paths);
     txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     let success = reporter.take_success();
     assert_eq!(success.num_dv_updates, 3);
@@ -372,7 +380,8 @@ async fn commit_dv_update_accumulates_file_count_across_calls(
         let dv_map = std::iter::once((path.clone(), all_descriptors[path].clone())).collect();
         txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
     }
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     let success = reporter.take_success();
     assert_eq!(success.num_dv_updates, 2);

--- a/kernel/tests/integration/metrics/mod.rs
+++ b/kernel/tests/integration/metrics/mod.rs
@@ -108,7 +108,10 @@ async fn setup_table_with_v1_checkpoint() -> DeltaResult<(
 
     let _ = create_table(&table_path, simple_schema(), "Test/1.0")
         .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(setup_engine.as_ref())?;
+        .commit(
+            setup_engine.as_ref(),
+            false, /* skip_duplicate_validation */
+        )?;
 
     let snap0 = Snapshot::builder_for(table_url.clone()).build(setup_engine.as_ref())?;
     let committed = insert_data(

--- a/kernel/tests/integration/metrics/snapshot_load.rs
+++ b/kernel/tests/integration/metrics/snapshot_load.rs
@@ -264,7 +264,10 @@ async fn crc_at_prior_version_roots_replay_at_crc_for_both_modes(
     // commit 0: create table, then write its CRC (write_checksum needs the post-commit CRC).
     let create_committed = create_table(&table_path, simple_schema(), "Test/1.0")
         .build(setup_engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(setup_engine.as_ref())?
+        .commit(
+            setup_engine.as_ref(),
+            false, /* skip_duplicate_validation */
+        )?
         .unwrap_committed();
     create_committed
         .post_commit_snapshot()
@@ -420,7 +423,7 @@ async fn setup_table_with_dms_and_set_txns(
         .with_table_properties(properties)
         .with_data_layout(DataLayout::clustered(["id"]))
         .build(engine.as_ref(), committer())?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     let snap_v1 = snap_v0
@@ -428,7 +431,7 @@ async fn setup_table_with_dms_and_set_txns(
         .with_operation("WRITE".to_string())
         .with_domain_metadata("myapp.config".to_string(), "v1".to_string())
         .with_transaction_id("my-app".to_string(), 1)
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     if write_crc {

--- a/kernel/tests/integration/metrics/table_type.rs
+++ b/kernel/tests/integration/metrics/table_type.rs
@@ -192,7 +192,7 @@ pub(super) fn create_simple_table(
     };
     builder
         .build(engine, make_committer(catalog_managed))?
-        .commit(engine)?
+        .commit(engine, false /* skip_duplicate_validation */)?
         .unwrap_committed();
     Ok(())
 }

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -137,7 +137,9 @@ async fn test_no_add_actions() -> Result<(), Box<dyn std::error::Error>> {
             .with_engine_info("default engine");
 
         // Commit without adding any add files
-        assert!(txn.commit(&engine)?.is_committed());
+        assert!(txn
+            .commit(&engine, false /* skip_duplicate_validation */)?
+            .is_committed());
 
         let commit1 = store
             .get(&Path::from(format!(
@@ -246,7 +248,9 @@ async fn test_append_partitioned() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // commit!
-        assert!(txn.commit(engine.as_ref())?.is_committed());
+        assert!(txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .is_committed());
 
         let commit1 = store
             .get(&Path::from(format!(
@@ -429,7 +433,7 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
         txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
 
         let err = txn
-            .commit(engine.as_ref())
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)
             .expect_err(&format!(
                 "commit should reject an add missing required field '{field}'"
             ))
@@ -489,7 +493,7 @@ async fn commit_rejects_add_with_invalid_partition_keys(
     }
     builder
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     let data_schema: Arc<ArrowSchema> = Arc::new(
@@ -534,6 +538,9 @@ async fn commit_rejects_add_with_invalid_partition_keys(
     let add = make_add(&txn, "b", 6)?;
     let corrupted = modify_add_file_partition_keys(into_record_batch(add), &modifications);
     txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
-    assert_result_error_with_message(txn.commit(engine.as_ref()), "partitionValues keys");
+    assert_result_error_with_message(
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */),
+        "partitionValues keys",
+    );
     Ok(())
 }

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -58,7 +58,7 @@ async fn write_data_to_table(
 
     add_files_to_transaction(&mut txn, engine, schema, values).await?;
 
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     match result {
         CommitResult::CommittedTransaction(committed) => Ok(committed.commit_version()),
         _ => panic!("Transaction should be committed"),
@@ -127,7 +127,7 @@ async fn test_cdf_write_all_removes_succeeds() -> Result<(), Box<dyn std::error:
     txn.remove_files(FilteredEngineData::try_new(data, selection_vector)?);
 
     // This should succeed - remove-only transactions are allowed with CDF
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     match result {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(committed.commit_version(), 2);
@@ -169,7 +169,7 @@ async fn test_cdf_write_mixed_no_data_change_succeeds() -> Result<(), Box<dyn st
     txn.remove_files(FilteredEngineData::try_new(data, selection_vector)?);
 
     // This should succeed - mixed operations are allowed when dataChange=false
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     match result {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(committed.commit_version(), 2);
@@ -211,7 +211,7 @@ async fn test_cdf_write_mixed_with_data_change_fails() -> Result<(), Box<dyn std
 
     // This should fail with our new error message
     assert_result_error_with_message(
-        txn.commit(engine.as_ref()),
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */),
         "Cannot add and remove data in the same transaction when Change Data Feed is enabled (delta.enableChangeDataFeed = true). \
          This would require writing CDC files for DML operations, which is not yet supported. \
          Consider using separate transactions: one to add files, another to remove files."

--- a/kernel/tests/integration/write/clustered.rs
+++ b/kernel/tests/integration/write/clustered.rs
@@ -122,7 +122,7 @@ fn setup_clustered_table(
             columns: clustering_cols,
         })
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = set_table_properties(
         &table_path,

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -705,7 +705,7 @@ async fn test_defaulted_clustering_column_round_trips_with_stats(
     kernel_create_table(&table_path, schema.clone(), "Test/1.0")
         .with_data_layout(DataLayout::clustered(["c"]))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     add_column_defaults_feature_commit(Path::new(&table_path), 1, None)?;
 
@@ -758,7 +758,7 @@ async fn test_column_default_round_trips_with_column_mapping_and_checkpoint(
         .with_data_layout(DataLayout::partitioned(["p"]))
         .with_table_properties(table_properties)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
     add_column_defaults_feature_commit(Path::new(&table_path), 1, None)?;
 

--- a/kernel/tests/integration/write/column_mapping.rs
+++ b/kernel/tests/integration/write/column_mapping.rs
@@ -409,7 +409,7 @@ async fn test_same_phy_name_different_path(
     let snapshot = create_table(table_url.as_str(), logical_schema.clone(), "Test/1.0")
         .with_table_properties([("delta.columnMapping.mode", cm_mode)])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
 
     // Build a RecordBatch matching the logical schema.

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -32,7 +32,7 @@ async fn test_commit_info() -> Result<(), Box<dyn std::error::Error>> {
             .with_engine_info("default engine");
 
         // commit!
-        let _ = txn.commit(&engine)?;
+        let _ = txn.commit(&engine, false /* skip_duplicate_validation */)?;
 
         let commit1 = store
             .get(&Path::from(format!(
@@ -76,7 +76,7 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
         let txn = load_and_begin_transaction(table_url.clone(), &engine)?
             .with_engine_info("default engine");
 
-        let _ = txn.commit(&engine)?;
+        let _ = txn.commit(&engine, false /* skip_duplicate_validation */)?;
 
         let commit = store
             .get(&Path::from(format!(
@@ -152,7 +152,7 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
             .with_operation("WRITE".to_string())
             .with_commit_info(Box::new(ArrowEngineData::new(batch)), engine_schema);
 
-        let _ = txn.commit(&engine)?;
+        let _ = txn.commit(&engine, false /* skip_duplicate_validation */)?;
 
         let commit = store
             .get(&Path::from(format!(

--- a/kernel/tests/integration/write/domain_metadata.rs
+++ b/kernel/tests/integration/write/domain_metadata.rs
@@ -46,7 +46,7 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
     assert!(txn
         .with_domain_metadata(domain1.to_string(), config1.to_string())
         .with_domain_metadata(domain2.to_string(), config2.to_string())
-        .commit(&engine)?
+        .commit(&engine, false /* skip_duplicate_validation */)?
         .is_committed());
 
     let commit_data = store
@@ -111,7 +111,7 @@ async fn test_set_domain_metadata_errors() -> Result<(), Box<dyn std::error::Err
     let txn = begin_transaction(snapshot.clone(), &engine)?;
     let res = txn
         .with_domain_metadata("delta.system".to_string(), "config".to_string())
-        .commit(&engine);
+        .commit(&engine, false /* skip_duplicate_validation */);
     assert_result_error_with_message(
         res,
         "Cannot modify domains that start with 'delta.' as those are system controlled",
@@ -122,7 +122,7 @@ async fn test_set_domain_metadata_errors() -> Result<(), Box<dyn std::error::Err
     let res = txn2
         .with_domain_metadata("app.config".to_string(), "v1".to_string())
         .with_domain_metadata("app.config".to_string(), "v2".to_string())
-        .commit(&engine);
+        .commit(&engine, false /* skip_duplicate_validation */);
     assert_result_error_with_message(
         res,
         "Metadata for domain app.config already specified in this transaction",
@@ -156,7 +156,7 @@ async fn test_set_domain_metadata_unsupported_writer_feature(
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let res = begin_transaction(snapshot, &engine)?
         .with_domain_metadata("app.config".to_string(), "test_config".to_string())
-        .commit(&engine);
+        .commit(&engine, false /* skip_duplicate_validation */);
 
     assert_result_error_with_message(res, "Domain metadata operations require writer version 7 and the 'domainMetadata' writer feature");
 
@@ -188,7 +188,7 @@ async fn test_remove_domain_metadata_unsupported_writer_feature(
     let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
     let res = begin_transaction(snapshot, &engine)?
         .with_domain_metadata_removed("app.config".to_string())
-        .commit(&engine);
+        .commit(&engine, false /* skip_duplicate_validation */);
 
     assert_result_error_with_message(res, "Domain metadata operations require writer version 7 and the 'domainMetadata' writer feature");
 
@@ -223,7 +223,7 @@ async fn test_remove_domain_metadata_non_existent_domain() -> Result<(), Box<dyn
     // removing domain metadata that doesn't exist should NOT write a tombstone
     let _ = txn
         .with_domain_metadata_removed(domain.to_string())
-        .commit(&engine)?;
+        .commit(&engine, false /* skip_duplicate_validation */)?;
 
     let commit_data = store
         .get(&Path::from(format!(
@@ -276,7 +276,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     let err = txn
         .with_domain_metadata("app.config".to_string(), "v1".to_string())
         .with_domain_metadata_removed("app.config".to_string())
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap_err();
     assert!(err
         .to_string()
@@ -287,7 +287,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     let err = txn2
         .with_domain_metadata_removed("test.domain".to_string())
         .with_domain_metadata("test.domain".to_string(), "v1".to_string())
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap_err();
     assert!(err
         .to_string()
@@ -298,7 +298,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     let err = txn3
         .with_domain_metadata_removed("another.domain".to_string())
         .with_domain_metadata_removed("another.domain".to_string())
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap_err();
     assert!(err
         .to_string()
@@ -308,7 +308,7 @@ async fn test_domain_metadata_set_remove_conflicts() -> Result<(), Box<dyn std::
     let txn4 = begin_transaction(snapshot.clone(), &engine)?;
     let err = txn4
         .with_domain_metadata_removed("delta.system".to_string())
-        .commit(&engine)
+        .commit(&engine, false /* skip_duplicate_validation */)
         .unwrap_err();
     assert!(err
         .to_string()
@@ -344,13 +344,13 @@ async fn test_domain_metadata_set_then_remove() -> Result<(), Box<dyn std::error
     let txn = load_and_begin_transaction(table_url.clone(), &engine)?;
     let _ = txn
         .with_domain_metadata(domain.to_string(), configuration.to_string())
-        .commit(&engine)?;
+        .commit(&engine, false /* skip_duplicate_validation */)?;
 
     // txn 2: remove the same domain metadata
     let txn = load_and_begin_transaction(table_url.clone(), &engine)?;
     let _ = txn
         .with_domain_metadata_removed(domain.to_string())
-        .commit(&engine)?;
+        .commit(&engine, false /* skip_duplicate_validation */)?;
 
     // verify removal commit preserves the previous configuration
     let commit_data = store

--- a/kernel/tests/integration/write/ict.rs
+++ b/kernel/tests/integration/write/ict.rs
@@ -115,7 +115,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
     generate_and_add_data_file(&mut txn, &engine, schema.clone(), vec![1, 2, 3]).await?;
 
     // First commit
-    let commit_result = txn.commit(&engine)?;
+    let commit_result = txn.commit(&engine, false /* skip_duplicate_validation */)?;
     match commit_result {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(
@@ -160,7 +160,7 @@ async fn test_ict_commit_e2e() -> Result<(), Box<dyn std::error::Error>> {
     generate_and_add_data_file(&mut txn2, &engine, schema, vec![4, 5, 6]).await?;
 
     // Second commit
-    let commit_result2 = txn2.commit(&engine)?;
+    let commit_result2 = txn2.commit(&engine, false /* skip_duplicate_validation */)?;
     match commit_result2 {
         CommitResult::CommittedTransaction(committed) => {
             assert_eq!(

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -60,7 +60,7 @@ mod supported {
         let snapshot = create_table_transaction(&table_path, schema.clone(), "Test/1.0")
             .with_table_properties([("delta.checkpoint.writeStatsAsStruct", "true")])
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_post_commit_snapshot();
         let table_url = snapshot.table_root().clone();
 
@@ -93,7 +93,9 @@ mod supported {
             .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
             .await?;
         txn.add_files(add_files_metadata);
-        let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+        let snapshot = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_post_commit_snapshot();
 
         let add_actions = read_actions_from_commit(&table_url, 1, "add")?;
         let add = &add_actions[0];
@@ -209,7 +211,7 @@ mod supported {
         let snapshot = create_table_transaction(&table_path, schema.clone(), "Test/1.0")
             .with_table_properties([(property_name, property_value)])
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_post_commit_snapshot();
 
         let arrow_schema: ArrowSchema = schema.as_ref().try_into_arrow()?;

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -788,7 +788,7 @@ fn create_interval_partitioned_table(
         .with_data_layout(DataLayout::partitioned(["period"]))
         .with_table_properties(properties)
         .build(engine, Box::new(FileSystemCommitter::new()))?
-        .commit(engine)?
+        .commit(engine, false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     Ok(snapshot)
 }
@@ -815,7 +815,7 @@ fn create_partitioned_table(
     }
     let _ = builder
         .build(engine, Box::new(FileSystemCommitter::new()))?
-        .commit(engine)?;
+        .commit(engine, false /* skip_duplicate_validation */)?;
     Ok(Snapshot::builder_for(table_path).build(engine)?)
 }
 
@@ -1005,7 +1005,7 @@ async fn test_materialized_partition_columns_excluded_from_stats(
         .with_data_layout(DataLayout::partitioned([partition_col]))
         .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let mut txn = test_utils::load_and_begin_transaction(&table_path, engine.as_ref())?
         .with_engine_info("default engine");
@@ -1028,7 +1028,9 @@ async fn test_materialized_partition_columns_excluded_from_stats(
     )]))?;
     let result = engine.write_parquet(&data, &write_context).await?;
     txn.add_files(result);
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     let (add, _) = read_single_add(&table_path, 1)?;
     let stats: serde_json::Value = serde_json::from_str(add["stats"].as_str().unwrap()).unwrap();
@@ -1085,7 +1087,7 @@ async fn test_materialize_partition_columns_e2e(
             ("delta.columnMapping.mode", cm),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     // Data schema excludes partition columns.
@@ -1127,7 +1129,9 @@ async fn test_materialize_partition_columns_e2e(
             .await?;
         txn.add_files(add);
     }
-    let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+    let snapshot = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_post_commit_snapshot();
 
     // ===== Verify the materialized partition columns from parquet =====
     let logical_schema = snapshot.schema();
@@ -1194,7 +1198,7 @@ async fn test_materialize_all_primitive_partition_types() -> Result<(), Box<dyn 
         .with_data_layout(DataLayout::partitioned(PARTITION_COLS.iter().copied()))
         .with_table_properties([("delta.feature.materializePartitionColumns", "supported")])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     // Data schema excludes partition columns.
@@ -1256,7 +1260,7 @@ async fn test_input_data_with_partition_column_errors(
         .with_data_layout(DataLayout::partitioned([partition_col]))
         .with_table_properties(properties)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let txn = test_utils::load_and_begin_transaction(&table_path, engine.as_ref())?
         .with_engine_info("default engine");
@@ -1353,7 +1357,7 @@ async fn test_partition_null_validation(
         .with_data_layout(DataLayout::partitioned(["p"]))
         .with_table_properties(properties)
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
     let result = begin_transaction(snapshot, engine.as_ref())?

--- a/kernel/tests/integration/write/post_commit.rs
+++ b/kernel/tests/integration/write/post_commit.rs
@@ -32,7 +32,7 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
     // Create table and verify post_commit_snapshot
     let create_result = create_table_txn(table_url.as_str(), schema, env!("CARGO_PKG_VERSION"))
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let mut current_snapshot = match create_result {
         CommitResult::CommittedTransaction(committed) => {
@@ -59,7 +59,7 @@ async fn test_post_commit_snapshot_create_then_insert() -> DeltaResult<()> {
         let txn =
             begin_transaction(current_snapshot.clone(), engine.as_ref())?.with_engine_info("test");
 
-        match txn.commit(engine.as_ref())? {
+        match txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)? {
             CommitResult::CommittedTransaction(committed) => {
                 let post_snapshot = committed
                     .post_commit_snapshot()

--- a/kernel/tests/integration/write/relative_paths.rs
+++ b/kernel/tests/integration/write/relative_paths.rs
@@ -30,7 +30,9 @@ async fn write_batch_to_table_simple(
         .write_parquet(&ArrowEngineData::new(data), &write_context)
         .await?;
     txn.add_files(add_meta);
-    let committed = txn.commit(engine)?.unwrap_committed();
+    let committed = txn
+        .commit(engine, false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     Ok(committed.post_commit_snapshot().unwrap().clone())
 }
 
@@ -85,7 +87,9 @@ async fn test_multiple_files_in_commit_all_use_relative_paths(
             .await?;
         txn.add_files(add_meta);
     }
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap().clone();
 
     let add_infos = read_add_infos(&snapshot, engine.as_ref())?;
@@ -144,7 +148,9 @@ async fn test_create_table_with_data_uses_relative_paths() -> Result<(), Box<dyn
         )
         .await?;
     txn.add_files(add_meta);
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let snapshot = committed.post_commit_snapshot().unwrap().clone();
 
     let add_infos = read_add_infos(&snapshot, engine.as_ref())?;

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -10,7 +10,6 @@ use delta_kernel::arrow::array::{
     new_null_array, Array, ArrayRef, AsArray, Int32Array, Int64Array, RecordBatch, StringArray,
     StructArray,
 };
-use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::compute::{concat, concat_batches};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
@@ -23,7 +22,6 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::expressions::{
     col, lit, null_lit, ExpressionStructPatchBuilder, MapData, Scalar,
 };
-use delta_kernel::log_replay::FileActionKey;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::{scan_row_schema, StatsOptions};
@@ -37,9 +35,9 @@ use serde_json::Deserializer;
 use tempfile::tempdir;
 use test_utils::{
     assert_result_error_with_message, begin_transaction, copy_directory, create_add_files_metadata,
-    create_default_engine, create_default_engine_mt_executor, insert_data, into_record_batch,
-    load_and_begin_transaction, read_actions_from_commit, replace_array_row, replace_column,
-    setup_test_table_p37, setup_test_tables, test_table_setup,
+    create_default_engine, create_default_engine_mt_executor, deletion_vector_array, insert_data,
+    into_record_batch, load_and_begin_transaction, read_actions_from_commit, replace_array_row,
+    replace_column, setup_test_table_p37, setup_test_tables, test_table_setup,
 };
 use url::Url;
 
@@ -352,7 +350,7 @@ async fn commit_validates_file_action_uniqueness(
             .iter()
             .map(|file| {
                 (
-                    file.path(),
+                    file.path,
                     1, /* size */
                     1, /* modification_time */
                     Some(1),
@@ -386,7 +384,7 @@ async fn commit_validates_file_action_uniqueness(
                 size_in_bytes: 1,
                 cardinality: 1,
             };
-            (file.path().to_string(), descriptor)
+            (file.path.to_string(), descriptor)
         })
         .collect();
     txn.update_deletion_vectors(
@@ -408,13 +406,13 @@ async fn commit_validates_file_action_uniqueness(
 
 #[derive(Clone)]
 struct SelectedFileActions {
-    rows: [FileActionKey; 2],
+    rows: [FileActionInput; 2],
     selection_vector: &'static [bool],
 }
 
 #[derive(Clone)]
 struct FileActionUniquenessCase {
-    adds: [FileActionKey; 2],
+    adds: [FileActionInput; 2],
     removes: SelectedFileActions,
     dv_updates: SelectedFileActions,
     expected_error: Option<&'static str>,
@@ -446,66 +444,43 @@ impl FileActionUniquenessCase {
     }
 }
 
-fn file_action(path: &str, dv_unique_id: Option<&str>) -> FileActionKey {
-    FileActionKey::new(path, dv_unique_id.map(str::to_owned))
+#[derive(Clone, Copy)]
+struct FileActionInput {
+    path: &'static str,
+    path_or_inline_dv: Option<&'static str>,
+}
+
+const fn file_action(
+    path: &'static str,
+    path_or_inline_dv: Option<&'static str>,
+) -> FileActionInput {
+    FileActionInput {
+        path,
+        path_or_inline_dv,
+    }
 }
 
 fn apply_path_dv(
     base_row: &RecordBatch,
-    file_action_keys: &[FileActionKey],
+    file_actions: &[FileActionInput],
 ) -> Result<RecordBatch, ArrowError> {
     let batch = concat_batches(
         &base_row.schema(),
-        &vec![base_row.clone(); file_action_keys.len()],
+        &vec![base_row.clone(); file_actions.len()],
     )?;
     let paths = Arc::new(StringArray::from(
-        file_action_keys
+        file_actions
             .iter()
-            .map(FileActionKey::path)
+            .map(|file| file.path)
             .collect::<Vec<_>>(),
     ));
     let batch = replace_column(&batch, "path", paths);
 
-    let schema = batch.schema();
-    let deletion_vector_index = schema.index_of("deletionVector")?;
-    let ArrowDataType::Struct(fields) = schema.field(deletion_vector_index).data_type() else {
-        panic!("deletionVector should be a struct");
-    };
-    let dv_unique_ids = file_action_keys
+    let paths_or_inline_dvs = file_actions
         .iter()
-        .map(FileActionKey::dv_unique_id)
+        .map(|file| file.path_or_inline_dv)
         .collect::<Vec<_>>();
-    let deletion_vectors = Arc::new(StructArray::new(
-        fields.clone(),
-        vec![
-            Arc::new(StringArray::from(
-                dv_unique_ids
-                    .iter()
-                    .map(|dv_unique_id| dv_unique_id.map(|_| "u"))
-                    .collect::<Vec<_>>(),
-            )) as ArrayRef, // storageType
-            Arc::new(StringArray::from(dv_unique_ids.clone())) as ArrayRef, // pathOrInlineDv
-            Arc::new(Int32Array::from(vec![None; file_action_keys.len()])) as ArrayRef, // offset
-            Arc::new(Int32Array::from(
-                dv_unique_ids
-                    .iter()
-                    .map(|dv_unique_id| dv_unique_id.map(|_| 1))
-                    .collect::<Vec<_>>(),
-            )) as ArrayRef, // sizeInBytes
-            Arc::new(Int64Array::from(
-                dv_unique_ids
-                    .iter()
-                    .map(|dv_unique_id| dv_unique_id.map(|_| 1))
-                    .collect::<Vec<_>>(),
-            )) as ArrayRef, // cardinality
-        ],
-        Some(NullBuffer::from(
-            dv_unique_ids
-                .iter()
-                .map(Option::is_some)
-                .collect::<Vec<_>>(),
-        )),
-    ));
+    let deletion_vectors = Arc::new(deletion_vector_array("u", &paths_or_inline_dvs));
     Ok(replace_column(&batch, "deletionVector", deletion_vectors))
 }
 

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -10,6 +10,7 @@ use delta_kernel::arrow::array::{
     new_null_array, Array, ArrayRef, AsArray, Int32Array, Int64Array, RecordBatch, StringArray,
     StructArray,
 };
+use delta_kernel::arrow::buffer::NullBuffer;
 use delta_kernel::arrow::compute::{concat, concat_batches};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
@@ -22,6 +23,7 @@ use delta_kernel::engine_data::FilteredEngineData;
 use delta_kernel::expressions::{
     col, lit, null_lit, ExpressionStructPatchBuilder, MapData, Scalar,
 };
+use delta_kernel::log_replay::FileActionKey;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::{scan_row_schema, StatsOptions};
@@ -36,8 +38,8 @@ use tempfile::tempdir;
 use test_utils::{
     assert_result_error_with_message, begin_transaction, copy_directory, create_add_files_metadata,
     create_default_engine, create_default_engine_mt_executor, insert_data, into_record_batch,
-    load_and_begin_transaction, read_actions_from_commit, replace_array_row, setup_test_table_p37,
-    setup_test_tables, test_table_setup,
+    load_and_begin_transaction, read_actions_from_commit, replace_array_row, replace_column,
+    setup_test_table_p37, setup_test_tables, test_table_setup,
 };
 use url::Url;
 
@@ -214,152 +216,124 @@ fn selected_scan_file_batch(
 }
 
 #[rstest]
-#[case::duplicate(&["same.parquet", "same.parquet"], Some("multiple AddFile actions"))]
-#[case::distinct(&["first.parquet", "second.parquet"], None)]
-#[tokio::test]
-async fn commit_validates_add_file_path_uniqueness(
-    #[case] paths: &[&str],
-    #[case] expected_error: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "id",
-        DataType::INTEGER,
-    )])?);
-    let (_store, engine, table_url, _) =
-        create_dv_table_with_files("add_path_uniqueness", schema, &[], &["existing.parquet"])
-            .await?;
-    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    let mut txn = begin_transaction(snapshot, engine.as_ref())?;
-    let adds = create_add_files_metadata(
-        txn.add_files_schema(),
-        paths
-            .iter()
-            .map(|path| {
-                (
-                    *path,
-                    1, /* size */
-                    1, /* modification_time */
-                    Some(1),
-                )
-            })
-            .collect(),
-    )?;
-    txn.add_files(adds);
-
-    let result = txn.commit(engine.as_ref());
-    if let Some(expected_error) = expected_error {
-        assert_result_error_with_message(result, expected_error);
-    } else {
-        result?.unwrap_committed();
-    }
-    Ok(())
-}
-
-#[rstest]
-#[case::duplicate_selected(RemovePathCase {
-    duplicate_paths: true,
-    selection_vector: &[true, true],
+#[case::valid(FileActionUniquenessCase::valid())]
+#[case::duplicate_add(FileActionUniquenessCase {
+    adds: [
+        file_action("same.parquet", None),
+        file_action("same.parquet", None),
+    ],
+    expected_error: Some("multiple AddFile actions"),
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::duplicate_remove(FileActionUniquenessCase {
+    removes: SelectedFileActions {
+        rows: [
+            file_action("remove-0.parquet", None),
+            file_action("remove-0.parquet", Some("different-dv")),
+        ],
+        selection_vector: &[true, true],
+    },
     expected_error: Some("multiple RemoveFile actions"),
+    ..FileActionUniquenessCase::valid()
 })]
-#[case::duplicate_implicitly_selected(RemovePathCase {
-    duplicate_paths: true,
-    selection_vector: &[true],
+#[case::duplicate_remove_implicit_tail(FileActionUniquenessCase {
+    removes: SelectedFileActions {
+        rows: [
+            file_action("remove-0.parquet", None),
+            file_action("remove-0.parquet", None),
+        ],
+        selection_vector: &[true],
+    },
     expected_error: Some("multiple RemoveFile actions"),
+    ..FileActionUniquenessCase::valid()
 })]
-#[case::duplicate_unselected(RemovePathCase {
-    duplicate_paths: true,
-    selection_vector: &[true, false],
-    expected_error: None,
+#[case::duplicate_remove_unselected(FileActionUniquenessCase {
+    removes: SelectedFileActions {
+        rows: [
+            file_action("remove-0.parquet", None),
+            file_action("remove-0.parquet", None),
+        ],
+        selection_vector: &[true, false],
+    },
+    ..FileActionUniquenessCase::valid()
 })]
-#[case::distinct_selected(RemovePathCase {
-    duplicate_paths: false,
-    selection_vector: &[true, true],
-    expected_error: None,
+#[case::add_remove_same_key(FileActionUniquenessCase {
+    adds: [
+        file_action("remove-0.parquet", None),
+        file_action("add-1.parquet", None),
+    ],
+    expected_error: Some("same deletion vector ID"),
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::add_remove_same_path_different_dv(FileActionUniquenessCase {
+    adds: [
+        file_action("remove-0.parquet", None),
+        file_action("add-1.parquet", None),
+    ],
+    removes: SelectedFileActions {
+        rows: [
+            file_action("remove-0.parquet", Some("old-dv")),
+            file_action("remove-1.parquet", None),
+        ],
+        selection_vector: &[true, true],
+    },
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::add_collides_with_dv_update(FileActionUniquenessCase {
+    adds: [
+        file_action("dv-0.parquet", None),
+        file_action("add-1.parquet", None),
+    ],
+    dv_updates: SelectedFileActions {
+        rows: [
+            file_action("dv-0.parquet", Some("old-dv")),
+            file_action("dv-1.parquet", None),
+        ],
+        selection_vector: &[true, true],
+    },
+    expected_error: Some("multiple AddFile actions"),
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::add_ignores_unselected_dv_update_collision(FileActionUniquenessCase {
+    adds: [
+        file_action("dv-0.parquet", None),
+        file_action("add-1.parquet", None),
+    ],
+    dv_updates: SelectedFileActions {
+        rows: [
+            file_action("dv-0.parquet", None),
+            file_action("dv-1.parquet", None),
+        ],
+        selection_vector: &[false, true],
+    },
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::remove_collides_with_dv_update(FileActionUniquenessCase {
+    removes: SelectedFileActions {
+        rows: [
+            file_action("dv-0.parquet", None),
+            file_action("remove-1.parquet", None),
+        ],
+        selection_vector: &[true, true],
+    },
+    expected_error: Some("multiple RemoveFile actions"),
+    ..FileActionUniquenessCase::valid()
 })]
 #[tokio::test]
-async fn commit_validates_selected_remove_file_path_uniqueness(
-    #[case] case: RemovePathCase,
+async fn commit_validates_file_action_uniqueness(
+    #[case] case: FileActionUniquenessCase,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "id",
-        DataType::INTEGER,
-    )])?);
+    let schema = schema_ref! { nullable "id": INTEGER };
     let (_store, engine, table_url, _) = create_dv_table_with_files(
-        "remove_path_uniqueness",
+        "file_action_uniqueness",
         schema,
         &[],
-        &["file-0.parquet", "file-1.parquet"],
-    )
-    .await?;
-    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    let scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
-    let batches = scan_files
-        .into_iter()
-        .map(|scan_files| scan_files.apply_selection_vector().map(into_record_batch))
-        .collect::<DeltaResult<Vec<_>>>()?;
-    let mut batch = concat_batches(&batches[0].schema(), &batches)?;
-    if case.duplicate_paths {
-        let path_index = batch.schema().index_of("path")?;
-        let duplicate_path = batch.column(path_index).as_string::<i32>().value(0);
-        let mut columns = batch.columns().to_vec();
-        columns[path_index] = replace_array_row(
-            &columns[path_index],
-            string_array(duplicate_path),
-            1, /* row_index */
-        );
-        batch = RecordBatch::try_new(batch.schema(), columns)?;
-    }
-    let removes = FilteredEngineData::try_new(
-        Box::new(ArrowEngineData::new(batch)),
-        case.selection_vector.to_vec(),
-    )?;
-    let mut txn = begin_transaction(snapshot, engine.as_ref())?;
-    txn.remove_files(removes);
-
-    let result = txn.commit(engine.as_ref());
-    if let Some(expected_error) = case.expected_error {
-        assert_result_error_with_message(result, expected_error);
-    } else {
-        result?.unwrap_committed();
-    }
-    Ok(())
-}
-
-#[rstest]
-#[case::duplicate_explicit(DvPathCase {
-    first_row: 0,
-    first_selection_vector: &[true, false],
-    second_row: 0,
-    second_selection_vector: &[true, false],
-    expected_error: Some("multiple RemoveFile actions"),
-})]
-#[case::duplicate_implicit_tail(DvPathCase {
-    first_row: 1,
-    first_selection_vector: &[false],
-    second_row: 1,
-    second_selection_vector: &[false],
-    expected_error: Some("multiple RemoveFile actions"),
-})]
-#[case::distinct(DvPathCase {
-    first_row: 0,
-    first_selection_vector: &[true, false],
-    second_row: 1,
-    second_selection_vector: &[false, true],
-    expected_error: None,
-})]
-#[tokio::test]
-async fn commit_validates_dv_update_path_uniqueness(
-    #[case] case: DvPathCase,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
-        "id",
-        DataType::INTEGER,
-    )])?);
-    let (_store, engine, table_url, _) = create_dv_table_with_files(
-        "dv_path_uniqueness",
-        schema,
-        &[],
-        &["file-0.parquet", "file-1.parquet"],
+        &[
+            "remove-0.parquet",
+            "remove-1.parquet",
+            "dv-0.parquet",
+            "dv-1.parquet",
+        ],
     )
     .await?;
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -369,41 +343,57 @@ async fn commit_validates_dv_update_path_uniqueness(
         .map(|scan_files| scan_files.apply_selection_vector().map(into_record_batch))
         .collect::<DeltaResult<Vec<_>>>()?;
     let batch = concat_batches(&batches[0].schema(), &batches)?;
-    let path_index = batch.schema().index_of("path")?;
-    let paths = batch
-        .column(path_index)
-        .as_string::<i32>()
-        .iter()
-        .map(|path| path.expect("scan path should be present").to_owned())
-        .collect::<Vec<_>>();
+    let base_row = batch.slice(0, 1);
     let mut txn = begin_transaction(snapshot, engine.as_ref())?;
 
-    let first_descriptor = DeletionVectorDescriptor {
-        storage_type: DeletionVectorStorageType::PersistedRelative,
-        path_or_inline_dv: "first-dv.bin".to_string(),
-        offset: Some(0),
-        size_in_bytes: 1,
-        cardinality: 1,
-    };
+    txn.add_files(create_add_files_metadata(
+        txn.add_files_schema(),
+        case.adds
+            .iter()
+            .map(|file| {
+                (
+                    file.path(),
+                    1, /* size */
+                    1, /* modification_time */
+                    Some(1),
+                )
+            })
+            .collect(),
+    )?);
+    let removes = apply_path_dv(&base_row, &case.removes.rows)?;
+    txn.remove_files(FilteredEngineData::try_new(
+        Box::new(ArrowEngineData::new(removes)),
+        case.removes.selection_vector.to_vec(),
+    )?);
+    let scan_file = apply_path_dv(&base_row, &case.dv_updates.rows)?;
+    let descriptors = case
+        .dv_updates
+        .rows
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| {
+            case.dv_updates
+                .selection_vector
+                .get(*index)
+                .copied()
+                .unwrap_or(true)
+        })
+        .map(|(index, file)| {
+            let descriptor = DeletionVectorDescriptor {
+                storage_type: DeletionVectorStorageType::PersistedRelative,
+                path_or_inline_dv: format!("new-dv-{index}.bin"),
+                offset: Some(0),
+                size_in_bytes: 1,
+                cardinality: 1,
+            };
+            (file.path().to_string(), descriptor)
+        })
+        .collect();
     txn.update_deletion_vectors(
-        HashMap::from([(paths[case.first_row].clone(), first_descriptor)]),
+        descriptors,
         std::iter::once(Ok(FilteredEngineData::try_new(
-            Box::new(ArrowEngineData::new(batch.clone())),
-            case.first_selection_vector.to_vec(),
-        )?)),
-    )?;
-    let second_descriptor = DeletionVectorDescriptor {
-        storage_type: DeletionVectorStorageType::PersistedRelative,
-        path_or_inline_dv: "second-dv.bin".to_string(),
-        offset: Some(0),
-        size_in_bytes: 1,
-        cardinality: 1,
-    };
-    txn.update_deletion_vectors(
-        HashMap::from([(paths[case.second_row].clone(), second_descriptor)]),
-        std::iter::once(Ok(FilteredEngineData::try_new(
-            Box::new(ArrowEngineData::new(batch)),
-            case.second_selection_vector.to_vec(),
+            Box::new(ArrowEngineData::new(scan_file)),
+            case.dv_updates.selection_vector.to_vec(),
         )?)),
     )?;
 
@@ -416,20 +406,107 @@ async fn commit_validates_dv_update_path_uniqueness(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-struct RemovePathCase {
-    duplicate_paths: bool,
+#[derive(Clone)]
+struct SelectedFileActions {
+    rows: [FileActionKey; 2],
     selection_vector: &'static [bool],
+}
+
+#[derive(Clone)]
+struct FileActionUniquenessCase {
+    adds: [FileActionKey; 2],
+    removes: SelectedFileActions,
+    dv_updates: SelectedFileActions,
     expected_error: Option<&'static str>,
 }
 
-#[derive(Clone, Copy)]
-struct DvPathCase {
-    first_row: usize,
-    first_selection_vector: &'static [bool],
-    second_row: usize,
-    second_selection_vector: &'static [bool],
-    expected_error: Option<&'static str>,
+impl FileActionUniquenessCase {
+    fn valid() -> Self {
+        Self {
+            adds: [
+                file_action("add-0.parquet", None),
+                file_action("add-1.parquet", None),
+            ],
+            removes: SelectedFileActions {
+                rows: [
+                    file_action("remove-0.parquet", None),
+                    file_action("remove-1.parquet", None),
+                ],
+                selection_vector: &[true, true],
+            },
+            dv_updates: SelectedFileActions {
+                rows: [
+                    file_action("dv-0.parquet", None),
+                    file_action("dv-1.parquet", None),
+                ],
+                selection_vector: &[true, true],
+            },
+            expected_error: None,
+        }
+    }
+}
+
+fn file_action(path: &str, dv_unique_id: Option<&str>) -> FileActionKey {
+    FileActionKey::new(path, dv_unique_id.map(str::to_owned))
+}
+
+fn apply_path_dv(
+    base_row: &RecordBatch,
+    file_action_keys: &[FileActionKey],
+) -> Result<RecordBatch, ArrowError> {
+    let batch = concat_batches(
+        &base_row.schema(),
+        &vec![base_row.clone(); file_action_keys.len()],
+    )?;
+    let paths = Arc::new(StringArray::from(
+        file_action_keys
+            .iter()
+            .map(FileActionKey::path)
+            .collect::<Vec<_>>(),
+    ));
+    let batch = replace_column(&batch, "path", paths);
+
+    let schema = batch.schema();
+    let deletion_vector_index = schema.index_of("deletionVector")?;
+    let ArrowDataType::Struct(fields) = schema.field(deletion_vector_index).data_type() else {
+        panic!("deletionVector should be a struct");
+    };
+    let dv_unique_ids = file_action_keys
+        .iter()
+        .map(FileActionKey::dv_unique_id)
+        .collect::<Vec<_>>();
+    let deletion_vectors = Arc::new(StructArray::new(
+        fields.clone(),
+        vec![
+            Arc::new(StringArray::from(
+                dv_unique_ids
+                    .iter()
+                    .map(|dv_unique_id| dv_unique_id.map(|_| "u"))
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef, // storageType
+            Arc::new(StringArray::from(dv_unique_ids.clone())) as ArrayRef, // pathOrInlineDv
+            Arc::new(Int32Array::from(vec![None; file_action_keys.len()])) as ArrayRef, // offset
+            Arc::new(Int32Array::from(
+                dv_unique_ids
+                    .iter()
+                    .map(|dv_unique_id| dv_unique_id.map(|_| 1))
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef, // sizeInBytes
+            Arc::new(Int64Array::from(
+                dv_unique_ids
+                    .iter()
+                    .map(|dv_unique_id| dv_unique_id.map(|_| 1))
+                    .collect::<Vec<_>>(),
+            )) as ArrayRef, // cardinality
+        ],
+        Some(NullBuffer::from(
+            dv_unique_ids
+                .iter()
+                .map(Option::is_some)
+                .collect::<Vec<_>>(),
+        )),
+    ));
+    Ok(replace_column(&batch, "deletionVector", deletion_vectors))
 }
 
 #[derive(Clone, Copy)]

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -97,7 +97,7 @@ async fn append_only_enforces_data_change_for_file_actions(
             ("delta.enableDeletionVectors", "true"),
         ])
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     let mut txn = begin_transaction(snapshot, engine.as_ref())?.with_data_change(true);
     let write_context = txn.unpartitioned_write_context()?;
@@ -110,7 +110,9 @@ async fn append_only_enforces_data_change_for_file_actions(
         )?);
         txn.add_files(engine.write_parquet(&data, &write_context).await?);
     }
-    let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();
+    let snapshot = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_post_commit_snapshot();
 
     let staged_batches = (0..2)
         .map(|index| {
@@ -135,7 +137,7 @@ async fn append_only_enforces_data_change_for_file_actions(
             for scan_files in staged_batches {
                 txn.remove_files(scan_files);
             }
-            txn.commit(engine.as_ref())
+            txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)
         }
         AppendOnlyWrite::DeletionVectorUpdate => {
             let add_actions = read_actions_from_commit(&table_url, 1, "add")?;
@@ -160,7 +162,7 @@ async fn append_only_enforces_data_change_for_file_actions(
                 })
                 .collect();
             txn.update_deletion_vectors(dv_map, staged_batches.into_iter().map(Ok))?;
-            txn.commit(engine.as_ref())
+            txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)
         }
     };
 
@@ -221,6 +223,14 @@ fn selected_scan_file_batch(
         file_action("same.parquet", None),
     ],
     expected_error: Some("multiple AddFile actions"),
+    ..FileActionUniquenessCase::valid()
+})]
+#[case::duplicate_add_allowed_when_validation_skipped(FileActionUniquenessCase {
+    adds: [
+        file_action("same.parquet", None),
+        file_action("same.parquet", None),
+    ],
+    skip_duplicate_validation: true,
     ..FileActionUniquenessCase::valid()
 })]
 #[case::duplicate_remove(FileActionUniquenessCase {
@@ -395,7 +405,7 @@ async fn commit_validates_file_action_uniqueness(
         )?)),
     )?;
 
-    let result = txn.commit(engine.as_ref());
+    let result = txn.commit(engine.as_ref(), case.skip_duplicate_validation);
     if let Some(expected_error) = case.expected_error {
         assert_result_error_with_message(result, expected_error);
     } else {
@@ -415,6 +425,7 @@ struct FileActionUniquenessCase {
     adds: [FileActionInput; 2],
     removes: SelectedFileActions,
     dv_updates: SelectedFileActions,
+    skip_duplicate_validation: bool,
     expected_error: Option<&'static str>,
 }
 
@@ -439,6 +450,7 @@ impl FileActionUniquenessCase {
                 ],
                 selection_vector: &[true, true],
             },
+            skip_duplicate_validation: false,
             expected_error: None,
         }
     }
@@ -615,7 +627,8 @@ async fn commit_validates_staged_remove_fields(
         ],
     )?;
     txn.add_files(adds);
-    txn.commit(engine.as_ref())?.unwrap_committed();
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     // === Modify staged remove metadata ===
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
@@ -650,7 +663,7 @@ async fn commit_validates_staged_remove_fields(
         Box::new(ArrowEngineData::new(corrupted)),
         selection_vector.to_vec(),
     )?);
-    let result = txn.commit(engine.as_ref());
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */);
     if let Some(expected_error) = expected_error {
         assert_result_error_with_message(result, expected_error);
     } else {
@@ -716,7 +729,7 @@ async fn test_remove_files_adds_expected_entries() -> Result<(), Box<dyn std::er
 
     txn.remove_files(remove_metadata);
 
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     match result {
         CommitResult::CommittedTransaction(committed) => {
@@ -866,7 +879,7 @@ async fn test_remove_scanned_file_sets_extended_metadata(
 
     let snapshot = create_table(&table_path, schema, "Test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_post_commit_snapshot();
     let snapshot = insert_data(
         snapshot,
@@ -885,7 +898,7 @@ async fn test_remove_scanned_file_sets_extended_metadata(
             missing_fields,
         )?);
     }
-    let commit_result = txn.commit(engine.as_ref());
+    let commit_result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */);
     commit_result?.unwrap_committed();
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
 
@@ -997,7 +1010,7 @@ async fn test_update_deletion_vectors_adds_expected_entries(
     txn.update_deletion_vectors(dv_map, scan_files.into_iter().map(Ok))?;
 
     // Commit the transaction
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     match result {
         CommitResult::CommittedTransaction(committed) => {
@@ -1360,7 +1373,10 @@ async fn test_update_deletion_vectors_rejects_corrupted_scan_files(
     }
     txn.update_deletion_vectors(descriptors, scan_files.into_iter().map(Ok))?;
 
-    assert_result_error_with_message(txn.commit(engine.as_ref()), expected_error);
+    assert_result_error_with_message(
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */),
+        expected_error,
+    );
     Ok(())
 }
 
@@ -1513,7 +1529,7 @@ async fn test_update_deletion_vectors_multiple_files(
     txn.update_deletion_vectors(dv_map, scan_files.drain(..).map(Ok))?;
 
     // Commit the transaction
-    let result = txn.commit(engine.as_ref())?;
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     match result {
         CommitResult::CommittedTransaction(committed) => {
@@ -1649,7 +1665,9 @@ async fn test_update_deletion_vectors_respects_selection_vector(
             .into_iter()
             .map(Ok),
     )?;
-    setup_txn.commit(engine.as_ref())?.unwrap_committed();
+    setup_txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
 
     let targeted: Vec<String> = target_indexes
         .iter()
@@ -1700,7 +1718,9 @@ async fn test_update_deletion_vectors_respects_selection_vector(
     } else {
         update_result?;
     }
-    let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+    let committed = txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .unwrap_committed();
     let version = committed.commit_version();
 
     // Read the commit directly from the (in-memory) store.
@@ -1836,7 +1856,7 @@ async fn test_remove_files_verify_files_excluded_from_scan(
         txn.remove_files(scan_metadata2.scan_files);
 
         // Commit the transaction
-        let result = txn.commit(engine.as_ref());
+        let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */);
 
         match result? {
             CommitResult::CommittedTransaction(committed) => {
@@ -2019,7 +2039,7 @@ async fn test_remove_files_with_modified_selection_vector() -> Result<(), Box<dy
         txn.remove_files(FilteredEngineData::try_new(data2, selection_vector2)?);
 
         // Commit the transaction
-        let result = txn.commit(engine.as_ref())?;
+        let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
         match result {
             CommitResult::CommittedTransaction(committed) => {
@@ -2151,7 +2171,9 @@ async fn test_remove_files_after_predicate_scan_includes_stats_parsed(
             txn.remove_files(scan_metadata?.scan_files);
         }
 
-        let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+        let committed = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_committed();
         assert_eq!(committed.commit_version(), expected_commit_version);
 
         let remove_actions =
@@ -2255,7 +2277,8 @@ async fn test_remove_files_partitioned_with_parsed_columns(
             let add_meta = engine.write_parquet(data?.as_ref(), ctx.as_ref()).await?;
             txn.add_files(add_meta);
         }
-        txn.commit(engine.as_ref())?.unwrap_committed();
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_committed();
 
         let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
         let mut scan_builder = snapshot
@@ -2271,7 +2294,9 @@ async fn test_remove_files_partitioned_with_parsed_columns(
         for scan_metadata in scan.scan_metadata(engine.as_ref())? {
             txn.remove_files(scan_metadata?.scan_files);
         }
-        let committed = txn.commit(engine.as_ref())?.unwrap_committed();
+        let committed = txn
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_committed();
         assert_eq!(committed.commit_version(), 2);
 
         let remove_actions = read_actions_from_commit(&table_url, 2, "remove")?;

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -213,6 +213,225 @@ fn selected_scan_file_batch(
     Err(Error::generic("expected at least one scan file"))
 }
 
+#[rstest]
+#[case::duplicate(&["same.parquet", "same.parquet"], Some("multiple AddFile actions"))]
+#[case::distinct(&["first.parquet", "second.parquet"], None)]
+#[tokio::test]
+async fn commit_validates_add_file_path_uniqueness(
+    #[case] paths: &[&str],
+    #[case] expected_error: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+    let (_store, engine, table_url, _) =
+        create_dv_table_with_files("add_path_uniqueness", schema, &[], &["existing.parquet"])
+            .await?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let mut txn = begin_transaction(snapshot, engine.as_ref())?;
+    let adds = create_add_files_metadata(
+        txn.add_files_schema(),
+        paths
+            .iter()
+            .map(|path| {
+                (
+                    *path,
+                    1, /* size */
+                    1, /* modification_time */
+                    Some(1),
+                )
+            })
+            .collect(),
+    )?;
+    txn.add_files(adds);
+
+    let result = txn.commit(engine.as_ref());
+    if let Some(expected_error) = expected_error {
+        assert_result_error_with_message(result, expected_error);
+    } else {
+        result?.unwrap_committed();
+    }
+    Ok(())
+}
+
+#[rstest]
+#[case::duplicate_selected(RemovePathCase {
+    duplicate_paths: true,
+    selection_vector: &[true, true],
+    expected_error: Some("multiple RemoveFile actions"),
+})]
+#[case::duplicate_implicitly_selected(RemovePathCase {
+    duplicate_paths: true,
+    selection_vector: &[true],
+    expected_error: Some("multiple RemoveFile actions"),
+})]
+#[case::duplicate_unselected(RemovePathCase {
+    duplicate_paths: true,
+    selection_vector: &[true, false],
+    expected_error: None,
+})]
+#[case::distinct_selected(RemovePathCase {
+    duplicate_paths: false,
+    selection_vector: &[true, true],
+    expected_error: None,
+})]
+#[tokio::test]
+async fn commit_validates_selected_remove_file_path_uniqueness(
+    #[case] case: RemovePathCase,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+    let (_store, engine, table_url, _) = create_dv_table_with_files(
+        "remove_path_uniqueness",
+        schema,
+        &[],
+        &["file-0.parquet", "file-1.parquet"],
+    )
+    .await?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
+    let batches = scan_files
+        .into_iter()
+        .map(|scan_files| scan_files.apply_selection_vector().map(into_record_batch))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    let mut batch = concat_batches(&batches[0].schema(), &batches)?;
+    if case.duplicate_paths {
+        let path_index = batch.schema().index_of("path")?;
+        let duplicate_path = batch.column(path_index).as_string::<i32>().value(0);
+        let mut columns = batch.columns().to_vec();
+        columns[path_index] = replace_array_row(
+            &columns[path_index],
+            string_array(duplicate_path),
+            1, /* row_index */
+        );
+        batch = RecordBatch::try_new(batch.schema(), columns)?;
+    }
+    let removes = FilteredEngineData::try_new(
+        Box::new(ArrowEngineData::new(batch)),
+        case.selection_vector.to_vec(),
+    )?;
+    let mut txn = begin_transaction(snapshot, engine.as_ref())?;
+    txn.remove_files(removes);
+
+    let result = txn.commit(engine.as_ref());
+    if let Some(expected_error) = case.expected_error {
+        assert_result_error_with_message(result, expected_error);
+    } else {
+        result?.unwrap_committed();
+    }
+    Ok(())
+}
+
+#[rstest]
+#[case::duplicate_explicit(DvPathCase {
+    first_row: 0,
+    first_selection_vector: &[true, false],
+    second_row: 0,
+    second_selection_vector: &[true, false],
+    expected_error: Some("multiple RemoveFile actions"),
+})]
+#[case::duplicate_implicit_tail(DvPathCase {
+    first_row: 1,
+    first_selection_vector: &[false],
+    second_row: 1,
+    second_selection_vector: &[false],
+    expected_error: Some("multiple RemoveFile actions"),
+})]
+#[case::distinct(DvPathCase {
+    first_row: 0,
+    first_selection_vector: &[true, false],
+    second_row: 1,
+    second_selection_vector: &[false, true],
+    expected_error: None,
+})]
+#[tokio::test]
+async fn commit_validates_dv_update_path_uniqueness(
+    #[case] case: DvPathCase,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let schema = Arc::new(StructType::try_new(vec![StructField::nullable(
+        "id",
+        DataType::INTEGER,
+    )])?);
+    let (_store, engine, table_url, _) = create_dv_table_with_files(
+        "dv_path_uniqueness",
+        schema,
+        &[],
+        &["file-0.parquet", "file-1.parquet"],
+    )
+    .await?;
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
+    let batches = scan_files
+        .into_iter()
+        .map(|scan_files| scan_files.apply_selection_vector().map(into_record_batch))
+        .collect::<DeltaResult<Vec<_>>>()?;
+    let batch = concat_batches(&batches[0].schema(), &batches)?;
+    let path_index = batch.schema().index_of("path")?;
+    let paths = batch
+        .column(path_index)
+        .as_string::<i32>()
+        .iter()
+        .map(|path| path.expect("scan path should be present").to_owned())
+        .collect::<Vec<_>>();
+    let mut txn = begin_transaction(snapshot, engine.as_ref())?;
+
+    let first_descriptor = DeletionVectorDescriptor {
+        storage_type: DeletionVectorStorageType::PersistedRelative,
+        path_or_inline_dv: "first-dv.bin".to_string(),
+        offset: Some(0),
+        size_in_bytes: 1,
+        cardinality: 1,
+    };
+    txn.update_deletion_vectors(
+        HashMap::from([(paths[case.first_row].clone(), first_descriptor)]),
+        std::iter::once(Ok(FilteredEngineData::try_new(
+            Box::new(ArrowEngineData::new(batch.clone())),
+            case.first_selection_vector.to_vec(),
+        )?)),
+    )?;
+    let second_descriptor = DeletionVectorDescriptor {
+        storage_type: DeletionVectorStorageType::PersistedRelative,
+        path_or_inline_dv: "second-dv.bin".to_string(),
+        offset: Some(0),
+        size_in_bytes: 1,
+        cardinality: 1,
+    };
+    txn.update_deletion_vectors(
+        HashMap::from([(paths[case.second_row].clone(), second_descriptor)]),
+        std::iter::once(Ok(FilteredEngineData::try_new(
+            Box::new(ArrowEngineData::new(batch)),
+            case.second_selection_vector.to_vec(),
+        )?)),
+    )?;
+
+    let result = txn.commit(engine.as_ref());
+    if let Some(expected_error) = case.expected_error {
+        assert_result_error_with_message(result, expected_error);
+    } else {
+        result?.unwrap_committed();
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct RemovePathCase {
+    duplicate_paths: bool,
+    selection_vector: &'static [bool],
+    expected_error: Option<&'static str>,
+}
+
+#[derive(Clone, Copy)]
+struct DvPathCase {
+    first_row: usize,
+    first_selection_vector: &'static [bool],
+    second_row: usize,
+    second_selection_vector: &'static [bool],
+    expected_error: Option<&'static str>,
+}
+
 #[derive(Clone, Copy)]
 struct StagedRemoveFileModification {
     field: &'static str,

--- a/kernel/tests/integration/write/row_tracking.rs
+++ b/kernel/tests/integration/write/row_tracking.rs
@@ -48,7 +48,7 @@ async fn test_row_tracking_remove_gate(
     kernel_create_table(table_path.as_str(), schema.clone(), "Test/1.0")
         .with_table_properties(create_properties.iter().copied())
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
         .unwrap_committed();
 
     // Optional v1: inject a metadata-only commit that sets `delta.rowTrackingSuspended=true`.
@@ -90,7 +90,7 @@ async fn test_row_tracking_remove_gate(
 
     if expect_err {
         let err = txn
-            .commit(engine.as_ref())
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)
             .expect_err("commit must fail when rowTracking is supported and not suspended");
         let msg = err.to_string();
         assert!(
@@ -98,7 +98,8 @@ async fn test_row_tracking_remove_gate(
             "expected remove-block error mentioning rowTracking, got: {msg}",
         );
     } else {
-        txn.commit(engine.as_ref())?.unwrap_committed();
+        txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+            .unwrap_committed();
     }
     Ok(())
 }

--- a/kernel/tests/integration/write/txn.rs
+++ b/kernel/tests/integration/write/txn.rs
@@ -25,7 +25,7 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             load_and_begin_transaction(table_url.clone(), &engine)?
                 .with_transaction_id("app_id1".to_string(), 0)
                 .with_transaction_id("app_id1".to_string(), 1)
-                .commit(&engine),
+                .commit(&engine, false /* skip_duplicate_validation */),
             Err(KernelError::Generic(msg)) if msg == "app_id app_id1 already exists in transaction"
         ));
 
@@ -35,7 +35,9 @@ async fn test_write_txn_actions() -> Result<(), Box<dyn std::error::Error>> {
             .with_transaction_id("app_id2".to_string(), 2);
 
         // commit!
-        assert!(txn.commit(&engine)?.is_committed());
+        assert!(txn
+            .commit(&engine, false /* skip_duplicate_validation */)?
+            .is_committed());
 
         let snapshot = Snapshot::builder_for(table_url.clone())
             .at_version(1)

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -81,7 +81,9 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
     txn.add_files(add_files_metadata);
 
     // Commit the transaction
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     // Verify the commit was written correctly
     let commit1 = store
@@ -159,7 +161,9 @@ async fn test_append_timestamp_stats_are_millisecond_truncated(
         .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
         .await?;
     txn.add_files(add_files_metadata);
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     let commit1 = store
         .get(&Path::from(
@@ -339,7 +343,9 @@ async fn test_append_variant(
     txn.add_files(add_files_metadata);
 
     // Commit the transaction
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     // Verify the commit was written correctly
     let commit1_url = tmp_test_dir_url
@@ -503,7 +509,9 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     txn.add_files(add_files_metadata);
 
     // Commit the transaction
-    assert!(txn.commit(engine.as_ref())?.is_committed());
+    assert!(txn
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
+        .is_committed());
 
     // Verify the commit was written correctly
     let commit1_url = tmp_test_dir_url
@@ -569,7 +577,7 @@ async fn test_not_null_data_column_rejects_null_in_batch(
     let (_tmp_dir, table_path, engine) = test_table_setup()?;
     let _ = kernel_create_table(&table_path, schema.clone(), "test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-        .commit(engine.as_ref())?;
+        .commit(engine.as_ref(), false /* skip_duplicate_validation */)?;
 
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
     // The non-null schema auto-enables the `invariants` writer feature.
@@ -643,7 +651,7 @@ async fn try_write_with_void_schema(schema: SchemaRef) -> KernelError {
         create_add_files_metadata(&add_schema, vec![("file.parquet", 100, 1000, Some(1))])
             .expect("metadata creation should succeed");
     txn.add_files(metadata);
-    txn.commit(engine.as_ref())
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)
         .expect_err("commit should fail for invalid void schema")
 }
 
@@ -897,7 +905,7 @@ async fn metadata_only_commit_with_void_in_array_succeeds() -> Result<(), Box<dy
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
 
     // Commit with NO add_files — this is a metadata-only operation and should succeed
-    let result = txn.commit(engine.as_ref());
+    let result = txn.commit(engine.as_ref(), false /* skip_duplicate_validation */);
     assert!(
         result.is_ok(),
         "Metadata-only commit on void-in-array schema should succeed, got: {:?}",

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1179,7 +1179,7 @@ pub async fn insert_data_with<E: TaskExecutor>(
         .await?;
     txn.add_files(add_files_metadata);
 
-    txn.commit(engine.as_ref())
+    txn.commit(engine.as_ref(), false /* skip_duplicate_validation */)
 }
 
 /// Starts a transaction using the passed snapshot using a [`FileSystemCommitter`].
@@ -1604,7 +1604,7 @@ pub async fn write_batch_to_table(
         .write_parquet(&ArrowEngineData::new(data), &write_context)
         .await?;
     txn.add_files(add_meta);
-    match txn.commit(engine)? {
+    match txn.commit(engine, false /* skip_duplicate_validation */)? {
         delta_kernel::transaction::CommitResult::CommittedTransaction(c) => Ok(c
             .post_commit_snapshot()
             .expect("Failed to get post_commit_snapshot")
@@ -1737,7 +1737,7 @@ pub fn create_table_and_load_snapshot(
     let _ = create_table(table_path, schema, "Test/1.0")
         .with_table_properties(properties.to_vec())
         .build(engine, Box::new(FileSystemCommitter::new()))?
-        .commit(engine)?;
+        .commit(engine, false /* skip_duplicate_validation */)?;
 
     let table_url = delta_kernel::try_parse_uri(table_path)?;
     Snapshot::builder_for(table_url).build(engine)
@@ -1909,7 +1909,7 @@ pub fn remove_all_and_get_remove_actions(
     for sm in all_scan_metadata {
         txn.remove_files(sm.scan_files);
     }
-    let committed = match txn.commit(engine)? {
+    let committed = match txn.commit(engine, false /* skip_duplicate_validation */)? {
         CommitResult::CommittedTransaction(c) => c,
         _ => panic!("Transaction should be committed"),
     };

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -168,6 +168,7 @@ pub use counting_reporter::{
     ensure_metrics_compatible_global_subscriber, install_thread_local_metrics_reporter,
     CapturingReporter, CountingReporter, RelaxedCounter,
 };
+use delta_kernel::actions::deletion_vector::DeletionVectorDescriptor;
 use delta_kernel::actions::{
     LOG_ADD_SCHEMA, MAX_VALUES, MIN_VALUES, NULL_COUNT, NUM_RECORDS, TIGHT_BOUNDS,
 };
@@ -175,7 +176,7 @@ use delta_kernel::arrow::array::{
     Array, ArrayRef, AsArray, BooleanArray, Float64Array, Int32Array, Int64Array, MapArray,
     MapBuilder, RecordBatch, StringArray, StringBuilder, StructArray,
 };
-use delta_kernel::arrow::buffer::OffsetBuffer;
+use delta_kernel::arrow::buffer::{NullBuffer, OffsetBuffer};
 use delta_kernel::arrow::compute::concat;
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field, Int64Type, Schema as ArrowSchema,
@@ -185,7 +186,7 @@ use delta_kernel::arrow::util::pretty::pretty_format_batches;
 use delta_kernel::committer::{
     CommitMetadata, CommitResponse, Committer, FileSystemCommitter, PublishMetadata,
 };
-use delta_kernel::engine::arrow_conversion::TryFromKernel;
+use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow};
 use delta_kernel::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
 use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::local::LocalFileSystem;
@@ -196,7 +197,7 @@ use delta_kernel::parquet::arrow::arrow_writer::ArrowWriter;
 use delta_kernel::parquet::file::properties::WriterProperties;
 use delta_kernel::scan::Scan;
 use delta_kernel::schema::{
-    ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType,
+    ColumnMetadataKey, DataType, MetadataValue, SchemaRef, StructField, StructType, ToSchema,
 };
 use delta_kernel::table_features::{assign_column_mapping_metadata, find_max_column_id_in_schema};
 use delta_kernel::transaction::{CommitResult, Transaction};
@@ -613,6 +614,56 @@ pub fn replace_array_row(column: &ArrayRef, replacement: ArrayRef, row: usize) -
     ];
     let arrays: Vec<&dyn Array> = slices.iter().map(|array| array.as_ref()).collect();
     concat(&arrays).expect("replacement value must match the modified column type")
+}
+
+/// Builds nullable deletion-vector values for tests.
+///
+/// Each entry supplies `pathOrInlineDv`; `None` produces a null descriptor. Present descriptors
+/// have no offset and use placeholder size and cardinality values.
+///
+/// # Panics
+///
+/// Panics if the deletion-vector schema cannot be converted to Arrow.
+pub fn deletion_vector_array(
+    storage_type: &str,
+    paths_or_inline_dvs: &[Option<&str>],
+) -> StructArray {
+    let schema: ArrowSchema = (&DeletionVectorDescriptor::to_schema())
+        .try_into_arrow()
+        .expect("deletion-vector schema should convert to Arrow");
+    let row_count = paths_or_inline_dvs.len();
+
+    StructArray::new(
+        schema.fields().clone(),
+        vec![
+            Arc::new(StringArray::from(
+                paths_or_inline_dvs
+                    .iter()
+                    .map(|path| path.map(|_| storage_type))
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(paths_or_inline_dvs.to_vec())),
+            Arc::new(Int32Array::from(vec![None; row_count])),
+            Arc::new(Int32Array::from(
+                paths_or_inline_dvs
+                    .iter()
+                    .map(|path| path.map(|_| 1))
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(
+                paths_or_inline_dvs
+                    .iter()
+                    .map(|path| path.map(|_| 1))
+                    .collect::<Vec<_>>(),
+            )),
+        ],
+        Some(NullBuffer::from(
+            paths_or_inline_dvs
+                .iter()
+                .map(Option::is_some)
+                .collect::<Vec<_>>(),
+        )),
+    )
 }
 
 /// Returns a copy of `batch` with `field` replaced by `column`.

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -615,6 +615,19 @@ pub fn replace_array_row(column: &ArrayRef, replacement: ArrayRef, row: usize) -
     concat(&arrays).expect("replacement value must match the modified column type")
 }
 
+/// Returns a copy of `batch` with `field` replaced by `column`.
+///
+/// # Panics
+///
+/// Panics if `field` does not exist or `column` is incompatible with the batch schema.
+pub fn replace_column(batch: &RecordBatch, field: &str, column: ArrayRef) -> RecordBatch {
+    let schema = batch.schema();
+    let index = schema.index_of(field).expect("field in schema");
+    let mut columns = batch.columns().to_vec();
+    columns[index] = column;
+    RecordBatch::try_new(schema, columns).expect("replacement column must match the batch schema")
+}
+
 pub fn create_default_engine(
     table_root: &url::Url,
 ) -> DeltaResult<Arc<DefaultEngine<TokioBackgroundExecutor>>> {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -641,21 +641,21 @@ pub fn deletion_vector_array(
                     .iter()
                     .map(|path| path.map(|_| storage_type))
                     .collect::<Vec<_>>(),
-            )),
-            Arc::new(StringArray::from(paths_or_inline_dvs.to_vec())),
-            Arc::new(Int32Array::from(vec![None; row_count])),
+            )), // storageType
+            Arc::new(StringArray::from(paths_or_inline_dvs.to_vec())), // pathOrInlineDv
+            Arc::new(Int32Array::from(vec![None; row_count])),         // offset
             Arc::new(Int32Array::from(
                 paths_or_inline_dvs
                     .iter()
                     .map(|path| path.map(|_| 1))
                     .collect::<Vec<_>>(),
-            )),
+            )), // sizeInBytes
             Arc::new(Int64Array::from(
                 paths_or_inline_dvs
                     .iter()
                     .map(|path| path.map(|_| 1))
                     .collect::<Vec<_>>(),
-            )),
+            )), // cardinality
         ],
         Some(NullBuffer::from(
             paths_or_inline_dvs

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1322,7 +1322,7 @@ impl TestTableBuilder {
 
         let mut snapshot = builder
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
-            .commit(engine.as_ref())?
+            .commit(engine.as_ref(), false /* skip_duplicate_validation */)?
             .unwrap_post_commit_snapshot();
 
         let crcs_at = self.log_state.crcs_at();
@@ -1496,7 +1496,7 @@ async fn write_data_commit<E: TaskExecutor>(
         txn.add_files(add_files);
     }
 
-    txn.commit(engine)
+    txn.commit(engine, false /* skip_duplicate_validation */)
 }
 
 /// Generate a single column of data based on its Arrow type.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Validate conflicting file actions at commit time. Within one transaction:

- Multiple `AddFile` actions with the same path are rejected, regardless of DV ID.
- Multiple `RemoveFile` actions with the same path are rejected, regardless of DV ID.
- An `AddFile` and `RemoveFile` with the same path and DV ID are rejected.
- An `AddFile` and `RemoveFile` with the same path but different DV IDs are allowed.

Also added `skip_duplicate_file_action_validation` to `transaction.commit`, so that connectors can skip this validation in favor of perf

## How was this change tested?

Added parameterized unit and integration tests covering all rules across different action types, selection vectors, and batch layouts.

### Perf result
`N` is the total action count: half are AddFiles and half are RemoveFiles carrying deletion
vectors. `N = 1` uses one AddFile.

Values through `N = 1,000` are medians of three
fresh-process Criterion mean estimates. `N = 10,000` uses the 20% trimmed mean from 10
fresh-process estimates after dropping the two lowest and two highest values for each case.

Local FS:

| N | baseline | with this validation|
|---|---|---|
| 1 | 349.85 µs | ~0 |
| 10 | 445.47 µs | +14.23 µs |
| 100 | 504.54 µs | +19.51 µs |
| 1,000 | 1.0930 ms | +0.1497 ms |
| 10,000 | 6.3944 ms | +1.9432 ms |
| 100,000 | 78.117 ms | +**36.973 ms** |

S3:

| N | baseline | 3 duplicate path |
|---|---|---|
| 1 | 30.411 ms | 31.108 ms |
| 10 | 29.329 ms | 30.903 ms |
| 100 | 33.145 ms | 35.018 ms |
| 1,000 | 61.114 ms | 58.135 ms |
| 10,000 | 83.997 ms | **87.014 ms(+~3.5%)** |
