### PR TITLE
feat!: add last checkpoint hint read metrics

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -173,10 +173,12 @@ events per scan: one for each phase.
 
 ### Storage and file I/O events
 
-These events track low-level I/O operations. The default storage, JSON, and
-Parquet handlers emit them automatically when the metrics layer is installed.
-Unlike snapshot events, these don't carry an `operation_id` because a single
-storage call may serve multiple higher-level operations.
+These events track file I/O at two levels. The default storage, JSON, and
+Parquet handlers emit their handler events automatically when the metrics layer
+is installed. Kernel itself emits the higher-level CRC and `_last_checkpoint`
+events. Unlike snapshot events, none of these events carries an `operation_id`:
+they are process-level measurements, and one handler call may serve multiple
+higher-level operations.
 
 | Event | Fields | What it measures |
 |-------|--------|------------------|
@@ -187,6 +189,11 @@ storage call may serve multiple higher-level operations.
 | `ParquetReadCompleted` | `num_files`, `bytes_read` | One `ParquetHandler::read_parquet_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
 | `CrcReadSuccess` | `duration`, `bytes_read` | One CRC file read and parsed successfully. `bytes_read` is the raw byte count from storage. |
 | `CrcReadFailure` | none | A CRC file read or parse failed. The caller falls back to log replay. |
+| `LastCheckpointReadCompleted` | `outcome`, `duration` | One `_last_checkpoint` read attempt. Use `outcome` on both a read counter and latency histogram. |
+
+`LastCheckpointReadOutcome` distinguishes a parsed hint (`Success`), an absent hint (`NotFound`),
+an empty or malformed hint (`Invalid`), and an unexpected storage or URL error (`Error`). `Unknown`
+is reserved for missing or unrecognized tracing span fields and is not emitted deliberately.
 
 > [!NOTE]
 > If you implement a custom `JsonHandler` or `ParquetHandler`, call

--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -189,11 +189,13 @@ higher-level operations.
 | `ParquetReadCompleted` | `num_files`, `bytes_read` | One `ParquetHandler::read_parquet_files` call completed. `bytes_read` is the sum of on-disk file sizes. |
 | `CrcReadSuccess` | `duration`, `bytes_read` | One CRC file read and parsed successfully. `bytes_read` is the raw byte count from storage. |
 | `CrcReadFailure` | none | A CRC file read or parse failed. The caller falls back to log replay. |
-| `LastCheckpointReadCompleted` | `outcome`, `duration` | One `_last_checkpoint` read attempt. Use `outcome` on both a read counter and latency histogram. |
+| `LastCheckpointReadSuccess` | `duration` | One `_last_checkpoint` hint was read and parsed successfully. |
+| `LastCheckpointReadFailure` | `reason`, `duration` | One `_last_checkpoint` read did not produce a usable hint. |
 
-`LastCheckpointReadOutcome` distinguishes a parsed hint (`Success`), an absent hint (`NotFound`),
-an empty or malformed hint (`Invalid`), and an unexpected storage or URL error (`Error`). `Unknown`
-is reserved for missing or unrecognized tracing span fields and is not emitted deliberately.
+For counters and latency histograms, use `success` as the outcome for
+`LastCheckpointReadSuccess`. For `LastCheckpointReadFailure`, use `reason.as_ref()`: `not_found`
+for an absent hint, `invalid` for an empty or malformed hint, or `error` for an unexpected storage
+or URL error. `unknown` means the recorded failure reason was empty or unrecognized.
 
 > [!NOTE]
 > If you implement a custom `JsonHandler` or `ParquetHandler`, call

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -105,6 +105,18 @@ void print_load_type(LogSegmentLoadType lt) {
   }
 }
 
+// utility to print out a _last_checkpoint read outcome
+void print_last_checkpoint_read_outcome(LastCheckpointReadOutcome outcome) {
+  printf("  outcome:");
+  switch (outcome) {
+  case LastCheckpointReadOutcomeSuccess: printf(" Success,\n"); break;
+  case LastCheckpointReadOutcomeNotFound: printf(" NotFound,\n"); break;
+  case LastCheckpointReadOutcomeInvalid: printf(" Invalid,\n"); break;
+  case LastCheckpointReadOutcomeError: printf(" Error,\n"); break;
+  case LastCheckpointReadOutcomeUnknown: printf(" Unknown,\n"); break;
+  }
+}
+
 #define PM_START(name) printf("\nMetric " #name " {\n")
 #define PM_END printf("}\n\n");
 #define PM_ID(s, f) print_metric_id(#f, (s).f)
@@ -323,6 +335,14 @@ void print_metric(MetricEvent event) {
     PM_START(MetricEventStorageCopyCompleted);
     StorageCopyCompleted scc = event.storage_copy_completed;
     PM_U64(scc, duration_ns);
+    PM_END;
+    return;
+
+  case MetricEventLastCheckpointReadCompleted:
+    PM_START(LastCheckpointReadCompleted);
+    LastCheckpointReadCompleted lcrc = event.last_checkpoint_read_completed;
+    print_last_checkpoint_read_outcome(lcrc.outcome);
+    PM_U64(lcrc, duration_ns);
     PM_END;
     return;
 

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -105,15 +105,13 @@ void print_load_type(LogSegmentLoadType lt) {
   }
 }
 
-// utility to print out a _last_checkpoint read outcome
-void print_last_checkpoint_read_outcome(LastCheckpointReadOutcome outcome) {
-  printf("  outcome:");
-  switch (outcome) {
-  case LastCheckpointReadOutcomeSuccess: printf(" Success,\n"); break;
-  case LastCheckpointReadOutcomeNotFound: printf(" NotFound,\n"); break;
-  case LastCheckpointReadOutcomeInvalid: printf(" Invalid,\n"); break;
-  case LastCheckpointReadOutcomeError: printf(" Error,\n"); break;
-  case LastCheckpointReadOutcomeUnknown: printf(" Unknown,\n"); break;
+void print_last_checkpoint_read_failure_reason(LastCheckpointReadFailureReason reason) {
+  printf("  reason:");
+  switch (reason) {
+  case LastCheckpointReadFailureReasonNotFound: printf(" NotFound,\n"); break;
+  case LastCheckpointReadFailureReasonInvalid: printf(" Invalid,\n"); break;
+  case LastCheckpointReadFailureReasonError: printf(" Error,\n"); break;
+  case LastCheckpointReadFailureReasonUnknown: printf(" Unknown,\n"); break;
   }
 }
 
@@ -338,11 +336,17 @@ void print_metric(MetricEvent event) {
     PM_END;
     return;
 
-  case MetricEventLastCheckpointReadCompleted:
-    PM_START(LastCheckpointReadCompleted);
-    LastCheckpointReadCompleted lcrc = event.last_checkpoint_read_completed;
-    print_last_checkpoint_read_outcome(lcrc.outcome);
-    PM_U64(lcrc, duration_ns);
+  case MetricEventLastCheckpointReadSuccess:
+    PM_START(LastCheckpointReadSuccess);
+    PM_U64(event.last_checkpoint_read_success, duration_ns);
+    PM_END;
+    return;
+
+  case MetricEventLastCheckpointReadFailure:
+    PM_START(LastCheckpointReadFailure);
+    LastCheckpointReadFailure lcrf = event.last_checkpoint_read_failure;
+    print_last_checkpoint_read_failure_reason(lcrf.reason);
+    PM_U64(lcrf, duration_ns);
     PM_END;
     return;
 

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -111,6 +111,35 @@ impl From<kernel::LogSegmentLoadType> for LogSegmentLoadType {
     }
 }
 
+/// The outcome of an attempt to read and parse a `_last_checkpoint` hint.
+///
+/// cbindgen:prefix-with-name=true
+#[repr(C)]
+pub enum LastCheckpointReadOutcome {
+    /// The hint was present and parsed successfully.
+    Success,
+    /// The hint file was not present.
+    NotFound,
+    /// The hint file was empty or could not be decoded as a valid hint.
+    Invalid,
+    /// Reading the hint failed with an unexpected error.
+    Error,
+    /// The outcome was missing, unrecognized, or added by a newer Kernel version.
+    Unknown,
+}
+
+impl From<kernel::LastCheckpointReadOutcome> for LastCheckpointReadOutcome {
+    fn from(outcome: kernel::LastCheckpointReadOutcome) -> Self {
+        match outcome {
+            kernel::LastCheckpointReadOutcome::Success => Self::Success,
+            kernel::LastCheckpointReadOutcome::NotFound => Self::NotFound,
+            kernel::LastCheckpointReadOutcome::Invalid => Self::Invalid,
+            kernel::LastCheckpointReadOutcome::Error => Self::Error,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// A log segment was loaded.
 #[repr(C)]
 pub struct LogSegmentLoadSuccess {
@@ -257,6 +286,15 @@ pub struct CrcReadSuccess {
     pub duration_ns: u64,
 }
 
+/// An attempt to read and parse a `_last_checkpoint` hint completed.
+#[repr(C)]
+pub struct LastCheckpointReadCompleted {
+    /// How the read attempt completed.
+    pub outcome: LastCheckpointReadOutcome,
+    /// Wall-clock time spent locating, reading, and parsing the hint, in nanoseconds.
+    pub duration_ns: u64,
+}
+
 /// A `JsonHandler::read_json_files` call completed.
 #[repr(C)]
 pub struct JsonReadCompleted {
@@ -338,6 +376,7 @@ pub enum MetricEvent {
     StorageListCompleted(StorageListCompleted),
     StorageReadCompleted(StorageReadCompleted),
     StorageCopyCompleted(StorageCopyCompleted),
+    LastCheckpointReadCompleted(LastCheckpointReadCompleted),
 }
 
 /// Borrow the caller-supplied correlation id as a [`KernelStringSlice`], or an empty slice when
@@ -523,6 +562,13 @@ impl MetricEvent {
                 duration_ns: ns(*duration),
             }),
             K::CrcReadFailure => Self::CrcReadFailure,
+            K::LastCheckpointReadCompleted(kernel::LastCheckpointReadCompleted {
+                outcome,
+                duration,
+            }) => Self::LastCheckpointReadCompleted(LastCheckpointReadCompleted {
+                outcome: (*outcome).into(),
+                duration_ns: ns(*duration),
+            }),
             K::JsonReadCompleted(kernel::JsonReadCompleted {
                 num_files,
                 bytes_read,
@@ -606,8 +652,49 @@ mod tests {
     use std::mem::discriminant;
     use std::time::Duration;
 
+    use rstest::rstest;
+
     use super::*;
     use crate::TryFromStringSlice;
+
+    #[rstest]
+    #[case::success(
+        kernel::LastCheckpointReadOutcome::Success,
+        LastCheckpointReadOutcome::Success
+    )]
+    #[case::not_found(
+        kernel::LastCheckpointReadOutcome::NotFound,
+        LastCheckpointReadOutcome::NotFound
+    )]
+    #[case::invalid(
+        kernel::LastCheckpointReadOutcome::Invalid,
+        LastCheckpointReadOutcome::Invalid
+    )]
+    #[case::error(
+        kernel::LastCheckpointReadOutcome::Error,
+        LastCheckpointReadOutcome::Error
+    )]
+    #[case::unknown(
+        kernel::LastCheckpointReadOutcome::Unknown,
+        LastCheckpointReadOutcome::Unknown
+    )]
+    fn from_kernel_last_checkpoint_read_completed_carries_outcome_and_duration(
+        #[case] kernel_outcome: kernel::LastCheckpointReadOutcome,
+        #[case] expected: LastCheckpointReadOutcome,
+    ) {
+        let event =
+            kernel::MetricEvent::LastCheckpointReadCompleted(kernel::LastCheckpointReadCompleted {
+                outcome: kernel_outcome,
+                duration: Duration::from_nanos(17),
+            });
+        with_ffi_event(&event, |ffi| {
+            let MetricEvent::LastCheckpointReadCompleted(e) = ffi else {
+                panic!("expected LastCheckpointReadCompleted");
+            };
+            assert_eq!(discriminant(&e.outcome), discriminant(&expected));
+            assert_eq!(e.duration_ns, 17);
+        });
+    }
 
     #[test]
     fn from_kernel_transaction_commit_success_carries_operation_and_id() {

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -111,31 +111,28 @@ impl From<kernel::LogSegmentLoadType> for LogSegmentLoadType {
     }
 }
 
-/// The outcome of an attempt to read and parse a `_last_checkpoint` hint.
+/// Why an attempt to read `_last_checkpoint` did not produce a usable hint.
 ///
 /// cbindgen:prefix-with-name=true
 #[repr(C)]
-pub enum LastCheckpointReadOutcome {
-    /// The hint was present and parsed successfully.
-    Success,
+pub enum LastCheckpointReadFailureReason {
     /// The hint file was not present.
     NotFound,
     /// The hint file was empty or could not be decoded as a valid hint.
     Invalid,
     /// Reading the hint failed with an unexpected error.
     Error,
-    /// The outcome was missing, unrecognized, or added by a newer Kernel version.
+    /// The recorded failure reason was empty or unrecognized.
     Unknown,
 }
 
-impl From<kernel::LastCheckpointReadOutcome> for LastCheckpointReadOutcome {
-    fn from(outcome: kernel::LastCheckpointReadOutcome) -> Self {
-        match outcome {
-            kernel::LastCheckpointReadOutcome::Success => Self::Success,
-            kernel::LastCheckpointReadOutcome::NotFound => Self::NotFound,
-            kernel::LastCheckpointReadOutcome::Invalid => Self::Invalid,
-            kernel::LastCheckpointReadOutcome::Error => Self::Error,
-            _ => Self::Unknown,
+impl From<kernel::LastCheckpointReadFailureReason> for LastCheckpointReadFailureReason {
+    fn from(reason: kernel::LastCheckpointReadFailureReason) -> Self {
+        match reason {
+            kernel::LastCheckpointReadFailureReason::NotFound => Self::NotFound,
+            kernel::LastCheckpointReadFailureReason::Invalid => Self::Invalid,
+            kernel::LastCheckpointReadFailureReason::Error => Self::Error,
+            kernel::LastCheckpointReadFailureReason::Unknown => Self::Unknown,
         }
     }
 }
@@ -286,11 +283,18 @@ pub struct CrcReadSuccess {
     pub duration_ns: u64,
 }
 
-/// An attempt to read and parse a `_last_checkpoint` hint completed.
+/// A `_last_checkpoint` hint was read and parsed successfully.
 #[repr(C)]
-pub struct LastCheckpointReadCompleted {
-    /// How the read attempt completed.
-    pub outcome: LastCheckpointReadOutcome,
+pub struct LastCheckpointReadSuccess {
+    /// Wall-clock time spent locating, reading, and parsing the hint, in nanoseconds.
+    pub duration_ns: u64,
+}
+
+/// An attempt to read `_last_checkpoint` did not produce a usable hint.
+#[repr(C)]
+pub struct LastCheckpointReadFailure {
+    /// Why the read attempt did not produce a usable hint.
+    pub reason: LastCheckpointReadFailureReason,
     /// Wall-clock time spent locating, reading, and parsing the hint, in nanoseconds.
     pub duration_ns: u64,
 }
@@ -376,7 +380,8 @@ pub enum MetricEvent {
     StorageListCompleted(StorageListCompleted),
     StorageReadCompleted(StorageReadCompleted),
     StorageCopyCompleted(StorageCopyCompleted),
-    LastCheckpointReadCompleted(LastCheckpointReadCompleted),
+    LastCheckpointReadSuccess(LastCheckpointReadSuccess),
+    LastCheckpointReadFailure(LastCheckpointReadFailure),
 }
 
 /// Borrow the caller-supplied correlation id as a [`KernelStringSlice`], or an empty slice when
@@ -562,11 +567,16 @@ impl MetricEvent {
                 duration_ns: ns(*duration),
             }),
             K::CrcReadFailure => Self::CrcReadFailure,
-            K::LastCheckpointReadCompleted(kernel::LastCheckpointReadCompleted {
-                outcome,
+            K::LastCheckpointReadSuccess(kernel::LastCheckpointReadSuccess { duration }) => {
+                Self::LastCheckpointReadSuccess(LastCheckpointReadSuccess {
+                    duration_ns: ns(*duration),
+                })
+            }
+            K::LastCheckpointReadFailure(kernel::LastCheckpointReadFailure {
+                reason,
                 duration,
-            }) => Self::LastCheckpointReadCompleted(LastCheckpointReadCompleted {
-                outcome: (*outcome).into(),
+            }) => Self::LastCheckpointReadFailure(LastCheckpointReadFailure {
+                reason: (*reason).into(),
                 duration_ns: ns(*duration),
             }),
             K::JsonReadCompleted(kernel::JsonReadCompleted {
@@ -657,41 +667,51 @@ mod tests {
     use super::*;
     use crate::TryFromStringSlice;
 
-    #[rstest]
-    #[case::success(
-        kernel::LastCheckpointReadOutcome::Success,
-        LastCheckpointReadOutcome::Success
-    )]
-    #[case::not_found(
-        kernel::LastCheckpointReadOutcome::NotFound,
-        LastCheckpointReadOutcome::NotFound
-    )]
-    #[case::invalid(
-        kernel::LastCheckpointReadOutcome::Invalid,
-        LastCheckpointReadOutcome::Invalid
-    )]
-    #[case::error(
-        kernel::LastCheckpointReadOutcome::Error,
-        LastCheckpointReadOutcome::Error
-    )]
-    #[case::unknown(
-        kernel::LastCheckpointReadOutcome::Unknown,
-        LastCheckpointReadOutcome::Unknown
-    )]
-    fn from_kernel_last_checkpoint_read_completed_carries_outcome_and_duration(
-        #[case] kernel_outcome: kernel::LastCheckpointReadOutcome,
-        #[case] expected: LastCheckpointReadOutcome,
-    ) {
+    #[test]
+    fn from_kernel_last_checkpoint_read_success_carries_duration() {
         let event =
-            kernel::MetricEvent::LastCheckpointReadCompleted(kernel::LastCheckpointReadCompleted {
-                outcome: kernel_outcome,
+            kernel::MetricEvent::LastCheckpointReadSuccess(kernel::LastCheckpointReadSuccess {
                 duration: Duration::from_nanos(17),
             });
         with_ffi_event(&event, |ffi| {
-            let MetricEvent::LastCheckpointReadCompleted(e) = ffi else {
-                panic!("expected LastCheckpointReadCompleted");
+            let MetricEvent::LastCheckpointReadSuccess(e) = ffi else {
+                panic!("expected LastCheckpointReadSuccess");
             };
-            assert_eq!(discriminant(&e.outcome), discriminant(&expected));
+            assert_eq!(e.duration_ns, 17);
+        });
+    }
+
+    #[rstest]
+    #[case::not_found(
+        kernel::LastCheckpointReadFailureReason::NotFound,
+        LastCheckpointReadFailureReason::NotFound
+    )]
+    #[case::invalid(
+        kernel::LastCheckpointReadFailureReason::Invalid,
+        LastCheckpointReadFailureReason::Invalid
+    )]
+    #[case::error(
+        kernel::LastCheckpointReadFailureReason::Error,
+        LastCheckpointReadFailureReason::Error
+    )]
+    #[case::unknown(
+        kernel::LastCheckpointReadFailureReason::Unknown,
+        LastCheckpointReadFailureReason::Unknown
+    )]
+    fn from_kernel_last_checkpoint_read_failure_carries_reason_and_duration(
+        #[case] kernel_reason: kernel::LastCheckpointReadFailureReason,
+        #[case] expected: LastCheckpointReadFailureReason,
+    ) {
+        let event =
+            kernel::MetricEvent::LastCheckpointReadFailure(kernel::LastCheckpointReadFailure {
+                reason: kernel_reason,
+                duration: Duration::from_nanos(17),
+            });
+        with_ffi_event(&event, |ffi| {
+            let MetricEvent::LastCheckpointReadFailure(e) = ffi else {
+                panic!("expected LastCheckpointReadFailure");
+            };
+            assert_eq!(discriminant(&e.reason), discriminant(&expected));
             assert_eq!(e.duration_ns, 17);
         });
     }

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,6 +11,8 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
+use crate::metrics::events::LAST_CHECKPOINT_READ_COMPLETED_SPAN;
+use crate::metrics::LastCheckpointReadOutcome;
 use crate::path::{CheckpointInstance, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
@@ -191,27 +193,47 @@ impl LastCheckpointHint {
     /// are assumed to cause failure.
     // TODO(#1047): weird that we propagate FileNotFound as part of the iterator instead of top-
     // level result coming from storage.read_files
-    #[instrument(name = "last_checkpoint.read", skip_all, err)]
+    #[instrument(
+        name = LAST_CHECKPOINT_READ_COMPLETED_SPAN,
+        skip_all,
+        fields(report, outcome),
+        err
+    )]
     pub(crate) fn try_read(
         storage: &dyn StorageHandler,
         log_root: &Url,
     ) -> DeltaResult<Option<LastCheckpointHint>> {
-        let file_path = Self::path(log_root)?;
-        match storage.read_files(vec![(file_path, None)])?.next() {
+        let file_path = Self::path(log_root).inspect_err(|_| {
+            record_read_outcome(LastCheckpointReadOutcome::Error);
+        })?;
+        let mut files = storage
+            .read_files(vec![(file_path, None)])
+            .inspect_err(|_| record_read_outcome(LastCheckpointReadOutcome::Error))?;
+        match files.next() {
             Some(Ok(data)) => {
                 let result: Option<LastCheckpointHint> =
                     Self::from_bytes_with_oversized_fields_dropped(&data)
                         .inspect_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
                         .ok();
+                record_read_outcome(if result.is_some() {
+                    LastCheckpointReadOutcome::Success
+                } else {
+                    LastCheckpointReadOutcome::Invalid
+                });
                 info!(hint = result.as_ref().map(|h| h.summary()));
                 Ok(result)
             }
             Some(Err(Error::FileNotFound(_))) => {
+                record_read_outcome(LastCheckpointReadOutcome::NotFound);
                 info!("_last_checkpoint file not found");
                 Ok(None)
             }
-            Some(Err(err)) => Err(err),
+            Some(Err(err)) => {
+                record_read_outcome(LastCheckpointReadOutcome::Error);
+                Err(err)
+            }
             None => {
+                record_read_outcome(LastCheckpointReadOutcome::Invalid);
                 warn!("empty _last_checkpoint file");
                 Ok(None)
             }
@@ -233,14 +255,99 @@ impl LastCheckpointHint {
     }
 }
 
+fn record_read_outcome(outcome: LastCheckpointReadOutcome) {
+    tracing::Span::current().record("outcome", outcome.as_ref());
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
     use rstest::rstest;
 
     use super::*;
+    use crate::metrics::MetricEvent;
     use crate::schema::schema;
     use crate::table_features::TableFeature;
-    use crate::unit_test_utils::create_log_path;
+    use crate::unit_test_utils::{
+        create_log_path, install_thread_local_metrics_reporter, CapturingReporter,
+    };
+
+    #[derive(Debug, Clone, Copy)]
+    enum ReadBehavior {
+        TopLevelError,
+        IteratorError,
+        EmptyIterator,
+    }
+
+    #[derive(Debug)]
+    struct ReadBehaviorStorage(ReadBehavior);
+
+    impl StorageHandler for ReadBehaviorStorage {
+        fn list_from(
+            &self,
+            _path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            Ok(Box::new(std::iter::empty()))
+        }
+
+        fn read_files(
+            &self,
+            _files: Vec<crate::FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+            match self.0 {
+                ReadBehavior::TopLevelError => Err(Error::generic("top-level read failure")),
+                ReadBehavior::IteratorError => Ok(Box::new(std::iter::once(Err(Error::generic(
+                    "iterator read failure",
+                ))))),
+                ReadBehavior::EmptyIterator => Ok(Box::new(std::iter::empty())),
+            }
+        }
+
+        fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+            unreachable!("not exercised by LastCheckpointHint::try_read")
+        }
+
+        fn put(&self, _path: &Url, _data: Bytes, _overwrite: bool) -> DeltaResult<()> {
+            unreachable!("not exercised by LastCheckpointHint::try_read")
+        }
+
+        fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+            unreachable!("not exercised by LastCheckpointHint::try_read")
+        }
+
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            unreachable!("not exercised by LastCheckpointHint::try_read")
+        }
+    }
+
+    #[rstest]
+    #[case::top_level_error(ReadBehavior::TopLevelError, LastCheckpointReadOutcome::Error, true)]
+    #[case::iterator_error(ReadBehavior::IteratorError, LastCheckpointReadOutcome::Error, true)]
+    #[case::empty_iterator(ReadBehavior::EmptyIterator, LastCheckpointReadOutcome::Invalid, false)]
+    fn read_storage_branches_emit_one_completion(
+        #[case] behavior: ReadBehavior,
+        #[case] expected_outcome: LastCheckpointReadOutcome,
+        #[case] expected_error: bool,
+    ) {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        let storage = ReadBehaviorStorage(behavior);
+        let log_root = Url::parse("memory:///_delta_log/").unwrap();
+
+        let result = LastCheckpointHint::try_read(&storage, &log_root);
+        assert_eq!(result.is_err(), expected_error);
+        let outcomes: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(outcomes, [expected_outcome]);
+    }
 
     /// A real `_last_checkpoint` for a V2 checkpoint carries a `v2Checkpoint` object; we parse its
     /// `path` and file metadata. An empty `sidecarFiles` (a leaf checkpoint) parses to `Some([])`,

--- a/kernel/src/last_checkpoint_hint.rs
+++ b/kernel/src/last_checkpoint_hint.rs
@@ -11,8 +11,8 @@ use url::Url;
 use crate::actions::{
     CheckpointMetadata, DomainMetadata, Metadata, Protocol, SetTransaction, Sidecar,
 };
-use crate::metrics::events::LAST_CHECKPOINT_READ_COMPLETED_SPAN;
-use crate::metrics::LastCheckpointReadOutcome;
+use crate::metrics::events::LAST_CHECKPOINT_READ_SPAN;
+use crate::metrics::LastCheckpointReadFailureReason;
 use crate::path::{CheckpointInstance, ParsedLogPath};
 use crate::schema::SchemaRef;
 use crate::{DeltaResult, Error, FileMeta, StorageHandler, Version};
@@ -194,46 +194,43 @@ impl LastCheckpointHint {
     // TODO(#1047): weird that we propagate FileNotFound as part of the iterator instead of top-
     // level result coming from storage.read_files
     #[instrument(
-        name = LAST_CHECKPOINT_READ_COMPLETED_SPAN,
+        name = LAST_CHECKPOINT_READ_SPAN,
         skip_all,
-        fields(report, outcome),
+        fields(report, failure_reason),
         err
     )]
     pub(crate) fn try_read(
         storage: &dyn StorageHandler,
         log_root: &Url,
     ) -> DeltaResult<Option<LastCheckpointHint>> {
-        let file_path = Self::path(log_root).inspect_err(|_| {
-            record_read_outcome(LastCheckpointReadOutcome::Error);
-        })?;
+        let file_path = Self::path(log_root)?;
         let mut files = storage
             .read_files(vec![(file_path, None)])
-            .inspect_err(|_| record_read_outcome(LastCheckpointReadOutcome::Error))?;
+            .inspect_err(|err| {
+                if matches!(err, Error::FileNotFound(_)) {
+                    record_read_failure(LastCheckpointReadFailureReason::NotFound);
+                }
+            })?;
         match files.next() {
             Some(Ok(data)) => {
-                let result: Option<LastCheckpointHint> =
-                    Self::from_bytes_with_oversized_fields_dropped(&data)
-                        .inspect_err(|e| warn!("invalid _last_checkpoint JSON: {e}"))
-                        .ok();
-                record_read_outcome(if result.is_some() {
-                    LastCheckpointReadOutcome::Success
-                } else {
-                    LastCheckpointReadOutcome::Invalid
-                });
+                let result = Self::from_bytes_with_oversized_fields_dropped(&data)
+                    .map(Some)
+                    .unwrap_or_else(|e| {
+                        record_read_failure(LastCheckpointReadFailureReason::Invalid);
+                        warn!("invalid _last_checkpoint JSON: {e}");
+                        None
+                    });
                 info!(hint = result.as_ref().map(|h| h.summary()));
                 Ok(result)
             }
             Some(Err(Error::FileNotFound(_))) => {
-                record_read_outcome(LastCheckpointReadOutcome::NotFound);
+                record_read_failure(LastCheckpointReadFailureReason::NotFound);
                 info!("_last_checkpoint file not found");
                 Ok(None)
             }
-            Some(Err(err)) => {
-                record_read_outcome(LastCheckpointReadOutcome::Error);
-                Err(err)
-            }
+            Some(Err(err)) => Err(err),
             None => {
-                record_read_outcome(LastCheckpointReadOutcome::Invalid);
+                record_read_failure(LastCheckpointReadFailureReason::Invalid);
                 warn!("empty _last_checkpoint file");
                 Ok(None)
             }
@@ -255,8 +252,8 @@ impl LastCheckpointHint {
     }
 }
 
-fn record_read_outcome(outcome: LastCheckpointReadOutcome) {
-    tracing::Span::current().record("outcome", outcome.as_ref());
+fn record_read_failure(reason: LastCheckpointReadFailureReason) {
+    tracing::Span::current().record("failure_reason", reason.as_ref());
 }
 
 #[cfg(test)]
@@ -277,6 +274,7 @@ mod tests {
     #[derive(Debug, Clone, Copy)]
     enum ReadBehavior {
         TopLevelError,
+        TopLevelFileNotFound,
         IteratorError,
         EmptyIterator,
     }
@@ -298,6 +296,9 @@ mod tests {
         ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
             match self.0 {
                 ReadBehavior::TopLevelError => Err(Error::generic("top-level read failure")),
+                ReadBehavior::TopLevelFileNotFound => {
+                    Err(Error::file_not_found("_last_checkpoint"))
+                }
                 ReadBehavior::IteratorError => Ok(Box::new(std::iter::once(Err(Error::generic(
                     "iterator read failure",
                 ))))),
@@ -323,12 +324,29 @@ mod tests {
     }
 
     #[rstest]
-    #[case::top_level_error(ReadBehavior::TopLevelError, LastCheckpointReadOutcome::Error, true)]
-    #[case::iterator_error(ReadBehavior::IteratorError, LastCheckpointReadOutcome::Error, true)]
-    #[case::empty_iterator(ReadBehavior::EmptyIterator, LastCheckpointReadOutcome::Invalid, false)]
-    fn read_storage_branches_emit_one_completion(
+    #[case::top_level_error(
+        ReadBehavior::TopLevelError,
+        LastCheckpointReadFailureReason::Error,
+        true
+    )]
+    #[case::top_level_file_not_found(
+        ReadBehavior::TopLevelFileNotFound,
+        LastCheckpointReadFailureReason::NotFound,
+        true
+    )]
+    #[case::iterator_error(
+        ReadBehavior::IteratorError,
+        LastCheckpointReadFailureReason::Error,
+        true
+    )]
+    #[case::empty_iterator(
+        ReadBehavior::EmptyIterator,
+        LastCheckpointReadFailureReason::Invalid,
+        false
+    )]
+    fn read_storage_branches_emit_one_failure(
         #[case] behavior: ReadBehavior,
-        #[case] expected_outcome: LastCheckpointReadOutcome,
+        #[case] expected_reason: LastCheckpointReadFailureReason,
         #[case] expected_error: bool,
     ) {
         let reporter = Arc::new(CapturingReporter::default());
@@ -338,15 +356,15 @@ mod tests {
 
         let result = LastCheckpointHint::try_read(&storage, &log_root);
         assert_eq!(result.is_err(), expected_error);
-        let outcomes: Vec<_> = reporter
+        let reasons: Vec<_> = reporter
             .events()
             .into_iter()
             .filter_map(|event| match event {
-                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                MetricEvent::LastCheckpointReadFailure(event) => Some(event.reason),
                 _ => None,
             })
             .collect();
-        assert_eq!(outcomes, [expected_outcome]);
+        assert_eq!(reasons, [expected_reason]);
     }
 
     /// A real `_last_checkpoint` for a V2 checkpoint carries a `v2Checkpoint` object; we parse its

--- a/kernel/src/metrics/README.md
+++ b/kernel/src/metrics/README.md
@@ -19,14 +19,19 @@ span-based events reuse small per-field helpers like `MetricId::from_attrs`, eac
 
 ## Failure events
 
-Success and failure are two variants of one event. Emit the success span, then fire `error` on it
-(`#[instrument(err)]` does this on `Err`; an emit helper calls `tracing::info!(error = ...)`). The
-layer sees `error` and flips the event via `MetricEvent::into_failure`.
+Metrics represent failure in two ways:
+
+- Lifecycle metrics have paired success and failure variants. Emit the success span, then fire
+  `error` on it (`#[instrument(err)]` does this on `Err`; an emit helper calls
+  `tracing::info!(error = ...)`). The layer sees `error` and flips the event via
+  `MetricEvent::into_failure`.
+- Completed metrics carry an `outcome` field on one variant. They record the outcome before the
+  span closes and remain unchanged when `MetricEvent::into_failure` sees an error event.
 
 ## Adding an event
 
