### PR TITLE
feat: add cancellation-aware StorageHandler list and read

### DIFF
--- a/default-engine/src/filesystem.rs
+++ b/default-engine/src/filesystem.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::{self, DynObjectStore, ObjectStoreExt as _, PutMode};
-use delta_kernel::{DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
+use delta_kernel::{CancellationTokenRef, DeltaResult, Error, FileMeta, FileSlice, StorageHandler};
 use futures::stream::{self, BoxStream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use url::Url;
@@ -192,8 +192,20 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
         &self,
         path: &Url,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        self.list_from_with_cancellation(path, None)
+    }
+
+    fn list_from_with_cancellation(
+        &self,
+        path: &Url,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
         let future = list_from_impl(self.inner.clone(), path.clone());
-        let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
+        let iter = super::stream_future_to_cancellable_iter(
+            self.task_executor.clone(),
+            future,
+            cancellation_token,
+        )?;
         Ok(iter) // type coercion drops the unneeded Send bound
     }
 
@@ -207,8 +219,20 @@ impl<E: TaskExecutor> StorageHandler for ObjectStoreStorageHandler<E> {
         &self,
         files: Vec<FileSlice>,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+        self.read_files_with_cancellation(files, None)
+    }
+
+    fn read_files_with_cancellation(
+        &self,
+        files: Vec<FileSlice>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
         let future = read_files_impl(self.inner.clone(), files, self.readahead);
-        let iter = super::stream_future_to_iter(self.task_executor.clone(), future)?;
+        let iter = super::stream_future_to_cancellable_iter(
+            self.task_executor.clone(),
+            future,
+            cancellation_token,
+        )?;
         Ok(iter) // type coercion drops the unneeded Send bound
     }
 
@@ -556,5 +580,20 @@ mod tests {
             Err(Error::FileNotFound(_))
         ));
         handler.delete(&missing_url).unwrap();
+    }
+    // The cancellation-aware overrides feed the racing helper, so an already-cancelled token stops
+    // the operation instead of performing I/O. (The race itself is covered by the
+    // `stream_future_to_cancellable_iter` tests in `lib.rs`.)
+    #[test]
+    fn precancelled_token_short_circuits_list_and_read() {
+        let (tempdir, _store, handler) = setup_test();
+        let url = Url::from_directory_path(tempdir.path()).unwrap();
+        let token: CancellationTokenRef = Arc::new(test_utils::TestCancellationToken::cancelled());
+
+        let listed = handler.list_from_with_cancellation(&url, Some(token.clone()));
+        assert!(matches!(listed, Err(Error::Cancelled)));
+
+        let read = handler.read_files_with_cancellation(vec![(url, None)], Some(token));
+        assert!(matches!(read, Err(Error::Cancelled)));
     }
 }

--- a/kernel/src/cancellation.rs
+++ b/kernel/src/cancellation.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::{DeltaResult, Error};
+use crate::{AsAny, DeltaResult, Error};
 
 /// A shared, thread-safe cancellation token. Held as an `Arc` because the lazy scan iterator and
 /// the engine reads it drives can outlive the builder call and run on other threads.
@@ -40,9 +40,38 @@ pub(crate) fn check_cancelled(token: Option<&CancellationTokenRef>) -> DeltaResu
 /// Kernel and cancellation-aware engines only *consume* it: Kernel polls [`is_cancelled`] between
 /// action batches, while an async engine may await [`cancelled_future`] to wake blocked I/O.
 ///
+/// # Recovering the underlying token
+///
+/// The `Arc` kernel hands to each `*_with_cancellation` [`Engine`] method is the same one the
+/// caller supplied, so an engine that supplied its own implementation can downcast it back to the
+/// concrete type through [`AsAny`]. (Kernel may poll a composed or derived token internally; the
+/// guarantee is only about what the engine receives.) This lets an engine reach a native
+/// cancellation handle it wrapped, for code that cannot accept a Rust trait object.
+///
+/// Borrow with `as_ref().any_ref()`, or take an owned handle with [`AsAny::as_any`] -- see
+/// [`AsAny::any_ref`] for why the borrow must go through `as_ref()` first.
+///
+/// ```
+/// # use delta_kernel::cancellation::{CancellationToken, CancellationTokenRef, CancelledFuture};
+/// # use delta_kernel::AsAny;
+/// # use std::sync::Arc;
+/// # struct MyToken;
+/// # impl CancellationToken for MyToken {
+/// #     fn is_cancelled(&self) -> bool { false }
+/// #     fn cancelled_future(&self) -> CancelledFuture<'_> { Box::pin(std::future::ready(())) }
+/// # }
+/// # let token: CancellationTokenRef = Arc::new(MyToken);
+/// // In an engine's `read_*_with_cancellation`, given `token: CancellationTokenRef`:
+/// if let Some(mine) = token.as_ref().any_ref().downcast_ref::<MyToken>() {
+///     let _ = mine.is_cancelled(); // recovered the caller's concrete token
+/// }
+/// ```
+///
 /// [`is_cancelled`]: CancellationToken::is_cancelled
 /// [`cancelled_future`]: CancellationToken::cancelled_future
-pub trait CancellationToken: Send + Sync {
+/// [`Engine`]: crate::Engine
+/// [`AsAny`]: crate::AsAny
+pub trait CancellationToken: AsAny {
     /// Returns `true` once cancellation has been requested. Cheap, synchronous, and monotonic:
     /// once it returns `true` it must never return `false` again.
     fn is_cancelled(&self) -> bool;
@@ -204,5 +233,65 @@ mod tests {
         assert!(check_cancelled(None).is_ok());
         token.cancel();
         assert!(matches!(check_cancelled(Some(&ct)), Err(Error::Cancelled)));
+    }
+
+    /// A second token type, to check that a downcast discriminates rather than always succeeding.
+    #[derive(Default)]
+    struct OtherToken;
+
+    impl CancellationToken for OtherToken {
+        fn is_cancelled(&self) -> bool {
+            false
+        }
+        fn cancelled_future(&self) -> CancelledFuture<'_> {
+            Box::pin(ready(()))
+        }
+    }
+
+    // Downcasting an erased token recovers the original value, not a copy: cancelling through the
+    // recovered handle is observable through the erased one.
+    #[test]
+    fn downcast_recovers_the_same_token() {
+        let erased: CancellationTokenRef = Arc::new(TestToken::default());
+
+        let recovered = erased
+            .clone()
+            .as_any()
+            .downcast::<TestToken>()
+            .expect("erased token should downcast to its concrete type");
+        recovered.cancel();
+
+        assert!(erased.is_cancelled());
+    }
+
+    #[test]
+    fn downcast_to_the_wrong_type_fails() {
+        let erased: CancellationTokenRef = Arc::new(TestToken::default());
+        assert!(erased.clone().as_any().downcast::<OtherToken>().is_err());
+        assert!(erased
+            .as_ref()
+            .any_ref()
+            .downcast_ref::<OtherToken>()
+            .is_none());
+    }
+
+    // `Arc<dyn CancellationToken>` satisfies the blanket `AsAny` impl in its own right, so
+    // `arc.any_ref()` resolves to the *`Arc`* rather than the token inside it and downcasts to the
+    // concrete type fail. Borrowing goes through the trait object: `arc.as_ref().any_ref()`.
+    #[test]
+    fn any_ref_borrows_the_token_through_the_trait_object() {
+        let token = Arc::new(TestToken::default());
+        let erased: CancellationTokenRef = token.clone();
+
+        assert!(erased.any_ref().downcast_ref::<TestToken>().is_none());
+
+        let borrowed = erased
+            .as_ref()
+            .any_ref()
+            .downcast_ref::<TestToken>()
+            .expect("erased token should downcast to its concrete type");
+        assert!(!borrowed.is_cancelled());
+        token.cancel();
+        assert!(borrowed.is_cancelled());
     }
 }

--- a/kernel/src/engine/sync/storage.rs
+++ b/kernel/src/engine/sync/storage.rs
@@ -27,6 +27,9 @@ impl SyncStorageHandler {
     }
 }
 
