### PR TITLE
chore: fix new warnings from clippy upgrade

### DIFF
--- a/ffi/src/expressions/arrow_eval.rs
+++ b/ffi/src/expressions/arrow_eval.rs
@@ -400,7 +400,6 @@ mod tests {
     };
     use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
     use delta_kernel::engine::arrow_expression::evaluate_expression::evaluate_predicate;
-    use delta_kernel::engine::arrow_expression::opaque::ArrowOpaquePredicate as _;
     use delta_kernel::expressions::{col, lit, Expression, Predicate};
 
     use super::*;
@@ -848,7 +847,6 @@ mod tests {
 
         use delta_kernel::arrow::array::Int64Array;
         use delta_kernel::arrow::datatypes::DataType as ArrowDataType;
-        use delta_kernel::engine::arrow_expression::opaque::ArrowOpaquePredicateOp as _;
         use delta_kernel::expressions::{
             col, column_name, joined_column_expr, lit, BinaryExpressionOp, BinaryPredicateOp,
             ColumnName, Expression, JunctionPredicateOp, OpaquePredicateOpRef, Scalar,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1991,7 +1991,7 @@ mod tests {
 
     use delta_kernel::object_store::memory::InMemory;
     use delta_kernel::object_store::path::Path;
-    use delta_kernel::object_store::{DynObjectStore, ObjectStore as _, ObjectStoreExt as _};
+    use delta_kernel::object_store::{DynObjectStore, ObjectStoreExt as _};
     use delta_kernel::schema::schema_ref;
     use delta_kernel_default_engine::executor::tokio::TokioMultiThreadExecutor;
     use delta_kernel_default_engine::DefaultEngineBuilder;

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -326,13 +326,14 @@ fn decode_binary_literal(input: &str) -> DeltaResult<Vec<u8>> {
             "binary literal must contain an even number of hex digits: {input}"
         )));
     }
-    hex.as_bytes()
-        .chunks_exact(2)
-        .map(|pair| {
-            let hi = (pair[0] as char)
+    let (pairs, _) = hex.as_bytes().as_chunks::<2>();
+    pairs
+        .iter()
+        .map(|&[hi, lo]| {
+            let hi = (hi as char)
                 .to_digit(16)
                 .ok_or_else(|| Error::generic(format!("invalid hex digit in {input}")))?;
-            let lo = (pair[1] as char)
+            let lo = (lo as char)
                 .to_digit(16)
                 .ok_or_else(|| Error::generic(format!("invalid hex digit in {input}")))?;
             Ok((hi << 4 | lo) as u8)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix clippy warning:

```
Error:    --> kernel/src/expressions/sql.rs:330:10
    |
330 |         .chunks_exact(2)
    |          ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
```

and unused imports.

## How was this change tested?

Existing tests/CI
