### PR TITLE
feat!: fix ScanMetrics parity with java kernel

### DIFF
--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -151,7 +151,7 @@ consumed. It provides detailed statistics about the log replay process:
 | `duration` | Wall-clock time from scan start to iterator exhaustion. |
 | `num_add_files_seen` | Add actions in replay input before predicate filtering and deduplication. Includes checkpoint and delta files. |
 | `num_add_files_seen_from_delta_files` | Add actions in delta-file replay input before predicate filtering and deduplication. |
-| `num_active_add_files` | Add files that survived log replay. These are the files your connector reads. |
+| `num_selected_add_files` | Add files that survived log replay. These are the files your connector reads. |
 | `num_remove_files_seen_from_delta_files` | Remove actions in delta-file replay input before deduplication. |
 | `num_non_file_actions` | Non-file actions (protocol, metadata, etc.) seen during replay. |
 | `num_predicate_filtered` | Files eliminated by predicate evaluation (data skipping and partition pruning). |

--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -149,9 +149,10 @@ consumed. It provides detailed statistics about the log replay process:
 | `operation_id` | Unique ID for this scan, useful for correlation. |
 | `scan_type` | Which scan path produced the event (see below). |
 | `duration` | Wall-clock time from scan start to iterator exhaustion. |
-| `num_add_files_seen` | Add files that entered deduplication. This normally excludes data-skipped files; parse-error fallback includes data-skipped files during retry. |
+| `num_add_files_seen` | Add actions in replay input before predicate filtering and deduplication. Includes checkpoint and delta files. |
+| `num_add_files_seen_from_delta_files` | Add actions in delta-file replay input before predicate filtering and deduplication. |
 | `num_active_add_files` | Add files that survived log replay. These are the files your connector reads. |
-| `num_remove_files_seen` | Remove actions encountered in commit files. |
+| `num_remove_files_seen_from_delta_files` | Remove actions in delta-file replay input before deduplication. |
 | `num_non_file_actions` | Non-file actions (protocol, metadata, etc.) seen during replay. |
 | `num_predicate_filtered` | Files eliminated by predicate evaluation (data skipping and partition pruning). |
 | `peak_hash_set_size` | Peak size of the internal deduplication set. Indicates memory pressure during log replay. |
@@ -168,8 +169,10 @@ The `scan_type` field tells you which scan execution path produced the event:
 | `ScanType::SequentialPhase` | The sequential phase of `Scan::parallel_scan_metadata()`. |
 | `ScanType::ParallelPhase` | The parallel phase of `Scan::parallel_scan_metadata()`. |
 
-If you use `parallel_scan_metadata`, you'll receive two `ScanMetadataCompleted`
-events per scan: one for each phase.
+For `parallel_scan_metadata`, `finish()` emits the sequential-phase event. If it
+returns parallel work, call `state.log_metrics()` exactly once after all workers
+complete to emit the parallel-phase event. The counters are phase-local. Combine
+the two events by `operation_id` to obtain whole-scan counts.
 
 ### Storage and file I/O events
 

--- a/docs/user-guide/src/observability/observability.md
+++ b/docs/user-guide/src/observability/observability.md
@@ -141,8 +141,8 @@ events from the same snapshot load together.
 
 ### Scan metadata events
 
-`ScanMetadataCompleted` is emitted when a scan metadata iterator is fully
-consumed. It provides detailed statistics about the log replay process:
+`ScanMetadataCompleted` reports completion of a full scan or one phase of a
+parallel scan. It describes the corresponding log replay work:
 
 | Field | Meaning |
 |-------|---------|
@@ -152,10 +152,11 @@ consumed. It provides detailed statistics about the log replay process:
 | `num_add_files_seen` | Add actions in replay input before predicate filtering and deduplication. Includes checkpoint and delta files. |
 | `num_add_files_seen_from_delta_files` | Add actions in delta-file replay input before predicate filtering and deduplication. |
 | `num_selected_add_files` | Add files that survived log replay. These are the files your connector reads. |
+| `selected_add_files_bytes` | Total size in bytes of the selected Add files. |
 | `num_remove_files_seen_from_delta_files` | Remove actions in delta-file replay input before deduplication. |
 | `num_non_file_actions` | Non-file actions (protocol, metadata, etc.) seen during replay. |
 | `num_predicate_filtered` | Files eliminated by predicate evaluation (data skipping and partition pruning). |
-| `peak_hash_set_size` | Peak size of the internal deduplication set. Indicates memory pressure during log replay. |
+| `peak_hash_set_size` | Whole-scan high-water mark for the internal deduplication set. This value is retained across sequential and parallel phase events. |
 | `dedup_visitor_time_ns` | Nanoseconds spent in the deduplication visitor. |
 | `predicate_eval_time_ns` | Nanoseconds spent evaluating predicates. |
 
@@ -171,8 +172,9 @@ The `scan_type` field tells you which scan execution path produced the event:
 
 For `parallel_scan_metadata`, `finish()` emits the sequential-phase event. If it
 returns parallel work, call `state.log_metrics()` exactly once after all workers
-complete to emit the parallel-phase event. The counters are phase-local. Combine
-the two events by `operation_id` to obtain whole-scan counts.
+complete to emit the parallel-phase event. Action counts and timings are phase-local;
+`peak_hash_set_size` is the whole-scan high-water mark and should not be combined.
+Join the two events by `operation_id` to obtain whole-scan metrics.
 
 ### Storage and file I/O events
 

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -291,9 +291,10 @@ void print_metric(MetricEvent event) {
     }
     PM_U64(smc, duration_ns);
     PM_U64(smc, num_add_files_seen);
+    PM_U64(smc, num_add_files_seen_from_delta_files);
     PM_U64(smc, num_active_add_files);
     PM_U64(smc, active_add_files_bytes);
-    PM_U64(smc, num_remove_files_seen);
+    PM_U64(smc, num_remove_files_seen_from_delta_files);
     PM_U64(smc, num_non_file_actions);
     PM_U64(smc, num_predicate_filtered);
     PM_U64(smc, peak_hash_set_size);

