### PR TITLE
docs: cross-cloud testing for engine changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,8 @@ directly: ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` acce
   when necessary: e.g. for states the builder cannot express, such as corrupt or malformed logs.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
-- When adding functionality to an engine that interacts with cloud storage (for example, writing
-  JSON files), make sure to test it against S3, Azure, and GCS.
+- When adding cloud-storage functionality to an engine, such as writing JSON files, make sure to
+  test it against S3, Azure, and GCS.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific
   version (time travel), and updating from an existing snapshot.
 - Consider table state: only versioned JSON commits, after a checkpoint, after a version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,8 @@ directly: ALWAYS use the visitor pattern (`visit_rows` with typed `GetData` acce
   when necessary: e.g. for states the builder cannot express, such as corrupt or malformed logs.
 - Consider how the feature interacts with Delta table features (see Protocol TLDR below).
 - Consider write paths: normal commits, checkpointing, CRC files, log compaction files.
+- When adding functionality to an engine that interacts with cloud storage (for example, writing
+  JSON files), make sure to test it against S3, Azure, and GCS.
 - Consider read paths: loading a snapshot from scratch at latest version, at a specific
   version (time travel), and updating from an existing snapshot.
 - Consider table state: only versioned JSON commits, after a checkpoint, after a version

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -27,6 +27,8 @@
 //! The [`Engine`] trait allows connectors to bring their own implementation of functionality such
 //! as reading and writing Parquet and JSON files, listing files in storage, and evaluating
 //! expressions. It exposes handler traits for each capability.
+//! When adding functionality to an engine that interacts with cloud storage (for example, writing
+//! JSON files), make sure to test it against S3, Azure, and GCS.
 //!
 //! ## Expression handling
 //!

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -27,8 +27,8 @@
 //! The [`Engine`] trait allows connectors to bring their own implementation of functionality such
 //! as reading and writing Parquet and JSON files, listing files in storage, and evaluating
 //! expressions. It exposes handler traits for each capability.
-//! When adding functionality to an engine that interacts with cloud storage (for example, writing
-//! JSON files), make sure to test it against S3, Azure, and GCS.
+//! When adding cloud-storage functionality to an engine, such as writing JSON files, make sure to
+//! test it against S3, Azure, and GCS.
 //!
 //! ## Expression handling
 //!


### PR DESCRIPTION
## What changes are proposed in this pull request?

Document that engine functionality interacting with cloud storage should be manually tested against
S3, Azure, and GCS. This guidance is included in both the crate-level documentation and contributor
instructions.

## How was this change tested?

Documentation-only change. Verified with `cargo +nightly fmt --check` and `git diff --check`.