### PR TITLE
feat!: support type-widening writes

### DIFF
--- a/kernel/src/schema/mod.rs
+++ b/kernel/src/schema/mod.rs
@@ -283,6 +283,7 @@ pub enum ColumnMetadataKey {
     InternalColumn,
     Invariants,
     MetadataSpec,
+    TypeChanges,
 }
 
 impl AsRef<str> for ColumnMetadataKey {
@@ -309,6 +310,7 @@ impl AsRef<str> for ColumnMetadataKey {
             Self::InternalColumn => "delta.isInternalColumn",
             Self::Invariants => "delta.invariants",
             Self::MetadataSpec => "delta.metadataSpec",
+            Self::TypeChanges => "delta.typeChanges",
         }
     }
 }

--- a/kernel/src/table_changes/log_replay/tests.rs
+++ b/kernel/src/table_changes/log_replay/tests.rs
@@ -609,8 +609,7 @@ async fn incompatible_schemas_fail() {
     };
     assert_incompatible_schema(schema, get_schema()).await;
 
-    // NOTE: Once type widening is supported, this should not return an error.
-    //
+    // CDF schema compatibility does not apply type-widening rules.
     // The CDF schema has fields: `id: long` and `value: string`.
     // This commit has schema with fields: `id: int` and `value: string`.
     let cdf_schema = schema_ref! {

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -32,9 +32,9 @@ use crate::table_features::{
     check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
     get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
     validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
-    FeatureType, KernelSupport, Operation, TableFeature, LEGACY_WRITER_FEATURES,
-    MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
-    TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
+    FeatureType, IcebergCompatValidationContext, KernelSupport, Operation, TableFeature,
+    LEGACY_WRITER_FEATURES, MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION,
+    TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
 };
 use crate::table_properties::TableProperties;
 use crate::transforms::SchemaTransform as _;
@@ -232,7 +232,11 @@ impl TableConfiguration {
         // Reject tables with geo-typed columns that don't declare the `geospatial` feature.
         #[cfg(feature = "geo-type-in-dev")]
         validate_geospatial_feature_support(&table_config)?;
-        validate_iceberg_compat_if_needed(&table_config, &V3_VALIDATOR)?;
+        validate_iceberg_compat_if_needed(
+            &table_config,
+            &V3_VALIDATOR,
+            IcebergCompatValidationContext::TableConfiguration,
+        )?;
 
         Ok(table_config)
     }

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -1782,7 +1782,6 @@ mod test {
             .build();
         assert!(config.ensure_operation_supported(Operation::Write).is_ok());
 
-        // Type Widening is not supported for writes
         let config = MockTableConfigurationBuilder::new()
             .with_protocol(
                 MockProtocolBuilder::new()
@@ -1790,10 +1789,7 @@ mod test {
                     .build(),
             )
             .build();
-        assert_result_error_with_message(
-            config.ensure_operation_supported(Operation::Write),
-            r#"Feature 'typeWidening' is not supported for writes"#,
-        );
+        assert!(config.ensure_operation_supported(Operation::Write).is_ok());
 
         #[cfg(feature = "geo-type-in-dev")]
         {

--- a/kernel/src/table_features/iceberg_compat/mod.rs
+++ b/kernel/src/table_features/iceberg_compat/mod.rs
@@ -3,7 +3,7 @@
 //! Each `delta.enableIcebergCompatV{N}` version owns a submodule (currently only
 //! [`v3`]), and exposes a single
 //! `pub(crate) const V{N}_VALIDATOR: IcebergCompatValidator`. Callers feed that
-//! constant to [`validate_iceberg_compat_if_needed`].
+//! constant and the validation context to [`validate_iceberg_compat_if_needed`].
 
 pub(crate) mod v3;
 
@@ -26,8 +26,46 @@ impl IcebergCompatVersion {
     }
 }
 
+type IcebergCompatCheckFn = fn(&TableConfiguration) -> DeltaResult<()>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IcebergCompatValidationContext {
+    TableConfiguration,
+    Write,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum IcebergCompatCheckMode {
+    Always,
+    WriteOnly,
+}
+
 /// A single invariant that must hold when an icebergCompat version is enabled.
-pub(crate) type IcebergCompatCheck = fn(&TableConfiguration) -> DeltaResult<()>;
+pub(crate) struct IcebergCompatCheck {
+    mode: IcebergCompatCheckMode,
+    check: IcebergCompatCheckFn,
+}
+
+impl IcebergCompatCheck {
+    pub(super) const fn always(check: IcebergCompatCheckFn) -> Self {
+        Self {
+            mode: IcebergCompatCheckMode::Always,
+            check,
+        }
+    }
+
+    pub(super) const fn write_only(check: IcebergCompatCheckFn) -> Self {
+        Self {
+            mode: IcebergCompatCheckMode::WriteOnly,
+            check,
+        }
+    }
+
+    fn runs_in(&self, context: IcebergCompatValidationContext) -> bool {
+        self.mode == IcebergCompatCheckMode::Always
+            || context == IcebergCompatValidationContext::Write
+    }
+}
 
 /// Pairs an [`IcebergCompatVersion`] with the ordered list of invariants that
 /// run when that version is enabled.
@@ -39,12 +77,15 @@ pub(crate) struct IcebergCompatValidator {
 pub(crate) fn validate_iceberg_compat_if_needed(
     tc: &TableConfiguration,
     validator: &IcebergCompatValidator,
+    context: IcebergCompatValidationContext,
 ) -> DeltaResult<()> {
     if !tc.is_feature_enabled(&validator.version.as_table_feature()) {
         return Ok(());
     }
     for check in validator.checks {
-        check(tc)?;
+        if check.runs_in(context) {
+            (check.check)(tc)?;
+        }
     }
     Ok(())
 }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -10,7 +10,9 @@ use crate::schema::PrimitiveType::{
     Binary, Boolean, Byte, Date, Decimal, Double, Float, Integer, Long, Short,
     String as StringType, Timestamp, TimestampNtz,
 };
-use crate::schema::{try_collect_column_defaults, DataType, MetadataValue, StructField};
+use crate::schema::{
+    try_collect_column_defaults, ColumnMetadataKey, DataType, MetadataValue, StructField,
+};
 use crate::table_configuration::TableConfiguration;
 use crate::table_features::TableFeature;
 use crate::transforms::{transform_output_type, SchemaTransform};
@@ -23,9 +25,12 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
     checks: V3_CHECKS,
 };
 
-const V3_CHECKS: &[IcebergCompatCheck] = &[check_v3_supported_types, check_no_legacy_nested_ids];
-
-const TYPE_CHANGES_METADATA_KEY: &str = "delta.typeChanges";
+const V3_CHECKS: &[IcebergCompatCheck] = &[
+    IcebergCompatCheck::always(check_v3_supported_types),
+    IcebergCompatCheck::always(check_no_legacy_nested_ids),
+    IcebergCompatCheck::write_only(iceberg_compat_v3_type_changes_validation),
+    IcebergCompatCheck::write_only(iceberg_compat_v3_column_defaults_validation),
+];
 
 fn is_v3_supported_type(dt: &DataType) -> bool {
     matches!(
@@ -108,19 +113,20 @@ struct TypeChangesValidator {
 
 impl TypeChangesValidator {
     fn validate_field_type_changes(&self, field: &StructField) -> DeltaResult<()> {
-        let Some(metadata) = field.metadata().get(TYPE_CHANGES_METADATA_KEY) else {
+        let type_changes_key = ColumnMetadataKey::TypeChanges.as_ref();
+        let Some(metadata) = field.metadata().get(type_changes_key) else {
             return Ok(());
         };
         let path = self.path.join(".");
         let MetadataValue::Other(value) = metadata else {
             return Err(Error::schema(format!(
-                "Field '{path}' has a non-array `{TYPE_CHANGES_METADATA_KEY}` annotation: \
+                "Field '{path}' has a non-array `{type_changes_key}` annotation: \
                  {metadata}"
             )));
         };
         let type_changes: Vec<TypeChange> = serde_json::from_value(value.clone()).map_err(|e| {
             Error::schema(format!(
-                "Field '{path}' has an invalid `{TYPE_CHANGES_METADATA_KEY}` annotation: {e}"
+                "Field '{path}' has an invalid `{type_changes_key}` annotation: {e}"
             ))
         })?;
         for type_change in type_changes {
@@ -400,7 +406,7 @@ mod type_change_tests {
 
     fn field_with_type_change(name: &str, from_type: &str, to_type: &str) -> StructField {
         StructField::nullable(name, DataType::STRING).add_metadata([(
-            super::TYPE_CHANGES_METADATA_KEY,
+            ColumnMetadataKey::TypeChanges.as_ref(),
             MetadataValue::Other(json!([{
                 "fromType": from_type,
                 "toType": to_type,
@@ -472,25 +478,48 @@ mod type_change_tests {
         );
     }
 
-    #[test]
-    fn v3_type_change_validation_reports_nested_field_path() {
-        let table_configuration = table_config_with_schema(schema! {
+    #[rstest]
+    #[case::nested_struct(
+        schema! {
             nullable "s": {
                 (field_with_type_change("inner", "integer", "double")),
             },
-        });
+        },
+        "s.inner",
+    )]
+    #[case::array_element_struct(
+        schema! {
+            nullable "arr": [ nullable {
+                (field_with_type_change("inner", "integer", "double")),
+            } ],
+        },
+        "arr.element.inner",
+    )]
+    #[case::map_value_struct(
+        schema! {
+            nullable "m": { STRING => nullable {
+                (field_with_type_change("inner", "integer", "double")),
+            } },
+        },
+        "m.value.inner",
+    )]
+    fn v3_type_change_validation_reports_field_path(
+        #[case] schema: StructType,
+        #[case] expected_path: &str,
+    ) {
+        let table_configuration = table_config_with_schema(schema);
 
         let err = iceberg_compat_v3_type_changes_validation(&table_configuration)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("s.inner"), "unexpected error: {err}");
+        assert!(err.contains(expected_path), "unexpected error: {err}");
     }
 
     #[test]
     fn v3_type_change_validation_rejects_malformed_type_change_metadata() {
         let table_configuration = table_config_with_schema(schema! {
             (StructField::nullable("a", DataType::STRING).add_metadata([(
-                super::TYPE_CHANGES_METADATA_KEY,
+                ColumnMetadataKey::TypeChanges.as_ref(),
                 MetadataValue::String("not an array".to_string()),
             )])),
         });
@@ -499,7 +528,7 @@ mod type_change_tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("non-array") && err.contains(super::TYPE_CHANGES_METADATA_KEY),
+            err.contains("non-array") && err.contains(ColumnMetadataKey::TypeChanges.as_ref()),
             "unexpected error: {err}"
         );
     }

--- a/kernel/src/table_features/iceberg_compat/v3.rs
+++ b/kernel/src/table_features/iceberg_compat/v3.rs
@@ -6,10 +6,15 @@ use super::{
     check_no_legacy_nested_ids, check_only_supported_types, IcebergCompatCheck,
     IcebergCompatValidator, IcebergCompatVersion,
 };
-use crate::schema::PrimitiveType::*;
-use crate::schema::{try_collect_column_defaults, DataType};
+use crate::schema::PrimitiveType::{
+    Binary, Boolean, Byte, Date, Decimal, Double, Float, Integer, Long, Short,
+    String as StringType, Timestamp, TimestampNtz,
+};
+use crate::schema::{try_collect_column_defaults, DataType, MetadataValue, StructField};
 use crate::table_configuration::TableConfiguration;
-use crate::DeltaResult;
+use crate::table_features::TableFeature;
+use crate::transforms::{transform_output_type, SchemaTransform};
+use crate::{DeltaResult, Error};
 
 /// V3 invariants paired with the version constant. Fed to
 /// [`super::validate_iceberg_compat_if_needed`].
@@ -19,6 +24,8 @@ pub(crate) const V3_VALIDATOR: IcebergCompatValidator = IcebergCompatValidator {
 };
 
 const V3_CHECKS: &[IcebergCompatCheck] = &[check_v3_supported_types, check_no_legacy_nested_ids];
+
+const TYPE_CHANGES_METADATA_KEY: &str = "delta.typeChanges";
 
 fn is_v3_supported_type(dt: &DataType) -> bool {
     matches!(
@@ -31,7 +38,7 @@ fn is_v3_supported_type(dt: &DataType) -> bool {
                 | Double
                 | Boolean
                 | Binary
-                | String
+                | StringType
                 | Date
                 | Timestamp
                 | TimestampNtz
@@ -49,6 +56,121 @@ fn check_v3_supported_types(tc: &TableConfiguration) -> DeltaResult<()> {
         is_v3_supported_type,
         IcebergCompatVersion::V3.as_table_feature().as_ref(),
     )
+}
+
+/// Validates that historical type changes on an IcebergCompatV3 table are compatible with Iceberg
+/// schema evolution rules.
+///
+/// This is a write-side guard because unsupported type changes do not prevent Delta reads. They
+/// only violate the IcebergCompatV3 writer contract that the table remains convertible to Iceberg.
+///
+/// # Errors
+///
+/// Returns an error if `delta.typeChanges` metadata is malformed, or if any recorded type change
+/// is outside Iceberg V3's allowed widening list.
+pub(crate) fn iceberg_compat_v3_type_changes_validation(
+    tc: &TableConfiguration,
+) -> DeltaResult<()> {
+    if !tc.is_feature_supported(&TableFeature::TypeWidening)
+        && !tc.is_feature_supported(&TableFeature::TypeWideningPreview)
+    {
+        return Ok(());
+    }
+
+    let mut validator = TypeChangesValidator { path: vec![] };
+    validator.transform_struct(tc.logical_schema_ref())
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TypeChange {
+    from_type: DataType,
+    to_type: DataType,
+}
+
+fn is_v3_allowed_type_change(from: &DataType, to: &DataType) -> bool {
+    match (from, to) {
+        (DataType::Primitive(Byte), DataType::Primitive(Short | Integer | Long)) => true,
+        (DataType::Primitive(Short), DataType::Primitive(Integer | Long)) => true,
+        (DataType::Primitive(Integer), DataType::Primitive(Long)) => true,
+        (DataType::Primitive(Float), DataType::Primitive(Double)) => true,
+        (DataType::Primitive(Decimal(from_decimal)), DataType::Primitive(Decimal(to_decimal))) => {
+            from_decimal.scale() == to_decimal.scale()
+                && to_decimal.precision() > from_decimal.precision()
+        }
+        _ => false,
+    }
+}
+
+struct TypeChangesValidator {
+    path: Vec<String>,
+}
+
+impl TypeChangesValidator {
+    fn validate_field_type_changes(&self, field: &StructField) -> DeltaResult<()> {
+        let Some(metadata) = field.metadata().get(TYPE_CHANGES_METADATA_KEY) else {
+            return Ok(());
+        };
+        let path = self.path.join(".");
+        let MetadataValue::Other(value) = metadata else {
+            return Err(Error::schema(format!(
+                "Field '{path}' has a non-array `{TYPE_CHANGES_METADATA_KEY}` annotation: \
+                 {metadata}"
+            )));
+        };
+        let type_changes: Vec<TypeChange> = serde_json::from_value(value.clone()).map_err(|e| {
+            Error::schema(format!(
+                "Field '{path}' has an invalid `{TYPE_CHANGES_METADATA_KEY}` annotation: {e}"
+            ))
+        })?;
+        for type_change in type_changes {
+            if !is_v3_allowed_type_change(&type_change.from_type, &type_change.to_type) {
+                return Err(Error::schema(format!(
+                    "icebergCompatV3 does not support type change on field '{path}': {} -> {}",
+                    type_change.from_type, type_change.to_type
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> SchemaTransform<'a> for TypeChangesValidator {
+    transform_output_type!(|'a, T| DeltaResult<()>);
+
+    fn transform_struct_field(&mut self, field: &'a StructField) -> DeltaResult<()> {
+        self.path.push(field.name().clone());
+        let result = self
+            .validate_field_type_changes(field)
+            .and_then(|_| self.recurse_into_struct_field(field));
+        self.path.pop();
+        result
+    }
+
+    fn transform_array_element(&mut self, etype: &'a DataType) -> DeltaResult<()> {
+        self.path.push("element".to_string());
+        let result = self.transform(etype);
+        self.path.pop();
+        result
+    }
+
+    fn transform_map_key(&mut self, ktype: &'a DataType) -> DeltaResult<()> {
+        self.path.push("key".to_string());
+        let result = self.transform(ktype);
+        self.path.pop();
+        result
+    }
+
+    fn transform_map_value(&mut self, vtype: &'a DataType) -> DeltaResult<()> {
+        self.path.push("value".to_string());
+        let result = self.transform(vtype);
+        self.path.pop();
+        result
+    }
+
+    fn transform_variant(&mut self, _stype: &'a crate::schema::StructType) -> DeltaResult<()> {
+        Ok(())
+    }
 }
 
 /// Validates IcebergCompatV3 column defaults and logs warnings kernel cannot verify.
@@ -241,5 +363,190 @@ mod column_default_tests {
                 assert!(logs.contains(needle), "logs: {logs}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod type_change_tests {
+    use rstest::rstest;
+    use serde_json::json;
+
+    use super::iceberg_compat_v3_type_changes_validation;
+    use crate::schema::{
+        schema, ColumnMetadataKey, DataType, MetadataValue, StructField, StructType,
+    };
+    use crate::table_configuration::TableConfiguration;
+    use crate::table_features::{ColumnMappingMode, TableFeature};
+    use crate::table_properties::{ENABLE_ICEBERG_COMPAT_V3, ENABLE_ROW_TRACKING};
+    use crate::unit_test_utils::{MockProtocolBuilder, MockTableConfigurationBuilder};
+
+    fn table_config_with_schema_and_features(
+        schema: StructType,
+        features: impl IntoIterator<Item = TableFeature>,
+    ) -> TableConfiguration {
+        MockTableConfigurationBuilder::new()
+            .with_schema(schema)
+            .with_protocol(MockProtocolBuilder::new().with_features(features).build())
+            .with_table_root("file:///t/")
+            .build()
+    }
+
+    fn table_config_with_schema(schema: StructType) -> TableConfiguration {
+        table_config_with_schema_and_features(
+            schema,
+            [TableFeature::IcebergCompatV3, TableFeature::TypeWidening],
+        )
+    }
+
+    fn field_with_type_change(name: &str, from_type: &str, to_type: &str) -> StructField {
+        StructField::nullable(name, DataType::STRING).add_metadata([(
+            super::TYPE_CHANGES_METADATA_KEY,
+            MetadataValue::Other(json!([{
+                "fromType": from_type,
+                "toType": to_type,
+                "tableVersion": 2
+            }])),
+        )])
+    }
+
+    fn field_with_type_change_and_column_mapping(
+        name: &str,
+        from_type: &str,
+        to_type: &str,
+    ) -> StructField {
+        field_with_type_change(name, from_type, to_type).add_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::Number(1),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::String("col-1".to_string()),
+            ),
+        ])
+    }
+
+    #[rstest]
+    #[case::byte_short("byte", "short")]
+    #[case::byte_integer("byte", "integer")]
+    #[case::byte_long("byte", "long")]
+    #[case::short_integer("short", "integer")]
+    #[case::short_long("short", "long")]
+    #[case::integer_long("integer", "long")]
+    #[case::float_double("float", "double")]
+    #[case::decimal_same_scale("decimal(10,2)", "decimal(20,2)")]
+    fn v3_type_change_validation_allows_iceberg_promotions(
+        #[case] from_type: &str,
+        #[case] to_type: &str,
+    ) {
+        let table_configuration = table_config_with_schema(schema! {
+            (field_with_type_change("a", from_type, to_type)),
+        });
+
+        iceberg_compat_v3_type_changes_validation(&table_configuration).unwrap();
+    }
+
+    #[rstest]
+    #[case::integer_double("integer", "double")]
+    #[case::integer_decimal("integer", "decimal(11,1)")]
+    #[case::decimal_scale_change("decimal(10,2)", "decimal(20,5)")]
+    #[case::date_timestamp_ntz("date", "timestamp_ntz")]
+    #[case::long_double("long", "double")]
+    fn v3_type_change_validation_rejects_non_iceberg_promotions(
+        #[case] from_type: &str,
+        #[case] to_type: &str,
+    ) {
+        let table_configuration = table_config_with_schema(schema! {
+            (field_with_type_change("a", from_type, to_type)),
+        });
+
+        let err = iceberg_compat_v3_type_changes_validation(&table_configuration)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("icebergCompatV3 does not support type change")
+                && err.contains("a")
+                && err.contains(from_type)
+                && err.contains(to_type),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn v3_type_change_validation_reports_nested_field_path() {
+        let table_configuration = table_config_with_schema(schema! {
+            nullable "s": {
+                (field_with_type_change("inner", "integer", "double")),
+            },
+        });
+
+        let err = iceberg_compat_v3_type_changes_validation(&table_configuration)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("s.inner"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn v3_type_change_validation_rejects_malformed_type_change_metadata() {
+        let table_configuration = table_config_with_schema(schema! {
+            (StructField::nullable("a", DataType::STRING).add_metadata([(
+                super::TYPE_CHANGES_METADATA_KEY,
+                MetadataValue::String("not an array".to_string()),
+            )])),
+        });
+
+        let err = iceberg_compat_v3_type_changes_validation(&table_configuration)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("non-array") && err.contains(super::TYPE_CHANGES_METADATA_KEY),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn v3_type_change_validation_skips_tables_without_type_widening_support() {
+        let table_configuration = table_config_with_schema_and_features(
+            schema! {
+                (field_with_type_change("a", "integer", "double")),
+            },
+            [TableFeature::IcebergCompatV3],
+        );
+
+        iceberg_compat_v3_type_changes_validation(&table_configuration).unwrap();
+    }
+
+    #[test]
+    fn v3_type_change_validation_blocks_writes_but_not_table_configuration() {
+        let table_configuration = MockTableConfigurationBuilder::new()
+            .with_schema(schema! {
+                (field_with_type_change_and_column_mapping("a", "integer", "double")),
+            })
+            .with_properties([
+                (ENABLE_ICEBERG_COMPAT_V3, "true"),
+                (ENABLE_ROW_TRACKING, "true"),
+            ])
+            .with_column_mapping(ColumnMappingMode::Name)
+            .with_protocol(
+                MockProtocolBuilder::new()
+                    .with_features([
+                        TableFeature::IcebergCompatV3,
+                        TableFeature::ColumnMapping,
+                        TableFeature::RowTracking,
+                        TableFeature::DomainMetadata,
+                        TableFeature::TypeWidening,
+                    ])
+                    .build(),
+            )
+            .build();
+
+        assert!(table_configuration.is_feature_enabled(&TableFeature::IcebergCompatV3));
+        let err = iceberg_compat_v3_type_changes_validation(&table_configuration)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("icebergCompatV3 does not support type change"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -15,7 +15,10 @@ pub(crate) use column_mapping::{
 use delta_kernel_derive::internal_api;
 #[cfg(feature = "geo-type-in-dev")]
 pub(crate) use geospatial::validate_geospatial_feature_support;
-pub(crate) use iceberg_compat::v3::{iceberg_compat_v3_column_defaults_validation, V3_VALIDATOR};
+pub(crate) use iceberg_compat::v3::{
+    iceberg_compat_v3_column_defaults_validation, iceberg_compat_v3_type_changes_validation,
+    V3_VALIDATOR,
+};
 pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -563,35 +563,23 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
-/// TODO: When type widening is supported on writes, restrict the allowed
-/// widenings on IcebergCompatV3 tables to the subset permitted by the Iceberg v3
-/// schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
+/// TODO: Restrict type-widening writes on IcebergCompatV3 tables to the subset permitted by
+/// Iceberg v3 schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Cdf => Ok(()),
-        Operation::Write => Err(Error::unsupported(
-            "Feature 'typeWidening' is not supported for writes",
-        )),
-    }),
+    kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 
-/// TODO: When type widening is supported on writes, restrict the allowed
-/// widenings on IcebergCompatV3 tables to the subset permitted by the Iceberg
-/// schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
+/// TODO: Restrict type-widening writes on IcebergCompatV3 tables to the subset permitted by
+/// Iceberg schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
-    kernel_support: KernelSupport::Custom(|_, _, op| match op {
-        Operation::Scan | Operation::Cdf => Ok(()),
-        Operation::Write => Err(Error::unsupported(
-            "Feature 'typeWidening-preview' is not supported for writes",
-        )),
-    }),
+    kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -15,11 +15,10 @@ pub(crate) use column_mapping::{
 use delta_kernel_derive::internal_api;
 #[cfg(feature = "geo-type-in-dev")]
 pub(crate) use geospatial::validate_geospatial_feature_support;
-pub(crate) use iceberg_compat::v3::{
-    iceberg_compat_v3_column_defaults_validation, iceberg_compat_v3_type_changes_validation,
-    V3_VALIDATOR,
+pub(crate) use iceberg_compat::v3::V3_VALIDATOR;
+pub(crate) use iceberg_compat::{
+    validate_iceberg_compat_if_needed, IcebergCompatValidationContext,
 };
-pub(crate) use iceberg_compat::validate_iceberg_compat_if_needed;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display as StrumDisplay, EnumCount, EnumIter, EnumString};
@@ -449,6 +448,7 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///
 /// Spec: <https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-compat-v3.md>
 ///
+/// TODO(#2492): Implement the schema-evolution requirements for IcebergCompatV3.
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
 ///
 /// Requirements to enforce when the corresponding write paths are supported:
@@ -569,6 +569,9 @@ static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
+    // TODO(#2492): When type widening is supported on ALTER TABLE, restrict the allowed widenings
+    // on IcebergCompatV3 tables to the subset permitted by Iceberg V3 schema-evolution rules.
+    // Ref: <https://iceberg.apache.org/spec/#schema-evolution>
     kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
@@ -577,6 +580,9 @@ static TYPE_WIDENING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
     feature_requirements: &[],
+    // TODO(#2492): When type widening is supported on ALTER TABLE, restrict the allowed widenings
+    // on IcebergCompatV3 tables to the subset permitted by Iceberg V3 schema-evolution rules.
+    // Ref: <https://iceberg.apache.org/spec/#schema-evolution>
     kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -449,10 +449,9 @@ static ICEBERG_COMPAT_V2_INFO: FeatureInfo = FeatureInfo {
 ///
 /// Spec: <https://github.com/delta-io/delta/blob/master/protocol_rfcs/iceberg-compat-v3.md>
 ///
-/// TODO: Implement the write-side requirements for IcebergCompatV3.
 /// TODO: Support ALTER TABLE on tables with IcebergCompatV3 enabled.
 ///
-/// Attention in the future:
+/// Requirements to enforce when the corresponding write paths are supported:
 /// - Geo types: when supported, they must not be usable as partition columns on IcebergCompatV3
 ///   tables.
 /// - REPLACE TABLE: when supported, partition columns must not change across the replace.
@@ -566,8 +565,6 @@ static TIMESTAMP_WITHOUT_TIMEZONE_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
 
-/// TODO: Restrict type-widening writes on IcebergCompatV3 tables to the subset permitted by
-/// Iceberg v3 schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
@@ -576,8 +573,6 @@ static TYPE_WIDENING_INFO: FeatureInfo = FeatureInfo {
     enablement_check: EnablementCheck::EnabledIf(|props| props.enable_type_widening == Some(true)),
 };
 
-/// TODO: Restrict type-widening writes on IcebergCompatV3 tables to the subset permitted by
-/// Iceberg schema-evolution rules. Ref: <https://iceberg.apache.org/spec/#schema-evolution>
 static TYPE_WIDENING_PREVIEW_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -34,8 +34,8 @@ use crate::scan::{restored_add_schema, scan_row_schema};
 use crate::schema::{lazy_schema_ref, ArrayType, SchemaRef, StructField, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
-    iceberg_compat_v3_column_defaults_validation, iceberg_compat_v3_type_changes_validation,
-    Operation, TableFeature,
+    validate_iceberg_compat_if_needed, IcebergCompatValidationContext, Operation, TableFeature,
+    V3_VALIDATOR,
 };
 use crate::utils::current_time_ms;
 use crate::{DataType, DeltaResult, Engine, Expression};
@@ -79,12 +79,11 @@ impl Transaction {
 
         let effective_table_config = read_snapshot.table_configuration().clone();
 
-        // Surface IcebergCompatV3 interoperability risks without rejecting tables based on
-        // kernel parser limitations.
-        if effective_table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
-            iceberg_compat_v3_type_changes_validation(&effective_table_config)?;
-            iceberg_compat_v3_column_defaults_validation(&effective_table_config)?;
-        }
+        validate_iceberg_compat_if_needed(
+            &effective_table_config,
+            &V3_VALIDATOR,
+            IcebergCompatValidationContext::Write,
+        )?;
 
         Ok(Transaction {
             span,

--- a/kernel/src/transaction/update.rs
+++ b/kernel/src/transaction/update.rs
@@ -34,7 +34,8 @@ use crate::scan::{restored_add_schema, scan_row_schema};
 use crate::schema::{lazy_schema_ref, ArrayType, SchemaRef, StructField, ToSchema};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::{
-    iceberg_compat_v3_column_defaults_validation, Operation, TableFeature,
+    iceberg_compat_v3_column_defaults_validation, iceberg_compat_v3_type_changes_validation,
+    Operation, TableFeature,
 };
 use crate::utils::current_time_ms;
 use crate::{DataType, DeltaResult, Engine, Expression};
@@ -81,6 +82,7 @@ impl Transaction {
         // Surface IcebergCompatV3 interoperability risks without rejecting tables based on
         // kernel parser limitations.
         if effective_table_config.is_feature_enabled(&TableFeature::IcebergCompatV3) {
+            iceberg_compat_v3_type_changes_validation(&effective_table_config)?;
             iceberg_compat_v3_column_defaults_validation(&effective_table_config)?;
         }
 

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -198,8 +198,7 @@ async fn v3_commit_validates_num_records(
 ///   auto-enablement of `columnMapping=name` + `rowTracking=true`.
 /// - `max`: maximum feature set we are able to enable through create table, with exceptions for:
 ///   `materializePartitionColumns` (omitted so the partition-materialization check below proves V3
-///   implies it), `typeWidening` (kernel rejects writes against tables declaring it), and
-///   `catalogManaged` (requires a catalog committer).
+///   implies it) and `catalogManaged` (requires a catalog committer).
 #[rstest::rstest]
 #[case::min(
     /* extra_props */ &[],
@@ -213,7 +212,7 @@ async fn v3_commit_validates_num_records(
     // Some features are enabled via schema content (e.g. TS_NTZ) so not in this list.
     /* enable_features */ &[
         "deletionVectors", "inCommitTimestamp", "changeDataFeed", "appendOnly",
-        "v2Checkpoint", "vacuumProtocolCheck", "invariants",
+        "v2Checkpoint", "vacuumProtocolCheck", "invariants", "typeWidening",
     ],
     /* expected_features */ &[READER_WRITER_FEATURES, WRITER_FEATURES],
 )]
@@ -626,6 +625,7 @@ const READER_WRITER_FEATURES: &[&str] = &[
     "columnMapping",
     "deletionVectors",
     "timestampNtz",
+    "typeWidening",
     "v2Checkpoint",
     "vacuumProtocolCheck",
     "variantType",
@@ -651,6 +651,7 @@ const FEATURE_ENABLE_PROPERTY: &[(&str, &str)] = &[
     ("icebergCompatV3", "delta.enableIcebergCompatV3"),
     ("inCommitTimestamp", "delta.enableInCommitTimestamps"),
     ("rowTracking", "delta.enableRowTracking"),
+    ("typeWidening", "delta.enableTypeWidening"),
 ];
 
 /// Returns the `delta.enable*` property name for `feature` if one exists, or `None` if the

--- a/kernel/tests/integration/features/iceberg_compat.rs
+++ b/kernel/tests/integration/features/iceberg_compat.rs
@@ -141,6 +141,101 @@ async fn snapshot_blocked_when_v3_schema_has_legacy_nested_ids() {
     );
 }
 
+#[tokio::test]
+async fn v3_invalid_type_change_blocks_writes_but_not_snapshot_loading() {
+    let (storage, engine) = make_default_engine_and_store();
+    let schema = schema! {
+        (StructField::nullable("a", DataType::STRING).with_metadata([
+            (
+                ColumnMetadataKey::ColumnMappingId.as_ref(),
+                MetadataValue::from(1),
+            ),
+            (
+                ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+                MetadataValue::from("col-1"),
+            ),
+            (
+                ColumnMetadataKey::TypeChanges.as_ref(),
+                MetadataValue::Other(serde_json::json!([{
+                    "fromType": "integer",
+                    "toType": "double",
+                    "tableVersion": 1,
+                }])),
+            ),
+        ])),
+    };
+    let schema_string = serde_json::to_string(&schema).unwrap();
+
+    let commit = [
+        serde_json::json!({
+            "commitInfo": {
+                "timestamp": 1587968586154_i64,
+                "operation": "CREATE TABLE",
+                "operationParameters": {},
+                "isBlindAppend": true,
+            }
+        }),
+        serde_json::json!({
+            "protocol": {
+                "minReaderVersion": 3,
+                "minWriterVersion": 7,
+                "readerFeatures": [
+                    "columnMapping",
+                    "typeWidening",
+                ],
+                "writerFeatures": [
+                    "icebergCompatV3",
+                    "columnMapping",
+                    "rowTracking",
+                    "domainMetadata",
+                    "typeWidening",
+                ],
+            }
+        }),
+        serde_json::json!({
+            "metaData": {
+                "id": "deadbeef-1234-5678-abcd-000000000002",
+                "format": { "provider": "parquet", "options": {} },
+                "schemaString": schema_string,
+                "partitionColumns": [],
+                "configuration": {
+                    "delta.enableIcebergCompatV3": "true",
+                    "delta.columnMapping.mode": "name",
+                    "delta.enableRowTracking": "true",
+                    "delta.enableTypeWidening": "true",
+                    "delta.rowTracking.materializedRowIdColumnName": "_row_id",
+                    "delta.rowTracking.materializedRowCommitVersionColumnName":
+                        "_row_commit_version",
+                    "delta.columnMapping.maxColumnId": "1",
+                },
+                "createdTime": 1234567890000_i64,
+            }
+        }),
+    ]
+    .into_iter()
+    .map(|action| serde_json::to_string(&action).unwrap())
+    .collect::<Vec<_>>()
+    .join("\n");
+    add_commit(TABLE_ROOT, storage.as_ref(), 0, commit)
+        .await
+        .unwrap();
+
+    let snapshot = Snapshot::builder_for(TABLE_ROOT)
+        .build(engine.as_ref())
+        .unwrap();
+    let err = snapshot
+        .transaction(Box::new(FileSystemCommitter::new()), engine.as_ref())
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("icebergCompatV3 does not support type change")
+            && err.contains("a")
+            && err.contains("integer")
+            && err.contains("double"),
+        "unexpected error: {err}",
+    );
+}
+
 #[rstest::rstest]
 #[case::missing_num_records(None/* num_records */, Err("'stats.numRecords' is required"))]
 #[case::with_num_records(Some(3), Ok(1))]

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -122,7 +122,7 @@ define_sweeps! {
     // TODO: max-CM=id / max-CM=name full set (needs checkpointProtection, clustering,
     //       materializePartitionColumns, invariants, checkConstraints, generatedColumns,
     //       allowColumnDefaults, identityColumns, NTZ/variant (schema-driven),
-    //       catalogManaged, collations for CM=name, typeWidening write support).
+    //       catalogManaged, collations for CM=name).
     // TODO: iceV2+writer (needs icebergCompatV2 + icebergWriterCompatV1).
     // TODO: iceV3 (needs icebergCompatV3).
     feature_set_values = (no_features(), all_features_cm_id(), all_features_cm_name()),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Marks `typeWidening` and `typeWidening-preview` as supported by kernel writes instead of rejecting write operations through a custom support guard.

Adds a write-time IcebergCompatV3 guard for tables that also support type widening: transaction creation now rejects malformed or Iceberg-incompatible `delta.typeChanges` metadata while still allowing snapshot loading for reads.

Centralizes IcebergCompatV3 validation through one validator entry point with separate table-configuration and write contexts.

Fixes #3198.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo test -p delta_kernel --lib ensure_operation_supported`
- `cargo test -p delta_kernel --lib v3_type_change_validation`
- `cargo test -p delta_kernel --test integration iceberg_compat`
- pre-commit hook completed successfully during `git commit`