### PR TITLE
fix!: expose commit info operation metrics

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -882,6 +882,9 @@ pub(crate) struct CommitInfo {
     /// Map of arbitrary string key-value pairs that provide additional information about the
     /// operation. This is specified by the engine. For now this is always empty on write.
     pub(crate) operation_parameters: Option<HashMap<String, Option<String>>>,
+    /// Map of arbitrary string key-value pairs that provide operation metrics.
+    /// This is specified by the engine.
+    pub(crate) operation_metrics: Option<HashMap<String, Option<String>>>,
     /// The version of the delta_kernel crate used to write this commit. The kernel will always
     /// write this field, but it is optional since many tables will not have this field (i.e. any
     /// tables not written by kernel).
@@ -907,6 +910,7 @@ impl CommitInfo {
             in_commit_timestamp,
             operation: Some(operation.unwrap_or_else(|| UNKNOWN_OPERATION.to_string())),
             operation_parameters: Some(HashMap::new()),
+            operation_metrics: None,
             kernel_version: Some(format!("v{KERNEL_VERSION}")),
             is_blind_append: is_blind_append.then_some(true),
             engine_info,
@@ -1940,6 +1944,7 @@ mod tests {
                 nullable "inCommitTimestamp": LONG,
                 nullable "operation": STRING,
                 nullable "operationParameters": { STRING => nullable STRING },
+                nullable "operationMetrics": { STRING => nullable STRING },
                 nullable "kernelVersion": STRING,
                 nullable "isBlindAppend": BOOLEAN,
                 nullable "engineInfo": STRING,
@@ -2256,6 +2261,9 @@ mod tests {
         let mut map_builder = create_string_map_builder(true);
         map_builder.append(true).unwrap();
         let operation_parameters = Arc::new(map_builder.finish());
+        let mut map_builder = create_string_map_builder(true);
+        map_builder.append(false).unwrap();
+        let operation_metrics = Arc::new(map_builder.finish());
 
         let expected = RecordBatch::try_new(
             record_batch.schema(),
@@ -2264,6 +2272,7 @@ mod tests {
                 Arc::new(Int64Array::from(vec![None::<i64>])),
                 Arc::new(StringArray::from(vec![Some("UNKNOWN")])),
                 operation_parameters,
+                operation_metrics,
                 Arc::new(StringArray::from(vec![Some(format!("v{KERNEL_VERSION}"))])),
                 Arc::new(BooleanArray::from(vec![None::<bool>])),
                 Arc::new(StringArray::from(vec![None::<String>])),

--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -275,7 +275,8 @@ mod tests {
     use super::*;
     use crate::actions::visitors::{AddVisitor, RemoveVisitor};
     use crate::actions::{Add, Remove};
-    use crate::engine::arrow_data::ArrowEngineData;
+    use crate::arrow::array::{Array, AsArray, MapArray, StringArray};
+    use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::RowVisitor;
     use crate::object_store::memory::InMemory;
@@ -354,6 +355,207 @@ mod tests {
             1,
             "v=1 has exactly one remove"
         );
+    }
+
+    #[tokio::test]
+    async fn test_commits_project_commit_info_operation_metrics() {
+        let commit = r#"{"commitInfo":{"timestamp":1000,"operation":"WRITE","operationMetrics":{"numFiles":"1","numOutputRows":"2"}}}"#;
+        let (engine, table_root) = engine_with_commits(&[(0, commit)]).await;
+
+        let range = CommitRange::builder_for(table_root, 0)
+            .with_end_version(0)
+            .build(engine.as_ref())
+            .unwrap();
+
+        let mut commit_iter = range
+            .commits(engine.clone(), None, &[DeltaAction::CommitInfo])
+            .unwrap();
+        let commit = commit_iter.next().expect("v=0 commit").unwrap();
+        let mut batches = commit.get_actions(engine.as_ref()).unwrap();
+        let record_batch = batches
+            .next()
+            .expect("commit action batch")
+            .unwrap()
+            .try_into_record_batch()
+            .unwrap();
+
+        let commit_info = record_batch
+            .column_by_name("commitInfo")
+            .expect("commitInfo column")
+            .as_struct_opt()
+            .expect("commitInfo should be a struct");
+        let operation_metrics = commit_info
+            .column_by_name("operationMetrics")
+            .expect("commitInfo.operationMetrics column")
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("operationMetrics should be a map");
+
+        let entries = operation_metrics.value(0);
+        let keys = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("operationMetrics keys should be strings");
+        let values = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("operationMetrics values should be strings");
+        let metrics: HashMap<_, _> = (0..entries.len())
+            .map(|idx| (keys.value(idx), values.value(idx)))
+            .collect();
+
+        assert_eq!(metrics.get("numFiles"), Some(&"1"));
+        assert_eq!(metrics.get("numOutputRows"), Some(&"2"));
+        assert!(batches.next().is_none(), "single-line commit has one batch");
+        assert!(commit_iter.next().is_none(), "single-commit range");
+    }
+
+    #[tokio::test]
+    async fn test_commits_project_commit_info_map_value_shapes() {
+        let commits = [
+            (
+                0,
+                r#"{"commitInfo":{"timestamp":1000,"operation":"CREATE TABLE","operationParameters":{"description":null,"partitionBy":"[]","statsOnLoad":false},"operationMetrics":{}}}"#,
+            ),
+            (
+                1,
+                r#"{"commitInfo":{"timestamp":1001,"operation":"WRITE","operationParameters":{"mode":"Append"},"operationMetrics":{"numFiles":"1","numOutputRows":"2"}}}"#,
+            ),
+            (
+                2,
+                r#"{"commitInfo":{"timestamp":1002,"operation":"WRITE","operationParameters":{"mode":"Append"}}}"#,
+            ),
+            (
+                3,
+                r#"{"commitInfo":{"timestamp":1003,"operation":"WRITE","operationParameters":{"mode":"Append"},"operationMetrics":null}}"#,
+            ),
+        ];
+        let (engine, table_root) = engine_with_commits(&commits).await;
+
+        let range = CommitRange::builder_for(table_root, 0)
+            .with_end_version(3)
+            .build(engine.as_ref())
+            .unwrap();
+
+        let mut commit_iter = range
+            .commits(engine.clone(), None, &[DeltaAction::CommitInfo])
+            .unwrap();
+
+        let commit = commit_iter.next().expect("v=0 commit").unwrap();
+        let commit_info = single_commit_info_batch(&commit, engine.as_ref());
+        let operation_parameters = commit_info_map(&commit_info, "operationParameters");
+        assert_eq!(operation_parameters.get("description"), Some(&None));
+        assert_eq!(
+            operation_parameters.get("partitionBy"),
+            Some(&Some("[]".to_string()))
+        );
+        assert_eq!(
+            operation_parameters.get("statsOnLoad"),
+            Some(&Some("false".to_string()))
+        );
+
+        let operation_metrics = commit_info
+            .column_by_name("operationMetrics")
+            .expect("commitInfo.operationMetrics column")
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("operationMetrics should be a map");
+        assert_eq!(operation_metrics.value(0).len(), 0);
+
+        let commit = commit_iter.next().expect("v=1 commit").unwrap();
+        let commit_info = single_commit_info_batch(&commit, engine.as_ref());
+        let operation_metrics = commit_info_map(&commit_info, "operationMetrics");
+        assert_eq!(
+            operation_metrics.get("numFiles"),
+            Some(&Some("1".to_string()))
+        );
+        assert_eq!(
+            operation_metrics.get("numOutputRows"),
+            Some(&Some("2".to_string()))
+        );
+
+        let commit = commit_iter.next().expect("v=2 commit").unwrap();
+        let commit_info = single_commit_info_batch(&commit, engine.as_ref());
+        let operation_metrics = commit_info
+            .column_by_name("operationMetrics")
+            .expect("commitInfo.operationMetrics column")
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("operationMetrics should be a map");
+        assert!(
+            operation_metrics.is_null(0),
+            "absent operationMetrics should project as a null map"
+        );
+
+        let commit = commit_iter.next().expect("v=3 commit").unwrap();
+        let commit_info = single_commit_info_batch(&commit, engine.as_ref());
+        let operation_metrics = commit_info
+            .column_by_name("operationMetrics")
+            .expect("commitInfo.operationMetrics column")
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .expect("operationMetrics should be a map");
+        assert!(
+            operation_metrics.is_null(0),
+            "explicit null operationMetrics should project as a null map"
+        );
+        assert!(commit_iter.next().is_none(), "four-commit range");
+    }
+
+    fn single_commit_info_batch(
+        commit: &CommitAction,
+        engine: &dyn Engine,
+    ) -> crate::arrow::array::StructArray {
+        let mut batches = commit.get_actions(engine).unwrap();
+        let record_batch = batches
+            .next()
+            .expect("commit action batch")
+            .unwrap()
+            .try_into_record_batch()
+            .unwrap();
+        assert!(batches.next().is_none(), "single-line commit has one batch");
+        record_batch
+            .column_by_name("commitInfo")
+            .expect("commitInfo column")
+            .as_struct_opt()
+            .expect("commitInfo should be a struct")
+            .clone()
+    }
+
+    fn commit_info_map(
+        commit_info: &crate::arrow::array::StructArray,
+        field_name: &str,
+    ) -> HashMap<String, Option<String>> {
+        let map = commit_info
+            .column_by_name(field_name)
+            .unwrap_or_else(|| panic!("commitInfo.{field_name} column"))
+            .as_any()
+            .downcast_ref::<MapArray>()
+            .unwrap_or_else(|| panic!("{field_name} should be a map"));
+        let entries = map.value(0);
+        let keys = entries
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("{field_name} keys should be strings"));
+        let values = entries
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("{field_name} values should be strings"));
+
+        (0..entries.len())
+            .map(|idx| {
+                let value = if values.is_null(idx) {
+                    None
+                } else {
+                    Some(values.value(idx).to_string())
+                };
+                (keys.value(idx).to_string(), value)
+            })
+            .collect()
     }
 
     /// Build an in-memory engine pre-loaded with `commits` (each `(version, body)` pair becomes

--- a/kernel/src/transaction/commit_info.rs
+++ b/kernel/src/transaction/commit_info.rs
@@ -14,7 +14,7 @@ use crate::{DataType, Engine, EngineData, Error, Expression, ExpressionRef, Into
 fn commit_info_literal_exprs(
     commit_info: CommitInfo,
 ) -> Result<Vec<(&'static str, ExpressionRef)>, Error> {
-    let op_params_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
+    let string_map_type = MapType::new(DataType::STRING, DataType::STRING, true);
     let literal_exprs = vec![
         ("timestamp", Arc::new(lit(commit_info.timestamp))),
         (
@@ -26,10 +26,20 @@ fn commit_info_literal_exprs(
             "operationParameters",
             Arc::new(match commit_info.operation_parameters {
                 Some(map) => lit(MapData::try_new(
-                    op_params_map_type,
+                    string_map_type.clone(),
                     map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
                 )?),
-                None => null_lit(op_params_map_type),
+                None => null_lit(string_map_type.clone()),
+            }),
+        ),
+        (
+            "operationMetrics",
+            Arc::new(match commit_info.operation_metrics {
+                Some(map) => lit(MapData::try_new(
+                    string_map_type,
+                    map.into_iter().map(|(k, v)| (Scalar::String(k), v)),
+                )?),
+                None => null_lit(string_map_type),
             }),
         ),
         ("kernelVersion", Arc::new(lit(commit_info.kernel_version))),
@@ -262,7 +272,7 @@ mod tests {
         )?;
         let commit_info = commit_info_struct(&result);
 
-        // All CommitInfo fields are appended -- total = 2 engine + 8 CommitInfo.
+        // All CommitInfo fields are appended after the two engine-only fields.
         assert_eq!(
             commit_info.num_columns(),
             2 + CommitInfo::to_schema().fields().count()
@@ -277,6 +287,7 @@ mod tests {
         assert_eq!(get_str(commit_info, "operation"), "WRITE");
         assert!(!get_str(commit_info, "kernelVersion").is_empty());
         assert!(get_map(commit_info, "operationParameters").len() == 0);
+        assert!(get_map(commit_info, "operationMetrics").is_empty());
         assert!(uuid::Uuid::parse_str(get_str(commit_info, "txnId")).is_ok());
         assert!(get_i64(commit_info, "timestamp") > 0);
         assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
@@ -295,6 +306,12 @@ mod tests {
         map_builder.values().append_value("stale_value");
         map_builder.append(true).unwrap();
         let stale_op_params = Arc::new(map_builder.finish()) as ArrayRef;
+        let mut metrics_map_builder =
+            MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        metrics_map_builder.keys().append_value("stale_metric");
+        metrics_map_builder.values().append_value("1");
+        metrics_map_builder.append(true).unwrap();
+        let stale_op_metrics = Arc::new(metrics_map_builder.finish()) as ArrayRef;
 
         let (data, schema) = make_engine_commit_info(
             vec![
@@ -304,6 +321,11 @@ mod tests {
                 ArrowField::new(
                     "operationParameters",
                     stale_op_params.data_type().clone(),
+                    true,
+                ),
+                ArrowField::new(
+                    "operationMetrics",
+                    stale_op_metrics.data_type().clone(),
                     true,
                 ),
                 ArrowField::new("kernelVersion", ArrowDataType::Utf8, true),
@@ -316,6 +338,7 @@ mod tests {
                 Arc::new(Int64Array::from(vec![None::<i64>])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
                 stale_op_params,
+                stale_op_metrics,
                 Arc::new(StringArray::from(vec!["v0.0.0"])) as ArrayRef,
                 Arc::new(BooleanArray::from(vec![None::<bool>])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["stale_engine"])) as ArrayRef,
@@ -329,12 +352,16 @@ mod tests {
         )?;
         let commit_info = commit_info_struct(&result);
 
-        // All 8 CommitInfo fields are present in the engine schema -- no fields appended.
-        assert_eq!(commit_info.num_columns(), 8);
+        // All CommitInfo fields are present in the engine schema -- no fields appended.
+        assert_eq!(
+            commit_info.num_columns(),
+            CommitInfo::to_schema().fields().count()
+        );
 
         assert_eq!(get_str(commit_info, "operation"), "WRITE");
         assert!(!get_str(commit_info, "kernelVersion").is_empty());
         assert_eq!(get_map(commit_info, "operationParameters").len(), 0);
+        assert!(get_map(commit_info, "operationMetrics").is_empty());
         assert!(uuid::Uuid::parse_str(get_str(commit_info, "txnId")).is_ok());
         assert!(get_i64(commit_info, "timestamp") > 0);
         assert_eq!(get_i64(commit_info, "inCommitTimestamp"), 134_000_000);
@@ -380,8 +407,7 @@ mod tests {
         assert_eq!(ci.fields()[1].name(), "operation");
         assert_eq!(ci.fields()[2].name(), "myCustomField");
 
-        // Remaining CommitInfo fields (6 not in engine schema) are appended after myCustomField.
-        // Total = 3 engine fields + 6 kernel-only fields.
+        // Remaining CommitInfo fields are appended after myCustomField.
         assert_eq!(
             ci.num_columns(),
             3 + CommitInfo::to_schema().fields().count() - 2

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -632,6 +632,7 @@ impl<S> Transaction<S> {
     /// - inCommitTimestamp
     /// - operation
     /// - operationParameters
+    /// - operationMetrics
     /// - kernelVersion
     /// - isBlindAppend
     /// - engineInfo

--- a/kernel/tests/integration/write/commit_info.rs
+++ b/kernel/tests/integration/write/commit_info.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use delta_kernel::arrow::array::{ArrayRef, RecordBatch, StringArray};
+use delta_kernel::arrow::array::{ArrayRef, MapBuilder, RecordBatch, StringArray, StringBuilder};
 use delta_kernel::arrow::datatypes::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
 use delta_kernel::engine::arrow_data::ArrowEngineData;
 use delta_kernel::object_store::path::Path;
@@ -117,6 +117,7 @@ async fn test_commit_info_action() -> Result<(), Box<dyn std::error::Error>> {
 /// - Fields that overlap with kernel-managed CommitInfo fields are overridden by kernel values,
 /// - All kernel-managed fields (`timestamp`, `kernelVersion`, `txnId`, `operationParameters`) are
 ///   present with correct values.
+/// - `operationMetrics` remains absent from the written JSON when kernel has no metrics to write.
 #[tokio::test]
 async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::error::Error>> {
     let _ = tracing_subscriber::fmt::try_init();
@@ -125,14 +126,26 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
     for (table_url, engine, store, table_name) in
         setup_test_tables(schema, &[], None, "test_table").await?
     {
+        let mut map_builder = MapBuilder::new(None, StringBuilder::new(), StringBuilder::new());
+        map_builder.keys().append_value("stale_metric");
+        map_builder.values().append_value("1");
+        map_builder.append(true)?;
+        let stale_operation_metrics = Arc::new(map_builder.finish()) as ArrayRef;
+
         // Build engine_commit_info with:
-        //   - "myApp"    : engine-only field, must pass through unchanged.
-        //   - "myVersion": engine-only field, must pass through unchanged.
-        //   - "operation": overlapping with CommitInfo; kernel must override with "WRITE".
+        //   - "myApp"           : engine-only field, must pass through unchanged.
+        //   - "myVersion"       : engine-only field, must pass through unchanged.
+        //   - "operation"       : overlapping with CommitInfo; kernel must override with "WRITE".
+        //   - "operationMetrics": overlapping with CommitInfo; kernel omits it when unset.
         let arrow_schema = Arc::new(ArrowSchema::new(vec![
             Field::new("myApp", ArrowDataType::Utf8, false),
             Field::new("myVersion", ArrowDataType::Utf8, false),
             Field::new("operation", ArrowDataType::Utf8, false),
+            Field::new(
+                "operationMetrics",
+                stale_operation_metrics.data_type().clone(),
+                true,
+            ),
         ]));
         let batch = RecordBatch::try_new(
             arrow_schema,
@@ -140,12 +153,14 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
                 Arc::new(StringArray::from(vec!["spark"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["3.5.0"])) as ArrayRef,
                 Arc::new(StringArray::from(vec!["STALE_OP"])) as ArrayRef,
+                stale_operation_metrics,
             ],
         )?;
         let engine_schema = schema_ref! {
             not_null "myApp": STRING,
             not_null "myVersion": STRING,
             nullable "operation": STRING,
+            nullable "operationMetrics": { STRING => nullable STRING },
         };
 
         let txn = load_and_begin_transaction(table_url.clone(), &engine)?
@@ -170,6 +185,12 @@ async fn test_commit_info_with_engine_commit_info() -> Result<(), Box<dyn std::e
         // Zero out non-deterministic fields for stable comparison.
         set_json_value(&mut parsed_commits[0], "commitInfo.timestamp", json!(0))?;
         set_json_value(&mut parsed_commits[0], "commitInfo.txnId", json!(ZERO_UUID))?;
+        assert!(
+            parsed_commits[0]["commitInfo"]
+                .get("operationMetrics")
+                .is_none(),
+            "unset operationMetrics should be omitted from commit JSON"
+        );
 
         // Null-valued CommitInfo fields (inCommitTimestamp, isBlindAppend, engineInfo) are
         // omitted from the JSON -- consistent with how the Delta log serializes optional fields.


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3190/files) to review incremental changes.
- [**stack/chiin/ffi-commit-info-operation-metrics**](https://github.com/delta-io/delta-kernel-rs/pull/3190) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3190/files)] <- this PR
  - [stack/chiin/ffi-commit-action-nullability](https://github.com/delta-io/delta-kernel-rs/pull/3191) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3191/files/18fdceb6d81ad85f1fe2082259f52bd346a58e88..69b0fa60cc17e352de84ab13d0b24ac7c6cff667)]

---------
## What changes are proposed in this pull request?

Expose `commitInfo.operationMetrics` through the kernel commit-info schema and commit-range action projection.

This also changes the commit-info maps to use `STRING => nullable STRING` values for both `operationParameters` and `operationMetrics`. The Delta protocol leaves `commitInfo` open-ended: "Implementations are free to store any valid JSON-formatted data via the `commitInfo` action." Delta schema serialization also models nullability explicitly; the protocol defines `nullable` for fields and shows map values with `valueContainsNull = true`.

The intended map semantics are:

```text
no operationMetrics key                -> absent/null map
"operationMetrics": null               -> null map, if encountered
"operationMetrics": {}                 -> present empty map
"operationMetrics": {"x":"1"}          -> present map with string value
"operationParameters": {"x": null}     -> present map, key x has null value
```

Kernel-generated commits still write `operationParameters` as an empty map. When kernel has no operation metrics to write, `operationMetrics` is omitted from the commit JSON rather than emitted as `null`.

### This PR affects the following public APIs

`CommitRange` action reads can now include a `commitInfo.operationMetrics` field, and the `commitInfo.operationParameters` / `commitInfo.operationMetrics` maps report nullable values. This is a schema-level change for clients that consume projected commit-info actions directly.

## How was this change tested?

Added unit coverage for:
- projecting `operationMetrics` from a commit-range read
- distinguishing omitted/null `operationMetrics`, empty maps, string values, and null map values
- preserving kernel-written commit JSON behavior by omitting `operationMetrics` when unset

Validated locally with:

```bash
cargo +nightly fmt
cargo nextest run -p delta_kernel --lib --all-features test_commits_project_commit_info_operation_metrics test_commits_project_commit_info_map_value_shapes test_commits_project_nullable_children_for_absent_actions
cargo nextest run -p delta_kernel --test integration --all-features test_commit_info_with_engine_commit_info
```

The parent commit pre-commit hook also passed formatting, clippy, full `cargo test`, doctests, and coverage generation.