### PR TITLE
refactor!: remove write context apis on transaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,11 @@ table at a specific version. From it you build a `Scan` (reads) or `Transaction`
 `parallel_scan_metadata()` (two-phase distributed log replay).
 
 
-**Write path:** `Snapshot` -> `Transaction` -> `commit()`. Kernel provides `BoundWriteContext`
-(via `partitioned_write_context` or `unpartitioned_write_context`) for local writers. Distributed
-writers can create and transport a `WriteState`, then bind partition values on each writer to get
-a `BoundWriteContext`. Kernel assembles commit actions, enforces protocol compliance, and delegates
-the atomic commit to a `Committer`.
+**Write path:** `Snapshot` -> `Transaction` -> `commit()`. Writers call
+`Transaction::write_state`, then bind partition values through the returned `WriteState` to get a
+`BoundWriteContext`. Distributed writers can encode and transport the state before binding it.
+Kernel assembles commit actions, enforces protocol compliance, and delegates the atomic commit to a
+`Committer`.
 
 **Engine trait:** exposes `StorageHandler`, `JsonHandler`, `ParquetHandler`, and
 `EvaluationHandler`, plus an optional `PlanExecutor` under `declarative-plans`. Metrics use tracing

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -77,9 +77,10 @@ a `Committer`.
 
 **Data-write steps:**
 1. Create `Transaction` from a snapshot with a `Committer` (e.g. `FileSystemCommitter`)
-2. Call `txn.write_state()` after configuring the transaction, then bind each partition from that
-   immutable state. Distributed writers can encode the state and decode it on each worker before
-   binding partition values.
+2. Call `txn.write_state()` after configuring the transaction, then get a `BoundWriteContext` from
+   `WriteState::unpartitioned_write_context()` or
+   `WriteState::partitioned_write_context()`. Distributed writers can encode the state and decode
+   it on each worker before binding partition values.
 3. Write Parquet files (via engine), collect file metadata
 4. Register files via `txn.add_files(metadata)` and stage any removals or deletion-vector updates
 5. Commit: returns `CommittedTransaction`, `ConflictedTransaction`, or `RetryableTransaction`

--- a/CLAUDE/architecture.md
+++ b/CLAUDE/architecture.md
@@ -77,10 +77,9 @@ a `Committer`.
 
 **Data-write steps:**
 1. Create `Transaction` from a snapshot with a `Committer` (e.g. `FileSystemCommitter`)
-2. For a single context, get a `BoundWriteContext` directly from the transaction. For multiple
-   partitions or distributed writers, call `txn.write_state()` once and bind each partition from
-   that immutable state. Calling a transaction convenience method creates a fresh state from the
-   transaction's current configuration.
+2. Call `txn.write_state()` after configuring the transaction, then bind each partition from that
+   immutable state. Distributed writers can encode the state and decode it on each worker before
+   binding partition values.
 3. Write Parquet files (via engine), collect file metadata
 4. Register files via `txn.add_files(metadata)` and stage any removals or deletion-vector updates
 5. Commit: returns `CommittedTransaction`, `ConflictedTransaction`, or `RetryableTransaction`

--- a/docs/user-guide/src/catalog_managed/writing.md
+++ b/docs/user-guide/src/catalog_managed/writing.md
@@ -67,7 +67,8 @@ let mut txn = snapshot
 // Drive your Parquet writer from the write context, then hand the resulting
 // add-file metadata batch to the transaction. See the
 // [Appending data](../writing/append.md) how-to for the full Parquet-writing flow.
-let write_context = txn.unpartitioned_write_context()?;
+let write_state = txn.write_state()?;
+let write_context = write_state.unpartitioned_write_context()?;
 // ... use write_context to produce add_metadata: Box<dyn EngineData>
 //     matching txn.add_files_schema() ...
 txn.add_files(add_metadata);

--- a/docs/user-guide/src/getting_started/quick_start_write.md
+++ b/docs/user-guide/src/getting_started/quick_start_write.md
@@ -86,7 +86,8 @@ async fn main() -> DeltaResult<()> {
     )?;
 
     // Write Parquet and add file metadata to the transaction
-    let write_context = Arc::new(txn.unpartitioned_write_context()?);
+    let write_state = txn.write_state()?;
+    let write_context = Arc::new(write_state.unpartitioned_write_context()?);
     let data = ArrowEngineData::new(batch);
     let file_metadata = engine
         .write_parquet(&data, write_context.as_ref())
@@ -175,15 +176,17 @@ let data = ArrowEngineData::new(batch);
 
 **Write the Parquet file and collect file metadata:**
 ```rust,ignore
-let write_context = Arc::new(txn.unpartitioned_write_context()?);
+let write_state = txn.write_state()?;
+let write_context = Arc::new(write_state.unpartitioned_write_context()?);
 let file_metadata = engine
     .write_parquet(&data, write_context.as_ref())
     .await?;
 txn.add_files(file_metadata);
 ```
 
-`unpartitioned_write_context()` creates a `BoundWriteContext` with the target directory, schema,
-and stats configuration.
+`write_state()` captures the transaction's table-wide write configuration.
+`unpartitioned_write_context()` binds that state into a `BoundWriteContext` with the target
+directory, schema, and stats configuration.
 `write_parquet` writes a Parquet file and returns metadata (path, size, stats) that the
 transaction needs. `add_files` registers that metadata with the transaction.
 

--- a/docs/user-guide/src/getting_started/quick_start_write.md
+++ b/docs/user-guide/src/getting_started/quick_start_write.md
@@ -87,10 +87,10 @@ async fn main() -> DeltaResult<()> {
 
     // Write Parquet and add file metadata to the transaction
     let write_state = txn.write_state()?;
-    let write_context = Arc::new(write_state.unpartitioned_write_context()?);
+    let write_context = write_state.unpartitioned_write_context()?;
     let data = ArrowEngineData::new(batch);
     let file_metadata = engine
-        .write_parquet(&data, write_context.as_ref())
+        .write_parquet(&data, &write_context)
         .await?;
     txn.add_files(file_metadata);
 
@@ -177,9 +177,9 @@ let data = ArrowEngineData::new(batch);
 **Write the Parquet file and collect file metadata:**
 ```rust,ignore
 let write_state = txn.write_state()?;
-let write_context = Arc::new(write_state.unpartitioned_write_context()?);
+let write_context = write_state.unpartitioned_write_context()?;
 let file_metadata = engine
-    .write_parquet(&data, write_context.as_ref())
+    .write_parquet(&data, &write_context)
     .await?;
 txn.add_files(file_metadata);
 ```

--- a/docs/user-guide/src/unity_catalog/writing.md
+++ b/docs/user-guide/src/unity_catalog/writing.md
@@ -102,7 +102,8 @@ write context, write Parquet files to the table's storage location, and add the
 resulting file metadata to the transaction.
 
 ```rust,ignore
-let write_context = txn.unpartitioned_write_context()?;
+let write_state = txn.write_state()?;
+let write_context = write_state.unpartitioned_write_context()?;
 // ... write Parquet files using write_context ...
 txn.add_files(file_metadata);
 ```
@@ -286,7 +287,8 @@ let mut txn = snapshot.clone().transaction(committer, &engine)?
     .with_operation("INSERT".to_string());
 
 // 6. Write data
-let write_context = txn.unpartitioned_write_context()?;
+let write_state = txn.write_state()?;
+let write_context = write_state.unpartitioned_write_context()?;
 // ... write Parquet files using write_context ...
 txn.add_files(file_metadata);
 

--- a/docs/user-guide/src/writing/alter_table.md
+++ b/docs/user-guide/src/writing/alter_table.md
@@ -122,7 +122,7 @@ time. In particular, the following are not callable on an `AlterTableTransaction
 
 | Method | Used for |
 |--------|----------|
-| `unpartitioned_write_context()` / `partitioned_write_context()` | Obtaining a `BoundWriteContext` to write Parquet files |
+| `write_state()` | Creating the `WriteState` used to bind a `BoundWriteContext` |
 | `add_files()` | Registering newly written data files |
 | `stats_schema()` | Retrieving the statistics schema for written files |
 

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -11,7 +11,7 @@ Appending data to a Delta table follows these steps:
 
 1. Get a `Snapshot` of the table
 2. Create a `Transaction` from the snapshot
-3. Get the `BoundWriteContext` from the transaction
+3. Create a `WriteState` and bind a `BoundWriteContext`
 4. [Write Parquet files](#writing-parquet-files) using the engine and `BoundWriteContext`
 5. Register the written files with the transaction via `add_files`
 6. Commit the transaction
@@ -47,8 +47,9 @@ let mut txn = snapshot
     .with_engine_info("my-app/1.0")
     .with_data_change(true);
 
-// 3. Get write context
-let write_context = Arc::new(txn.unpartitioned_write_context()?);
+// 3. Create write state and bind a write context
+let write_state = txn.write_state()?;
+let write_context = Arc::new(write_state.unpartitioned_write_context()?);
 
 // 4. Write Parquet file(s)
 // Assumes the table schema is: name (STRING), age (INTEGER), city (STRING)
@@ -100,17 +101,19 @@ The builder methods:
 | `with_engine_info(impl Into<String>)` | Identifies your application in the commit log |
 | `with_data_change(bool)` | Whether this commit materially changes data (`true`) or just reorganizes it (`false`, e.g. OPTIMIZE) |
 
-## The BoundWriteContext
+## WriteState and BoundWriteContext
 
-Before writing data, obtain a `BoundWriteContext`. A `BoundWriteContext` bundles everything
-needed to correctly write Parquet files:
+Before writing data, obtain a `WriteState` from the transaction. Bind the state to create a
+`BoundWriteContext`, which bundles everything needed to correctly write Parquet files:
 
 ```rust,ignore
+let write_state = txn.write_state()?;
+
 // For unpartitioned tables
-let write_context = txn.unpartitioned_write_context()?;
+let write_context = write_state.unpartitioned_write_context()?;
 
 // For partitioned tables, pass the partition values for this file
-let write_context = txn.partitioned_write_context(partition_values)?;
+let write_context = write_state.partitioned_write_context(partition_values)?;
 ```
 
 For partitioned tables, see
@@ -145,7 +148,8 @@ let file_metadata = engine
 ```
 
 - **`data`**: An `ArrowEngineData` wrapping a `RecordBatch` matching the logical schema
-- **`write_context`**: From `unpartitioned_write_context()` or `partitioned_write_context()`
+- **`write_context`**: Bound from a `WriteState` with `unpartitioned_write_context()` or
+  `partitioned_write_context()`
 
 `DefaultEngine::write_parquet` handles the logical-to-physical transformation, generates a unique filename,
 writes the file, collects statistics, and returns file metadata that you pass to
@@ -181,10 +185,9 @@ txn.add_files(add_file_metadata);
 You can call `add_files` multiple times to write multiple files in one transaction.
 
 > [!NOTE]
-> Methods that produce or register data files (`unpartitioned_write_context`,
-> `partitioned_write_context`, `add_files`, `stats_schema`) are gated by the
-> `SupportsDataFiles` trait bound and are available on standard write transactions but not
-> on metadata-only transaction states (such as a future `AlterTable`).
+> Transaction methods that prepare or register data files (`write_state`, `add_files`, and
+> `stats_schema`) are gated by the `SupportsDataFiles` trait bound. They're available on standard
+> write transactions but not on metadata-only transaction states such as `AlterTable`.
 
 ## Committing
 

--- a/docs/user-guide/src/writing/append.md
+++ b/docs/user-guide/src/writing/append.md
@@ -49,7 +49,7 @@ let mut txn = snapshot
 
 // 3. Create write state and bind a write context
 let write_state = txn.write_state()?;
-let write_context = Arc::new(write_state.unpartitioned_write_context()?);
+let write_context = write_state.unpartitioned_write_context()?;
 
 // 4. Write Parquet file(s)
 // Assumes the table schema is: name (STRING), age (INTEGER), city (STRING)
@@ -63,7 +63,7 @@ let batch = RecordBatch::try_new(
 )?;
 let data = ArrowEngineData::new(batch);
 let file_metadata = engine
-    .write_parquet(&data, write_context.as_ref())
+    .write_parquet(&data, &write_context)
     .await?;
 
 // 5. Register the files
@@ -143,7 +143,7 @@ The `DefaultEngine` provides an async helper that does everything for you:
 
 ```rust,ignore
 let file_metadata = engine
-    .write_parquet(&data, write_context.as_ref())
+    .write_parquet(&data, &write_context)
     .await?;
 ```
 

--- a/ffi/src/transaction/mod.rs
+++ b/ffi/src/transaction/mod.rs
@@ -810,10 +810,10 @@ mod tests {
     use test_utils::delta_kernel_default_engine::DefaultEngine;
     use test_utils::{set_json_value, setup_test_tables, test_read};
     use write_context::{
-        create_table_get_unpartitioned_write_context, free_write_context, get_logical_to_physical,
-        get_partitioned_write_context, get_physical_write_schema, get_unpartitioned_write_context,
-        get_write_dir, get_write_path, get_write_schema, resolve_file_path, visit_partition_values,
-        SharedWriteContext,
+        create_table_get_partitioned_write_context, create_table_get_unpartitioned_write_context,
+        free_write_context, get_logical_to_physical, get_partitioned_write_context,
+        get_physical_write_schema, get_unpartitioned_write_context, get_write_dir, get_write_path,
+        get_write_schema, resolve_file_path, visit_partition_values, SharedWriteContext,
     };
 
     use super::*;
@@ -2271,7 +2271,48 @@ mod tests {
                 engine.shallow_copy(),
             )
         });