-1. Define the struct + `SPAN_NAME` in `events.rs`; add a `MetricEvent` variant and its
-   `into_failure` arm.
+1. Define the struct + `SPAN_NAME` in `events.rs`; add a `MetricEvent` variant and decide whether
+   its `into_failure` arm maps to a paired failure variant or preserves an outcome-bearing event.
 2. For emit, add an `emit_*` helper and a `from_attrs`; register the span name in `on_new_span`
    (`reporter.rs`).
 3. Make each label a strum enum (`serialize_all = "snake_case"`).

--- a/kernel/src/metrics/README.md
+++ b/kernel/src/metrics/README.md
@@ -19,22 +19,19 @@ span-based events reuse small per-field helpers like `MetricId::from_attrs`, eac
 
 ## Failure events
 
-Metrics represent failure in two ways:
-
-- Lifecycle metrics have paired success and failure variants. Emit the success span, then fire
-  `error` on it (`#[instrument(err)]` does this on `Err`; an emit helper calls
-  `tracing::info!(error = ...)`). The layer sees `error` and flips the event via
-  `MetricEvent::into_failure`.
-- Completed metrics carry an `outcome` field on one variant. They record the outcome before the
-  span closes and remain unchanged when `MetricEvent::into_failure` sees an error event.
+Lifecycle metrics have paired success and failure variants. Emit the success span, then fire
+`error` on it (`#[instrument(err)]` does this on `Err`; an emit helper calls
+`tracing::info!(error = ...)`). The layer sees `error` and flips the event via
+`MetricEvent::into_failure`. A lifecycle operation that returns a recoverable result can instead
+record `failure_reason` to select its failure variant.
 
 ## Adding an event
 
