### PR TITLE
ci: install AI reviewer CLIs

### DIFF
--- a/.github/omnigent/package-lock.json
+++ b/.github/omnigent/package-lock.json
@@ -1,0 +1,264 @@
+{
+  "name": "delta-kernel-rs-ai-review",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "delta-kernel-rs-ai-review",
+      "private": true,
+      "dependencies": {
+        "@anthropic-ai/claude-code": "2.1.243",
+        "@openai/codex": "0.149.1"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.243.tgz",
+      "integrity": "sha512-akByOU+klFON4/Ob6RMGeXvS2G+NMaPfNAtG4whrmoGjhNtkGcHzLiGB0VFVtVj9mbnHZ7OSM1/LPwANWeJVIg==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.243",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.243",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.243",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.243",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.243",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.243",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.243",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.243"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.243.tgz",
+      "integrity": "sha512-2OZNo+OK6FpryjC3N+n+DCKLHkzqMf7+J6vCRe6WyWoBlScD+S7e1Pe1GNyoeykXJREt/XWCAk8QBqT89h5N9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.243.tgz",
+      "integrity": "sha512-o4Oj8rhxGTdE6ky7BIUFfxcAjnwA0rjcCSVSJGDi/3bhcXucz4nqlu+7dCdH2BOHJA8eSVeiIBFe26HwpqhVSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.243.tgz",
+      "integrity": "sha512-Lqb0HG/j7PlLGiQ/3zfxRfWCfBFqNzIGkHrl39urB3mSXHIDt6wtoJVRyHR1xvwpf9vBel/L6ESNACA23cUNaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.243.tgz",
+      "integrity": "sha512-9VUEvM9CZyZwtqNc1i88U5j7C71vp58VhJ0ihlvXMwgx4IPiQq/IEkZEltJbBe8lID2MNzkoPDxNhzsne5nobw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.243.tgz",
+      "integrity": "sha512-0IWHHChk350ASg7tbqIfsULb8WV+/h/H5bclj1dqv5Ey6tBRVPGj3sjCKvcvazzXhYWaoDxJHP98/+7EuJkKxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.243.tgz",
+      "integrity": "sha512-lj36JZjt3aveTXsuA0469xNeoWB9WqFM+c3TeR51+aeW5WzVr5Qq0vRY2GSI0j5NLpS2eJebpg9y2Fl92iHLiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.243.tgz",
+      "integrity": "sha512-8gYdANQQGZ6rDfBz/4j028dGJ5iwFp8A8Hkr8YbCPGSs124Ge6QauFCFxneHem101B4Qzw7+7WEia9ExLgUpQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.243",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.243.tgz",
+      "integrity": "sha512-OMkjQZ0yVTLKLMNUgvHMsspdKbChGgZpy0baoGIUq3BFCw6usk0C8/0tgR+OorvYfj6I6zaIIshYnD0B7VsLDA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.149.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1.tgz",
+      "integrity": "sha512-6q5pbcpFbJbqOpkubSDBwXmktQ55aD8eUzGzBF1zASob2DjwhBKDSNGtdZKalfrNJUdTDTPDMmzCXEXs5tMBYA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.149.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.149.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.149.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.149.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.149.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.149.1-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-arm64.tgz",
+      "integrity": "sha512-6X84kTCbnTgPIJ2EdcPsrvwS0Wxsqpa+bCswGmRf4BjhcQ5nPMnBC6yCAaCMj+vrbXQHj+L6sa9FaR4QkmA1qw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-darwin-x64.tgz",
+      "integrity": "sha512-MfLBQLfcElJL9tvj6y45qVHHMGSXCPnQOixuD3/Zq0g1BW/eFizkrGLdn48cFpc+l8cK+gt5nYG5pQYwVs6g4A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-arm64.tgz",
+      "integrity": "sha512-OqxUfZ1TVvHd18zHPKK/8ZRlpk8Vy11mg5CMHaLxNWldTbwVImDKtSLWT+m8m4NM5Sz4PbjtZMrVT/RfpBW/mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-linux-x64.tgz",
+      "integrity": "sha512-Of5fGYgr7tAMsyj6vhXb4/RM/UoA3Zq8BLegUBDC09UNy1XTLGYP/2XD+UX8z3qh0NDwxYdCjFIWdDNijKZggQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-arm64.tgz",
+      "integrity": "sha512-5K0DmOKGK9Bos627p8sK8ATHjovPK0sDyT6h9Cb+4v+5CW5SGw1HLgjGxoLfJ8g3cg6mtg/pRCXXo2L/j71UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.149.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.149.1-win32-x64.tgz",
+      "integrity": "sha512-G3QXGAg7nyyhqOeooAMUekBCeHd8a1QByhKcVAFyzNBaI06t6Ft7nsF+1SzFS0spuIdU4YyMi5YD26ukADBQUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/.github/omnigent/package.json
+++ b/.github/omnigent/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "delta-kernel-rs-ai-review",
+  "private": true,
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.243",
+    "@openai/codex": "0.149.1"
+  }
+}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -212,6 +212,8 @@ jobs:
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             releases.astral.sh:443
+            nodejs.org:443
+            registry.npmjs.org:443
             pypi.org:443
             files.pythonhosted.org:443
             ${{ vars.GATEWAY_HOST }}:443