-        build_and_commit(builder, &engine);
+        let txn =
+            ok_or_panic(unsafe { create_table_builder_build(builder, engine.shallow_copy()) });
+
+        let partition_values = partition_value_map_new();
+        let value = "2024-01-01";
+        assert!(ok_or_panic(unsafe {
+            partition_value_map_insert_string(
+                partition_values.shallow_copy(),
+                kernel_string_slice!(col),
+                kernel_string_slice!(value),
+                engine.shallow_copy(),
+            )
+        }));
+        let write_context = ok_or_panic(unsafe {
+            create_table_get_partitioned_write_context(
+                txn.shallow_copy(),
+                partition_values,
+                engine.shallow_copy(),
+            )
+        });
+        let write_dir = recover_string(
+            unsafe { get_write_dir(write_context.shallow_copy(), allocate_str) }.unwrap(),
+        );
+        assert!(write_dir.ends_with("date=2024-01-01/"), "{write_dir}");
+        unsafe { free_write_context(write_context) };
+
+        let missing_partition_value = unsafe {
+            create_table_get_partitioned_write_context(
+                txn.shallow_copy(),
+                partition_value_map_new(),
+                engine.shallow_copy(),
+            )
+        };
+        assert_extern_result_error_with_message(
+            missing_partition_value,
+            KernelError::UnknownError,
+            Some("Invalid partition values: missing partition column 'date'. Provided: []"),
+        );
+
+        let committed = ok_or_panic(unsafe { create_table_commit(txn, engine.shallow_copy()) });
+        let version = unsafe { version_and_free(committed) };
+        assert_eq!(version, 0);
 
         // A partitioned create records the partition columns in the table metadata.
         let log = read_v0_commit(&store, &table_url).await;

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -39,7 +39,8 @@ pub unsafe extern "C" fn get_unpartitioned_write_context(
 ) -> ExternResult<Handle<SharedWriteContext>> {
     let txn = unsafe { txn.as_ref() };
     let engine = unsafe { engine.as_ref() };
-    txn.unpartitioned_write_context()
+    txn.write_state()
+        .and_then(|state| state.unpartitioned_write_context())
         .map(|context| Arc::new(context).into())
         .into_extern_result(&engine)
 }
@@ -59,7 +60,8 @@ pub unsafe extern "C" fn create_table_get_unpartitioned_write_context(
 ) -> ExternResult<Handle<SharedWriteContext>> {
     let txn = unsafe { txn.as_ref() };
     let engine = unsafe { engine.as_ref() };
-    txn.unpartitioned_write_context()
+    txn.write_state()
+        .and_then(|state| state.unpartitioned_write_context())
         .map(|context| Arc::new(context).into())
         .into_extern_result(&engine)
 }
@@ -90,8 +92,11 @@ pub unsafe extern "C" fn get_partitioned_write_context(
     let txn = unsafe { txn.as_ref() };
     let partition_values = unsafe { partition_values.into_inner() };
     let engine = unsafe { engine.as_ref() };
-    partitioned_write_context_impl(|pv| txn.partitioned_write_context(pv), *partition_values)
-        .into_extern_result(&engine)
+    partitioned_write_context_impl(
+        |pv| txn.write_state()?.partitioned_write_context(pv),
+        *partition_values,
+    )
+    .into_extern_result(&engine)
 }
 
 /// Gets the write context from a create-table transaction for a partitioned table. See
@@ -110,12 +115,15 @@ pub unsafe extern "C" fn create_table_get_partitioned_write_context(
     let txn = unsafe { txn.as_ref() };
     let partition_values = unsafe { partition_values.into_inner() };
     let engine = unsafe { engine.as_ref() };
-    partitioned_write_context_impl(|pv| txn.partitioned_write_context(pv), *partition_values)
-        .into_extern_result(&engine)
+    partitioned_write_context_impl(
+        |pv| txn.write_state()?.partitioned_write_context(pv),
+        *partition_values,
+    )
+    .into_extern_result(&engine)
 }
 