+// This handler collects eagerly under `block_on`, so there is no in-flight I/O for a cancellation
+// token to interrupt. It deliberately does not override the `*_with_cancellation` methods: their
+// default up-front check is the only cancellation it can honor.
 impl StorageHandler for SyncStorageHandler {
     fn list_from(
         &self,

--- a/kernel/src/history_manager/mod.rs
+++ b/kernel/src/history_manager/mod.rs
@@ -718,22 +718,29 @@ fn get_earliest_published_commit_version(
     log_root: &Url,
     earliest_ratified_commit_version: Option<Version>,
 ) -> DeltaResult<Version> {
-    list_delta_log_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?
-        .filter_ok(|f| f.file_type == LogPathFileType::Commit)
-        .next()
-        .transpose()?
-        .map(|f| f.version)
-        .ok_or_else(|| {
-            if earliest_ratified_commit_version == Some(0) {
-                return DeltaError::generic(format!(
-                    "expected a published v0 commit for catalog-managed table {log_root}, \
+    // TODO: thread a cancellation token through the history-manager entry points.
+    list_delta_log_from_storage(
+        engine.storage_handler().as_ref(),
+        log_root,
+        0,
+        Version::MAX,
+        None,
+    )?
+    .filter_ok(|f| f.file_type == LogPathFileType::Commit)
+    .next()
+    .transpose()?
+    .map(|f| f.version)
+    .ok_or_else(|| {
+        if earliest_ratified_commit_version == Some(0) {
+            return DeltaError::generic(format!(
+                "expected a published v0 commit for catalog-managed table {log_root}, \
                        but the log listing returned no commits"
-                ));
-            }
-            DeltaError::from(LogHistoryError::NoCommitsFound {
-                log_root: log_root.clone(),
-            })
+            ));
+        }
+        DeltaError::from(LogHistoryError::NoCommitsFound {
+            log_root: log_root.clone(),
         })
+    })
 }
 
 /// Returns the earliest table version that can be fully reconstructed, and from which we can replay
@@ -768,8 +775,14 @@ fn get_earliest_recreatable_commit(
     let mut multi_part_checkpoint_progress = HashMap::<(Version, u32), HashSet<u32>>::new();
     let mut earliest_commit_version: Option<Version> = None;
 
-    let listing =
-        list_delta_log_from_storage(engine.storage_handler().as_ref(), log_root, 0, Version::MAX)?;
+    // TODO: thread a cancellation token through the history-manager entry points.
+    let listing = list_delta_log_from_storage(
+        engine.storage_handler().as_ref(),
+        log_root,
+        0,
+        Version::MAX,
+        None,
+    )?;
     for parsed_result in listing {
         let parsed_log_path = parsed_result?;
         if !should_process_log_file(&parsed_log_path) {

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,6 +11,7 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
+use crate::cancellation::CancellationTokenRef;
 use crate::path::{CheckpointInstance, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
@@ -195,9 +196,13 @@ impl LastCheckpointHint {
     pub(crate) fn try_read(
         storage: &dyn StorageHandler,
         log_root: &Url,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Option<LastCheckpointHint>> {
         let file_path = Self::path(log_root)?;
-        match storage.read_files(vec![(file_path, None)])?.next() {
+        match storage
+            .read_files_with_cancellation(vec![(file_path, None)], cancellation_token.cloned())?
+            .next()
+        {
             Some(Ok(data)) => {
                 let result: Option<LastCheckpointHint> =
                     Self::from_bytes_with_oversized_fields_dropped(&data)
@@ -578,8 +583,9 @@ mod tests {
 
         let (engine, snapshot, _tempdir) = load_test_table(table)?;
         let seg = snapshot.log_segment();
-        let hint = LastCheckpointHint::try_read(engine.storage_handler().as_ref(), &seg.log_root)?
-            .expect("table has a _last_checkpoint");
+        let hint =
+            LastCheckpointHint::try_read(engine.storage_handler().as_ref(), &seg.log_root, None)?
+                .expect("table has a _last_checkpoint");
         let v2 = hint.v2_checkpoint.as_ref().expect("V2 checkpoint hint");
 
         // Version, checkpoint file path, and sidecar paths are this table's exact identity.
@@ -717,5 +723,49 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    /// A storage handler whose every method panics, so a test can prove an operation never touched
+    /// storage.
+    struct NoIoStorageHandler;
+
+    impl StorageHandler for NoIoStorageHandler {
+        fn list_from(
+            &self,
+            _path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            panic!("list_from should not be called");
+        }
+        fn read_files(
+            &self,
+            _files: Vec<crate::FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+            panic!("read_files should not be called");
+        }
+        fn put(&self, _path: &Url, _data: bytes::Bytes, _overwrite: bool) -> DeltaResult<()> {
+            panic!("put should not be called");
+        }
+        fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+            panic!("copy_atomic should not be called");
+        }
+        fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+            panic!("head should not be called");
+        }
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            panic!("delete should not be called");
+        }
+    }
+
+    // A cancelled token must surface as `Err(Cancelled)`, never swallowed as "no hint"
+    // (`Ok(None)`). The pre-cancelled token short-circuits the default
+    // `read_files_with_cancellation` before any read, so the panicking handler is never
+    // touched.
+    #[test]
+    fn try_read_propagates_cancellation() {
+        let log_root = Url::parse("memory:///_delta_log/").unwrap();
+        let token: CancellationTokenRef =
+            std::sync::Arc::new(crate::unit_test_utils::TestCancellationToken::cancelled());
+        let result = LastCheckpointHint::try_read(&NoIoStorageHandler, &log_root, Some(&token));
+        assert!(matches!(result, Err(Error::Cancelled)));
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -627,11 +627,56 @@ pub trait StorageHandler: AsAny {
     fn list_from(&self, path: &Url)
         -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>>;
 
+    /// Cancellation-aware variant of [`list_from`](Self::list_from).
+    ///
+    /// When `cancellation_token` is `Some`, an engine may race its listing against the token and
+    /// terminate the returned iterator with [`Error::Cancelled`] once cancellation is observed,
+    /// rather than paging through the whole listing.
+    ///
+    /// The default implementation returns [`Error::Cancelled`] if the token is already cancelled
+    /// and otherwise delegates to [`list_from`](Self::list_from), ignoring the token for the rest
+    /// of the listing. So an engine that does not override this stays source-compatible while still
+    /// honoring an up-front cancellation; kernel additionally polls the token as it consumes the
+    /// listing. An engine that overrides this takes over the up-front check and should also
+    /// fast-path an already-cancelled token before starting I/O.
+    ///
+    /// [`Error::Cancelled`]: crate::Error::Cancelled
+    fn list_from_with_cancellation(
+        &self,
+        path: &Url,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        check_cancelled(cancellation_token.as_ref())?;
+        self.list_from(path)
+    }
+
     /// Read data specified by the start and end offset from the file.
     fn read_files(
         &self,
         files: Vec<FileSlice>,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>>;
+
+    /// Cancellation-aware variant of [`read_files`](Self::read_files).
+    ///
+    /// When `cancellation_token` is `Some`, an engine may race its I/O against the token and
+    /// terminate the returned iterator with [`Error::Cancelled`] once cancellation is observed,
+    /// rather than reading every file slice to completion.
+    ///
+    /// The default implementation returns [`Error::Cancelled`] if the token is already cancelled
+    /// and otherwise delegates to [`read_files`](Self::read_files), ignoring the token for the rest
+    /// of the read. So an engine that does not override this stays source-compatible while still
+    /// honoring an up-front cancellation. An engine that overrides this takes over the up-front
+    /// check and should also fast-path an already-cancelled token before starting I/O.
+    ///
+    /// [`Error::Cancelled`]: crate::Error::Cancelled
+    fn read_files_with_cancellation(
+        &self,
+        files: Vec<FileSlice>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+        check_cancelled(cancellation_token.as_ref())?;
+        self.read_files(files)
+    }
 
     /// Copy a file atomically from source to destination. If the destination file already exists,
     /// it must return Err(Error::FileAlreadyExists).
@@ -714,8 +759,8 @@ pub trait JsonHandler: AsAny {
     /// and otherwise delegates to [`read_json_files`](Self::read_json_files), ignoring the token
     /// for the rest of the read. So an engine that does not override this stays source-compatible
     /// while still honoring an up-front cancellation; kernel additionally polls the token at
-    /// action-batch boundaries. An engine that overrides this may assume kernel has already
-    /// performed the pre-read check, and should focus on interrupting its in-flight I/O.
+    /// action-batch boundaries. An engine that overrides this takes over the up-front check and
+    /// should also fast-path an already-cancelled token before starting I/O.
     ///
     /// [`Error::Cancelled`]: crate::Error::Cancelled
     fn read_json_files_with_cancellation(
@@ -961,8 +1006,8 @@ pub trait ParquetHandler: AsAny {
     /// and otherwise delegates to [`read_parquet_files`](Self::read_parquet_files), ignoring the
     /// token for the rest of the read. So an engine that does not override this stays
     /// source-compatible while still honoring an up-front cancellation; kernel additionally polls
-    /// the token at action-batch boundaries. An engine that overrides this may assume kernel has
-    /// already performed the pre-read check, and should focus on interrupting its in-flight I/O.
+    /// the token at action-batch boundaries. An engine that overrides this takes over the up-front
+    /// check and should also fast-path an already-cancelled token before starting I/O.
     ///
     /// [`Error::Cancelled`]: crate::Error::Cancelled
     fn read_parquet_files_with_cancellation(
@@ -1064,8 +1109,8 @@ pub trait ParquetHandler: AsAny {
     /// and otherwise delegates to [`read_parquet_footer`](Self::read_parquet_footer), ignoring the
     /// token for the rest of the read. So an engine that does not override this stays
     /// source-compatible while still honoring an up-front cancellation. An engine that overrides
-    /// this may assume kernel has already performed the pre-read check, and should focus on
-    /// interrupting its in-flight I/O.
+    /// this takes over the up-front check and should also fast-path an already-cancelled token
+    /// before starting I/O.
     ///
     /// [`Error::Cancelled`]: crate::Error::Cancelled
     fn read_parquet_footer_with_cancellation(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -357,6 +357,13 @@ pub trait AsAny: Any + Send + Sync {
     /// let a: &dyn Any = f.any_ref();
     /// let b: &Bar = a.downcast_ref().unwrap();
     /// ```
+    ///
+    /// When downcasting from behind an `Arc<dyn Trait>`, borrow the trait object first
+    /// (`arc.as_ref().any_ref()`): `Arc<dyn Trait>` is itself `Sized + Any`, so calling `any_ref()`
+    /// directly on the `Arc` downcasts the *`Arc`*, not the value inside it. The owning [`as_any`]
+    /// has no such hazard -- its `Arc<Self>` receiver binds to the inner value.
+    ///
+    /// [`as_any`]: AsAny::as_any
     fn any_ref(&self) -> &(dyn Any + Send + Sync);
 
     /// Obtains an `Arc<dyn Any>` reference to the object:

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -952,6 +952,7 @@ mod tests {
             vec![],
             None,
             Some(2),
+            None,
         )
         .unwrap();
 
@@ -1029,6 +1030,7 @@ mod tests {
             vec![],
             None,
             Some(0),
+            None,
         )
         .unwrap();
         for base in [0, 5] {
@@ -1059,6 +1061,7 @@ mod tests {
             vec![],
             None,
             Some(1),
+            None,
         )
         .unwrap();
         assert_result_error_with_message(

--- a/kernel/src/log_segment/crc_tests.rs
+++ b/kernel/src/log_segment/crc_tests.rs
@@ -395,7 +395,7 @@ impl BuiltCrcTest {
         let storage = self.engine.storage_handler();
         let log_root = self.url.join("_delta_log/").unwrap();
         let log_segment =
-            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
+            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None, None)?;
         log_segment.build_crc_from_base(&self.engine, base)
     }
 
@@ -407,7 +407,7 @@ impl BuiltCrcTest {
         let storage = self.engine.storage_handler();
         let log_root = self.url.join("_delta_log/").unwrap();
         let log_segment =
-            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None)?;
+            LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, None, None)?;
         Ok(log_segment
             .pick_latest_base_crc(&self.engine, in_memory_base)
             .map(|c| c.version))

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -324,17 +324,20 @@ impl LogSegment {
         log_tail: Vec<ParsedLogPath>,
         time_travel_version: impl Into<Option<Version>>,
         metric_context: SnapshotLoadMetricContext,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         let time_travel_version = time_travel_version.into();
         let start = std::time::Instant::now();
         let build = || {
-            let checkpoint_hint = LastCheckpointHint::try_read(storage, &log_root)?;
+            let checkpoint_hint =
+                LastCheckpointHint::try_read(storage, &log_root, cancellation_token)?;
             Self::for_snapshot_impl(
                 storage,
                 log_root,
                 log_tail,
                 checkpoint_hint,
                 time_travel_version,
+                cancellation_token,
             )
         };
         let log_segment =
@@ -362,6 +365,7 @@ impl LogSegment {
         log_tail: Vec<ParsedLogPath>,
         checkpoint_hint: Option<LastCheckpointHint>,
         time_travel_version: Option<Version>,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         // The end_version is the time_travel_version, if present
         // TODO: When max catalog version is implemented, we would use that as end_version if
@@ -393,13 +397,20 @@ impl LogSegment {
                 &log_root,
                 log_tail,
                 end_version,
+                cancellation_token,
             )?,
             // Case 3
             (None, Some(end)) => LogSegmentFiles::list_with_backward_checkpoint_scan(
-                storage, &log_root, log_tail, end,
+                storage,
+                &log_root,
+                log_tail,
+                end,
+                cancellation_token,
             )?,
             // Case 4
-            (None, None) => LogSegmentFiles::list(storage, &log_root, log_tail, None, None)?,
+            (None, None) => {
+                LogSegmentFiles::list(storage, &log_root, log_tail, None, None, cancellation_token)?
+            }
         };
 
         LogSegment::try_new(listed_files, log_root, time_travel_version, checkpoint_hint)
@@ -435,6 +446,7 @@ impl LogSegment {
             vec![], // log-tail
             Some(start_version),
             end_version,
+            None, // table-changes does not carry a cancellation token yet
         )?;
         // - Here check that the start version is correct.
         // - [`LogSegment::try_new`] will verify that the `end_version` is correct if present.
@@ -490,6 +502,7 @@ impl LogSegment {
             log_tail,
             start_from,
             Some(end_version),
+            None, // timestamp conversion does not carry a cancellation token yet
         )?;
 
         // remove gaps - return latest contiguous chunk of commits

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -334,6 +334,7 @@ async fn build_snapshot_with_uuid_checkpoint_parquet() {
         vec![], // log_tail
         None,
         None,
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -369,6 +370,7 @@ async fn build_snapshot_with_uuid_checkpoint_json() {
         storage.as_ref(),
         log_root,
         vec![], // log_tail
+        None,
         None,
         None,
     )
@@ -422,6 +424,7 @@ async fn build_snapshot_with_correct_last_uuid_checkpoint() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -465,6 +468,7 @@ async fn build_snapshot_with_multiple_incomplete_multipart_checkpoints() {
         storage.as_ref(),
         log_root,
         vec![], // log_tail
+        None,
         None,
         None,
     )
@@ -514,6 +518,7 @@ async fn build_snapshot_with_out_of_date_last_checkpoint() {
         log_root,
         vec![], // log_tail
         Some(checkpoint_metadata),
+        None,
         None,
     )
     .unwrap();
@@ -567,6 +572,7 @@ async fn build_snapshot_with_correct_last_multipart_checkpoint() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -618,6 +624,7 @@ async fn build_snapshot_with_missing_checkpoint_part_from_hint_fails() {
         log_root,
         vec![], // log_tail
         Some(checkpoint_metadata),
+        None,
         None,
     );
     assert_result_error_with_message(
@@ -677,6 +684,7 @@ async fn build_snapshot_applies_checkpoint_hint_iff_it_names_the_selected_checkp
         log_root,
         vec![], // log_tail
         Some(checkpoint_metadata),
+        None,
         None,
     )
     .unwrap();
@@ -742,6 +750,7 @@ async fn build_snapshot_with_missing_checkpoint_part_no_hint() {
         vec![], // log_tail
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -797,6 +806,7 @@ async fn build_snapshot_with_out_of_date_last_checkpoint_and_incomplete_recent_c
         vec![], // log_tail
         Some(checkpoint_metadata),
         None,
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -837,6 +847,7 @@ async fn build_snapshot_without_checkpoints() {
         vec![], // log_tail
         None,
         None,
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -857,6 +868,7 @@ async fn build_snapshot_without_checkpoints() {
         vec![], // log_tail
         None,
         Some(2),
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -908,6 +920,7 @@ async fn build_snapshot_with_checkpoint_greater_than_time_travel_version() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         Some(4),
+        None,
     )
     .unwrap();
     let commit_files = log_segment.listed.ascending_commit_files;
@@ -955,6 +968,7 @@ async fn build_snapshot_with_start_checkpoint_and_time_travel_version() {
         vec![], // log_tail
         Some(checkpoint_metadata),
         Some(4),
+        None,
     )
     .unwrap();
 
@@ -984,7 +998,8 @@ async fn build_snapshot_time_travel_no_checkpoint_falls_back_to_v0(
     let (storage, log_root) = build_log_with_paths_and_checkpoint(&paths, None).await;
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], hint, Some(5)).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], hint, Some(5), None)
+            .unwrap();
 
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
@@ -1011,7 +1026,8 @@ async fn build_snapshot_time_travel_no_hint_checkpoint_at_end_version_included()
     .await;
 
     let log_segment =
-        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, Some(5)).unwrap();
+        LogSegment::for_snapshot_impl(storage.as_ref(), log_root, vec![], None, Some(5), None)
+            .unwrap();
 
     let commit_files = log_segment.listed.ascending_commit_files;
     let checkpoint_parts = log_segment.listed.checkpoint_parts;
@@ -1920,6 +1936,7 @@ async fn create_segment_for(segment: LogSegmentConfig<'_>) -> LogSegment {
         staged_commits_log_tail,
         None,
         segment.version_to_load,
+        None,
     )
     .unwrap()
 }
@@ -1942,6 +1959,7 @@ async fn test_list_log_files_with_version() -> DeltaResult<()> {
         &log_root,
         vec![], // log_tail
         Some(0),
+        None,
         None,
     )?;
     let latest_crc = result.latest_crc_file.unwrap();
@@ -2350,6 +2368,7 @@ async fn test_commit_cover_zero_byte_compaction_uses_commits() {
         engine.storage_handler().as_ref(),
         log_root.clone(),
         vec![],
+        None,
         None,
         None,
     )
@@ -2880,6 +2899,7 @@ async fn test_latest_commit_file_field_is_captured() {
         vec![],
         None,
         SnapshotLoadMetricContext::for_test(),
+        None,
     )
     .unwrap();
 
@@ -2913,6 +2933,7 @@ async fn test_latest_commit_file_with_checkpoint_filtering() {
         vec![],
         None,
         SnapshotLoadMetricContext::for_test(),
+        None,
     )
     .unwrap();
 
@@ -2940,6 +2961,7 @@ async fn test_latest_commit_file_with_no_commits() {
         vec![],
         None,
         SnapshotLoadMetricContext::for_test(),
+        None,
     )
     .unwrap();
 
@@ -2970,6 +2992,7 @@ async fn test_latest_commit_file_with_checkpoint_at_same_version() {
         vec![],
         None,
         SnapshotLoadMetricContext::for_test(),
+        None,
     )
     .unwrap();
 
@@ -3002,6 +3025,7 @@ async fn test_latest_commit_file_edge_case_commit_before_checkpoint() {
         vec![],
         None,
         SnapshotLoadMetricContext::for_test(),
+        None,
     )
     .unwrap();
 

--- a/kernel/src/log_segment_files/mod.rs
+++ b/kernel/src/log_segment_files/mod.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use tracing::{debug, info, instrument, warn};
 use url::Url;
 
+use crate::cancellation::{check_cancelled, CancellableIterator, CancellationTokenRef};
 use crate::last_checkpoint_hint::LastCheckpointHint;
 use crate::path::LogPathFileType::*;
 use crate::path::{
@@ -64,17 +65,22 @@ pub(crate) struct LogSegmentFiles {
 /// This is a thin wrapper around [`StorageHandler::list_from`] that provides the standard
 /// Delta log file discovery pipeline. Callers are responsible for handling the `log_tail`
 /// (catalog-provided commits) and tracking `max_published_version`.
+///
+/// With a `cancellation_token`, the listing becomes cancellable: the engine may interrupt its own
+/// I/O, and the returned iterator is polled against the token so cancellation arrives as a terminal
+/// [`Error::Cancelled`] rather than an early end.
 #[internal_api]
 pub(crate) fn list_delta_log_from_storage(
     storage: &dyn StorageHandler,
     log_root: &Url,
     start_version: Version,
     end_version: Version,
+    cancellation_token: Option<&CancellationTokenRef>,
 ) -> DeltaResult<impl Iterator<Item = DeltaResult<ParsedLogPath>>> {
     let start_from = log_root.join(&format!("{start_version:020}"))?;
     let log_root_str = log_root.to_string();
     let files = storage
-        .list_from(&start_from)?
+        .list_from_with_cancellation(&start_from, cancellation_token.cloned())?
         // The listing is sorted by full path, so nothing relevant follows the first relative path
         // past the version-named region (see `may_begin_listable_log_path`). Stopping there avoids
         // paging through `_staged_commits/` and `_sidecars/`, which can hold thousands of files.
@@ -101,7 +107,10 @@ pub(crate) fn list_delta_log_from_storage(
             Ok(path) => path.version <= end_version,
             Err(_) => true,
         });
-    Ok(files)
+    // Poll for cancellation OUTSIDE the version `take_while` above. Inside it, cancellation would
+    // end the iterator with `None`, making a truncated listing indistinguishable from a complete
+    // one; outside, it always surfaces as a terminal `Error::Cancelled`.
+    Ok(CancellableIterator::new(files, cancellation_token.cloned()))
 }
 
 /// Groups all checkpoint parts according to the checkpoint they belong to.
@@ -502,6 +511,7 @@ impl LogSegmentFiles {
         log_tail: Vec<ParsedLogPath>,
         start_version: Option<Version>,
         end_version: Option<Version>,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         debug_assert!(
             log_tail.iter().all(|entry| entry.is_commit()),
@@ -509,7 +519,8 @@ impl LogSegmentFiles {
         );
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
-        let fs_iter = list_delta_log_from_storage(storage, log_root, start, end)?;
+        let fs_iter =
+            list_delta_log_from_storage(storage, log_root, start, end, cancellation_token)?;
 
         let log_tail_start_version = log_tail.first().map(|f| f.version);
         let mut listed_commits = Vec::new();
@@ -568,10 +579,12 @@ impl LogSegmentFiles {
         log_tail: Vec<ParsedLogPath>,
         start_version: Option<Version>,
         end_version: Option<Version>,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         let start = start_version.unwrap_or(0);
         let end = end_version.unwrap_or(Version::MAX);
-        let fs_iter = list_delta_log_from_storage(storage, log_root, start, end)?;
+        let fs_iter =
+            list_delta_log_from_storage(storage, log_root, start, end, cancellation_token)?;
         Self::build_log_segment_files(fs_iter, log_tail, start, end_version)
     }
 
@@ -588,6 +601,7 @@ impl LogSegmentFiles {
         log_root: &Url,
         log_tail: Vec<ParsedLogPath>,
         end_version: Option<Version>,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         let listed_files = Self::list(
             storage,
@@ -595,6 +609,7 @@ impl LogSegmentFiles {
             log_tail,
             Some(checkpoint_metadata.version),
             end_version,
+            cancellation_token,
         )?;
 
         let Some(latest_checkpoint) = listed_files.checkpoint_parts.last() else {
@@ -665,6 +680,7 @@ impl LogSegmentFiles {
         log_root: &Url,
         log_tail: Vec<ParsedLogPath>,
         end_version: Version,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Self> {
         // Scan backward in 1000-version windows, collecting ALL file types, until a complete
         // checkpoint is found or the log is exhausted.
@@ -675,9 +691,18 @@ impl LogSegmentFiles {
         // [lower, upper - 1].
         let mut upper = end_version + 1;
         while upper > 0 {
+            // Each window is collected eagerly, so check between windows too: a long backward scan
+            // would otherwise keep going after cancellation.
+            check_cancelled(cancellation_token)?;
             let lower = upper.saturating_sub(BACKWARD_SCAN_WINDOW_SIZE);
-            let window_files: Vec<_> =
-                list_delta_log_from_storage(storage, log_root, lower, upper - 1)?.try_collect()?;
+            let window_files: Vec<_> = list_delta_log_from_storage(
+                storage,
+                log_root,
+                lower,
+                upper - 1,
+                cancellation_token,
+            )?
+            .try_collect()?;
 
             found_checkpoint_version = find_complete_checkpoint_version(&window_files);
             windows.push(window_files);

--- a/kernel/src/log_segment_files/tests.rs
+++ b/kernel/src/log_segment_files/tests.rs
@@ -217,7 +217,15 @@ fn list_and_destructure(
     Option<ParsedLogPath>,
     Option<Version>,
 ) {
-    let r = LogSegmentFiles::list(storage, log_root, log_tail, start_version, end_version).unwrap();
+    let r = LogSegmentFiles::list(
+        storage,
+        log_root,
+        log_tail,
+        start_version,
+        end_version,
+        None,
+    )
+    .unwrap();
     (
         r.ascending_commit_files,
         r.ascending_compaction_files,
@@ -689,9 +697,14 @@ async fn backward_scan_single_checkpoint_cases(
     let (storage, log_root) = create_storage(log_files).await;
     let counter = CountingStorageHandler::new(storage);
 
-    let result =
-        LogSegmentFiles::list_with_backward_checkpoint_scan(&counter, &log_root, vec![], 1005)
-            .unwrap();
+    let result = LogSegmentFiles::list_with_backward_checkpoint_scan(
+        &counter,
+        &log_root,
+        vec![],
+        1005,
+        None,
+    )
+    .unwrap();
 
     assert_eq!(counter.call_count(), expected_listings);
 
@@ -818,6 +831,7 @@ async fn backward_scan_multipart_checkpoint_cases(
         &log_root,
         vec![],
         end_version,
+        None,
     )
     .unwrap();
 
@@ -868,6 +882,7 @@ async fn backward_scan_with_log_tail_derives_lower_bound_from_checkpoint() {
         &log_root,
         log_tail,
         10,
+        None,
     )
     .unwrap();
 
@@ -918,6 +933,7 @@ async fn backward_scan_with_log_tail_starting_before_checkpoint() {
         &log_root,
         log_tail,
         8,
+        None,
     )
     .unwrap();
 
@@ -960,6 +976,7 @@ async fn backward_scan_log_tail_defines_latest_version() {
         &log_root,
         log_tail,
         5,
+        None,
     )
     .unwrap();
 
@@ -1017,7 +1034,7 @@ async fn test_zero_byte_commit_kept_in_listing() {
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result =
-        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(2)).unwrap();
+        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(2), None).unwrap();
     assert_eq!(result.ascending_commit_files.len(), 3);
     assert_eq!(result.ascending_commit_files[0].version, 0);
     assert_eq!(result.ascending_commit_files[1].version, 1);
@@ -1046,10 +1063,16 @@ async fn test_zero_byte_compaction_skipped_commits_used(#[case] use_backward_sca
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result = if use_backward_scan {
-        LogSegmentFiles::list_with_backward_checkpoint_scan(storage.as_ref(), &log_root, vec![], 4)
-            .unwrap()
+        LogSegmentFiles::list_with_backward_checkpoint_scan(
+            storage.as_ref(),
+            &log_root,
+            vec![],
+            4,
+            None,
+        )
+        .unwrap()
     } else {
-        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(4)).unwrap()
+        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(4), None).unwrap()
     };
 
     assert!(
@@ -1086,10 +1109,16 @@ async fn test_zero_byte_checkpoint_skipped_older_used(#[case] use_backward_scan:
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result = if use_backward_scan {
-        LogSegmentFiles::list_with_backward_checkpoint_scan(storage.as_ref(), &log_root, vec![], 10)
-            .unwrap()
+        LogSegmentFiles::list_with_backward_checkpoint_scan(
+            storage.as_ref(),
+            &log_root,
+            vec![],
+            10,
+            None,
+        )
+        .unwrap()
     } else {
-        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(10)).unwrap()
+        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(10), None).unwrap()
     };
 
     // Should fall back to checkpoint at v5 (the empty v10 checkpoint is skipped)
@@ -1115,7 +1144,7 @@ async fn test_zero_byte_crc_kept() {
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result =
-        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(2)).unwrap();
+        LogSegmentFiles::list(storage.as_ref(), &log_root, vec![], Some(0), Some(2), None).unwrap();
 
     // The 0-byte CRC at v2 is kept (latest_crc_file tracks the highest version)
     let crc = result.latest_crc_file.unwrap();
@@ -1138,9 +1167,14 @@ async fn test_zero_byte_checkpoint_backward_scan_crosses_windows() {
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
     let counter = CountingStorageHandler::new(storage);
 
-    let result =
-        LogSegmentFiles::list_with_backward_checkpoint_scan(&counter, &log_root, vec![], 1005)
-            .unwrap();
+    let result = LogSegmentFiles::list_with_backward_checkpoint_scan(
+        &counter,
+        &log_root,
+        vec![],
+        1005,
+        None,
+    )
+    .unwrap();
 
     // Needed 2 windows because the 0-byte checkpoint at v1005 was skipped
     assert_eq!(counter.call_count(), 2);
@@ -1163,7 +1197,7 @@ async fn test_list_commits_zero_byte_commit_kept() {
     let (storage, log_root) = create_storage_with_empty_files(log_files).await;
 
     let result =
-        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(2))
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(2), None)
             .unwrap();
     assert_eq!(result.ascending_commit_files.len(), 3);
     assert_eq!(result.ascending_commit_files[2].version, 2);
@@ -1235,7 +1269,8 @@ async fn list_commits_merges_log_tail(
         .collect();
 
     let result =
-        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, log_tail, start, end).unwrap();
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, log_tail, start, end, None)
+            .unwrap();
 
     let commits = &result.ascending_commit_files;
     assert_eq!(commits.len(), expected.len());
@@ -1262,7 +1297,7 @@ async fn test_list_commits_keeps_commits_across_checkpoint() {
     let (storage, log_root) = create_storage(files).await;
 
     let result =
-        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(5))
+        LogSegmentFiles::list_commits(storage.as_ref(), &log_root, vec![], Some(0), Some(5), None)
             .unwrap();
     let versions: Vec<_> = result
         .ascending_commit_files
@@ -1595,6 +1630,7 @@ async fn last_checkpoint_hint_applies_iff_it_names_the_selected_checkpoint(
         &log_root,
         vec![],
         None,
+        None,
     )
     .unwrap();
 
@@ -1728,4 +1764,214 @@ fn find_complete_checkpoint_version_same_version_cases(
     #[case] expected: Option<u64>,
 ) {
     assert_eq!(find_complete_checkpoint_version(&files), expected);
+}
+
+// ===== cancellation tests =====
+
+/// A storage handler whose listing yields `count` synthetic commit paths and records how many were
+/// pulled, so a test can tell where a cancelled listing actually stopped.
+struct EndlessListingHandler {
+    log_root: Url,
+    count: usize,
+    items_pulled: Arc<AtomicU32>,
+}
+
+impl StorageHandler for EndlessListingHandler {
+    fn list_from(
+        &self,
+        _path: &Url,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        let log_root = self.log_root.clone();
+        let pulled = self.items_pulled.clone();
+        let iter = (0..self.count as u64).map(move |version| {
+            pulled.fetch_add(1, Ordering::Relaxed);
+            Ok(FileMeta::new(
+                log_root.join(&format!("{version:020}.json"))?,
+                version as i64,
+                1,
+            ))
+        });
+        Ok(Box::new(iter))
+    }
+
+    fn read_files(
+        &self,
+        _files: Vec<crate::FileSlice>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+        panic!("read_files should not be called during listing");
+    }
+
+    fn put(&self, _path: &Url, _data: bytes::Bytes, _overwrite: bool) -> DeltaResult<()> {
+        panic!("put should not be called during listing");
+    }
+
+    fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+        panic!("copy_atomic should not be called during listing");
+    }
+
+    fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+        panic!("head should not be called during listing");
+    }
+
+    fn delete(&self, _path: &Url) -> DeltaResult<()> {
+        panic!("delete should not be called during listing");
+    }
+}
+
+// An already-cancelled token fails the listing before any storage call, via the default
+// `list_from_with_cancellation` (this handler does not override it).
+#[test]
+fn precancelled_token_stops_listing_before_any_storage_call() {
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let pulled = Arc::new(AtomicU32::new(0));
+    let storage = EndlessListingHandler {
+        log_root: log_root.clone(),
+        count: 100,
+        items_pulled: pulled.clone(),
+    };
+
+    let token: CancellationTokenRef =
+        Arc::new(crate::unit_test_utils::TestCancellationToken::cancelled());
+
+    let result = list_delta_log_from_storage(&storage, &log_root, 0, Version::MAX, Some(&token));
+    assert!(matches!(result, Err(Error::Cancelled)));
+    assert_eq!(pulled.load(Ordering::Relaxed), 0);
+}
+
+// Cancelling partway yields the items already produced, then exactly one terminal
+// `Error::Cancelled` -- never a bare `None`, which would make a truncated listing look complete.
+// This is the regression guard for polling inside (rather than outside) the version `take_while`.
+#[test]
+fn mid_listing_cancellation_yields_terminal_error_not_silent_truncation() {
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let pulled = Arc::new(AtomicU32::new(0));
+    let storage = EndlessListingHandler {
+        log_root: log_root.clone(),
+        count: 100,
+        items_pulled: pulled.clone(),
+    };
+
+    let token = Arc::new(crate::unit_test_utils::TestCancellationToken::default());
+    let token_ref: CancellationTokenRef = token.clone();
+    let mut iter =
+        list_delta_log_from_storage(&storage, &log_root, 0, Version::MAX, Some(&token_ref))
+            .unwrap();
+
+    assert!(matches!(iter.next(), Some(Ok(p)) if p.version == 0));
+    assert!(matches!(iter.next(), Some(Ok(p)) if p.version == 1));
+
+    token.cancel();
+
+    assert!(matches!(iter.next(), Some(Err(Error::Cancelled))));
+    // Fused: no second error and no further items.
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+    // The listing stopped early rather than draining all 100 entries.
+    assert!(pulled.load(Ordering::Relaxed) < 100);
+}
+
+// With no token the listing is unchanged, so cancellation support is strictly opt-in.
+#[test]
+fn listing_without_token_is_unchanged() {
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let pulled = Arc::new(AtomicU32::new(0));
+    let storage = EndlessListingHandler {
+        log_root: log_root.clone(),
+        count: 5,
+        items_pulled: pulled.clone(),
+    };
+
+    let listed: Vec<_> = list_delta_log_from_storage(&storage, &log_root, 0, Version::MAX, None)
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
+    assert_eq!(listed.len(), 5);
+}
+
+/// An iterator that yields nothing but cancels `token` the instant it is polled (i.e. as the
+/// enclosing listing is exhausted), so a later poll of the token observes the cancellation.
+struct CancelOnExhaustion {
+    token: Arc<crate::unit_test_utils::TestCancellationToken>,
+    done: bool,
+}
+
+impl Iterator for CancelOnExhaustion {
+    type Item = DeltaResult<FileMeta>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.done {
+            self.done = true;
+            self.token.cancel();
+        }
+        None
+    }
+}
+
+/// A storage handler that returns an empty listing and cancels `token` as that listing is
+/// exhausted, counting its `list_from` calls. Lets a test flip the token *between* backward-scan
+/// windows rather than before the first one.
+struct CancelAfterListingHandler {
+    token: Arc<crate::unit_test_utils::TestCancellationToken>,
+    list_calls: Arc<AtomicU32>,
+}
+
+impl StorageHandler for CancelAfterListingHandler {
+    fn list_from(
+        &self,
+        _path: &Url,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        self.list_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(Box::new(CancelOnExhaustion {
+            token: self.token.clone(),
+            done: false,
+        }))
+    }
+
+    fn read_files(
+        &self,
+        _files: Vec<crate::FileSlice>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+        panic!("read_files should not be called during listing");
+    }
+
+    fn put(&self, _path: &Url, _data: bytes::Bytes, _overwrite: bool) -> DeltaResult<()> {
+        panic!("put should not be called during listing");
+    }
+
+    fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+        panic!("copy_atomic should not be called during listing");
+    }
+
+    fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+        panic!("head should not be called during listing");
+    }
+
+    fn delete(&self, _path: &Url) -> DeltaResult<()> {
+        panic!("delete should not be called during listing");
+    }
+}
+
+// The backward scan collects each window eagerly and re-checks the token at the top of every
+// window. Window 1 lists an empty window and succeeds; the token flips as that listing is
+// exhausted, so it is window 2's up-front check -- not window 1's -- that surfaces the cancellation
+// (exactly one listing ran).
+#[test]
+fn backward_scan_checks_cancellation_between_windows() {
+    let log_root = Url::parse("memory:///_delta_log/").unwrap();
+    let token = Arc::new(crate::unit_test_utils::TestCancellationToken::default());
+    let list_calls = Arc::new(AtomicU32::new(0));
+    let storage = CancelAfterListingHandler {
+        token: token.clone(),
+        list_calls: list_calls.clone(),
+    };
+    let token_ref: CancellationTokenRef = token;
+
+    let result = LogSegmentFiles::list_with_backward_checkpoint_scan(
+        &storage,
+        &log_root,
+        vec![],
+        5_000,
+        Some(&token_ref),
+    );
+    assert!(matches!(result, Err(Error::Cancelled)));
+    assert_eq!(list_calls.load(Ordering::Relaxed), 1);
 }

--- a/kernel/src/metrics/metered_storage.rs
+++ b/kernel/src/metrics/metered_storage.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::metrics::events::{StorageCopyCompleted, StorageListCompleted, StorageReadCompleted};
 use crate::metrics::{emit_storage_span, MetricsIterator};
-use crate::{DeltaResult, FileMeta, FileSlice, StorageHandler};
+use crate::{CancellationTokenRef, DeltaResult, FileMeta, FileSlice, StorageHandler};
 
 /// Decorator over an engine-provided `Arc<dyn StorageHandler>` that emits the kernel's
 /// standard `"storage"` spans on operations that produce metrics. `put`, `head`, and `delete`
@@ -55,12 +55,46 @@ impl StorageHandler for MeteredStorageHandler {
         )))
     }
 
+    // The token is forwarded exactly as received: `CancellationToken` guarantees a caller gets back
+    // the value it supplied, so wrapping it here would break its downcast.
+    fn list_from_with_cancellation(
+        &self,
+        path: &Url,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        let start = Instant::now();
+        let inner = self
+            .inner
+            .list_from_with_cancellation(path, cancellation_token)?;
+        Ok(Box::new(MetricsIterator::<_, FileMeta>::new(
+            inner,
+            StorageListCompleted::NAME,
+            start,
+        )))
+    }
+
     fn read_files(
         &self,
         files: Vec<FileSlice>,
     ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
         let start = Instant::now();
         let inner = self.inner.read_files(files)?;
+        Ok(Box::new(MetricsIterator::<_, Bytes>::new(
+            inner,
+            StorageReadCompleted::NAME,
+            start,
+        )))
+    }
+
+    fn read_files_with_cancellation(
+        &self,
+        files: Vec<FileSlice>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+        let start = Instant::now();
+        let inner = self
+            .inner
+            .read_files_with_cancellation(files, cancellation_token)?;
         Ok(Box::new(MetricsIterator::<_, Bytes>::new(
             inner,
             StorageReadCompleted::NAME,
@@ -231,5 +265,124 @@ mod tests {
         });
         let once: Arc<dyn StorageHandler> = Arc::new(MeteredStorageHandler::new(inner));
         let _twice = MeteredStorageHandler::new(once);
+    }
+
+    /// Records the token it is handed, so a test can check what survived the metered wrapper.
+    #[derive(Default)]
+    struct TokenCapturingStorageHandler {
+        seen: std::sync::Mutex<Option<CancellationTokenRef>>,
+    }
+
+    impl StorageHandler for TokenCapturingStorageHandler {
+        fn list_from(
+            &self,
+            _path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn list_from_with_cancellation(
+            &self,
+            _path: &Url,
+            cancellation_token: Option<CancellationTokenRef>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            *self.seen.lock().unwrap() = cancellation_token;
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn read_files(
+            &self,
+            _files: Vec<FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn read_files_with_cancellation(
+            &self,
+            _files: Vec<FileSlice>,
+            cancellation_token: Option<CancellationTokenRef>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+            *self.seen.lock().unwrap() = cancellation_token;
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+            Ok(())
+        }
+
+        fn put(&self, _path: &Url, _data: Bytes, _overwrite: bool) -> DeltaResult<()> {
+            Ok(())
+        }
+
+        fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+            unreachable!("not exercised in these tests")
+        }
+
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            Ok(())
+        }
+    }
+
+    // The wrapper forwards to the inner cancellation-aware methods and passes the token through by
+    // identity, so a caller can still downcast it to recover what it supplied.
+    #[rstest::rstest]
+    #[case::list(true)]
+    #[case::read(false)]
+    fn forwards_cancellation_token_by_identity(#[case] list: bool) {
+        let stub = Arc::new(TokenCapturingStorageHandler::default());
+        let storage = MeteredStorageHandler::new(stub.clone());
+        let token: CancellationTokenRef =
+            Arc::new(crate::unit_test_utils::TestCancellationToken::default());
+
+        if list {
+            let iter = storage
+                .list_from_with_cancellation(&fake_url(), Some(token.clone()))
+                .unwrap();
+            let _: Vec<_> = iter.collect();
+        } else {
+            let iter = storage
+                .read_files_with_cancellation(vec![], Some(token.clone()))
+                .unwrap();
+            let _: Vec<_> = iter.collect();
+        }
+
+        let seen = stub
+            .seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("inner handler should have received the token");
+        assert!(
+            Arc::ptr_eq(&token, &seen),
+            "the metered wrapper must not wrap or replace the token"
+        );
+    }
+
+    // Metrics are still emitted when the cancellation-aware variants are used.
+    #[test]
+    fn cancellation_variants_still_emit_metrics() {
+        let (reporter, _guard) = install_capture();
+        let inner: Arc<dyn StorageHandler> = Arc::new(StubStorageHandler {
+            list_results: vec![fake_file_meta("00000000000000000000.json")],
+            read_results: vec![Bytes::from(vec![0u8; 4])],
+        });
+        let storage = MeteredStorageHandler::new(inner);
+
+        let _: Vec<_> = storage
+            .list_from_with_cancellation(&fake_url(), None)
+            .unwrap()
+            .collect();
+        let _: Vec<_> = storage
+            .read_files_with_cancellation(vec![], None)
+            .unwrap()
+            .collect();
+
+        let events = reporter.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, MetricEvent::StorageListCompleted(_))));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, MetricEvent::StorageReadCompleted(_))));
     }
 }

--- a/kernel/src/snapshot/builder.rs
+++ b/kernel/src/snapshot/builder.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use tracing::{info, instrument};
 
+use crate::cancellation::CancellationTokenRef;
 use crate::log_path::LogPath;
 use crate::log_segment::LogSegment;
 use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
@@ -35,7 +36,6 @@ use crate::{DeltaResult, Engine, Error, Snapshot, Version};
 // Note the SnapshotBuilder must have either a table_root or an existing_snapshot (but not both).
 // We enforce this in the constructors. We could improve this in the future with different
 // types/add type state.
-#[derive(Debug)]
 pub struct SnapshotBuilder {
     table_root: Option<String>,
     existing_snapshot: Option<SnapshotRef>,
@@ -48,6 +48,28 @@ pub struct SnapshotBuilder {
     /// Opaque, caller-supplied id recorded on this build's metric events. Not interpreted by
     /// kernel; set via [`with_correlation_id`](Self::with_correlation_id).
     correlation_id: Option<Arc<str>>,
+    /// Optional cooperative cancellation token supplied via
+    /// [`with_cancellation_token`](Self::with_cancellation_token). `None` means the build is not
+    /// cancellable.
+    cancellation_token: Option<CancellationTokenRef>,
+}
+
+// Hand-written because `CancellationToken` is not `Debug`: the token is projected to a bool. Ends
+// with `finish_non_exhaustive` so a future field is not silently dropped from the output.
+impl std::fmt::Debug for SnapshotBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SnapshotBuilder")
+            .field("table_root", &self.table_root)
+            .field("existing_snapshot", &self.existing_snapshot)
+            .field("version", &self.version)
+            .field("log_tail", &self.log_tail)
+            .field("max_catalog_version", &self.max_catalog_version)
+            .field("incremental_replay", &self.incremental_replay)
+            .field("operation_id", &self.operation_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("cancellable", &self.cancellation_token.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 /// Controls whether kernel replays commits to advance a stale base CRC (the existing snapshot's
@@ -109,6 +131,7 @@ impl SnapshotBuilder {
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
             correlation_id: None,
+            cancellation_token: None,
         }
     }
 
@@ -122,6 +145,7 @@ impl SnapshotBuilder {
             incremental_replay: IncrementalReplay::default(),
             operation_id: MetricId::new(),
             correlation_id: None,
+            cancellation_token: None,
         }
     }
 
@@ -169,6 +193,23 @@ impl SnapshotBuilder {
     /// [`at_version`]: Self::at_version
     pub fn with_max_catalog_version(mut self, max_catalog_version: Version) -> Self {
         self.max_catalog_version = Some(max_catalog_version);
+        self
+    }
+
+    /// Supply a [`CancellationToken`] so building the snapshot can be abandoned partway.
+    ///
+    /// Kernel polls the token as it consumes the log listing, and a cancellation-aware [`Engine`]
+    /// additionally races its listing and log reads against it. On cancellation
+    /// [`build`](Self::build) returns [`Error::Cancelled`] rather than a snapshot built from a
+    /// partial listing. With no token the build is not cancellable.
+    ///
+    /// [`CancellationToken`]: crate::CancellationToken
+    /// [`Error::Cancelled`]: crate::Error::Cancelled
+    pub fn with_cancellation_token(
+        mut self,
+        token: impl Into<Option<CancellationTokenRef>>,
+    ) -> Self {
+        self.cancellation_token = token.into();
         self
     }
 
@@ -243,6 +284,7 @@ impl SnapshotBuilder {
             incremental_replay,
             operation_id,
             correlation_id,
+            cancellation_token,
         } = self;
 
         let metric_context = SnapshotLoadMetricContext {
@@ -274,6 +316,7 @@ impl SnapshotBuilder {
                     log_tail,
                     effective_version,
                     metric_context.clone(),
+                    cancellation_token.as_ref(),
                 )?;
                 Snapshot::try_new_from_log_segment(
                     table_url,
@@ -301,6 +344,7 @@ impl SnapshotBuilder {
                         metric_context,
                         incremental_replay,
                         built_as_latest,
+                        cancellation_token.as_ref(),
                     )
                 })
         };

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use tracing::instrument;
 
 use super::{IncrementalReplay, Snapshot};
+use crate::cancellation::CancellationTokenRef;
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
 use crate::metrics::{
@@ -98,7 +99,8 @@ impl Snapshot {
     ///
     /// [`SnapshotBuilder::at_version`]: crate::snapshot::SnapshotBuilder::at_version
     /// [`SnapshotBuilder::with_max_catalog_version`]: crate::snapshot::SnapshotBuilder::with_max_catalog_version
-    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, target_version))]
+    #[allow(clippy::too_many_arguments)]
+    #[instrument(err, fields(version, operation_id = %metric_context.operation_id, correlation_id = metric_context.correlation_id.as_deref().unwrap_or("")), skip(engine, target_version, cancellation_token))]
     pub(super) fn try_new_from(
         existing_snapshot: Arc<Snapshot>,
         log_tail: Vec<ParsedLogPath>,
@@ -107,6 +109,7 @@ impl Snapshot {
         metric_context: SnapshotLoadMetricContext,
         incremental_replay: IncrementalReplay,
         built_as_latest: bool,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<Arc<Self>> {
         let existing_log_segment = &existing_snapshot.log_segment;
         let existing_snapshot_version = existing_snapshot.version();
@@ -137,6 +140,7 @@ impl Snapshot {
             existing_snapshot_version,
             log_tail,
             requested_version,
+            cancellation_token,
         )
         .inspect_err(|_| emit_log_segment_load_failure(&metric_context))?
         {
@@ -237,6 +241,7 @@ impl Snapshot {
         existing_snapshot_version: Version,
         log_tail: Vec<ParsedLogPath>,
         requested_version: Option<Version>,
+        cancellation_token: Option<&CancellationTokenRef>,
     ) -> DeltaResult<NewSegment> {
         let log_root = existing_log_segment.log_root.clone();
         let storage = engine.storage_handler();
@@ -250,6 +255,7 @@ impl Snapshot {
             log_tail,
             Some(listing_start),
             requested_version,
+            cancellation_token,
         )?;
 
         // NB: we need to check both checkpoints and commits since we filter commits at and below
@@ -640,6 +646,7 @@ mod tests {
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             true, /* built_as_latest */
+            None, /* cancellation_token */
         )?;
         assert_eq!(result, base_snapshot);
         // `PartialEq` ignores `built_as_latest`, so assert it explicitly.
@@ -720,6 +727,7 @@ mod tests {
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
+            None,  /* cancellation_token */
         )?;
 
         // Latest commit should now be version 2
@@ -779,6 +787,7 @@ mod tests {
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
+            None,  /* cancellation_token */
         )?;
         assert!(Arc::ptr_eq(&same_version, &base_snapshot));
 
@@ -791,6 +800,7 @@ mod tests {
             SnapshotLoadMetricContext::for_test(),
             IncrementalReplay::Disabled,
             false, /* built_as_latest */
+            None,  /* cancellation_token */
         );
         assert!(matches!(
             older_version,

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1505,7 +1505,7 @@ mod tests {
 
         let engine = SyncEngine::new();
         let storage = engine.storage_handler();
-        let cp = LastCheckpointHint::try_read(storage.as_ref(), &url).unwrap();
+        let cp = LastCheckpointHint::try_read(storage.as_ref(), &url, None).unwrap();
         assert!(cp.is_none());
     }
 
@@ -1564,8 +1564,8 @@ mod tests {
         let engine = SyncEngine::new_with_store(store);
         let storage = engine.storage_handler();
         let url = Url::parse("memory:///invalid/").expect("valid url");
-        let invalid =
-            LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
+        let invalid = LastCheckpointHint::try_read(storage.as_ref(), &url, None)
+            .expect("read last checkpoint");
         assert!(invalid.is_none())
     }
 
@@ -1599,8 +1599,8 @@ mod tests {
         // valid, invalid and valid with tags.
         for (path_prefix, _, expected_result) in test_cases {
             let url = Url::parse(&format!("memory:///{path_prefix}/")).expect("valid url");
-            let result =
-                LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
+            let result = LastCheckpointHint::try_read(storage.as_ref(), &url, None)
+                .expect("read last checkpoint");
             assert_eq!(result, expected_result);
         }
     }

--- a/kernel/src/unit_test_utils.rs
+++ b/kernel/src/unit_test_utils.rs
@@ -1092,3 +1092,35 @@ pub(crate) fn geometry_type(crs: &str) -> KernelDataType {
 pub(crate) fn geography_type(crs: &str, algorithm: EdgeInterpolationAlgorithm) -> KernelDataType {
     PrimitiveType::Geography(Box::new(GeographyType::try_new(crs, algorithm).unwrap())).into()
 }
+
+/// A [`CancellationToken`](crate::CancellationToken) for kernel unit tests, cancellable on demand.
+///
+/// `test_utils::TestCancellationToken` cannot be used here: it implements the trait against
+/// `test_utils`'s own `delta_kernel` dependency, a different crate instance than the
+/// crate-under-test, so its impl does not satisfy the crate-self trait in unit tests. Integration
+/// tests (which see one external `delta_kernel`) use the `test_utils` one instead.
+#[derive(Default)]
+pub(crate) struct TestCancellationToken(std::sync::atomic::AtomicBool);
+
+impl TestCancellationToken {
+    /// A token that is already cancelled.
+    pub(crate) fn cancelled() -> Self {
+        let token = Self::default();
+        token.cancel();
+        token
+    }
+
+    /// Request cancellation.
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+impl crate::cancellation::CancellationToken for TestCancellationToken {
+    fn is_cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+    fn cancelled_future(&self) -> crate::cancellation::CancelledFuture<'_> {
+        Box::pin(std::future::ready(()))
+    }
+}

--- a/kernel/tests/integration/read/scan_cancellation.rs
+++ b/kernel/tests/integration/read/scan_cancellation.rs
@@ -11,8 +11,8 @@ use delta_kernel::scan::StatsOptions;
 use delta_kernel::schema::SchemaRef;
 use delta_kernel::{
     CancellationToken as _, CancellationTokenRef, DeltaResult, Engine, EngineData, Error,
-    FileDataReadResultIterator, FileMeta, FilteredEngineData, JsonHandler, ParquetHandler,
-    PredicateRef, Snapshot,
+    FileDataReadResultIterator, FileMeta, FileSlice, FilteredEngineData, JsonHandler,
+    ParquetHandler, PredicateRef, Snapshot, StorageHandler,
 };
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
@@ -435,6 +435,150 @@ async fn parallel_scan_metadata_errors_when_token_set() -> Result<(), Box<dyn st
     assert!(
         matches!(result, Err(Error::Unsupported(_))),
         "parallel_scan_metadata must reject a cancellation token"
+    );
+    Ok(())
+}
+
+// Building a snapshot with an already-cancelled token fails rather than returning a snapshot built
+// from a partial log listing.
+#[tokio::test]
+async fn precancelled_snapshot_build_yields_cancelled() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, table_root) = json_only_table().await?;
+    let engine = DefaultEngineBuilder::new(storage).build();
+
+    let token: CancellationTokenRef = Arc::new(TestCancellationToken::cancelled());
+    let result = Snapshot::builder_for(table_root)
+        .with_cancellation_token(token)
+        .build(&engine);
+
+    assert!(
+        matches!(result, Err(Error::Cancelled)),
+        "a cancelled snapshot build must surface Error::Cancelled"
+    );
+    Ok(())
+}
+
+// An uncancelled token leaves snapshot building unchanged, so the feature is opt-in and the token's
+// mere presence costs nothing.
+#[tokio::test]
+async fn snapshot_build_with_uncancelled_token_succeeds() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (storage, table_root) = json_only_table().await?;
+    let engine = DefaultEngineBuilder::new(storage).build();
+
+    let token: CancellationTokenRef = Arc::new(TestCancellationToken::default());
+    let with_token = Snapshot::builder_for(table_root)
+        .with_cancellation_token(token)
+        .build(&engine)?;
+    let without_token = Snapshot::builder_for(table_root).build(&engine)?;
+
+    assert_eq!(with_token.version(), without_token.version());
+    Ok(())
+}
+
+/// A storage decorator that cancels `token` when a listing begins, delegating everything else to
+/// the real handler. `_last_checkpoint` is read (via `read_files`) *before* the log listing, so
+/// this drives cancellation into the listing specifically -- the read has already succeeded by
+/// then.
+struct CancelOnListHandler {
+    inner: Arc<dyn StorageHandler>,
+    token: Arc<TestCancellationToken>,
+}
+
+impl StorageHandler for CancelOnListHandler {
+    fn list_from(
+        &self,
+        path: &url::Url,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        self.inner.list_from(path)
+    }
+
+    fn list_from_with_cancellation(
+        &self,
+        path: &url::Url,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+        self.token.cancel();
+        self.inner
+            .list_from_with_cancellation(path, cancellation_token)
+    }
+
+    fn read_files(
+        &self,
+        files: Vec<FileSlice>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+        self.inner.read_files(files)
+    }
+
+    fn read_files_with_cancellation(
+        &self,
+        files: Vec<FileSlice>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<bytes::Bytes>>>> {
+        self.inner
+            .read_files_with_cancellation(files, cancellation_token)
+    }
+
+    fn put(&self, path: &url::Url, data: bytes::Bytes, overwrite: bool) -> DeltaResult<()> {
+        self.inner.put(path, data, overwrite)
+    }
+
+    fn copy_atomic(&self, src: &url::Url, dest: &url::Url) -> DeltaResult<()> {
+        self.inner.copy_atomic(src, dest)
+    }
+
+    fn head(&self, path: &url::Url) -> DeltaResult<FileMeta> {
+        self.inner.head(path)
+    }
+
+    fn delete(&self, path: &url::Url) -> DeltaResult<()> {
+        self.inner.delete(path)
+    }
+}
+
+/// Installs a [`CancelOnListHandler`] over the real engine's storage, delegating other handlers.
+struct CancelOnListEngine {
+    inner: Arc<dyn Engine>,
+    storage: Arc<CancelOnListHandler>,
+}
+
+impl Engine for CancelOnListEngine {
+    fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn StorageHandler> {
+        self.storage.clone()
+    }
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        self.inner.json_handler()
+    }
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        self.inner.parquet_handler()
+    }
+}
+
+// Cancellation reaches the log listing during a real `build()`, not only the pre-listing
+// `_last_checkpoint` read: the token is live when `try_read` runs (so that read succeeds) and flips
+// only once listing begins, so the `Err(Cancelled)` `build()` surfaces must come from the listing.
+// Guards the SnapshotBuilder -> listing token wiring against silent removal.
+#[tokio::test]
+async fn snapshot_build_cancelled_during_listing() -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, table_root) = json_only_table().await?;
+    let token = Arc::new(TestCancellationToken::default());
+    let engine = CancelOnListEngine {
+        inner: Arc::new(DefaultEngineBuilder::new(storage.clone()).build()),
+        storage: Arc::new(CancelOnListHandler {
+            inner: DefaultEngineBuilder::new(storage).build().storage_handler(),
+            token: token.clone(),
+        }),
+    };
+
+    let result = Snapshot::builder_for(table_root)
+        .with_cancellation_token(token.clone() as CancellationTokenRef)
+        .build(&engine);
+    assert!(
+        matches!(result, Err(Error::Cancelled)),
+        "cancellation during listing must surface from build()"
     );
     Ok(())
 }

--- a/kernel/tests/integration/read/scan_cancellation.rs
+++ b/kernel/tests/integration/read/scan_cancellation.rs
@@ -2,13 +2,18 @@
 //! surface `Error::Cancelled` through the real Default Engine and can never be mistaken for a
 //! complete listing.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use delta_kernel::object_store::memory::InMemory;
 use delta_kernel::object_store::path::Path;
 use delta_kernel::object_store::ObjectStoreExt as _;
 use delta_kernel::scan::StatsOptions;
-use delta_kernel::{CancellationTokenRef, Error, Snapshot};
+use delta_kernel::schema::SchemaRef;
+use delta_kernel::{
+    CancellationToken as _, CancellationTokenRef, DeltaResult, Engine, EngineData, Error,
+    FileDataReadResultIterator, FileMeta, FilteredEngineData, JsonHandler, ParquetHandler,
+    PredicateRef, Snapshot,
+};
 use rstest::rstest;
 use test_utils::delta_kernel_default_engine::DefaultEngineBuilder;
 use test_utils::{
@@ -187,6 +192,227 @@ async fn precancelled_scan_over_checkpoint_yields_cancelled(
         .build()?;
 
     assert_cancelled(scan.scan_metadata(engine.as_ref()));
+    Ok(())
+}
+
+/// A [`JsonHandler`] that records the cancellation token handed to it, so a test can check what
+/// kernel actually passed down. Delegates the read itself to the real handler.
+struct TokenCapturingJsonHandler {
+    inner: Arc<dyn JsonHandler>,
+    seen: Mutex<Option<CancellationTokenRef>>,
+}
+
+impl JsonHandler for TokenCapturingJsonHandler {
+    fn parse_json(
+        &self,
+        json_strings: Box<dyn EngineData>,
+        output_schema: SchemaRef,
+    ) -> DeltaResult<Box<dyn EngineData>> {
+        self.inner.parse_json(json_strings, output_schema)
+    }
+
+    fn read_json_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.inner
+            .read_json_files(files, physical_schema, predicate)
+    }
+
+    fn read_json_files_with_cancellation(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        *self.seen.lock().unwrap() = cancellation_token.clone();
+        self.inner.read_json_files_with_cancellation(
+            files,
+            physical_schema,
+            predicate,
+            cancellation_token,
+        )
+    }
+
+    fn write_json_file(
+        &self,
+        path: &url::Url,
+        data: Box<dyn Iterator<Item = DeltaResult<FilteredEngineData>> + Send + '_>,
+        overwrite: bool,
+    ) -> DeltaResult<u64> {
+        self.inner.write_json_file(path, data, overwrite)
+    }
+}
+
+/// A [`ParquetHandler`] counterpart to [`TokenCapturingJsonHandler`]: records the token handed to
+/// its cancellation-aware read and delegates everything to the real handler. Checkpoint/sidecar
+/// replay drives the parquet read path, which a JSON-only fixture never reaches.
+struct TokenCapturingParquetHandler {
+    inner: Arc<dyn ParquetHandler>,
+    seen: Mutex<Option<CancellationTokenRef>>,
+}
+
+impl ParquetHandler for TokenCapturingParquetHandler {
+    fn read_parquet_files(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        self.inner
+            .read_parquet_files(files, physical_schema, predicate)
+    }
+
+    fn read_parquet_files_with_cancellation(
+        &self,
+        files: &[FileMeta],
+        physical_schema: SchemaRef,
+        predicate: Option<PredicateRef>,
+        cancellation_token: Option<CancellationTokenRef>,
+    ) -> DeltaResult<FileDataReadResultIterator> {
+        // Keep the first token seen: a later empty-sidecar read must not clobber it.
+        let mut seen = self.seen.lock().unwrap();
+        if seen.is_none() {
+            seen.clone_from(&cancellation_token);
+        }
+        drop(seen);
+        self.inner.read_parquet_files_with_cancellation(
+            files,
+            physical_schema,
+            predicate,
+            cancellation_token,
+        )
+    }
+
+    fn write_parquet_file(
+        &self,
+        location: url::Url,
+        data: FileDataReadResultIterator,
+    ) -> DeltaResult<()> {
+        self.inner.write_parquet_file(location, data)
+    }
+
+    fn read_parquet_footer(&self, file: &FileMeta) -> DeltaResult<delta_kernel::ParquetFooter> {
+        self.inner.read_parquet_footer(file)
+    }
+}
+
+/// Swaps in a token-capturing JSON and/or Parquet handler, delegating every other handler to the
+/// real engine. A test installs whichever handler its fixture's read path exercises.
+struct TokenCapturingEngine {
+    inner: Arc<dyn Engine>,
+    json: Option<Arc<TokenCapturingJsonHandler>>,
+    parquet: Option<Arc<TokenCapturingParquetHandler>>,
+}
+
+impl Engine for TokenCapturingEngine {
+    fn evaluation_handler(&self) -> Arc<dyn delta_kernel::EvaluationHandler> {
+        self.inner.evaluation_handler()
+    }
+    fn storage_handler(&self) -> Arc<dyn delta_kernel::StorageHandler> {
+        self.inner.storage_handler()
+    }
+    fn json_handler(&self) -> Arc<dyn JsonHandler> {
+        match &self.json {
+            Some(json) => json.clone(),
+            None => self.inner.json_handler(),
+        }
+    }
+    fn parquet_handler(&self) -> Arc<dyn ParquetHandler> {
+        match &self.parquet {
+            Some(parquet) => parquet.clone(),
+            None => self.inner.parquet_handler(),
+        }
+    }
+}
+
+/// Asserts the captured token is the exact `Arc` the caller supplied (identity), and therefore
+/// downcasts back to the caller's concrete type and observes cancellation through it.
+fn assert_token_recovered_by_identity(
+    seen: Option<CancellationTokenRef>,
+    token: Arc<TestCancellationToken>,
+) {
+    let seen = seen.expect("kernel should have passed the cancellation token to the handler");
+    // Same allocation, not an equivalent wrapper.
+    assert!(
+        Arc::ptr_eq(&(token.clone() as CancellationTokenRef), &seen),
+        "kernel must pass the caller's token through by identity"
+    );
+    let recovered = seen
+        .as_ref()
+        .any_ref()
+        .downcast_ref::<TestCancellationToken>()
+        .expect("token must downcast to the type the caller supplied");
+    assert!(!recovered.is_cancelled());
+    token.cancel();
+    assert!(recovered.is_cancelled());
+}
+
+// Pins the pass-through-identity guarantee on the JSON read path: the engine receives the very
+// `Arc` the caller supplied, not a wrapper, so it can downcast back to its own token type.
+#[tokio::test]
+async fn engine_receives_the_callers_token_by_identity_json(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (storage, table_root) = json_only_table().await?;
+    let json = Arc::new(TokenCapturingJsonHandler {
+        inner: DefaultEngineBuilder::new(storage.clone())
+            .build()
+            .json_handler(),
+        seen: Mutex::new(None),
+    });
+    let engine = TokenCapturingEngine {
+        inner: Arc::new(DefaultEngineBuilder::new(storage).build()),
+        json: Some(json.clone()),
+        parquet: None,
+    };
+    let snapshot = Snapshot::builder_for(table_root).build(&engine)?;
+
+    let token = Arc::new(TestCancellationToken::default());
+    let scan = snapshot
+        .scan_builder()
+        .with_cancellation_token(token.clone() as CancellationTokenRef)
+        .build()?;
+    scan.scan_metadata(&engine)?.for_each(drop);
+
+    let seen = json.seen.lock().unwrap().clone();
+    assert_token_recovered_by_identity(seen, token);
+    Ok(())
+}
+
+// Same guarantee on the PARQUET read path, which the JSON-only fixture cannot reach. Checkpoint
+// replay threads the token through separate `.cloned()` call sites; a live (uncancelled) token lets
+// the read actually execute so the parquet handler observes it.
+#[tokio::test]
+async fn engine_receives_the_callers_token_by_identity_parquet(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let table_name = "with_checkpoint_no_last_checkpoint";
+    let url =
+        url::Url::from_directory_path(std::fs::canonicalize(format!("./tests/data/{table_name}"))?)
+            .unwrap();
+
+    let parquet = Arc::new(TokenCapturingParquetHandler {
+        inner: test_utils::create_default_engine(&url)?.parquet_handler(),
+        seen: Mutex::new(None),
+    });
+    let engine = TokenCapturingEngine {
+        inner: test_utils::create_default_engine(&url)?,
+        json: None,
+        parquet: Some(parquet.clone()),
+    };
+    let snapshot = Snapshot::builder_for(url).build(&engine)?;
+
+    let token = Arc::new(TestCancellationToken::default());
+    let scan = snapshot
+        .scan_builder()
+        .with_cancellation_token(token.clone() as CancellationTokenRef)
+        .build()?;
+    scan.scan_metadata(&engine)?.for_each(drop);
+
+    let seen = parquet.seen.lock().unwrap().clone();
+    assert_token_recovered_by_identity(seen, token);
     Ok(())
 }
 


### PR DESCRIPTION
> Stacked on #3153 (`CancellationToken: AsAny`). Until that merges, the diff here
> includes its commit; review the top commit (`add cancellation-aware StorageHandler
> list and read`) for this PR's own changes.

## What changes are proposed in this pull request?

Kernel's cancellation token already reaches the JSON and Parquet decode reads, but
it never reached `StorageHandler`. The log-directory listing and the raw byte reads
behind it ran to completion after cancellation, so a cancelled snapshot load kept
issuing storage I/O in its retry loops.

This PR adds `list_from_with_cancellation` and `read_files_with_cancellation` to
`StorageHandler`, mirroring the `read_json_files_with_cancellation` /
`read_parquet_files_with_cancellation` pair that already exists. Both default to failing fast on an
already-cancelled token and then delegating to the existing method, so an engine
that does not override them keeps compiling and still honors an up-front
cancellation. The default engine overrides both to race its I/O against the token,
reusing the same helper the JSON and Parquet readers already use. `SyncStorageHandler`
keeps the default (its eager `block_on` can only honor the up-front check).

It then threads a token from `SnapshotBuilder::with_cancellation_token` down through
log listing — `LogSegment::for_snapshot`, the `LogSegmentFiles` listing entry
points, `list_delta_log_from_storage`, and the `_last_checkpoint` read — because
listing and the raw checkpoint-hint read happen at snapshot construction time,
before any `Scan` exists, so the Scan's token cannot reach them. The listing's
cancellation poll sits outside the version `take_while`, so a cancelled listing
surfaces as a terminal `Error::Cancelled` rather than a `None` that looks like a
complete (but truncated) listing, and the backward checkpoint scan checks the token
between windows.

Change-data-feed, timestamp-conversion, history-manager, and deletion-vector reads
pass `None` for now; threading a token through those paths is follow-up work.

### This PR affects the following public APIs

Adds two default-implemented methods to the public `StorageHandler` trait and a
`with_cancellation_token` builder method to `SnapshotBuilder`. Both are additive —
existing implementors and callers are unaffected — so this is not a breaking change.

A couple of related follow-ups are deliberately left out of scope: promoting the
shared test scaffolding (a delegating engine and a storage-handler stub) into
`test-utils`, and folding the listing call's arguments into a small request struct
to retire the `too_many_arguments` allow.

## How was this change tested?

- Trait defaults: an already-cancelled token short-circuits before the inner call;
  `None`/uncancelled behaves like the base call.
- `list_delta_log_from_storage`: a mid-listing cancellation yields the items seen so
  far followed by exactly one terminal `Error::Cancelled` (the test that catches a
  mis-placed cancellation wrap).
- Backward checkpoint scan: a token that flips to cancelled after the first window
  stops the scan between windows.
- Metered wrapper: the new methods still emit their storage spans and forward the
  token by identity (`Arc::ptr_eq`).
- Default engine: a cancelled token short-circuits before I/O.
- Snapshot build: pre-cancelled and uncancelled builds behave as expected, plus a
  build cancelled specifically during listing (while the checkpoint-hint read
  succeeds) returns `Error::Cancelled`.
