### PR TITLE
fix!: preserve outer-list nullability on column reorder

### DIFF
--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -3482,9 +3482,7 @@ mod tests {
         }
     }
 
-    // A nullable list column with a non-nullable element struct and null rows: the outer column's
-    // nullability must survive reorder, else its null rows fail `StructArray::try_new`. `List`
-    // (i32 offsets) and `LargeList` (i64) take separate reorder arms, so cover both.
+    // Reorder must keep a nullable list column nullable, for both List and LargeList.
     #[rstest]
     #[case::list(false)]
     #[case::large_list(true)]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -914,7 +914,9 @@ pub(crate) fn reorder_struct_array(
                     final_fields_cols[reorder_index.index] = Some((new_field, col));
                 }
                 ReorderIndexTransform::Nested(children) => {
-                    let input_field_name = input_fields[parquet_position].name();
+                    let field = &input_fields[parquet_position];
+                    let input_field_name = field.name();
+                    let field_nullable = field.is_nullable();
                     match input_cols[parquet_position].data_type() {
                         ArrowDataType::Struct(_) => {
                             let struct_array = input_cols[parquet_position].as_struct().clone();
@@ -930,7 +932,7 @@ pub(crate) fn reorder_struct_array(
                             let new_field = Arc::new(ArrowField::new_struct(
                                 input_field_name,
                                 result_array.fields().clone(),
-                                input_fields[parquet_position].is_nullable(),
+                                field_nullable,
                             ));
                             final_fields_cols[reorder_index.index] =
                                 Some((new_field, result_array));
@@ -940,7 +942,7 @@ pub(crate) fn reorder_struct_array(
                             final_fields_cols[reorder_index.index] = reorder_list(
                                 list_array,
                                 input_field_name,
-                                input_fields[parquet_position].is_nullable(),
+                                field_nullable,
                                 children,
                             )?;
                         }
@@ -949,7 +951,7 @@ pub(crate) fn reorder_struct_array(
                             final_fields_cols[reorder_index.index] = reorder_list(
                                 list_array,
                                 input_field_name,
-                                input_fields[parquet_position].is_nullable(),
+                                field_nullable,
                                 children,
                             )?;
                         }
@@ -1025,7 +1027,7 @@ fn reorder_list<O: OffsetSizeTrait>(
     list_nullable: bool,
     children: &[ReorderIndex],
 ) -> DeltaResult<FieldArrayOpt> {
-    let (list_field, offset_buffer, maybe_sa, null_buf) = list_array.into_parts();
+    let (list_values_field, offset_buffer, maybe_sa, null_buf) = list_array.into_parts();
     if let Some(struct_array) = maybe_sa.as_struct_opt() {
         let struct_array = struct_array.clone();
         let result_array = Arc::new(reorder_struct_array(
@@ -1036,9 +1038,9 @@ fn reorder_list<O: OffsetSizeTrait>(
             None, // No file_location passed since metadata columns can't be nested
         )?);
         let new_list_field = Arc::new(ArrowField::new_struct(
-            list_field.name(),
+            list_values_field.name(),
             result_array.fields().clone(),
-            list_field.is_nullable(),
+            list_values_field.is_nullable(),
         ));
         let new_field = Arc::new(ArrowField::new_list(
             input_field_name,

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -937,13 +937,21 @@ pub(crate) fn reorder_struct_array(
                         }
                         ArrowDataType::List(_) => {
                             let list_array = input_cols[parquet_position].as_list::<i32>().clone();
-                            final_fields_cols[reorder_index.index] =
-                                reorder_list(list_array, input_field_name, children)?;
+                            final_fields_cols[reorder_index.index] = reorder_list(
+                                list_array,
+                                input_field_name,
+                                input_fields[parquet_position].is_nullable(),
+                                children,
+                            )?;
                         }
                         ArrowDataType::LargeList(_) => {
                             let list_array = input_cols[parquet_position].as_list::<i64>().clone();
-                            final_fields_cols[reorder_index.index] =
-                                reorder_list(list_array, input_field_name, children)?;
+                            final_fields_cols[reorder_index.index] = reorder_list(
+                                list_array,
+                                input_field_name,
+                                input_fields[parquet_position].is_nullable(),
+                                children,
+                            )?;
                         }
                         ArrowDataType::Map(_, _) => {
                             let map_array = input_cols[parquet_position].as_map().clone();
@@ -1014,6 +1022,7 @@ pub(crate) fn reorder_struct_array(
 fn reorder_list<O: OffsetSizeTrait>(
     list_array: GenericListArray<O>,
     input_field_name: &str,
+    list_nullable: bool,
     children: &[ReorderIndex],
 ) -> DeltaResult<FieldArrayOpt> {
     let (list_field, offset_buffer, maybe_sa, null_buf) = list_array.into_parts();
@@ -1029,12 +1038,12 @@ fn reorder_list<O: OffsetSizeTrait>(
         let new_list_field = Arc::new(ArrowField::new_struct(
             list_field.name(),
             result_array.fields().clone(),
-            result_array.is_nullable(),
+            list_field.is_nullable(),
         ));
         let new_field = Arc::new(ArrowField::new_list(
             input_field_name,
             new_list_field.clone(),
-            list_field.is_nullable(),
+            list_nullable,
         ));
         let list = Arc::new(GenericListArray::try_new(
             new_list_field,
@@ -3469,6 +3478,65 @@ mod tests {
             let struct_item = array_item.as_struct();
             assert_eq!(struct_item.column_names(), vec!["c", "b"]);
         }
+    }
+
+    // A nullable list column with a non-nullable element struct and null rows: the outer column's
+    // nullability must survive reorder, else its null rows fail `StructArray::try_new`.
+    #[test]
+    fn reorder_nullable_list_of_non_nullable_struct_with_null_rows() {
+        // Row 0 holds two elements; row 1 is a null list entry.
+        let boolean = Arc::new(BooleanArray::from(vec![false, true]));
+        let int = Arc::new(Int32Array::from(vec![42, 28]));
+        let list_sa = StructArray::from(vec![
+            (
+                Arc::new(ArrowField::new("b", ArrowDataType::Boolean, false)),
+                boolean as ArrowArrayRef,
+            ),
+            (
+                Arc::new(ArrowField::new("c", ArrowDataType::Int32, false)),
+                int as ArrowArrayRef,
+            ),
+        ]);
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2]));
+        let item_field = ArrowField::new("item", list_sa.data_type().clone(), false);
+        let nulls = NullBuffer::from(vec![true, false]);
+        let list = Arc::new(
+            GenericListArray::try_new(
+                Arc::new(item_field),
+                offsets,
+                Arc::new(list_sa),
+                Some(nulls),
+            )
+            .unwrap(),
+        );
+        let element_fields: ArrowFields = vec![
+            Arc::new(ArrowField::new("b", ArrowDataType::Boolean, false)),
+            Arc::new(ArrowField::new("c", ArrowDataType::Int32, false)),
+        ]
+        .into();
+        let list_field = Arc::new(ArrowField::new(
+            "list",
+            ArrowDataType::new_list(ArrowDataType::Struct(element_fields), false),
+            true,
+        ));
+        let struct_array = StructArray::from(vec![(list_field, list as ArrowArrayRef)]);
+        let reorder = vec![ReorderIndex::nested(
+            0,
+            vec![ReorderIndex::identity(1), ReorderIndex::identity(0)],
+        )];
+
+        let ordered = reorder_struct_array(struct_array, &reorder, None, None).unwrap();
+
+        assert!(ordered.fields()[0].is_nullable());
+        let ordered_list_col = ordered.column(0).as_list::<i32>();
+        assert!(!ordered_list_col.is_null(0));
+        assert!(ordered_list_col.is_null(1));
+        let ArrowDataType::List(element_field) = ordered.fields()[0].data_type() else {
+            panic!("expected a list column");
+        };
+        assert!(!element_field.is_nullable());
+        let present = ordered_list_col.value(0);
+        assert_eq!(present.as_struct().column_names(), vec!["c", "b"]);
     }
 
     // boy howdy this is more complicated than expected

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1046,7 +1046,7 @@ fn reorder_list<O: OffsetSizeTrait>(
             result_array,
             null_buf,
         )?);
-        // Derive the field type from the rebuilt array so it stays List or LargeList per `O`.
+        // Take the field's type from the rebuilt array so a LargeList isn't forced to List.
         let new_field = Arc::new(ArrowField::new(
             input_field_name,
             list.data_type().clone(),

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -1040,7 +1040,7 @@ fn reorder_list<O: OffsetSizeTrait>(
         let new_list_field = Arc::new(ArrowField::new_struct(
             list_values_field.name(),
             result_array.fields().clone(),
-            list_values_field.is_nullable(),
+            result_array.is_nullable(),
         ));
         let new_field = Arc::new(ArrowField::new_list(
             input_field_name,

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -915,8 +915,6 @@ pub(crate) fn reorder_struct_array(
                 }
                 ReorderIndexTransform::Nested(children) => {
                     let field = &input_fields[parquet_position];
-                    let input_field_name = field.name();
-                    let field_nullable = field.is_nullable();
                     match input_cols[parquet_position].data_type() {
                         ArrowDataType::Struct(_) => {
                             let struct_array = input_cols[parquet_position].as_struct().clone();
@@ -930,9 +928,9 @@ pub(crate) fn reorder_struct_array(
                             )?);
                             // create the new field specifying the correct order for the struct
                             let new_field = Arc::new(ArrowField::new_struct(
-                                input_field_name,
+                                field.name(),
                                 result_array.fields().clone(),
-                                field_nullable,
+                                field.is_nullable(),
                             ));
                             final_fields_cols[reorder_index.index] =
                                 Some((new_field, result_array));
@@ -941,8 +939,8 @@ pub(crate) fn reorder_struct_array(
                             let list_array = input_cols[parquet_position].as_list::<i32>().clone();
                             final_fields_cols[reorder_index.index] = reorder_list(
                                 list_array,
-                                input_field_name,
-                                field_nullable,
+                                field.name(),
+                                field.is_nullable(),
                                 children,
                             )?;
                         }
@@ -950,15 +948,15 @@ pub(crate) fn reorder_struct_array(
                             let list_array = input_cols[parquet_position].as_list::<i64>().clone();
                             final_fields_cols[reorder_index.index] = reorder_list(
                                 list_array,
-                                input_field_name,
-                                field_nullable,
+                                field.name(),
+                                field.is_nullable(),
                                 children,
                             )?;
                         }
                         ArrowDataType::Map(_, _) => {
                             let map_array = input_cols[parquet_position].as_map().clone();
                             final_fields_cols[reorder_index.index] =
-                                reorder_map(map_array, input_field_name, children)?;
+                                reorder_map(map_array, field.name(), children)?;
                         }
                         _ => {
                             return Err(Error::internal_error(
@@ -1042,17 +1040,18 @@ fn reorder_list<O: OffsetSizeTrait>(
             result_array.fields().clone(),
             result_array.is_nullable(),
         ));
-        let new_field = Arc::new(ArrowField::new_list(
-            input_field_name,
-            new_list_field.clone(),
-            list_nullable,
-        ));
         let list = Arc::new(GenericListArray::try_new(
             new_list_field,
             offset_buffer,
             result_array,
             null_buf,
         )?);
+        // Derive the field type from the rebuilt array so it stays List or LargeList per `O`.
+        let new_field = Arc::new(ArrowField::new(
+            input_field_name,
+            list.data_type().clone(),
+            list_nullable,
+        ));
         Ok(Some((new_field, list)))
     } else {
         Err(Error::internal_error(
@@ -1572,7 +1571,8 @@ mod tests {
     use crate::arrow::array::{
         Array, ArrayRef as ArrowArrayRef, AsArray, BooleanArray, GenericListArray, Int32Array,
         Int32Builder, Int64Array, LargeStringArray, ListArray, MapArray, MapBuilder, MapFieldNames,
-        NullArray, StringArray, StringBuilder, StringViewArray, StructArray, StructBuilder,
+        NullArray, OffsetSizeTrait, StringArray, StringBuilder, StringViewArray, StructArray,
+        StructBuilder,
     };
     use crate::arrow::buffer::{OffsetBuffer, ScalarBuffer};
     use crate::arrow::datatypes::{
@@ -3483,44 +3483,41 @@ mod tests {
     }
 
     // A nullable list column with a non-nullable element struct and null rows: the outer column's
-    // nullability must survive reorder, else its null rows fail `StructArray::try_new`.
-    #[test]
-    fn reorder_nullable_list_of_non_nullable_struct_with_null_rows() {
+    // nullability must survive reorder, else its null rows fail `StructArray::try_new`. `List`
+    // (i32 offsets) and `LargeList` (i64) take separate reorder arms, so cover both.
+    #[rstest]
+    #[case::list(false)]
+    #[case::large_list(true)]
+    fn reorder_nullable_list_of_non_nullable_struct_with_null_rows(#[case] large_list: bool) {
+        if large_list {
+            reorder_nullable_list_preserves_outer_nullability::<i64>();
+        } else {
+            reorder_nullable_list_preserves_outer_nullability::<i32>();
+        }
+    }
+
+    fn reorder_nullable_list_preserves_outer_nullability<O: OffsetSizeTrait>() {
         // Row 0 holds two elements; row 1 is a null list entry.
-        let boolean = Arc::new(BooleanArray::from(vec![false, true]));
-        let int = Arc::new(Int32Array::from(vec![42, 28]));
+        let boolean = Arc::new(BooleanArray::from(vec![false, true])) as ArrowArrayRef;
+        let int = Arc::new(Int32Array::from(vec![42, 28])) as ArrowArrayRef;
         let list_sa = StructArray::from(vec![
             (
                 Arc::new(ArrowField::new("b", ArrowDataType::Boolean, false)),
-                boolean as ArrowArrayRef,
+                boolean,
             ),
             (
                 Arc::new(ArrowField::new("c", ArrowDataType::Int32, false)),
-                int as ArrowArrayRef,
+                int,
             ),
         ]);
-        let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 2]));
-        let item_field = ArrowField::new("item", list_sa.data_type().clone(), false);
+        let offsets = OffsetBuffer::<O>::from_lengths([2, 0]);
+        let item_field = Arc::new(ArrowField::new("item", list_sa.data_type().clone(), false));
         let nulls = NullBuffer::from(vec![true, false]);
         let list = Arc::new(
-            GenericListArray::try_new(
-                Arc::new(item_field),
-                offsets,
-                Arc::new(list_sa),
-                Some(nulls),
-            )
-            .unwrap(),
+            GenericListArray::<O>::try_new(item_field, offsets, Arc::new(list_sa), Some(nulls))
+                .unwrap(),
         );
-        let element_fields: ArrowFields = vec![
-            Arc::new(ArrowField::new("b", ArrowDataType::Boolean, false)),
-            Arc::new(ArrowField::new("c", ArrowDataType::Int32, false)),
-        ]
-        .into();
-        let list_field = Arc::new(ArrowField::new(
-            "list",
-            ArrowDataType::new_list(ArrowDataType::Struct(element_fields), false),
-            true,
-        ));
+        let list_field = Arc::new(ArrowField::new("list", list.data_type().clone(), true));
         let struct_array = StructArray::from(vec![(list_field, list as ArrowArrayRef)]);
         let reorder = vec![ReorderIndex::nested(
             0,
@@ -3530,10 +3527,12 @@ mod tests {
         let ordered = reorder_struct_array(struct_array, &reorder, None, None).unwrap();
 
         assert!(ordered.fields()[0].is_nullable());
-        let ordered_list_col = ordered.column(0).as_list::<i32>();
+        let ordered_list_col = ordered.column(0).as_list::<O>();
         assert!(!ordered_list_col.is_null(0));
         assert!(ordered_list_col.is_null(1));
-        let ArrowDataType::List(element_field) = ordered.fields()[0].data_type() else {
+        let (ArrowDataType::List(element_field) | ArrowDataType::LargeList(element_field)) =
+            ordered.fields()[0].data_type()
+        else {
             panic!("expected a list column");
         };
         assert!(!element_field.is_nullable());

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -3530,12 +3530,11 @@ mod tests {
         let ordered_list_col = ordered.column(0).as_list::<O>();
         assert!(!ordered_list_col.is_null(0));
         assert!(ordered_list_col.is_null(1));
-        let (ArrowDataType::List(element_field) | ArrowDataType::LargeList(element_field)) =
-            ordered.fields()[0].data_type()
-        else {
-            panic!("expected a list column");
-        };
-        assert!(!element_field.is_nullable());
+        // The reordered column stays a list whose element struct is non-nullable.
+        assert!(matches!(
+            ordered.fields()[0].data_type(),
+            ArrowDataType::List(f) | ArrowDataType::LargeList(f) if !f.is_nullable()
+        ));
         let present = ordered_list_col.value(0);
         assert_eq!(present.as_struct().column_names(), vec!["c", "b"]);
     }

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -958,6 +958,7 @@ pub(crate) fn reorder_struct_array(
                             final_fields_cols[reorder_index.index] =
                                 reorder_map(map_array, field.name(), children)?;
                         }
+                        // TODO(#3178): ListView/LargeListView fall through here.
                         _ => {
                             return Err(Error::internal_error(
                                 "Nested reorder can only apply to struct/list/map.",


### PR DESCRIPTION
> Base of a 2-PR stack. #3133 builds on this -- merge this first.

## What changes are proposed in this pull request?

When reordering a list column, `reorder_list` was tagging the outer column
with its element's nullability instead of its own. A nullable list of
non-nullable structs (the adaptiveMetadata `checkpoint` action) with null rows
would then fail `StructArray::try_new`: field says non-nullable, data has nulls.
Fix threads the outer column's nullability through from the caller.

## How was this change tested?

Added `reorder_nullable_list_of_non_nullable_struct_with_null_rows`: reorders a
nullable list of non-nullable structs with a null row, asserts it succeeds and
the outer column stays nullable. Failed before the fix.
