### PR TITLE
feat: implement plan executor

### DIFF
--- a/datafusion-executor/Cargo.lock
+++ b/datafusion-executor/Cargo.lock
@@ -1375,10 +1375,12 @@ dependencies = [
 name = "datafusion_executor"
 version = "0.26.0"
 dependencies = [
+ "async-trait",
  "datafusion",
  "delta_kernel",
  "itertools",
  "rstest",
+ "tempfile",
  "tokio",
 ]
 

--- a/datafusion-executor/Cargo.lock
+++ b/datafusion-executor/Cargo.lock
@@ -1376,12 +1376,15 @@ name = "datafusion_executor"
 version = "0.26.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "datafusion",
  "delta_kernel",
+ "futures",
  "itertools",
  "rstest",
  "tempfile",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/datafusion-executor/Cargo.toml
+++ b/datafusion-executor/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.88"
 
 [dependencies]
 async-trait = "0.1"
+bytes = "1"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "declarative-plans",
   "vendored-protoc",
@@ -19,9 +20,12 @@ delta_kernel = { path = "../kernel", default-features = false, features = [
   "default-engine-base",
 ] }
 datafusion = "54"
+futures = "0.3"
 itertools = "0.14"
+tokio = { version = "1", features = ["rt"] }
 
 [dev-dependencies]
 rstest = "0.23"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+url = "2"

--- a/datafusion-executor/Cargo.toml
+++ b/datafusion-executor/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.88"
 [workspace]
 
 [dependencies]
+async-trait = "0.1"
 delta_kernel = { path = "../kernel", default-features = false, features = [
   "declarative-plans",
   "vendored-protoc",
@@ -22,4 +23,5 @@ itertools = "0.14"
 
 [dev-dependencies]
 rstest = "0.23"
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -1,17 +1,24 @@
-//! A DataFusion-based [`PlanExecutor`](delta_kernel::PlanExecutor) for delta_kernel declarative
-//! plans.
+//! A DataFusion-based [`PlanExecutor`] for delta_kernel declarative plans.
 //!
-//! Kernel emits executor-independent logical [`Plan`](delta_kernel::plans::ir::plan::Plan)s; this
-//! crate executes them by lowering each plan to a DataFusion `LogicalPlan`, optimizing it, and
-//! running the resulting `ExecutionPlan`.
+//! Kernel emits executor-independent logical [`Plan`]s. This crate lowers them to DataFusion
+//! logical plans, plans and executes them, and adapts their Arrow output back to [`EngineData`].
 
-// TODO: remove once `session_ctx` and `storage_handler` are consumed by the query-execution path.
-#![allow(dead_code)]
-
+use std::ops::Range;
 use std::sync::Arc;
 
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
-use delta_kernel::StorageHandler;
+use datafusion::parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+use datafusion::parquet::file::metadata::{FooterTail, ParquetMetaDataReader};
+use datafusion::physical_plan::collect;
+use delta_kernel::engine::arrow_conversion::TryIntoKernel as _;
+use delta_kernel::engine::arrow_data::{fix_nested_null_masks, ArrowEngineData};
+use delta_kernel::plans::ir::plan::Plan;
+use delta_kernel::{
+    DeltaResult, DeltaResultIteratorStatic, EngineData, Error, FileMeta, IoOperation, Operation,
+    ParquetFooter, PlanExecutor, PlanResult, StorageHandler,
+};
+use tokio::runtime::Handle;
 
 mod expression;
 mod operator;
@@ -23,40 +30,449 @@ mod scan;
 mod utils;
 
 pub use expression::to_df_expr;
+use plan::to_df_plan;
 pub use predicate::to_df_predicate_expr;
 pub use scalar::to_df_scalar;
 
 /// Executes kernel declarative plans on DataFusion.
 ///
-/// Holds two handles, each owning a distinct part of the work:
-/// - `session_ctx` -- *plan it, then run it*: DataFusion's `SessionContext` is the front door to
-///   the query engine. It holds the session-scoped state needed to turn a query into something
-///   runnable: configuration, registered tables/catalogs and functions, the logical/physical
-///   optimizer rules, and a handle to the shared runtime environment (memory pool, object-store
-///   registry). We use it to compile and optimize a kernel plan into a DataFusion `LogicalPlan`,
-///   then lower it to a physical `ExecutionPlan`. It is heavyweight and meant to be long-lived and
-///   shared. At execution time we derive a fresh per-run `TaskContext` from it via
-///   `session_ctx.task_ctx()` and pass that to `ExecutionPlan::execute`.
-/// - `storage_handler` -- *fetch the bytes the query engine can't*: a kernel [`StorageHandler`] for
-///   the storage I/O DataFusion cannot do itself (deletion-vector resolution, footer reads,
-///   listing). This is the file-system subset of a kernel [`Engine`](delta_kernel::Engine) -- the
-///   executor needs nothing else from the engine, so it holds only this.
+/// The caller supplies three resources because each belongs to the connector rather than the
+/// executor:
+///
+/// - `session_context` is DataFusion's long-lived [`SessionContext`]. It holds optimizer rules,
+///   functions, catalogs, and the runtime environment whose object stores and resource limits are
+///   used by parquet and JSON scans. The caller supplies it so kernel plans use the connector's
+///   DataFusion configuration. The executor snapshots it per query to create both the physical plan
+///   and its matching task context.
+/// - `storage_handler` implements kernel's [`StorageHandler`] contract for explicit
+///   [`IoOperation`]s such as listing files, reading or writing bytes, and reading parquet footers.
+///   These operations do not run through DataFusion's object stores. The caller therefore supplies
+///   its underlying handler, not a `PlanBasedStorageHandler` backed by this executor, which would
+///   recurse into itself.
+/// - `runtime_handle` identifies the caller-owned Tokio [`Handle`]. DataFusion planning and
+///   execution are asynchronous, while [`PlanExecutor`] is synchronous, so the executor uses this
+///   handle to schedule the query and waits for its collected result. A Tokio runtime is separate
+///   from DataFusion's runtime environment, and the executor does not create one because its
+///   lifecycle and enabled drivers belong to the connector.
+///
+/// [`PlanExecutor::execute_op`] is synchronous and does not return until query results are
+/// collected. Callers using the executor from async code must run it on a blocking thread such as
+/// one provided by `tokio::task::spawn_blocking`. The returned data iterator is entirely in memory
+/// and can be consumed directly. Blocking a current-thread runtime while this executor submits work
+/// to that runtime will deadlock.
 pub struct DataFusionExecutor {
-    session_ctx: SessionContext,
+    session_context: SessionContext,
     storage_handler: Arc<dyn StorageHandler>,
+    runtime_handle: Handle,
 }
 
 impl DataFusionExecutor {
-    /// Creates an executor that plans and runs scans through `session_ctx`.
+    /// Creates an executor from caller-owned DataFusion, storage, and Tokio resources.
     ///
-    /// The supplied [`SessionContext`] controls scan parallelism and provides the object-store
-    /// registry used by [`ScanParquet`](delta_kernel::plans::ir::nodes::ScanParquet) and
-    /// [`ScanJson`](delta_kernel::plans::ir::nodes::ScanJson). The object store referenced by a
-    /// scan must be registered in that context's runtime environment.
-    pub fn new(session_ctx: SessionContext, storage_handler: Arc<dyn StorageHandler>) -> Self {
+    /// The runtime referenced by `runtime_handle` must remain alive while a query operation is
+    /// executing. Returned iterators do not depend on it.
+    ///
+    /// Returns an executor that uses only these caller-provided resources.
+    pub fn new(
+        session_context: SessionContext,
+        storage_handler: Arc<dyn StorageHandler>,
+        runtime_handle: Handle,
+    ) -> Self {
         Self {
-            session_ctx,
+            session_context,
             storage_handler,
+            runtime_handle,
         }
+    }
+
+    fn execute_query(&self, plan: Plan) -> DeltaResult<PlanResult> {
+        let logical_plan = to_df_plan(&plan).map_err(Error::generic_err)?;
+        let session_state = self.session_context.state();
+        let task_ctx = session_state.task_ctx();
+        let batches = futures::executor::block_on(self.runtime_handle.spawn(async move {
+            let physical_plan = session_state.create_physical_plan(&logical_plan).await?;
+            collect(physical_plan, task_ctx).await
+        }))
+        .map_err(Error::join_failure)?
+        .map_err(Error::generic_err)?;
+
+        let data: DeltaResultIteratorStatic<Box<dyn EngineData>> =
+            Box::new(batches.into_iter().map(|batch| {
+                let batch: RecordBatch = fix_nested_null_masks(batch.into()).into();
+                Ok(Box::new(ArrowEngineData::new(batch)) as Box<dyn EngineData>)
+            }));
+        Ok(PlanResult::Data(data))
+    }
+
+    fn execute_io(&self, op: IoOperation) -> DeltaResult<PlanResult> {
+        match op {
+            IoOperation::FileListing { url } => {
+                // TODO(#2619): Remove this collection when StorageHandler returns Send iterators.
+                let files: Vec<_> = self.storage_handler.list_from(&url)?.collect();
+                Ok(PlanResult::FileMeta(Box::new(files.into_iter())))
+            }
+            IoOperation::ReadBytes { files } => {
+                // TODO(#2619): Remove this collection when StorageHandler returns Send iterators.
+                let bytes: Vec<_> = self.storage_handler.read_files(files)?.collect();
+                Ok(PlanResult::Bytes(Box::new(bytes.into_iter())))
+            }
+            IoOperation::WriteBytes {
+                url,
+                data,
+                overwrite,
+            } => {
+                self.storage_handler.put(&url, data, overwrite)?;
+                Ok(PlanResult::Unit)
+            }
+            IoOperation::HeadFile { url } => {
+                let file = self.storage_handler.head(&url)?;
+                Ok(PlanResult::FileMeta(Box::new(std::iter::once(Ok(file)))))
+            }
+            IoOperation::AtomicCopy {
+                source,
+                destination,
+            } => {
+                self.storage_handler.copy_atomic(&source, &destination)?;
+                Ok(PlanResult::Unit)
+            }
+            IoOperation::ParquetFooter { file } => {
+                let footer = self.read_footer(&file)?;
+                Ok(PlanResult::ParquetFooter(footer))
+            }
+        }
+    }
+
+    fn read_footer(&self, file: &FileMeta) -> DeltaResult<ParquetFooter> {
+        const FOOTER_SIZE: u64 = 8;
+
+        let footer_start = file
+            .size
+            .checked_sub(FOOTER_SIZE)
+            .ok_or_else(|| Error::generic("Parquet file is smaller than its eight-byte footer"))?;
+        let footer_bytes = self.read_range(file, footer_start..file.size)?;
+        let footer_bytes: [u8; FOOTER_SIZE as usize] = footer_bytes
+            .as_ref()
+            .try_into()
+            .map_err(Error::generic_err)?;
+        let footer = FooterTail::try_new(&footer_bytes)?;
+        if footer.is_encrypted_footer() {
+            return Err(Error::unsupported(
+                "encrypted Parquet footers require decryption properties",
+            ));
+        }
+
+        let metadata_length: u64 = footer
+            .metadata_length()
+            .try_into()
+            .map_err(Error::generic_err)?;
+        let metadata_start = footer_start.checked_sub(metadata_length).ok_or_else(|| {
+            Error::generic("Parquet footer metadata length exceeds the file size")
+        })?;
+        let metadata_bytes = self.read_range(file, metadata_start..footer_start)?;
+        let metadata = ParquetMetaDataReader::decode_metadata(&metadata_bytes)?;
+        let options = ArrowReaderOptions::new().with_skip_arrow_metadata(true);
+        let metadata = ArrowReaderMetadata::try_new(Arc::new(metadata), options)?;
+        let schema = Arc::new(metadata.schema().as_ref().try_into_kernel()?);
+        Ok(ParquetFooter { schema })
+    }
+
+    fn read_range(&self, file: &FileMeta, range: Range<u64>) -> DeltaResult<bytes::Bytes> {
+        let expected_length = range
+            .end
+            .checked_sub(range.start)
+            .ok_or_else(|| Error::internal_error("Parquet footer read range is inverted"))?;
+        let mut results = self
+            .storage_handler
+            .read_files(vec![(file.location.clone(), Some(range.clone()))])?;
+        let bytes = results
+            .next()
+            .ok_or_else(|| Error::generic("StorageHandler returned no bytes for a range read"))??;
+        if results.next().is_some() {
+            return Err(Error::generic(
+                "StorageHandler returned multiple results for one range read",
+            ));
+        }
+
+        let actual_length: u64 = bytes.len().try_into().map_err(Error::generic_err)?;
+        if actual_length == expected_length {
+            return Ok(bytes);
+        }
+        if actual_length != file.size {
+            let message = format!(
+                "StorageHandler returned {actual_length} bytes for a range of {expected_length} bytes"
+            );
+            return Err(Error::generic(message));
+        }
+
+        // A handler that cannot issue range requests may return the full file; slice it locally.
+        let start: usize = range.start.try_into().map_err(Error::generic_err)?;
+        let end: usize = range.end.try_into().map_err(Error::generic_err)?;
+        Ok(bytes.slice(start..end))
+    }
+}
+
+impl PlanExecutor for DataFusionExecutor {
+    fn execute_op(&self, op: Operation) -> DeltaResult<PlanResult> {
+        match op {
+            Operation::QueryPlan(plan) => self.execute_query(plan),
+            Operation::IoOperation(op) => self.execute_io(op),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use bytes::Bytes;
+    use datafusion::arrow::array::{Int64Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
+    use datafusion::assert_batches_eq;
+    use datafusion::object_store::memory::InMemory;
+    use datafusion::object_store::path::Path as ObjectPath;
+    use datafusion::object_store::ObjectStoreExt as _;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use delta_kernel::engine::arrow_data::EngineDataArrowExt as _;
+    use delta_kernel::plans::ir::nodes::{ScanFile, ScanParquet, Values};
+    use delta_kernel::plans::ir::plan::{Plan, PlanNode};
+    use delta_kernel::schema::{
+        ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
+    use delta_kernel::{FileSlice, StorageHandler};
+    use rstest::rstest;
+    use url::Url;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestStorage {
+        data: Bytes,
+        return_full_file: bool,
+    }
+
+    impl StorageHandler for TestStorage {
+        fn list_from(
+            &self,
+            _path: &Url,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<FileMeta>>>> {
+            unimplemented!()
+        }
+
+        fn read_files(
+            &self,
+            files: Vec<FileSlice>,
+        ) -> DeltaResult<Box<dyn Iterator<Item = DeltaResult<Bytes>>>> {
+            let mut output = Vec::with_capacity(files.len());
+            for (_, range) in files {
+                let bytes = match (self.return_full_file, range) {
+                    (false, Some(range)) => self.data.slice(
+                        usize::try_from(range.start).unwrap()..usize::try_from(range.end).unwrap(),
+                    ),
+                    _ => self.data.clone(),
+                };
+                output.push(Ok(bytes));
+            }
+            Ok(Box::new(output.into_iter()))
+        }
+
+        fn copy_atomic(&self, _src: &Url, _dest: &Url) -> DeltaResult<()> {
+            unimplemented!()
+        }
+
+        fn put(&self, _path: &Url, _data: Bytes, _overwrite: bool) -> DeltaResult<()> {
+            unimplemented!()
+        }
+
+        fn head(&self, _path: &Url) -> DeltaResult<FileMeta> {
+            unimplemented!()
+        }
+
+        fn delete(&self, _path: &Url) -> DeltaResult<()> {
+            unimplemented!()
+        }
+    }
+
+    fn test_executor(runtime_handle: Handle) -> DataFusionExecutor {
+        DataFusionExecutor::new(
+            SessionContext::new(),
+            Arc::new(TestStorage::default()),
+            runtime_handle,
+        )
+    }
+
+    fn test_file(data: &Bytes) -> FileMeta {
+        FileMeta::new(
+            Url::parse("memory:///test.parquet").unwrap(),
+            0,
+            data.len().try_into().unwrap(),
+        )
+    }
+
+    fn values_plan() -> Plan {
+        let schema = StructType::try_new([StructField::nullable("a", DataType::LONG)]).unwrap();
+        let values = Values::new(schema, vec![vec![1i64.into()], vec![2i64.into()]]);
+        Plan {
+            nodes: vec![PlanNode::new(values, vec![])],
+        }
+    }
+
+    fn parquet_scan_plan(files: impl IntoIterator<Item = FileMeta>) -> Plan {
+        let schema =
+            Arc::new(StructType::try_new([StructField::nullable("id", DataType::LONG)]).unwrap());
+        let scan = ScanParquet {
+            files: files.into_iter().map(ScanFile::new).collect(),
+            file_constant_columns: Vec::new(),
+            schema,
+        };
+        Plan {
+            nodes: vec![PlanNode::new(scan, vec![])],
+        }
+    }
+
+    fn parquet_bytes() -> Bytes {
+        let field = Field::new("id", ArrowDataType::Int64, true).with_metadata(HashMap::from([(
+            "PARQUET:field_id".to_string(),
+            "7".to_string(),
+        )]));
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![Some(1), None]))],
+        )
+        .unwrap();
+        let mut output = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut output, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        Bytes::from(output)
+    }
+
+    async fn assert_query_execution_from_spawn_blocking() {
+        let executor = test_executor(Handle::current());
+        let data = tokio::task::spawn_blocking(move || -> DeltaResult<_> {
+            executor
+                .execute_op(Operation::QueryPlan(values_plan()))?
+                .into_data()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        let batches: Vec<_> = data
+            .map(|batch| batch?.try_into_record_batch())
+            .collect::<DeltaResult<_>>()
+            .unwrap();
+
+        assert_batches_eq!(
+            &["+---+", "| a |", "+---+", "| 1 |", "| 2 |", "+---+"],
+            &batches
+        );
+    }
+
+    #[tokio::test]
+    async fn query_execution_uses_a_current_thread_runtime_from_spawn_blocking() {
+        assert_query_execution_from_spawn_blocking().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn query_execution_uses_a_multi_thread_runtime_from_spawn_blocking() {
+        assert_query_execution_from_spawn_blocking().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn query_execution_observes_later_session_context_registration() {
+        let parquet = parquet_bytes();
+        let store = Arc::new(InMemory::new());
+        let locations = ["first.parquet", "second.parquet"];
+        for location in locations {
+            store
+                .put(&ObjectPath::from(location), parquet.clone().into())
+                .await
+                .unwrap();
+        }
+
+        let session = SessionContext::new();
+        let executor = DataFusionExecutor::new(
+            session.clone(),
+            Arc::new(TestStorage::default()),
+            Handle::current(),
+        );
+        session.register_object_store(&Url::parse("memory:///").unwrap(), store);
+
+        let size = parquet.len().try_into().unwrap();
+        let files = locations.map(|location| {
+            FileMeta::new(
+                Url::parse(&format!("memory:///{location}")).unwrap(),
+                0,
+                size,
+            )
+        });
+        let batches = tokio::task::spawn_blocking(move || -> DeltaResult<Vec<RecordBatch>> {
+            executor
+                .execute_op(Operation::QueryPlan(parquet_scan_plan(files)))?
+                .into_data()?
+                .map(|batch| batch?.try_into_record_batch())
+                .collect()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 4);
+    }
+
+    #[test]
+    fn stopped_runtime_returns_an_error() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let executor = test_executor(runtime.handle().clone());
+        drop(runtime);
+
+        let error = executor
+            .execute_op(Operation::QueryPlan(values_plan()))
+            .err()
+            .unwrap();
+
+        assert!(matches!(error, Error::JoinFailure(_)), "{error}");
+    }
+
+    #[rstest]
+    #[case::range_responses(false)]
+    #[case::whole_file_responses(true)]
+    fn parquet_footer_uses_storage_ranges_and_preserves_field_ids(#[case] return_full_file: bool) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let data = parquet_bytes();
+        let file = test_file(&data);
+        let executor = DataFusionExecutor::new(
+            SessionContext::new(),
+            Arc::new(TestStorage {
+                data,
+                return_full_file,
+            }),
+            runtime.handle().clone(),
+        );
+        let footer = executor.read_footer(&file).unwrap();
+
+        let field = footer.schema.field("id").unwrap();
+        assert_eq!(
+            field.get_config_value(&ColumnMetadataKey::ParquetFieldId),
+            Some(&MetadataValue::Number(7))
+        );
+    }
+
+    #[test]
+    fn parquet_footer_rejects_files_smaller_than_the_tail() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let data = Bytes::from_static(b"PAR1");
+        let file = test_file(&data);
+        let executor = test_executor(runtime.handle().clone());
+
+        let error = executor.read_footer(&file).unwrap_err();
+
+        assert!(error.to_string().contains("smaller"), "{error}");
     }
 }

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -15,9 +15,11 @@ use delta_kernel::StorageHandler;
 
 mod expression;
 mod operator;
+mod parquet_expr_adapter;
 mod plan;
 mod predicate;
 mod scalar;
+mod scan;
 mod utils;
 
 pub use expression::to_df_expr;
@@ -45,9 +47,15 @@ pub struct DataFusionExecutor {
 }
 
 impl DataFusionExecutor {
-    pub fn new(storage_handler: Arc<dyn StorageHandler>) -> Self {
+    /// Creates an executor that plans and runs scans through `session_ctx`.
+    ///
+    /// The supplied [`SessionContext`] controls scan parallelism and provides the object-store
+    /// registry used by [`ScanParquet`](delta_kernel::plans::ir::nodes::ScanParquet) and
+    /// [`ScanJson`](delta_kernel::plans::ir::nodes::ScanJson). The object store referenced by a
+    /// scan must be registered in that context's runtime environment.
+    pub fn new(session_ctx: SessionContext, storage_handler: Arc<dyn StorageHandler>) -> Self {
         Self {
-            session_ctx: SessionContext::new(),
+            session_ctx,
             storage_handler,
         }
     }

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -33,6 +33,7 @@ use delta_kernel::schema::{StructField, StructType};
 use crate::expression::to_df_struct_columns;
 use crate::predicate::to_df_predicate_expr;
 use crate::scalar::to_df_scalar;
+use crate::scan::{lower_json_scan, lower_parquet_scan};
 use crate::utils::column_to_df_expr;
 
 /// Lowers one kernel [`Operator`](KernelOperator) over its already-lowered inputs.
@@ -82,8 +83,19 @@ pub(crate) fn lower_operator(
             lower_semi_join(semi_join, probe, build)
         }
         KernelOperator::UnionAll(union_all) => lower_union_all(union_all, inputs),
-        // TODO: lower the remaining operators (scans and Load), each in its own change.
-        _ => Err(DataFusionError::NotImplemented(format!(
+        KernelOperator::ScanParquet(scan) => {
+            let [] = inputs else {
+                return Err(input_count_error(0));
+            };
+            lower_parquet_scan(scan)
+        }
+        KernelOperator::ScanJson(scan) => {
+            let [] = inputs else {
+                return Err(input_count_error(0));
+            };
+            lower_json_scan(scan)
+        }
+        KernelOperator::DynamicScan(_) => Err(DataFusionError::NotImplemented(format!(
             "lowering operator {op} to a DataFusion LogicalPlan"
         ))),
     }

--- a/datafusion-executor/src/parquet_expr_adapter.rs
+++ b/datafusion-executor/src/parquet_expr_adapter.rs
@@ -157,6 +157,8 @@ fn align_nullable_data_types(kernel_type: &DataType, physical_type: &DataType) -
             let field = align_nullable_field(kernel_field, physical_field, data_type);
             DataType::Map(field, *physical_keys_sorted)
         }
+        // Only align nullability for matching container shapes. Preserve other type differences so
+        // DataFusion can cast compatible types or reject incompatible ones.
         _ => physical_type.clone(),
     }
 }

--- a/datafusion-executor/src/parquet_expr_adapter.rs
+++ b/datafusion-executor/src/parquet_expr_adapter.rs
@@ -1,0 +1,637 @@
+//! Parquet adaptation for legacy checkpoints whose nested fields have weaker nullability than the
+//! schema requested by kernel.
+
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, AsArray, ListArray, MapArray, StructArray};
+use datafusion::arrow::datatypes::{DataType, FieldRef, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
+use datafusion::common::{exec_err, internal_err, Result as DataFusionResult};
+use datafusion::logical_expr::ColumnarValue;
+use datafusion::physical_expr::expressions::Column as DFColumn;
+use datafusion::physical_expr_adapter::{
+    DefaultPhysicalExprAdapter, PhysicalExprAdapter, PhysicalExprAdapterFactory,
+};
+use datafusion::physical_expr_common::physical_expr::PhysicalExpr;
+
+/// Creates [`PhysicalExprAdapter`]s that reconcile a checkpoint's physical Parquet schema with
+/// the schema requested by a kernel scan.
+///
+/// DataFusion calls this factory after reading each file's physical schema, since files in the
+/// same scan may have different schemas.
+///
+/// Each adapter delegates ordinary schema evolution to DataFusion and additionally validates
+/// required nested fields that legacy checkpoint schemas mark nullable.
+#[derive(Debug)]
+pub(crate) struct KernelParquetExprAdapterFactory;
+
+impl PhysicalExprAdapterFactory for KernelParquetExprAdapterFactory {
+    fn create(
+        &self,
+        kernel_schema: SchemaRef,
+        physical_file_schema: SchemaRef,
+    ) -> DataFusionResult<Arc<dyn PhysicalExprAdapter>> {
+        let aligned_physical_schema = Arc::new(align_nested_nullability(
+            &kernel_schema,
+            &physical_file_schema,
+        ));
+        let default_adapter =
+            DefaultPhysicalExprAdapter::new(kernel_schema, Arc::clone(&aligned_physical_schema));
+        let adapter = KernelParquetExprAdapter {
+            default_adapter,
+            physical_file_schema,
+            aligned_physical_schema,
+        };
+        Ok(Arc::new(adapter))
+    }
+}
+
+#[derive(Debug)]
+struct KernelParquetExprAdapter {
+    default_adapter: DefaultPhysicalExprAdapter,
+    physical_file_schema: SchemaRef,
+    aligned_physical_schema: SchemaRef,
+}
+
+// DataFusion's default adapter handles ordinary schema evolution. It compares each Kernel field
+// with the physical field and adds a cast when they differ. Consider this column:
+//
+//   physical: action?: struct<required?: i32>
+//   aligned:  action?: struct<required: i32>
+//   Kernel:   action?: struct<required: i64, added?: utf8>
+//
+// Given the raw physical schema, the default adapter rejects nullable `required?` -> required
+// `required` during rewriting, without checking whether the array actually contains nulls. We
+// instead give the default adapter the aligned schema before inserting reconciliation.
+//
+// Alignment changes only nested nullability; it leaves `required` as i32 and leaves `added`
+// missing. The default adapter can then add a cast for the remaining conversion: widening i32 to
+// i64 and filling `added` with nulls.
+//
+//   column(action) -> cast(column(action) to Kernel's action type)
+//
+// Passing the aligned schema does not change the actual Parquet array read by `column(action)`.
+//
+// After the default rewrite, our bottom-up pass replaces that column with reconciliation:
+//
+//   cast(column(action))
+//     -> cast(reconcile_kernel_nullability(column(action)))
+//
+// At execution, the child expression runs first. Reconciliation rebuilds the physical array with
+// the aligned type and verifies that `required` contains no unmasked nulls. The cast then performs
+// the remaining conversion to Kernel's type. If nullability is the only difference, the default
+// adapter adds no cast and the final expression is just reconciliation around the column.
+impl PhysicalExprAdapter for KernelParquetExprAdapter {
+    fn rewrite(&self, expr: Arc<dyn PhysicalExpr>) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let adapted = self.default_adapter.rewrite(expr)?;
+        let reconcile_column = |expr: Arc<dyn PhysicalExpr>| {
+            let Some(column): Option<&DFColumn> = expr.downcast_ref() else {
+                return Ok(Transformed::no(expr));
+            };
+            let index = self.physical_file_schema.index_of(column.name())?;
+            let physical_field = self.physical_file_schema.field(index);
+            let aligned_field = self.aligned_physical_schema.field(index);
+            if physical_field.data_type() == aligned_field.data_type() {
+                return Ok(Transformed::no(expr));
+            }
+
+            let reconciled: Arc<dyn PhysicalExpr> = Arc::new(ReconcileKernelNullabilityExpr {
+                expr,
+                field: Arc::new(aligned_field.clone()),
+            });
+            Ok(Transformed::yes(reconciled))
+        };
+        adapted.transform_up(reconcile_column).data()
+    }
+}
+
+/// Builds an intermediate physical schema with Kernel's required nested fields.
+///
+/// The intermediate schema starts from the physical schema and changes only nullable flags on
+/// matched nested fields. Names, metadata, primitive types, absent fields, and top-level
+/// nullability stay as declared by the file. DataFusion performs all other conversions to the
+/// requested Kernel schema.
+fn align_nested_nullability(kernel_schema: &Schema, physical_schema: &Schema) -> Schema {
+    let mut aligned_fields = Vec::with_capacity(physical_schema.fields().len());
+    for physical_field in physical_schema.fields() {
+        let Some((_, kernel_field)) = kernel_schema.fields().find(physical_field.name()) else {
+            aligned_fields.push(Arc::clone(physical_field));
+            continue;
+        };
+        let data_type =
+            align_nullable_data_types(kernel_field.data_type(), physical_field.data_type());
+        aligned_fields.push(Arc::new(
+            physical_field.as_ref().clone().with_data_type(data_type),
+        ));
+    }
+    Schema::new_with_metadata(aligned_fields, physical_schema.metadata().clone())
+}
+
+fn align_nullable_data_types(kernel_type: &DataType, physical_type: &DataType) -> DataType {
+    match (kernel_type, physical_type) {
+        (DataType::Struct(kernel_fields), DataType::Struct(physical_fields)) => {
+            let mut aligned_fields = Vec::with_capacity(physical_fields.len());
+            for physical_field in physical_fields {
+                let Some((_, kernel_field)) = kernel_fields.find(physical_field.name()) else {
+                    aligned_fields.push(Arc::clone(physical_field));
+                    continue;
+                };
+                let data_type =
+                    align_nullable_data_types(kernel_field.data_type(), physical_field.data_type());
+                let field = align_nullable_field(kernel_field, physical_field, data_type);
+                aligned_fields.push(field);
+            }
+            DataType::Struct(aligned_fields.into())
+        }
+        (DataType::List(kernel_field), DataType::List(physical_field)) => {
+            let data_type =
+                align_nullable_data_types(kernel_field.data_type(), physical_field.data_type());
+            let field = align_nullable_field(kernel_field, physical_field, data_type);
+            DataType::List(field)
+        }
+        (DataType::Map(kernel_field, _), DataType::Map(physical_field, physical_keys_sorted)) => {
+            let data_type =
+                align_nullable_data_types(kernel_field.data_type(), physical_field.data_type());
+            let field = align_nullable_field(kernel_field, physical_field, data_type);
+            DataType::Map(field, *physical_keys_sorted)
+        }
+        _ => physical_type.clone(),
+    }
+}
+
+fn align_nullable_field(
+    kernel_field: &FieldRef,
+    physical_field: &FieldRef,
+    data_type: DataType,
+) -> FieldRef {
+    // A field is required if either schema marks it required. This normally tightens a nullable
+    // physical field to match Kernel, while also preserving requirements declared by the file.
+    let is_nullable = physical_field.is_nullable() && kernel_field.is_nullable();
+    let field = physical_field
+        .as_ref()
+        .clone()
+        .with_data_type(data_type)
+        .with_nullable(is_nullable);
+    Arc::new(field)
+}
+
+/// Reconciles nested fields with Kernel's schema after verifying their values satisfy the tighter
+/// nullability.
+///
+/// DataFusion's cast expression rejects nullable-to-non-nullable nested fields from schema
+/// metadata alone. This expression defers that decision to Arrow's array constructors, which
+/// validate the actual values.
+#[derive(Debug, Eq)]
+struct ReconcileKernelNullabilityExpr {
+    expr: Arc<dyn PhysicalExpr>,
+    field: FieldRef,
+}
+
+impl PartialEq for ReconcileKernelNullabilityExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr.eq(&other.expr) && self.field == other.field
+    }
+}
+
+impl Hash for ReconcileKernelNullabilityExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.expr.hash(state);
+        self.field.hash(state);
+    }
+}
+
+impl std::fmt::Display for ReconcileKernelNullabilityExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "reconcile_kernel_nullability({})", self.expr)
+    }
+}
+
+// DataFusion calls this implementation to evaluate the inserted reconciliation expr against each
+// physical record batch.
+impl PhysicalExpr for ReconcileKernelNullabilityExpr {
+    fn evaluate(&self, batch: &RecordBatch) -> DataFusionResult<ColumnarValue> {
+        let ColumnarValue::Array(array) = self.expr.evaluate(batch)? else {
+            return exec_err!("Kernel nullability reconciliation requires an array value");
+        };
+        reconcile_array_nullability(&array, self.field.data_type()).map(ColumnarValue::Array)
+    }
+
+    fn return_field(&self, _input_schema: &Schema) -> DataFusionResult<FieldRef> {
+        Ok(Arc::clone(&self.field))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![&self.expr]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DataFusionResult<Arc<dyn PhysicalExpr>> {
+        let [expr] = children.as_slice() else {
+            return internal_err!(
+                "ReconcileKernelNullabilityExpr expected one child, got {}",
+                children.len()
+            );
+        };
+        let reconciled = Self {
+            expr: Arc::clone(expr),
+            field: Arc::clone(&self.field),
+        };
+        Ok(Arc::new(reconciled))
+    }
+
+    fn fmt_sql(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "reconcile_kernel_nullability(")?;
+        self.expr.fmt_sql(f)?;
+        write!(f, ")")
+    }
+}
+
+// Recursively rebuild nested Struct, List, and Map arrays. Their constructors verify that fields
+// being marked non-nullable contain no unmasked nulls.
+fn reconcile_array_nullability(
+    array: &ArrayRef,
+    target_type: &DataType,
+) -> DataFusionResult<ArrayRef> {
+    if array.data_type() == target_type {
+        return Ok(Arc::clone(array));
+    }
+
+    match target_type {
+        DataType::Struct(target_fields) => {
+            let Some(source) = array.as_struct_opt() else {
+                return exec_err!("Arrow struct downcast failed");
+            };
+            if source.num_columns() != target_fields.len() {
+                return exec_err!(
+                    "Cannot reconcile struct with {} fields as struct with {} fields",
+                    source.num_columns(),
+                    target_fields.len()
+                );
+            }
+
+            let mut columns = Vec::with_capacity(source.num_columns());
+            for (column, field) in source.columns().iter().zip(target_fields) {
+                columns.push(reconcile_array_nullability(column, field.data_type())?);
+            }
+            let reconciled =
+                StructArray::try_new(target_fields.clone(), columns, source.nulls().cloned())?;
+            Ok(Arc::new(reconciled))
+        }
+        DataType::List(target_field) => {
+            let Some(source) = array.as_list_opt::<i32>() else {
+                return exec_err!("Arrow list downcast failed");
+            };
+            let values = reconcile_array_nullability(source.values(), target_field.data_type())?;
+            let reconciled = ListArray::try_new(
+                Arc::clone(target_field),
+                source.offsets().clone(),
+                values,
+                source.nulls().cloned(),
+            )?;
+            Ok(Arc::new(reconciled))
+        }
+        DataType::Map(target_field, keys_sorted) => {
+            let Some(source) = array.as_map_opt() else {
+                return exec_err!("Arrow map downcast failed");
+            };
+            let entries: ArrayRef = Arc::new(source.entries().clone());
+            let entries = reconcile_array_nullability(&entries, target_field.data_type())?;
+            let Some(entries) = entries.as_struct_opt() else {
+                return exec_err!("Arrow map entries downcast failed");
+            };
+            let reconciled = MapArray::try_new(
+                Arc::clone(target_field),
+                source.offsets().clone(),
+                entries.clone(),
+                source.nulls().cloned(),
+                *keys_sorted,
+            )?;
+            Ok(Arc::new(reconciled))
+        }
+        _ => exec_err!(
+            "Cannot reconcile Parquet nullability from {} to {target_type}",
+            array.data_type()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Int32Array, Int64Array, StringArray};
+    use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer};
+    use datafusion::arrow::datatypes::{Field, Fields};
+    use datafusion::physical_expr::expressions::CastExpr;
+
+    use super::*;
+
+    // === Tests ===
+
+    // A `?` after a field name marks that field nullable in the schema summaries below.
+
+    // Physical:
+    //   action?: struct<
+    //     required?: i32,
+    //     nested?: struct<required?: i32>,
+    //     items?: list<item?: i32>,
+    //     properties?: map<entries: struct<key: utf8, value?: i32>>
+    //   >
+    // Requested Kernel:
+    //   action?: struct<
+    //     required: i32,
+    //     nested?: struct<required: i32>,
+    //     items?: list<element: i32>,
+    //     properties?: map<key_value: struct<key: utf8, value: i32>>
+    //   >
+    // Expected:
+    //   action?: struct<
+    //     required: i32,
+    //     nested?: struct<required: i32>,
+    //     items?: list<item: i32>,
+    //     properties?: map<entries: struct<key: utf8, value: i32>>
+    //   >
+    #[test]
+    fn alignment_tightens_nested_fields() {
+        let kernel = Schema::new(vec![Field::new_struct(
+            "action",
+            vec![
+                Field::new("required", DataType::Int32, false),
+                Field::new_struct(
+                    "nested",
+                    vec![Field::new("required", DataType::Int32, false)],
+                    true,
+                ),
+                Field::new(
+                    "items",
+                    DataType::List(Arc::new(Field::new("element", DataType::Int32, false))),
+                    true,
+                ),
+                Field::new("properties", map_data_type("key_value", false), true),
+            ],
+            true,
+        )]);
+        let physical = Schema::new(vec![Field::new_struct(
+            "action",
+            vec![
+                Field::new("required", DataType::Int32, true),
+                Field::new_struct(
+                    "nested",
+                    vec![Field::new("required", DataType::Int32, true)],
+                    true,
+                ),
+                Field::new(
+                    "items",
+                    DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+                    true,
+                ),
+                Field::new("properties", map_data_type("entries", true), true),
+            ],
+            true,
+        )]);
+
+        let aligned = align_nested_nullability(&kernel, &physical);
+
+        let DataType::Struct(fields) = aligned.field(0).data_type() else {
+            panic!("expected a struct")
+        };
+        assert!(!fields[0].is_nullable());
+        let DataType::Struct(nested_fields) = fields[1].data_type() else {
+            panic!("expected a nested struct")
+        };
+        assert!(!nested_fields[0].is_nullable());
+        let DataType::List(element) = fields[2].data_type() else {
+            panic!("expected a list")
+        };
+        assert_eq!(element.name(), "item");
+        assert!(!element.is_nullable());
+        let DataType::Map(entries, _) = fields[3].data_type() else {
+            panic!("expected a map")
+        };
+        assert_eq!(entries.name(), "entries");
+        let DataType::Struct(entry_fields) = entries.data_type() else {
+            panic!("expected map entries")
+        };
+        assert!(!entry_fields.find("value").unwrap().1.is_nullable());
+    }
+
+    // Physical: struct<nested?: struct<child?: i32>>
+    // Requested Kernel: struct<nested?: struct<child: i32>>
+    // Expected: struct<nested?: struct<child: i32>>, or an error for an unmasked null child.
+    #[test]
+    fn reconciling_nested_required_child_checks_parent_validity() {
+        let source_children: Fields = vec![Field::new("child", DataType::Int32, true)].into();
+        let source_fields: Fields =
+            vec![Field::new_struct("nested", source_children.clone(), true)].into();
+        let target_children: Fields = vec![Field::new("child", DataType::Int32, false)].into();
+        let target_type =
+            DataType::Struct(vec![Field::new_struct("nested", target_children, true)].into());
+        let nested = |nulls| -> ArrayRef {
+            let child: ArrayRef = Arc::new(Int32Array::from(vec![None]));
+            let nested = StructArray::try_new(source_children.clone(), vec![child], nulls).unwrap();
+            Arc::new(nested)
+        };
+        let outer = |nested| -> ArrayRef {
+            let outer = StructArray::try_new(source_fields.clone(), vec![nested], None).unwrap();
+            Arc::new(outer)
+        };
+
+        let masked = outer(nested(Some(NullBuffer::from(vec![false]))));
+        let _ = reconcile_array_nullability(&masked, &target_type).unwrap();
+
+        let unmasked = outer(nested(None));
+        let error = reconcile_array_nullability(&unmasked, &target_type).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains(r#"Found unmasked nulls for non-nullable StructArray field "child""#),
+            "{error}"
+        );
+    }
+
+    // Physical: list<item?: i32>
+    // Requested Kernel: list<item: i32>
+    // Expected: list<item: i32>, or an error if an item is null.
+    #[test]
+    fn reconciling_required_list_elements_checks_values() {
+        let list = |values: Vec<Option<i32>>| -> ArrayRef {
+            let len = values.len() as i32;
+            let values: ArrayRef = Arc::new(Int32Array::from(values));
+            let field = Arc::new(Field::new("item", DataType::Int32, true));
+            Arc::new(
+                ListArray::try_new(field, OffsetBuffer::new(vec![0, len].into()), values, None)
+                    .unwrap(),
+            )
+        };
+        let target_type = DataType::List(Arc::new(Field::new("item", DataType::Int32, false)));
+
+        let valid = list(vec![Some(1), Some(2)]);
+        let reconciled = reconcile_array_nullability(&valid, &target_type).unwrap();
+        assert_eq!(reconciled.data_type(), &target_type);
+
+        let invalid = list(vec![Some(1), None]);
+        let error = reconcile_array_nullability(&invalid, &target_type).unwrap_err();
+        assert!(
+            error.to_string().contains("cannot contain nulls"),
+            "{error}"
+        );
+    }
+
+    // Physical: map<entries: struct<key: utf8, value?: i32>, keys_sorted=false>
+    // Requested Kernel: map<entries: struct<key: utf8, value: i32>, keys_sorted=false>
+    // Expected:
+    //   map<entries: struct<key: utf8, value: i32>, keys_sorted=false>,
+    //   or an error if a value is null.
+    #[test]
+    fn reconciling_required_map_values_checks_values() {
+        let map = |values: Vec<Option<i32>>| -> ArrayRef {
+            let len = values.len();
+            let fields: Fields = vec![
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Int32, true),
+            ]
+            .into();
+            let keys: ArrayRef = Arc::new(StringArray::from_iter_values(
+                (0..len).map(|index| index.to_string()),
+            ));
+            let values: ArrayRef = Arc::new(Int32Array::from(values));
+            let entries = StructArray::try_new(fields.clone(), vec![keys, values], None).unwrap();
+            let entries_field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+            Arc::new(
+                MapArray::try_new(
+                    entries_field,
+                    OffsetBuffer::new(vec![0, len as i32].into()),
+                    entries,
+                    None,
+                    false,
+                )
+                .unwrap(),
+            )
+        };
+        let target_type = map_data_type("entries", false);
+
+        let valid = map(vec![Some(1), Some(2)]);
+        let reconciled = reconcile_array_nullability(&valid, &target_type).unwrap();
+        assert_eq!(reconciled.data_type(), &target_type);
+
+        let invalid = map(vec![Some(1), None]);
+        let error = reconcile_array_nullability(&invalid, &target_type).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains(r#"Found unmasked nulls for non-nullable StructArray field "value""#),
+            "{error}"
+        );
+    }
+
+    // Physical: action?: struct<required?: i32>
+    // Requested Kernel: action?: struct<required: i64, added?: utf8>
+    // Expected: an error because reconcile(cast(column)) executes the cast first.
+    #[test]
+    fn reconciling_before_default_rewrite_places_cast_inside_reconciliation() {
+        let (kernel_schema, physical_schema, batch) = schema_evolution_case();
+        let aligned_schema = Arc::new(align_nested_nullability(&kernel_schema, &physical_schema));
+        let column: Arc<dyn PhysicalExpr> = Arc::new(DFColumn::new("action", 0));
+        let reconciled: Arc<dyn PhysicalExpr> = Arc::new(ReconcileKernelNullabilityExpr {
+            expr: column,
+            field: Arc::clone(&aligned_schema.fields()[0]),
+        });
+
+        let adapted =
+            DefaultPhysicalExprAdapter::new(kernel_schema, aligned_schema).rewrite(reconciled);
+        let adapted = adapted.unwrap();
+
+        let reconciliation = adapted
+            .downcast_ref::<ReconcileKernelNullabilityExpr>()
+            .expect("reconciliation should remain outside the rewritten child");
+        assert!(reconciliation.expr.downcast_ref::<CastExpr>().is_some());
+        let error = adapted.evaluate(&batch).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Cannot cast nullable struct field 'required' to non-nullable field"),
+            "{error}"
+        );
+    }
+
+    // Physical: action?: struct<required?: i32>
+    // Requested Kernel: action?: struct<required: i64, added?: utf8>
+    // Expected: action?: struct<required: i64, added?: utf8>, with added filled with nulls.
+    #[test]
+    fn default_rewrite_preserves_type_casts_and_fills_missing_fields() {
+        let (kernel_schema, physical_schema, batch) = schema_evolution_case();
+        let adapter = KernelParquetExprAdapterFactory
+            .create(Arc::clone(&kernel_schema), physical_schema)
+            .unwrap();
+        let column: Arc<dyn PhysicalExpr> = Arc::new(DFColumn::new("action", 0));
+
+        let adapted = adapter.rewrite(column).unwrap();
+
+        let cast = adapted
+            .downcast_ref::<CastExpr>()
+            .expect("default rewrite should add a cast");
+        let reconciliation = cast
+            .expr()
+            .downcast_ref::<ReconcileKernelNullabilityExpr>()
+            .expect("reconciliation should run before the cast");
+        let ColumnarValue::Array(reconciled_only) = reconciliation.evaluate(&batch).unwrap() else {
+            panic!("expected an array")
+        };
+        let reconciled_action = reconciled_only.as_struct();
+        assert_eq!(reconciled_action.num_columns(), 1);
+        assert!(reconciled_action.column(0).as_any().is::<Int32Array>());
+        assert!(reconciled_action.column_by_name("added").is_none());
+
+        let ColumnarValue::Array(array) = adapted.evaluate(&batch).unwrap() else {
+            panic!("expected an array")
+        };
+        assert_eq!(array.data_type(), kernel_schema.field(0).data_type());
+        let action = array.as_struct();
+        let required = action
+            .column_by_name("required")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(required.values().as_ref(), &[1, 2]);
+        assert_eq!(action.column_by_name("added").unwrap().null_count(), 2);
+    }
+
+    fn schema_evolution_case() -> (SchemaRef, SchemaRef, RecordBatch) {
+        let physical_fields: Fields = vec![Field::new("required", DataType::Int32, true)].into();
+        let kernel_fields: Fields = vec![
+            Field::new("required", DataType::Int64, false),
+            Field::new("added", DataType::Utf8, true),
+        ]
+        .into();
+        let physical_schema = Arc::new(Schema::new(vec![Field::new_struct(
+            "action",
+            physical_fields.clone(),
+            true,
+        )]));
+        let kernel_schema = Arc::new(Schema::new(vec![Field::new_struct(
+            "action",
+            kernel_fields,
+            true,
+        )]));
+        let required: ArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
+        let action: ArrayRef =
+            Arc::new(StructArray::try_new(physical_fields, vec![required], None).unwrap());
+        let batch = RecordBatch::try_new(Arc::clone(&physical_schema), vec![action]).unwrap();
+        (kernel_schema, physical_schema, batch)
+    }
+
+    fn map_data_type(entries_name: &str, value_nullable: bool) -> DataType {
+        let fields: Fields = vec![
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Int32, value_nullable),
+        ]
+        .into();
+        DataType::Map(
+            Arc::new(Field::new(entries_name, DataType::Struct(fields), false)),
+            false,
+        )
+    }
+}