-/// Shared body for the partitioned write-context entry points: hand the owned partition values to
-/// the transaction's `partitioned_write_context` and wrap the result in a shared handle.
+/// Shared body for the partitioned write-context entry points: bind the owned partition values to
+/// the transaction's write state and wrap the result in a shared handle.
 fn partitioned_write_context_impl(
     build: impl FnOnce(HashMap<String, Scalar>) -> DeltaResult<BoundWriteContext>,
     partition_values: PartitionValueMap,

--- a/ffi/src/transaction/write_context.rs
+++ b/ffi/src/transaction/write_context.rs
@@ -122,8 +122,6 @@ pub unsafe extern "C" fn create_table_get_partitioned_write_context(
     .into_extern_result(&engine)
 }
 
-/// Shared body for the partitioned write-context entry points: bind the owned partition values to
-/// the transaction's write state and wrap the result in a shared handle.
 fn partitioned_write_context_impl(
     build: impl FnOnce(HashMap<String, Scalar>) -> DeltaResult<BoundWriteContext>,
     partition_values: PartitionValueMap,

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -94,10 +94,8 @@ async fn try_main() -> DeltaResult<()> {
         .with_data_change(true);
 
     // Write the data using the engine
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
-    let file_metadata = engine
-        .write_parquet(&sample_data, write_context.as_ref())
-        .await?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
+    let file_metadata = engine.write_parquet(&sample_data, &write_context).await?;
 
     // Add the file metadata to the transaction
     txn.add_files(file_metadata);

--- a/kernel/examples/write-table/src/main.rs
+++ b/kernel/examples/write-table/src/main.rs
@@ -94,7 +94,7 @@ async fn try_main() -> DeltaResult<()> {
         .with_data_change(true);
 
     // Write the data using the engine
-    let write_context = Arc::new(txn.unpartitioned_write_context()?);
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let file_metadata = engine
         .write_parquet(&sample_data, write_context.as_ref())
         .await?;

--- a/kernel/src/transaction/bound_write_context.rs
+++ b/kernel/src/transaction/bound_write_context.rs
@@ -13,9 +13,8 @@ use crate::schema::SchemaRef;
 use crate::table_features::ColumnMappingMode;
 use crate::{DeltaResult, Error};
 
-/// A write context for a specific partition or an unpartitioned table. Created by either a
-/// [`WriteState`](super::WriteState) or the convenience methods on
-/// [`Transaction`](super::Transaction).
+/// A write context for a specific partition or an unpartitioned table. Created by a
+/// [`WriteState`](super::WriteState).
 ///
 /// Note: clustered tables are unpartitioned and use `unpartitioned_write_context`.
 ///
@@ -30,8 +29,8 @@ use crate::{DeltaResult, Error};
 /// - **Fully custom (non-Arrow) engines**: use [`physical_partition_values`] to build the
 ///   `partitionValues` map in Add actions directly.
 ///
-/// [`Transaction::partitioned_write_context`]: super::Transaction::partitioned_write_context
-/// [`Transaction::unpartitioned_write_context`]: super::Transaction::unpartitioned_write_context
+/// [`WriteState::partitioned_write_context`]: super::WriteState::partitioned_write_context
+/// [`WriteState::unpartitioned_write_context`]: super::WriteState::unpartitioned_write_context
 /// [`Transaction::add_files`]: super::Transaction::add_files
 /// [`physical_partition_values`]: BoundWriteContext::physical_partition_values
 #[derive(Debug)]
@@ -244,7 +243,8 @@ impl BoundWriteContext {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// let write_context = transaction.unpartitioned_write_context()?;
+    /// let write_state = transaction.write_state()?;
+    /// let write_context = write_state.unpartitioned_write_context()?;
     /// let dv_path = write_context.new_deletion_vector_path(String::from(rand_string()));
     /// ```
     // TODO(#2357): generate the random prefix internally based on table properties

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -22,7 +22,7 @@ use crate::error::Error;
 use crate::expressions::UnaryExpressionOp::ToJson;
 use crate::expressions::{
     col, column_name, lit, ArrayData, ColumnName, ExpressionStructPatch,
-    ExpressionStructPatchBuilder, Scalar,
+    ExpressionStructPatchBuilder,
 };
 use crate::log_replay::HasSelectionVector;
 use crate::log_segment::LogSegment;
@@ -819,14 +819,14 @@ impl<S> Transaction<S> {
             return Ok(());
         }
         if self.has_data_file_actions() {
-            self.ensure_schema_non_empty_for_write_context()?;
+            self.ensure_schema_non_empty_for_write_state()?;
         }
         Ok(())
     }
 
-    /// Reject `BoundWriteContext` handouts on empty-schema tables, so engines fail
-    /// before staging any parquet. CREATE TABLE is exempt.
-    fn ensure_schema_non_empty_for_write_context(&self) -> DeltaResult<()> {
+    /// Reject write-state creation on empty-schema tables, so engines fail before staging any
+    /// parquet. CREATE TABLE is exempt.
+    fn ensure_schema_non_empty_for_write_state(&self) -> DeltaResult<()> {
         if self.is_create_table() {
             return Ok(());
         }
@@ -840,7 +840,7 @@ impl<S> Transaction<S> {
         Ok(())
     }
 
-    /// Rejects write-context creation when a table declares column defaults and the connector has
+    /// Rejects write-state creation when a table declares column defaults and the connector has
     /// not acknowledged handling them.
     fn ensure_column_defaults_acknowledged(&self) -> DeltaResult<()> {
         require!(
@@ -957,10 +957,10 @@ impl<S: SupportsDataFiles> Transaction<S> {
     // TODO(#2499): Remove this API when Engine responsibilities encode column-default handling.
     /// Acknowledges that the connector applies column defaults before writing data files.
     ///
-    /// Call this before requesting a write context for a table that enables the
+    /// Call this before requesting write state for a table that enables the
     /// `allowColumnDefaults` feature and declares at least one column default. The connector must
     /// materialize every omitted column's default itself; this method records that responsibility
-    /// but does not apply any defaults. Without this acknowledgement, write-context creation fails
+    /// but does not apply any defaults. Without this acknowledgement, write-state creation fails
     /// with an error.
     pub fn ack_column_defaults(&mut self) {
         self.column_defaults_acknowledged = true;
@@ -1027,7 +1027,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// [`ColumnDefault::to_scalar`] on each (or fall back to [`ColumnDefault::raw_sql`] when the
     /// kernel cannot parse the default) to materialize the column before writing. After handling
     /// every omitted column, call [`ack_column_defaults`](Self::ack_column_defaults) before
-    /// requesting a write context.
+    /// requesting write state.
     ///
     /// Keys are `String` rather than [`ColumnName`] because the kernel currently surfaces defaults
     /// only for top-level columns, consistent with partition columns. This is a kernel limitation,
@@ -1063,12 +1063,11 @@ impl<S: SupportsDataFiles> Transaction<S> {
 
     /// Validates that the table's logical schema supports data writes.
     ///
-    /// Called at the top of [`partitioned_write_context`](Self::partitioned_write_context) and
-    /// [`unpartitioned_write_context`](Self::unpartitioned_write_context), before any Parquet is
-    /// written, so connectors fail fast when the schema contains unsupported data types or void
-    /// placements that cannot produce valid files.
+    /// Called by [`write_state`](Self::write_state), before any Parquet is written, so connectors
+    /// fail fast when the schema contains unsupported data types or void placements that cannot
+    /// produce valid files.
     /// The commit-time check in [`commit`](Self::commit) remains as defense-in-depth for callers
-    /// that reach [`add_files`](Self::add_files) without going through a write context.
+    /// that reach [`add_files`](Self::add_files) without going through write state.
     fn validate_for_data_write(&self) -> DeltaResult<()> {
         validate_schema_for_write(&self.effective_table_config.logical_schema())
     }
@@ -1079,7 +1078,8 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// or it can be encoded and transported to distributed writers. Each context retains a
     /// reference to the same immutable state. All table-wide write validation runs before the
     /// state is returned so a writer does not begin producing files for a table that kernel cannot
-    /// write to safely.
+    /// write to safely. Call [`WriteState::unpartitioned_write_context`] for an unpartitioned table
+    /// or [`WriteState::partitioned_write_context`] for each partition being written.
     ///
     /// The state captures the transaction configuration when this method is called. If the
     /// transaction is subsequently modified, call this method again to capture the updated
@@ -1088,7 +1088,7 @@ impl<S: SupportsDataFiles> Transaction<S> {
     /// Returns an error if the table has an empty or unsupported schema, or if the table declares
     /// column defaults that the connector has not acknowledged.
     pub fn write_state(&self) -> DeltaResult<Arc<WriteState>> {
-        self.ensure_schema_non_empty_for_write_context()?;
+        self.ensure_schema_non_empty_for_write_state()?;
         self.ensure_column_defaults_acknowledged()?;
         self.validate_for_data_write()?;
         // The effective table configuration can change while building a transaction, so this
@@ -1098,75 +1098,6 @@ impl<S: SupportsDataFiles> Transaction<S> {
             &self.effective_table_config,
             self.stats_columns(),
         )))
-    }
-
-    /// Creates a write context for writing data to a specific partition.
-    ///
-    /// Performs the following validations and transformations:
-    ///
-    /// - **Key completeness**: ensures all partition columns are present and no extra keys exist.
-    ///   For example, if the table has partition columns `["year", "region"]` and you pass
-    ///   `{"year": Scalar::Integer(2024)}`, this returns an error for missing "region".
-    ///
-    /// - **Case normalization**: matches keys case-insensitively against the schema and normalizes
-    ///   to schema case. For example, passing `"YEAR"` for a column named `"year"` is accepted and
-    ///   normalized.
-    ///
-    /// - **Type checking**: rejects non-primitive partition column types (struct, array, map) and
-    ///   validates that each non-null `Scalar`'s type matches the partition column's schema type.
-    ///   For example, passing `Scalar::String("2024")` for an `INTEGER` column returns an error.
-    ///   Null-equivalent scalars (null scalars, empty strings, and empty binary) all of which
-    ///   collapse to JSON null in `partitionValues`) skip the value type check, but they are only
-    ///   legal when the partition column is nullable; passing any of these for a `nullable: false`
-    ///   partition column returns an error.
-    ///
-    /// - **Value serialization**: serializes each `Scalar` to a protocol-compliant string per the
-    ///   Delta protocol's "Partition Value Serialization" rules. `Scalar::Null(...)` becomes `None`
-    ///   in `add.partitionValues` (JSON null). `Scalar::String("")` also becomes `None` (empty
-    ///   string equals null for all types). `Scalar::Date(19723)` becomes `Some("2024-01-01")`.
-    ///
-    /// - **Key translation**: translates logical column names to physical names using the table's
-    ///   column mapping mode. For example, under `ColumnMappingMode::Name`, logical `"year"` might
-    ///   become physical `"col-abc-123"` in the `partitionValues` map.
-    ///
-    /// - **Partition column materialization**: the returned [`BoundWriteContext`]'s
-    ///   [`logical_to_physical`] expression injects partition columns when the table requires
-    ///   materializing partition columns (e.g. `materializePartitionColumns` or `icebergCompatV3`).
-    ///   The input data fed to that expression must not contain partition columns.
-    ///
-    /// The returned [`BoundWriteContext`] also provides a [`write_dir`] that returns the correct
-    /// target directory (Hive-style paths when column mapping is off, random prefix when on).
-    /// This convenience method is equivalent to creating a fresh [`WriteState`] and immediately
-    /// binding `partition_values`. When writing multiple partitions, call [`write_state`] once and
-    /// create every context from the returned shared state.
-    ///
-    /// Returns an error if the table is not partitioned (use
-    /// [`unpartitioned_write_context`](Self::unpartitioned_write_context) instead), or if the
-    /// table enables `allowColumnDefaults`, declares at least one column default, and
-    /// [`ack_column_defaults`](Self::ack_column_defaults) has not been called.
-    ///
-    /// [`write_dir`]: BoundWriteContext::write_dir
-    /// [`logical_to_physical`]: BoundWriteContext::logical_to_physical
-    /// [`write_state`]: Self::write_state
-    pub fn partitioned_write_context(
-        &self,
-        partition_values: HashMap<String, Scalar>,
-    ) -> DeltaResult<BoundWriteContext> {
-        self.write_state()?
-            .partitioned_write_context(partition_values)
-    }
-
-    /// Creates a write context for writing data to an unpartitioned table.
-    ///
-    /// This convenience method is equivalent to creating a fresh [`WriteState`] and immediately
-    /// creating an unpartitioned context from it.
-    ///
-    /// Returns an error if the table has partition columns (use
-    /// [`partitioned_write_context`](Self::partitioned_write_context) instead), or if the table
-    /// enables `allowColumnDefaults`, declares at least one column default, and
-    /// [`ack_column_defaults`](Self::ack_column_defaults) has not been called.
-    pub fn unpartitioned_write_context(&self) -> DeltaResult<BoundWriteContext> {
-        self.write_state()?.unpartitioned_write_context()
     }
 
     /// Add files to include in this transaction. This API generally enables the engine to
@@ -2060,7 +1991,8 @@ mod tests {
         let txn = snapshot
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
-        let write_context = txn.unpartitioned_write_context().unwrap();
+        let write_state = txn.write_state().unwrap();
+        let write_context = write_state.unpartitioned_write_context().unwrap();
 
         // Test with empty prefix
         let dv_path1 = write_context.new_deletion_vector_path(String::from(""));
@@ -2083,7 +2015,7 @@ mod tests {
     }
 
     #[test]
-    fn write_context_reflects_updated_effective_table_config(
+    fn write_state_reflects_updated_effective_table_config(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (engine, snapshot) = setup_non_dv_table();
         let mut txn = snapshot
@@ -2093,7 +2025,8 @@ mod tests {
 
         // Regression coverage for stale WriteState caching: keep the first context alive
         // while the transaction's effective table config changes.
-        let initial_write_context = txn.unpartitioned_write_context()?;
+        let initial_write_state = txn.write_state()?;
+        let initial_write_context = initial_write_state.unpartitioned_write_context()?;
         assert!(!initial_write_context
             .logical_schema()
             .contains("fresh_column"));
@@ -2114,7 +2047,8 @@ mod tests {
         )?;
         txn.replace_effective_table_config(evolved_table_config);
 
-        let updated_write_context = txn.unpartitioned_write_context()?;
+        let updated_write_state = txn.write_state()?;
+        let updated_write_context = updated_write_state.unpartitioned_write_context()?;
         assert!(updated_write_context
             .logical_schema()
             .contains("fresh_column"));
@@ -2269,7 +2203,8 @@ mod tests {
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?
             .with_engine_info("default engine");
 
-        let write_context = txn.partitioned_write_context(HashMap::from([(
+        let write_state = txn.write_state()?;
+        let write_context = write_state.partitioned_write_context(HashMap::from([(
             "letter".to_string(),
             Scalar::String("a".into()),
         )]))?;
@@ -2313,7 +2248,8 @@ mod tests {
         let txn = snapshot
             .clone()
             .transaction(Box::new(FileSystemCommitter::new()), &engine)?;
-        let wc = txn.partitioned_write_context(partition_values)?;
+        let write_state = txn.write_state()?;
+        let wc = write_state.partitioned_write_context(partition_values)?;
         Ok((snapshot, wc))
     }
 
@@ -2419,7 +2355,8 @@ mod tests {
             ])
             .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
 
-        let wc = txn.partitioned_write_context(HashMap::from([
+        let write_state = txn.write_state()?;
+        let wc = write_state.partitioned_write_context(HashMap::from([
             ("p1".to_string(), Scalar::String("aa".into())),
             ("p2".to_string(), Scalar::Integer(7)),
             ("p3".to_string(), Scalar::String("cc".into())),
@@ -2511,10 +2448,12 @@ mod tests {
         let url = url::Url::from_directory_path(path).unwrap();
         let snapshot = Snapshot::builder_for(url).build(&engine)?;
         let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
+        let write_state = txn.write_state()?;
         let result = if call_partitioned {
-            txn.partitioned_write_context(HashMap::from([("x".to_string(), Scalar::Integer(1))]))
+            write_state
+                .partitioned_write_context(HashMap::from([("x".to_string(), Scalar::Integer(1))]))
         } else {
-            txn.unpartitioned_write_context()
+            write_state.unpartitioned_write_context()
         };
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3046,7 +2985,8 @@ mod tests {
         #[case] mode: ColumnMappingMode,
     ) -> DeltaResult<()> {
         let (_engine, txn) = crate::unit_test_utils::setup_column_mapping_txn(schema, mode)?;
-        let write_context = txn.unpartitioned_write_context().unwrap();
+        let write_state = txn.write_state().unwrap();
+        let write_context = write_state.unpartitioned_write_context().unwrap();
         crate::unit_test_utils::validate_physical_schema_column_mapping(
             write_context.logical_schema(),
             write_context.physical_schema(),
@@ -3095,7 +3035,8 @@ mod tests {
     fn validate_logical_to_physical_transform(mode: ColumnMappingMode) -> DeltaResult<()> {
         let schema = test_schema_nested();
         let (_engine, txn) = crate::unit_test_utils::setup_column_mapping_txn(schema, mode)?;
-        let write_context = txn.unpartitioned_write_context().unwrap();
+        let write_state = txn.write_state().unwrap();
+        let write_context = write_state.unpartitioned_write_context().unwrap();
         let logical_schema = write_context.logical_schema();
         let physical_schema = write_context.physical_schema();
         let logical_to_physical_expression = write_context.logical_to_physical();

--- a/kernel/src/transaction/write_state.rs
+++ b/kernel/src/transaction/write_state.rs
@@ -88,12 +88,46 @@ impl WriteState {
 
     /// Creates a write context for writing data to a specific partition.
     ///
-    /// The supplied map must contain exactly one entry for every logical partition column. Keys
-    /// are matched case-insensitively and values are validated against the table schema before
-    /// being serialized according to the Delta partition-value rules.
+    /// Performs the following validations and transformations:
+    ///
+    /// - **Key completeness**: ensures all partition columns are present and no extra keys exist.
+    ///   For example, if the table has partition columns `["year", "region"]` and you pass
+    ///   `{"year": Scalar::Integer(2024)}`, this returns an error for missing "region".
+    ///
+    /// - **Case normalization**: matches keys case-insensitively against the schema and normalizes
+    ///   to schema case. For example, passing `"YEAR"` for a column named `"year"` is accepted and
+    ///   normalized.
+    ///
+    /// - **Type checking**: rejects non-primitive partition column types (struct, array, map) and
+    ///   validates that each non-null `Scalar`'s type matches the partition column's schema type.
+    ///   For example, passing `Scalar::String("2024")` for an `INTEGER` column returns an error.
+    ///   Null-equivalent scalars (null scalars, empty strings, and empty binary) all of which
+    ///   collapse to JSON null in `partitionValues`) skip the value type check, but they are only
+    ///   legal when the partition column is nullable; passing any of these for a `nullable: false`
+    ///   partition column returns an error.
+    ///
+    /// - **Value serialization**: serializes each `Scalar` to a protocol-compliant string per the
+    ///   Delta protocol's "Partition Value Serialization" rules. `Scalar::Null(...)` becomes `None`
+    ///   in `add.partitionValues` (JSON null). `Scalar::String("")` also becomes `None` (empty
+    ///   string equals null for all types). `Scalar::Date(19723)` becomes `Some("2024-01-01")`.
+    ///
+    /// - **Key translation**: translates logical column names to physical names using the table's
+    ///   column mapping mode. For example, under `ColumnMappingMode::Name`, logical `"year"` might
+    ///   become physical `"col-abc-123"` in the `partitionValues` map.
+    ///
+    /// - **Partition column materialization**: the returned [`BoundWriteContext`]'s
+    ///   [`logical_to_physical`] expression injects partition columns when the table requires
+    ///   materializing partition columns (e.g. `materializePartitionColumns` or `icebergCompatV3`).
+    ///   The input data fed to that expression must not contain partition columns.
+    ///
+    /// The returned [`BoundWriteContext`] also provides a [`write_dir`] that returns the correct
+    /// target directory (Hive-style paths when column mapping is off, random prefix when on).
     ///
     /// Returns an error if the table is not partitioned or if the partition keys or values are
     /// invalid.
+    ///
+    /// [`write_dir`]: BoundWriteContext::write_dir
+    /// [`logical_to_physical`]: BoundWriteContext::logical_to_physical
     pub fn partitioned_write_context(
         self: &Arc<Self>,
         partition_values: HashMap<String, Scalar>,

--- a/kernel/src/transaction/write_state.rs
+++ b/kernel/src/transaction/write_state.rs
@@ -86,48 +86,17 @@ impl WriteState {
         }
     }
 
-    /// Creates a write context for writing data to a specific partition.
+    /// Creates a write context bound to one partition.
     ///
-    /// Performs the following validations and transformations:
+    /// `partition_values` must contain one typed value for every logical partition column and no
+    /// other keys. Names are matched case-insensitively and normalized to schema case. Values are
+    /// validated, serialized according to the Delta protocol, and keyed by physical column name in
+    /// the returned context. Null-equivalent values require nullable partition columns.
     ///
-    /// - **Key completeness**: ensures all partition columns are present and no extra keys exist.
-    ///   For example, if the table has partition columns `["year", "region"]` and you pass
-    ///   `{"year": Scalar::Integer(2024)}`, this returns an error for missing "region".
+    /// The context materializes partition columns when required by the table protocol. Input data
+    /// passed to its logical-to-physical expression must omit partition columns.
     ///
-    /// - **Case normalization**: matches keys case-insensitively against the schema and normalizes
-    ///   to schema case. For example, passing `"YEAR"` for a column named `"year"` is accepted and
-    ///   normalized.
-    ///
-    /// - **Type checking**: rejects non-primitive partition column types (struct, array, map) and
-    ///   validates that each non-null `Scalar`'s type matches the partition column's schema type.
-    ///   For example, passing `Scalar::String("2024")` for an `INTEGER` column returns an error.
-    ///   Null-equivalent scalars (null scalars, empty strings, and empty binary) all of which
-    ///   collapse to JSON null in `partitionValues`) skip the value type check, but they are only
-    ///   legal when the partition column is nullable; passing any of these for a `nullable: false`
-    ///   partition column returns an error.
-    ///
-    /// - **Value serialization**: serializes each `Scalar` to a protocol-compliant string per the
-    ///   Delta protocol's "Partition Value Serialization" rules. `Scalar::Null(...)` becomes `None`
-    ///   in `add.partitionValues` (JSON null). `Scalar::String("")` also becomes `None` (empty
-    ///   string equals null for all types). `Scalar::Date(19723)` becomes `Some("2024-01-01")`.
-    ///
-    /// - **Key translation**: translates logical column names to physical names using the table's
-    ///   column mapping mode. For example, under `ColumnMappingMode::Name`, logical `"year"` might
-    ///   become physical `"col-abc-123"` in the `partitionValues` map.
-    ///
-    /// - **Partition column materialization**: the returned [`BoundWriteContext`]'s
-    ///   [`logical_to_physical`] expression injects partition columns when the table requires
-    ///   materializing partition columns (e.g. `materializePartitionColumns` or `icebergCompatV3`).
-    ///   The input data fed to that expression must not contain partition columns.
-    ///
-    /// The returned [`BoundWriteContext`] also provides a [`write_dir`] that returns the correct
-    /// target directory (Hive-style paths when column mapping is off, random prefix when on).
-    ///
-    /// Returns an error if the table is not partitioned or if the partition keys or values are
-    /// invalid.
-    ///
-    /// [`write_dir`]: BoundWriteContext::write_dir
-    /// [`logical_to_physical`]: BoundWriteContext::logical_to_physical
+    /// Returns an error if the table is unpartitioned or the keys or values are invalid.
     pub fn partitioned_write_context(
         self: &Arc<Self>,
         partition_values: HashMap<String, Scalar>,

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -225,7 +225,12 @@ pub async fn write_data_and_check_result_and_stats(
     });
 
     // write data out by spawning async tasks to simulate executors
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
     let tasks = append_data.into_iter().map(|data| {
         // arc clones
         let engine = engine.clone();

--- a/kernel/tests/integration/common/write_utils.rs
+++ b/kernel/tests/integration/common/write_utils.rs
@@ -225,12 +225,7 @@ pub async fn write_data_and_check_result_and_stats(
     });
 
     // write data out by spawning async tasks to simulate executors
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let tasks = append_data.into_iter().map(|data| {
         // arc clones
         let engine = engine.clone();

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -260,9 +260,9 @@ async fn run_ctas_test(
     }
     let mut tgt_txn = tgt_builder.build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
 
-    let write_context = Arc::new(tgt_txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = tgt_txn.write_state()?.unpartitioned_write_context()?;
     let add_meta = engine
-        .write_parquet(&ArrowEngineData::new(source_data), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(source_data), &write_context)
         .await?;
     tgt_txn.add_files(add_meta);
 

--- a/kernel/tests/integration/create_table/ctas.rs
+++ b/kernel/tests/integration/create_table/ctas.rs
@@ -260,7 +260,7 @@ async fn run_ctas_test(
     }
     let mut tgt_txn = tgt_builder.build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
 
-    let write_context = Arc::new(tgt_txn.unpartitioned_write_context()?);
+    let write_context = Arc::new(tgt_txn.write_state()?.unpartitioned_write_context()?);
     let add_meta = engine
         .write_parquet(&ArrowEngineData::new(source_data), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/create_table/row_tracking.rs
+++ b/kernel/tests/integration/create_table/row_tracking.rs
@@ -96,7 +96,7 @@ async fn test_create_table_with_row_tracking(
         )
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-        let write_context = Arc::new(txn.unpartitioned_write_context()?);
+        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
         let add_files = engine
             .write_parquet(&ArrowEngineData::new(batch), write_context.as_ref())
             .await?;
@@ -222,7 +222,7 @@ async fn test_create_table_with_multiple_files_and_row_tracking() -> DeltaResult
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-    let write_context = Arc::new(txn.unpartitioned_write_context()?);
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let adds1 = engine
         .write_parquet(&ArrowEngineData::new(batch1), write_context.as_ref())
         .await?;
@@ -335,7 +335,7 @@ async fn test_create_table_with_row_tracking_and_clustering_and_data() -> DeltaR
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-    let write_context = Arc::new(txn.unpartitioned_write_context()?);
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let add_files = engine
         .write_parquet(&ArrowEngineData::new(batch), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/create_table/row_tracking.rs
+++ b/kernel/tests/integration/create_table/row_tracking.rs
@@ -96,9 +96,9 @@ async fn test_create_table_with_row_tracking(
         )
         .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+        let write_context = txn.write_state()?.unpartitioned_write_context()?;
         let add_files = engine
-            .write_parquet(&ArrowEngineData::new(batch), write_context.as_ref())
+            .write_parquet(&ArrowEngineData::new(batch), &write_context)
             .await?;
         txn.add_files(add_files);
     }
@@ -222,12 +222,12 @@ async fn test_create_table_with_multiple_files_and_row_tracking() -> DeltaResult
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let adds1 = engine
-        .write_parquet(&ArrowEngineData::new(batch1), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(batch1), &write_context)
         .await?;
     let adds2 = engine
-        .write_parquet(&ArrowEngineData::new(batch2), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(batch2), &write_context)
         .await?;
 
     txn.add_files(adds1);
@@ -335,9 +335,9 @@ async fn test_create_table_with_row_tracking_and_clustering_and_data() -> DeltaR
     )
     .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let add_files = engine
-        .write_parquet(&ArrowEngineData::new(batch), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(batch), &write_context)
         .await?;
     txn.add_files(add_files);
 

--- a/kernel/tests/integration/features/alter_table.rs
+++ b/kernel/tests/integration/features/alter_table.rs
@@ -460,16 +460,16 @@ async fn empty_create_then_add_column(
             && scan_err.to_string().contains("ALTER TABLE ADD COLUMN"),
         "scan error must point at ALTER TABLE ADD COLUMN, got: {scan_err}"
     );
-    let write_err = v0
+    let write_state_err = v0
         .clone()
         .transaction(committer(), engine.as_ref())?
         .with_engine_info("EmptySchemaApp/0.1.0")
-        .unpartitioned_write_context()
-        .expect_err("unpartitioned_write_context() must reject empty-schema snapshots");
+        .write_state()
+        .expect_err("write_state() must reject empty-schema snapshots");
     assert!(
-        write_err.to_string().contains("empty schema")
-            && write_err.to_string().contains("alter_table"),
-        "write_context error must point at alter_table, got: {write_err}"
+        write_state_err.to_string().contains("empty schema")
+            && write_state_err.to_string().contains("alter_table"),
+        "write_state error must point at alter_table, got: {write_state_err}"
     );
 
     v0.alter_table()

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -243,7 +243,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     // Step 5: Update deletion vectors for first file only
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let dv_descriptor_1 =
         write_deletion_vector_to_store(&store, &write_context, dv_file1_first, "").await?;
     let scan_files = get_scan_files(snapshot.clone(), engine.as_ref())?;
@@ -280,7 +280,7 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     // Step 8: Update deletion vectors for both files
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     // Write deletion vectors for both files
     let dv_descriptor_1_second =
@@ -420,7 +420,7 @@ async fn test_dv_update_stats_tight_bound(
     dv.add_deleted_row_indexes([3u64]);
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;
     let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let dv_descriptor = write_deletion_vector_to_store(&store, &write_context, dv, "").await?;
 
     let scan_files = get_scan_files(snapshot, engine.as_ref())?;

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -89,7 +89,7 @@ async fn write_data_to_table(
         load_and_begin_transaction(table_url.clone(), engine.as_ref())?.with_data_change(true);
 
     // Write data out by spawning async tasks to simulate executors
-    let write_context = Arc::new(txn.unpartitioned_write_context()?);
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let tasks = data.into_iter().map(|data| {
         let engine = engine.clone();
         let write_context = write_context.clone();
@@ -678,8 +678,8 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     )?;
 
     // Write data for both transactions
-    let write_context1 = Arc::new(txn1.unpartitioned_write_context()?);
-    let write_context2 = Arc::new(txn2.unpartitioned_write_context()?);
+    let write_context1 = Arc::new(txn1.write_state()?.unpartitioned_write_context()?);
+    let write_context2 = Arc::new(txn2.write_state()?.unpartitioned_write_context()?);
 
     let metadata1 = engine1
         .write_parquet(&ArrowEngineData::new(data1), write_context1.as_ref())
@@ -964,7 +964,7 @@ async fn test_read_row_ids_stable_across_deletion_vector_update(
     let mut dv = KernelDeletionVector::new();
     dv.add_deleted_row_indexes(deleted_indexes.iter().copied());
     let mut txn = create_dv_update_transaction(&table_url, engine.as_ref())?;
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let dv_descriptor = write_deletion_vector_to_store(&store, &write_context, dv, "").await?;
 
     let file_path = read_add_infos(snapshot.as_ref(), engine.as_ref())?[0]

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -678,15 +678,15 @@ async fn test_row_tracking_parallel_transactions_conflict() -> DeltaResult<()> {
     )?;
 
     // Write data for both transactions
-    let write_context1 = Arc::new(txn1.write_state()?.unpartitioned_write_context()?);
-    let write_context2 = Arc::new(txn2.write_state()?.unpartitioned_write_context()?);
+    let write_context1 = txn1.write_state()?.unpartitioned_write_context()?;
+    let write_context2 = txn2.write_state()?.unpartitioned_write_context()?;
 
     let metadata1 = engine1
-        .write_parquet(&ArrowEngineData::new(data1), write_context1.as_ref())
+        .write_parquet(&ArrowEngineData::new(data1), &write_context1)
         .await?;
 
     let metadata2 = engine2
-        .write_parquet(&ArrowEngineData::new(data2), write_context2.as_ref())
+        .write_parquet(&ArrowEngineData::new(data2), &write_context2)
         .await?;
 
     txn1.add_files(metadata1);

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -632,7 +632,7 @@ async fn test_write_checksum_resolves_correct_crc_from_each_root(
         if v == 3 {
             txn = txn.with_domain_metadata_removed(removed_domain.to_string());
         }
-        let write_context = txn.unpartitioned_write_context()?;
+        let write_context = txn.write_state()?.unpartitioned_write_context()?;
         let adds = engine
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
             .await?;
@@ -818,7 +818,7 @@ async fn setup_incremental_below_checkpoint_base<E: TaskExecutor>(
             .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
             .with_operation("WRITE".to_string())
             .with_data_change(true);
-        let write_context = txn.unpartitioned_write_context()?;
+        let write_context = txn.write_state()?.unpartitioned_write_context()?;
         let adds = engine
             .write_parquet(&ArrowEngineData::new(batch), &write_context)
             .await?;
@@ -2116,7 +2116,7 @@ async fn commit_data<E: TaskExecutor>(
         .with_operation("WRITE".to_string())
         .with_data_change(true);
     let mut txn = customize(txn);
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let adds = engine
         .write_parquet(&ArrowEngineData::new(batch), &write_context)
         .await?;

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -369,12 +369,7 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
 
         // write data out by spawning async tasks to simulate executors
         let engine = Arc::new(engine);
-        let write_context = Arc::new(
-            txn.write_state()
-                .unwrap()
-                .unpartitioned_write_context()
-                .unwrap(),
-        );
+        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
         let tasks = append_data.into_iter().map(|data| {
             // arc clones
             let engine = engine.clone();

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -18,7 +18,7 @@ use delta_kernel::schema::{schema, schema_ref};
 use delta_kernel::table_features::ColumnMappingMode;
 use delta_kernel::transaction::create_table::create_table;
 use delta_kernel::transaction::data_layout::DataLayout;
-use delta_kernel::transaction::{Transaction, WriteState};
+use delta_kernel::transaction::WriteState;
 use delta_kernel::{DeltaResult, Error as KernelError, Snapshot};
 use itertools::Itertools;
 use rstest::rstest;
@@ -187,7 +187,7 @@ async fn test_append_twice() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[rstest]
-#[case::transaction_context(false)]
+#[case::local_write_state(false)]
 #[case::transported_write_state(true)]
 #[tokio::test]
 async fn test_append_partitioned(
@@ -225,8 +225,9 @@ async fn test_append_partitioned(
 
         // write data out by spawning async tasks to simulate executors
         let engine = Arc::new(engine);
+        let write_state = txn.write_state()?;
         let encoded_write_state = transport_write_state
-            .then(|| txn.write_state()?.encode())
+            .then(|| write_state.encode())
             .transpose()?;
         let tasks = append_data
             .into_iter()
@@ -239,7 +240,7 @@ async fn test_append_partitioned(
                 let write_context = match &encoded_write_state {
                     Some(encoded) => WriteState::decode(encoded)
                         .and_then(|state| state.partitioned_write_context(partition_values)),
-                    None => txn.partitioned_write_context(partition_values),
+                    None => write_state.partitioned_write_context(partition_values),
                 }
                 .unwrap();
                 let write_context = Arc::new(write_context);
@@ -368,7 +369,12 @@ async fn test_append_invalid_schema() -> Result<(), Box<dyn std::error::Error>> 
 
         // write data out by spawning async tasks to simulate executors
         let engine = Arc::new(engine);
-        let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+        let write_context = Arc::new(
+            txn.write_state()
+                .unwrap()
+                .unpartitioned_write_context()
+                .unwrap(),
+        );
         let tasks = append_data.into_iter().map(|data| {
             // arc clones
             let engine = engine.clone();
@@ -415,7 +421,7 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
             Arc::new(schema.as_ref().try_into_arrow()?),
             vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
         )?);
-        let write_context = Arc::new(txn.unpartitioned_write_context()?);
+        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
 
         // Corrupt the addFile at the second batch.
         let valid_meta = engine.write_parquet(&data, write_context.as_ref()).await?;
@@ -506,8 +512,8 @@ async fn commit_rejects_add_with_invalid_partition_keys(
 
     let data_schema = schema! { nullable "d": INTEGER };
     let data_schema: Arc<ArrowSchema> = Arc::new((&data_schema).try_into_arrow()?);
-    let make_add = |txn: &Transaction, p1: &str, p2: i32| {
-        let wc = txn.partitioned_write_context(HashMap::from([
+    let make_add = |write_state: &Arc<WriteState>, p1: &str, p2: i32| {
+        let wc = write_state.partitioned_write_context(HashMap::from([
             ("p1".to_string(), Scalar::String(p1.into())),
             ("p2".to_string(), Scalar::Integer(p2)),
         ]))?;
@@ -541,7 +547,8 @@ async fn commit_rejects_add_with_invalid_partition_keys(
     let mut txn = snapshot
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_data_change(true);
-    let add = make_add(&txn, "b", 6)?;
+    let write_state = txn.write_state()?;
+    let add = make_add(&write_state, "b", 6)?;
     let corrupted = modify_add_file_partition_keys(into_record_batch(add), &modifications);
     txn.add_files(Box::new(ArrowEngineData::new(corrupted)));
     assert_result_error_with_message(txn.commit(engine.as_ref()), "partitionValues keys");

--- a/kernel/tests/integration/write/append.rs
+++ b/kernel/tests/integration/write/append.rs
@@ -243,12 +243,10 @@ async fn test_append_partitioned(
                     None => write_state.partitioned_write_context(partition_values),
                 }
                 .unwrap();
-                let write_context = Arc::new(write_context);
-                // arc clones
                 let engine = engine.clone();
                 tokio::task::spawn(async move {
                     engine
-                        .write_parquet(data.as_ref().unwrap(), write_context.as_ref())
+                        .write_parquet(data.as_ref().unwrap(), &write_context)
                         .await
                 })
             });
@@ -416,12 +414,12 @@ async fn commit_rejects_add_missing_required_field() -> Result<(), Box<dyn std::
             Arc::new(schema.as_ref().try_into_arrow()?),
             vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
         )?);
-        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+        let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
         // Corrupt the addFile at the second batch.
-        let valid_meta = engine.write_parquet(&data, write_context.as_ref()).await?;
+        let valid_meta = engine.write_parquet(&data, &write_context).await?;
         txn.add_files(valid_meta);
-        let to_be_corrupted_meta = engine.write_parquet(&data, write_context.as_ref()).await?;
+        let to_be_corrupted_meta = engine.write_parquet(&data, &write_context).await?;
 
         let batch = into_record_batch(to_be_corrupted_meta);
         let index = batch.schema().index_of(field)?;

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -80,9 +80,9 @@ async fn add_files_to_transaction(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let add_files_metadata = engine
-        .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(data), &write_context)
         .await?;
     txn.add_files(add_files_metadata);
     Ok(())

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -80,7 +80,12 @@ async fn add_files_to_transaction(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/write/cdf.rs
+++ b/kernel/tests/integration/write/cdf.rs
@@ -80,12 +80,7 @@ async fn add_files_to_transaction(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/write/column_defaults.rs
+++ b/kernel/tests/integration/write/column_defaults.rs
@@ -259,7 +259,7 @@ async fn test_blind_append_to_column_defaults_table_is_supported(
 #[case::unpartitioned("unpartitioned", &[])]
 #[case::partitioned("partitioned", &["p"])]
 #[tokio::test]
-async fn write_context_acknowledgement_depends_on_column_defaults(
+async fn write_state_acknowledgement_depends_on_column_defaults(
     #[case] label: &str,
     #[case] partition_columns: &[&str],
     #[values(false, true)] has_default: bool,
@@ -273,7 +273,7 @@ async fn write_context_acknowledgement_depends_on_column_defaults(
     } else {
         Arc::new(base)
     };
-    let table_name = format!("write_context_ack_{label}_{has_default}");
+    let table_name = format!("write_state_ack_{label}_{has_default}");
     let (store, engine, table_location) = engine_store_setup(&table_name, None);
     let table_url = create_table(
         store,
@@ -299,12 +299,9 @@ async fn write_context_acknowledgement_depends_on_column_defaults(
 
     let partition_values = HashMap::from([("p".to_string(), Scalar::Integer(7))]);
     if has_default {
-        let error = if partition_columns.is_empty() {
-            txn.unpartitioned_write_context()
-        } else {
-            txn.partitioned_write_context(partition_values.clone())
-        }
-        .expect_err("inspecting defaults must not implicitly acknowledge them");
+        let error = txn
+            .write_state()
+            .expect_err("inspecting defaults must not implicitly acknowledge them");
         assert!(matches!(
             &error,
             delta_kernel::Error::InvalidTransactionState(_)
@@ -313,10 +310,11 @@ async fn write_context_acknowledgement_depends_on_column_defaults(
 
         txn.ack_column_defaults();
     }
+    let write_state = txn.write_state()?;
     if partition_columns.is_empty() {
-        txn.unpartitioned_write_context()?;
+        write_state.unpartitioned_write_context()?;
     } else {
-        txn.partitioned_write_context(partition_values)?;
+        write_state.partitioned_write_context(partition_values)?;
     }
 
     Ok(())
@@ -561,13 +559,13 @@ async fn test_load_and_write_allow_orphan_default() -> Result<(), Box<dyn std::e
     // Read: snapshot loads despite the orphaned metadata.
     let snapshot = Snapshot::builder_for(table_url).build(&engine)?;
 
-    // Write: a write context builds without error.
+    // Write: a write state and context build without error.
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), &engine)?;
     assert!(
         txn.top_level_column_defaults()?.is_empty(),
         "orphaned defaults must not be surfaced without allowColumnDefaults",
     );
-    txn.unpartitioned_write_context()?;
+    txn.write_state()?.unpartitioned_write_context()?;
 
     Ok(())
 }

--- a/kernel/tests/integration/write/domain_metadata.rs
+++ b/kernel/tests/integration/write/domain_metadata.rs
@@ -35,7 +35,11 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
     let txn = load_and_begin_transaction(table_url.clone(), &engine)?;
 
     // write context does not conflict with domain metadata
-    let _write_context = txn.unpartitioned_write_context().unwrap();
+    let _write_context = txn
+        .write_state()
+        .unwrap()
+        .unpartitioned_write_context()
+        .unwrap();
 
     // set multiple domain metadata
     let domain1 = "app.config";

--- a/kernel/tests/integration/write/domain_metadata.rs
+++ b/kernel/tests/integration/write/domain_metadata.rs
@@ -35,11 +35,7 @@ async fn test_set_domain_metadata_basic() -> Result<(), Box<dyn std::error::Erro
     let txn = load_and_begin_transaction(table_url.clone(), &engine)?;
 
     // write context does not conflict with domain metadata
-    let _write_context = txn
-        .write_state()
-        .unwrap()
-        .unpartitioned_write_context()
-        .unwrap();
+    let _write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     // set multiple domain metadata
     let domain1 = "app.config";

--- a/kernel/tests/integration/write/ict.rs
+++ b/kernel/tests/integration/write/ict.rs
@@ -65,12 +65,7 @@ async fn generate_and_add_data_file(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let file_meta = engine
         .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/write/ict.rs
+++ b/kernel/tests/integration/write/ict.rs
@@ -65,9 +65,9 @@ async fn generate_and_add_data_file(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let file_meta = engine
-        .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(data), &write_context)
         .await?;
     txn.add_files(file_meta);
     Ok(())

--- a/kernel/tests/integration/write/ict.rs
+++ b/kernel/tests/integration/write/ict.rs
@@ -65,7 +65,12 @@ async fn generate_and_add_data_file(
         vec![Arc::new(Int32Array::from(values))],
     )?;
 
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
     let file_meta = engine
         .write_parquet(&ArrowEngineData::new(data), write_context.as_ref())
         .await?;

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -85,9 +85,9 @@ mod supported {
             ],
         )?;
 
-        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+        let write_context = txn.write_state()?.unpartitioned_write_context()?;
         let add_files_metadata = engine
-            .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
+            .write_parquet(&ArrowEngineData::new(data.clone()), &write_context)
             .await?;
         txn.add_files(add_files_metadata);
         let snapshot = txn.commit(engine.as_ref())?.unwrap_post_commit_snapshot();

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -85,12 +85,7 @@ mod supported {
             ],
         )?;
 
-        let write_context = Arc::new(
-            txn.write_state()
-                .unwrap()
-                .unpartitioned_write_context()
-                .unwrap(),
-        );
+        let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
         let add_files_metadata = engine
             .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
             .await?;

--- a/kernel/tests/integration/write/interval.rs
+++ b/kernel/tests/integration/write/interval.rs
@@ -85,7 +85,12 @@ mod supported {
             ],
         )?;
 
-        let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+        let write_context = Arc::new(
+            txn.write_state()
+                .unwrap()
+                .unpartitioned_write_context()
+                .unwrap(),
+        );
         let add_files_metadata = engine
             .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
             .await?;

--- a/kernel/tests/integration/write/partitioned.rs
+++ b/kernel/tests/integration/write/partitioned.rs
@@ -1013,7 +1013,8 @@ async fn test_materialized_partition_columns_excluded_from_stats(
     )?;
     let data = Box::new(ArrowEngineData::new(batch));
 
-    let write_context = txn.partitioned_write_context(HashMap::from([(
+    let write_state = txn.write_state()?;
+    let write_context = write_state.partitioned_write_context(HashMap::from([(
         partition_col.to_string(),
         Scalar::String("a".into()),
     )]))?;
@@ -1108,11 +1109,12 @@ async fn test_materialize_partition_columns_e2e(
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?
         .with_engine_info("default engine")
         .with_data_change(true);
+    let write_state = txn.write_state()?;
     for (d1, d2, p1, p2) in [
         (vec![1, 2, 3], vec![10, 20, 30], "x", 5),
         (vec![4, 5], vec![40, 50], "y", 6),
     ] {
-        let wc = txn.partitioned_write_context(partition_values(p1, p2))?;
+        let wc = write_state.partitioned_write_context(partition_values(p1, p2))?;
         let add = engine
             .write_parquet(&ArrowEngineData::new(make_batch(d1, d2)), &wc)
             .await?;
@@ -1263,7 +1265,8 @@ async fn test_input_data_with_partition_column_errors(
     )?;
     let data = Box::new(ArrowEngineData::new(batch));
 
-    let write_context = txn.partitioned_write_context(HashMap::from([(
+    let write_state = txn.write_state()?;
+    let write_context = write_state.partitioned_write_context(HashMap::from([(
         partition_col.to_string(),
         Scalar::String("a".into()),
     )]))?;
@@ -1347,9 +1350,9 @@ async fn test_partition_null_validation(
         .commit(engine.as_ref())?;
     let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
 
-    let result = begin_transaction(snapshot, engine.as_ref())?
-        .with_engine_info("default engine")
-        .partitioned_write_context(HashMap::from([("p".to_string(), value)]));
+    let txn = begin_transaction(snapshot, engine.as_ref())?.with_engine_info("default engine");
+    let write_state = txn.write_state()?;
+    let result = write_state.partitioned_write_context(HashMap::from([("p".to_string(), value)]));
 
     match expected_err {
         Some(needle) => {
@@ -1401,22 +1404,20 @@ async fn test_partition_null_validation_mixed_nullability(
         false, // write_partition_values_parsed; unused, no checkpoint in this test
     )?;
 
-    begin_transaction(snapshot.clone(), engine.as_ref())?
-        .with_engine_info("default engine")
-        .partitioned_write_context(HashMap::from([
-            ("p_required".to_string(), Scalar::String("a".into())),
-            ("p_optional".to_string(), Scalar::Null(DataType::STRING)),
-        ]))?;
+    let txn = begin_transaction(snapshot, engine.as_ref())?.with_engine_info("default engine");
+    let write_state = txn.write_state()?;
 
-    begin_transaction(snapshot.clone(), engine.as_ref())?
-        .with_engine_info("default engine")
-        .partitioned_write_context(HashMap::from([
-            ("p_required".to_string(), Scalar::String("a".into())),
-            ("p_optional".to_string(), Scalar::String(String::new())),
-        ]))?;
+    write_state.partitioned_write_context(HashMap::from([
+        ("p_required".to_string(), Scalar::String("a".into())),
+        ("p_optional".to_string(), Scalar::Null(DataType::STRING)),
+    ]))?;
 
-    let err = begin_transaction(snapshot, engine.as_ref())?
-        .with_engine_info("default engine")
+    write_state.partitioned_write_context(HashMap::from([
+        ("p_required".to_string(), Scalar::String("a".into())),
+        ("p_optional".to_string(), Scalar::String(String::new())),
+    ]))?;
+
+    let err = write_state
         .partitioned_write_context(HashMap::from([
             ("p_required".to_string(), Scalar::Null(DataType::STRING)),
             ("p_optional".to_string(), Scalar::String("b".into())),

--- a/kernel/tests/integration/write/post_commit.rs
+++ b/kernel/tests/integration/write/post_commit.rs
@@ -130,8 +130,9 @@ async fn test_write_parquet_rejects_partitioned_write_context_on_unpartitioned_t
     {
         let snapshot = Snapshot::builder_for(table_url.clone()).build(&engine)?;
         let txn = begin_transaction(snapshot.clone(), &engine)?.with_engine_info("test");
+        let write_state = txn.write_state()?;
 
-        let result = txn.partitioned_write_context(HashMap::from([(
+        let result = write_state.partitioned_write_context(HashMap::from([(
             "nonexistent".to_string(),
             Scalar::String("val".into()),
         )]));

--- a/kernel/tests/integration/write/relative_paths.rs
+++ b/kernel/tests/integration/write/relative_paths.rs
@@ -25,7 +25,7 @@ async fn write_batch_to_table_simple(
     data: RecordBatch,
 ) -> Result<Arc<Snapshot>, Box<dyn std::error::Error>> {
     let mut txn = begin_transaction(snapshot.clone(), engine)?.with_engine_info("test");
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let add_meta = engine
         .write_parquet(&ArrowEngineData::new(data), &write_context)
         .await?;
@@ -75,7 +75,11 @@ async fn test_multiple_files_in_commit_all_use_relative_paths(
         create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
 
     let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?.with_engine_info("test");
-    let write_context = txn.unpartitioned_write_context().unwrap();
+    let write_context = txn
+        .write_state()
+        .unwrap()
+        .unpartitioned_write_context()
+        .unwrap();
     for values in [vec![1, 2], vec![3, 4]] {
         let add_meta = engine
             .write_parquet(
@@ -136,7 +140,7 @@ async fn test_create_table_with_data_uses_relative_paths() -> Result<(), Box<dyn
 
     let mut txn = create_table_txn(table_url.as_str(), schema.clone(), "test/1.0")
         .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?;
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let add_meta = engine
         .write_parquet(
             &ArrowEngineData::new(simple_id_batch(&schema, vec![10, 20])),

--- a/kernel/tests/integration/write/relative_paths.rs
+++ b/kernel/tests/integration/write/relative_paths.rs
@@ -75,11 +75,7 @@ async fn test_multiple_files_in_commit_all_use_relative_paths(
         create_table_and_load_snapshot(&table_path, schema.clone(), engine.as_ref(), &[])?;
 
     let mut txn = begin_transaction(snapshot.clone(), engine.as_ref())?.with_engine_info("test");
-    let write_context = txn
-        .write_state()
-        .unwrap()
-        .unpartitioned_write_context()
-        .unwrap();
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     for values in [vec![1, 2], vec![3, 4]] {
         let add_meta = engine
             .write_parquet(

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -100,7 +100,7 @@ async fn append_only_enforces_data_change_for_file_actions(
         .commit(engine.as_ref())?
         .unwrap_post_commit_snapshot();
     let mut txn = begin_transaction(snapshot, engine.as_ref())?.with_data_change(true);
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let arrow_schema: Arc<ArrowSchema> =
         Arc::new(write_context.physical_schema().as_ref().try_into_arrow()?);
     for value in [1, 2, 3] {
@@ -1969,6 +1969,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
         // Write two partitions: country="usa" and country="japan".
         let mut txn =
             load_and_begin_transaction(table_url.clone(), engine.as_ref())?.with_data_change(true);
+        let write_state = txn.write_state()?;
         let append_data = [[1, 2, 3], [10, 20, 30]].map(|data| -> delta_kernel::DeltaResult<_> {
             let data = RecordBatch::try_new(
                 Arc::new(data_schema.as_ref().try_into_arrow()?),
@@ -1977,7 +1978,7 @@ async fn test_remove_files_partitioned_with_parsed_columns(
             Ok(Box::new(ArrowEngineData::new(data)))
         });
         for (data, partition_val) in append_data.into_iter().zip(["usa", "japan"]) {
-            let ctx = Arc::new(txn.partitioned_write_context(HashMap::from([(
+            let ctx = Arc::new(write_state.partitioned_write_context(HashMap::from([(
                 partition_col.to_string(),
                 Scalar::String(partition_val.into()),
             )]))?);

--- a/kernel/tests/integration/write/remove_dv.rs
+++ b/kernel/tests/integration/write/remove_dv.rs
@@ -1978,11 +1978,11 @@ async fn test_remove_files_partitioned_with_parsed_columns(
             Ok(Box::new(ArrowEngineData::new(data)))
         });
         for (data, partition_val) in append_data.into_iter().zip(["usa", "japan"]) {
-            let ctx = Arc::new(write_state.partitioned_write_context(HashMap::from([(
+            let ctx = write_state.partitioned_write_context(HashMap::from([(
                 partition_col.to_string(),
                 Scalar::String(partition_val.into()),
-            )]))?);
-            let add_meta = engine.write_parquet(data?.as_ref(), ctx.as_ref()).await?;
+            )]))?;
+            let add_meta = engine.write_parquet(data?.as_ref(), &ctx).await?;
             txn.add_files(add_meta);
         }
         txn.commit(engine.as_ref())?.unwrap_committed();

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -67,12 +67,7 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
 
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
@@ -151,12 +146,7 @@ async fn test_append_timestamp_stats_are_millisecond_truncated(
     )?;
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
         .await?;
@@ -327,12 +317,7 @@ async fn test_append_variant(
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()
@@ -487,12 +472,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     .unwrap();
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(
-        txn.write_state()
-            .unwrap()
-            .unpartitioned_write_context()
-            .unwrap(),
-    );
+    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()
@@ -714,11 +694,9 @@ async fn write_rejects_invalid_void_placement(
     );
 }
 
-// Validation must trigger when the connector requests write state, before any Parquet is written.
-// Both partitioned and unpartitioned table layouts are covered, and the `all_void_table` case is
-// included because it is the shape where `strip_void_from_schema` would otherwise silently produce
-// an empty physical schema -- so the fail-fast guard is most load-bearing there. The commit-time
-// check (exercised by `write_rejects_invalid_void_placement`) remains as defense-in-depth.
+// Requesting write state must reject invalid schemas before any Parquet is written.
+// Keep the all-void case because stripping void fields would otherwise produce an empty physical
+// schema; commit-time validation remains defense-in-depth.
 #[rstest]
 #[case::unpartitioned_void_array(
     "void_fail_fast_unpartitioned_array",

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -1,6 +1,5 @@
 //! Integration tests for type-specific writes (timestampNtz, variant, shredded variant).
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use delta_kernel::arrow::array::{
@@ -12,7 +11,6 @@ use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::committer::FileSystemCommitter;
 use delta_kernel::engine::arrow_conversion::{TryFromKernel, TryIntoArrow as _};
 use delta_kernel::engine::arrow_data::ArrowEngineData;
-use delta_kernel::expressions::Scalar;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::schema::{schema_ref, DataType, SchemaRef, StructField};
@@ -69,7 +67,12 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
 
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
@@ -148,7 +151,12 @@ async fn test_append_timestamp_stats_are_millisecond_truncated(
     )?;
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
         .await?;
@@ -319,7 +327,12 @@ async fn test_append_variant(
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()
@@ -474,7 +487,12 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     .unwrap();
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.unpartitioned_write_context().unwrap());
+    let write_context = Arc::new(
+        txn.write_state()
+            .unwrap()
+            .unpartitioned_write_context()
+            .unwrap(),
+    );
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()
@@ -560,9 +578,8 @@ async fn test_not_null_data_column_rejects_null_in_batch(
         "non-null schema must auto-enable the `invariants` writer feature",
     );
 
-    let write_context = begin_transaction(snapshot, engine.as_ref())?
-        .with_engine_info("default engine")
-        .unpartitioned_write_context()?;
+    let txn = begin_transaction(snapshot, engine.as_ref())?.with_engine_info("default engine");
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     // Use the connector-facing physical schema (not the logical one); the logical schema
     // would hide bugs in the logical->physical mapping that engines hit in production.
@@ -697,39 +714,34 @@ async fn write_rejects_invalid_void_placement(
     );
 }
 
-// Validation must trigger when the connector requests a write context, before any Parquet is
-// written. Both public entry points (partitioned and unpartitioned) are covered, and the
-// `all_void_table` case is included because it is the shape where `strip_void_from_schema`
-// would otherwise silently produce an empty physical schema -- so the fail-fast guard is most
-// load-bearing there. The commit-time check (exercised by `write_rejects_invalid_void_placement`)
-// remains as defense-in-depth.
+// Validation must trigger when the connector requests write state, before any Parquet is written.
+// Both partitioned and unpartitioned table layouts are covered, and the `all_void_table` case is
+// included because it is the shape where `strip_void_from_schema` would otherwise silently produce
+// an empty physical schema -- so the fail-fast guard is most load-bearing there. The commit-time
+// check (exercised by `write_rejects_invalid_void_placement`) remains as defense-in-depth.
 #[rstest]
 #[case::unpartitioned_void_array(
     "void_fail_fast_unpartitioned_array",
     vec![],
-    HashMap::new(),
     schema_ref! { nullable "id": INTEGER, nullable "arr": [ nullable VOID ] },
     "array element type",
 )]
 #[case::partitioned_void_array(
     "void_fail_fast_partitioned_array",
     vec!["id"],
-    HashMap::from([("id".to_string(), Scalar::Integer(1))]),
     schema_ref! { nullable "id": INTEGER, nullable "arr": [ nullable VOID ] },
     "array element type",
 )]
 #[case::unpartitioned_all_void(
     "void_fail_fast_unpartitioned_all_void",
     vec![],
-    HashMap::new(),
     schema_ref! { nullable "a": VOID, nullable "b": VOID },
     "at least one non-void column",
 )]
 #[tokio::test]
-async fn write_context_creation_fails_fast_on_invalid_void_schema(
+async fn write_state_creation_fails_fast_on_invalid_void_schema(
     #[case] test_name: &str,
     #[case] partition_columns: Vec<&str>,
-    #[case] partition_values: HashMap<String, Scalar>,
     #[case] schema: SchemaRef,
     #[case] expected_msg: &str,
 ) {
@@ -753,13 +765,9 @@ async fn write_context_creation_fails_fast_on_invalid_void_schema(
         .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
         .expect("transaction should create");
 
-    let err = if partition_columns.is_empty() {
-        txn.unpartitioned_write_context()
-            .expect_err("unpartitioned_write_context should reject invalid void schema")
-    } else {
-        txn.partitioned_write_context(partition_values)
-            .expect_err("partitioned_write_context should reject invalid void schema")
-    };
+    let err = txn
+        .write_state()
+        .expect_err("write_state should reject invalid void schema");
     assert!(
         err.to_string().contains(expected_msg),
         "expected error containing '{expected_msg}', got: {err}"
@@ -788,7 +796,7 @@ async fn write_context_excludes_void_from_physical_schema() -> Result<(), Box<dy
 
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
 
-    let wc = txn.unpartitioned_write_context()?;
+    let wc = txn.write_state()?.unpartitioned_write_context()?;
     let physical = wc.physical_schema();
 
     // Physical schema should NOT contain void column
@@ -858,7 +866,7 @@ async fn write_context_excludes_nested_void_from_physical_schema(
     }
 
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
-    let wc = txn.unpartitioned_write_context()?;
+    let wc = txn.write_state()?.unpartitioned_write_context()?;
     let physical = wc.physical_schema();
 
     // Physical schema struct should NOT contain the void field
@@ -896,7 +904,7 @@ async fn write_transform_drops_nested_void_fields() -> Result<(), Box<dyn std::e
     let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
 
     let txn = snapshot.transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())?;
-    let wc = txn.unpartitioned_write_context()?;
+    let wc = txn.write_state()?.unpartitioned_write_context()?;
 
     // The transform expression should mention dropping "b" inside the struct
     let l2p = wc.logical_to_physical();

--- a/kernel/tests/integration/write/types.rs
+++ b/kernel/tests/integration/write/types.rs
@@ -67,10 +67,10 @@ async fn test_append_timestamp_ntz() -> Result<(), Box<dyn std::error::Error>> {
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     let add_files_metadata = engine
-        .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(data.clone()), &write_context)
         .await?;
 
     txn.add_files(add_files_metadata);
@@ -146,9 +146,9 @@ async fn test_append_timestamp_stats_are_millisecond_truncated(
     )?;
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
     let add_files_metadata = engine
-        .write_parquet(&ArrowEngineData::new(data.clone()), write_context.as_ref())
+        .write_parquet(&ArrowEngineData::new(data.clone()), &write_context)
         .await?;
     txn.add_files(add_files_metadata);
     assert!(txn.commit(engine.as_ref())?.is_committed());
@@ -317,7 +317,7 @@ async fn test_append_variant(
 
     // Write data
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()
@@ -472,7 +472,7 @@ async fn test_shredded_variant_read_rejection() -> Result<(), Box<dyn std::error
     .unwrap();
 
     let engine = Arc::new(engine);
-    let write_context = Arc::new(txn.write_state()?.unpartitioned_write_context()?);
+    let write_context = txn.write_state()?.unpartitioned_write_context()?;
 
     let add_files_metadata = (*engine)
         .default_parquet_handler()

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1111,7 +1111,8 @@ pub async fn insert_data_with<E: TaskExecutor>(
         txn = txn.with_blind_append();
     }
 
-    let write_context = txn.unpartitioned_write_context()?;
+    let write_state = txn.write_state()?;
+    let write_context = write_state.unpartitioned_write_context()?;
     let add_files_metadata = engine
         .write_parquet(&ArrowEngineData::new(batch), &write_context)
         .await?;
@@ -1524,14 +1525,15 @@ pub async fn write_batch_to_table(
         .with_engine_info("DefaultEngine")
         .with_data_change(true);
     txn.ack_column_defaults();
+    let write_state = txn.write_state()?;
     let write_context = if txn.logical_partition_columns().is_empty() {
         assert!(
             partition_values.is_empty(),
             "partition_values should be empty for unpartitioned tables"
         );
-        txn.unpartitioned_write_context()?
+        write_state.unpartitioned_write_context()?
     } else {
-        txn.partitioned_write_context(partition_values)?
+        write_state.partitioned_write_context(partition_values)?
     };
     let add_meta = engine
         .write_parquet(&ArrowEngineData::new(data), &write_context)

--- a/test-utils/src/table_builder.rs
+++ b/test-utils/src/table_builder.rs
@@ -1431,7 +1431,7 @@ fn write_crc(snapshot: &Arc<Snapshot>, engine: &dyn Engine) -> DeltaResult<()> {
 /// Write a data commit using kernel's transaction + write_parquet path.
 /// Produces `num_files` parquet files with `rows_per_file` rows each. For partitioned
 /// tables, all rows in a file share the same partition values; for unpartitioned or
-/// clustered tables, uses `unpartitioned_write_context`. Non-partition columns get
+/// clustered tables, binds an unpartitioned write context. Non-partition columns get
 /// varying data derived from version and file index. Partition columns are never nulled
 /// so their data matches the declared partition value; all other nullable columns
 /// (including clustering columns, which kernel permits to be null) get sparse nulls.
@@ -1451,6 +1451,7 @@ async fn write_data_commit<E: TaskExecutor>(
         .transaction(Box::new(FileSystemCommitter::new()), engine)?
         .with_operation("WRITE".to_string())
         .with_data_change(true);
+    let write_state = txn.write_state()?;
 
     let partition_set: HashSet<&str> = partition_columns.iter().map(String::as_str).collect();
 
@@ -1480,14 +1481,14 @@ async fn write_data_commit<E: TaskExecutor>(
             .map_err(|e| delta_kernel::Error::generic(e.to_string()))?;
 
         let write_context = if partition_columns.is_empty() {
-            txn.unpartitioned_write_context()?
+            write_state.unpartitioned_write_context()?
         } else {
             let partition_values = generate_partition_values(
                 logical_schema.as_ref(),
                 partition_columns,
                 partition_seed,
             );
-            txn.partitioned_write_context(partition_values)?
+            write_state.partitioned_write_context(partition_values)?
         };
 
         let add_files = engine


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR makes `WriteState` the single entry point for creating bound write contexts.

### This PR affects the following public APIs

This is a breaking Rust API change. Callers must migrate from:

`transaction.unpartitioned_write_context()` / `transaction.partitioned_write_context(values)`

to:

`transaction.write_state()?.unpartitioned_write_context()` /
`transaction.write_state()?.partitioned_write_context(values)`

## How was this change tested?

Unit tests and Integration Tests Passing

## Motivation

This PR follows #3089 which added support for imperative distributed writes. As part of that change it was pointed out that creating a `BoundWriteContext` with `Transaction::partitioned_write_context` always creates a fresh `WriteState`. With this change now connectors are forced to call `Transaction::write_state` and incentivized to keep a reference to the produced `WriteState` which connectors then call `WriteState::partitioned_write_context` on for each necessary `BoundWriteContext` which does not create a fresh `WriteState` every invocation. 