-1. Define the struct + `SPAN_NAME` in `events.rs`; add a `MetricEvent` variant and decide whether
-   its `into_failure` arm maps to a paired failure variant or preserves an outcome-bearing event.
-2. For emit, add an `emit_*` helper and a `from_attrs`; register the span name in `on_new_span`
-   (`reporter.rs`).
-3. Make each label a strum enum (`serialize_all = "snake_case"`).
+1. Define the event struct, `SPAN_NAME`, and `from_attrs`, then add its `MetricEvent` variant(s).
+2. Register the span in `on_new_span`.
+3. For an emit-based event, add an `emit_*` helper.
+4. For a lifecycle event, add paired success/failure variants and an `into_failure` mapping.
+5. Make each label a strum enum (`serialize_all = "snake_case"`).
 
 The FFI mirror (`ffi/src/ffi_metrics.rs`) and connectors destructure these structs, so adding a
 field or variant is a breaking change.

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -106,7 +106,8 @@ pub enum MetricEvent {
     SetTransactionLoadFailure,
     CrcReadSuccess(CrcReadSuccess),
     CrcReadFailure,
-    LastCheckpointReadCompleted(LastCheckpointReadCompleted),
+    LastCheckpointReadSuccess(LastCheckpointReadSuccess),
+    LastCheckpointReadFailure(LastCheckpointReadFailure),
     JsonReadCompleted(JsonReadCompleted),
     ParquetReadCompleted(ParquetReadCompleted),
     ScanMetadataCompleted(ScanMetadataCompleted),
@@ -125,7 +126,8 @@ impl MetricEvent {
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
-            Self::LastCheckpointReadCompleted(e) => e.set_duration(d),
+            Self::LastCheckpointReadSuccess(e) => e.set_duration(d),
+            Self::LastCheckpointReadFailure(e) => e.set_duration(d),
 
             // Emit-based success events set their duration as a creation attribute, so the
             // span-close hook must not overwrite it.
@@ -161,7 +163,9 @@ impl MetricEvent {
             Self::LogSegmentLoadSuccess(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadSuccess::SPAN_NAME),
-            Self::LastCheckpointReadCompleted(_) => Err(LastCheckpointReadCompleted::SPAN_NAME),
+            Self::LastCheckpointReadSuccess(_) | Self::LastCheckpointReadFailure(_) => {
+                Err(LastCheckpointReadSuccess::SPAN_NAME)
+            }
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -192,7 +196,9 @@ impl MetricEvent {
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
             Self::CrcReadSuccess(_) => Err(CrcReadSuccess::SPAN_NAME),
-            Self::LastCheckpointReadCompleted(_) => Err(LastCheckpointReadCompleted::SPAN_NAME),
+            Self::LastCheckpointReadSuccess(_) | Self::LastCheckpointReadFailure(_) => {
+                Err(LastCheckpointReadSuccess::SPAN_NAME)
+            }
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -211,27 +217,55 @@ impl MetricEvent {
         }
     }
 
+    pub(crate) fn record_str_warning(&self, name: &str, value: &str) -> Option<String> {
+        if name != "failure_reason" {
+            return None;
+        }
+        match self {
+            Self::TransactionCommitSuccess(_) => value
+                .parse::<CommitFailureReason>()
+                .err()
+                .map(|e| format!("Invalid failure_reason '{value}' on span: {e}. Using Error.")),
+            Self::LastCheckpointReadSuccess(_) if !value.is_empty() => value
+                .parse::<LastCheckpointReadFailureReason>()
+                .err()
+                .map(|e| {
+                    format!(
+                        "Invalid last checkpoint read failure reason '{value}': {e}. Using Unknown."
+                    )
+                }),
+            _ => None,
+        }
+    }
+
     pub(crate) fn record_str(&mut self, name: &str, value: &str) -> Result<(), &'static str> {
         if name == "failure_reason" {
-            if let Self::TransactionCommitSuccess(e) = self {
-                let operation_id = e.operation_id;
-                let table_type = e.table_type;
-                let correlation_id = e.correlation_id.take();
-                *self = Self::TransactionCommitFailure(TransactionCommitFailure {
-                    operation_id,
-                    table_type,
-                    correlation_id,
-                    reason: value.parse().unwrap_or_else(|e| {
-                        warn!("Invalid failure_reason '{value}' on span: {e}. Using Error.");
-                        CommitFailureReason::Error
-                    }),
-                });
+            match self {
+                Self::TransactionCommitSuccess(e) => {
+                    let operation_id = e.operation_id;
+                    let table_type = e.table_type;
+                    let correlation_id = e.correlation_id.take();
+                    *self = Self::TransactionCommitFailure(TransactionCommitFailure {
+                        operation_id,
+                        table_type,
+                        correlation_id,
+                        reason: value.parse().unwrap_or(CommitFailureReason::Error),
+                    });
+                }
+                Self::LastCheckpointReadSuccess(e) => {
+                    *self = Self::LastCheckpointReadFailure(
+                        e.to_failure(LastCheckpointReadFailureReason::parse_or_unknown(value)),
+                    );
+                }
+                _ => {}
             }
             return Ok(());
         }
         match self {
             Self::TransactionCommitSuccess(e) => e.record_str(name, value),
-            Self::LastCheckpointReadCompleted(e) => e.record_str(name, value),
+            Self::LastCheckpointReadSuccess(_) | Self::LastCheckpointReadFailure(_) => {
+                Err(LastCheckpointReadSuccess::SPAN_NAME)
+            }
             _ => Ok(()),
         }
     }
@@ -270,6 +304,9 @@ impl MetricEvent {
             Self::DomainMetadataLoadSuccess(_) => Self::DomainMetadataLoadFailure,
             Self::SetTransactionLoadSuccess(_) => Self::SetTransactionLoadFailure,
             Self::CrcReadSuccess(_) => Self::CrcReadFailure,
+            Self::LastCheckpointReadSuccess(e) => Self::LastCheckpointReadFailure(
+                e.to_failure(LastCheckpointReadFailureReason::Error),
+            ),
             // Events with no failure form pass through unchanged.
             // Note: here we list explicitly so adding a lifecycle event without a failure mapping
             //       fails to compile.
@@ -280,7 +317,7 @@ impl MetricEvent {
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
             | Self::CrcReadFailure
-            | Self::LastCheckpointReadCompleted(_)
+            | Self::LastCheckpointReadFailure(_)
             | Self::JsonReadCompleted(_)
             | Self::ParquetReadCompleted(_)
             | Self::ScanMetadataCompleted(_)
@@ -308,7 +345,8 @@ impl fmt::Display for MetricEvent {
             Self::SetTransactionLoadFailure => f.write_str("SetTransactionLoadFailure"),
             Self::CrcReadSuccess(e) => e.fmt(f),
             Self::CrcReadFailure => f.write_str("CrcReadFailure"),
-            Self::LastCheckpointReadCompleted(e) => e.fmt(f),
+            Self::LastCheckpointReadSuccess(e) => e.fmt(f),
+            Self::LastCheckpointReadFailure(e) => e.fmt(f),
             Self::JsonReadCompleted(e) => e.fmt(f),
             Self::ParquetReadCompleted(e) => e.fmt(f),
             Self::ScanMetadataCompleted(e) => e.fmt(f),
@@ -1102,85 +1140,95 @@ impl fmt::Display for CrcReadSuccess {
 }
 
 // ====================================================================
-// LastCheckpointReadCompleted
+// LastCheckpointRead
 // ====================================================================
 
-pub(crate) const LAST_CHECKPOINT_READ_COMPLETED_SPAN: &str = "last_checkpoint.read";
+pub(crate) const LAST_CHECKPOINT_READ_SPAN: &str = "last_checkpoint.read";
 
-/// The outcome of an attempt to read and parse a `_last_checkpoint` hint.
+/// Why an attempt to read `_last_checkpoint` did not produce a usable hint.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
 )]
 #[strum(serialize_all = "snake_case")]
-#[non_exhaustive]
-pub enum LastCheckpointReadOutcome {
-    /// The hint was present and parsed successfully.
-    Success,
+pub enum LastCheckpointReadFailureReason {
     /// The hint file was not present.
     NotFound,
     /// The hint file was empty or could not be decoded as a valid hint.
     Invalid,
     /// Reading the hint failed with an unexpected error.
     Error,
-    /// Decode fell back here because the span's `outcome` field was unset or unrecognized.
-    /// Kernel never emits this deliberately.
+    /// The recorded failure reason was empty or unrecognized.
     #[default]
     Unknown,
 }
 
-impl LastCheckpointReadOutcome {
+impl LastCheckpointReadFailureReason {
     fn parse_or_unknown(s: &str) -> Self {
-        if s.is_empty() {
-            return Self::Unknown;
-        }
-        Self::from_str(s).unwrap_or_else(|e| {
-            warn!("Invalid last checkpoint read outcome '{s}': {e}. Using Unknown.");
-            Self::Unknown
-        })
+        Self::from_str(s).unwrap_or_default()
     }
 }
 
-/// An attempt to read and parse a `_last_checkpoint` hint completed.
+/// A `_last_checkpoint` hint was read and parsed successfully.
 ///
-/// Reporters can increment a read counter and record `duration` in a latency histogram, using
-/// `outcome` as the dimension for both instruments.
+/// Reporters can count this event and record [`Self::duration`] with the outcome `success`.
+/// Failed attempts use [`LastCheckpointReadFailure::reason`] as the outcome.
 #[derive(Debug, Clone)]
-pub struct LastCheckpointReadCompleted {
-    /// How the read attempt completed.
-    pub outcome: LastCheckpointReadOutcome,
+pub struct LastCheckpointReadSuccess {
     /// Wall-clock time spent locating, reading, and parsing the hint.
     pub duration: Duration,
 }
 
-impl LastCheckpointReadCompleted {
-    pub(crate) const SPAN_NAME: &'static str = LAST_CHECKPOINT_READ_COMPLETED_SPAN;
+impl LastCheckpointReadSuccess {
+    pub(crate) const SPAN_NAME: &'static str = LAST_CHECKPOINT_READ_SPAN;
 
     pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
         Self {
-            outcome: LastCheckpointReadOutcome::Unknown,
             duration: Duration::ZERO,
         }
-    }
-
-    pub(crate) fn record_str(&mut self, name: &str, value: &str) -> Result<(), &'static str> {
-        match name {
-            "outcome" => self.outcome = LastCheckpointReadOutcome::parse_or_unknown(value),
-            _ => return Err(Self::SPAN_NAME),
-        }
-        Ok(())
     }
 
     pub(crate) fn set_duration(&mut self, d: Duration) {
         self.duration = d;
     }
+
+    fn to_failure(&self, reason: LastCheckpointReadFailureReason) -> LastCheckpointReadFailure {
+        LastCheckpointReadFailure {
+            reason,
+            duration: self.duration,
+        }
+    }
 }
 
-impl fmt::Display for LastCheckpointReadCompleted {
+impl fmt::Display for LastCheckpointReadSuccess {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { outcome, duration } = self;
+        write!(f, "LastCheckpointReadSuccess(duration={:?})", self.duration)
+    }
+}
+
+/// An attempt to read `_last_checkpoint` did not produce a usable hint.
+///
+/// Reporters can count this event and record [`Self::duration`] with [`Self::reason`] as the
+/// outcome. Successful attempts use the outcome `success`.
+#[derive(Debug, Clone)]
+pub struct LastCheckpointReadFailure {
+    /// Why the read attempt did not produce a usable hint.
+    pub reason: LastCheckpointReadFailureReason,
+    /// Wall-clock time spent locating, reading, and parsing the hint.
+    pub duration: Duration,
+}
+
+impl LastCheckpointReadFailure {
+    pub(crate) fn set_duration(&mut self, d: Duration) {
+        self.duration = d;
+    }
+}
+
+impl fmt::Display for LastCheckpointReadFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { reason, duration } = self;
         write!(
             f,
-            "LastCheckpointReadCompleted(outcome={outcome}, duration={duration:?})"
+            "LastCheckpointReadFailure(reason={reason}, duration={duration:?})"
         )
     }
 }
@@ -1923,28 +1971,73 @@ mod tests {
     }
 
     #[test]
-    fn last_checkpoint_completed_dispatches_fields_and_display() {
-        let mut event = MetricEvent::LastCheckpointReadCompleted(LastCheckpointReadCompleted {
-            outcome: LastCheckpointReadOutcome::Success,
+    fn last_checkpoint_read_success_dispatches_fields_and_display() {
+        let mut event = MetricEvent::LastCheckpointReadSuccess(LastCheckpointReadSuccess {
             duration: Duration::from_nanos(17),
         });
 
         assert_eq!(
-            event.record_u64("outcome", 1),
-            Err(LastCheckpointReadCompleted::SPAN_NAME)
+            event.record_u64("failure_reason", 1),
+            Err(LastCheckpointReadSuccess::SPAN_NAME)
         );
         assert_eq!(
-            event.record_bool("outcome", true),
-            Err(LastCheckpointReadCompleted::SPAN_NAME)
+            event.record_bool("failure_reason", true),
+            Err(LastCheckpointReadSuccess::SPAN_NAME)
         );
         assert_eq!(
             event.record_str("unexpected", "value"),
-            Err(LastCheckpointReadCompleted::SPAN_NAME)
+            Err(LastCheckpointReadSuccess::SPAN_NAME)
         );
         assert_eq!(
             event.to_string(),
-            "LastCheckpointReadCompleted(outcome=success, duration=17ns)"
+            "LastCheckpointReadSuccess(duration=17ns)"
         );
+    }
+
+    #[rstest]
+    #[case::not_found("not_found", LastCheckpointReadFailureReason::NotFound)]
+    #[case::invalid("invalid", LastCheckpointReadFailureReason::Invalid)]
+    #[case::error("error", LastCheckpointReadFailureReason::Error)]
+    #[case::empty("", LastCheckpointReadFailureReason::Unknown)]
+    #[case::unrecognized("unrecognized", LastCheckpointReadFailureReason::Unknown)]
+    fn last_checkpoint_failure_reason_flips_success(
+        #[case] value: &str,
+        #[case] expected: LastCheckpointReadFailureReason,
+    ) {
+        let mut event = MetricEvent::LastCheckpointReadSuccess(LastCheckpointReadSuccess {
+            duration: Duration::from_nanos(17),
+        });
+
+        event.record_str("failure_reason", value).unwrap();
+
+        let MetricEvent::LastCheckpointReadFailure(failure) = event else {
+            panic!("expected LastCheckpointReadFailure");
+        };
+        assert_eq!(failure.reason, expected);
+        assert_eq!(failure.duration, Duration::from_nanos(17));
+        assert_eq!(
+            failure.to_string(),
+            format!("LastCheckpointReadFailure(reason={expected}, duration=17ns)")
+        );
+    }
+
+    #[rstest]
+    #[case::success(MetricEvent::LastCheckpointReadSuccess(LastCheckpointReadSuccess {
+        duration: Duration::ZERO,
+    }))]
+    #[case::failure(MetricEvent::LastCheckpointReadFailure(LastCheckpointReadFailure {
+        reason: LastCheckpointReadFailureReason::Invalid,
+        duration: Duration::ZERO,
+    }))]
+    fn last_checkpoint_read_span_close_sets_duration(#[case] mut event: MetricEvent) {
+        event.set_duration_if_applicable(Duration::from_nanos(17));
+
+        let duration = match event {
+            MetricEvent::LastCheckpointReadSuccess(event) => event.duration,
+            MetricEvent::LastCheckpointReadFailure(event) => event.duration,
+            _ => panic!("expected a last checkpoint read event"),
+        };
+        assert_eq!(duration, Duration::from_nanos(17));
     }
 
     #[rstest]

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -106,6 +106,7 @@ pub enum MetricEvent {
     SetTransactionLoadFailure,
     CrcReadSuccess(CrcReadSuccess),
     CrcReadFailure,
+    LastCheckpointReadCompleted(LastCheckpointReadCompleted),
     JsonReadCompleted(JsonReadCompleted),
     ParquetReadCompleted(ParquetReadCompleted),
     ScanMetadataCompleted(ScanMetadataCompleted),
@@ -124,6 +125,7 @@ impl MetricEvent {
             Self::DomainMetadataLoadSuccess(e) => e.set_duration(d),
             Self::SetTransactionLoadSuccess(e) => e.set_duration(d),
             Self::CrcReadSuccess(e) => e.set_duration(d),
+            Self::LastCheckpointReadCompleted(e) => e.set_duration(d),
 
             // Emit-based success events set their duration as a creation attribute, so the
             // span-close hook must not overwrite it.
@@ -159,6 +161,7 @@ impl MetricEvent {
             Self::LogSegmentLoadSuccess(_) => Err(LogSegmentLoadSuccess::SPAN_NAME),
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SetTransactionLoadSuccess(_) => Err(SetTransactionLoadSuccess::SPAN_NAME),
+            Self::LastCheckpointReadCompleted(_) => Err(LastCheckpointReadCompleted::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -189,6 +192,7 @@ impl MetricEvent {
             Self::ProtocolMetadataLoadSuccess(_) => Err(ProtocolMetadataLoadSuccess::SPAN_NAME),
             Self::SnapshotBuildSuccess(_) => Err(SnapshotBuildSuccess::SPAN_NAME),
             Self::CrcReadSuccess(_) => Err(CrcReadSuccess::SPAN_NAME),
+            Self::LastCheckpointReadCompleted(_) => Err(LastCheckpointReadCompleted::SPAN_NAME),
             Self::ScanMetadataCompleted(_) => Err(ScanMetadataCompleted::SPAN_NAME),
             Self::JsonReadCompleted(_) => Err(JsonReadCompleted::SPAN_NAME),
             Self::ParquetReadCompleted(_) => Err(ParquetReadCompleted::SPAN_NAME),
@@ -225,10 +229,9 @@ impl MetricEvent {
             }
             return Ok(());
         }
-        // Only TransactionCommitSuccess records string fields today. If other events need them,
-        // dispatch per-variant like `record_u64`/`record_bool` above instead of this catch-all.
         match self {
             Self::TransactionCommitSuccess(e) => e.record_str(name, value),
+            Self::LastCheckpointReadCompleted(e) => e.record_str(name, value),
             _ => Ok(()),
         }
     }
@@ -277,6 +280,7 @@ impl MetricEvent {
             | Self::DomainMetadataLoadFailure
             | Self::SetTransactionLoadFailure
             | Self::CrcReadFailure
+            | Self::LastCheckpointReadCompleted(_)
             | Self::JsonReadCompleted(_)
             | Self::ParquetReadCompleted(_)
             | Self::ScanMetadataCompleted(_)
@@ -304,6 +308,7 @@ impl fmt::Display for MetricEvent {
             Self::SetTransactionLoadFailure => f.write_str("SetTransactionLoadFailure"),
             Self::CrcReadSuccess(e) => e.fmt(f),
             Self::CrcReadFailure => f.write_str("CrcReadFailure"),
+            Self::LastCheckpointReadCompleted(e) => e.fmt(f),
             Self::JsonReadCompleted(e) => e.fmt(f),
             Self::ParquetReadCompleted(e) => e.fmt(f),
             Self::ScanMetadataCompleted(e) => e.fmt(f),
@@ -1097,6 +1102,90 @@ impl fmt::Display for CrcReadSuccess {
 }
 
 // ====================================================================
+// LastCheckpointReadCompleted
+// ====================================================================
+
+pub(crate) const LAST_CHECKPOINT_READ_COMPLETED_SPAN: &str = "last_checkpoint.read";
+
+/// The outcome of an attempt to read and parse a `_last_checkpoint` hint.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, EnumString, StrumDisplay, AsRefStr, IntoStaticStr,
+)]
+#[strum(serialize_all = "snake_case")]
+#[non_exhaustive]
+pub enum LastCheckpointReadOutcome {
+    /// The hint was present and parsed successfully.
+    Success,
+    /// The hint file was not present.
+    NotFound,
+    /// The hint file was empty or could not be decoded as a valid hint.
+    Invalid,
+    /// Reading the hint failed with an unexpected error.
+    Error,
+    /// Decode fell back here because the span's `outcome` field was unset or unrecognized.
+    /// Kernel never emits this deliberately.
+    #[default]
+    Unknown,
+}
+
+impl LastCheckpointReadOutcome {
+    fn parse_or_unknown(s: &str) -> Self {
+        if s.is_empty() {
+            return Self::Unknown;
+        }
+        Self::from_str(s).unwrap_or_else(|e| {
+            warn!("Invalid last checkpoint read outcome '{s}': {e}. Using Unknown.");
+            Self::Unknown
+        })
+    }
+}
+
+/// An attempt to read and parse a `_last_checkpoint` hint completed.
+///
+/// Reporters can increment a read counter and record `duration` in a latency histogram, using
+/// `outcome` as the dimension for both instruments.
+#[derive(Debug, Clone)]
+pub struct LastCheckpointReadCompleted {
+    /// How the read attempt completed.
+    pub outcome: LastCheckpointReadOutcome,
+    /// Wall-clock time spent locating, reading, and parsing the hint.
+    pub duration: Duration,
+}
+
+impl LastCheckpointReadCompleted {
+    pub(crate) const SPAN_NAME: &'static str = LAST_CHECKPOINT_READ_COMPLETED_SPAN;
+
+    pub(crate) fn from_attrs(_attrs: &Attributes<'_>) -> Self {
+        Self {
+            outcome: LastCheckpointReadOutcome::Unknown,
+            duration: Duration::ZERO,
+        }
+    }
+
+    pub(crate) fn record_str(&mut self, name: &str, value: &str) -> Result<(), &'static str> {
+        match name {
+            "outcome" => self.outcome = LastCheckpointReadOutcome::parse_or_unknown(value),
+            _ => return Err(Self::SPAN_NAME),
+        }
+        Ok(())
+    }
+
+    pub(crate) fn set_duration(&mut self, d: Duration) {
+        self.duration = d;
+    }
+}
+
+impl fmt::Display for LastCheckpointReadCompleted {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { outcome, duration } = self;
+        write!(
+            f,
+            "LastCheckpointReadCompleted(outcome={outcome}, duration={duration:?})"
+        )
+    }
+}
+
+// ====================================================================
 // JsonReadCompleted
 // ====================================================================
 
@@ -1831,6 +1920,31 @@ mod tests {
             committer_duration: Duration::default(),
             total_duration: Duration::default(),
         }
+    }
+
+    #[test]
+    fn last_checkpoint_completed_dispatches_fields_and_display() {
+        let mut event = MetricEvent::LastCheckpointReadCompleted(LastCheckpointReadCompleted {
+            outcome: LastCheckpointReadOutcome::Success,
+            duration: Duration::from_nanos(17),
+        });
+
+        assert_eq!(
+            event.record_u64("outcome", 1),
+            Err(LastCheckpointReadCompleted::SPAN_NAME)
+        );
+        assert_eq!(
+            event.record_bool("outcome", true),
+            Err(LastCheckpointReadCompleted::SPAN_NAME)
+        );
+        assert_eq!(
+            event.record_str("unexpected", "value"),
+            Err(LastCheckpointReadCompleted::SPAN_NAME)
+        );
+        assert_eq!(
+            event.to_string(),
+            "LastCheckpointReadCompleted(outcome=success, duration=17ns)"
+        );
     }
 
     #[rstest]

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -85,8 +85,9 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    DomainMetadataLoadSuccess, JsonReadCompleted, LogSegmentLoadFailure, LogSegmentLoadSuccess,
-    LogSegmentLoadType, MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LastCheckpointReadCompleted,
+    LastCheckpointReadOutcome, LogSegmentLoadFailure, LogSegmentLoadSuccess, LogSegmentLoadType,
+    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
     ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
     SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
     SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,

