### PR TITLE
fix: require variant type for variant shredding

### DIFF
--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -390,6 +390,16 @@ mod tests {
 
     const VALID_PROTOCOL_LINE: &str = r#"{"protocol":{"minReaderVersion":1,"minWriterVersion":1}}"#;
     const UNSUPPORTED_PROTOCOL_LINE: &str = r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["futureFeature"],"writerFeatures":["futureFeature"]}}"#;
+    const VARIANT_SHREDDING_PROTOCOL_LINE: &str = concat!(
+        r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"#,
+        r#""readerFeatures":["variantShredding"],"#,
+        r#""writerFeatures":["variantShredding"]}}"#,
+    );
+    const VARIANT_SHREDDING_WITH_TYPE_PROTOCOL_LINE: &str = concat!(
+        r#"{"protocol":{"minReaderVersion":3,"minWriterVersion":7,"#,
+        r#""readerFeatures":["variantShredding","variantType"],"#,
+        r#""writerFeatures":["variantShredding","variantType"]}}"#,
+    );
     const VALID_METADATA_LINE: &str = r#"{"metaData":{"id":"00000000-0000-0000-0000-000000000000","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[]}","partitionColumns":[],"configuration":{},"createdTime":1000}}"#;
     /// Like [`VALID_METADATA_LINE`] but with a non-empty `configuration` (`foo=bar`), used to
     /// forge a metadata-only change in a later commit.
@@ -635,6 +645,12 @@ mod tests {
         }
     }
 
