### PR TITLE
refactor!: reclassify generic log segment errors

### DIFF
--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -234,7 +234,7 @@ async fn test_cannot_checkpoint_unpublished_snapshot() -> Result<(), TestError> 
 
     let snapshot = commit(&snapshot, &update_table_client, &engine)?;
     let err = snapshot.checkpoint(&engine, None).unwrap_err();
-    assert!(matches!(err, delta_kernel::Error::Generic(msg) if msg.contains("not published")));
+    assert!(matches!(err, delta_kernel::Error::MissingVersionAt(3)));
     Ok(())
 }
 

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -234,7 +234,7 @@ async fn test_cannot_checkpoint_unpublished_snapshot() -> Result<(), TestError> 
 
     let snapshot = commit(&snapshot, &update_table_client, &engine)?;
     let err = snapshot.checkpoint(&engine, None).unwrap_err();
-    assert!(matches!(err, delta_kernel::Error::MissingVersion(Some(1))));
+    assert!(matches!(err, delta_kernel::Error::UnpublishedVersion(1)));
     Ok(())
 }
 

--- a/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
+++ b/delta-kernel-unity-catalog/tests/e2e_in_memory.rs
@@ -234,7 +234,7 @@ async fn test_cannot_checkpoint_unpublished_snapshot() -> Result<(), TestError> 
 
     let snapshot = commit(&snapshot, &update_table_client, &engine)?;
     let err = snapshot.checkpoint(&engine, None).unwrap_err();
-    assert!(matches!(err, delta_kernel::Error::MissingVersionAt(3)));
+    assert!(matches!(err, delta_kernel::Error::MissingVersion(Some(1))));
     Ok(())
 }
 

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -590,7 +590,11 @@ mod tests {
             ))
         };
         let result = unsafe { commit_range_builder_build(builder) };
-        assert_extern_result_error_with_message(result, KernelError::MissingVersionError, None);
+        assert_extern_result_error_with_message(
+            result,
+            KernelError::MissingVersionError,
+            Some("Table version 5 is missing or unavailable for this log operation."),
+        );
 
         unsafe { free_engine(engine) }
         Ok(())

--- a/ffi/src/commit_range.rs
+++ b/ffi/src/commit_range.rs
@@ -590,7 +590,7 @@ mod tests {
             ))
         };
         let result = unsafe { commit_range_builder_build(builder) };