--- a/datafusion-executor/src/scan.rs
+++ b/datafusion-executor/src/scan.rs
@@ -1,0 +1,897 @@
+//! Static-file scan lowering and physical planning.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{
+    DataType as ArrowDataType, FieldRef as ArrowFieldRef, Schema as ArrowSchema,
+    SchemaRef as ArrowSchemaRef,
+};
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::common::DataFusionError;
+use datafusion::datasource::listing::{ListingTableUrl, PartitionedFile};
+use datafusion::datasource::physical_plan::{
+    FileGroup, FileScanConfigBuilder, FileSource, JsonSource, ParquetSource,
+};
+use datafusion::datasource::source::DataSourceExec;
+use datafusion::datasource::table_schema::TableSchema;
+use datafusion::datasource::DefaultTableSource;
+use datafusion::execution::object_store::ObjectStoreUrl;
+use datafusion::logical_expr::{
+    Expr as DFExpr, LogicalPlan as DFLogicalPlan, LogicalPlanBuilder, TableType,
+};
+use datafusion::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+use datafusion::physical_expr_adapter::PhysicalExprAdapterFactory;
+use datafusion::physical_plan::empty::EmptyExec;
+use datafusion::physical_plan::ExecutionPlan;
+use delta_kernel::engine::arrow_conversion::TryIntoArrow;
+use delta_kernel::plans::ir::nodes::{
+    ScanFile as KernelScanFile, ScanJson as KernelScanJson, ScanParquet as KernelScanParquet,
+};
+use delta_kernel::schema::StructType as KernelStructType;
+use itertools::Itertools;
+
+use crate::parquet_expr_adapter::KernelParquetExprAdapterFactory;
+use crate::scalar::to_df_scalar;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ScanFormat {
+    Parquet,
+    Json,
+}
+
+struct StaticFileProvider {
+    file_source: Arc<dyn FileSource>,
+    expr_adapter: Option<Arc<dyn PhysicalExprAdapterFactory>>,
+    store_url: Option<ObjectStoreUrl>,
+    files: Vec<PartitionedFile>,
+}
+
+impl std::fmt::Debug for StaticFileProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticFileProvider")
+            .field("file_type", &self.file_source.file_type())
+            .field("expr_adapter", &self.expr_adapter)
+            .field("store_url", &self.store_url)
+            .field("files", &self.files)
+            .finish()
+    }
+}
+
+/// Lowers a kernel [`ScanParquet`](KernelScanParquet) into a DataFusion
+/// [`LogicalPlan`](DFLogicalPlan) that reads exactly the files named by the scan node.
+///
+/// The physical scan uses [`KernelParquetExprAdapterFactory`] to reconcile each checkpoint's
+/// physical schema with the schema requested by kernel.
+///
+/// # Errors
+/// Returns an error if the schema or file locations cannot be represented by DataFusion.
+pub(crate) fn lower_parquet_scan(
+    scan: &KernelScanParquet,
+) -> Result<DFLogicalPlan, DataFusionError> {
+    lower_scan(
+        ScanFormat::Parquet,
+        &scan.files,
+        &scan.file_constant_columns,
+        scan.schema.as_ref(),
+    )
+}
+
+/// Lowers a kernel [`ScanJson`](KernelScanJson) into a DataFusion [`LogicalPlan`](DFLogicalPlan)
+/// that reads exactly the files named by the scan node.
+///
+/// # Errors
+/// Returns an error if the schema or file locations cannot be represented by DataFusion.
+pub(crate) fn lower_json_scan(scan: &KernelScanJson) -> Result<DFLogicalPlan, DataFusionError> {
+    lower_scan(
+        ScanFormat::Json,
+        &scan.files,
+        &scan.file_constant_columns,
+        scan.schema.as_ref(),
+    )
+}
+
+fn lower_scan(
+    format: ScanFormat,
+    files: &[KernelScanFile],
+    file_constant_columns: &[String],
+    schema: &KernelStructType,
+) -> Result<DFLogicalPlan, DataFusionError> {
+    let output_schema: ArrowSchemaRef = Arc::new(schema.try_into_arrow()?);
+    validate_scan_schema(format, schema, &output_schema)?;
+
+    let (table_schema, projection) =
+        build_scan_table_schema_and_projection(&output_schema, file_constant_columns);
+    let (store_url, files) = scan_files(files)?;
+    let file_source: Arc<dyn FileSource> = match format {
+        ScanFormat::Parquet => Arc::new(ParquetSource::new(table_schema)),
+        ScanFormat::Json => Arc::new(JsonSource::new(table_schema)),
+    };
+    let expr_adapter = (format == ScanFormat::Parquet)
+        .then(|| Arc::new(KernelParquetExprAdapterFactory) as Arc<dyn PhysicalExprAdapterFactory>);
+    let provider = StaticFileProvider {
+        file_source,
+        expr_adapter,
+        store_url,
+        files,
+    };
+    let source = Arc::new(DefaultTableSource::new(Arc::new(provider)));
+    let table_name = match format {
+        ScanFormat::Parquet => "scan_parquet",
+        ScanFormat::Json => "scan_json",
+    };
+    LogicalPlanBuilder::scan(table_name, source, Some(projection))?.build()
+}
+
+// TODO(#3167): support metadata columns and Parquet field-ID resolution.
+fn validate_scan_schema(
+    format: ScanFormat,
+    schema: &KernelStructType,
+    output_schema: &ArrowSchemaRef,
+) -> Result<(), DataFusionError> {
+    if let Some(field) = schema.metadata_columns().next() {
+        return Err(DataFusionError::NotImplemented(format!(
+            "scan metadata column `{}` is not supported by the DataFusion executor",
+            field.name()
+        )));
+    }
+    if format == ScanFormat::Parquet {
+        if let Some(field_name) = parquet_field_id_name(output_schema.fields()) {
+            return Err(DataFusionError::NotImplemented(format!(
+                "Parquet field-ID resolution for `{}` is not supported by the DataFusion executor",
+                field_name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn parquet_field_id_name(fields: &[ArrowFieldRef]) -> Option<String> {
+    fields.iter().find_map(|field| {
+        if field.metadata().contains_key(PARQUET_FIELD_ID_META_KEY) {
+            return Some(field.name().clone());
+        }
+
+        match field.data_type() {
+            ArrowDataType::Struct(fields) => parquet_field_id_name(fields),
+            ArrowDataType::List(field)
+            | ArrowDataType::LargeList(field)
+            | ArrowDataType::FixedSizeList(field, _)
+            | ArrowDataType::ListView(field)
+            | ArrowDataType::LargeListView(field)
+            | ArrowDataType::Map(field, _) => parquet_field_id_name(std::slice::from_ref(field)),
+            _ => None,
+        }
+    })
+}
+
+#[async_trait]
+impl TableProvider for StaticFileProvider {
+    fn schema(&self) -> ArrowSchemaRef {
+        Arc::clone(self.file_source.table_schema().table_schema())
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[DFExpr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        let Some(store_url) = &self.store_url else {
+            let schema = match projection {
+                Some(projection) => Arc::new(self.schema().project(projection)?),
+                None => self.schema(),
+            };
+            return Ok(Arc::new(EmptyExec::new(schema)));
+        };
+
+        // A single initial group lets DataFusion's physical optimizer choose file and
+        // Parquet row-group splits from the caller's target-partition configuration.
+        let config = FileScanConfigBuilder::new(store_url.clone(), Arc::clone(&self.file_source))
+            .with_file_group(FileGroup::new(self.files.clone()))
+            .with_projection_indices(projection.cloned())?
+            .with_expr_adapter(self.expr_adapter.clone())
+            .with_limit(limit)
+            .with_partitioned_by_file_group(false)
+            .build();
+        Ok(DataSourceExec::from_data_source(config))
+    }
+}
+
+/// Builds DataFusion's file-first table schema and a projection back to kernel output order.
+fn build_scan_table_schema_and_projection(
+    output_schema: &ArrowSchemaRef,
+    file_constant_columns: &[String],
+) -> (TableSchema, Vec<usize>) {
+    // DataFusion models per-file constants as partition columns appended after physical file
+    // columns. The table-scan projection restores the kernel schema's arbitrary indexing.
+    let constant_positions: HashMap<&str, usize> = file_constant_columns
+        .iter()
+        .enumerate()
+        .map(|(index, name)| (name.as_str(), index))
+        .collect();
+    let mut file_fields = Vec::new();
+    let mut constant_fields = Vec::new();
+    for field in output_schema.fields() {
+        if let Some(&constant_index) = constant_positions.get(field.name().as_str()) {
+            constant_fields.push((constant_index, Arc::clone(field)));
+        } else {
+            file_fields.push(Arc::clone(field));
+        }
+    }
+    constant_fields.sort_by_key(|(index, _)| *index);
+
+    let file_field_count = file_fields.len();
+    let mut projection = Vec::with_capacity(output_schema.fields().len());
+    let mut file_index = 0;
+    for field in output_schema.fields() {
+        if let Some(&constant_index) = constant_positions.get(field.name().as_str()) {
+            projection.push(file_field_count + constant_index);
+        } else {
+            projection.push(file_index);
+            file_index += 1;
+        }
+    }
+    let constant_fields = constant_fields
+        .into_iter()
+        .map(|(_, field)| field)
+        .collect();
+
+    let file_schema = Arc::new(ArrowSchema::new(file_fields));
+    (TableSchema::new(file_schema, constant_fields), projection)
+}
+
+fn scan_files(
+    files: &[KernelScanFile],
+) -> Result<(Option<ObjectStoreUrl>, Vec<PartitionedFile>), DataFusionError> {
+    let Some((first_file, remaining_files)) = files.split_first() else {
+        return Ok((None, Vec::new()));
+    };
+
+    let (store_url, first_scan_file) = to_df_object_store_and_partitioned_file(first_file)?;
+    let mut scan_files = Vec::with_capacity(files.len());
+    scan_files.push(first_scan_file);
+    for file in remaining_files {
+        let (file_store_url, scan_file) = to_df_object_store_and_partitioned_file(file)?;
+        if file_store_url != store_url {
+            return Err(DataFusionError::Plan(format!(
+                "scan files must use one object store, found `{store_url}` and \
+                 `{file_store_url}`"
+            )));
+        }
+        scan_files.push(scan_file);
+    }
+    Ok((Some(store_url), scan_files))
+}
+
+fn to_df_object_store_and_partitioned_file(
+    file: &KernelScanFile,
+) -> Result<(ObjectStoreUrl, PartitionedFile), DataFusionError> {
+    let constants = file
+        .file_constants
+        .iter()
+        .map(|scalar| {
+            to_df_scalar(scalar).map_err(|error| DataFusionError::External(Box::new(error)))
+        })
+        .try_collect()?;
+    let location = ListingTableUrl::parse(file.meta.location.as_str())?;
+    let store_url = location.object_store();
+    let mut partitioned_file = PartitionedFile::new("", file.meta.size);
+    partitioned_file.object_meta.location = location.prefix().clone();
+    partitioned_file.partition_values = constants;
+    Ok((store_url, partitioned_file))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Cursor;
+
+    use datafusion::arrow::array::{Int64Array, RecordBatch};
+    use datafusion::arrow::datatypes::{
+        DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
+    };
+    use datafusion::arrow::json::ReaderBuilder as JsonReaderBuilder;
+    use datafusion::assert_batches_sorted_eq;
+    use datafusion::logical_expr::col as df_col;
+    use datafusion::parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use datafusion::parquet::arrow::ArrowWriter;
+    use datafusion::prelude::SessionContext;
+    use delta_kernel::expressions::{
+        ArrayData as KernelArrayData, MapData as KernelMapData, Scalar as KernelScalar,
+    };
+    use delta_kernel::plans::ir::nodes::Operator as KernelOperator;
+    use delta_kernel::schema::{
+        ArrayType as KernelArrayType, DataType as KernelDataType, MapType as KernelMapType,
+        StructField as KernelStructField, StructType as KernelStructType,
+    };
+    use delta_kernel::FileMeta as KernelFileMeta;
+    use rstest::rstest;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::operator::lower_operator;
+
+    // === Shared helpers ===
+
+    #[derive(Debug, Clone, Copy)]
+    enum TestFormat {
+        Parquet,
+        Json,
+    }
+
+    impl TestFormat {
+        fn extension(self) -> &'static str {
+            match self {
+                Self::Parquet => "parquet",
+                Self::Json => "json",
+            }
+        }
+    }
+
+    fn scan_schema() -> KernelStructType {
+        KernelStructType::try_new([
+            KernelStructField::not_null("partition", KernelDataType::STRING),
+            KernelStructField::not_null("id", KernelDataType::LONG),
+            KernelStructField::not_null("score", KernelDataType::LONG),
+            KernelStructField::not_null("version", KernelDataType::LONG),
+        ])
+        .unwrap()
+    }
+
+    fn scan_file(
+        directory: &TempDir,
+        format: TestFormat,
+        stem: &str,
+        ids: &[i64],
+        partition: &str,
+        version: i64,
+    ) -> KernelScanFile {
+        let path = directory
+            .path()
+            .join(format!("{stem}.{}", format.extension()));
+        match format {
+            TestFormat::Parquet => write_parquet(&path, ids),
+            TestFormat::Json => write_json(&path, ids),
+        }
+        data_scan_file(&path, partition, version)
+    }
+
+    fn data_scan_file(path: &std::path::Path, partition: &str, version: i64) -> KernelScanFile {
+        let size = std::fs::metadata(path).unwrap().len();
+        let location = format!("file://{}", path.display()).parse().unwrap();
+        KernelScanFile {
+            meta: KernelFileMeta {
+                location,
+                last_modified: 0,
+                size,
+            },
+            file_constants: vec![
+                KernelScalar::Long(version),
+                KernelScalar::String(partition.to_string()),
+            ],
+        }
+    }
+
+    fn write_parquet(path: &std::path::Path, ids: &[i64]) {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("id", ArrowDataType::Int64, false),
+            ArrowField::new("score", ArrowDataType::Int64, false),
+        ]));
+        let scores: Vec<_> = ids.iter().map(|id| id * 10).collect();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(Int64Array::from(ids.to_vec())),
+                Arc::new(Int64Array::from(scores)),
+            ],
+        )
+        .unwrap();
+        write_parquet_batch(path, &batch);
+    }
+
+    fn write_parquet_batch(path: &std::path::Path, batch: &RecordBatch) {
+        let mut writer =
+            ArrowWriter::try_new(File::create(path).unwrap(), batch.schema(), None).unwrap();
+        writer.write(batch).unwrap();
+        writer.close().unwrap();
+    }
+
+    fn write_json(path: &std::path::Path, ids: &[i64]) {
+        let lines: Vec<String> = ids
+            .iter()
+            .map(|id| format!(r#"{{"id":{id},"score":{}}}"#, id * 10))
+            .collect();
+        let contents = format!("{}\n", lines.join("\n"));
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn nested_file_fields(contains_null: bool) -> [KernelStructField; 6] {
+        [
+            KernelStructField::not_null(
+                "array",
+                KernelArrayType::new(KernelDataType::LONG, contains_null),
+            ),
+            KernelStructField::not_null(
+                "array_of_arrays",
+                KernelArrayType::new(
+                    KernelArrayType::new(KernelDataType::LONG, contains_null),
+                    contains_null,
+                ),
+            ),
+            KernelStructField::not_null(
+                "map",
+                KernelMapType::new(KernelDataType::STRING, KernelDataType::LONG, contains_null),
+            ),
+            KernelStructField::not_null(
+                "map_of_maps",
+                KernelMapType::new(
+                    KernelDataType::STRING,
+                    KernelMapType::new(KernelDataType::STRING, KernelDataType::LONG, contains_null),
+                    contains_null,
+                ),
+            ),
+            KernelStructField::not_null(
+                "array_of_maps",
+                KernelArrayType::new(
+                    KernelMapType::new(KernelDataType::STRING, KernelDataType::LONG, contains_null),
+                    contains_null,
+                ),
+            ),
+            KernelStructField::not_null(
+                "map_of_arrays",
+                KernelMapType::new(
+                    KernelDataType::STRING,
+                    KernelArrayType::new(
+                        KernelArrayType::new(KernelDataType::LONG, contains_null),
+                        contains_null,
+                    ),
+                    contains_null,
+                ),
+            ),
+        ]
+    }
+
+    fn nested_scan_schema() -> KernelStructType {
+        let [array, array_of_arrays, map, map_of_maps, array_of_maps, map_of_arrays] =
+            nested_file_fields(false);
+        KernelStructType::try_new([
+            KernelStructField::not_null("partition", KernelDataType::STRING),
+            array,
+            array_of_arrays,
+            map,
+            map_of_maps,
+            array_of_maps,
+            map_of_arrays,
+            KernelStructField::not_null("version", KernelDataType::LONG),
+        ])
+        .unwrap()
+    }
+
+    fn nested_scan_file(
+        directory: &TempDir,
+        format: TestFormat,
+    ) -> (KernelScanFile, Option<ArrowSchemaRef>) {
+        let path = directory
+            .path()
+            .join(format!("nested.{}", format.extension()));
+        let contents = concat!(
+            r#"{"array":[1,2],"array_of_arrays":[[1,2],[3]],"map":{"a":10,"b":20},"#,
+            r#""map_of_maps":{"outer":{"inner":30}},"#,
+            r#""array_of_maps":[{"c":30},{"d":40}],"#,
+            r#""map_of_arrays":{"nested":[[5,6],[7]]}}"#,
+            "\n",
+            r#"{"array":[],"array_of_arrays":[],"map":{},"map_of_maps":{},"#,
+            r#""array_of_maps":[],"map_of_arrays":{}}"#,
+            "\n",
+        );
+        let physical_schema = match format {
+            TestFormat::Json => {
+                std::fs::write(&path, contents).unwrap();
+                None
+            }
+            TestFormat::Parquet => {
+                let kernel_schema = KernelStructType::try_new(nested_file_fields(true)).unwrap();
+                let schema = Arc::new((&kernel_schema).try_into_arrow().unwrap());
+                let batch = JsonReaderBuilder::new(Arc::clone(&schema))
+                    .build(Cursor::new(contents))
+                    .unwrap()
+                    .next()
+                    .unwrap()
+                    .unwrap();
+                write_parquet_batch(&path, &batch);
+                let reader =
+                    ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap()).unwrap();
+                Some(reader.schema().clone())
+            }
+        };
+        (data_scan_file(&path, "nested", 7), physical_schema)
+    }
+
+    fn array_to_arrays_map_type(contains_null: bool) -> KernelMapType {
+        KernelMapType::new(
+            KernelArrayType::new(KernelDataType::LONG, contains_null),
+            KernelArrayType::new(
+                KernelArrayType::new(KernelDataType::LONG, contains_null),
+                contains_null,
+            ),
+            contains_null,
+        )
+    }
+
+    fn kernel_array(
+        array_type: KernelArrayType,
+        values: impl IntoIterator<Item = KernelScalar>,
+    ) -> KernelScalar {
+        KernelScalar::Array(KernelArrayData::try_new(array_type, values).unwrap())
+    }
+
+    fn lower_test_scan(
+        format: TestFormat,
+        files: Vec<KernelScanFile>,
+        schema: KernelStructType,
+    ) -> Result<DFLogicalPlan, DataFusionError> {
+        let file_constant_columns = vec!["version".to_string(), "partition".to_string()];
+        let operator = match format {
+            TestFormat::Parquet => KernelOperator::ScanParquet(KernelScanParquet {
+                files,
+                file_constant_columns,
+                schema: Arc::new(schema),
+            }),
+            TestFormat::Json => KernelOperator::ScanJson(KernelScanJson {
+                files,
+                file_constant_columns,
+                schema: Arc::new(schema),
+            }),
+        };
+        lower_operator(&operator, &[])
+    }
+
+    // === Tests ===
+
+    // In schema summaries, `?` marks a nullable field, list element, or map value.
+
+    #[rstest]
+    #[case::parquet(TestFormat::Parquet)]
+    #[case::json(TestFormat::Json)]
+    #[tokio::test]
+    async fn scans_multiple_files_with_constants_and_projection(#[case] format: TestFormat) {
+        let directory = TempDir::new().unwrap();
+        let files = vec![
+            scan_file(&directory, format, "one", &[1, 2], "a", 10),
+            scan_file(&directory, format, "two", &[3], "b", 20),
+        ];
+        let plan = lower_test_scan(format, files, scan_schema()).unwrap();
+        let DFLogicalPlan::TableScan(scan) = &plan else {
+            panic!("expected a table scan")
+        };
+        assert_eq!(scan.projection.as_deref(), Some(&[3, 0, 1, 2][..]));
+        let projected = LogicalPlanBuilder::from(plan)
+            .project([
+                df_col("version"),
+                df_col("score"),
+                df_col("partition"),
+                df_col("id"),
+            ])
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let batches = SessionContext::new()
+            .execute_logical_plan(projected)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_sorted_eq!(
+            [
+                "+---------+-------+-----------+----+",
+                "| version | score | partition | id |",
+                "+---------+-------+-----------+----+",
+                "| 10      | 10    | a         | 1  |",
+                "| 10      | 20    | a         | 2  |",
+                "| 20      | 30    | b         | 3  |",
+                "+---------+-------+-----------+----+",
+            ],
+            &batches
+        );
+    }
+
+    #[rstest]
+    #[case::parquet(TestFormat::Parquet)]
+    #[case::json(TestFormat::Json)]
+    #[tokio::test]
+    async fn fills_nullable_file_columns_missing_from_a_file(#[case] format: TestFormat) {
+        let directory = TempDir::new().unwrap();
+        let files = vec![scan_file(&directory, format, "one", &[7], "west", 42)];
+        let schema = KernelStructType::try_new([
+            KernelStructField::not_null("partition", KernelDataType::STRING),
+            KernelStructField::not_null("id", KernelDataType::LONG),
+            KernelStructField::nullable("missing", KernelDataType::STRING),
+            KernelStructField::not_null("version", KernelDataType::LONG),
+        ])
+        .unwrap();
+        let plan = lower_test_scan(format, files, schema).unwrap();
+
+        let batches = SessionContext::new()
+            .execute_logical_plan(plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_sorted_eq!(
+            [
+                "+-----------+----+---------+---------+",
+                "| partition | id | missing | version |",
+                "+-----------+----+---------+---------+",
+                "| west      | 7  |         | 42      |",
+                "+-----------+----+---------+---------+",
+            ],
+            &batches
+        );
+    }
+
+    // Physical Parquet:
+    //   array<i64?>, array<array<i64?>?>, map<string, i64?>,
+    //   map<string, map<string, i64?>?>, array<map<string, i64?>?>,
+    //   map<string, array<array<i64?>?>?>
+    // Requested Kernel: the same types with every `?` removed.
+    // Expected: values below, with every output field exactly matching its requested Kernel field.
+    #[rstest]
+    #[case::basic(
+        &["array", "array_of_arrays", "map"],
+        &[
+            "+--------+-----------------+----------------+",
+            "| array  | array_of_arrays | map            |",
+            "+--------+-----------------+----------------+",
+            "| [1, 2] | [[1, 2], [3]]   | {a: 10, b: 20} |",
+            "| []     | []              | {}             |",
+            "+--------+-----------------+----------------+",
+        ]
+    )]
+    #[case::cursed(
+        &["map_of_maps", "array_of_maps", "map_of_arrays"],
+        &[
+            "+----------------------+--------------------+-------------------------+",
+            "| map_of_maps          | array_of_maps      | map_of_arrays           |",
+            "+----------------------+--------------------+-------------------------+",
+            "| {outer: {inner: 30}} | [{c: 30}, {d: 40}] | {nested: [[5, 6], [7]]} |",
+            "| {}                   | []                 | {}                      |",
+            "+----------------------+--------------------+-------------------------+",
+        ]
+    )]
+    #[tokio::test]
+    async fn reads_nested_array_and_map_columns(
+        #[values(TestFormat::Parquet, TestFormat::Json)] format: TestFormat,
+        #[case] columns: &[&str],
+        #[case] expected: &[&str],
+    ) {
+        let directory = TempDir::new().unwrap();
+        let (file, physical_schema) = nested_scan_file(&directory, format);
+        let requested_schema = nested_scan_schema();
+        let requested_arrow_schema: ArrowSchema = (&requested_schema).try_into_arrow().unwrap();
+        if let Some(physical_schema) = physical_schema {
+            for name in columns {
+                assert_ne!(
+                    physical_schema.field_with_name(name).unwrap(),
+                    requested_arrow_schema.field_with_name(name).unwrap()
+                );
+            }
+        }
+
+        let scan = lower_test_scan(format, vec![file], requested_schema).unwrap();
+        let projected = LogicalPlanBuilder::from(scan)
+            .project(columns.iter().map(|name| df_col(*name)))
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let batches = SessionContext::new()
+            .execute_logical_plan(projected)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        for batch in &batches {
+            for name in columns {
+                assert_eq!(
+                    batch.schema().field_with_name(name).unwrap(),
+                    requested_arrow_schema.field_with_name(name).unwrap()
+                );
+            }
+        }
+        assert_batches_sorted_eq!(expected, &batches);
+    }
+
+    // Physical Parquet: map<array<i64?>, array<array<i64?>?>?>
+    // Requested Kernel: map<array<i64>, array<array<i64>>>
+    // Expected: `{[1, 2]: [[3, 4], [5]]}` with the complete requested Kernel field.
+    #[tokio::test]
+    async fn parquet_reads_map_from_array_keys_to_nested_array_values() {
+        let physical_array_type = KernelArrayType::new(KernelDataType::LONG, true);
+        let key = kernel_array(
+            physical_array_type.clone(),
+            [KernelScalar::Long(1), KernelScalar::Long(2)],
+        );
+        let value = kernel_array(
+            KernelArrayType::new(physical_array_type.clone(), true),
+            [
+                kernel_array(
+                    physical_array_type.clone(),
+                    [KernelScalar::Long(3), KernelScalar::Long(4)],
+                ),
+                kernel_array(physical_array_type, [KernelScalar::Long(5)]),
+            ],
+        );
+        let physical_map_type = array_to_arrays_map_type(true);
+        let map = KernelScalar::Map(
+            KernelMapData::try_new(physical_map_type.clone(), [(key, value)]).unwrap(),
+        );
+
+        let physical_schema = KernelStructType::try_new([KernelStructField::not_null(
+            "array_to_arrays_map",
+            physical_map_type,
+        )])
+        .unwrap();
+        let physical_arrow_schema: ArrowSchema = (&physical_schema).try_into_arrow().unwrap();
+        let physical_arrow_schema = Arc::new(physical_arrow_schema);
+        let array = to_df_scalar(&map).unwrap().to_array_of_size(1).unwrap();
+        let batch = RecordBatch::try_new(Arc::clone(&physical_arrow_schema), vec![array]).unwrap();
+        let directory = TempDir::new().unwrap();
+        let path = directory.path().join("array-map.parquet");
+        write_parquet_batch(&path, &batch);
+
+        let requested_schema = KernelStructType::try_new([
+            KernelStructField::not_null("partition", KernelDataType::STRING),
+            KernelStructField::not_null("array_to_arrays_map", array_to_arrays_map_type(false)),
+            KernelStructField::not_null("version", KernelDataType::LONG),
+        ])
+        .unwrap();
+        let requested_arrow_schema: ArrowSchema = (&requested_schema).try_into_arrow().unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(File::open(&path).unwrap()).unwrap();
+        assert_ne!(
+            reader
+                .schema()
+                .field_with_name("array_to_arrays_map")
+                .unwrap(),
+            requested_arrow_schema
+                .field_with_name("array_to_arrays_map")
+                .unwrap()
+        );
+
+        let file = data_scan_file(&path, "nested", 7);
+        let scan = lower_test_scan(TestFormat::Parquet, vec![file], requested_schema).unwrap();
+        let projected = LogicalPlanBuilder::from(scan)
+            .project([df_col("array_to_arrays_map")])
+            .unwrap()
+            .build()
+            .unwrap();
+        let batches = SessionContext::new()
+            .execute_logical_plan(projected)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            batches[0]
+                .schema()
+                .field_with_name("array_to_arrays_map")
+                .unwrap(),
+            requested_arrow_schema
+                .field_with_name("array_to_arrays_map")
+                .unwrap()
+        );
+        assert_batches_sorted_eq!(
+            [
+                "+-------------------------+",
+                "| array_to_arrays_map     |",
+                "+-------------------------+",
+                "| {[1, 2]: [[3, 4], [5]]} |",
+                "+-------------------------+",
+            ],
+            &batches
+        );
+    }
+
+    #[rstest]
+    #[case::parquet(TestFormat::Parquet)]
+    #[case::json(TestFormat::Json)]
+    #[tokio::test]
+    async fn empty_scan_preserves_declared_schema(#[case] format: TestFormat) {
+        let plan = lower_test_scan(format, vec![], scan_schema()).unwrap();
+        let dataframe = SessionContext::new()
+            .execute_logical_plan(plan)
+            .await
+            .unwrap();
+        let physical = dataframe.create_physical_plan().await.unwrap();
+
+        let physical_schema = physical.schema();
+        let names: Vec<&str> = physical_schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect();
+        assert_eq!(names, ["partition", "id", "score", "version"]);
+        assert!(dataframe.collect().await.unwrap().is_empty());
+    }
+
+    #[rstest]
+    #[case::parquet(TestFormat::Parquet)]
+    #[case::json(TestFormat::Json)]
+    fn scan_rejects_input_plan(#[case] format: TestFormat) {
+        let operator = match format {
+            TestFormat::Parquet => KernelOperator::ScanParquet(KernelScanParquet {
+                files: vec![],
+                file_constant_columns: vec![],
+                schema: Arc::new(KernelStructType::new_unchecked([])),
+            }),
+            TestFormat::Json => KernelOperator::ScanJson(KernelScanJson {
+                files: vec![],
+                file_constant_columns: vec![],
+                schema: Arc::new(KernelStructType::new_unchecked([])),
+            }),
+        };
+        let input = Arc::new(lower_operator(&operator, &[]).unwrap());
+        let error = lower_operator(&operator, &[input]).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("expects 0 input(s), but received 1"));
+    }
+
+    #[test]
+    fn scan_rejects_multiple_object_stores() {
+        let files = ["s3://first/table/a.json", "s3://second/table/b.json"]
+            .into_iter()
+            .map(|location| KernelScanFile {
+                meta: KernelFileMeta {
+                    location: location.parse().unwrap(),
+                    last_modified: 0,
+                    size: 1,
+                },
+                file_constants: vec![KernelScalar::Long(1), KernelScalar::String("a".to_string())],
+            })
+            .collect();
+
+        let error = lower_test_scan(TestFormat::Json, files, scan_schema()).unwrap_err();
+        assert!(
+            error.to_string().contains(
+                "scan files must use one object store, found `s3://first/` and `s3://second/`"
+            ),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_rejects_unregistered_object_store() {
+        let file = KernelScanFile {
+            meta: KernelFileMeta {
+                location: "unregistered://bucket/file.json".parse().unwrap(),
+                last_modified: 0,
+                size: 1,
+            },
+            file_constants: vec![KernelScalar::Long(1), KernelScalar::String("a".to_string())],
+        };
+        let plan = lower_test_scan(TestFormat::Json, vec![file], scan_schema()).unwrap();
+        let error = SessionContext::new()
+            .execute_logical_plan(plan)
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("unregistered://bucket"),
+            "{error}"
+        );
+    }
+}


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3162/files/e142baaf156f99d63987259b37a005516b1003ee..091678a769f91ffc665da5fb5f26b17f69c606cf) to review incremental changes.
- [stack/aaron/lower-metadata-scans-minimal](https://github.com/delta-io/delta-kernel-rs/pull/3152) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3152/files)]
  - [**stack/aaron/plan-executor**](https://github.com/delta-io/delta-kernel-rs/pull/3162) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3162/files/e142baaf156f99d63987259b37a005516b1003ee..091678a769f91ffc665da5fb5f26b17f69c606cf)] ← _this PR_
    - [stack/aaron/lower-dynamic-scan](https://github.com/delta-io/delta-kernel-rs/pull/3163) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3163/files/091678a769f91ffc665da5fb5f26b17f69c606cf..bb155429fcb26e69c024f9298d520fbf8e88103b)]
      - [stack/aaron/upgrade-datafusion-arrow](https://github.com/delta-io/delta-kernel-rs/pull/3219) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3219/files/bb155429fcb26e69c024f9298d520fbf8e88103b..c530a9f32238c35eb6fa9c62e93315d0fed35507)]

---------
## What changes are proposed in this pull request?

Implements `PlanExecutor` for `DataFusionExecutor`, completing the execution boundary for the DataFusion lowering introduced by the preceding PRs in this stack.

- Query plans lower to DataFusion logical and physical plans using the caller's current `SessionContext`, execute on a caller-owned Tokio runtime, and return collected `EngineData` batches after repairing nested Arrow null masks. The returned iterator is intentionally backed by a full collect: `execute_op` runs intermediate, non-terminal Kernel plans rather than the connector's terminal data stream, so end-to-end streaming is less important here than keeping the synchronous execution boundary simple.
- Explicit I/O operations delegate file listing, byte reads and writes, HEAD requests, and atomic copies to the supplied `StorageHandler`. Parquet footer operations use range reads with whole-file fallback, preserve Parquet field IDs in the Kernel schema, and reject malformed or encrypted footers.
- Documents resource ownership and the synchronous execution contract. Async callers run `execute_op` on a blocking thread, while later object-store registrations on the supplied session remain visible to subsequent queries.

### This PR affects the following public APIs

`DataFusionExecutor::new` now accepts the connector's `SessionContext`, underlying `StorageHandler`, and Tokio `Handle`. This keeps DataFusion configuration, storage, and runtime lifecycle under connector control.

## How was this change tested?

`(cd datafusion-executor && cargo test)` (281 tests) and `(cd datafusion-executor && cargo clippy --all-targets -- -D warnings)`. New tests cover execution through `spawn_blocking` on current-thread and multi-thread runtimes, late object-store registration, stopped-runtime errors, ranged and whole-file footer reads, field-ID preservation, and undersized Parquet files.
