### PR TITLE
docs: document connector-native plan results

### DIFF
--- a/kernel/src/plans/ir/plan.rs
+++ b/kernel/src/plans/ir/plan.rs
@@ -50,6 +50,10 @@ impl PlanNode {
 /// `nodes`: no other node lists its index in `inputs`, and its rows are the value the engine
 /// streams to the caller.
 ///
+/// The terminal node describes the rows produced by the plan. The calling API determines who
+/// consumes them: kernel may use [`PlanExecutor`](crate::plans::PlanExecutor), or the connector may
+/// consume them directly when kernel returns the plan.
+///
 /// # Optimization
 ///
 /// For the best performance, connectors are encouraged to run kernel-produced

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -39,6 +39,26 @@
 //! for an unsupported one is fine, and kernel surfaces it to the caller. The sync engine's
 //! `SyncPlanExecutor` is a complete reference implementation.
 //!
+//! # Consuming terminal results
+//!
+//! [`PlanExecutor::execute_op`] and [`PlanResult::Data`] provide the generic result contract for
+//! operations whose output is consumed by kernel.
+//!
+//! Some kernel APIs instead return a [`Plan`](ir::plan::Plan) whose terminal rows belong to the
+//! connector. The connector may execute the plan through its ordinary query engine and keep the
+//! result in the engine's native representation instead of adapting it through [`EngineData`] only
+//! to pass it back to itself. [`Scan::declarative_metadata_scan_plan`] is one example: the
+//! connector may consume the live `add` rows from the returned plan itself.
+//!
+//! Connectors should use this native path when they own the result and adapting it through
+//! [`EngineData`] adds no semantic value. The native path must preserve the plan's relational
+//! semantics and declared output schema. Schema validation, streaming behavior, error propagation,
+//! and cancellation must work the same way as they do on the generic path.
+//!
+//! The generic [`PlanExecutor`] path remains required for operations whose results kernel consumes.
+//!
+//! [`Scan::declarative_metadata_scan_plan`]: crate::scan::Scan::declarative_metadata_scan_plan
+//!
 //! # Where to look
 //!
 //! - [`PlanBuilder`] builds plans through a fluent, schema-validating API, each method documenting

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1066,6 +1066,12 @@ impl Scan {
     /// `engine` supplies the plan executor used to inspect checkpoint shape. Returns `None` when
     /// no Delta metadata matches this scan.
     ///
+    /// This method returns the metadata plan without executing it. A connector that consumes the
+    /// resulting live `add` rows may run the plan through the generic
+    /// [`PlanExecutor`](crate::plans::PlanExecutor) interface or its native query engine. The
+    /// native path can keep the engine's batch representation instead of adapting it through
+    /// [`EngineData`].
+    ///
     /// # Errors
     ///
     /// Returns an error if the engine provides no [`PlanExecutor`](crate::plans::PlanExecutor),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Document when a connector can consume a declarative plan's terminal rows in its native representation. Result ownership determines whether data must return to Kernel through `PlanExecutor` and `EngineData`. `Scan::declarative_metadata_scan_plan` is the concrete example.

Native execution must preserve the plan's semantics, schema validation, streaming behavior, errors, and cancellation.

## How was this change tested?

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --doc --workspace --all-features`