### PR TITLE
ci: prevent semver tool failures from adding breaking-change labels

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -45,7 +45,7 @@ jobs:
           cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
+        uses: taiki-e/install-action@cb33e69fad06166ca28a42b2575e4dadabf62ee8 # v2.85.8
         with:
           tool: cargo-semver-checks@0.50.0
       - name: Compute baseline revision
@@ -82,8 +82,11 @@ jobs:
           set -e
 
           case "$EXIT_CODE" in
+            # No SemVer violations were found.
             0) OUTCOME=success ;;
+            # cargo-semver-checks reserves exit code 100 for detected SemVer violations.
             100) OUTCOME=failure ;;
+            # Any other exit code is a tool error and must not change the label.
             *) OUTCOME=error ;;
           esac
 

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,8 +1,8 @@
 name: semver-checks
 
 # Trigger when a PR is opened or changed. This runs with `pull_request` trigger, which means it has
-# only read perms. The adding of the label happens in semver-label.yml via workflow_run which will
-# will look at the status of this job, and always runs in the base-repo context.
+# only read perms. The label update happens in semver-label.yml via workflow_run, which reads the
+# outcome artifact from this workflow and always runs in the base-repo context.
 on:
   pull_request:
     types:
@@ -45,9 +45,9 @@ jobs:
           cache-bin: false
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@7bc99eee1f1b8902a125006cf790a1f4c8461e63 # v2.69.8
+        uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
-          tool: cargo-semver-checks
+          tool: cargo-semver-checks@0.50.0
       - name: Compute baseline revision
         id: baseline
         shell: bash
@@ -68,7 +68,6 @@ jobs:
           fi
       - name: Run semver check
         id: check
-        continue-on-error: true
         shell: bash
         env:
           BASELINE_REV: ${{ steps.baseline.outputs.rev }}
@@ -76,16 +75,28 @@ jobs:
         # note that this won't run on proc macro/derive crates, so don't need to include
         # delta_kernel_derive etc.
         run: |
-          cargo semver-checks -p delta_kernel -p delta_kernel_ffi --all-features \
+          set +e
+          cargo-semver-checks -p delta_kernel -p delta_kernel_ffi --all-features \
             --baseline-rev "$BASELINE_REV"
-      # Upload the step outcome as an artifact so semver-label.yml can read it via workflow_run.
-      # steps.check.outcome is the raw result *before* continue-on-error converts it to "success",
-      # so it correctly reflects whether a breaking change was detected.
+          EXIT_CODE=$?
+          set -e
+
+          case "$EXIT_CODE" in
+            0) OUTCOME=success ;;
+            100) OUTCOME=failure ;;
+            *) OUTCOME=error ;;
+          esac
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "outcome=$OUTCOME" >> "$GITHUB_OUTPUT"
+      # Upload the classified outcome as an artifact so semver-label.yml can read it via
+      # workflow_run. Exit code 100 means a SemVer violation; any other nonzero exit means the
+      # check could not complete and must not change the label.
       # Only upload for pull_request events; merge_group runs have no PR to label.
       - name: Save semver outcome
         if: github.event_name == 'pull_request'
         env:
-          SEMVER_OUTCOME: ${{ steps.check.outcome }}
+          SEMVER_OUTCOME: ${{ steps.check.outputs.outcome }}
         run: echo "$SEMVER_OUTCOME" > semver-outcome.txt
       - name: Upload semver outcome
         if: github.event_name == 'pull_request'
@@ -94,3 +105,10 @@ jobs:
           name: semver-outcome
           path: semver-outcome.txt
           retention-days: 1
+      - name: Fail if semver check could not complete
+        if: steps.check.outputs.outcome == 'error'
+        env:
+          SEMVER_EXIT_CODE: ${{ steps.check.outputs.exit_code }}
+        run: |
+          echo "::error::cargo-semver-checks failed with exit code ${SEMVER_EXIT_CODE}"
+          exit 1

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -9,14 +9,22 @@ on:
     workflows: ["semver-checks"]
     types: [completed]
 
+concurrency:
+  group: >-
+    semver-label-${{ github.event.workflow_run.head_repository.full_name }}-${{
+      github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
 jobs:
   update_label_if_needed:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       actions: read
-    # Label updates only apply to PRs; merge_group runs have no associated PR to label.
-    if: github.event.workflow_run.event == 'pull_request'
+    # Label updates only apply to successful PR runs. A failed check has no trustworthy result.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
       # Resolve PR number from the triggering workflow run's branch. For fork PRs the branch
       # must be prefixed with `<owner>:` so gh pr view can locate it.
@@ -50,16 +58,27 @@ jobs:
       - name: Update breaking-change label
         if: steps.pr-context.outputs.number != ''
         env:
+          CHECKED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr-context.outputs.number }}
         run: |
