### PR TITLE
feat: allow create table with variant/variantShredding feature

### DIFF
--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -75,6 +75,8 @@ const ALLOWED_DELTA_FEATURES: &[TableFeature] = &[
     TableFeature::ChangeDataFeed,
     TableFeature::TypeWidening,
     TableFeature::RowTracking,
+    TableFeature::VariantType,
+    TableFeature::VariantShredding,
     // Invariants is auto-enabled by `maybe_enable_invariants` when the schema has non-null
     // fields. Allowing explicit `delta.feature.invariants=supported` lets users pre-enable
     // the feature on an all-nullable table so a later ALTER TABLE ADD COLUMN NOT NULL does
@@ -701,11 +703,19 @@ fn validate_extract_table_features_and_properties(
 
         // Add to appropriate feature lists based on feature type
         let needs_domain_metadata = feature == TableFeature::RowTracking;
+        let needs_variant_type = feature == TableFeature::VariantShredding;
         add_feature_to_lists(feature, &mut reader_features, &mut writer_features);
         // RowTracking requires DomainMetadata as a dependency
         if needs_domain_metadata {
             add_feature_to_lists(
                 TableFeature::DomainMetadata,
+                &mut reader_features,
+                &mut writer_features,
+            );
+        }
+        if needs_variant_type {
+            add_feature_to_lists(
+                TableFeature::VariantType,
                 &mut reader_features,
                 &mut writer_features,
             );
@@ -1516,6 +1526,8 @@ mod tests {
     #[case::append_only(TableFeature::AppendOnly, "appendOnly")]
     #[case::change_data_feed(TableFeature::ChangeDataFeed, "changeDataFeed")]
     #[case::type_widening(TableFeature::TypeWidening, "typeWidening")]
+    #[case::variant_type(TableFeature::VariantType, "variantType")]
+    #[case::variant_shredding(TableFeature::VariantShredding, "variantShredding")]
     #[case::catalog_managed(TableFeature::CatalogManaged, "catalogManaged")]
     #[case::invariants(TableFeature::Invariants, "invariants")]
     fn test_feature_signal_accepted(#[case] feature: TableFeature, #[case] feature_name: &str) {
@@ -1541,6 +1553,28 @@ mod tests {
                 "{feature:?} is WriterOnly but reader_features is not empty"
             ),
         }
+    }
+
+    #[test]
+    fn test_variant_shredding_feature_signal_adds_variant_type_dependency() {
+        let properties = HashMap::from([(
+            "delta.feature.variantShredding".to_string(),
+            "supported".to_string(),
+        )]);
+        let validated = validate_extract_table_features_and_properties(properties).unwrap();
+
+        assert!(validated
+            .reader_features
+            .contains(&TableFeature::VariantType));
+        assert!(validated
+            .reader_features
+            .contains(&TableFeature::VariantShredding));
+        assert!(validated
+            .writer_features
+            .contains(&TableFeature::VariantType));
+        assert!(validated
+            .writer_features
+            .contains(&TableFeature::VariantShredding));
     }
 
     fn multi_column_schema() -> SchemaRef {

--- a/kernel/src/transaction/builder/create_table.rs
+++ b/kernel/src/transaction/builder/create_table.rs
@@ -701,25 +701,25 @@ fn validate_extract_table_features_and_properties(
             )));
         }
 
-        // Add to appropriate feature lists based on feature type
-        let needs_domain_metadata = feature == TableFeature::RowTracking;
-        let needs_variant_type = feature == TableFeature::VariantShredding;
-        add_feature_to_lists(feature, &mut reader_features, &mut writer_features);
         // RowTracking requires DomainMetadata as a dependency
-        if needs_domain_metadata {
+        if feature == TableFeature::RowTracking {
             add_feature_to_lists(
                 TableFeature::DomainMetadata,
                 &mut reader_features,
                 &mut writer_features,
             );
         }
-        if needs_variant_type {
+        // VariantShredding requires VariantType as a dependency
+        if feature == TableFeature::VariantShredding {
             add_feature_to_lists(
                 TableFeature::VariantType,
                 &mut reader_features,
                 &mut writer_features,
             );
         }
+
+        // Add to appropriate feature lists based on feature type
+        add_feature_to_lists(feature, &mut reader_features, &mut writer_features);
     }
 
     // Validate remaining delta.* properties against the allow list

--- a/kernel/tests/integration/create_table/mod.rs
+++ b/kernel/tests/integration/create_table/mod.rs
@@ -525,6 +525,8 @@ async fn test_create_table_txn_debug() -> DeltaResult<()> {
 // ReaderWriter features (AlwaysIfSupported)
 #[case("vacuumProtocolCheck", TableFeature::VacuumProtocolCheck, true, true)]
 #[case("v2Checkpoint", TableFeature::V2Checkpoint, true, true)]
+#[case("variantType", TableFeature::VariantType, true, true)]
+#[case("variantShredding", TableFeature::VariantShredding, true, true)]
 // ReaderWriter features (EnabledIf -- feature signal alone does not enable)
 #[case("deletionVectors", TableFeature::DeletionVectors, true, false)]
 #[case("typeWidening", TableFeature::TypeWidening, true, false)]
@@ -580,6 +582,35 @@ fn test_create_table_with_feature_signal(
             "{feature_name} should be in reader features"
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_create_table_with_variant_shredding_has_variant_feature() -> DeltaResult<()> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = schema_ref! {
+        nullable "id": INTEGER,
+    };
+
+    let _ = create_table(&table_path, schema, "Test/1.0")
+        .with_table_properties([("delta.feature.variantShredding", "supported")])
+        .build(engine.as_ref(), Box::new(FileSystemCommitter::new()))?
+        .commit(engine.as_ref())?;
+
+    let snapshot = Snapshot::builder_for(&table_path).build(engine.as_ref())?;
+    let protocol = snapshot.table_configuration().protocol();
+    let reader_features = protocol
+        .reader_features()
+        .expect("reader features must be present");
+    let writer_features = protocol
+        .writer_features()
+        .expect("writer features must be present");
+
+    assert!(reader_features.contains(&TableFeature::VariantType));
+    assert!(reader_features.contains(&TableFeature::VariantShredding));
+    assert!(writer_features.contains(&TableFeature::VariantType));
+    assert!(writer_features.contains(&TableFeature::VariantShredding));
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Allow CREATE TABLE to accept explicit `delta.feature.variantType=supported` and
  `delta.feature.variantShredding=supported` feature signals.
- When `variantShredding` is requested, also add the required `variantType` protocol feature.
- Add unit and integration coverage for creating tables with variant feature signals.

## How was this change tested?

New unit test and integration test was added.