+    enum ExpectedProtocolValidation {
+        Ok,
+        InvalidProtocol,
+        Unsupported,
+    }
+
     #[rstest::rstest]
     #[case::validates_first_commit_pm(
         vec![
@@ -642,23 +658,33 @@ mod tests {
             (1, METADATA_CONFIG_CHANGE_LINE.to_string()),
         ],
         &[DeltaAction::Add, DeltaAction::Remove],
-        false,
+        ExpectedProtocolValidation::Ok,
     )]
     #[case::rejects_unsupported_protocol(
         vec![(0u64, r#"{"protocol":{"minReaderVersion":99,"minWriterVersion":99}}"#.to_string())],
         &[DeltaAction::Add],
-        true,
+        ExpectedProtocolValidation::Unsupported,
+    )]
+    #[case::rejects_missing_protocol_dependency(
+        vec![(0u64, VARIANT_SHREDDING_PROTOCOL_LINE.to_string())],
+        &[DeltaAction::Add],
+        ExpectedProtocolValidation::InvalidProtocol,
+    )]
+    #[case::accepts_supported_protocol_dependency(
+        vec![(0u64, VARIANT_SHREDDING_WITH_TYPE_PROTOCOL_LINE.to_string())],
+        &[DeltaAction::Add],
+        ExpectedProtocolValidation::Ok,
     )]
     #[case::skip_when_neither_pm(
         vec![(0u64, r#"{"commitInfo":{"timestamp":1000,"operation":"WRITE"}}"#.to_string())],
         &[DeltaAction::CommitInfo],
-        false,
+        ExpectedProtocolValidation::Ok,
     )]
     #[tokio::test]
     async fn test_protocol_validation_is_commit_driven(
         #[case] commits: Vec<(u64, String)>,
         #[case] actions: &[DeltaAction],
-        #[case] expects_unsupported: bool,
+        #[case] expected: ExpectedProtocolValidation,
     ) {
         let commit_refs: Vec<(u64, &str)> = commits
             .iter()
@@ -673,14 +699,18 @@ mod tests {
             .unwrap();
 
         let result = drain_commits(&range, engine, None, actions);
-        if expects_unsupported {
-            let err = result.expect_err("commit-driven validation must reject");
-            assert!(
-                matches!(err, Error::Unsupported(_)),
-                "expected Error::Unsupported, got: {err:?}",
-            );
-        } else {
-            result.expect("snapshot-less range must drain cleanly");
+        match expected {
+            ExpectedProtocolValidation::Ok => {
+                result.expect("snapshot-less range must drain cleanly");
+            }
+            ExpectedProtocolValidation::InvalidProtocol => assert!(
+                matches!(result, Err(Error::InvalidProtocol(_))),
+                "expected Error::InvalidProtocol, got: {result:?}",
+            ),
+            ExpectedProtocolValidation::Unsupported => assert!(
+                matches!(result, Err(Error::Unsupported(_))),
+                "expected Error::Unsupported, got: {result:?}",
+            ),
         }
     }
 

--- a/kernel/src/table_configuration.rs
+++ b/kernel/src/table_configuration.rs
@@ -30,10 +30,10 @@ use crate::schema::{
 use crate::table_features::validate_geospatial_feature_support;
 use crate::table_features::{
     check_reader_version_range, column_mapping_mode, extract_enabled_reader_features,
-    get_any_level_column_physical_name, validate_iceberg_compat_if_needed,
-    validate_timestamp_ntz_feature_support, ColumnMappingMode, EnablementCheck, FeatureRequirement,
-    FeatureType, KernelSupport, Operation, TableFeature, LEGACY_WRITER_FEATURES,
-    MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION, TABLE_FEATURES_MIN_READER_VERSION,
+    get_any_level_column_physical_name, protocol_supports_feature,
+    validate_iceberg_compat_if_needed, validate_timestamp_ntz_feature_support, ColumnMappingMode,
+    EnablementCheck, FeatureRequirement, KernelSupport, Operation, TableFeature,
+    LEGACY_WRITER_FEATURES, MAX_VALID_WRITER_VERSION, MIN_VALID_RW_VERSION,
     TABLE_FEATURES_MIN_WRITER_VERSION, V3_VALIDATOR,
 };
 use crate::table_properties::TableProperties;
@@ -825,71 +825,11 @@ impl TableConfiguration {
         self.is_feature_supported(&TableFeature::RowTracking) && !self.is_row_tracking_suspended()
     }
 
-    /// Returns true if the protocol uses legacy reader version (< 3)
-    #[allow(dead_code)]
-    fn is_legacy_reader_version(&self) -> bool {
-        self.protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION
-    }
-
-    /// Returns true if the protocol uses legacy writer version (< 7)
-    #[allow(dead_code)]
-    fn is_legacy_writer_version(&self) -> bool {
-        self.protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION
-    }
-
-    /// Helper to check if a feature is present in a feature list.
-    fn has_feature(features: Option<&[TableFeature]>, feature: &TableFeature) -> bool {
-        features
-            .map(|features| features.contains(feature))
-            .unwrap_or(false)
-    }
-
     /// Helper method to check if a feature is supported.
     /// This checks protocol versions and feature lists but does NOT check enablement properties.
     #[internal_api]
     pub(crate) fn is_feature_supported(&self, feature: &TableFeature) -> bool {
-        let info = feature.info();
-        let min_legacy_version = info.min_legacy_version.as_ref();
-        let min_reader_version =
-            min_legacy_version.map_or(TABLE_FEATURES_MIN_READER_VERSION, |v| v.reader);
-        let min_writer_version =
-            min_legacy_version.map_or(TABLE_FEATURES_MIN_WRITER_VERSION, |v| v.writer);
-        match info.feature_type {
-            FeatureType::WriterOnly => {
-                if self.is_legacy_writer_version() {
-                    // Legacy writer: protocol writer version meets minimum requirement
-                    self.protocol.min_writer_version() >= min_writer_version
-                } else {
-                    // Table features writer: feature is in writer_features list
-                    Self::has_feature(self.protocol.writer_features(), feature)
-                }
-            }
-            FeatureType::ReaderWriter => {
-                let reader_supported = if self.is_legacy_reader_version() {
-                    // Legacy reader: protocol reader version meets minimum requirement
-                    self.protocol.min_reader_version() >= min_reader_version
-                } else {
-                    // Reader-supported if the feature is in reader_features, or it is a legacy
-                    // ReaderWriter feature (only ColumnMapping) whose minimum reader version is
-                    // met. The second case stays compatible with tables a past delta-spark bug
-                    // created with ReaderWriter features in writerFeatures only, absent from
-                    // readerFeatures.
-                    Self::has_feature(self.protocol.reader_features(), feature)
-                        || feature.is_valid_for_legacy_reader(self.protocol.min_reader_version())
-                };
-
-                let writer_supported = if self.is_legacy_writer_version() {
-                    // Legacy writer: protocol writer version meets minimum requirement
-                    self.protocol.min_writer_version() >= min_writer_version
-                } else {
-                    // Table features writer: feature is in writer_features list
-                    Self::has_feature(self.protocol.writer_features(), feature)
-                };
-
-                reader_supported && writer_supported
-            }
-            FeatureType::Unknown => Self::has_feature(self.protocol.writer_features(), feature),
-        }
+        protocol_supports_feature(&self.protocol, feature)
     }
 
     /// Generic method to check if a feature is enabled.
@@ -1830,33 +1770,43 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_illegal_writer_feature_combination() {
+    #[rstest]
+    #[case::row_tracking(TableFeature::RowTracking, TableFeature::DomainMetadata)]
+    #[case::variant_shredding(TableFeature::VariantShredding, TableFeature::VariantType)]
+    fn feature_requires_protocol_dependency(
+        #[case] feature: TableFeature,
+        #[case] dependency: TableFeature,
+    ) {
         let config = MockTableConfigurationBuilder::new()
             .with_protocol(
                 MockProtocolBuilder::new()
-                    .with_features([TableFeature::RowTracking])
+                    .with_features([feature.clone()])
                     .build(),
             )
             .build();
         assert_result_error_with_message(
             config.ensure_operation_supported(Operation::Write),
-            "Feature 'rowTracking' requires 'domainMetadata' to be supported",
+            &format!("Feature '{feature}' requires '{dependency}' to be supported"),
         );
     }
 
-    #[test]
-    fn test_row_tracking_with_domain_metadata_requirement() {
+    #[rstest]
+    #[case::row_tracking(TableFeature::RowTracking, TableFeature::DomainMetadata)]
+    #[case::variant_shredding(TableFeature::VariantShredding, TableFeature::VariantType)]
+    fn feature_with_protocol_dependency_is_supported_for_writes(
+        #[case] feature: TableFeature,
+        #[case] dependency: TableFeature,
+    ) {
         let config = MockTableConfigurationBuilder::new()
             .with_protocol(
                 MockProtocolBuilder::new()
-                    .with_features([TableFeature::RowTracking, TableFeature::DomainMetadata])
+                    .with_features([feature, dependency])
                     .build(),
             )
             .build();
         assert!(
             config.ensure_operation_supported(Operation::Write).is_ok(),
-            "RowTracking with DomainMetadata should be supported for writes"
+            "feature with its protocol dependency should be supported for writes"
         );
     }
 

--- a/kernel/src/table_features/mod.rs
+++ b/kernel/src/table_features/mod.rs
@@ -630,7 +630,7 @@ static VARIANT_TYPE_PREVIEW_INFO: FeatureInfo = FeatureInfo {
 static VARIANT_SHREDDING_INFO: FeatureInfo = FeatureInfo {
     feature_type: FeatureType::ReaderWriter,
     min_legacy_version: None,
-    feature_requirements: &[],
+    feature_requirements: &[FeatureRequirement::Supported(TableFeature::VariantType)],
     kernel_support: KernelSupport::Supported,
     enablement_check: EnablementCheck::AlwaysIfSupported,
 };
@@ -852,6 +852,47 @@ pub(crate) fn extract_enabled_reader_features(protocol: &Protocol) -> Vec<TableF
     }
 }
 
+/// Returns whether `protocol` supports `feature`, including legacy version inference.
+pub(crate) fn protocol_supports_feature(protocol: &Protocol, feature: &TableFeature) -> bool {
+    let info = feature.info();
+    let min_legacy_version = info.min_legacy_version.as_ref();
+    let min_reader_version =
+        min_legacy_version.map_or(TABLE_FEATURES_MIN_READER_VERSION, |v| v.reader);
+    let min_writer_version =
+        min_legacy_version.map_or(TABLE_FEATURES_MIN_WRITER_VERSION, |v| v.writer);
+    let has_feature = |features: Option<&[TableFeature]>| {
+        features.is_some_and(|features| features.contains(feature))
+    };
+
+    match info.feature_type {
+        FeatureType::WriterOnly => {
+            if protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION {
+                protocol.min_writer_version() >= min_writer_version
+            } else {
+                has_feature(protocol.writer_features())
+            }
+        }
+        FeatureType::ReaderWriter => {
+            let reader_supported =
+                if protocol.min_reader_version() < TABLE_FEATURES_MIN_READER_VERSION {
+                    protocol.min_reader_version() >= min_reader_version
+                } else {
+                    has_feature(protocol.reader_features())
+                        || feature.is_valid_for_legacy_reader(protocol.min_reader_version())
+                };
+            let writer_supported =
+                if protocol.min_writer_version() < TABLE_FEATURES_MIN_WRITER_VERSION {
+                    protocol.min_writer_version() >= min_writer_version
+                } else {
+                    has_feature(protocol.writer_features())
+                };
+
+            reader_supported && writer_supported
+        }
+        FeatureType::Unknown => has_feature(protocol.writer_features()),
+    }
+}
+
 /// Add `feature` to the appropriate feature list(s) for its type, skipping duplicates.
 pub(crate) fn add_feature_to_lists(
     feature: TableFeature,
@@ -939,6 +980,25 @@ pub(crate) fn ensure_table_can_be_read(protocol: &Protocol) -> DeltaResult<()> {
             }
             KernelSupport::Custom(_) => {}
         }
+        for requirement in feature.info().feature_requirements {
+            match requirement {
+                FeatureRequirement::Supported(dependency) => require!(
+                    protocol_supports_feature(protocol, dependency),
+                    Error::invalid_protocol(format!(
+                        "Feature '{feature}' requires '{dependency}' to be supported"
+                    ))
+                ),
+                FeatureRequirement::NotSupported(dependency) => require!(
+                    !protocol_supports_feature(protocol, dependency),
+                    Error::invalid_protocol(format!(
+                        "Feature '{feature}' requires '{dependency}' to not be supported"
+                    ))
+                ),
+                FeatureRequirement::Enabled(_)
+                | FeatureRequirement::NotEnabled(_)
+                | FeatureRequirement::Custom(_) => {}
+            }
+        }
     }
 
     Ok(())
@@ -1011,6 +1071,22 @@ mod tests {
         Protocol::try_new_modern(
             [TableFeature::DeletionVectors],
             [TableFeature::DeletionVectors],
+        )
+        .unwrap(),
+        ExpectRead::Ok
+    )]
+    #[case::missing_protocol_dependency(
+        Protocol::try_new_modern(
+            [TableFeature::VariantShredding],
+            [TableFeature::VariantShredding],
+        )
+        .unwrap(),
+        ExpectRead::InvalidProtocol
+    )]
+    #[case::supported_protocol_dependency(
+        Protocol::try_new_modern(
+            [TableFeature::VariantShredding, TableFeature::VariantType],
+            [TableFeature::VariantShredding, TableFeature::VariantType],
         )
         .unwrap(),
         ExpectRead::Ok


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Declare `variantType` as a required protocol dependency of stable `variantShredding`, matching the Delta protocol.
- Share protocol feature-support inference between metadata-aware validation and protocol-only reads so snapshot-less commit ranges also reject the invalid feature combination.
- Keep dependency handling validation-only: Kernel does not add or enable `variantType`, or emit protocol or metadata actions.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo nextest run -p delta_kernel --lib --all-features protocol_dependency`
- `cargo nextest run -p delta_kernel --lib --all-features test_protocol_validation_is_commit_driven`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