@@ -259,6 +261,14 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Node.js
+        if: steps.creds.outputs.available == 'true'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38  # v6.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: .github/omnigent/package-lock.json
+
       - name: Install Omnigent
         if: steps.creds.outputs.available == 'true'
         run: |
@@ -282,6 +292,66 @@ jobs:
             --no-build-isolation \
             -r .github/omnigent/requirements.txt
           echo "$PWD/.omnigent-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Install AI reviewer CLIs
+        if: steps.creds.outputs.available == 'true'
+        working-directory: .github/omnigent
+        run: |
+          set -euo pipefail
+          npm ci
+          echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          node --version
+          npm --version
+          claude --version
+          codex --version
+
+      - name: Validate AI reviewer runtime
+        if: steps.creds.outputs.available == 'true'
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import pathlib
+          import re
+          import shutil
+          import subprocess
+          import sys
+
+          harness_commands = {
+              "claude-sdk": "claude",
+              "codex": "codex",
+          }
+          harnesses = set()
+          for path in pathlib.Path(".github/omnigent/reviewer").rglob("config.yaml"):
+              text = path.read_text()
+              harnesses.update(
+                  re.findall(r"^\s*harness:\s*([A-Za-z0-9_.-]+)\s*$", text, re.MULTILINE)
+              )
+
+          if not harnesses:
+              print("::error::No Omnigent harnesses found.")
+              sys.exit(1)
+
+          unknown = sorted(harnesses - harness_commands.keys())
+          if unknown:
+              print(f"::error::No CLI validation mapping for harnesses: {', '.join(unknown)}")
+              sys.exit(1)
+
+          missing = {
+              harness: command
+              for harness, command in sorted(harness_commands.items())
+              if harness in harnesses and shutil.which(command) is None
+          }
+          if missing:
+              details = ", ".join(f"{harness} -> {command}" for harness, command in missing.items())
+              print(f"::error::Missing required AI reviewer CLIs: {details}")
+              sys.exit(1)
+
+          for command in sorted({harness_commands[harness] for harness in harnesses}):
+              subprocess.run([command, "--version"], check=True)
+
+          print("Validated AI reviewer harnesses: " + ", ".join(sorted(harnesses)))
+          PYEOF
 
       - name: Write Omnigent provider config
         if: steps.creds.outputs.available == 'true'


### PR DESCRIPTION
## Description

Follow-up to the AI review workflow prototype. The first artifact-mode test reached Omnigent but failed before producing output because the GitHub runner did not have the Claude Code CLI installed.

This PR:
- installs the Claude Code and Codex CLIs from a checked-in npm lockfile
- verifies both CLI entrypoints before running Omnigent
- adds a runtime preflight that scans the Omnigent reviewer configs and fails if a configured harness has no matching CLI validation
- expands the harden-runner egress allowlist only for Node/npm package installation

## How was this tested?

- npm ci in .github/omnigent
- .github/omnigent/node_modules/.bin/claude --version
- .github/omnigent/node_modules/.bin/codex --version
- local runtime preflight over .github/omnigent/reviewer configs
- git diff --check
- pre-commit hook: cargo +nightly fmt --check, clippy, cargo test, coverage