### PR TITLE
fix: omit recursive for REST offset listings

### DIFF
--- a/default-engine/src/rest_store/store.rs
+++ b/default-engine/src/rest_store/store.rs
@@ -630,6 +630,11 @@ impl ObjectStore for RestObjectStore {
                 raw.to_string()
             }
         };
+        // NOTE: This intentionally diverges from `ObjectStore::list_with_offset`, which is
+        // expected to behave like recursive `list(prefix)` filtered by `offset`. Delta log
+        // continuation only needs direct children because `_delta_log` is flat.
+        // TODO: Split the Delta-log-specific REST listing path from the general `ObjectStore`
+        // method so `list_with_offset` can preserve the recursive trait contract.
         self.list_paginated(prefix, Some(offset_str), Some(offset.clone()), false)
     }
 

--- a/default-engine/src/rest_store/store.rs
+++ b/default-engine/src/rest_store/store.rs
@@ -610,7 +610,6 @@ impl ObjectStore for RestObjectStore {
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
         let prefix = prefix.map(|p| p.as_ref().to_string()).unwrap_or_default();
-        // Both `list` and `list_with_offset` recurse; only `list_with_delimiter` is non-recursive.
         self.list_paginated(prefix, None, None, true)
     }
 
@@ -631,7 +630,7 @@ impl ObjectStore for RestObjectStore {
                 raw.to_string()
             }
         };
-        self.list_paginated(prefix, Some(offset_str), Some(offset.clone()), true)
+        self.list_paginated(prefix, Some(offset_str), Some(offset.clone()), false)
     }
 
     fn delete_stream(

--- a/default-engine/src/rest_store/tests.rs
+++ b/default-engine/src/rest_store/tests.rs
@@ -506,6 +506,24 @@ async fn list_with_offset_excludes_offset_entry() {
     assert_eq!(paths, vec!["d/3"]);
 }
 
+#[tokio::test]
+async fn list_with_offset_sends_start_from_without_recursive() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/dirs/d"))
+        .and(wiremock::matchers::query_param("start_from", "2"))
+        .and(wiremock::matchers::query_param_is_missing("recursive"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"contents":[]}"#))
+        .mount(&server)
+        .await;
+    let store = store_for(&server, HeaderMap::new());
+    let metas = store
+        .list_with_offset(Some(&Path::from("d")), &Path::from("d/2"))
+        .collect::<Vec<_>>()
+        .await;
+    assert!(metas.is_empty());
+}
+
 /// An out-of-order page violates the sorted-listing contract and must surface as an error
 /// rather than feeding log replay a misordered listing.
 #[tokio::test]


### PR DESCRIPTION
## What changed

`RestObjectStore::list_with_offset` now sends `start_from` without `recursive=true`.
Regular `list` requests still use recursive listing.

## Why

Offset listings are used today to continue scanning a Delta table's `_delta_log`, and
Delta log directories are flat: commit and checkpoint files live directly under
`_delta_log`, not in nested subdirectories. Because of that, `list_with_offset`
can omit `recursive=true` while ordinary `list` keeps using recursive listing
for the object-store contract.

## Testing

- `cargo test -p delta_kernel_default_engine rest_store`
- pre-commit hook: formatting, clippy, full `cargo test`, coverage generation
