### PR TITLE
feat!: make CancellationToken downcastable to recover the caller's token

### DIFF
--- a/kernel/src/cancellation.rs
+++ b/kernel/src/cancellation.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::{DeltaResult, Error};
+use crate::{AsAny, DeltaResult, Error};
 
 /// A shared, thread-safe cancellation token. Held as an `Arc` because the lazy scan iterator and
 /// the engine reads it drives can outlive the builder call and run on other threads.
@@ -40,9 +40,38 @@ pub(crate) fn check_cancelled(token: Option<&CancellationTokenRef>) -> DeltaResu
 /// Kernel and cancellation-aware engines only *consume* it: Kernel polls [`is_cancelled`] between
 /// action batches, while an async engine may await [`cancelled_future`] to wake blocked I/O.
 ///
+/// # Recovering the underlying token
+///
+/// The `Arc` kernel hands to each `*_with_cancellation` [`Engine`] method is the same one the
+/// caller supplied, so an engine that supplied its own implementation can downcast it back to the
+/// concrete type through [`AsAny`]. (Kernel may poll a composed or derived token internally; the
+/// guarantee is only about what the engine receives.) This lets an engine reach a native
+/// cancellation handle it wrapped, for code that cannot accept a Rust trait object.
+///
+/// Borrow with `as_ref().any_ref()`, or take an owned handle with [`AsAny::as_any`] -- see
+/// [`AsAny::any_ref`] for why the borrow must go through `as_ref()` first.
+///
+/// ```
+/// # use delta_kernel::cancellation::{CancellationToken, CancellationTokenRef, CancelledFuture};
+/// # use delta_kernel::AsAny;
+/// # use std::sync::Arc;
+/// # struct MyToken;
+/// # impl CancellationToken for MyToken {
+/// #     fn is_cancelled(&self) -> bool { false }
+/// #     fn cancelled_future(&self) -> CancelledFuture<'_> { Box::pin(std::future::ready(())) }
+/// # }
+/// # let token: CancellationTokenRef = Arc::new(MyToken);
+/// // In an engine's `read_*_with_cancellation`, given `token: CancellationTokenRef`:
+/// if let Some(mine) = token.as_ref().any_ref().downcast_ref::<MyToken>() {
+///     let _ = mine.is_cancelled(); // recovered the caller's concrete token
+/// }
+/// ```
+///
 /// [`is_cancelled`]: CancellationToken::is_cancelled
 /// [`cancelled_future`]: CancellationToken::cancelled_future