-        assert_extern_result_error_with_message(result, KernelError::GenericError, None);
+        assert_extern_result_error_with_message(result, KernelError::MissingVersionError, None);
 
         unsafe { free_engine(engine) }
         Ok(())

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -73,8 +73,8 @@ pub enum KernelError {
     RowTrackingChangeFeedUnsupported = 44,
     CancelledError = 45,
     InvalidTransactionStateError = 46,
-    /// The selected log files violate their declared kinds, ordering, or version bounds.
     InvalidLogSegment = 47,
+    UnpublishedVersionError = 48,
 }
 
 impl From<Error> for KernelError {
@@ -103,7 +103,8 @@ impl From<Error> for KernelError {
             Error::MissingColumn(_) => KernelError::MissingColumnError,
             Error::UnexpectedColumnType(_) => KernelError::UnexpectedColumnTypeError,
             Error::MissingData(_) => KernelError::MissingDataError,
-            Error::MissingVersion(_) => KernelError::MissingVersionError,
+            Error::EmptyLog | Error::MissingVersion(_) => KernelError::MissingVersionError,
+            Error::UnpublishedVersion(_) => KernelError::UnpublishedVersionError,
             Error::DeletionVector(_) => KernelError::DeletionVectorError,
             Error::InvalidUrl(_) => KernelError::InvalidUrlError,
             Error::MalformedJson(_) => KernelError::MalformedJsonError,
@@ -325,7 +326,7 @@ impl From<EngineExecError> for Error {
             KernelError::SchemaError => Error::Schema(message),
             KernelError::InvalidTransactionStateError => Error::InvalidTransactionState(message),
             code @ KernelError::MissingVersionError => {
-                messageless_error(code, message, Error::MissingVersion(None))
+                messageless_error(code, message, Error::EmptyLog)
             }
             code @ KernelError::MissingMetadataError => {
                 messageless_error(code, message, Error::MissingMetadata)
@@ -357,7 +358,8 @@ impl From<EngineExecError> for Error {
             | KernelError::ChangeDataFeedIncompatibleSchema
             | KernelError::RowTrackingChangeFeedUnsupported
             | KernelError::LiteralExpressionTransformError
-            | KernelError::LogHistoryError) => {
+            | KernelError::LogHistoryError
+            | KernelError::UnpublishedVersionError) => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
             #[cfg(feature = "default-engine-base")]
@@ -387,7 +389,7 @@ mod error_code_tests {
 
     #[test]
     fn log_segment_errors_have_stable_ffi_mappings() {
-        let missing_version = Error::MissingVersion(Some(7));
+        let missing_version = Error::MissingVersion(7);
         assert_eq!(
             missing_version.to_string(),
             "Table version 7 is missing or unavailable for this log operation."
@@ -397,10 +399,19 @@ mod error_code_tests {
             KernelError::MissingVersionError
         );
         assert_eq!(
+            KernelError::from(Error::EmptyLog),
+            KernelError::MissingVersionError
+        );
+        assert_eq!(
+            KernelError::from(Error::UnpublishedVersion(7)),
+            KernelError::UnpublishedVersionError
+        );
+        assert_eq!(
             KernelError::from(Error::InvalidLogSegment("invalid".to_string())),
             KernelError::InvalidLogSegment
         );
         assert_eq!(KernelError::InvalidLogSegment as i32, 47);
+        assert_eq!(KernelError::UnpublishedVersionError as i32, 48);
     }
 }
 
@@ -415,9 +426,8 @@ mod tests {
         EngineExecError { etype, message }
     }
 
-    /// Each code should translate into its matching kernel error variant (preserving the message),
-    /// payloads unavailable through FFI drop the message, and unmapped codes fall back to a generic
-    /// error that retains both the original code and message.
+    /// Variants that cannot preserve their original message across FFI reconstruct from their
+    /// default `Display`; unmapped codes retain the original code and message.
     #[rstest]
     #[case::file_not_found(KernelError::FileNotFoundError, "File not found: boom")]
     #[case::schema(KernelError::SchemaError, "Schema error: boom")]
@@ -436,6 +446,10 @@ mod tests {
     #[case::fallback_row_tracking(
         KernelError::RowTrackingChangeFeedUnsupported,
         "Generic delta kernel error: engine execution error (RowTrackingChangeFeedUnsupported): boom"
+    )]
+    #[case::fallback_unpublished_version(
+        KernelError::UnpublishedVersionError,
+        "Generic delta kernel error: engine execution error (UnpublishedVersionError): boom"
     )]
     fn engine_exec_error_maps_kernel_error_code(
         #[case] etype: KernelError,

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -73,6 +73,7 @@ pub enum KernelError {
     RowTrackingChangeFeedUnsupported = 44,
     CancelledError = 45,
     InvalidTransactionStateError = 46,
+    /// The selected log files violate their declared kinds, ordering, or version bounds.
     InvalidLogSegment = 47,
 }
 

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -103,8 +103,7 @@ impl From<Error> for KernelError {
             Error::MissingColumn(_) => KernelError::MissingColumnError,
             Error::UnexpectedColumnType(_) => KernelError::UnexpectedColumnTypeError,
             Error::MissingData(_) => KernelError::MissingDataError,
-            Error::MissingVersion => KernelError::MissingVersionError,
-            Error::MissingVersionAt(_) => KernelError::MissingVersionError,
+            Error::MissingVersion(_) => KernelError::MissingVersionError,
             Error::DeletionVector(_) => KernelError::DeletionVectorError,
             Error::InvalidUrl(_) => KernelError::InvalidUrlError,
             Error::MalformedJson(_) => KernelError::MalformedJsonError,
@@ -326,7 +325,7 @@ impl From<EngineExecError> for Error {
             KernelError::SchemaError => Error::Schema(message),
             KernelError::InvalidTransactionStateError => Error::InvalidTransactionState(message),
             code @ KernelError::MissingVersionError => {
-                messageless_error(code, message, Error::MissingVersion)
+                messageless_error(code, message, Error::MissingVersion(None))
             }
             code @ KernelError::MissingMetadataError => {
                 messageless_error(code, message, Error::MissingMetadata)
@@ -388,8 +387,13 @@ mod error_code_tests {
 
     #[test]
     fn log_segment_errors_have_stable_ffi_mappings() {
+        let missing_version = Error::MissingVersion(Some(7));
         assert_eq!(
-            KernelError::from(Error::MissingVersionAt(7)),
+            missing_version.to_string(),
+            "Table version 7 is missing or unavailable for this log operation."
+        );
+        assert_eq!(
+            KernelError::from(missing_version),
             KernelError::MissingVersionError
         );
         assert_eq!(
@@ -412,8 +416,8 @@ mod tests {
     }
 
     /// Each code should translate into its matching kernel error variant (preserving the message),
-    /// unit variants drop the message, and unmapped codes fall back to a generic error that retains
-    /// both the original code and message.
+    /// payloads unavailable through FFI drop the message, and unmapped codes fall back to a generic
+    /// error that retains both the original code and message.
     #[rstest]
     #[case::file_not_found(KernelError::FileNotFoundError, "File not found: boom")]
     #[case::schema(KernelError::SchemaError, "Schema error: boom")]
@@ -421,7 +425,10 @@ mod tests {
     #[case::generic(KernelError::GenericError, "Generic delta kernel error: boom")]
     #[case::invalid_expr(KernelError::InvalidExpression, "Invalid expression evaluation: boom")]
     #[case::invalid_log_segment(KernelError::InvalidLogSegment, "Invalid log segment: boom")]
-    #[case::unit_missing_version(KernelError::MissingVersionError, "No table version found.")]
+    #[case::missing_version_without_payload(
+        KernelError::MissingVersionError,
+        "No table version found."
+    )]
     #[case::fallback_io(
         KernelError::IOErrorError,
         "Generic delta kernel error: engine execution error (IOErrorError): boom"

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -1,4 +1,4 @@
-use delta_kernel::{DeltaResult, Error};
+use delta_kernel::{DeltaResult, Error, Version};
 use tracing::warn;
 
 use crate::handle::Handle;
@@ -75,6 +75,7 @@ pub enum KernelError {
     InvalidTransactionStateError = 46,
     InvalidLogSegment = 47,
     UnpublishedVersionError = 48,
+    EmptyLogError = 49,
 }
 
 impl From<Error> for KernelError {
@@ -103,7 +104,8 @@ impl From<Error> for KernelError {
             Error::MissingColumn(_) => KernelError::MissingColumnError,
             Error::UnexpectedColumnType(_) => KernelError::UnexpectedColumnTypeError,
             Error::MissingData(_) => KernelError::MissingDataError,
-            Error::EmptyLog | Error::MissingVersion(_) => KernelError::MissingVersionError,
+            Error::EmptyLog => KernelError::EmptyLogError,
+            Error::MissingVersion(_) => KernelError::MissingVersionError,
             Error::UnpublishedVersion(_) => KernelError::UnpublishedVersionError,
             Error::DeletionVector(_) => KernelError::DeletionVectorError,
             Error::InvalidUrl(_) => KernelError::InvalidUrlError,
@@ -256,7 +258,9 @@ impl<T> IntoExternResult<T> for DeltaResult<T> {
 ///
 /// The message is an [`ExclusiveRustString`] handle, which means the engine must
 /// downcall to [`allocate_kernel_string`](crate::allocate_kernel_string) to construct it. Kernel
-/// can then take ownership and free it appropriately after receiving the error.
+/// can then take ownership and free it appropriately after receiving the error. For
+/// [`KernelError::MissingVersionError`], the message must be the missing [`Version`] as an unsigned
+/// base-10 integer.
 #[repr(C)]
 pub struct EngineExecError {
     // TODO: we re-use KernelError for convenience, but we should ideally split this into a
@@ -289,6 +293,15 @@ fn messageless_error(code: KernelError, message: String, error: Error) -> Error 
         warn!("Discarding message for engine execution error ({code:?}): {message}");
     }
     error
+}
+
+fn missing_version_error(code: KernelError, message: String) -> Error {
+    match message.parse::<Version>() {
+        Ok(version) => Error::MissingVersion(version),
+        Err(_) => Error::generic(format!(
+            "engine execution error ({code:?}) has invalid missing-version payload: {message}"
+        )),
+    }
 }
 
 impl From<EngineExecError> for Error {
@@ -325,9 +338,8 @@ impl From<EngineExecError> for Error {
             KernelError::InvalidCheckpoint => Error::InvalidCheckpoint(message),
             KernelError::SchemaError => Error::Schema(message),
             KernelError::InvalidTransactionStateError => Error::InvalidTransactionState(message),
-            code @ KernelError::MissingVersionError => {
-                messageless_error(code, message, Error::EmptyLog)
-            }
+            code @ KernelError::MissingVersionError => missing_version_error(code, message),
+            code @ KernelError::EmptyLogError => messageless_error(code, message, Error::EmptyLog),
             code @ KernelError::MissingMetadataError => {
                 messageless_error(code, message, Error::MissingMetadata)
             }
@@ -378,6 +390,11 @@ impl From<EngineExecError> for Error {
 mod error_code_tests {
     use super::*;
 
+    fn exec_error(etype: KernelError, message: &str) -> EngineExecError {
+        let message: Handle<ExclusiveRustString> = Box::new(message.to_string()).into();
+        EngineExecError { etype, message }
+    }
+
     #[test]
     fn row_tracking_change_feed_error_has_stable_ffi_mapping() {
         assert_eq!(
@@ -400,7 +417,7 @@ mod error_code_tests {
         );
         assert_eq!(
             KernelError::from(Error::EmptyLog),
-            KernelError::MissingVersionError
+            KernelError::EmptyLogError
         );
         assert_eq!(
             KernelError::from(Error::UnpublishedVersion(7)),
@@ -412,6 +429,17 @@ mod error_code_tests {
         );
         assert_eq!(KernelError::InvalidLogSegment as i32, 47);
         assert_eq!(KernelError::UnpublishedVersionError as i32, 48);
+        assert_eq!(KernelError::EmptyLogError as i32, 49);
+    }
+
+    #[test]
+    fn log_segment_errors_preserve_their_ffi_contract() {
+        let missing_version: Error = exec_error(KernelError::MissingVersionError, "7").into();
+        assert!(matches!(missing_version, Error::MissingVersion(7)));
+
+        let empty_log: Error = exec_error(KernelError::EmptyLogError, "").into();
+        assert_eq!(empty_log.to_string(), "No table version found.");
+        assert!(matches!(empty_log, Error::EmptyLog));
     }
 }
 
@@ -435,10 +463,7 @@ mod tests {
     #[case::generic(KernelError::GenericError, "Generic delta kernel error: boom")]
     #[case::invalid_expr(KernelError::InvalidExpression, "Invalid expression evaluation: boom")]
     #[case::invalid_log_segment(KernelError::InvalidLogSegment, "Invalid log segment: boom")]
-    #[case::missing_version_without_payload(
-        KernelError::MissingVersionError,
-        "No table version found."
-    )]
+    #[case::empty_log(KernelError::EmptyLogError, "No table version found.")]
     #[case::fallback_io(
         KernelError::IOErrorError,
         "Generic delta kernel error: engine execution error (IOErrorError): boom"

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -73,6 +73,7 @@ pub enum KernelError {
     RowTrackingChangeFeedUnsupported = 44,
     CancelledError = 45,
     InvalidTransactionStateError = 46,
+    InvalidLogSegment = 47,
 }
 
 impl From<Error> for KernelError {
@@ -102,6 +103,7 @@ impl From<Error> for KernelError {
             Error::UnexpectedColumnType(_) => KernelError::UnexpectedColumnTypeError,
             Error::MissingData(_) => KernelError::MissingDataError,
             Error::MissingVersion => KernelError::MissingVersionError,
+            Error::MissingVersionAt(_) => KernelError::MissingVersionError,
             Error::DeletionVector(_) => KernelError::DeletionVectorError,
             Error::InvalidUrl(_) => KernelError::InvalidUrlError,
             Error::MalformedJson(_) => KernelError::MalformedJsonError,
@@ -124,6 +126,7 @@ impl From<Error> for KernelError {
             } => Self::from(*source),
             Error::InvalidExpressionEvaluation(_) => KernelError::InvalidExpression,
             Error::InvalidLogPath(_) => KernelError::InvalidLogPath,
+            Error::InvalidLogSegment(_) => KernelError::InvalidLogSegment,
             Error::FileAlreadyExists(_) => KernelError::FileAlreadyExists,
             Error::Unsupported(_) => KernelError::UnsupportedError,
             Error::ParseIntervalError(_) => KernelError::ParseIntervalError,
@@ -315,6 +318,7 @@ impl From<EngineExecError> for Error {
             KernelError::InvalidStructDataError => Error::InvalidStructData(message),
             KernelError::InvalidExpression => Error::InvalidExpressionEvaluation(message),
             KernelError::InvalidLogPath => Error::InvalidLogPath(message),
+            KernelError::InvalidLogSegment => Error::InvalidLogSegment(message),
             KernelError::FileAlreadyExists => Error::FileAlreadyExists(message),
             KernelError::UnsupportedError => Error::Unsupported(message),
             KernelError::InvalidCheckpoint => Error::InvalidCheckpoint(message),
@@ -380,6 +384,19 @@ mod error_code_tests {
         );
         assert_eq!(KernelError::RowTrackingChangeFeedUnsupported as i32, 44);
     }
+
+    #[test]
+    fn log_segment_errors_have_stable_ffi_mappings() {
+        assert_eq!(
+            KernelError::from(Error::MissingVersionAt(7)),
+            KernelError::MissingVersionError
+        );
+        assert_eq!(
+            KernelError::from(Error::InvalidLogSegment("invalid".to_string())),
+            KernelError::InvalidLogSegment
+        );
+        assert_eq!(KernelError::InvalidLogSegment as i32, 47);
+    }
 }
 
 #[cfg(all(test, feature = "declarative-plans"))]
@@ -402,6 +419,7 @@ mod tests {
     #[case::unsupported(KernelError::UnsupportedError, "Unsupported: boom")]
     #[case::generic(KernelError::GenericError, "Generic delta kernel error: boom")]
     #[case::invalid_expr(KernelError::InvalidExpression, "Invalid expression evaluation: boom")]
+    #[case::invalid_log_segment(KernelError::InvalidLogSegment, "Invalid log segment: boom")]
     #[case::unit_missing_version(KernelError::MissingVersionError, "No table version found.")]
     #[case::fallback_io(
         KernelError::IOErrorError,

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -1,4 +1,4 @@
-use delta_kernel::{DeltaResult, Error, Version};
+use delta_kernel::{DeltaResult, Error};
 use tracing::warn;
 
 use crate::handle::Handle;
@@ -90,7 +90,7 @@ impl From<Error> for KernelError {
             Error::Generic(_) => KernelError::GenericError,
             Error::GenericError { .. } => KernelError::GenericError,
             Error::MaxCatalogVersion(_) => KernelError::GenericError,
-            Error::LogTailVersionsNotContiguous { .. } => KernelError::GenericError,
+            Error::LogTailVersionsNotContiguous { .. } => KernelError::InvalidLogSegment,
             Error::IOError(_) => KernelError::IOErrorError,
             #[cfg(feature = "default-engine-base")]
             Error::Parquet(_) => KernelError::ParquetError,
@@ -258,9 +258,7 @@ impl<T> IntoExternResult<T> for DeltaResult<T> {
 ///
 /// The message is an [`ExclusiveRustString`] handle, which means the engine must
 /// downcall to [`allocate_kernel_string`](crate::allocate_kernel_string) to construct it. Kernel
-/// can then take ownership and free it appropriately after receiving the error. For
-/// [`KernelError::MissingVersionError`], the message must be the missing [`Version`] as an unsigned
-/// base-10 integer.
+/// can then take ownership and free it appropriately after receiving the error.
 #[repr(C)]
 pub struct EngineExecError {
     // TODO: we re-use KernelError for convenience, but we should ideally split this into a
@@ -293,15 +291,6 @@ fn messageless_error(code: KernelError, message: String, error: Error) -> Error 
         warn!("Discarding message for engine execution error ({code:?}): {message}");
     }
     error
-}
-
-fn missing_version_error(code: KernelError, message: String) -> Error {
-    match message.parse::<Version>() {
-        Ok(version) => Error::MissingVersion(version),
-        Err(_) => Error::generic(format!(
-            "engine execution error ({code:?}) has invalid missing-version payload: {message}"
-        )),
-    }
 }
 
 impl From<EngineExecError> for Error {
@@ -338,7 +327,6 @@ impl From<EngineExecError> for Error {
             KernelError::InvalidCheckpoint => Error::InvalidCheckpoint(message),
             KernelError::SchemaError => Error::Schema(message),
             KernelError::InvalidTransactionStateError => Error::InvalidTransactionState(message),
-            code @ KernelError::MissingVersionError => missing_version_error(code, message),
             code @ KernelError::EmptyLogError => messageless_error(code, message, Error::EmptyLog),
             code @ KernelError::MissingMetadataError => {
                 messageless_error(code, message, Error::MissingMetadata)
@@ -371,6 +359,7 @@ impl From<EngineExecError> for Error {
             | KernelError::RowTrackingChangeFeedUnsupported
             | KernelError::LiteralExpressionTransformError
             | KernelError::LogHistoryError
+            | KernelError::MissingVersionError
             | KernelError::UnpublishedVersionError) => {
                 Error::generic(format!("engine execution error ({code:?}): {message}"))
             }
@@ -427,15 +416,26 @@ mod error_code_tests {
             KernelError::from(Error::InvalidLogSegment("invalid".to_string())),
             KernelError::InvalidLogSegment
         );
+        assert_eq!(
+            KernelError::from(Error::LogTailVersionsNotContiguous {
+                first_version: 1,
+                second_version: 3,
+            }),
+            KernelError::InvalidLogSegment
+        );
         assert_eq!(KernelError::InvalidLogSegment as i32, 47);
         assert_eq!(KernelError::UnpublishedVersionError as i32, 48);
         assert_eq!(KernelError::EmptyLogError as i32, 49);
     }
 
     #[test]
-    fn log_segment_errors_preserve_their_ffi_contract() {
+    fn engine_log_segment_errors_use_supported_ffi_mappings() {
         let missing_version: Error = exec_error(KernelError::MissingVersionError, "7").into();
-        assert!(matches!(missing_version, Error::MissingVersion(7)));
+        assert!(matches!(
+            missing_version,
+            Error::Generic(message)
+                if message == "engine execution error (MissingVersionError): 7"
+        ));
 
         let empty_log: Error = exec_error(KernelError::EmptyLogError, "").into();
         assert_eq!(empty_log.to_string(), "No table version found.");
@@ -471,6 +471,10 @@ mod tests {
     #[case::fallback_row_tracking(
         KernelError::RowTrackingChangeFeedUnsupported,
         "Generic delta kernel error: engine execution error (RowTrackingChangeFeedUnsupported): boom"
+    )]
+    #[case::fallback_missing_version(
+        KernelError::MissingVersionError,
+        "Generic delta kernel error: engine execution error (MissingVersionError): boom"
     )]
     #[case::fallback_unpublished_version(
         KernelError::UnpublishedVersionError,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -3653,7 +3653,11 @@ mod tests {
             snapshot_builder_set_version(&mut ptr, 99);
             snapshot_builder_build(ptr)
         };
-        assert_extern_result_error_with_message(result, KernelError::MissingVersionError, None);
+        assert_extern_result_error_with_message(
+            result,
+            KernelError::MissingVersionError,
+            Some("Table version 1 is missing or unavailable for this log operation."),
+        );
 
         unsafe { free_engine(engine) }
         Ok(())

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2183,7 +2183,11 @@ mod tests {
             snapshot_builder_set_version(&mut ptr, 1);
             snapshot_builder_build(ptr)
         };
-        assert_extern_result_error_with_message(snapshot_at_non_existent_version, KernelError::GenericError, Some("Generic delta kernel error: LogSegment end version 0 not the same as the specified end version 1"));
+        assert_extern_result_error_with_message(
+            snapshot_at_non_existent_version,
+            KernelError::MissingVersionError,
+            Some("Table version 1 is missing or unavailable for this log operation."),
+        );
 
         let snapshot_table_root_str =
             unsafe { snapshot_table_root(snapshot1.shallow_copy(), allocate_str) };
@@ -3649,7 +3653,7 @@ mod tests {
             snapshot_builder_set_version(&mut ptr, 99);
             snapshot_builder_build(ptr)
         };
-        assert_extern_result_error_with_message(result, KernelError::GenericError, None);
+        assert_extern_result_error_with_message(result, KernelError::MissingVersionError, None);
 
         unsafe { free_engine(engine) }
         Ok(())

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -646,7 +646,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
 
     assert!(matches!(
         snapshot.create_checkpoint_writer(&engine).unwrap_err(),
-        crate::Error::MissingVersion(Some(1))
+        crate::Error::UnpublishedVersion(1)
     ));
     Ok(())
 }

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -646,7 +646,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
 
     assert!(matches!(
         snapshot.create_checkpoint_writer(&engine).unwrap_err(),
-        crate::Error::Generic(e) if e == "Log segment is not published"
+        crate::Error::MissingVersionAt(1)
     ));
     Ok(())
 }

--- a/kernel/src/checkpoint/tests.rs
+++ b/kernel/src/checkpoint/tests.rs
@@ -646,7 +646,7 @@ async fn test_no_checkpoint_on_unpublished_snapshot() -> DeltaResult<()> {
 
     assert!(matches!(
         snapshot.create_checkpoint_writer(&engine).unwrap_err(),
-        crate::Error::MissingVersionAt(1)
+        crate::Error::MissingVersion(Some(1))
     ));
     Ok(())
 }

--- a/kernel/src/commit_range/builder.rs
+++ b/kernel/src/commit_range/builder.rs
@@ -60,9 +60,10 @@ impl CommitRangeBuilder {
     /// List `_delta_log/`, validate contiguity, and produce a [`CommitRange`]. Performs
     /// filesystem listing but no JSON reads.
     ///
-    /// Returns an error if the resolved version range is invalid (start > end), the
-    /// listed commits are non-contiguous, or the requested start version is not present
-    /// on the filesystem.
+    /// Returns [`Error::MissingVersion`] if a snapshot-derived range requires a commit that is not
+    /// available in the snapshot's log segment. Returns an error if the resolved version range is
+    /// invalid (start > end), the listed commits are non-contiguous, or the requested start version
+    /// is not present on the filesystem.
     pub fn build(&self, engine: &dyn Engine) -> DeltaResult<CommitRange> {
         let table_root = Self::parse_table_root(&self.table_root)?;
         let log_root = table_root.join("_delta_log/")?;
@@ -80,15 +81,12 @@ impl CommitRangeBuilder {
             )?,
         };
 
-        let end_version = end_version.unwrap_or(log_segment.end_version);
-
-        // Snapshot-derived ranges can't extend past the snapshot version.
-        if self.snapshot.is_some() && end_version > log_segment.end_version {
-            return Err(Error::generic(format!(
-                "end_version ({end_version}) cannot exceed snapshot version ({})",
-                log_segment.end_version
-            )));
+        // Preserve invalid-input errors for an explicitly reversed range. When no end was
+        // supplied, a start beyond a snapshot is an availability error instead.
+        if let Some(end_version) = end_version {
+            validate_version_range(start_version, end_version)?;
         }
+        let end_version = end_version.unwrap_or(log_segment.end_version);
 
         // Snapshot's log segment may extend past [start, end]; filter to the requested range.
         let mut commit_files: Vec<ParsedLogPath> = log_segment
@@ -98,9 +96,11 @@ impl CommitRangeBuilder {
             .filter(|f| f.version >= start_version && f.version <= end_version)
             .collect();
 
-        validate_version_range(start_version, end_version)?;
         if self.snapshot.is_some() {
             validate_start_version_available(start_version, commit_files.first())?;
+            if end_version > log_segment.end_version {
+                return Err(Error::MissingVersion(log_segment.end_version + 1));
+            }
         }
         validate_number_of_commit_files(start_version, end_version, commit_files.len())?;
 
@@ -151,13 +151,7 @@ fn validate_start_version_available(
     if first_commit.map(|f| f.version) == Some(start_version) {
         return Ok(());
     }
-    let earliest_available_commit = first_commit
-        .map(|f| f.version)
-        .ok_or_else(|| Error::generic("snapshot's log segment must have at least one commit"))?;
-    Err(Error::generic(format!(
-        "start_version {start_version} is not available in the snapshot's log segment \
-         (earliest available commit: {earliest_available_commit})",
-    )))
+    Err(Error::MissingVersion(start_version))
 }
 
 fn validate_number_of_commit_files(
@@ -225,24 +219,13 @@ mod tests {
         assert_eq!(range.end_version(), snapshot_version);
     }
 
-    /// Snapshot-based ranges must reject any version that lands past the snapshot's
-    /// version. Both the start-past-snapshot and end-past-snapshot cases surface as a
-    /// generic error before the iterator is constructed.
     #[rstest::rstest]
-    #[case::start_past_snapshot_version(
-        5,
-        None,
-        &["start_version (5)", "end_version"],
-    )]
-    #[case::end_past_snapshot_version(
-        0,
-        Some(99),
-        &["99", "snapshot"],
-    )]
-    fn test_build_errors_on_version_past_snapshot_version(
+    #[case::start_past_snapshot_version(5, None, 5)]
+    #[case::end_past_snapshot_version(0, Some(99), 2)]
+    fn test_build_snapshot_based_reports_unavailable_version(
         #[case] start: Version,
         #[case] end: Option<Version>,
-        #[case] expected_substrings: &[&str],
+        #[case] expected_missing_version: Version,
     ) {
         let table_root = dv_small_table_root();
         let engine = SyncEngine::new();
@@ -253,13 +236,46 @@ mod tests {
             .fold_with(end, CommitRangeBuilder::with_end_version)
             .build(&engine)
             .expect_err("must error");
-        let msg = format!("{err}");
-        for needle in expected_substrings {
-            assert!(
-                msg.contains(needle),
-                "expected message to contain {needle:?}, got: {msg}",
-            );
-        }
+        assert!(matches!(
+            err,
+            Error::MissingVersion(version) if version == expected_missing_version
+        ));
+    }
+
+    #[test]
+    fn test_build_snapshot_based_preserves_explicit_reversed_range_error() {
+        let table_root = dv_small_table_root();
+        let engine = SyncEngine::new();
+        let snapshot = Snapshot::builder_for(table_root.as_str())
+            .build(&engine)
+            .unwrap();
+        let err = CommitRange::builder_from(snapshot, 1)
+            .with_end_version(0)
+            .build(&engine)
+            .expect_err("must error");
+        assert!(matches!(
+            err,
+            Error::Generic(message)
+                if message.contains("start_version (1) must be <= end_version (0)")
+        ));
+    }
+
+    #[test]
+    fn test_build_snapshot_based_reports_start_trimmed_by_checkpoint() {
+        let path = std::fs::canonicalize(PathBuf::from(
+            "./tests/data/with_checkpoint_no_last_checkpoint/",
+        ))
+        .unwrap();
+        let table_root = Url::from_directory_path(path).unwrap();
+        let engine = SyncEngine::new();
+        let snapshot = Snapshot::builder_for(table_root.as_str())
+            .build(&engine)
+            .unwrap();
+
+        let err = CommitRange::builder_from(snapshot, 1)
+            .build(&engine)
+            .expect_err("commit at version 1 must be unavailable after checkpoint filtering");
+        assert!(matches!(err, Error::MissingVersion(1)));
     }
 
     #[test]

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -199,13 +199,21 @@ pub enum Error {
     #[error("Expected is missing: {0}")]
     MissingData(String),
 
+    /// No table versions were found for the requested log operation.
+    #[error("No table version found.")]
+    EmptyLog,
+
     /// One or more table versions required by a log operation are unavailable.
     ///
-    /// The payload is the first missing version when it can be determined. It is [`None`] when no
-    /// version can be inferred, such as when the operation has no explicit target and the log
-    /// contains no versions.
-    #[error("{}", MissingVersionDisplay(.0))]
-    MissingVersion(Option<Version>),
+    /// The payload is the first missing version.
+    #[error("Table version {0} is missing or unavailable for this log operation.")]
+    MissingVersion(Version),
+
+    /// A table version required by an operation has not been published to the Delta log.
+    ///
+    /// The payload is the first unpublished version.
+    #[error("Table version {0} has not been published to the Delta log.")]
+    UnpublishedVersion(Version),
 
     /// An error occurred while working with deletion vectors
     #[error("Deletion Vector error: {0}")]
@@ -356,20 +364,6 @@ pub enum Error {
     /// exhaustion. See [`CancellableIterator`](crate::cancellation) for the enforced contract.
     #[error("Operation cancelled")]
     Cancelled,
-}
-
-struct MissingVersionDisplay<'a>(&'a Option<Version>);
-
-impl std::fmt::Display for MissingVersionDisplay<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.0 {
-            Some(version) => write!(
-                f,
-                "Table version {version} is missing or unavailable for this log operation."
-            ),
-            None => f.write_str("No table version found."),
-        }
-    }
 }
 
 // Convenience constructors for Error types that take a String argument

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -199,16 +199,13 @@ pub enum Error {
     #[error("Expected is missing: {0}")]
     MissingData(String),
 
-    /// A version for the delta table could not be found in the log
-    #[error("No table version found.")]
-    MissingVersion,
-
-    /// A table version required by a log operation is unavailable.
+    /// One or more table versions required by a log operation are unavailable.
     ///
-    /// For an interior gap, this is the first missing version. If the log ends before a requested
-    /// endpoint, this is the requested endpoint.
-    #[error("Table version {0} is missing or unavailable for this log operation.")]
-    MissingVersionAt(Version),
+    /// The payload is the first missing version when it can be determined. It is [`None`] when no
+    /// version can be inferred, such as when the operation has no explicit target and the log
+    /// contains no versions.
+    #[error("{}", MissingVersionDisplay(.0))]
+    MissingVersion(Option<Version>),
 
     /// An error occurred while working with deletion vectors
     #[error("Deletion Vector error: {0}")]
@@ -359,6 +356,20 @@ pub enum Error {
     /// exhaustion. See [`CancellableIterator`](crate::cancellation) for the enforced contract.
     #[error("Operation cancelled")]
     Cancelled,
+}
+
+struct MissingVersionDisplay<'a>(&'a Option<Version>);
+
+impl std::fmt::Display for MissingVersionDisplay<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(version) => write!(
+                f,
+                "Table version {version} is missing or unavailable for this log operation."
+            ),
+            None => f.write_str("No table version found."),
+        }
+    }
 }
 
 // Convenience constructors for Error types that take a String argument

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -205,7 +205,7 @@ pub enum Error {
 
     /// One or more table versions required by a log operation are unavailable.
     ///
-    /// The payload is the first missing version.
+    /// The payload is the lowest version that the operation requires but cannot obtain.
     #[error("Table version {0} is missing or unavailable for this log operation.")]
     MissingVersion(Version),
 

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -203,6 +203,10 @@ pub enum Error {
     #[error("No table version found.")]
     MissingVersion,
 
+    /// A specific version for the Delta table is missing or unavailable for a log operation.
+    #[error("Table version {0} is missing or unavailable for this log operation.")]
+    MissingVersionAt(Version),
+
     /// An error occurred while working with deletion vectors
     #[error("Deletion Vector error: {0}")]
     DeletionVector(String),
@@ -281,6 +285,10 @@ pub enum Error {
     /// Unable to parse the name of a log path
     #[error("Invalid log path: {0}")]
     InvalidLogPath(String),
+
+    /// The files assembled for a log segment violate its structural requirements.
+    #[error("Invalid log segment: {0}")]
+    InvalidLogSegment(String),
 
     /// The file already exists at the path, prohibiting a non-overwrite write
     #[error("File already exists: {0}")]

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -203,7 +203,10 @@ pub enum Error {
     #[error("No table version found.")]
     MissingVersion,
 
-    /// A specific version for the Delta table is missing or unavailable for a log operation.
+    /// A table version required by a log operation is unavailable.
+    ///
+    /// For an interior gap, this is the first missing version. If the log ends before a requested
+    /// endpoint, this is the requested endpoint.
     #[error("Table version {0} is missing or unavailable for this log operation.")]
     MissingVersionAt(Version),
 
@@ -286,7 +289,8 @@ pub enum Error {
     #[error("Invalid log path: {0}")]
     InvalidLogPath(String),
 
-    /// The files assembled for a log segment violate its structural requirements.
+    /// The assembled log segment is inconsistent with its declared file kinds, ordering, or
+    /// version bounds. Malformed checkpoint file sets use [`Error::InvalidCheckpoint`].
     #[error("Invalid log segment: {0}")]
     InvalidLogSegment(String),
 
@@ -423,6 +427,10 @@ impl Error {
     }
     pub(crate) fn invalid_log_path(msg: impl ToString) -> Self {
         Self::InvalidLogPath(msg.to_string())
+    }
+
+    pub(crate) fn invalid_log_segment(msg: impl ToString) -> Self {
+        Self::InvalidLogSegment(msg.to_string())
     }
 
     pub fn internal_error(msg: impl ToString) -> Self {

--- a/kernel/src/log_segment/crc_replay.rs
+++ b/kernel/src/log_segment/crc_replay.rs
@@ -195,14 +195,7 @@ impl LogSegment {
         };
         // A log with no checkpoint must start at version 0; a higher first version means a table
         // truncated without a checkpoint.
-        require!(
-            first.version == 0,
-            Error::generic(format!(
-                "Cannot build CRC: log has no checkpoint but its first commit is at version {} \
-                 (expected 0); the log appears truncated without a checkpoint",
-                first.version
-            ))
-        );
+        require!(first.version == 0, Error::MissingVersion(0));
         let delta = self.replay_commits_into_crc_delta(
             engine,
             self.listed.ascending_commit_files.iter(),
@@ -1087,9 +1080,9 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_result_error_with_message(
+        assert!(matches!(
             segment.build_crc_from_version_zero(&engine),
-            "log appears truncated without a checkpoint",
-        );
+            Err(Error::MissingVersion(0))
+        ));
     }
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -482,7 +482,7 @@ impl LogSegment {
                 .ascending_commit_files()
                 .first()
                 .is_some_and(|first_commit| first_commit.version == start_version),
-            Error::MissingVersion(Some(start_version))
+            Error::MissingVersion(start_version)
         );
         LogSegment::try_new(listed_files, log_root, end_version, None)
     }
@@ -524,7 +524,7 @@ impl LogSegment {
             None, // timestamp conversion does not thread a cancellation token
         )?;
         if listed_commits.ascending_commit_files().is_empty() {
-            return Err(Error::MissingVersion(Some(end_version)));
+            return Err(Error::EmptyLog);
         }
 
         // remove gaps - return latest contiguous chunk of commits
@@ -1364,17 +1364,16 @@ impl LogSegment {
     }
 
     pub(crate) fn validate_published(&self) -> DeltaResult<()> {
-        if self
-            .listed
-            .max_published_version
-            .is_none_or(|version| version != self.end_version)
-        {
-            let first_unpublished_version = match self.listed.max_published_version {
+        let published_through = self
+            .checkpoint_version
+            .max(self.listed.max_published_version);
+        if published_through != Some(self.end_version) {
+            let first_unpublished_version = match published_through {
                 Some(version) if version < self.end_version => version + 1,
                 Some(_) => self.end_version,
                 None => 0,
             };
-            return Err(Error::MissingVersion(Some(first_unpublished_version)));
+            return Err(Error::UnpublishedVersion(first_unpublished_version));
         }
         Ok(())
     }
@@ -1621,7 +1620,7 @@ fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()
     for pair in commits.windows(2) {
         let expected_version = pair[0].version + 1;
         if expected_version != pair[1].version {
-            return Err(Error::MissingVersion(Some(expected_version)));
+            return Err(Error::MissingVersion(expected_version));
         }
     }
     Ok(())
@@ -1640,7 +1639,7 @@ fn validate_checkpoint_commit_gap(
         let expected_version = checkpoint_version + 1;
         require!(
             expected_version == first_commit.version,
-            Error::MissingVersion(Some(expected_version))
+            Error::MissingVersion(expected_version)
         );
     }
     Ok(())
@@ -1657,15 +1656,14 @@ fn validate_end_version(
     checkpoint_parts: &[ParsedLogPath],
     end_version: Option<Version>,
 ) -> DeltaResult<Version> {
-    let first_missing_version = end_version.map(|_| 0);
     let effective_version = commits
         .last()
         .or(checkpoint_parts.first())
-        .ok_or(Error::MissingVersion(first_missing_version))?
+        .ok_or(Error::EmptyLog)?
         .version;
     if let Some(end_version) = end_version {
         if effective_version < end_version {
-            return Err(Error::MissingVersion(Some(effective_version + 1)));
+            return Err(Error::MissingVersion(effective_version + 1));
         }
         if effective_version > end_version {
             return Err(Error::invalid_log_segment(format!(

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -209,7 +209,7 @@ impl LogSegment {
         validate_compaction_files(&listed_files.ascending_compaction_files)?;
         validate_checkpoint_parts(&listed_files.checkpoint_parts)?;
         validate_commit_file_types(&listed_files.ascending_commit_files)?;
-        validate_commit_files_contiguous(&listed_files.ascending_commit_files)?;
+        validate_commit_files_sorted(&listed_files.ascending_commit_files)?;
 
         // Filter commits before/at checkpoint version
         let checkpoint_version =
@@ -223,6 +223,7 @@ impl LogSegment {
                 None
             };
 
+        validate_commit_files_contiguous(&listed_files.ascending_commit_files)?;
         validate_checkpoint_commit_gap(checkpoint_version, &listed_files.ascending_commit_files)?;
         let effective_version = validate_end_version(
             &listed_files.ascending_commit_files,
@@ -1606,7 +1607,7 @@ fn validate_commit_file_types(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     Ok(())
 }
 
-fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()> {
+fn validate_commit_files_sorted(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     if let Some(pair) = commits
         .windows(2)
         .find(|pair| pair[0].version >= pair[1].version)
@@ -1616,7 +1617,10 @@ fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()
             pair[0], pair[1]
         )));
     }
+    Ok(())
+}
 
+fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     for pair in commits.windows(2) {
         let expected_version = pair[0].version + 1;
         if expected_version != pair[1].version {

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -223,8 +223,8 @@ impl LogSegment {
                 None
             };
 
-        validate_commit_files_contiguous(&listed_files.ascending_commit_files)?;
         validate_checkpoint_commit_gap(checkpoint_version, &listed_files.ascending_commit_files)?;
+        validate_commit_files_contiguous(&listed_files.ascending_commit_files)?;
         let effective_version = validate_end_version(
             &listed_files.ascending_commit_files,
             &listed_files.checkpoint_parts,
@@ -530,14 +530,11 @@ impl LogSegment {
 
         // remove gaps - return latest contiguous chunk of commits
         let commits = listed_commits.ascending_commit_files_mut();
-        if !commits.is_empty() {
-            let mut start_idx = commits.len() - 1;
-            while start_idx > 0 && commits[start_idx].version == 1 + commits[start_idx - 1].version
-            {
-                start_idx -= 1;
-            }
-            commits.drain(..start_idx);
+        let mut start_idx = commits.len() - 1;
+        while start_idx > 0 && commits[start_idx].version == 1 + commits[start_idx - 1].version {
+            start_idx -= 1;
         }
+        commits.drain(..start_idx);
 
         LogSegment::try_new(listed_commits, log_root, Some(end_version), None)
     }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1527,12 +1527,12 @@ impl LogSegment {
 fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
     for (i, f) in compactions.iter().enumerate() {
         let LogPathFileType::CompactedCommit { hi } = f.file_type else {
-            return Err(Error::InvalidLogSegment(
-                "ascending_compaction_files contains non-compaction file".to_string(),
+            return Err(Error::invalid_log_segment(
+                "ascending_compaction_files contains non-compaction file",
             ));
         };
         if f.version > hi {
-            return Err(Error::InvalidLogSegment(format!(
+            return Err(Error::invalid_log_segment(format!(
                 "compaction file has start version {} > end version {}",
                 f.version, hi
             )));
@@ -1542,7 +1542,7 @@ fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
             // CompactedCommit since the type error will be caught then.
             if let LogPathFileType::CompactedCommit { hi: next_hi } = next.file_type {
                 if !(f.version < next.version || (f.version == next.version && hi <= next_hi)) {
-                    return Err(Error::InvalidLogSegment(format!(
+                    return Err(Error::invalid_log_segment(format!(
                         "ascending_compaction_files is not sorted: {f:?} -> {next:?}"
                     )));
                 }
@@ -1590,8 +1590,8 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
 fn validate_commit_file_types(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     for f in commits {
         if !f.is_commit() {
-            return Err(Error::InvalidLogSegment(
-                "ascending_commit_files contains non-commit file".to_string(),
+            return Err(Error::invalid_log_segment(
+                "ascending_commit_files contains non-commit file",
             ));
         }
     }
@@ -1599,13 +1599,17 @@ fn validate_commit_file_types(commits: &[ParsedLogPath]) -> DeltaResult<()> {
 }
 
 fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()> {
+    if let Some(pair) = commits
+        .windows(2)
+        .find(|pair| pair[0].version >= pair[1].version)
+    {
+        return Err(Error::invalid_log_segment(format!(
+            "ascending_commit_files is not sorted: {:?} -> {:?}",
+            pair[0], pair[1]
+        )));
+    }
+
     for pair in commits.windows(2) {
-        if pair[0].version >= pair[1].version {
-            return Err(Error::InvalidLogSegment(format!(
-                "ascending_commit_files is not sorted: {:?} -> {:?}",
-                pair[0], pair[1]
-            )));
-        }
         let expected_version = pair[0].version + 1;
         if expected_version != pair[1].version {
             return Err(Error::MissingVersionAt(expected_version));
@@ -1658,7 +1662,7 @@ fn validate_end_version(
             return Err(Error::MissingVersionAt(end_version));
         }
         if effective_version > end_version {
-            return Err(Error::InvalidLogSegment(format!(
+            return Err(Error::invalid_log_segment(format!(
                 "effective version {effective_version} is newer than requested end version {end_version}"
             )));
         }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -482,7 +482,7 @@ impl LogSegment {
                 .ascending_commit_files()
                 .first()
                 .is_some_and(|first_commit| first_commit.version == start_version),
-            Error::MissingVersionAt(start_version)
+            Error::MissingVersion(Some(start_version))
         );
         LogSegment::try_new(listed_files, log_root, end_version, None)
     }
@@ -523,6 +523,9 @@ impl LogSegment {
             Some(end_version),
             None, // timestamp conversion does not thread a cancellation token
         )?;
+        if listed_commits.ascending_commit_files().is_empty() {
+            return Err(Error::MissingVersion(Some(end_version)));
+        }
 
         // remove gaps - return latest contiguous chunk of commits
         let commits = listed_commits.ascending_commit_files_mut();
@@ -1361,12 +1364,18 @@ impl LogSegment {
     }
 
     pub(crate) fn validate_published(&self) -> DeltaResult<()> {
-        require!(
-            self.listed
-                .max_published_version
-                .is_some_and(|v| v == self.end_version),
-            Error::MissingVersionAt(self.end_version)
-        );
+        if self
+            .listed
+            .max_published_version
+            .is_none_or(|version| version != self.end_version)
+        {
+            let first_unpublished_version = match self.listed.max_published_version {
+                Some(version) if version < self.end_version => version + 1,
+                Some(_) => self.end_version,
+                None => 0,
+            };
+            return Err(Error::MissingVersion(Some(first_unpublished_version)));
+        }
         Ok(())
     }
 
@@ -1612,7 +1621,7 @@ fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()
     for pair in commits.windows(2) {
         let expected_version = pair[0].version + 1;
         if expected_version != pair[1].version {
-            return Err(Error::MissingVersionAt(expected_version));
+            return Err(Error::MissingVersion(Some(expected_version)));
         }
     }
     Ok(())
@@ -1631,7 +1640,7 @@ fn validate_checkpoint_commit_gap(
         let expected_version = checkpoint_version + 1;
         require!(
             expected_version == first_commit.version,
-            Error::MissingVersionAt(expected_version)
+            Error::MissingVersion(Some(expected_version))
         );
     }
     Ok(())
@@ -1648,18 +1657,15 @@ fn validate_end_version(
     checkpoint_parts: &[ParsedLogPath],
     end_version: Option<Version>,
 ) -> DeltaResult<Version> {
+    let first_missing_version = end_version.map(|_| 0);
     let effective_version = commits
         .last()
         .or(checkpoint_parts.first())
-        .ok_or_else(|| {
-            end_version
-                .map(Error::MissingVersionAt)
-                .unwrap_or(Error::MissingVersion)
-        })?
+        .ok_or(Error::MissingVersion(first_missing_version))?
         .version;
     if let Some(end_version) = end_version {
         if effective_version < end_version {
-            return Err(Error::MissingVersionAt(end_version));
+            return Err(Error::MissingVersion(Some(effective_version + 1)));
         }
         if effective_version > end_version {
             return Err(Error::invalid_log_segment(format!(

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -475,20 +475,14 @@ impl LogSegment {
         )?;
         // - Here check that the start version is correct.
         // - [`LogSegment::try_new`] will verify that the `end_version` is correct if present.
-        // - [`LogSegmentFiles::list_commits`] also checks that there are no gaps between commits.
+        // - [`LogSegment::try_new`] also checks that there are no gaps between commits.
         // If all three are satisfied, this implies that all the desired commits are present.
         require!(
             listed_files
                 .ascending_commit_files()
                 .first()
                 .is_some_and(|first_commit| first_commit.version == start_version),
-            Error::generic(format!(
-                "Expected the first commit to have version {start_version}, got {:?}",
-                listed_files
-                    .ascending_commit_files()
-                    .first()
-                    .map(|c| c.version)
-            ))
+            Error::MissingVersionAt(start_version)
         );
         LogSegment::try_new(listed_files, log_root, end_version, None)
     }
@@ -913,7 +907,9 @@ impl LogSegment {
             return Ok(None);
         };
         let version = self.checkpoint_version.ok_or_else(|| {
-            Error::generic("Checkpoint hint sidecars require a selected checkpoint version")
+            Error::invalid_checkpoint(
+                "Checkpoint hint sidecars require a selected checkpoint version",
+            )
         })?;
         let version = crate::version_as_i64(version)?;
         sidecars
@@ -1175,7 +1171,7 @@ impl LogSegment {
                     cancellation_token.cloned(),
                 )?,
             Some(parsed_log_path) => {
-                return Err(Error::generic(format!(
+                return Err(Error::invalid_checkpoint(format!(
                     "Unsupported checkpoint file type: {}",
                     parsed_log_path.extension,
                 )));
@@ -1369,7 +1365,7 @@ impl LogSegment {
             self.listed
                 .max_published_version
                 .is_some_and(|v| v == self.end_version),
-            Error::generic("Log segment is not published")
+            Error::MissingVersionAt(self.end_version)
         );
         Ok(())
     }
@@ -1531,12 +1527,12 @@ impl LogSegment {
 fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
     for (i, f) in compactions.iter().enumerate() {
         let LogPathFileType::CompactedCommit { hi } = f.file_type else {
-            return Err(Error::generic(
-                "ascending_compaction_files contains non-compaction file",
+            return Err(Error::InvalidLogSegment(
+                "ascending_compaction_files contains non-compaction file".to_string(),
             ));
         };
         if f.version > hi {
-            return Err(Error::generic(format!(
+            return Err(Error::InvalidLogSegment(format!(
                 "compaction file has start version {} > end version {}",
                 f.version, hi
             )));
@@ -1546,7 +1542,7 @@ fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
             // CompactedCommit since the type error will be caught then.
             if let LogPathFileType::CompactedCommit { hi: next_hi } = next.file_type {
                 if !(f.version < next.version || (f.version == next.version && hi <= next_hi)) {
-                    return Err(Error::generic(format!(
+                    return Err(Error::InvalidLogSegment(format!(
                         "ascending_compaction_files is not sorted: {f:?} -> {next:?}"
                     )));
                 }
@@ -1564,24 +1560,24 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
     let first_version = parts[0].version;
     for p in parts {
         if !p.is_checkpoint() {
-            return Err(Error::generic(
+            return Err(Error::invalid_checkpoint(
                 "checkpoint_parts contains non-checkpoint file",
             ));
         }
         if p.version != first_version {
-            return Err(Error::generic(
+            return Err(Error::invalid_checkpoint(
                 "multi-part checkpoint parts have different versions",
             ));
         }
         match p.file_type {
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } if num_parts as usize == n => {}
             LogPathFileType::MultiPartCheckpoint { num_parts, .. } => {
-                return Err(Error::generic(format!(
+                return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint part count mismatch: slice has {n} parts but num_parts field says {num_parts}"
                 )));
             }
             _ if n > 1 => {
-                return Err(Error::generic(format!(
+                return Err(Error::invalid_checkpoint(format!(
                     "multi-part checkpoint part count mismatch: expected {n} multi-part checkpoint files but got a non-multi-part checkpoint"
                 )));
             }
@@ -1594,8 +1590,8 @@ fn validate_checkpoint_parts(parts: &[ParsedLogPath]) -> DeltaResult<()> {
 fn validate_commit_file_types(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     for f in commits {
         if !f.is_commit() {
-            return Err(Error::generic(
-                "ascending_commit_files contains non-commit file",
+            return Err(Error::InvalidLogSegment(
+                "ascending_commit_files contains non-commit file".to_string(),
             ));
         }
     }
@@ -1604,11 +1600,15 @@ fn validate_commit_file_types(commits: &[ParsedLogPath]) -> DeltaResult<()> {
 
 fn validate_commit_files_contiguous(commits: &[ParsedLogPath]) -> DeltaResult<()> {
     for pair in commits.windows(2) {
-        if pair[0].version + 1 != pair[1].version {
-            return Err(Error::generic(format!(
-                "Expected contiguous commit files, but found gap: {:?} -> {:?}",
+        if pair[0].version >= pair[1].version {
+            return Err(Error::InvalidLogSegment(format!(
+                "ascending_commit_files is not sorted: {:?} -> {:?}",
                 pair[0], pair[1]
             )));
+        }
+        let expected_version = pair[0].version + 1;
+        if expected_version != pair[1].version {
+            return Err(Error::MissingVersionAt(expected_version));
         }
     }
     Ok(())
@@ -1624,12 +1624,10 @@ fn validate_checkpoint_commit_gap(
     commits: &[ParsedLogPath],
 ) -> DeltaResult<()> {
     if let (Some(checkpoint_version), Some(first_commit)) = (checkpoint_version, commits.first()) {
+        let expected_version = checkpoint_version + 1;
         require!(
-            checkpoint_version + 1 == first_commit.version,
-            Error::InvalidCheckpoint(format!(
-                "Gap between checkpoint version {checkpoint_version} and next commit {}",
-                first_commit.version
-            ))
+            expected_version == first_commit.version,
+            Error::MissingVersionAt(expected_version)
         );
     }
     Ok(())
@@ -1649,15 +1647,21 @@ fn validate_end_version(
     let effective_version = commits
         .last()
         .or(checkpoint_parts.first())
-        .ok_or(Error::generic("No files in log segment"))?
+        .ok_or_else(|| {
+            end_version
+                .map(Error::MissingVersionAt)
+                .unwrap_or(Error::MissingVersion)
+        })?
         .version;
     if let Some(end_version) = end_version {
-        require!(
-            effective_version == end_version,
-            Error::generic(format!(
-                "LogSegment end version {effective_version} not the same as the specified end version {end_version}"
-            ))
-        );
+        if effective_version < end_version {
+            return Err(Error::MissingVersionAt(end_version));
+        }
+        if effective_version > end_version {
+            return Err(Error::InvalidLogSegment(format!(
+                "effective version {effective_version} is newer than requested end version {end_version}"
+            )));
+        }
     }
     Ok(effective_version)
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1533,9 +1533,10 @@ impl LogSegment {
 fn validate_compaction_files(compactions: &[ParsedLogPath]) -> DeltaResult<()> {
     for (i, f) in compactions.iter().enumerate() {
         let LogPathFileType::CompactedCommit { hi } = f.file_type else {
-            return Err(Error::invalid_log_segment(
-                "ascending_compaction_files contains non-compaction file",
-            ));
+            return Err(Error::invalid_log_segment(format!(
+                "ascending_compaction_files contains non-compaction file type: {:?}",
+                f.file_type
+            )));
         };
         if f.version > hi {
             return Err(Error::invalid_log_segment(format!(

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1362,10 +1362,7 @@ impl LogSegment {
     }
 
     pub(crate) fn validate_published(&self) -> DeltaResult<()> {
-        let published_through = self
-            .checkpoint_version
-            .max(self.listed.max_published_version);
-        match published_through {
+        match self.listed.max_published_version {
             Some(version) if version == self.end_version => Ok(()),
             Some(version) if version < self.end_version => {
                 Err(Error::UnpublishedVersion(version + 1))

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -1365,15 +1365,17 @@ impl LogSegment {
         let published_through = self
             .checkpoint_version
             .max(self.listed.max_published_version);
-        if published_through != Some(self.end_version) {
-            let first_unpublished_version = match published_through {
-                Some(version) if version < self.end_version => version + 1,
-                Some(_) => self.end_version,
-                None => 0,
-            };
-            return Err(Error::UnpublishedVersion(first_unpublished_version));
+        match published_through {
+            Some(version) if version == self.end_version => Ok(()),
+            Some(version) if version < self.end_version => {
+                Err(Error::UnpublishedVersion(version + 1))
+            }
+            Some(version) => Err(Error::invalid_log_segment(format!(
+                "publication watermark {version} exceeds log segment end version {}",
+                self.end_version
+            ))),
+            None => Err(Error::UnpublishedVersion(0)),
         }
-        Ok(())
     }
 
     /// Schema to read just the sidecar column from a checkpoint file.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2505,24 +2505,31 @@ fn test_validate_truncated_log_segment_reports_first_missing_version() {
     assert!(matches!(result, Err(Error::MissingVersion(3))));
 }
 
-#[test]
-fn test_validate_checkpoint_commit_gap_reports_first_missing_version() {
+#[rstest]
+#[case::checkpoint_gap(1, &[3], 2)]
+#[case::checkpoint_and_inter_commit_gaps(2, &[4, 6], 3)]
+fn test_validate_checkpoint_commit_gap_reports_lowest_missing_version(
+    #[case] checkpoint_version: Version,
+    #[case] commit_versions: &[Version],
+    #[case] expected: Version,
+) {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(
         LogSegmentFiles {
-            checkpoint_parts: vec![create_log_path(
-                "file:///_delta_log/00000000000000000001.checkpoint.parquet",
-            )],
-            ascending_commit_files: vec![create_log_path(
-                "file:///_delta_log/00000000000000000003.json",
-            )],
+            checkpoint_parts: vec![create_log_path(&format!(
+                "file:///_delta_log/{checkpoint_version:020}.checkpoint.parquet"
+            ))],
+            ascending_commit_files: commit_versions
+                .iter()
+                .map(|version| create_log_path(&format!("file:///_delta_log/{version:020}.json")))
+                .collect(),
             ..Default::default()
         },
         log_root,
         None,
         None,
     );
-    assert!(matches!(result, Err(Error::MissingVersion(2))));
+    assert!(matches!(result, Err(Error::MissingVersion(version)) if version == expected));
 }
 
 #[test]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1112,23 +1112,14 @@ async fn test_non_contiguous_log() {
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None);
-    assert!(matches!(
-        log_segment_res,
-        Err(Error::MissingVersion(Some(1)))
-    ));
+    assert!(matches!(log_segment_res, Err(Error::MissingVersion(1))));
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None);
-    assert!(matches!(
-        log_segment_res,
-        Err(Error::MissingVersion(Some(1)))
-    ));
+    assert!(matches!(log_segment_res, Err(Error::MissingVersion(1))));
 
     let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1));
-    assert!(matches!(
-        log_segment_res,
-        Err(Error::MissingVersion(Some(1)))
-    ));
+    assert!(matches!(log_segment_res, Err(Error::MissingVersion(1))));
 }
 
 #[tokio::test]
@@ -2488,15 +2479,12 @@ fn test_validate_listed_log_file_invalid_commit_sequence(
 }
 
 #[rstest]
-#[case::latest(None, None)]
-#[case::specific_version(Some(9), Some(0))]
-fn test_validate_empty_log_segment(
-    #[case] end_version: Option<Version>,
-    #[case] expected: Option<Version>,
-) {
+#[case::latest(None)]
+#[case::specific_version(Some(9))]
+fn test_validate_empty_log_segment(#[case] end_version: Option<Version>) {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(LogSegmentFiles::default(), log_root, end_version, None);
-    assert!(matches!(result, Err(Error::MissingVersion(version)) if version == expected));
+    assert!(matches!(result, Err(Error::EmptyLog)));
 }
 
 #[test]
@@ -2514,7 +2502,7 @@ fn test_validate_truncated_log_segment_reports_first_missing_version() {
         Some(4),
         None,
     );
-    assert!(matches!(result, Err(Error::MissingVersion(Some(3)))));
+    assert!(matches!(result, Err(Error::MissingVersion(3))));
 }
 
 #[test]
@@ -2534,7 +2522,7 @@ fn test_validate_checkpoint_commit_gap_reports_first_missing_version() {
         None,
         None,
     );
-    assert!(matches!(result, Err(Error::MissingVersion(Some(2)))));
+    assert!(matches!(result, Err(Error::MissingVersion(2))));
 }
 
 #[test]
@@ -2927,7 +2915,7 @@ async fn for_timestamp_conversion_no_commit_files() {
 
     let res =
         LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None, vec![]);
-    assert!(matches!(res, Err(Error::MissingVersion(Some(0)))));
+    assert!(matches!(res, Err(Error::EmptyLog)));
 }
 
 #[tokio::test]
@@ -3129,7 +3117,7 @@ fn test_log_segment_contiguous_commit_files() {
         None,
         None,
     );
-    assert!(matches!(log_segment, Err(Error::MissingVersion(Some(2)))));
+    assert!(matches!(log_segment, Err(Error::MissingVersion(2))));
 }
 
 /// `checkpoint_sidecars()` distinguishes "the matched hint lists zero sidecars" (`Some(&[])`) from
@@ -3476,6 +3464,42 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 // ============================================================================
 // max_published_version tests
 // ============================================================================
+
+#[rstest]
+#[case::staged_only(&[], &[0, 1, 2], None, Some(0))]
+#[case::published_prefix(&[0, 1, 2], &[3, 4, 5], None, Some(3))]
+#[case::checkpoint_with_staged_tail(&[], &[6, 7, 8], Some(5), Some(6))]
+#[case::checkpoint_supersedes_older_commits(
+    &[0, 1, 2, 3, 4],
+    &[6, 7, 8],
+    Some(5),
+    Some(6)
+)]
+#[case::checkpoint_only(&[], &[], Some(5), None)]
+#[tokio::test]
+async fn validate_published_uses_checkpoint_and_commit_watermarks(
+    #[case] published_commit_versions: &[Version],
+    #[case] staged_commit_versions: &[Version],
+    #[case] checkpoint_version: Option<Version>,
+    #[case] expected: Option<Version>,
+) {
+    let log_segment = create_segment_for(LogSegmentConfig {
+        published_commit_versions,
+        staged_commit_versions,
+        checkpoint_version,
+        ..Default::default()
+    })
+    .await;
+
+    let result = log_segment.validate_published();
+    match expected {
+        Some(expected) => assert!(matches!(
+            result,
+            Err(Error::UnpublishedVersion(version)) if version == expected
+        )),
+        None => assert!(result.is_ok()),
+    }
+}
 
 #[tokio::test]
 async fn test_max_published_version_only_published_commits() {

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1112,26 +1112,14 @@ async fn test_non_contiguous_log() {
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None);
-    // check the error message up to the timestamp
-    let expected_error_pattern = "Generic delta kernel error: Expected contiguous commit files, \
-        but found gap: ParsedLogPath { location: FileMeta { location: Url { scheme: \"memory\", \
-        cannot_be_a_base: false, username: \"\", password: None, host: None, port: None, path: \
-        \"/_delta_log/00000000000000000000.json\", query: None, fragment: None }, last_modified:";
-    assert_result_error_with_message(log_segment_res, expected_error_pattern);
+    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None);
-    assert_result_error_with_message(
-        log_segment_res,
-        "Generic delta kernel error: Expected the first commit to have version 1",
-    );
+    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
 
     let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1));
-    assert_result_error_with_message(
-        log_segment_res,
-        "Generic delta kernel error: LogSegment end version 0 not the same as the specified end \
-        version 1",
-    );
+    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
 }
 
 #[tokio::test]
@@ -2421,7 +2409,7 @@ fn test_validate_listed_log_file_in_order_compaction_files() {
 #[ignore = "log compaction disabled (#2337)"]
 fn test_validate_listed_log_file_out_of_order_compaction_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000001.json",
@@ -2439,14 +2427,14 @@ fn test_validate_listed_log_file_out_of_order_compaction_files() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_different_multipart_checkpoint_versions() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![
                 create_log_path(
@@ -2461,14 +2449,14 @@ fn test_validate_listed_log_file_different_multipart_checkpoint_versions() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_out_of_order_commit_files() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![
                 create_log_path("file:///_delta_log/00000000000000000003.json"),
@@ -2479,8 +2467,71 @@ fn test_validate_listed_log_file_out_of_order_commit_files() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
+}
+
+#[test]
+fn test_validate_listed_log_file_duplicate_commit_versions() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
+            ],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
+}
+
+#[test]
+fn test_validate_listed_log_file_newer_than_requested_end_version() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
+                create_log_path("file:///_delta_log/00000000000000000002.json"),
+            ],
+            ..Default::default()
+        },
+        log_root,
+        Some(1),
+        None,
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
+}
+
+#[test]
+fn test_validate_empty_log_segment_without_requested_version() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(LogSegmentFiles::default(), log_root, None, None);
+    assert!(matches!(result, Err(Error::MissingVersion)));
+}
+
+#[test]
+fn test_validate_checkpoint_commit_gap_reports_first_missing_version() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path(
+                "file:///_delta_log/00000000000000000001.checkpoint.parquet",
+            )],
+            ascending_commit_files: vec![create_log_path(
+                "file:///_delta_log/00000000000000000003.json",
+            )],
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    );
+    assert!(matches!(result, Err(Error::MissingVersionAt(2))));
 }
 
 #[test]
@@ -2558,7 +2609,7 @@ fn test_try_new_crc_older_than_checkpoint_is_err() {
 #[test]
 fn test_validate_listed_log_file_checkpoint_parts_contains_non_checkpoint() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(
                 "file:///_delta_log/00000000000000000010.json",
@@ -2568,15 +2619,15 @@ fn test_validate_listed_log_file_checkpoint_parts_contains_non_checkpoint() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_multipart_checkpoint_part_count_mismatch() {
     // Two parts that agree on version but claim num_parts=3 (count mismatch: 2 != 3)
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![
                 create_log_path(
@@ -2591,15 +2642,15 @@ fn test_validate_listed_log_file_multipart_checkpoint_part_count_mismatch() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_single_multipart_checkpoint_num_parts_mismatch() {
     // A single checkpoint file that claims num_parts=2: the count (1) disagrees with num_parts
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![create_log_path(
                 "file:///_delta_log/00000000000000000010.checkpoint.0000000001.0000000002.parquet",
@@ -2609,15 +2660,15 @@ fn test_validate_listed_log_file_single_multipart_checkpoint_num_parts_mismatch(
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_multiple_single_part_checkpoints() {
     // Two ClassicCheckpoints at the same version: n=2 but neither is a MultiPartCheckpoint
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             checkpoint_parts: vec![
                 create_log_path("file:///_delta_log/00000000000000000010.checkpoint.parquet"),
@@ -2628,14 +2679,14 @@ fn test_validate_listed_log_file_multiple_single_part_checkpoints() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
 #[test]
 fn test_validate_listed_log_file_commit_files_contains_non_commit() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000010.checkpoint.parquet",
@@ -2645,15 +2696,15 @@ fn test_validate_listed_log_file_commit_files_contains_non_commit() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 }
 
 #[test]
 #[ignore = "log compaction disabled (#2337)"]
 fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000002.json",
@@ -2666,8 +2717,8 @@ fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 }
 
 #[test]
@@ -2675,7 +2726,7 @@ fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
 fn test_validate_listed_log_file_compaction_start_exceeds_end() {
     // A compaction file where the start version is greater than the end version
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    assert!(LogSegment::try_new(
+    let result = LogSegment::try_new(
         LogSegmentFiles {
             ascending_commit_files: vec![create_log_path(
                 "file:///_delta_log/00000000000000000005.json",
@@ -2688,8 +2739,8 @@ fn test_validate_listed_log_file_compaction_start_exceeds_end() {
         log_root,
         None,
         None,
-    )
-    .is_err());
+    );
+    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 }
 
 #[tokio::test]
@@ -2873,7 +2924,7 @@ async fn for_timestamp_conversion_no_commit_files() {
 
     let res =
         LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None, vec![]);
-    assert_result_error_with_message(res, "Generic delta kernel error: No files in log segment");
+    assert!(matches!(res, Err(Error::MissingVersionAt(0))));
 }
 
 #[tokio::test]
@@ -3075,19 +3126,7 @@ fn test_log_segment_contiguous_commit_files() {
         None,
         None,
     );
-    assert_result_error_with_message(
-        log_segment,
-        "Generic delta kernel error: Expected contiguous commit files, but found gap: \
-        ParsedLogPath { location: FileMeta { location: Url { scheme: \
-        \"file\", cannot_be_a_base: false, username: \"\", password: None, host: None, port: \
-        None, path: \"/_delta_log/00000000000000000001.json\", query: None, fragment: None }, last_modified: \
-        0, size: 0 }, filename: \"00000000000000000001.json\", extension: \"json\", version: 1, \
-        file_type: Commit } -> ParsedLogPath { location: FileMeta { location: Url { scheme: \
-        \"file\", cannot_be_a_base: false, username: \"\", password: None, host: None, port: \
-        None, path: \"/_delta_log/00000000000000000003.json\", query: None, fragment: None }, last_modified: \
-        0, size: 0 }, filename: \"00000000000000000003.json\", extension: \"json\", version: 3, \
-        file_type: Commit }",
-    );
+    assert!(matches!(log_segment, Err(Error::MissingVersionAt(2))));
 }
 
 /// `checkpoint_sidecars()` distinguishes "the matched hint lists zero sidecars" (`Some(&[])`) from

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2453,55 +2453,26 @@ fn test_validate_listed_log_file_different_multipart_checkpoint_versions() {
     assert!(matches!(result, Err(Error::InvalidCheckpoint(_))));
 }
 
-#[test]
-fn test_validate_listed_log_file_out_of_order_commit_files() {
+#[rstest]
+#[case::out_of_order(&[3, 1], None)]
+#[case::duplicate_versions(&[1, 1], None)]
+#[case::gap_before_out_of_order(&[0, 2, 1], None)]
+#[case::newer_than_requested_end(&[1, 2], Some(1))]
+fn test_validate_listed_log_file_invalid_commit_sequence(
+    #[case] versions: &[Version],
+    #[case] end_version: Option<Version>,
+) {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     let result = LogSegment::try_new(
         LogSegmentFiles {
-            ascending_commit_files: vec![
-                create_log_path("file:///_delta_log/00000000000000000003.json"),
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
-            ],
+            ascending_commit_files: versions
+                .iter()
+                .map(|version| create_log_path(&format!("file:///_delta_log/{version:020}.json")))
+                .collect(),
             ..Default::default()
         },
         log_root,
-        None,
-        None,
-    );
-    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
-}
-
-#[test]
-fn test_validate_listed_log_file_duplicate_commit_versions() {
-    let log_root = Url::parse("file:///_delta_log/").unwrap();
-    let result = LogSegment::try_new(
-        LogSegmentFiles {
-            ascending_commit_files: vec![
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
-            ],
-            ..Default::default()
-        },
-        log_root,
-        None,
-        None,
-    );
-    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
-}
-
-#[test]
-fn test_validate_listed_log_file_newer_than_requested_end_version() {
-    let log_root = Url::parse("file:///_delta_log/").unwrap();
-    let result = LogSegment::try_new(
-        LogSegmentFiles {
-            ascending_commit_files: vec![
-                create_log_path("file:///_delta_log/00000000000000000001.json"),
-                create_log_path("file:///_delta_log/00000000000000000002.json"),
-            ],
-            ..Default::default()
-        },
-        log_root,
-        Some(1),
+        end_version,
         None,
     );
     assert!(matches!(result, Err(Error::InvalidLogSegment(_))));

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -1112,14 +1112,23 @@ async fn test_non_contiguous_log() {
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 0, None);
-    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
+    assert!(matches!(
+        log_segment_res,
+        Err(Error::MissingVersion(Some(1)))
+    ));
 
     let log_segment_res =
         LogSegment::for_table_changes(storage.as_ref(), log_root.clone(), 1, None);
-    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
+    assert!(matches!(
+        log_segment_res,
+        Err(Error::MissingVersion(Some(1)))
+    ));
 
     let log_segment_res = LogSegment::for_table_changes(storage.as_ref(), log_root, 0, Some(1));
-    assert!(matches!(log_segment_res, Err(Error::MissingVersionAt(1))));
+    assert!(matches!(
+        log_segment_res,
+        Err(Error::MissingVersion(Some(1)))
+    ));
 }
 
 #[tokio::test]
@@ -2478,11 +2487,34 @@ fn test_validate_listed_log_file_invalid_commit_sequence(
     assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 }
 
-#[test]
-fn test_validate_empty_log_segment_without_requested_version() {
+#[rstest]
+#[case::latest(None, None)]
+#[case::specific_version(Some(9), Some(0))]
+fn test_validate_empty_log_segment(
+    #[case] end_version: Option<Version>,
+    #[case] expected: Option<Version>,
+) {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
-    let result = LogSegment::try_new(LogSegmentFiles::default(), log_root, None, None);
-    assert!(matches!(result, Err(Error::MissingVersion)));
+    let result = LogSegment::try_new(LogSegmentFiles::default(), log_root, end_version, None);
+    assert!(matches!(result, Err(Error::MissingVersion(version)) if version == expected));
+}
+
+#[test]
+fn test_validate_truncated_log_segment_reports_first_missing_version() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(
+        LogSegmentFiles {
+            ascending_commit_files: vec![
+                create_log_path("file:///_delta_log/00000000000000000001.json"),
+                create_log_path("file:///_delta_log/00000000000000000002.json"),
+            ],
+            ..Default::default()
+        },
+        log_root,
+        Some(4),
+        None,
+    );
+    assert!(matches!(result, Err(Error::MissingVersion(Some(3)))));
 }
 
 #[test]
@@ -2502,7 +2534,7 @@ fn test_validate_checkpoint_commit_gap_reports_first_missing_version() {
         None,
         None,
     );
-    assert!(matches!(result, Err(Error::MissingVersionAt(2))));
+    assert!(matches!(result, Err(Error::MissingVersion(Some(2)))));
 }
 
 #[test]
@@ -2895,7 +2927,7 @@ async fn for_timestamp_conversion_no_commit_files() {
 
     let res =
         LogSegment::for_timestamp_conversion(storage.as_ref(), log_root.clone(), 0, None, vec![]);
-    assert!(matches!(res, Err(Error::MissingVersionAt(0))));
+    assert!(matches!(res, Err(Error::MissingVersion(Some(0)))));
 }
 
 #[tokio::test]
@@ -3089,7 +3121,7 @@ fn test_log_segment_contiguous_commit_files() {
         LogSegmentFiles {
             ascending_commit_files: vec![
                 create_log_path("file:///_delta_log/00000000000000000001.json"),
-                create_log_path("file:///_delta_log/00000000000000000003.json"),
+                create_log_path("file:///_delta_log/00000000000000000004.json"),
             ],
             ..Default::default()
         },
@@ -3097,7 +3129,7 @@ fn test_log_segment_contiguous_commit_files() {
         None,
         None,
     );
-    assert!(matches!(log_segment, Err(Error::MissingVersionAt(2))));
+    assert!(matches!(log_segment, Err(Error::MissingVersion(Some(2)))));
 }
 
 /// `checkpoint_sidecars()` distinguishes "the matched hint lists zero sidecars" (`Some(&[])`) from

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2526,6 +2526,39 @@ fn test_validate_checkpoint_commit_gap_reports_first_missing_version() {
 }
 
 #[test]
+fn test_checkpoint_covers_gap_before_retained_commits() {
+    let log_root = Url::parse("file:///_delta_log/").unwrap();
+    let result = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path(
+                "file:///_delta_log/00000000000000000005.checkpoint.parquet",
+            )],
+            ascending_commit_files: vec![
+                create_log_path("file:///_delta_log/00000000000000000004.json"),
+                create_log_path("file:///_delta_log/00000000000000000006.json"),
+                create_log_path("file:///_delta_log/00000000000000000007.json"),
+            ],
+            latest_commit_file: Some(create_log_path(
+                "file:///_delta_log/00000000000000000007.json",
+            )),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let versions = result
+        .listed
+        .ascending_commit_files
+        .iter()
+        .map(|commit| commit.version)
+        .collect_vec();
+    assert_eq!(versions, vec![6, 7]);
+}
+
+#[test]
 fn test_try_new_crc_at_end_version_is_ok() {
     let log_root = Url::parse("file:///_delta_log/").unwrap();
     assert!(LogSegment::try_new(

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -2749,7 +2749,10 @@ fn test_validate_listed_log_file_compaction_files_contains_non_compaction() {
         None,
         None,
     );
-    assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
+    assert!(matches!(
+        result,
+        Err(Error::InvalidLogSegment(message)) if message.contains("Commit")
+    ));
 }
 
 #[test]

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3512,16 +3512,17 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 #[case::published_through_snapshot(&[0, 1, 2], &[], None, None)]
 #[case::staged_only(&[], &[0, 1, 2], None, Some(0))]
 #[case::published_prefix(&[0, 1, 2], &[3, 4, 5], None, Some(3))]
-#[case::checkpoint_with_staged_tail(&[], &[6, 7, 8], Some(5), Some(6))]
+#[case::checkpoint_without_published_commit(&[], &[], Some(5), Some(0))]
+#[case::checkpoint_with_staged_tail(&[5], &[6, 7, 8], Some(5), Some(6))]
 #[case::checkpoint_supersedes_older_commits(
-    &[0, 1, 2, 3, 4],
+    &[0, 1, 2, 3, 4, 5],
     &[6, 7, 8],
     Some(5),
     Some(6)
 )]
-#[case::checkpoint_only(&[], &[], Some(5), None)]
+#[case::checkpoint_at_published_end(&[5], &[], Some(5), None)]
 #[tokio::test]
-async fn validate_published_uses_checkpoint_and_commit_watermarks(
+async fn validate_published_uses_published_commit_watermark(
     #[case] published_commit_versions: &[Version],
     #[case] staged_commit_versions: &[Version],
     #[case] checkpoint_version: Option<Version>,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3509,6 +3509,7 @@ async fn test_get_file_actions_schema_multi_part_v1(#[case] use_hint: bool) -> D
 // ============================================================================
 
 #[rstest]
+#[case::published_through_snapshot(&[0, 1, 2], &[], None, None)]
 #[case::staged_only(&[], &[0, 1, 2], None, Some(0))]
 #[case::published_prefix(&[0, 1, 2], &[3, 4, 5], None, Some(3))]
 #[case::checkpoint_with_staged_tail(&[], &[6, 7, 8], Some(5), Some(6))]
@@ -3542,6 +3543,23 @@ async fn validate_published_uses_checkpoint_and_commit_watermarks(
         )),
         None => assert!(result.is_ok()),
     }
+}
+
+#[tokio::test]
+async fn validate_published_rejects_watermark_after_segment_end() {
+    let mut log_segment = create_segment_for(LogSegmentConfig {
+        published_commit_versions: &[0, 1, 2],
+        ..Default::default()
+    })
+    .await;
+    log_segment.listed.max_published_version = Some(3);
+
+    let result = log_segment.validate_published();
+    assert!(matches!(
+        result,
+        Err(Error::InvalidLogSegment(message))
+            if message == "publication watermark 3 exceeds log segment end version 2"
+    ));
 }
 
 #[tokio::test]

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -268,7 +268,7 @@ impl Snapshot {
                 // Case C.1: caller requested a specific version (necessarily >
                 // existing_snapshot_version since cases A and B were handled above), but
                 // no such commit exists in the log.
-                Some(requested_version) => Err(Error::MissingVersionAt(requested_version)),
+                Some(_) => Err(Error::MissingVersion(Some(existing_snapshot_version + 1))),
                 // Case C.2: no new commits and no explicit target; latest is existing.
                 None => Ok(NewSegment::Unchanged),
             };
@@ -1109,7 +1109,7 @@ mod tests {
             Snapshot::builder_from(base_snapshot.clone())
                 .at_version(1)
                 .build(&engine),
-            Err(Error::MissingVersionAt(1))
+            Err(Error::MissingVersion(Some(1)))
         ));
 
         // b. log segment for old..=new version has a checkpoint (with new protocol/metadata)
@@ -1175,9 +1175,9 @@ mod tests {
             .build(&engine)?;
         assert!(matches!(
             Snapshot::builder_from(base_snapshot.clone())
-                .at_version(2)
+                .at_version(4)
                 .build(&engine),
-            Err(Error::MissingVersionAt(2))
+            Err(Error::MissingVersion(Some(2)))
         ));
 
         // ii. commits have (new protocol, no metadata)
@@ -2210,7 +2210,7 @@ mod tests {
         let result = Snapshot::builder_from(base)
             .at_version(9)
             .build(ctx.engine.as_ref());
-        assert!(matches!(result, Err(Error::MissingVersionAt(9))));
+        assert!(matches!(result, Err(Error::MissingVersion(Some(4)))));
 
         let events = reporter.events();
         let failure = events

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -1176,8 +1176,10 @@ mod tests {
             .at_version(0)
             .build(&engine)?;
         assert!(matches!(
-            Snapshot::builder_from(base_snapshot.clone()).at_version(2).build(&engine),
-            Err(Error::Generic(msg)) if msg == "LogSegment end version 1 not the same as the specified end version 2"
+            Snapshot::builder_from(base_snapshot.clone())
+                .at_version(2)
+                .build(&engine),
+            Err(Error::MissingVersionAt(2))
         ));
 
         // ii. commits have (new protocol, no metadata)

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -268,7 +268,7 @@ impl Snapshot {
                 // Case C.1: caller requested a specific version (necessarily >
                 // existing_snapshot_version since cases A and B were handled above), but
                 // no such commit exists in the log.
-                Some(_) => Err(Error::MissingVersion(Some(existing_snapshot_version + 1))),
+                Some(_) => Err(Error::MissingVersion(existing_snapshot_version + 1)),
                 // Case C.2: no new commits and no explicit target; latest is existing.
                 None => Ok(NewSegment::Unchanged),
             };
@@ -1109,7 +1109,7 @@ mod tests {
             Snapshot::builder_from(base_snapshot.clone())
                 .at_version(1)
                 .build(&engine),
-            Err(Error::MissingVersion(Some(1)))
+            Err(Error::MissingVersion(1))
         ));
 
         // b. log segment for old..=new version has a checkpoint (with new protocol/metadata)
@@ -1177,7 +1177,7 @@ mod tests {
             Snapshot::builder_from(base_snapshot.clone())
                 .at_version(4)
                 .build(&engine),
-            Err(Error::MissingVersion(Some(2)))
+            Err(Error::MissingVersion(2))
         ));
 
         // ii. commits have (new protocol, no metadata)
@@ -2198,19 +2198,19 @@ mod tests {
     async fn test_incremental_unavailable_version_emits_log_segment_load_failure() -> DeltaResult<()>
     {
         let ctx = setup_incremental_snapshot_test()?;
-        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 4).await?; // v0..=v3
+        setup_test_table_with_commits(ctx.url.as_str(), &ctx.store, 3).await?; // v0..=v2
         let base = Snapshot::builder_for(ctx.url.as_str())
-            .at_version(3)
+            .at_version(2)
             .build(ctx.engine.as_ref())?;
 
         let reporter = Arc::new(CapturingReporter::default());
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
 
-        // Request a version beyond the log: the listing above v3 is empty (case C.1).
+        // Request a version beyond the log: the listing above v2 is empty (case C.1).
         let result = Snapshot::builder_from(base)
-            .at_version(9)
+            .at_version(5)
             .build(ctx.engine.as_ref());
-        assert!(matches!(result, Err(Error::MissingVersion(Some(4)))));
+        assert!(matches!(result, Err(Error::MissingVersion(3))));
 
         let events = reporter.events();
         let failure = events

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -268,11 +268,7 @@ impl Snapshot {
                 // Case C.1: caller requested a specific version (necessarily >
                 // existing_snapshot_version since cases A and B were handled above), but
                 // no such commit exists in the log.
-                Some(requested_version) => Err(Error::Generic(format!(
-                    "Requested snapshot version {requested_version} is not available: \
-                     no new commits were found after existing snapshot version \
-                     {existing_snapshot_version}"
-                ))),
+                Some(requested_version) => Err(Error::MissingVersionAt(requested_version)),
                 // Case C.2: no new commits and no explicit target; latest is existing.
                 None => Ok(NewSegment::Unchanged),
             };
@@ -1110,8 +1106,10 @@ mod tests {
         assert_eq!(snapshot, expected);
         // version exceeds latest version of the table = err
         assert!(matches!(
-            Snapshot::builder_from(base_snapshot.clone()).at_version(1).build(&engine),
-            Err(Error::Generic(msg)) if msg == "Requested snapshot version 1 is not available: no new commits were found after existing snapshot version 0"
+            Snapshot::builder_from(base_snapshot.clone())
+                .at_version(1)
+                .build(&engine),
+            Err(Error::MissingVersionAt(1))
         ));
 
         // b. log segment for old..=new version has a checkpoint (with new protocol/metadata)
@@ -2212,7 +2210,7 @@ mod tests {
         let result = Snapshot::builder_from(base)
             .at_version(9)
             .build(ctx.engine.as_ref());
-        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::MissingVersionAt(9))));
 
         let events = reporter.events();
         let failure = events

--- a/kernel/src/snapshot/incremental.rs
+++ b/kernel/src/snapshot/incremental.rs
@@ -289,7 +289,7 @@ impl Snapshot {
         if new_end_version < existing_snapshot_version {
             // we should never see a new log segment with a version < the existing snapshot
             // version, that would mean a commit was incorrectly deleted from the log
-            return Err(Error::Generic(format!(
+            return Err(Error::invalid_log_segment(format!(
                 "Unexpected state: the newest version in the log {new_end_version} is \
                  older than the existing snapshot version {existing_snapshot_version}"
             )));
@@ -2172,7 +2172,7 @@ mod tests {
         let _guard = install_thread_local_metrics_reporter(reporter.clone());
 
         let result = Snapshot::builder_from(base).build(ctx.engine.as_ref());
-        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::InvalidLogSegment(_))));
 
         let events = reporter.events();
         let failure = events

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -809,7 +809,7 @@ impl Snapshot {
                 let ict = commit_file_meta.read_in_commit_timestamp(engine)?;
                 Ok(Some(ict))
             }
-            None => Err(Error::generic("Last commit file not found in log segment")),
+            None => Err(Error::MissingVersion(self.version())),
         }
     }
 
@@ -837,28 +837,18 @@ impl Snapshot {
                         let ts = commit_file_meta.location.last_modified;
                         Ok(ts)
                     }
-                    None => Err(Error::generic(format!(
-                        "Last commit file not found in log segment for version {} \
-                         (ICT disabled): cannot read filesystem modification timestamp",
-                        self.version()
-                    ))),
+                    None => Err(Error::MissingVersion(self.version())),
                 }
             }
-            InCommitTimestampEnablement::Enabled { .. } => self
-                .get_in_commit_timestamp(engine)
-                .map_err(|e| {
-                    Error::generic(format!(
-                        "Unable to read in-commit timestamp for version {}: {e}",
-                        self.version()
-                    ))
-                })?
-                .ok_or_else(|| {
+            InCommitTimestampEnablement::Enabled { .. } => {
+                self.get_in_commit_timestamp(engine)?.ok_or_else(|| {
                     Error::internal_error(format!(
                         "Invalid state: version {}, ICT is enabled \
                         but get_in_commit_timestamp returned None",
                         self.version()
                     ))
-                }),
+                })
+            }
         }
     }
 
@@ -1995,9 +1985,8 @@ mod tests {
             snapshot.table_configuration().clone(),
         )?;
 
-        // Should return an error when commit file is missing
         let result = snapshot_no_commit.get_in_commit_timestamp(&engine);
-        assert_result_error_with_message(result, "Last commit file not found in log segment");
+        assert!(matches!(result, Err(Error::MissingVersion(0))));
 
         Ok(())
     }
@@ -2160,7 +2149,43 @@ mod tests {
         )?;
 
         let result = snapshot_no_commit.get_timestamp(&engine);
-        assert_result_error_with_message(result, "Last commit file not found in log segment");
+        assert!(matches!(result, Err(Error::MissingVersion(0))));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_timestamp_preserves_commit_read_error() -> DeltaResult<()> {
+        let table_root = "memory:///";
+        let store = Arc::new(InMemory::new());
+        let engine = SyncEngine::new_with_store(store.clone());
+        let commit_data = vec![
+            create_commit_info(1677811175819, Some(1677811175999)),
+            create_protocol(true, Some(TABLE_FEATURES_MIN_READER_VERSION as u32)),
+            create_metadata(
+                Some("test_id"),
+                Some("{\"type\":\"struct\",\"fields\":[]}"),
+                Some(1677811175819),
+                Some(("0".to_string(), "1612345678".to_string())),
+                false,
+            ),
+        ];
+        commit(table_root, store.as_ref(), 0, commit_data).await;
+        let loaded_snapshot = Snapshot::builder_for(table_root).build(&engine)?;
+        // Drop the synthesized CRC so timestamp resolution reads the referenced commit file.
+        let snapshot = Snapshot::new_with_crc(
+            loaded_snapshot.log_segment().clone(),
+            loaded_snapshot.table_configuration().clone(),
+            None,
+            false,
+        )?;
+        store.delete(&delta_path_for_version(0, "json")).await?;
+
+        let result = snapshot.get_timestamp(&engine);
+        assert!(
+            matches!(&result, Err(Error::FileNotFound(_))),
+            "expected FileNotFound, got {result:?}"
+        );
 
         Ok(())
     }

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -442,7 +442,7 @@ fn invalid_range_end_before_start() {
 #[test]
 fn invalid_range_start_after_last_version_of_table() {
     let res = read_cdf_for_table("cdf-table-simple", 3, 4, None);
-    assert!(matches!(res, Err(Error::MissingVersion(Some(3)))));
+    assert!(matches!(res, Err(Error::MissingVersion(3))));
 }
 
 #[test]

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -442,7 +442,7 @@ fn invalid_range_end_before_start() {
 #[test]
 fn invalid_range_start_after_last_version_of_table() {
     let res = read_cdf_for_table("cdf-table-simple", 3, 4, None);
-    assert!(matches!(res, Err(Error::MissingVersionAt(3))));
+    assert!(matches!(res, Err(Error::MissingVersion(Some(3)))));
 }
 
 #[test]

--- a/kernel/tests/integration/features/cdf.rs
+++ b/kernel/tests/integration/features/cdf.rs
@@ -442,8 +442,7 @@ fn invalid_range_end_before_start() {
 #[test]
 fn invalid_range_start_after_last_version_of_table() {
     let res = read_cdf_for_table("cdf-table-simple", 3, 4, None);
-    let expected_msg = "Expected the first commit to have version 3, got None";
-    assert!(matches!(res, Err(Error::Generic(msg)) if msg == expected_msg));
+    assert!(matches!(res, Err(Error::MissingVersionAt(3))));
 }
 
 #[test]

--- a/kernel/tests/integration/log/log_tail.rs
+++ b/kernel/tests/integration/log/log_tail.rs
@@ -447,21 +447,19 @@ async fn log_tail_behind_requested_version() -> Result<(), Box<dyn std::error::E
     let actions = vec![TestAction::Add("file_4.parquet".to_string())];
     add_commit(table_root, storage.as_ref(), 4, actions_to_string(actions)).await?;
 
-    // Log tail only goes up to version 3
+    // Log tail only goes up to version 2
     let log_tail = vec![
         create_log_path(&table_url, delta_path_for_version(1, "json")),
         create_log_path(&table_url, delta_path_for_version(2, "json")),
-        create_log_path(&table_url, delta_path_for_version(3, "json")),
     ];
 
-    // User asks for version 4, but log tail only has up to version 3
-    // This should fail with an error
+    // User asks for version 4, but versions 3 and 4 are unavailable through the log tail.
     let result = Snapshot::builder_for(table_root)
         .at_version(4)
         .with_log_tail(log_tail)
         .build(engine.as_ref());
 
-    assert!(matches!(result, Err(Error::MissingVersionAt(4))));
+    assert!(matches!(result, Err(Error::MissingVersion(Some(3)))));
 
     Ok(())
 }

--- a/kernel/tests/integration/log/log_tail.rs
+++ b/kernel/tests/integration/log/log_tail.rs
@@ -459,7 +459,7 @@ async fn log_tail_behind_requested_version() -> Result<(), Box<dyn std::error::E
         .with_log_tail(log_tail)
         .build(engine.as_ref());
 
-    assert!(matches!(result, Err(Error::MissingVersion(Some(3)))));
+    assert!(matches!(result, Err(Error::MissingVersion(3))));
 
     Ok(())
 }

--- a/kernel/tests/integration/log/log_tail.rs
+++ b/kernel/tests/integration/log/log_tail.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use delta_kernel::history_manager::{first_version_after, latest_version_as_of, HistoryCommitType};
 use delta_kernel::object_store::memory::InMemory;
-use delta_kernel::Snapshot;
+use delta_kernel::{Error, Snapshot};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::{DefaultEngine, DefaultEngineBuilder};
 use test_utils::{
@@ -461,10 +461,7 @@ async fn log_tail_behind_requested_version() -> Result<(), Box<dyn std::error::E
         .with_log_tail(log_tail)
         .build(engine.as_ref());
 
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("LogSegment end version 3 not the same as the specified end version 4"));
+    assert!(matches!(result, Err(Error::MissingVersionAt(4))));
 
     Ok(())
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Classifies log-segment failures as `MissingVersion`, `InvalidCheckpoint`, or `InvalidLogSegment` instead of generic errors. Missing-version errors now include the affected version when known, with corresponding FFI mappings and test coverage.

## How was this change tested?

All unit tests and integration tests pass.
