### PR TITLE
fix: allow nullable commit info operation parameters

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -861,7 +861,7 @@ pub(crate) struct CommitInfo {
     pub(crate) operation: Option<String>,
     /// Map of arbitrary string key-value pairs that provide additional information about the
     /// operation. This is specified by the engine. For now this is always empty on write.
-    pub(crate) operation_parameters: Option<HashMap<String, String>>,
+    pub(crate) operation_parameters: Option<HashMap<String, Option<String>>>,
     /// The version of the delta_kernel crate used to write this commit. The kernel will always
     /// write this field, but it is optional since many tables will not have this field (i.e. any
     /// tables not written by kernel).
@@ -1787,7 +1787,7 @@ mod tests {
                 nullable "timestamp": LONG,
                 nullable "inCommitTimestamp": LONG,
                 nullable "operation": STRING,
-                nullable "operationParameters": { STRING => not_null STRING },
+                nullable "operationParameters": { STRING => nullable STRING },
                 nullable "kernelVersion": STRING,
                 nullable "isBlindAppend": BOOLEAN,
                 nullable "engineInfo": STRING,
@@ -2101,7 +2101,7 @@ mod tests {
         let engine_data = commit_info.into_engine_data(CommitInfo::to_schema().into(), &engine);
         let record_batch = engine_data.try_into_record_batch().unwrap();
 
-        let mut map_builder = create_string_map_builder(false);
+        let mut map_builder = create_string_map_builder(true);
         map_builder.append(true).unwrap();
         let operation_parameters = Arc::new(map_builder.finish());
 

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -4900,10 +4900,8 @@ fn test_combine_checkpoint_predicates(
     "tags",
     r#"{"checkpointMetadata":{"version":0,"tags":{"key1":"val1","key2":null}}}"#
 )]
-// Known issues: these map fields don't yet have #[allow_null_container_values].
 // commitInfo.operationParameters.description: null
-#[should_panic(expected = "StructArray re-validation failed")]
-#[case::commit_info_operation_parameters_known_issue(
+#[case::commit_info_operation_parameters(
     "commitInfo",
     "operationParameters",
     r#"{"commitInfo":{"timestamp":1000,"operation":"WRITE","operationParameters":{"mode":"ErrorIfExists","description":null}}}"#

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -27,8 +27,7 @@ fn commit_info_literal_exprs(
             Arc::new(match commit_info.operation_parameters {
                 Some(map) => lit(MapData::try_new(
                     op_params_map_type,
-                    map.into_iter()
-                        .map(|(k, v)| (Scalar::String(k), Scalar::String(v))),
+                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
                 )?),
                 None => null_lit(op_params_map_type),
             }),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Delta log JSON can contain null values inside `commitInfo.operationParameters`, but the
`CommitInfo` action schema represented that field as `HashMap<String, String>`. That made the
derived schema a nullable map with non-nullable values, so JSON log replay could fail during
struct re-validation before it got a chance to drop the null map entry.

This changes `operation_parameters` to `HashMap<String, Option<String>>`, so the generated schema
and `IntoEngineData` path both agree that the map values are nullable. The existing null-map log
replay case is changed from a known panic to passing coverage.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo test -p delta_kernel test_commit_info_schema`
- `cargo test -p delta_kernel test_commit_info_into_engine_data`
- `cargo test -p delta_kernel read_actions_with_null_map_values`
- `cargo test -p delta_kernel transaction::commit_info::tests::test_build_commit_info_none_branch`
- `git stack commit` pre-commit hook: formatting check, clippy, and full `cargo test`