-pub trait CancellationToken: Send + Sync {
+/// [`Engine`]: crate::Engine
+/// [`AsAny`]: crate::AsAny
+pub trait CancellationToken: AsAny {
     /// Returns `true` once cancellation has been requested. Cheap, synchronous, and monotonic:
     /// once it returns `true` it must never return `false` again.
     fn is_cancelled(&self) -> bool;
@@ -204,5 +233,65 @@ mod tests {
         assert!(check_cancelled(None).is_ok());
         token.cancel();
         assert!(matches!(check_cancelled(Some(&ct)), Err(Error::Cancelled)));
+    }
+
+    /// A second token type, to check that a downcast discriminates rather than always succeeding.
+    #[derive(Default)]
+    struct OtherToken;
+
+    impl CancellationToken for OtherToken {
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+        fn cancelled_future(&self) -> CancelledFuture<'_> {
+            Box::pin(ready(()))
+        }
+    }
+
+    // Downcasting an erased token recovers the original value, not a copy: cancelling through the
+    // recovered handle is observable through the erased one.
+    #[test]
+    fn downcast_recovers_the_same_token() {
+        let erased: CancellationTokenRef = Arc::new(TestToken::default());
+
+        let recovered = erased
+            .clone()
+            .as_any()
+            .downcast::<TestToken>()
+            .expect("erased token should downcast to its concrete type");
+        recovered.cancel();
+
+        assert!(erased.is_cancelled());
+    }
+
+    #[test]
+    fn downcast_to_the_wrong_type_fails() {
+        let erased: CancellationTokenRef = Arc::new(TestToken::default());
+        assert!(erased.clone().as_any().downcast::<OtherToken>().is_err());
+        assert!(erased
+            .as_ref()
+            .any_ref()
+            .downcast_ref::<OtherToken>()
+            .is_none());
+    }
+
+    // `Arc<dyn CancellationToken>` satisfies the blanket `AsAny` impl in its own right, so
+    // `arc.any_ref()` resolves to the *`Arc`* rather than the token inside it and downcasts to the
+    // concrete type fail. Borrowing goes through the trait object: `arc.as_ref().any_ref()`.
+    #[test]
+    fn any_ref_borrows_the_token_through_the_trait_object() {
+        let token = Arc::new(TestToken::default());
+        let erased: CancellationTokenRef = token.clone();
+
+        assert!(erased.any_ref().downcast_ref::<TestToken>().is_none());
+
+        let borrowed = erased
+            .as_ref()
+            .any_ref()
+            .downcast_ref::<TestToken>()
+            .expect("erased token should downcast to its concrete type");
+        assert!(!borrowed.is_cancelled());
+        token.cancel();
+        assert!(borrowed.is_cancelled());
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -357,6 +357,13 @@ pub trait AsAny: Any + Send + Sync {
     /// let a: &dyn Any = f.any_ref();
     /// let b: &Bar = a.downcast_ref().unwrap();
     /// ```
+    ///
+    /// When downcasting from behind an `Arc<dyn Trait>`, borrow the trait object first
+    /// (`arc.as_ref().any_ref()`): `Arc<dyn Trait>` is itself `Sized + Any`, so calling `any_ref()`
+    /// directly on the `Arc` downcasts the *`Arc`*, not the value inside it. The owning [`as_any`]
+    /// has no such hazard -- its `Arc<Self>` receiver binds to the inner value.
+    ///
+    /// [`as_any`]: AsAny::as_any
     fn any_ref(&self) -> &(dyn Any + Send + Sync);
 
     /// Obtains an `Arc<dyn Any>` reference to the object:

--- a/kernel/tests/integration/read/scan_cancellation.rs
+++ b/kernel/tests/integration/read/scan_cancellation.rs
@@ -2,13 +2,18 @@
 //! surface `Error::Cancelled` through the real Default Engine and can never be mistaken for a
 //! complete listing.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::StatsOptions;
-use delta_kernel::{CancellationTokenRef, Error, Snapshot};
+use delta_kernel::schema::SchemaRef;
+use delta_kernel::{
+    CancellationToken as _, CancellationTokenRef, DeltaResult, Engine, EngineData, Error,
+    FileDataReadResultIterator, FileMeta, FilteredEngineData, JsonHandler, ParquetHandler,
+    PredicateRef, Snapshot,
+};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
@@ -187,6 +192,227 @@ async fn precancelled_scan_over_checkpoint_yields_cancelled(
         .build()?;
 
     assert_cancelled(scan.scan_metadata(engine.as_ref()));
+    Ok(())
+}
+
+/// A [`JsonHandler`] that records the cancellation token handed to it, so a test can check what
+/// kernel actually passed down. Delegates the read itself to the real handler.
+struct TokenCapturingJsonHandler {
+    inner: Arc<dyn JsonHandler>,
+    seen: Mutex<Option<CancellationTokenRef>>,
+}
+
+impl JsonHandler for TokenCapturingJsonHandler {
+    fn parse_json(
+        &self,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        self.inner.parse_json(json_strings, output_schema)
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.inner
+            .read_json_files(files, physical_schema, predicate)
+    }
+
+    fn read_json_files_with_cancellation(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        *self.seen.lock().unwrap() = cancellation_token.clone();
+        self.inner.read_json_files_with_cancellation(
+            files,
+            physical_schema,
+            predicate,
+            cancellation_token,
+        )
+    }
+
+    fn write_json_file(
+        &self,
+        path: &url::Url,
+        data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
+        overwrite: bool,
+    ) -> DeltaResult<u64> {
+        self.inner.write_json_file(path, data, overwrite)
+    }
+}
+
+/// A [`ParquetHandler`] counterpart to [`TokenCapturingJsonHandler`]: records the token handed to
+/// its cancellation-aware read and delegates everything to the real handler. Checkpoint/sidecar
+/// replay drives the parquet read path, which a JSON-only fixture never reaches.
+struct TokenCapturingParquetHandler {
+    inner: Arc<dyn ParquetHandler>,
+    seen: Mutex<Option<CancellationTokenRef>>,
+}
+
+impl ParquetHandler for TokenCapturingParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.inner
+            .read_parquet_files(files, physical_schema, predicate)
+    }
+
+    fn read_parquet_files_with_cancellation(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        // Keep the first token seen: a later empty-sidecar read must not clobber it.
+        let mut seen = self.seen.lock().unwrap();
+        if seen.is_none() {
+            seen.clone_from(&cancellation_token);
+        }
+        drop(seen);
+        self.inner.read_parquet_files_with_cancellation(
+            files,
+            physical_schema,
+            predicate,
+            cancellation_token,
+        )
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: url::Url,
+        data: FileDataReadResultIterator,
+    ) -> DeltaResult<()> {
+        self.inner.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<delta_kernel::ParquetFooter> {
+        self.inner.read_parquet_footer(file)
+    }
+}
+
+/// Swaps in a token-capturing JSON and/or Parquet handler, delegating every other handler to the
+/// real engine. A test installs whichever handler its fixture's read path exercises.
+struct TokenCapturingEngine {
+    inner: Arc<dyn Engine>,
+    json: Option<Arc<TokenCapturingJsonHandler>>,
+    parquet: Option<Arc<TokenCapturingParquetHandler>>,
+}
+
+impl Engine for TokenCapturingEngine {
+    fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn delta_kernel::StorageHandler> {
+        self.inner.storage_handler()
+    }
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        match &self.json {
+            Some(json) => json.clone(),
+            None => self.inner.json_handler(),
+        }
+    }
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        match &self.parquet {
+            Some(parquet) => parquet.clone(),
+            None => self.inner.parquet_handler(),
+        }
+    }
+}
+
+/// Asserts the captured token is the exact `Arc` the caller supplied (identity), and therefore
+/// downcasts back to the caller's concrete type and observes cancellation through it.
+fn assert_token_recovered_by_identity(
+    seen: Option<CancellationTokenRef>,
+    token: Arc<TestCancellationToken>,
+) {
+    let seen = seen.expect("kernel should have passed the cancellation token to the handler");
+    // Same allocation, not an equivalent wrapper.
+    assert!(
+        Arc::ptr_eq(&(token.clone() as CancellationTokenRef), &seen),
+        "kernel must pass the caller's token through by identity"
+    );
+    let recovered = seen
+        .as_ref()
+        .any_ref()
+        .downcast_ref::<TestCancellationToken>()
+        .expect("token must downcast to the type the caller supplied");
+    assert!(!recovered.is_cancelled());
+    token.cancel();
+    assert!(recovered.is_cancelled());
+}
+
+// Pins the pass-through-identity guarantee on the JSON read path: the engine receives the very
+// `Arc` the caller supplied, not a wrapper, so it can downcast back to its own token type.
+#[tokio::test]
+async fn engine_receives_the_callers_token_by_identity_json(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, table_root) = json_only_table().await?;
+    let json = Arc::new(TokenCapturingJsonHandler {
+        inner: DefaultEngineBuilder::new(storage.clone())
+            .build()
+            .json_handler(),
+        seen: Mutex::new(None),
+    });
+    let engine = TokenCapturingEngine {
+        inner: Arc::new(DefaultEngineBuilder::new(storage).build()),
+        json: Some(json.clone()),
+        parquet: None,
+    };
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
+
+    let token = Arc::new(TestCancellationToken::default());
+    let scan = snapshot
+        .scan_builder()
+        .with_cancellation_token(token.clone() as CancellationTokenRef)
+        .build()?;
+    scan.scan_metadata(&engine)?.for_each(drop);
+
+    let seen = json.seen.lock().unwrap().clone();
+    assert_token_recovered_by_identity(seen, token);
+    Ok(())
+}
+
+// Same guarantee on the PARQUET read path, which the JSON-only fixture cannot reach. Checkpoint
+// replay threads the token through separate `.cloned()` call sites; a live (uncancelled) token lets
+// the read actually execute so the parquet handler observes it.
+#[tokio::test]
+async fn engine_receives_the_callers_token_by_identity_parquet(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = "with_checkpoint_no_last_checkpoint";
+    let url =
+        url::Url::from_directory_path(std::fs::canonicalize(format!("./tests/data/{table_name}"))?)
+            .unwrap();
+
+    let parquet = Arc::new(TokenCapturingParquetHandler {
+        inner: test_utils::create_default_engine(&url)?.parquet_handler(),
+        seen: Mutex::new(None),
+    });
+    let engine = TokenCapturingEngine {
+        inner: test_utils::create_default_engine(&url)?,
+        json: None,
+        parquet: Some(parquet.clone()),
+    };
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
+
+    let token = Arc::new(TestCancellationToken::default());
+    let scan = snapshot
+        .scan_builder()
+        .with_cancellation_token(token.clone() as CancellationTokenRef)
+        .build()?;
+    scan.scan_metadata(&engine)?.for_each(drop);
+
+    let seen = parquet.seen.lock().unwrap().clone();
+    assert_token_recovered_by_identity(seen, token);
     Ok(())
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

An engine that supplies a `CancellationToken` usually wraps a native cancellation
handle from its own runtime. Sometimes it needs that native handle back — for
example to hand it to code that cannot hold a Rust trait object. Kernel already
passes the token it was given to every `*_with_cancellation` engine method by
identity: it clones the `Arc` but never wraps or substitutes it. So the original
value is recoverable in principle, but there was no way to downcast the
`Arc<dyn CancellationToken>` back to the concrete type.

This PR adds `AsAny` as a supertrait of `CancellationToken`. The blanket `AsAny`
impl covers every existing implementor, so no implementation changes. It also
documents that an engine can recover its concrete token by downcasting the `Arc`
kernel hands to each `*_with_cancellation` method, and records the general
`Arc<dyn Trait>`-vs-inner `any_ref` borrowing hazard on `AsAny::any_ref`, where it
applies to every downcaster rather than just this trait.

### This PR affects the following public APIs

Adds the `AsAny` supertrait bound to the public `CancellationToken` trait. The
blanket impl makes this source-compatible for existing implementors (all already
`'static + Send + Sync`), but `cargo-semver-checks` classifies an added supertrait
bound as breaking, so this carries the `breaking-changes` label. The one edge is a
downstream impl on a non-`'static` type, which would newly fail to compile since
`Any: 'static`.

## How was this change tested?

Unit tests cover the downcast round-trip, wrong-type downcast failure, and the
`Arc<dyn Trait>`-vs-inner borrow edge. An integration test asserts `Arc::ptr_eq`
identity end to end: a token handed to a builder is recovered by the engine on both
the JSON and Parquet read paths, pinning the pass-through-identity guarantee so a
future refactor that wraps the token fails loudly.