--- a/kernel/src/metrics/mod.rs
+++ b/kernel/src/metrics/mod.rs
@@ -4,9 +4,9 @@
 //! snapshot creation, scans, and transactions. Metrics are collected during operations
 //! and reported as events via the `MetricsReporter` trait.
 //!
-//! Each operation (Snapshot, Transaction, Scan) is assigned a unique operation ID ([`MetricId`])
-//! when it starts, and all subsequent events for that operation reference this ID.
-//! This allows reporters to correlate events and track operation lifecycles.
+//! Lifecycle, transaction, and scan events with an `operation_id` use [`MetricId`] for correlation.
+//! Handler and file-read events, including `_last_checkpoint` reads, are process-level and do not
+//! carry an operation ID.
 //!
 //! # Example: Implementing a Custom MetricsReporter
 //!
@@ -85,13 +85,13 @@ use std::sync::Arc;
 
 pub use events::{
     emit_json_read_completed, emit_parquet_read_completed, CommitFailureReason, CrcReadSuccess,
-    DomainMetadataLoadSuccess, JsonReadCompleted, LastCheckpointReadCompleted,
-    LastCheckpointReadOutcome, LogSegmentLoadFailure, LogSegmentLoadSuccess, LogSegmentLoadType,
-    MetricEvent, MetricId, ParquetReadCompleted, ProtocolMetadataLoadFailure,
-    ProtocolMetadataLoadSuccess, ProtocolMetadataSource, ScanMetadataCompleted, ScanType,
-    SetTransactionLoadSuccess, SnapshotBuildFailure, SnapshotBuildSuccess,
-    SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-    TableType, TransactionCommitFailure, TransactionCommitSuccess,
+    DomainMetadataLoadSuccess, JsonReadCompleted, LastCheckpointReadFailure,
+    LastCheckpointReadFailureReason, LastCheckpointReadSuccess, LogSegmentLoadFailure,
+    LogSegmentLoadSuccess, LogSegmentLoadType, MetricEvent, MetricId, ParquetReadCompleted,
+    ProtocolMetadataLoadFailure, ProtocolMetadataLoadSuccess, ProtocolMetadataSource,
+    ScanMetadataCompleted, ScanType, SetTransactionLoadSuccess, SnapshotBuildFailure,
+    SnapshotBuildSuccess, SnapshotLoadMetricContext, StorageCopyCompleted, StorageListCompleted,
+    StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
 };
 pub(crate) use events::{
     emit_log_segment_load, emit_log_segment_load_failure, emit_protocol_metadata_load,

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -11,9 +11,9 @@ use tracing_subscriber::Layer;
 
 use super::events::{
     storage_metric_from_attrs, CrcReadSuccess, DomainMetadataLoadSuccess, JsonReadCompleted,
-    LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted, ProtocolMetadataLoadSuccess,
-    ScanMetadataCompleted, SetTransactionLoadSuccess, SnapshotBuildSuccess,
-    TransactionCommitSuccess, STORAGE_SPAN,
+    LastCheckpointReadCompleted, LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted,
+    ProtocolMetadataLoadSuccess, ScanMetadataCompleted, SetTransactionLoadSuccess,
+    SnapshotBuildSuccess, TransactionCommitSuccess, STORAGE_SPAN,
 };
 
 // ====================================================================
@@ -129,6 +129,11 @@ where
             CrcReadSuccess::SPAN_NAME => Some(MetricEvent::CrcReadSuccess(
                 CrcReadSuccess::from_attrs(attrs),
             )),
+            LastCheckpointReadCompleted::SPAN_NAME => {
+                Some(MetricEvent::LastCheckpointReadCompleted(
+                    LastCheckpointReadCompleted::from_attrs(attrs),
+                ))
+            }
             JsonReadCompleted::SPAN_NAME => Some(MetricEvent::JsonReadCompleted(
                 JsonReadCompleted::from_attrs(attrs),
             )),
@@ -298,6 +303,7 @@ mod tests {
     use std::io::Error;
     use std::sync::{Arc, Mutex};
 
+    use rstest::rstest;
     use test_utils::{ensure_metrics_compatible_global_subscriber, LogWriter};
     use tracing::field::Empty;
     use tracing::subscriber::with_default;
@@ -308,7 +314,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-    use crate::metrics::{MetricEvent, WithMetricsReporterLayer as _};
+    use crate::metrics::{LastCheckpointReadOutcome, MetricEvent, WithMetricsReporterLayer as _};
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     /// Run `f` under a subscriber that layers the metrics layer over an fmt layer capturing to a
@@ -365,6 +371,33 @@ mod tests {
             logs.contains("Invalid field 'bogus' recorded on snap.build span"),
             "an unrecognized .record() field is a declared-field typo and must still warn; got: {logs}"
         );
+    }
+
+    #[rstest]
+    #[case::unset(None)]
+    #[case::empty(Some(""))]
+    #[case::unrecognized(Some("not_an_outcome"))]
+    fn last_checkpoint_unset_or_invalid_outcome_decodes_as_unknown(
+        #[case] recorded_outcome: Option<&str>,
+    ) {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+        {
+            let span = info_span!("last_checkpoint.read", report = Empty, outcome = Empty,);
+            if let Some(outcome) = recorded_outcome {
+                span.record("outcome", outcome);
+            }
+        }
+
+        let outcomes: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(outcomes, [LastCheckpointReadOutcome::Unknown]);
     }
 
     // A log line whose field name collides with a real metric field must NOT overwrite the value a

--- a/kernel/src/metrics/reporter.rs
+++ b/kernel/src/metrics/reporter.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::Layer;
 
 use super::events::{
     storage_metric_from_attrs, CrcReadSuccess, DomainMetadataLoadSuccess, JsonReadCompleted,
-    LastCheckpointReadCompleted, LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted,
+    LastCheckpointReadSuccess, LogSegmentLoadSuccess, MetricEvent, ParquetReadCompleted,
     ProtocolMetadataLoadSuccess, ScanMetadataCompleted, SetTransactionLoadSuccess,
     SnapshotBuildSuccess, TransactionCommitSuccess, STORAGE_SPAN,
 };
@@ -129,11 +129,9 @@ where
             CrcReadSuccess::SPAN_NAME => Some(MetricEvent::CrcReadSuccess(
                 CrcReadSuccess::from_attrs(attrs),
             )),
-            LastCheckpointReadCompleted::SPAN_NAME => {
-                Some(MetricEvent::LastCheckpointReadCompleted(
-                    LastCheckpointReadCompleted::from_attrs(attrs),
-                ))
-            }
+            LastCheckpointReadSuccess::SPAN_NAME => Some(MetricEvent::LastCheckpointReadSuccess(
+                LastCheckpointReadSuccess::from_attrs(attrs),
+            )),
             JsonReadCompleted::SPAN_NAME => Some(MetricEvent::JsonReadCompleted(
                 JsonReadCompleted::from_attrs(attrs),
             )),
@@ -263,6 +261,9 @@ impl Visit for EventVisitor {
         let Some(event) = self.event.as_mut() else {
             return;
         };
+        if let Some(warning) = event.record_str_warning(field.name(), value) {
+            self.pending_warnings.push(warning);
+        }
         if let Err(span_name) = event.record_str(field.name(), value) {
             self.warn_invalid(field, span_name);
         }
@@ -314,7 +315,9 @@ mod tests {
     use uuid::Uuid;
 
     use crate::metrics::events::SNAPSHOT_COMPLETED_SPAN;
-    use crate::metrics::{LastCheckpointReadOutcome, MetricEvent, WithMetricsReporterLayer as _};
+    use crate::metrics::{
+        LastCheckpointReadFailureReason, MetricEvent, WithMetricsReporterLayer as _,
+    };
     use crate::unit_test_utils::{install_thread_local_metrics_reporter, CapturingReporter};
 
     /// Run `f` under a subscriber that layers the metrics layer over an fmt layer capturing to a
@@ -374,30 +377,29 @@ mod tests {
     }
 
     #[rstest]
-    #[case::unset(None)]
-    #[case::empty(Some(""))]
-    #[case::unrecognized(Some("not_an_outcome"))]
-    fn last_checkpoint_unset_or_invalid_outcome_decodes_as_unknown(
-        #[case] recorded_outcome: Option<&str>,
-    ) {
+    #[case::empty("")]
+    #[case::unrecognized("not_a_reason")]
+    fn last_checkpoint_invalid_failure_reason_decodes_as_unknown(#[case] reason: &str) {
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
         {
-            let span = info_span!("last_checkpoint.read", report = Empty, outcome = Empty,);
-            if let Some(outcome) = recorded_outcome {
-                span.record("outcome", outcome);
-            }
+            let span = info_span!(
+                "last_checkpoint.read",
+                report = Empty,
+                failure_reason = Empty,
+            );
+            span.record("failure_reason", reason);
         }
 
-        let outcomes: Vec<_> = reporter
+        let reasons: Vec<_> = reporter
             .events()
             .into_iter()
             .filter_map(|event| match event {
-                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                MetricEvent::LastCheckpointReadFailure(event) => Some(event.reason),
                 _ => None,
             })
             .collect();
-        assert_eq!(outcomes, [LastCheckpointReadOutcome::Unknown]);
+        assert_eq!(reasons, [LastCheckpointReadFailureReason::Unknown]);
     }
 
     // A log line whose field name collides with a real metric field must NOT overwrite the value a

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1330,7 +1330,7 @@ mod tests {
     use crate::last_checkpoint_hint::LastCheckpointHint;
     use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
-    use crate::metrics::{LastCheckpointReadOutcome, MetricEvent};
+    use crate::metrics::{LastCheckpointReadFailureReason, MetricEvent};
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
@@ -1461,15 +1461,26 @@ mod tests {
         )
     }
 
-    fn assert_last_checkpoint_outcomes(
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ExpectedLastCheckpointRead {
+        Success,
+        Failure(LastCheckpointReadFailureReason),
+    }
+
+    fn assert_last_checkpoint_reads(
         reporter: &CapturingReporter,
-        expected: &[LastCheckpointReadOutcome],
+        expected: &[ExpectedLastCheckpointRead],
     ) {
         let actual: Vec<_> = reporter
             .events()
             .into_iter()
             .filter_map(|event| match event {
-                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                MetricEvent::LastCheckpointReadSuccess(_) => {
+                    Some(ExpectedLastCheckpointRead::Success)
+                }
+                MetricEvent::LastCheckpointReadFailure(event) => {
+                    Some(ExpectedLastCheckpointRead::Failure(event.reason))
+                }
                 _ => None,
             })
             .collect();
@@ -1529,11 +1540,16 @@ mod tests {
         let storage = engine.storage_handler();
         let cp = LastCheckpointHint::try_read(storage.as_ref(), &url).unwrap();
         assert!(cp.is_none());
-        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::NotFound]);
+        assert_last_checkpoint_reads(
+            &reporter,
+            &[ExpectedLastCheckpointRead::Failure(
+                LastCheckpointReadFailureReason::NotFound,
+            )],
+        );
     }
 
     #[test]
-    fn invalid_last_checkpoint_log_root_emits_error_outcome() {
+    fn invalid_last_checkpoint_log_root_emits_error_failure() {
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
 
@@ -1542,7 +1558,12 @@ mod tests {
         assert!(
             LastCheckpointHint::try_read(engine.storage_handler().as_ref(), &log_root).is_err()
         );
-        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::Error]);
+        assert_last_checkpoint_reads(
+            &reporter,
+            &[ExpectedLastCheckpointRead::Failure(
+                LastCheckpointReadFailureReason::Error,
+            )],
+        );
     }
 
     fn valid_last_checkpoint() -> (Vec<u8>, LastCheckpointHint) {
@@ -1606,7 +1627,12 @@ mod tests {
         let invalid =
             LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
         assert!(invalid.is_none());
-        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::Invalid]);
+        assert_last_checkpoint_reads(
+            &reporter,
+            &[ExpectedLastCheckpointRead::Failure(
+                LastCheckpointReadFailureReason::Invalid,
+            )],
+        );
     }
 
     #[tokio::test]
@@ -1625,19 +1651,19 @@ mod tests {
                 "valid",
                 data,
                 Some(expected),
-                LastCheckpointReadOutcome::Success,
+                ExpectedLastCheckpointRead::Success,
             ),
             (
                 "invalid",
                 "invalid".as_bytes().to_vec(),
                 None,
-                LastCheckpointReadOutcome::Invalid,
+                ExpectedLastCheckpointRead::Failure(LastCheckpointReadFailureReason::Invalid),
             ),
             (
                 "valid_with_tags",
                 data_with_tags,
                 Some(expected_with_tags),
-                LastCheckpointReadOutcome::Success,
+                ExpectedLastCheckpointRead::Success,
             ),
         ];
 
@@ -1655,15 +1681,15 @@ mod tests {
 
         // Test reading all checkpoints from the in memory file system for cases where the data is
         // valid, invalid and valid with tags.
-        let mut expected_outcomes = vec![];
-        for (path_prefix, _, expected_result, expected_outcome) in test_cases {
+        let mut expected_reads = vec![];
+        for (path_prefix, _, expected_result, expected_read) in test_cases {
             let url = Url::parse(&format!("memory:///{path_prefix}/")).expect("valid url");
             let result =
                 LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
             assert_eq!(result, expected_result);
-            expected_outcomes.push(expected_outcome);
+            expected_reads.push(expected_read);
         }
-        assert_last_checkpoint_outcomes(&reporter, &expected_outcomes);
+        assert_last_checkpoint_reads(&reporter, &expected_reads);
     }
 
     #[test_log::test]

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1330,6 +1330,7 @@ mod tests {
     use crate::last_checkpoint_hint::LastCheckpointHint;
     use crate::log_segment::LogSegment;
     use crate::log_segment_files::LogSegmentFiles;
+    use crate::metrics::{LastCheckpointReadOutcome, MetricEvent};
     use crate::object_store::memory::InMemory;
     use crate::object_store::path::Path;
     use crate::object_store::ObjectStoreExt as _;
@@ -1341,7 +1342,10 @@ mod tests {
     };
     use crate::table_properties::ENABLE_IN_COMMIT_TIMESTAMPS;
     use crate::transaction::create_table::create_table;
-    use crate::unit_test_utils::{assert_result_error_with_message, string_array_to_engine_data};
+    use crate::unit_test_utils::{
+        assert_result_error_with_message, install_thread_local_metrics_reporter,
+        string_array_to_engine_data, CapturingReporter,
+    };
     use crate::utils::FoldWithOption as _;
 
     /// Helper function to create a commitInfo action with optional ICT
@@ -1457,6 +1461,21 @@ mod tests {
         )
     }
 
+    fn assert_last_checkpoint_outcomes(
+        reporter: &CapturingReporter,
+        expected: &[LastCheckpointReadOutcome],
+    ) {
+        let actual: Vec<_> = reporter
+            .events()
+            .into_iter()
+            .filter_map(|event| match event {
+                MetricEvent::LastCheckpointReadCompleted(event) => Some(event.outcome),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(actual, expected);
+    }
+
     #[test]
     fn test_snapshot_read_metadata() {
         let path =
@@ -1496,6 +1515,9 @@ mod tests {
 
     #[test]
     fn test_read_table_with_missing_last_checkpoint() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
         // this table doesn't have a _last_checkpoint file
         let path = std::fs::canonicalize(PathBuf::from(
             "./tests/data/table-with-dv-small/_delta_log/",
@@ -1507,6 +1529,20 @@ mod tests {
         let storage = engine.storage_handler();
         let cp = LastCheckpointHint::try_read(storage.as_ref(), &url).unwrap();
         assert!(cp.is_none());
+        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::NotFound]);
+    }
+
+    #[test]
+    fn invalid_last_checkpoint_log_root_emits_error_outcome() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
+        let engine = SyncEngine::new();
+        let log_root = Url::parse("data:text/plain,not-a-hierarchical-url").unwrap();
+        assert!(
+            LastCheckpointHint::try_read(engine.storage_handler().as_ref(), &log_root).is_err()
+        );
+        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::Error]);
     }
 
     fn valid_last_checkpoint() -> (Vec<u8>, LastCheckpointHint) {
@@ -1549,6 +1585,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_table_with_empty_last_checkpoint() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
         // in memory file system
         let store = Arc::new(InMemory::new());
 
@@ -1566,11 +1605,15 @@ mod tests {
         let url = Url::parse("memory:///invalid/").expect("valid url");
         let invalid =
             LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
-        assert!(invalid.is_none())
+        assert!(invalid.is_none());
+        assert_last_checkpoint_outcomes(&reporter, &[LastCheckpointReadOutcome::Invalid]);
     }
 
     #[tokio::test]
     async fn test_read_table_with_last_checkpoint() {
+        let reporter = Arc::new(CapturingReporter::default());
+        let _guard = install_thread_local_metrics_reporter(reporter.clone());
+
         // in memory file system
         let store = Arc::new(InMemory::new());
 
@@ -1578,13 +1621,28 @@ mod tests {
         let (data, expected) = valid_last_checkpoint();
         let (data_with_tags, expected_with_tags) = valid_last_checkpoint_with_tags();
         let test_cases = vec![
-            ("valid", data, Some(expected)),
-            ("invalid", "invalid".as_bytes().to_vec(), None),
-            ("valid_with_tags", data_with_tags, Some(expected_with_tags)),
+            (
+                "valid",
+                data,
+                Some(expected),
+                LastCheckpointReadOutcome::Success,
+            ),
+            (
+                "invalid",
+                "invalid".as_bytes().to_vec(),
+                None,
+                LastCheckpointReadOutcome::Invalid,
+            ),
+            (
+                "valid_with_tags",
+                data_with_tags,
+                Some(expected_with_tags),
+                LastCheckpointReadOutcome::Success,
+            ),
         ];
 
         // Write all test files to the in memory file system
-        for (path_prefix, data, _) in &test_cases {
+        for (path_prefix, data, _, _) in &test_cases {
             let path = Path::from(format!("{path_prefix}/_last_checkpoint"));
             store
                 .put(&path, data.clone().into())
@@ -1597,12 +1655,15 @@ mod tests {
 
         // Test reading all checkpoints from the in memory file system for cases where the data is
         // valid, invalid and valid with tags.
-        for (path_prefix, _, expected_result) in test_cases {
+        let mut expected_outcomes = vec![];
+        for (path_prefix, _, expected_result, expected_outcome) in test_cases {
             let url = Url::parse(&format!("memory:///{path_prefix}/")).expect("valid url");
             let result =
                 LastCheckpointHint::try_read(storage.as_ref(), &url).expect("read last checkpoint");
             assert_eq!(result, expected_result);
+            expected_outcomes.push(expected_outcome);
         }
+        assert_last_checkpoint_outcomes(&reporter, &expected_outcomes);
     }
 
     #[test_log::test]

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -8,7 +8,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use delta_kernel::metrics::{
-    CommitFailureReason, MetricEvent, MetricsReporter, WithMetricsReporterLayer as _,
+    CommitFailureReason, LastCheckpointReadOutcome, MetricEvent, MetricsReporter,
+    WithMetricsReporterLayer as _,
 };
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::util::SubscriberInitExt as _;
@@ -179,6 +180,20 @@ pub struct CountingReporter {
     /// Total number of bytes read from CRC files, across all CRC read calls.
     pub crc_bytes_read: RelaxedCounter,
 
+    // _last_checkpoint reader counters
+    /// Number of `_last_checkpoint` read attempts.
+    pub last_checkpoint_reads: RelaxedCounter,
+    /// Number of `_last_checkpoint` hints parsed successfully.
+    pub last_checkpoint_read_successes: RelaxedCounter,
+    /// Number of `_last_checkpoint` read attempts where the hint was absent.
+    pub last_checkpoint_read_not_found: RelaxedCounter,
+    /// Number of `_last_checkpoint` read attempts where the hint was invalid.
+    pub last_checkpoint_read_invalid: RelaxedCounter,
+    /// Number of `_last_checkpoint` read attempts that failed unexpectedly.
+    pub last_checkpoint_read_errors: RelaxedCounter,
+    /// Number of `_last_checkpoint` read attempts with an unknown or future outcome.
+    pub last_checkpoint_read_unknown: RelaxedCounter,
+
     // Domain metadata load counters (Snapshot::get_domain_metadatas_internal)
     pub domain_metadata_loads: RelaxedCounter,
     pub domain_metadata_load_failures: RelaxedCounter,
@@ -232,6 +247,12 @@ impl CountingReporter {
         self.latest_crc_files_found.reset();
         self.crc_read_calls.reset();
         self.crc_bytes_read.reset();
+        self.last_checkpoint_reads.reset();
+        self.last_checkpoint_read_successes.reset();
+        self.last_checkpoint_read_not_found.reset();
+        self.last_checkpoint_read_invalid.reset();
+        self.last_checkpoint_read_errors.reset();
+        self.last_checkpoint_read_unknown.reset();
         self.domain_metadata_loads.reset();
         self.domain_metadata_load_failures.reset();
         self.domain_metadata_cache_hits.reset();
@@ -270,6 +291,12 @@ impl CountingReporter {
         let parquet_kib = self.parquet_bytes_read.get() / 1024;
         let crc_calls = self.crc_read_calls.get();
         let crc_kib = self.crc_bytes_read.get() / 1024;
+        let hint_reads = self.last_checkpoint_reads.get();
+        let hint_successes = self.last_checkpoint_read_successes.get();
+        let hint_not_found = self.last_checkpoint_read_not_found.get();
+        let hint_invalid = self.last_checkpoint_read_invalid.get();
+        let hint_errors = self.last_checkpoint_read_errors.get();
+        let hint_unknown = self.last_checkpoint_read_unknown.get();
         let log_loads = self.log_segment_loads.get();
         let commits = self.commit_files.get();
         let checkpoints = self.checkpoint_files.get();
@@ -281,6 +308,11 @@ impl CountingReporter {
         println!("    json    : {json_calls} call(s)  {json_files} files  {json_kib} KiB");
         println!("    parquet : {parquet_calls} call(s)  {parquet_files} files  {parquet_kib} KiB");
         println!("    crc     : {crc_calls} call(s)  {crc_kib} KiB");
+        println!("    checkpoint hint: {hint_reads} read(s)");
+        println!(
+            "      {hint_successes} success  {hint_not_found} not found  {hint_invalid} invalid"
+        );
+        println!("      {hint_errors} error  {hint_unknown} unknown");
         println!("    log     : {log_loads} segment load(s) -- {commits} commits  {checkpoints} checkpoints  {compactions} compactions  {crc_files_found} latest_crc_files");
     }
 }
@@ -324,6 +356,18 @@ impl MetricsReporter for CountingReporter {
             MetricEvent::CrcReadSuccess(e) => {
                 self.crc_read_calls.inc();
                 self.crc_bytes_read.add(e.bytes_read);
+            }
+            MetricEvent::LastCheckpointReadCompleted(e) => {
+                self.last_checkpoint_reads.inc();
+                match e.outcome {
+                    LastCheckpointReadOutcome::Success => self.last_checkpoint_read_successes.inc(),
+                    LastCheckpointReadOutcome::NotFound => {
+                        self.last_checkpoint_read_not_found.inc()
+                    }
+                    LastCheckpointReadOutcome::Invalid => self.last_checkpoint_read_invalid.inc(),
+                    LastCheckpointReadOutcome::Error => self.last_checkpoint_read_errors.inc(),
+                    _ => self.last_checkpoint_read_unknown.inc(),
+                }
             }
             MetricEvent::DomainMetadataLoadSuccess(e) => {
                 self.domain_metadata_loads.inc();
@@ -397,11 +441,13 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadSuccess, DomainMetadataLoadSuccess, LogSegmentLoadSuccess, LogSegmentLoadType,
-        MetricId, ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
-        SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
-        StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        CrcReadSuccess, DomainMetadataLoadSuccess, LastCheckpointReadCompleted,
+        LogSegmentLoadSuccess, LogSegmentLoadType, MetricId, ProtocolMetadataLoadSuccess,
+        ProtocolMetadataSource, SetTransactionLoadSuccess, SnapshotBuildFailure,
+        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
+        TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
+    use rstest::rstest;
 
     use super::*;
 
@@ -512,6 +558,59 @@ mod tests {
         }));
         assert_eq!(reporter.crc_read_calls.get(), 2);
         assert_eq!(reporter.crc_bytes_read.get(), 768);
+    }
+
+    #[rstest]
+    #[case::success(LastCheckpointReadOutcome::Success)]
+    #[case::not_found(LastCheckpointReadOutcome::NotFound)]
+    #[case::invalid(LastCheckpointReadOutcome::Invalid)]
+    #[case::error(LastCheckpointReadOutcome::Error)]
+    #[case::unknown(LastCheckpointReadOutcome::Unknown)]
+    fn report_last_checkpoint_read_increments_outcome_counter(
+        #[case] outcome: LastCheckpointReadOutcome,
+    ) {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::LastCheckpointReadCompleted(
+            LastCheckpointReadCompleted {
+                outcome,
+                duration: dur(),
+            },
+        ));
+
+        assert_eq!(reporter.last_checkpoint_reads.get(), 1);
+        assert_eq!(
+            reporter.last_checkpoint_read_successes.get(),
+            u64::from(outcome == LastCheckpointReadOutcome::Success)
+        );
+        assert_eq!(
+            reporter.last_checkpoint_read_not_found.get(),
+            u64::from(outcome == LastCheckpointReadOutcome::NotFound)
+        );
+        assert_eq!(
+            reporter.last_checkpoint_read_invalid.get(),
+            u64::from(outcome == LastCheckpointReadOutcome::Invalid)
+        );
+        assert_eq!(
+            reporter.last_checkpoint_read_errors.get(),
+            u64::from(outcome == LastCheckpointReadOutcome::Error)
+        );
+        assert_eq!(
+            reporter.last_checkpoint_read_unknown.get(),
+            u64::from(outcome == LastCheckpointReadOutcome::Unknown)
+        );
+    }
+
+    #[test]
+    fn print_summary_includes_last_checkpoint_counters() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::LastCheckpointReadCompleted(
+            LastCheckpointReadCompleted {
+                outcome: LastCheckpointReadOutcome::Unknown,
+                duration: dur(),
+            },
+        ));
+
+        reporter.print_summary("last checkpoint");
     }
 
     #[test]
@@ -662,6 +761,12 @@ mod tests {
             duration: dur(),
             bytes_read: 512,
         }));
+        reporter.report(MetricEvent::LastCheckpointReadCompleted(
+            LastCheckpointReadCompleted {
+                outcome: LastCheckpointReadOutcome::Success,
+                duration: dur(),
+            },
+        ));
         reporter.report(MetricEvent::DomainMetadataLoadSuccess(
             DomainMetadataLoadSuccess {
                 from_cache: true,
@@ -699,6 +804,12 @@ mod tests {
         assert_eq!(reporter.latest_crc_files_found.get(), 0);
         assert_eq!(reporter.crc_read_calls.get(), 0);
         assert_eq!(reporter.crc_bytes_read.get(), 0);
+        assert_eq!(reporter.last_checkpoint_reads.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_successes.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_not_found.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_invalid.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_errors.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_unknown.get(), 0);
         assert_eq!(reporter.domain_metadata_loads.get(), 0);
         assert_eq!(reporter.domain_metadata_load_failures.get(), 0);
         assert_eq!(reporter.domain_metadata_cache_hits.get(), 0);

--- a/test-utils/src/counting_reporter.rs
+++ b/test-utils/src/counting_reporter.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use delta_kernel::metrics::{
-    CommitFailureReason, LastCheckpointReadOutcome, MetricEvent, MetricsReporter,
+    CommitFailureReason, LastCheckpointReadFailureReason, MetricEvent, MetricsReporter,
     WithMetricsReporterLayer as _,
 };
 use tracing::subscriber::DefaultGuard;
@@ -357,16 +357,25 @@ impl MetricsReporter for CountingReporter {
                 self.crc_read_calls.inc();
                 self.crc_bytes_read.add(e.bytes_read);
             }
-            MetricEvent::LastCheckpointReadCompleted(e) => {
+            MetricEvent::LastCheckpointReadSuccess(_) => {
                 self.last_checkpoint_reads.inc();
-                match e.outcome {
-                    LastCheckpointReadOutcome::Success => self.last_checkpoint_read_successes.inc(),
-                    LastCheckpointReadOutcome::NotFound => {
+                self.last_checkpoint_read_successes.inc();
+            }
+            MetricEvent::LastCheckpointReadFailure(e) => {
+                self.last_checkpoint_reads.inc();
+                match e.reason {
+                    LastCheckpointReadFailureReason::NotFound => {
                         self.last_checkpoint_read_not_found.inc()
                     }
-                    LastCheckpointReadOutcome::Invalid => self.last_checkpoint_read_invalid.inc(),
-                    LastCheckpointReadOutcome::Error => self.last_checkpoint_read_errors.inc(),
-                    _ => self.last_checkpoint_read_unknown.inc(),
+                    LastCheckpointReadFailureReason::Invalid => {
+                        self.last_checkpoint_read_invalid.inc()
+                    }
+                    LastCheckpointReadFailureReason::Error => {
+                        self.last_checkpoint_read_errors.inc()
+                    }
+                    LastCheckpointReadFailureReason::Unknown => {
+                        self.last_checkpoint_read_unknown.inc()
+                    }
                 }
             }
             MetricEvent::DomainMetadataLoadSuccess(e) => {
@@ -441,11 +450,11 @@ mod tests {
     use std::time::Duration;
 
     use delta_kernel::metrics::{
-        CrcReadSuccess, DomainMetadataLoadSuccess, LastCheckpointReadCompleted,
-        LogSegmentLoadSuccess, LogSegmentLoadType, MetricId, ProtocolMetadataLoadSuccess,
-        ProtocolMetadataSource, SetTransactionLoadSuccess, SnapshotBuildFailure,
-        SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted, StorageReadCompleted,
-        TableType, TransactionCommitFailure, TransactionCommitSuccess,
+        CrcReadSuccess, DomainMetadataLoadSuccess, LastCheckpointReadFailure,
+        LastCheckpointReadSuccess, LogSegmentLoadSuccess, LogSegmentLoadType, MetricId,
+        ProtocolMetadataLoadSuccess, ProtocolMetadataSource, SetTransactionLoadSuccess,
+        SnapshotBuildFailure, SnapshotBuildSuccess, StorageCopyCompleted, StorageListCompleted,
+        StorageReadCompleted, TableType, TransactionCommitFailure, TransactionCommitSuccess,
     };
     use rstest::rstest;
 
@@ -560,52 +569,63 @@ mod tests {
         assert_eq!(reporter.crc_bytes_read.get(), 768);
     }
 
+    #[test]
+    fn report_last_checkpoint_read_success_increments_success_counter() {
+        let reporter = CountingReporter::new();
+        reporter.report(MetricEvent::LastCheckpointReadSuccess(
+            LastCheckpointReadSuccess { duration: dur() },
+        ));
+
+        assert_eq!(reporter.last_checkpoint_reads.get(), 1);
+        assert_eq!(reporter.last_checkpoint_read_successes.get(), 1);
+        assert_eq!(reporter.last_checkpoint_read_not_found.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_invalid.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_errors.get(), 0);
+        assert_eq!(reporter.last_checkpoint_read_unknown.get(), 0);
+    }
+
     #[rstest]
-    #[case::success(LastCheckpointReadOutcome::Success)]
-    #[case::not_found(LastCheckpointReadOutcome::NotFound)]
-    #[case::invalid(LastCheckpointReadOutcome::Invalid)]
-    #[case::error(LastCheckpointReadOutcome::Error)]
-    #[case::unknown(LastCheckpointReadOutcome::Unknown)]
-    fn report_last_checkpoint_read_increments_outcome_counter(
-        #[case] outcome: LastCheckpointReadOutcome,
+    #[case::not_found(LastCheckpointReadFailureReason::NotFound)]
+    #[case::invalid(LastCheckpointReadFailureReason::Invalid)]
+    #[case::error(LastCheckpointReadFailureReason::Error)]
+    #[case::unknown(LastCheckpointReadFailureReason::Unknown)]
+    fn report_last_checkpoint_read_failure_increments_reason_counter(
+        #[case] reason: LastCheckpointReadFailureReason,
     ) {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LastCheckpointReadCompleted(
-            LastCheckpointReadCompleted {
-                outcome,
+        reporter.report(MetricEvent::LastCheckpointReadFailure(
+            LastCheckpointReadFailure {
+                reason,
                 duration: dur(),
             },
         ));
 
         assert_eq!(reporter.last_checkpoint_reads.get(), 1);
-        assert_eq!(
-            reporter.last_checkpoint_read_successes.get(),
-            u64::from(outcome == LastCheckpointReadOutcome::Success)
-        );
+        assert_eq!(reporter.last_checkpoint_read_successes.get(), 0);
         assert_eq!(
             reporter.last_checkpoint_read_not_found.get(),
-            u64::from(outcome == LastCheckpointReadOutcome::NotFound)
+            u64::from(reason == LastCheckpointReadFailureReason::NotFound)
         );
         assert_eq!(
             reporter.last_checkpoint_read_invalid.get(),
-            u64::from(outcome == LastCheckpointReadOutcome::Invalid)
+            u64::from(reason == LastCheckpointReadFailureReason::Invalid)
         );
         assert_eq!(
             reporter.last_checkpoint_read_errors.get(),
-            u64::from(outcome == LastCheckpointReadOutcome::Error)
+            u64::from(reason == LastCheckpointReadFailureReason::Error)
         );
         assert_eq!(
             reporter.last_checkpoint_read_unknown.get(),
-            u64::from(outcome == LastCheckpointReadOutcome::Unknown)
+            u64::from(reason == LastCheckpointReadFailureReason::Unknown)
         );
     }
 
     #[test]
-    fn print_summary_includes_last_checkpoint_counters() {
+    fn print_summary_handles_last_checkpoint_counters() {
         let reporter = CountingReporter::new();
-        reporter.report(MetricEvent::LastCheckpointReadCompleted(
-            LastCheckpointReadCompleted {
-                outcome: LastCheckpointReadOutcome::Unknown,
+        reporter.report(MetricEvent::LastCheckpointReadFailure(
+            LastCheckpointReadFailure {
+                reason: LastCheckpointReadFailureReason::Unknown,
                 duration: dur(),
             },
         ));
@@ -761,12 +781,22 @@ mod tests {
             duration: dur(),
             bytes_read: 512,
         }));
-        reporter.report(MetricEvent::LastCheckpointReadCompleted(
-            LastCheckpointReadCompleted {
-                outcome: LastCheckpointReadOutcome::Success,
-                duration: dur(),
-            },
+        reporter.report(MetricEvent::LastCheckpointReadSuccess(
+            LastCheckpointReadSuccess { duration: dur() },
         ));
+        for reason in [
+            LastCheckpointReadFailureReason::NotFound,
+            LastCheckpointReadFailureReason::Invalid,
+            LastCheckpointReadFailureReason::Error,
+            LastCheckpointReadFailureReason::Unknown,
+        ] {
+            reporter.report(MetricEvent::LastCheckpointReadFailure(
+                LastCheckpointReadFailure {
+                    reason,
+                    duration: dur(),
+                },
+            ));
+        }
         reporter.report(MetricEvent::DomainMetadataLoadSuccess(
             DomainMetadataLoadSuccess {
                 from_cache: true,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Emit a metric after each attempt to read `_last_checkpoint`.

The event depends on the result:

```
Ok(Some(valid_hint)) -> LastCheckpointReadSuccess
missing hint         -> LastCheckpointReadFailure { reason: NotFound }
empty or invalid     -> LastCheckpointReadFailure { reason: Invalid }
other error          -> LastCheckpointReadFailure { reason: Error }
```

Both events include the read duration.

This uses separate success and failure events instead of one `LastCheckpointReadCompleted` event with an outcome field, following the convention introduced [here](https://github.com/delta-io/delta-kernel-rs/commit/cffe83679973238c9aedb796ce764eadb24bc218) for `CrcReadFailure`/`CrcReadSuccess`. To simplify things, this could be 1 enum (`LastCheckpointReadCompleted`) as well, open to opinions.

This does not change any snapshot behavior; a missing, empty, or invalid hint still returns `Ok(None)`, and Kernel falls back to listing the log. Other read errors still return Err.

Reporters can use one outcome dimension for both metrics:

```
last_checkpoint_reads_total{outcome="success"}
last_checkpoint_read_duration_ms{outcome="success"}

last_checkpoint_reads_total{outcome="not_found"}
last_checkpoint_read_duration_ms{outcome="not_found"}
```

I left duration in as it could potentially be useful for diagnosing abnormal read times, etc.

This PR also:

- Exposes the events through the C FFI.
- Adds counters to CountingReporter.
- Updates the observability docs and C example.

### This PR affects the following public APIs

It adds:

- MetricEvent::LastCheckpointReadSuccess
- MetricEvent::LastCheckpointReadFailure
- LastCheckpointReadSuccess
- LastCheckpointReadFailure
- LastCheckpointReadFailureReason

## How was this change tested?

Unit tests.