### PR TITLE
fix!: relax commit action projection nullability

### DIFF
--- a/kernel/src/commit_range/mod.rs
+++ b/kernel/src/commit_range/mod.rs
@@ -47,6 +47,7 @@
 mod actions;
 mod builder;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 pub use actions::{CommitAction, DeltaAction};
@@ -59,9 +60,10 @@ use crate::actions::{
     SIDECAR_FIELD,
 };
 use crate::path::ParsedLogPath;
-use crate::schema::{SchemaRef, StructField, StructType};
+use crate::schema::{ArrayType, MapType, SchemaRef, StructField, StructType};
 use crate::snapshot::SnapshotRef;
 use crate::table_features::Operation;
+use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::{DeltaResult, Engine, Error, Version};
 
 /// A contiguous range of Delta commits, holding resolved `[start_version, end_version]` bounds
@@ -250,17 +252,59 @@ impl Iterator for CommitActionsIterator {
 
 /// Build the nullable [`StructField`] that represents this action kind in the read schema.
 fn action_to_field(action: &DeltaAction) -> StructField {
-    match action {
-        DeltaAction::Add => ADD_FIELD.clone(),
-        DeltaAction::Remove => REMOVE_FIELD.clone(),
-        DeltaAction::Metadata => METADATA_FIELD.clone(),
-        DeltaAction::Protocol => PROTOCOL_FIELD.clone(),
-        DeltaAction::CommitInfo => COMMIT_INFO_FIELD.clone(),
-        DeltaAction::Cdc => CDC_FIELD.clone(),
-        DeltaAction::DomainMetadata => DOMAIN_METADATA_FIELD.clone(),
-        DeltaAction::SetTxn => SET_TRANSACTION_FIELD.clone(),
-        DeltaAction::CheckpointMetadata => CHECKPOINT_METADATA_FIELD.clone(),
-        DeltaAction::Sidecar => SIDECAR_FIELD.clone(),
+    NullableActionTransform
+        .transform_struct_field(match action {
+            DeltaAction::Add => &ADD_FIELD,
+            DeltaAction::Remove => &REMOVE_FIELD,
+            DeltaAction::Metadata => &METADATA_FIELD,
+            DeltaAction::Protocol => &PROTOCOL_FIELD,
+            DeltaAction::CommitInfo => &COMMIT_INFO_FIELD,
+            DeltaAction::Cdc => &CDC_FIELD,
+            DeltaAction::DomainMetadata => &DOMAIN_METADATA_FIELD,
+            DeltaAction::SetTxn => &SET_TRANSACTION_FIELD,
+            DeltaAction::CheckpointMetadata => &CHECKPOINT_METADATA_FIELD,
+            DeltaAction::Sidecar => &SIDECAR_FIELD,
+        })
+        .into_owned()
+}
+
+struct NullableActionTransform;
+
+impl<'a> SchemaTransform<'a> for NullableActionTransform {
+    transform_output_type!(|'a, T| Cow<'a, T>);
+
+    fn transform_struct_field(&mut self, field: &'a StructField) -> Cow<'a, StructField> {
+        let data_type = self.transform(&field.data_type);
+        match data_type {
+            Cow::Borrowed(_) if field.is_nullable() => Cow::Borrowed(field),
+            data_type => Cow::Owned(StructField {
+                name: field.name.clone(),
+                data_type: data_type.into_owned(),
+                nullable: true,
+                metadata: field.metadata.clone(),
+            }),
+        }
+    }
+
+    fn transform_array(&mut self, array: &'a ArrayType) -> Cow<'a, ArrayType> {
+        let element_type = self.transform_array_element(array.element_type());
+        match element_type {
+            Cow::Borrowed(_) if array.contains_null() => Cow::Borrowed(array),
+            element_type => Cow::Owned(ArrayType::new(element_type.into_owned(), true)),
+        }
+    }
+
+    fn transform_map(&mut self, map: &'a MapType) -> Cow<'a, MapType> {
+        let key_type = self.transform_map_key(map.key_type());
+        let value_type = self.transform_map_value(map.value_type());
+        match (key_type, value_type) {
+            (Cow::Borrowed(_), Cow::Borrowed(_)) if map.value_contains_null() => Cow::Borrowed(map),
+            (key_type, value_type) => Cow::Owned(MapType::new(
+                key_type.into_owned(),
+                value_type.into_owned(),
+                true,
+            )),
+        }
     }
 }
 
@@ -275,7 +319,7 @@ mod tests {
     use super::*;
     use crate::actions::visitors::{AddVisitor, RemoveVisitor};
     use crate::actions::{Add, Remove};
-    use crate::arrow::array::{Array, AsArray, MapArray, StringArray};
+    use crate::arrow::array::{Array, AsArray, MapArray, StringArray, StructArray};
     use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt};
     use crate::engine::sync::SyncEngine;
     use crate::engine_data::RowVisitor;
@@ -502,6 +546,53 @@ mod tests {
             "explicit null operationMetrics should project as a null map"
         );
         assert!(commit_iter.next().is_none(), "four-commit range");
+    }
+
+    #[tokio::test]
+    async fn test_commits_project_nullable_children_for_absent_actions() {
+        let commit = r#"{"commitInfo":{"timestamp":1000,"operation":"WRITE"}}
+{"add":{"path":"part-00000.parquet","partitionValues":{},"size":1,"modificationTime":1000,"dataChange":true}}"#;
+        let (engine, table_root) = engine_with_commits(&[(0, commit)]).await;
+
+        let range = CommitRange::builder_for(table_root, 0)
+            .with_end_version(0)
+            .build(engine.as_ref())
+            .unwrap();
+
+        let mut commit_iter = range
+            .commits(
+                engine.clone(),
+                None,
+                &[DeltaAction::CommitInfo, DeltaAction::Add],
+            )
+            .unwrap();
+        let commit = commit_iter.next().expect("v=0 commit").unwrap();
+        let mut batches = commit.get_actions(engine.as_ref()).unwrap();
+        let record_batch = batches
+            .next()
+            .expect("commit action batch")
+            .unwrap()
+            .try_into_record_batch()
+            .unwrap();
+
+        let add = record_batch
+            .column_by_name("add")
+            .expect("add column")
+            .as_struct_opt()
+            .expect("add should be a struct");
+        assert_eq!(add.len(), 2);
+        assert!(add.is_null(0), "first row is commitInfo, so add is null");
+        assert!(add.is_valid(1), "second row is add");
+
+        StructArray::try_new(
+            add.fields().clone(),
+            add.columns().to_vec(),
+            add.nulls().cloned(),
+        )
+        .expect("nullable action children should revalidate");
+
+        assert!(batches.next().is_none(), "two-line commit has one batch");
+        assert!(commit_iter.next().is_none(), "single-commit range");
     }
 
     fn single_commit_info_batch(


### PR DESCRIPTION
## Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3191/files/18fdceb6d81ad85f1fe2082259f52bd346a58e88..69b0fa60cc17e352de84ab13d0b24ac7c6cff667) to review incremental changes.
- [stack/chiin/ffi-commit-info-operation-metrics](https://github.com/delta-io/delta-kernel-rs/pull/3190) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3190/files)]
  - [**stack/chiin/ffi-commit-action-nullability**](https://github.com/delta-io/delta-kernel-rs/pull/3191) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3191/files/18fdceb6d81ad85f1fe2082259f52bd346a58e88..69b0fa60cc17e352de84ab13d0b24ac7c6cff667)] <- this PR

---------
## What changes are proposed in this pull request?

Relax the read schema that `CommitRange` uses when it projects selected action columns from JSON commit files.

Commit files are row-wise action streams. A `commitInfo` row has no `add` action, an `add` row has no `commitInfo` action, and so on. The top-level action struct has to be nullable for that shape.

Before this change, `CommitRange` reused the canonical action schemas directly. That preserved the required fields from the Delta action model, but it also made absent actions look invalid in sparse projections because null parent structs can carry null child slots. This PR rebuilds the projected action schema with recursive nullability so the JSON reader can represent absent action rows correctly.

This is a projection-schema change, not a protocol change. It does not make required Delta fields optional for a real action. Callers that parse the returned batches through action visitors still get `MissingData` errors for required fields once an action is identified. `get_actions()` continues to return raw projected action batches, so full action validation remains a semantic parsing step rather than something the read schema can express by itself.

### This PR affects the following public APIs

`CommitRange` action reads now expose relaxed nullability in their projected schemas. Clients that inspect the returned schema directly may see nullable nested fields and nullable container values where the canonical action schema marks those fields as required for a present action. Treat that schema as the shape of a sparse action projection, not as the Delta protocol contract for a single action payload.

## How was this change tested?

Added unit coverage for a commit with both `commitInfo` and `add` rows. The test reads both action types through `CommitRange`, verifies that the absent `add` row is represented as null, and revalidates the projected nullable `add` struct.

Validated locally with:

```bash
cargo +nightly fmt
cargo nextest run -p delta_kernel --lib --all-features test_commits_project_commit_info_operation_metrics test_commits_project_commit_info_map_value_shapes test_commits_project_nullable_children_for_absent_actions
```