-          STEP_OUTCOME=$(cat semver-outcome.txt)
-          echo "Semver check outcome: '${STEP_OUTCOME}' for PR #${PR_NUMBER}"
+          SEMVER_OUTCOME=$(cat semver-outcome.txt)
+          echo "Semver check outcome: '${SEMVER_OUTCOME}' for PR #${PR_NUMBER}"
 
-          if [[ "$STEP_OUTCOME" == "failure" ]]; then
+          # Re-read the PR head immediately before mutation so stale workflow runs cannot change
+          # the current label.
+          PR_HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid --jq '.headRefOid')
+          if [[ "$CHECKED_HEAD_SHA" != "$PR_HEAD_SHA" ]]; then
+            echo "Semver result is for stale head ${CHECKED_HEAD_SHA}; current head is ${PR_HEAD_SHA}"
+            echo "Leaving labels unchanged"
+            exit 0
+          fi
+
+          if [[ "$SEMVER_OUTCOME" == "failure" ]]; then
             echo "Breaking change detected -- adding 'breaking-change' label to PR #$PR_NUMBER"
             gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "breaking-change"
-          elif [[ "$STEP_OUTCOME" == "success" ]]; then
+          elif [[ "$SEMVER_OUTCOME" == "success" ]]; then
             # Remove the label only if it is currently present; gh pr edit fails on absent labels.
             CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name]')
             echo "Current PR labels: $CURRENT_LABELS"
@@ -69,11 +88,11 @@ jobs:
             else
               echo "Semver check passed -- 'breaking-change' label not present, nothing to do"
             fi
-          elif [[ "$STEP_OUTCOME" == "error" ]]; then
+          elif [[ "$SEMVER_OUTCOME" == "error" ]]; then
             echo "ERROR: semver check did not complete; leaving labels unchanged"
             exit 1
           else
-            echo "ERROR: unexpected semver outcome '${STEP_OUTCOME}' in semver-outcome.txt"
+            echo "ERROR: unexpected semver outcome '${SEMVER_OUTCOME}' in semver-outcome.txt"
             exit 1
           fi
 

--- a/.github/workflows/semver-label.yml
+++ b/.github/workflows/semver-label.yml
@@ -39,9 +39,7 @@ jobs:
             >> "${GITHUB_OUTPUT}"
           echo "PR lookup complete: $(cat "${GITHUB_OUTPUT}")"
 
-      # Download the semver outcome artifact written by semver-checks.yml.
-      # steps.check.outcome in that workflow is the raw result before continue-on-error
-      # converts it to "success", so it correctly reflects whether a breaking change was found.
+      # Download the classified semver outcome artifact written by semver-checks.yml.
       - name: Download semver outcome
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -71,6 +69,9 @@ jobs:
             else
               echo "Semver check passed -- 'breaking-change' label not present, nothing to do"
             fi
+          elif [[ "$STEP_OUTCOME" == "error" ]]; then
+            echo "ERROR: semver check did not complete; leaving labels unchanged"
+            exit 1
           else
             echo "ERROR: unexpected semver outcome '${STEP_OUTCOME}' in semver-outcome.txt"
             exit 1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Docs-only PR [#3182](https://github.com/delta-io/delta-kernel-rs/pull/3182) incorrectly received the `breaking-change` label. Its [SemVer check](https://github.com/delta-io/delta-kernel-rs/actions/runs/32759774349) installed `cargo-semver-checks` 0.47.0. Rust 1.98's `rustdoc` emits API metadata using JSON schema v60, but version 0.47.0 only supports schemas v56 and v57. The check therefore stopped before comparing APIs. The workflow treated that tool failure as a SemVer violation, so the [label workflow](https://github.com/delta-io/delta-kernel-rs/actions/runs/32760007526) added the label.

This pins `cargo-semver-checks` 0.50.0 and distinguishes an actual SemVer violation (exit code 100) from tool errors. Tool errors now fail CI without changing labels.

The label workflow also ignores failed source workflows, serializes updates per branch, and verifies the result's commit against the PR's current `headRefOid` immediately before changing its label.

## How was this change tested?

- Ran `cargo-semver-checks` 0.50.0 across both released crates, completing all 196 checks.
- Verified handling of exit codes 0, 100, 101, and 2.
- Ran `actionlint` and `git diff --check`.