--- a/ffi/examples/common/kernel_utils.c
+++ b/ffi/examples/common/kernel_utils.c
@@ -292,8 +292,8 @@ void print_metric(MetricEvent event) {
     PM_U64(smc, duration_ns);
     PM_U64(smc, num_add_files_seen);
     PM_U64(smc, num_add_files_seen_from_delta_files);
-    PM_U64(smc, num_active_add_files);
-    PM_U64(smc, active_add_files_bytes);
+    PM_U64(smc, num_selected_add_files);
+    PM_U64(smc, selected_add_files_bytes);
     PM_U64(smc, num_remove_files_seen_from_delta_files);
     PM_U64(smc, num_non_file_actions);
     PM_U64(smc, num_predicate_filtered);

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -281,9 +281,10 @@ pub struct ScanMetadataCompleted {
     pub scan_type: ScanType,
     pub duration_ns: u64,
     pub num_add_files_seen: u64,
+    pub num_add_files_seen_from_delta_files: u64,
     pub num_active_add_files: u64,
     pub active_add_files_bytes: u64,
-    pub num_remove_files_seen: u64,
+    pub num_remove_files_seen_from_delta_files: u64,
     pub num_non_file_actions: u64,
     pub num_predicate_filtered: u64,
     pub peak_hash_set_size: u64,
@@ -544,9 +545,10 @@ impl MetricEvent {
                 scan_type,
                 duration,
                 num_add_files_seen,
+                num_add_files_seen_from_delta_files,
                 num_active_add_files,
                 active_add_files_bytes,
-                num_remove_files_seen,
+                num_remove_files_seen_from_delta_files,
                 num_non_file_actions,
                 num_predicate_filtered,
                 peak_hash_set_size,
@@ -559,9 +561,10 @@ impl MetricEvent {
                 scan_type: (*scan_type).into(),
                 duration_ns: ns(*duration),
                 num_add_files_seen: *num_add_files_seen,
+                num_add_files_seen_from_delta_files: *num_add_files_seen_from_delta_files,
                 num_active_add_files: *num_active_add_files,
                 active_add_files_bytes: *active_add_files_bytes,
-                num_remove_files_seen: *num_remove_files_seen,
+                num_remove_files_seen_from_delta_files: *num_remove_files_seen_from_delta_files,
                 num_non_file_actions: *num_non_file_actions,
                 num_predicate_filtered: *num_predicate_filtered,
                 peak_hash_set_size: *peak_hash_set_size as u64, // note usize -> u64 cast
@@ -716,9 +719,10 @@ mod tests {
             scan_type: kernel::ScanType::ParallelPhase,
             duration: Duration::from_nanos(13),
             num_add_files_seen: 17,
+            num_add_files_seen_from_delta_files: 18,
             num_active_add_files: 19,
             active_add_files_bytes: 23,
-            num_remove_files_seen: 29,
+            num_remove_files_seen_from_delta_files: 29,
             num_non_file_actions: 31,
             num_predicate_filtered: 37,
             peak_hash_set_size: 41,
@@ -740,9 +744,10 @@ mod tests {
             );
             assert_eq!(e.duration_ns, 13);
             assert_eq!(e.num_add_files_seen, 17);
+            assert_eq!(e.num_add_files_seen_from_delta_files, 18);
             assert_eq!(e.num_active_add_files, 19);
             assert_eq!(e.active_add_files_bytes, 23);
-            assert_eq!(e.num_remove_files_seen, 29);
+            assert_eq!(e.num_remove_files_seen_from_delta_files, 29);
             assert_eq!(e.num_non_file_actions, 31);
             assert_eq!(e.num_predicate_filtered, 37);
             assert_eq!(e.peak_hash_set_size, 41);

--- a/ffi/src/ffi_metrics.rs
+++ b/ffi/src/ffi_metrics.rs
@@ -282,8 +282,8 @@ pub struct ScanMetadataCompleted {
     pub duration_ns: u64,
     pub num_add_files_seen: u64,
     pub num_add_files_seen_from_delta_files: u64,
-    pub num_active_add_files: u64,
-    pub active_add_files_bytes: u64,
+    pub num_selected_add_files: u64,
+    pub selected_add_files_bytes: u64,
     pub num_remove_files_seen_from_delta_files: u64,
     pub num_non_file_actions: u64,
     pub num_predicate_filtered: u64,
@@ -546,8 +546,8 @@ impl MetricEvent {
                 duration,
                 num_add_files_seen,
                 num_add_files_seen_from_delta_files,
-                num_active_add_files,
-                active_add_files_bytes,
+                num_selected_add_files,
+                selected_add_files_bytes,
                 num_remove_files_seen_from_delta_files,
                 num_non_file_actions,
                 num_predicate_filtered,
@@ -562,8 +562,8 @@ impl MetricEvent {
                 duration_ns: ns(*duration),
                 num_add_files_seen: *num_add_files_seen,
                 num_add_files_seen_from_delta_files: *num_add_files_seen_from_delta_files,
-                num_active_add_files: *num_active_add_files,
-                active_add_files_bytes: *active_add_files_bytes,
+                num_selected_add_files: *num_selected_add_files,
+                selected_add_files_bytes: *selected_add_files_bytes,
                 num_remove_files_seen_from_delta_files: *num_remove_files_seen_from_delta_files,
                 num_non_file_actions: *num_non_file_actions,
                 num_predicate_filtered: *num_predicate_filtered,
@@ -720,8 +720,8 @@ mod tests {
             duration: Duration::from_nanos(13),
             num_add_files_seen: 17,
             num_add_files_seen_from_delta_files: 18,
-            num_active_add_files: 19,
-            active_add_files_bytes: 23,
+            num_selected_add_files: 19,
+            selected_add_files_bytes: 23,
             num_remove_files_seen_from_delta_files: 29,
             num_non_file_actions: 31,
             num_predicate_filtered: 37,
@@ -745,8 +745,8 @@ mod tests {
             assert_eq!(e.duration_ns, 13);
             assert_eq!(e.num_add_files_seen, 17);
             assert_eq!(e.num_add_files_seen_from_delta_files, 18);
-            assert_eq!(e.num_active_add_files, 19);
-            assert_eq!(e.active_add_files_bytes, 23);
+            assert_eq!(e.num_selected_add_files, 19);
+            assert_eq!(e.selected_add_files_bytes, 23);
             assert_eq!(e.num_remove_files_seen_from_delta_files, 29);
             assert_eq!(e.num_non_file_actions, 31);
             assert_eq!(e.num_predicate_filtered, 37);

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1387,9 +1387,9 @@ pub struct ScanMetadataCompleted {
     /// Add actions in delta-file replay input before predicate filtering and deduplication.
     pub num_add_files_seen_from_delta_files: u64,
     /// Add files that survived log replay (the files the connector reads).
-    pub num_active_add_files: u64,
+    pub num_selected_add_files: u64,
     /// Size in bytes of the files that survived log replay (files to read).
-    pub active_add_files_bytes: u64,
+    pub selected_add_files_bytes: u64,
     /// Remove actions in delta-file replay input before deduplication.
     pub num_remove_files_seen_from_delta_files: u64,
     /// Non-file actions seen (protocol, metadata, etc.).
@@ -1418,8 +1418,8 @@ impl ScanMetadataCompleted {
             duration: Duration::from_nanos(v.duration_ns),
             num_add_files_seen: v.num_add_files_seen,
             num_add_files_seen_from_delta_files: v.num_add_files_seen_from_delta_files,
-            num_active_add_files: v.num_active_add_files,
-            active_add_files_bytes: v.active_add_files_bytes,
+            num_selected_add_files: v.num_selected_add_files,
+            selected_add_files_bytes: v.selected_add_files_bytes,
             num_remove_files_seen_from_delta_files: v.num_remove_files_seen_from_delta_files,
             num_non_file_actions: v.num_non_file_actions,
             num_predicate_filtered: v.num_predicate_filtered,
@@ -1440,8 +1440,8 @@ impl fmt::Display for ScanMetadataCompleted {
             duration,
             num_add_files_seen,
             num_add_files_seen_from_delta_files,
-            num_active_add_files,
-            active_add_files_bytes,
+            num_selected_add_files,
+            selected_add_files_bytes,
             num_remove_files_seen_from_delta_files,
             num_non_file_actions,
             num_predicate_filtered,
@@ -1455,8 +1455,8 @@ impl fmt::Display for ScanMetadataCompleted {
              correlation_id={correlation_id:?}, scan_type={scan_type}, duration={duration:?}, \
              add_files_seen={num_add_files_seen}, \
              add_files_seen_from_delta_files={num_add_files_seen_from_delta_files}, \
-             active_add_files={num_active_add_files}, \
-             active_add_files_bytes={active_add_files_bytes}, \
+             selected_add_files={num_selected_add_files}, \
+             selected_add_files_bytes={selected_add_files_bytes}, \
              remove_files_seen_from_delta_files={num_remove_files_seen_from_delta_files}, \
              non_file_actions={num_non_file_actions}, \
              predicate_filtered={num_predicate_filtered}, peak_hash_set_size={peak_hash_set_size}, \
@@ -1474,8 +1474,8 @@ struct ScanMetadataCompletedAttrs {
     duration_ns: u64,
     num_add_files_seen: u64,
     num_add_files_seen_from_delta_files: u64,
-    num_active_add_files: u64,
-    active_add_files_bytes: u64,
+    num_selected_add_files: u64,
+    selected_add_files_bytes: u64,
     num_remove_files_seen_from_delta_files: u64,
     num_non_file_actions: u64,
     num_predicate_filtered: u64,
@@ -1504,8 +1504,8 @@ impl Visit for ScanMetadataCompletedAttrs {
             "num_add_files_seen_from_delta_files" => {
                 self.num_add_files_seen_from_delta_files = value
             }
-            "num_active_add_files" => self.num_active_add_files = value,
-            "active_add_files_bytes" => self.active_add_files_bytes = value,
+            "num_selected_add_files" => self.num_selected_add_files = value,
+            "selected_add_files_bytes" => self.selected_add_files_bytes = value,
             "num_remove_files_seen_from_delta_files" => {
                 self.num_remove_files_seen_from_delta_files = value
             }
@@ -1736,8 +1736,8 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         duration_ns = e.duration.as_nanos() as u64,
         num_add_files_seen = e.num_add_files_seen,
         num_add_files_seen_from_delta_files = e.num_add_files_seen_from_delta_files,
-        num_active_add_files = e.num_active_add_files,
-        active_add_files_bytes = e.active_add_files_bytes,
+        num_selected_add_files = e.num_selected_add_files,
+        selected_add_files_bytes = e.selected_add_files_bytes,
         num_remove_files_seen_from_delta_files = e.num_remove_files_seen_from_delta_files,
         num_non_file_actions = e.num_non_file_actions,
         num_predicate_filtered = e.num_predicate_filtered,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1361,8 +1361,12 @@ pub(crate) fn load_type_from_attrs(attrs: &Attributes<'_>) -> LogSegmentLoadType
     v.0
 }
 
-/// A `parallel_scan_metadata` scan emits **two** events (one per phase) sharing the same
-/// `operation_id`; `scan_metadata` emits one event with [`ScanType::Full`].
+/// A `scan_metadata` scan emits one event with [`ScanType::Full`] after iterator exhaustion.
+/// Calling [`SequentialScanMetadata::finish`](crate::scan::SequentialScanMetadata::finish) emits
+/// a [`ScanType::SequentialPhase`] event. If it returns parallel work, the caller emits a
+/// [`ScanType::ParallelPhase`] event by calling
+/// [`ParallelState::log_metrics`](crate::scan::ParallelState::log_metrics) after all workers
+/// complete. The two phase events share an `operation_id` and contain phase-local counters.
 #[derive(Debug, Clone)]
 pub struct ScanMetadataCompleted {
     // === Set on span creation ===
@@ -1377,17 +1381,17 @@ pub struct ScanMetadataCompleted {
     pub scan_type: ScanType,
     /// Wall-clock time from scan start to iterator exhaustion.
     pub duration: Duration,
-    /// Add files that entered deduplication. This normally excludes add files filtered by data
-    /// skipping. During parse-error fallback, deduplication runs first, so add files filtered by
-    /// retry-time data skipping are included. See
-    /// [`LogReplayProcessor::process_actions_batch`](crate::log_replay::LogReplayProcessor::process_actions_batch).
+    /// Add actions in replay input before predicate filtering and deduplication. Includes
+    /// checkpoint and delta files.
     pub num_add_files_seen: u64,
+    /// Add actions in delta-file replay input before predicate filtering and deduplication.
+    pub num_add_files_seen_from_delta_files: u64,
     /// Add files that survived log replay (the files the connector reads).
     pub num_active_add_files: u64,
     /// Size in bytes of the files that survived log replay (files to read).
     pub active_add_files_bytes: u64,
-    /// Remove files seen (from delta/commit files only).
-    pub num_remove_files_seen: u64,
+    /// Remove actions in delta-file replay input before deduplication.
+    pub num_remove_files_seen_from_delta_files: u64,
     /// Non-file actions seen (protocol, metadata, etc.).
     pub num_non_file_actions: u64,
     /// Files filtered by predicates (data skipping + partition pruning).
@@ -1413,9 +1417,10 @@ impl ScanMetadataCompleted {
             scan_type: ScanType::parse_lenient(&v.scan_type),
             duration: Duration::from_nanos(v.duration_ns),
             num_add_files_seen: v.num_add_files_seen,
+            num_add_files_seen_from_delta_files: v.num_add_files_seen_from_delta_files,
             num_active_add_files: v.num_active_add_files,
             active_add_files_bytes: v.active_add_files_bytes,
-            num_remove_files_seen: v.num_remove_files_seen,
+            num_remove_files_seen_from_delta_files: v.num_remove_files_seen_from_delta_files,
             num_non_file_actions: v.num_non_file_actions,
             num_predicate_filtered: v.num_predicate_filtered,
             peak_hash_set_size: v.peak_hash_set_size as usize,
@@ -1434,9 +1439,10 @@ impl fmt::Display for ScanMetadataCompleted {
             scan_type,
             duration,
             num_add_files_seen,
+            num_add_files_seen_from_delta_files,
             num_active_add_files,
             active_add_files_bytes,
-            num_remove_files_seen,
+            num_remove_files_seen_from_delta_files,
             num_non_file_actions,
             num_predicate_filtered,
             peak_hash_set_size,
@@ -1447,9 +1453,12 @@ impl fmt::Display for ScanMetadataCompleted {
             f,
             "ScanMetadataCompleted(id={operation_id}, table_type={table_type}, \
              correlation_id={correlation_id:?}, scan_type={scan_type}, duration={duration:?}, \
-             add_files_seen={num_add_files_seen}, active_add_files={num_active_add_files}, \
+             add_files_seen={num_add_files_seen}, \
+             add_files_seen_from_delta_files={num_add_files_seen_from_delta_files}, \
+             active_add_files={num_active_add_files}, \
              active_add_files_bytes={active_add_files_bytes}, \
-             remove_files_seen={num_remove_files_seen}, non_file_actions={num_non_file_actions}, \
+             remove_files_seen_from_delta_files={num_remove_files_seen_from_delta_files}, \
+             non_file_actions={num_non_file_actions}, \
              predicate_filtered={num_predicate_filtered}, peak_hash_set_size={peak_hash_set_size}, \
              dedup_visitor_time={dedup_visitor_time:?}, predicate_eval_time={predicate_eval_time:?})"
         )
@@ -1464,9 +1473,10 @@ struct ScanMetadataCompletedAttrs {
     scan_type: String,
     duration_ns: u64,
     num_add_files_seen: u64,
+    num_add_files_seen_from_delta_files: u64,
     num_active_add_files: u64,
     active_add_files_bytes: u64,
-    num_remove_files_seen: u64,
+    num_remove_files_seen_from_delta_files: u64,
     num_non_file_actions: u64,
     num_predicate_filtered: u64,
     peak_hash_set_size: u64,
@@ -1491,9 +1501,14 @@ impl Visit for ScanMetadataCompletedAttrs {
         match field.name() {
             "duration_ns" => self.duration_ns = value,
             "num_add_files_seen" => self.num_add_files_seen = value,
+            "num_add_files_seen_from_delta_files" => {
+                self.num_add_files_seen_from_delta_files = value
+            }
             "num_active_add_files" => self.num_active_add_files = value,
             "active_add_files_bytes" => self.active_add_files_bytes = value,
-            "num_remove_files_seen" => self.num_remove_files_seen = value,
+            "num_remove_files_seen_from_delta_files" => {
+                self.num_remove_files_seen_from_delta_files = value
+            }
             "num_non_file_actions" => self.num_non_file_actions = value,
             "num_predicate_filtered" => self.num_predicate_filtered = value,
             "peak_hash_set_size" => self.peak_hash_set_size = value,
@@ -1720,9 +1735,10 @@ pub(crate) fn emit_scan_metadata_completed(e: &ScanMetadataCompleted) {
         scan_type = %e.scan_type,
         duration_ns = e.duration.as_nanos() as u64,
         num_add_files_seen = e.num_add_files_seen,
+        num_add_files_seen_from_delta_files = e.num_add_files_seen_from_delta_files,
         num_active_add_files = e.num_active_add_files,
         active_add_files_bytes = e.active_add_files_bytes,
-        num_remove_files_seen = e.num_remove_files_seen,
+        num_remove_files_seen_from_delta_files = e.num_remove_files_seen_from_delta_files,
         num_non_file_actions = e.num_non_file_actions,
         num_predicate_filtered = e.num_predicate_filtered,
         peak_hash_set_size = e.peak_hash_set_size as u64,

--- a/kernel/src/metrics/events.rs
+++ b/kernel/src/metrics/events.rs
@@ -1366,7 +1366,8 @@ pub(crate) fn load_type_from_attrs(attrs: &Attributes<'_>) -> LogSegmentLoadType
 /// a [`ScanType::SequentialPhase`] event. If it returns parallel work, the caller emits a
 /// [`ScanType::ParallelPhase`] event by calling
 /// [`ParallelState::log_metrics`](crate::scan::ParallelState::log_metrics) after all workers
-/// complete. The two phase events share an `operation_id` and contain phase-local counters.
+/// complete. The two phase events share an `operation_id`. Action counts and timings are
+/// phase-local, while `peak_hash_set_size` is the whole-scan high-water mark.
 #[derive(Debug, Clone)]
 pub struct ScanMetadataCompleted {
     // === Set on span creation ===

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -584,7 +584,7 @@ mod tests {
     struct ExpectedMetrics {
         add_files_seen: u64,
         add_files_seen_from_delta_files: u64,
-        active_add_files: u64,
+        selected_add_files: u64,
         remove_files_seen: u64,
         non_file_actions: u64,
         predicate_filtered: u64,
@@ -619,7 +619,7 @@ mod tests {
         let add_files_seen = extract_metric(sequential_logs, "add_files_seen");
         let add_files_seen_from_delta_files =
             extract_metric(sequential_logs, "add_files_seen_from_delta_files");
-        let active_add_files = extract_metric(sequential_logs, "active_add_files");
+        let selected_add_files = extract_metric(sequential_logs, "selected_add_files");
         let remove_files_seen =
             extract_metric(sequential_logs, "remove_files_seen_from_delta_files");
         let non_file_actions = extract_metric(sequential_logs, "non_file_actions");
@@ -634,8 +634,8 @@ mod tests {
             "Sequential add_files_seen_from_delta_files mismatch"
         );
         assert_eq!(
-            active_add_files, sequential_expected.active_add_files,
-            "Sequential active_add_files mismatch"
+            selected_add_files, sequential_expected.selected_add_files,
+            "Sequential selected_add_files mismatch"
         );
         assert_eq!(
             remove_files_seen, sequential_expected.remove_files_seen,
@@ -659,7 +659,7 @@ mod tests {
             // Accumulate totals across all parallel logs
             let mut total_add_files_seen = 0u64;
             let mut total_add_files_seen_from_delta_files = 0u64;
-            let mut total_active_add_files = 0u64;
+            let mut total_selected_add_files = 0u64;
             let mut total_remove_files_seen = 0u64;
             let mut total_non_file_actions = 0u64;
             let mut total_predicate_filtered = 0u64;
@@ -673,7 +673,7 @@ mod tests {
                 total_add_files_seen += extract_metric(remaining, "add_files_seen");
                 total_add_files_seen_from_delta_files +=
                     extract_metric(remaining, "add_files_seen_from_delta_files");
-                total_active_add_files += extract_metric(remaining, "active_add_files");
+                total_selected_add_files += extract_metric(remaining, "selected_add_files");
                 total_remove_files_seen +=
                     extract_metric(remaining, "remove_files_seen_from_delta_files");
                 total_non_file_actions += extract_metric(remaining, "non_file_actions");
@@ -696,8 +696,8 @@ mod tests {
                 "Parallel add_files_seen_from_delta_files mismatch"
             );
             assert_eq!(
-                total_active_add_files, expected.active_add_files,
-                "Parallel active_add_files mismatch"
+                total_selected_add_files, expected.selected_add_files,
+                "Parallel selected_add_files mismatch"
             );
             assert_eq!(
                 total_remove_files_seen, expected.remove_files_seen,
@@ -728,7 +728,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
@@ -736,7 +736,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 101,
+            selected_add_files: 101,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -748,7 +748,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
@@ -756,7 +756,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 101,
+            selected_add_files: 101,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -772,17 +772,17 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
         },
         // Data skipping predicate filters 4 files (101 -> 97). add_files_seen counts all input
-        // Adds, while active_add_files counts the Adds remaining after filtering and deduplication.
+        // Adds, while selected_add_files counts the Adds remaining after filtering and deduplication.
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 97,
+            selected_add_files: 97,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 4,
@@ -805,7 +805,7 @@ mod tests {
             // add_files_seen counts all 6 input Adds.
             add_files_seen: 6,
             add_files_seen_from_delta_files: 6,
-            active_add_files: 2,
+            selected_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 4,
@@ -819,7 +819,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 3,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 3,
+            selected_add_files: 3,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -832,7 +832,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -840,7 +840,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 2,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 2,
+            selected_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -852,7 +852,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 3,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 3,
+            selected_add_files: 3,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -865,7 +865,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -873,7 +873,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 2,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 2,
+            selected_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -885,7 +885,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -893,7 +893,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 4,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 4,
+            selected_add_files: 4,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -905,7 +905,7 @@ mod tests {
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 0,
+            selected_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -913,7 +913,7 @@ mod tests {
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 4,
             add_files_seen_from_delta_files: 0,
-            active_add_files: 4,
+            selected_add_files: 4,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -926,7 +926,7 @@ mod tests {
             // This table has only commit files, so it completes in the sequential phase.
             add_files_seen: 1,
             add_files_seen_from_delta_files: 1,
-            active_add_files: 1,
+            selected_add_files: 1,
             remove_files_seen: 0,
             non_file_actions: 3,
             predicate_filtered: 0,
@@ -935,7 +935,7 @@ mod tests {
         expected_parallel_metrics: None,
     })]
     #[case::with_removes_deduplication(ParallelLogReplayCase {
-        // This table has removes that filter checkpoint adds, showing add_files_seen > active_add_files
+        // This table has removes that filter checkpoint adds, showing add_files_seen > selected_add_files
         path: "with_checkpoint_no_last_checkpoint",
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
@@ -946,7 +946,7 @@ mod tests {
             // Result: 2 adds seen, 1 active (only C), 1 remove seen, B filtered by dedup
             add_files_seen: 2,
             add_files_seen_from_delta_files: 1,
-            active_add_files: 1,
+            selected_add_files: 1,
             remove_files_seen: 1,
             non_file_actions: 4,
             predicate_filtered: 0,

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -583,6 +583,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct ExpectedMetrics {
         add_files_seen: u64,
+        add_files_seen_from_delta_files: u64,
         active_add_files: u64,
         remove_files_seen: u64,
         non_file_actions: u64,
@@ -616,14 +617,21 @@ mod tests {
 
         // Extract and verify counter values from Phase 1 (sequential log line)
         let add_files_seen = extract_metric(sequential_logs, "add_files_seen");
+        let add_files_seen_from_delta_files =
+            extract_metric(sequential_logs, "add_files_seen_from_delta_files");
         let active_add_files = extract_metric(sequential_logs, "active_add_files");
-        let remove_files_seen = extract_metric(sequential_logs, "remove_files_seen");
+        let remove_files_seen =
+            extract_metric(sequential_logs, "remove_files_seen_from_delta_files");
         let non_file_actions = extract_metric(sequential_logs, "non_file_actions");
         let predicate_filtered = extract_metric(sequential_logs, "predicate_filtered");
 
         assert_eq!(
             add_files_seen, sequential_expected.add_files_seen,
             "Sequential add_files_seen mismatch"
+        );
+        assert_eq!(
+            add_files_seen_from_delta_files, sequential_expected.add_files_seen_from_delta_files,
+            "Sequential add_files_seen_from_delta_files mismatch"
         );
         assert_eq!(
             active_add_files, sequential_expected.active_add_files,
@@ -650,6 +658,7 @@ mod tests {
         if let Some(expected) = parallel_expected {
             // Accumulate totals across all parallel logs
             let mut total_add_files_seen = 0u64;
+            let mut total_add_files_seen_from_delta_files = 0u64;
             let mut total_active_add_files = 0u64;
             let mut total_remove_files_seen = 0u64;
             let mut total_non_file_actions = 0u64;
@@ -662,8 +671,11 @@ mod tests {
 
                 // Extract and accumulate metrics
                 total_add_files_seen += extract_metric(remaining, "add_files_seen");
+                total_add_files_seen_from_delta_files +=
+                    extract_metric(remaining, "add_files_seen_from_delta_files");
                 total_active_add_files += extract_metric(remaining, "active_add_files");
-                total_remove_files_seen += extract_metric(remaining, "remove_files_seen");
+                total_remove_files_seen +=
+                    extract_metric(remaining, "remove_files_seen_from_delta_files");
                 total_non_file_actions += extract_metric(remaining, "non_file_actions");
                 total_predicate_filtered += extract_metric(remaining, "predicate_filtered");
 
@@ -678,6 +690,10 @@ mod tests {
             assert_eq!(
                 total_add_files_seen, expected.add_files_seen,
                 "Parallel add_files_seen mismatch"
+            );
+            assert_eq!(
+                total_add_files_seen_from_delta_files, expected.add_files_seen_from_delta_files,
+                "Parallel add_files_seen_from_delta_files mismatch"
             );
             assert_eq!(
                 total_active_add_files, expected.active_add_files,
@@ -711,6 +727,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
@@ -718,6 +735,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 101,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 101,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -729,6 +747,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
@@ -736,6 +755,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 101,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 101,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -751,15 +771,17 @@ mod tests {
         }),
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
         },
-        // Data skipping predicate filters 4 files (101 -> 97).
-        // add_files_seen counts files AFTER data skipping.
+        // Data skipping predicate filters 4 files (101 -> 97). add_files_seen counts all input
+        // Adds, while active_add_files counts the Adds remaining after filtering and deduplication.
         expected_parallel_metrics: Some(ExpectedMetrics {
-            add_files_seen: 97,
+            add_files_seen: 101,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 97,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -779,9 +801,10 @@ mod tests {
             Arc::new(Expr::eq(col!("letter"), lit("a")))
         }),
         expected_sequential_metrics: ExpectedMetrics {
-            // Columnar filter prunes all 4 non-matching files (b, c, e, null) before the
-            // visitor. The is_add guard protects Removes but not null-partition Adds.
-            add_files_seen: 2,
+            // Columnar filtering prunes all 4 non-matching files (b, c, e, null), but
+            // add_files_seen counts all 6 input Adds.
+            add_files_seen: 6,
+            add_files_seen_from_delta_files: 6,
             active_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -795,6 +818,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 3,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 3,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -807,6 +831,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -814,6 +839,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 2,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -825,6 +851,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 3,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 3,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -837,6 +864,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -844,6 +872,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 2,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 2,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -855,6 +884,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -862,6 +892,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 4,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 4,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -873,6 +904,7 @@ mod tests {
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
             add_files_seen: 0,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
@@ -880,6 +912,7 @@ mod tests {
         },
         expected_parallel_metrics: Some(ExpectedMetrics {
             add_files_seen: 4,
+            add_files_seen_from_delta_files: 0,
             active_add_files: 4,
             remove_files_seen: 0,
             non_file_actions: 0,
@@ -890,8 +923,9 @@ mod tests {
         path: "table-without-dv-small",
         predicate: None,
         expected_sequential_metrics: ExpectedMetrics {
-            // This table has single-part checkpoint, completes in sequential phase
+            // This table has only commit files, so it completes in the sequential phase.
             add_files_seen: 1,
+            add_files_seen_from_delta_files: 1,
             active_add_files: 1,
             remove_files_seen: 0,
             non_file_actions: 3,
@@ -911,6 +945,7 @@ mod tests {
             //             then checkpoint (add B filtered by remove)
             // Result: 2 adds seen, 1 active (only C), 1 remove seen, B filtered by dedup
             add_files_seen: 2,
+            add_files_seen_from_delta_files: 1,
             active_add_files: 1,
             remove_files_seen: 1,
             non_file_actions: 4,

--- a/kernel/src/parallel/parallel_phase.rs
+++ b/kernel/src/parallel/parallel_phase.rs
@@ -585,6 +585,7 @@ mod tests {
         add_files_seen: u64,
         add_files_seen_from_delta_files: u64,
         selected_add_files: u64,
+        selected_add_files_bytes: u64,
         remove_files_seen: u64,
         non_file_actions: u64,
         predicate_filtered: u64,
@@ -620,6 +621,7 @@ mod tests {
         let add_files_seen_from_delta_files =
             extract_metric(sequential_logs, "add_files_seen_from_delta_files");
         let selected_add_files = extract_metric(sequential_logs, "selected_add_files");
+        let selected_add_files_bytes = extract_metric(sequential_logs, "selected_add_files_bytes");
         let remove_files_seen =
             extract_metric(sequential_logs, "remove_files_seen_from_delta_files");
         let non_file_actions = extract_metric(sequential_logs, "non_file_actions");
@@ -636,6 +638,10 @@ mod tests {
         assert_eq!(
             selected_add_files, sequential_expected.selected_add_files,
             "Sequential selected_add_files mismatch"
+        );
+        assert_eq!(
+            selected_add_files_bytes, sequential_expected.selected_add_files_bytes,
+            "Sequential selected_add_files_bytes mismatch"
         );
         assert_eq!(
             remove_files_seen, sequential_expected.remove_files_seen,
@@ -660,6 +666,7 @@ mod tests {
             let mut total_add_files_seen = 0u64;
             let mut total_add_files_seen_from_delta_files = 0u64;
             let mut total_selected_add_files = 0u64;
+            let mut total_selected_add_files_bytes = 0u64;
             let mut total_remove_files_seen = 0u64;
             let mut total_non_file_actions = 0u64;
             let mut total_predicate_filtered = 0u64;
@@ -674,6 +681,8 @@ mod tests {
                 total_add_files_seen_from_delta_files +=
                     extract_metric(remaining, "add_files_seen_from_delta_files");
                 total_selected_add_files += extract_metric(remaining, "selected_add_files");
+                total_selected_add_files_bytes +=
+                    extract_metric(remaining, "selected_add_files_bytes");
                 total_remove_files_seen +=
                     extract_metric(remaining, "remove_files_seen_from_delta_files");
                 total_non_file_actions += extract_metric(remaining, "non_file_actions");
@@ -698,6 +707,10 @@ mod tests {
             assert_eq!(
                 total_selected_add_files, expected.selected_add_files,
                 "Parallel selected_add_files mismatch"
+            );
+            assert_eq!(
+                total_selected_add_files_bytes, expected.selected_add_files_bytes,
+                "Parallel selected_add_files_bytes mismatch"
             );
             assert_eq!(
                 total_remove_files_seen, expected.remove_files_seen,
@@ -729,6 +742,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
@@ -737,6 +751,7 @@ mod tests {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 101,
+            selected_add_files_bytes: 54541,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -749,6 +764,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
@@ -757,6 +773,7 @@ mod tests {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 101,
+            selected_add_files_bytes: 54541,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -773,6 +790,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 5,
             predicate_filtered: 0,
@@ -783,6 +801,7 @@ mod tests {
             add_files_seen: 101,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 97,
+            selected_add_files_bytes: 52616,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 4,
@@ -806,6 +825,7 @@ mod tests {
             add_files_seen: 6,
             add_files_seen_from_delta_files: 6,
             selected_add_files: 2,
+            selected_add_files_bytes: 1502,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 4,
@@ -820,6 +840,7 @@ mod tests {
             add_files_seen: 3,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 3,
+            selected_add_files_bytes: 1481,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -833,6 +854,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -841,6 +863,7 @@ mod tests {
             add_files_seen: 2,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 2,
+            selected_add_files_bytes: 1003,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -853,6 +876,7 @@ mod tests {
             add_files_seen: 3,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 3,
+            selected_add_files_bytes: 1481,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -866,6 +890,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -874,6 +899,7 @@ mod tests {
             add_files_seen: 2,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 2,
+            selected_add_files_bytes: 1003,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -886,6 +912,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -894,6 +921,7 @@ mod tests {
             add_files_seen: 4,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 4,
+            selected_add_files_bytes: 2009,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -906,6 +934,7 @@ mod tests {
             add_files_seen: 0,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 0,
+            selected_add_files_bytes: 0,
             remove_files_seen: 0,
             non_file_actions: 4,
             predicate_filtered: 0,
@@ -914,6 +943,7 @@ mod tests {
             add_files_seen: 4,
             add_files_seen_from_delta_files: 0,
             selected_add_files: 4,
+            selected_add_files_bytes: 2009,
             remove_files_seen: 0,
             non_file_actions: 0,
             predicate_filtered: 0,
@@ -927,6 +957,7 @@ mod tests {
             add_files_seen: 1,
             add_files_seen_from_delta_files: 1,
             selected_add_files: 1,
+            selected_add_files_bytes: 548,
             remove_files_seen: 0,
             non_file_actions: 3,
             predicate_filtered: 0,
@@ -947,6 +978,7 @@ mod tests {
             add_files_seen: 2,
             add_files_seen_from_delta_files: 1,
             selected_add_files: 1,
+            selected_add_files_bytes: 1010,
             remove_files_seen: 1,
             non_file_actions: 4,
             predicate_filtered: 0,

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -534,7 +534,7 @@ impl ScanLogReplayProcessor {
         })
     }
 
-    fn record_active_add_files(
+    fn record_selected_add_files(
         &self,
         selection_vector: &[bool],
         active_add_file_sizes: &[u64],
@@ -549,7 +549,7 @@ impl ScanLogReplayProcessor {
         );
         for (selected, size) in selection_vector.iter().zip(active_add_file_sizes) {
             if *selected {
-                self.metrics.record_active_add_file(*size);
+                self.metrics.record_selected_add_file(*size);
             }
         }
         Ok(())
@@ -997,7 +997,7 @@ impl ParallelLogReplayProcessor for ScanLogReplayProcessor {
                 active_add_file_sizes,
             }
         };
-        self.record_active_add_files(&final_selection, &active_add_file_sizes)?;
+        self.record_selected_add_files(&final_selection, &active_add_file_sizes)?;
         let scan_metadata =
             ScanMetadata::try_new(transformed_actions, final_selection, row_transform_exprs)?;
         self.metrics
@@ -1096,7 +1096,7 @@ impl LogReplayProcessor for ScanLogReplayProcessor {
                 active_add_file_sizes,
             }
         };
-        self.record_active_add_files(&final_selection, &active_add_file_sizes)?;
+        self.record_selected_add_files(&final_selection, &active_add_file_sizes)?;
         let scan_metadata =
             ScanMetadata::try_new(transformed_actions, final_selection, row_transform_exprs)?;
         self.metrics

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -593,6 +593,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         &mut self,
         row: usize,
         getters: &[&'b dyn GetData<'b>],
+        selected: bool,
     ) -> DeltaResult<bool> {
         // When processing file actions, we extract path and deletion vector information based on
         // action type:
@@ -603,6 +604,13 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         // The file extraction logic selects the appropriate indexes based on whether we found a
         // valid path. Remove getters are not included when visiting a non-log batch
         // (checkpoint batch), so do not try to extract remove actions in that case.
+        let is_log_batch = self.deduplicator.is_log_batch();
+        if !selected {
+            // Data-skipping predicates keep non-Add rows, so an unselected row is an Add. Count it
+            // without constructing the deduplication key that the predicate made unnecessary.
+            self.metrics.record_add_file_seen(is_log_batch);
+            return Ok(false);
+        }
         let Some(FileActionInfo {
             key: file_key,
             size,
@@ -610,7 +618,7 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         }) = self.deduplicator.extract_file_action(
             row,
             getters,
-            !self.deduplicator.is_log_batch(), // skip_removes. true if this is a checkpoint batch
+            !is_log_batch, // skip_removes. true if this is a checkpoint batch
         )?
         else {
             self.metrics.incr_non_file_actions();
@@ -618,9 +626,9 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         };
 
         if is_add {
-            self.metrics.incr_add_files_seen()
+            self.metrics.record_add_file_seen(is_log_batch);
         } else {
-            self.metrics.incr_remove_files_seen()
+            self.metrics.incr_remove_files_seen_from_delta_files();
         };
 
         // Check both adds and removes (skipping already-seen), but only transform and return adds
@@ -723,9 +731,8 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
         );
 
         for row in 0..row_count {
-            if self.selection_vector[row] {
-                self.selection_vector[row] = self.is_valid_add(row, getters)?;
-            }
+            let selected = self.selection_vector[row];
+            self.selection_vector[row] = self.is_valid_add(row, getters, selected)?;
         }
 
         self.metrics

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -11,17 +11,18 @@ use crate::metrics::{MetricId, ScanMetadataCompleted, ScanType, TableType};
 /// Metrics collected during scan log replay. Metrics are updated and read using relaxed ordering
 /// to keep updates fast across parallel executing threads.
 pub(crate) struct ScanMetrics {
-    /// Add files that entered deduplication. This normally excludes add files filtered by data
-    /// skipping. During parse-error fallback, deduplication runs first, so add files filtered by
-    /// retry-time data skipping are included.
+    /// Add actions in replay input before predicate filtering and deduplication. Includes
+    /// checkpoint and delta files.
     num_add_files_seen: AtomicU64,
+    /// Add actions in delta-file replay input before predicate filtering and deduplication.
+    num_add_files_seen_from_delta_files: AtomicU64,
     /// Add files that survived log replay (files to read). includes files that survived
     /// dataskipping, partition pruning, and add/remove deduplication.
     num_active_add_files: AtomicU64,
     /// Number of bytes in the active add files as reported by the add action size field
     active_add_files_bytes: AtomicU64,
-    /// Remove files seen (from delta/commit files only).
-    num_remove_files_seen: AtomicU64,
+    /// Remove actions in delta-file replay input before deduplication.
+    num_remove_files_seen_from_delta_files: AtomicU64,
     /// Non-file actions seen (protocol, metadata, etc.).
     num_non_file_actions: AtomicU64,
     /// Files filtered by predicates (data skipping + partition pruning).
@@ -38,9 +39,10 @@ impl Default for ScanMetrics {
     fn default() -> Self {
         Self {
             num_add_files_seen: AtomicU64::new(0),
+            num_add_files_seen_from_delta_files: AtomicU64::new(0),
             num_active_add_files: AtomicU64::new(0),
             active_add_files_bytes: AtomicU64::new(0),
-            num_remove_files_seen: AtomicU64::new(0),
+            num_remove_files_seen_from_delta_files: AtomicU64::new(0),
             num_non_file_actions: AtomicU64::new(0),
             num_predicate_filtered: AtomicU64::new(0),
             peak_hash_set_size: AtomicUsize::new(0),
@@ -51,8 +53,12 @@ impl Default for ScanMetrics {
 }
 
 impl ScanMetrics {
-    pub(crate) fn incr_add_files_seen(&self) {
+    pub(crate) fn record_add_file_seen(&self, is_from_delta_file: bool) {
         self.num_add_files_seen.fetch_add(1, Ordering::Relaxed);
+        if is_from_delta_file {
+            self.num_add_files_seen_from_delta_files
+                .fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     /// Record that we've seen an active add file, plus its size
@@ -62,8 +68,9 @@ impl ScanMetrics {
             .fetch_add(bytes, Ordering::Relaxed);
     }
 
-    pub(crate) fn incr_remove_files_seen(&self) {
-        self.num_remove_files_seen.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn incr_remove_files_seen_from_delta_files(&self) {
+        self.num_remove_files_seen_from_delta_files
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub(crate) fn incr_non_file_actions(&self) {
@@ -96,9 +103,12 @@ impl ScanMetrics {
     /// preserved since it represents a high-water mark across all phases.
     pub(crate) fn reset_counters(&self) {
         self.num_add_files_seen.store(0, Ordering::Relaxed);
+        self.num_add_files_seen_from_delta_files
+            .store(0, Ordering::Relaxed);
         self.num_active_add_files.store(0, Ordering::Relaxed);
         self.active_add_files_bytes.store(0, Ordering::Relaxed);
-        self.num_remove_files_seen.store(0, Ordering::Relaxed);
+        self.num_remove_files_seen_from_delta_files
+            .store(0, Ordering::Relaxed);
         self.num_non_file_actions.store(0, Ordering::Relaxed);
         self.num_predicate_filtered.store(0, Ordering::Relaxed);
         self.dedup_visitor_time_ns.store(0, Ordering::Relaxed);
@@ -124,9 +134,14 @@ impl ScanMetrics {
             scan_type,
             duration,
             num_add_files_seen: self.num_add_files_seen.load(Ordering::Relaxed),
+            num_add_files_seen_from_delta_files: self
+                .num_add_files_seen_from_delta_files
+                .load(Ordering::Relaxed),
             num_active_add_files: self.num_active_add_files.load(Ordering::Relaxed),
             active_add_files_bytes: self.active_add_files_bytes.load(Ordering::Relaxed),
-            num_remove_files_seen: self.num_remove_files_seen.load(Ordering::Relaxed),
+            num_remove_files_seen_from_delta_files: self
+                .num_remove_files_seen_from_delta_files
+                .load(Ordering::Relaxed),
             num_non_file_actions: self.num_non_file_actions.load(Ordering::Relaxed),
             num_predicate_filtered: self.num_predicate_filtered.load(Ordering::Relaxed),
             peak_hash_set_size: self.peak_hash_set_size.load(Ordering::Relaxed),
@@ -142,9 +157,14 @@ impl ScanMetrics {
     /// Log all metrics with a message in the current tracing span context.
     pub(crate) fn log(&self, message: impl AsRef<str>) {
         let add_files_seen = self.num_add_files_seen.load(Ordering::Relaxed);
+        let add_files_seen_from_delta_files = self
+            .num_add_files_seen_from_delta_files
+            .load(Ordering::Relaxed);
         let active_add_files = self.num_active_add_files.load(Ordering::Relaxed);
         let active_add_files_bytes = self.active_add_files_bytes.load(Ordering::Relaxed);
-        let remove_files_seen = self.num_remove_files_seen.load(Ordering::Relaxed);
+        let remove_files_seen_from_delta_files = self
+            .num_remove_files_seen_from_delta_files
+            .load(Ordering::Relaxed);
         let non_file_actions = self.num_non_file_actions.load(Ordering::Relaxed);
         let predicate_filtered = self.num_predicate_filtered.load(Ordering::Relaxed);
         let peak_hash_set_size = self.peak_hash_set_size.load(Ordering::Relaxed);
@@ -152,9 +172,10 @@ impl ScanMetrics {
         let predicate_eval_time_ns = self.predicate_eval_time_ns.load(Ordering::Relaxed);
         info!(
             add_files_seen,
+            add_files_seen_from_delta_files,
             active_add_files,
             active_add_files_bytes,
-            remove_files_seen,
+            remove_files_seen_from_delta_files,
             non_file_actions,
             predicate_filtered,
             peak_hash_set_size,

--- a/kernel/src/scan/metrics.rs
+++ b/kernel/src/scan/metrics.rs
@@ -18,9 +18,9 @@ pub(crate) struct ScanMetrics {
     num_add_files_seen_from_delta_files: AtomicU64,
     /// Add files that survived log replay (files to read). includes files that survived
     /// dataskipping, partition pruning, and add/remove deduplication.
-    num_active_add_files: AtomicU64,
+    num_selected_add_files: AtomicU64,
     /// Number of bytes in the active add files as reported by the add action size field
-    active_add_files_bytes: AtomicU64,
+    selected_add_files_bytes: AtomicU64,
     /// Remove actions in delta-file replay input before deduplication.
     num_remove_files_seen_from_delta_files: AtomicU64,
     /// Non-file actions seen (protocol, metadata, etc.).
@@ -40,8 +40,8 @@ impl Default for ScanMetrics {
         Self {
             num_add_files_seen: AtomicU64::new(0),
             num_add_files_seen_from_delta_files: AtomicU64::new(0),
-            num_active_add_files: AtomicU64::new(0),
-            active_add_files_bytes: AtomicU64::new(0),
+            num_selected_add_files: AtomicU64::new(0),
+            selected_add_files_bytes: AtomicU64::new(0),
             num_remove_files_seen_from_delta_files: AtomicU64::new(0),
             num_non_file_actions: AtomicU64::new(0),
             num_predicate_filtered: AtomicU64::new(0),
@@ -61,10 +61,10 @@ impl ScanMetrics {
         }
     }
 
-    /// Record that we've seen an active add file, plus its size
-    pub(crate) fn record_active_add_file(&self, bytes: u64) {
-        self.num_active_add_files.fetch_add(1, Ordering::Relaxed);
-        self.active_add_files_bytes
+    /// Record that we've seen a selected add file, plus its size
+    pub(crate) fn record_selected_add_file(&self, bytes: u64) {
+        self.num_selected_add_files.fetch_add(1, Ordering::Relaxed);
+        self.selected_add_files_bytes
             .fetch_add(bytes, Ordering::Relaxed);
     }
 
@@ -105,8 +105,8 @@ impl ScanMetrics {
         self.num_add_files_seen.store(0, Ordering::Relaxed);
         self.num_add_files_seen_from_delta_files
             .store(0, Ordering::Relaxed);
-        self.num_active_add_files.store(0, Ordering::Relaxed);
-        self.active_add_files_bytes.store(0, Ordering::Relaxed);
+        self.num_selected_add_files.store(0, Ordering::Relaxed);
+        self.selected_add_files_bytes.store(0, Ordering::Relaxed);
         self.num_remove_files_seen_from_delta_files
             .store(0, Ordering::Relaxed);
         self.num_non_file_actions.store(0, Ordering::Relaxed);
@@ -137,8 +137,8 @@ impl ScanMetrics {
             num_add_files_seen_from_delta_files: self
                 .num_add_files_seen_from_delta_files
                 .load(Ordering::Relaxed),
-            num_active_add_files: self.num_active_add_files.load(Ordering::Relaxed),
-            active_add_files_bytes: self.active_add_files_bytes.load(Ordering::Relaxed),
+            num_selected_add_files: self.num_selected_add_files.load(Ordering::Relaxed),
+            selected_add_files_bytes: self.selected_add_files_bytes.load(Ordering::Relaxed),
             num_remove_files_seen_from_delta_files: self
                 .num_remove_files_seen_from_delta_files
                 .load(Ordering::Relaxed),
@@ -160,8 +160,8 @@ impl ScanMetrics {
         let add_files_seen_from_delta_files = self
             .num_add_files_seen_from_delta_files
             .load(Ordering::Relaxed);
-        let active_add_files = self.num_active_add_files.load(Ordering::Relaxed);
-        let active_add_files_bytes = self.active_add_files_bytes.load(Ordering::Relaxed);
+        let selected_add_files = self.num_selected_add_files.load(Ordering::Relaxed);
+        let selected_add_files_bytes = self.selected_add_files_bytes.load(Ordering::Relaxed);
         let remove_files_seen_from_delta_files = self
             .num_remove_files_seen_from_delta_files
             .load(Ordering::Relaxed);
@@ -173,8 +173,8 @@ impl ScanMetrics {
         info!(
             add_files_seen,
             add_files_seen_from_delta_files,
-            active_add_files,
-            active_add_files_bytes,
+            selected_add_files,
+            selected_add_files_bytes,
             remove_files_seen_from_delta_files,
             non_file_actions,
             predicate_filtered,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -2325,50 +2325,57 @@ mod scan_metadata_completed_tests {
     }
 
     #[rstest]
-    #[case::basic_scan("./tests/data/parsed-stats/", None, 6, 6, 17236, 0, 0)]
+    #[case::basic_scan("./tests/data/parsed-stats/", None, (6, 2, 6, 17236, 0, 0))]
     #[case::static_skip_all(
         "./tests/data/parsed-stats/",
         Some(Arc::new(Pred::FALSE)),
-        0,
-        0,
-        0,
-        0,
-        0
+        (0, 0, 0, 0, 0, 0)
     )]
-    #[case::with_removes("./tests/data/table-with-cdf/", None, 1, 0, 0, 2, 0)]
+    #[case::with_removes("./tests/data/table-with-cdf/", None, (1, 1, 0, 0, 2, 0))]
     #[case::with_checkpoint(
         "./tests/data/with_checkpoint_no_last_checkpoint/",
         None,
-        2,
-        1,
-        1010,
-        1,
-        0
+        (2, 1, 1, 1010, 1, 0)
     )]
     #[case::partition_filter(
         "./tests/data/basic_partitioned/",
         Some(Arc::new(Expr::eq(col!("letter"), lit("a")))),
-        2, 2, 1502, 0, 4
+        (6, 6, 2, 1502, 0, 4)
     )]
     fn test_scan_metrics(
         #[case] table: &str,
         #[case] predicate: Option<Arc<Pred>>,
-        #[case] expected_add_seen: u64,
-        #[case] expected_active: u64,
-        #[case] expected_active_bytes: u64,
-        #[case] expected_removes: u64,
-        #[case] expected_filtered: u64,
+        #[case] expected: (u64, u64, u64, u64, u64, u64),
     ) {
+        let (
+            expected_add_seen,
+            expected_add_seen_from_delta,
+            expected_active,
+            expected_active_bytes,
+            expected_removes,
+            expected_filtered,
+        ) = expected;
         let (reporter, _guard, _) = run_scan(table, predicate, None);
         let MetricEvent::ScanMetadataCompleted(e) = get_scan_event(&reporter) else {
             panic!("expected ScanMetadataCompleted");
         };
         assert!(e.duration > Duration::ZERO);
         assert_eq!(e.num_add_files_seen, expected_add_seen);
+        assert_eq!(
+            e.num_add_files_seen_from_delta_files,
+            expected_add_seen_from_delta
+        );
         assert_eq!(e.num_active_add_files, expected_active);
         assert_eq!(e.active_add_files_bytes, expected_active_bytes);
-        assert_eq!(e.num_remove_files_seen, expected_removes);
+        assert_eq!(e.num_remove_files_seen_from_delta_files, expected_removes);
         assert_eq!(e.num_predicate_filtered, expected_filtered);
+        let rendered = e.to_string();
+        assert!(rendered.contains(&format!(
+            "add_files_seen_from_delta_files={expected_add_seen_from_delta}"
+        )));
+        assert!(rendered.contains(&format!(
+            "remove_files_seen_from_delta_files={expected_removes}"
+        )));
     }
 
     // The parallel-scan paths (both sequential and parallel phase events) are covered by

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -2365,8 +2365,8 @@ mod scan_metadata_completed_tests {
             e.num_add_files_seen_from_delta_files,
             expected_add_seen_from_delta
         );
-        assert_eq!(e.num_active_add_files, expected_active);
-        assert_eq!(e.active_add_files_bytes, expected_active_bytes);
+        assert_eq!(e.num_selected_add_files, expected_active);
+        assert_eq!(e.selected_add_files_bytes, expected_active_bytes);
         assert_eq!(e.num_remove_files_seen_from_delta_files, expected_removes);
         assert_eq!(e.num_predicate_filtered, expected_filtered);
         let rendered = e.to_string();

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -857,7 +857,14 @@ async fn scan_with_replace_table_schema_change(
             .iter()
             .map(|e| e.num_add_files_seen)
             .sum::<u64>(),
-        4
+        6
+    );
+    assert_eq!(
+        scan_events
+            .iter()
+            .map(|e| e.num_add_files_seen_from_delta_files)
+            .sum::<u64>(),
+        if checkpoint_old_add { 3 } else { 6 }
     );
     assert_eq!(
         scan_events
@@ -876,7 +883,7 @@ async fn scan_with_replace_table_schema_change(
     assert_eq!(
         scan_events
             .iter()
-            .map(|e| e.num_remove_files_seen)
+            .map(|e| e.num_remove_files_seen_from_delta_files)
             .sum::<u64>(),
         3
     );

--- a/kernel/tests/integration/data_skipping.rs
+++ b/kernel/tests/integration/data_skipping.rs
@@ -869,14 +869,14 @@ async fn scan_with_replace_table_schema_change(
     assert_eq!(
         scan_events
             .iter()
-            .map(|e| e.num_active_add_files)
+            .map(|e| e.num_selected_add_files)
             .sum::<u64>(),
         expected_active_files
     );
     assert_eq!(
         scan_events
             .iter()
-            .map(|e| e.active_add_files_bytes)
+            .map(|e| e.selected_add_files_bytes)
             .sum::<u64>(),
         expected_active_bytes
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR aligns three Rust scan source-action counters with Java Kernel:

- `num_add_files_seen` counts replay-input Add actions from checkpoints and delta files.
- `num_add_files_seen_from_delta_files` counts replay-input Add actions from delta files.
- `num_remove_files_seen_from_delta_files` counts replay-input Remove actions from delta files.

It also renames the post-filter metrics to describe their selection boundary:

- `num_selected_add_files` (previously `num_active_add_files`) counts Add files that survive
  filtering and deduplication.
- `selected_add_files_bytes` (previously `active_add_files_bytes`) sums their sizes.

This is not full scan-metrics parity. Rust's `num_selected_add_files` remains post-filter and does
not yet expose Java's `numDuplicateAddFiles`. Java's report-level `isFullyConsumed` also has no
Rust equivalent.

### Keep action counts stable during parse-error fallback

Java kernel actually does de-dup before predicate eval/data-skipping (seems like [ActiveAddFilesIterator](https://github.com/delta-io/delta/blob/master/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java#L227) performs de-dup and increments activeAddFilesCounter before [ScanImpl](https://github.com/delta-io/delta/blob/master/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java#L184) applies downstream partition pruning and data skipping). This difference allows for parse errors to change how the num_add_files_seen metric was counted during parse exceptions (like the below example).

Since Rust's predicate eval then de-dup path needs a fallback for an old `Add` whose partition values or statistics cannot be parsed using the current table schema, Rust deduplicates the raw actions first and
retries parsing only the surviving Adds. This PR does not change that ordering or fallback. It
records the source action counters before either path, so the counters do not depend on which path
runs.

For example, consider the following relevant Delta log actions.

`_delta_log/00000000000000000001.json` contains three Adds written with the old string partition
schema:

```json
{"add":{"path":"old-a.parquet","partitionValues":{"part":"not-an-integer-a"},"size":201,"modificationTime":1700000000000,"dataChange":true}}
{"add":{"path":"old-b.parquet","partitionValues":{"part":"not-an-integer-b"},"size":202,"modificationTime":1700000000000,"dataChange":true}}
{"add":{"path":"old-c.parquet","partitionValues":{"part":"not-an-integer-c"},"size":203,"modificationTime":1700000000000,"dataChange":true}}
```

`_delta_log/00000000000000000002.json` replaces the schema with a `LONG` partition column and
removes those files:

```json
{"metaData":{"id":"replacement-table","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"part\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"value\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["part"],"configuration":{},"createdTime":1700000001000}}
{"remove":{"path":"old-a.parquet","deletionTimestamp":1700000001000,"dataChange":true,"extendedFileMetadata":false}}
{"remove":{"path":"old-b.parquet","deletionTimestamp":1700000001000,"dataChange":true,"extendedFileMetadata":false}}
{"remove":{"path":"old-c.parquet","deletionTimestamp":1700000001000,"dataChange":true,"extendedFileMetadata":false}}
```

`_delta_log/00000000000000000003.json` contains three Adds written with the new schema:

```json
{"add":{"path":"current-a.parquet","partitionValues":{"part":"1"},"size":101,"modificationTime":1700000002000,"dataChange":true}}
{"add":{"path":"current-b.parquet","partitionValues":{"part":"2"},"size":102,"modificationTime":1700000002000,"dataChange":true}}
{"add":{"path":"current-c.parquet","partitionValues":{"part":"3"},"size":103,"modificationTime":1700000002000,"dataChange":true}}
```

For a scan with `part = 1`:

- There are six Add actions in the input log.
- There are three Remove actions in the input log.
- Deduplication removes the three `old-*.parquet` Adds.
- Data skipping keeps `current-a.parquet` and skips `current-b.parquet` and
  `current-c.parquet`.

Previously, the metrics reported:

| Metric | Value | Reason |
|---|---:|---|
| `num_add_files_seen` | 4 | One current Add and three old Adds entered deduplication. |
| `num_add_files_seen_from_delta_files` | Not available | This metric did not exist. |
| `num_remove_files_seen` | 3 | The three Removes came from the version 2 delta file. |
| `num_active_add_files` | 1 | One Add remained after data skipping and deduplication. |

`num_add_files_seen` was incremented inside the deduplication visitor. It reported four rather than
six because:

- `current-a.parquet` entered deduplication after passing the predicate.
- The parse error caused the fallback to send all three `old-*.parquet` Adds through
  deduplication before retrying the predicate.
- `current-b.parquet` and `current-c.parquet` were filtered before deduplication and were not
  counted.

The new metrics report:

| Metric | Value | Reason |
|---|---:|---|
| `num_add_files_seen` | 6 | All six Add actions were read. |
| `num_add_files_seen_from_delta_files` | 6 | All six Adds came from delta files. |
| `num_remove_files_seen_from_delta_files` | 3 | The three Removes came from the version 2 delta file. |
| `num_selected_add_files` | 1 | Rust reports the one Add remaining after data skipping and deduplication. |

The first three values describe actions read from the log and remain the same whether or not the
parse-error fallback runs.

`num_selected_add_files` is not intended to match Java Kernel's `activeAddFilesCounter`. Java
increments that counter after deduplication but before downstream partition pruning and data
skipping, so Java would report three active Adds for this example. Rust currently records
`num_selected_add_files` after both filtering and deduplication, so Rust reports one.

### This PR affects the following public APIs

This is a breaking metrics API change:

- `num_remove_files_seen` is renamed to `num_remove_files_seen_from_delta_files`.
- `num_active_add_files` is renamed to `num_selected_add_files`.
- `active_add_files_bytes` is renamed to `selected_add_files_bytes`.
- `num_add_files_seen_from_delta_files` is added to the Rust and FFI metric events.
- The meaning of `num_add_files_seen` changes to include predicate-filtered Adds.
- The FFI `ScanMetadataCompleted` struct gains a field, which changes its layout.

## How was this change tested?

UTs
