### PR TITLE
fix: add projection fix for column mapping scans

### DIFF
--- a/docs/user-guide/src/reading/building_a_scan.md
+++ b/docs/user-guide/src/reading/building_a_scan.md
@@ -47,20 +47,15 @@ Pass a schema containing only the columns you want to read:
 ```rust,no_run
 # extern crate delta_kernel;
 # extern crate delta_kernel_default_engine;
-# use std::sync::Arc;
 # use delta_kernel_default_engine::DefaultEngine;
 # use delta_kernel_default_engine::storage::store_from_url;
-# use delta_kernel::schema::{DataType, StructField, StructType};
 # use delta_kernel::{DeltaResult, Snapshot};
 # fn example() -> DeltaResult<()> {
 # let url = delta_kernel::try_parse_uri("/tmp/table")?;
 # let store = store_from_url(&url)?;
 # let engine = DefaultEngine::builder(store).build();
 # let snapshot = Snapshot::builder_for(url).build(&engine)?;
-let read_schema = Arc::new(StructType::try_new([
-    StructField::nullable("name", DataType::STRING),
-    StructField::nullable("age", DataType::INTEGER),
-])?);
+let read_schema = snapshot.schema().project(&["name", "age"])?;
 
 let scan = snapshot
     .scan_builder()
@@ -70,8 +65,10 @@ let scan = snapshot
 # }
 ```
 
-The schema you provide must be a subset of the table's schema. Kernel only reads the
-columns you specify from each Parquet file.
+Build the projection from the current `Snapshot` schema. `project()` retains the field
+types, nullability, and column-mapping metadata that Kernel needs to read table columns.
+`build()` returns a schema error if a projected partition field conflicts with the
+`Snapshot` schema. Kernel only reads the columns you specify from each Parquet file.
 
 For more details, see [Column Selection](./column_selection.md).
 

--- a/docs/user-guide/src/reading/column_selection.md
+++ b/docs/user-guide/src/reading/column_selection.md
@@ -1,7 +1,7 @@
-# Column Selection
+# Column selection
 
-By default a scan reads all columns from a table. You can select a subset of columns
-(projection pushdown) so the engine only reads the data you need.
+To read a subset of table columns, build a projection from the current `Snapshot` schema
+and pass it to the `ScanBuilder`.
 
 ## Projecting columns
 
@@ -33,6 +33,11 @@ let scan = snapshot
 
 The returned data will contain only the projected columns, in the order you specified.
 Requesting a column that does not exist in the table schema returns an error.
+
+Always derive table-backed projections from the current `Snapshot`. `project()` copies each
+field's type, nullability, and column-mapping metadata. If a projected partition field
+conflicts with the authoritative field, `build()` returns a schema error that directs you
+back to `Schema::project()`.
 
 ## Reordering columns
 

--- a/kernel/src/scan/field_classifiers.rs
+++ b/kernel/src/scan/field_classifiers.rs
@@ -57,6 +57,7 @@ impl TransformFieldClassifier for CdfTransformFieldClassifier {
                 Some(FieldTransformSpec::MetadataDerivedColumn {
                     field_index,
                     insert_after: last_physical_field.clone(),
+                    partition_source: None,
                 })
             }
             _ => None,

--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -257,13 +257,18 @@ impl ScanBuilder {
         }
     }
 
-    /// Provide [`Schema`] for columns to select from the [`Snapshot`].
+    /// Provides a [`Schema`] for columns to select from the [`Snapshot`].
     ///
     /// A table with columns `[a, b, c]` could have a scan which reads only the first
-    /// two columns by using the schema `[a, b]`.
+    /// two columns by using the schema `[a, b]`. Build table-backed projections with
+    /// [`Snapshot::schema`]'s [`Schema::project`] method so the projected fields retain their
+    /// authoritative type, nullability, and column-mapping metadata. [`Self::build`] returns a
+    /// schema error if a projected partition field conflicts with the snapshot schema.
     ///
     /// [`Schema`]: crate::schema::Schema
+    /// [`Schema::project`]: crate::schema::Schema::project
     /// [`Snapshot`]: crate::snapshot::Snapshot
+    /// [`Snapshot::schema`]: crate::snapshot::Snapshot::schema
     pub fn with_schema(mut self, logical_read_schema: SchemaRef) -> Self {
         self.logical_read_schema = Some(logical_read_schema);
         self

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -9,7 +9,7 @@ use tracing::{debug, enabled, warn, Level};
 use crate::actions::NULL_COUNT;
 use crate::expressions::ColumnName;
 use crate::scan::field_classifiers::TransformFieldClassifier;
-use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
+use crate::scan::transform_spec::{FieldTransformSpec, PartitionColumnSource, TransformSpec};
 use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions, StructStats};
 use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
@@ -262,10 +262,21 @@ impl StateInfo {
                 // Classifier has handled this field via a transformation, just push it and move on
                 transform_spec.push(spec);
             } else if partition_columns.contains(logical_field.name()) {
+                let authoritative_field = validate_projected_partition_field(
+                    logical_field,
+                    table_configuration,
+                    column_mapping_mode,
+                )?;
                 // push the transform for this partition column
                 transform_spec.push(FieldTransformSpec::MetadataDerivedColumn {
                     field_index: index,
                     insert_after: last_physical_field.clone(),
+                    partition_source: Some(PartitionColumnSource {
+                        physical_name: authoritative_field
+                            .physical_name(column_mapping_mode)
+                            .to_string(),
+                        data_type: authoritative_field.data_type().clone(),
+                    }),
                 });
             } else {
                 // Regular field field or a metadata column, figure out which and handle it
@@ -468,6 +479,86 @@ impl StateInfo {
     }
 }
 
+fn validate_projected_partition_field<'a>(
+    projected_field: &StructField,
+    table_configuration: &'a TableConfiguration,
+    column_mapping_mode: ColumnMappingMode,
+) -> DeltaResult<&'a StructField> {
+    let authoritative_field = table_configuration
+        .logical_schema_ref()
+        .field(projected_field.name())
+        .ok_or_else(|| {
+            Error::internal_error(format!(
+                "Partition field '{}' is absent from the authoritative table schema",
+                projected_field.name()
+            ))
+        })?;
+
+    if projected_field.data_type() != authoritative_field.data_type() {
+        return Err(invalid_partition_projection(
+            projected_field,
+            format!(
+                "expected type {:?}, found {:?}",
+                authoritative_field.data_type(),
+                projected_field.data_type()
+            ),
+        ));
+    }
+    if projected_field.is_nullable() != authoritative_field.is_nullable() {
+        return Err(invalid_partition_projection(
+            projected_field,
+            format!(
+                "expected nullable={}, found nullable={}",
+                authoritative_field.is_nullable(),
+                projected_field.is_nullable()
+            ),
+        ));
+    }
+
+    if column_mapping_mode != ColumnMappingMode::None {
+        let projected_annotations = projected_field
+            .validate_and_extract_existing_column_mapping_annotations()
+            .map_err(|error| invalid_partition_projection(projected_field, error.to_string()))?;
+        let authoritative_annotations = authoritative_field
+            .validate_and_extract_existing_column_mapping_annotations()
+            .map_err(|error| {
+                Error::internal_error(format!(
+                    "Invalid column mapping metadata on authoritative field '{}': {error}",
+                    authoritative_field.name()
+                ))
+            })?;
+
+        if projected_annotations.id != authoritative_annotations.id {
+            return Err(invalid_partition_projection(
+                projected_field,
+                format!(
+                    "expected delta.columnMapping.id {:?}, found {:?}",
+                    authoritative_annotations.id, projected_annotations.id
+                ),
+            ));
+        }
+        if projected_annotations.physical_name != authoritative_annotations.physical_name {
+            return Err(invalid_partition_projection(
+                projected_field,
+                format!(
+                    "expected delta.columnMapping.physicalName {:?}, found {:?}",
+                    authoritative_annotations.physical_name, projected_annotations.physical_name
+                ),
+            ));
+        }
+    }
+
+    Ok(authoritative_field)
+}
+
+fn invalid_partition_projection(field: &StructField, reason: impl std::fmt::Display) -> Error {
+    Error::schema(format!(
+        "Projected partition field '{}' does not match the authoritative table schema: {reason}. \
+         Build the projection from the scan's authoritative schema with Schema::project",
+        field.name()
+    ))
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use std::collections::HashMap;
@@ -660,6 +751,7 @@ pub(crate) mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index,
                 insert_after,
+                ..
             } => {
                 assert_eq!(*field_index, 1); // Index of "date" in logical schema
                 assert_eq!(insert_after, &Some("id".to_string())); // After "id" which is physical
@@ -698,6 +790,7 @@ pub(crate) mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index,
                 insert_after,
+                ..
             } => {
                 assert_eq!(*field_index, 1); // Index of "part1"
                 assert_eq!(insert_after, &Some("col1".to_string()));
@@ -710,6 +803,7 @@ pub(crate) mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index,
                 insert_after,
+                ..
             } => {
                 assert_eq!(*field_index, 3); // Index of "part2"
                 assert_eq!(insert_after, &Some("col2".to_string()));
@@ -770,6 +864,7 @@ pub(crate) mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index,
                 insert_after,
+                ..
             } => {
                 assert_eq!(*field_index, 0); // Index of "date"
                 assert_eq!(insert_after, &None); // No physical field before it, so prepend
@@ -800,6 +895,160 @@ pub(crate) mod tests {
                 MetadataValue::String(physical_name.into()),
             ),
         ])
+    }
+
+    #[derive(Clone, Copy)]
+    enum PartitionProjectionMutation {
+        Canonical,
+        UnrelatedMetadata,
+        MissingMappingMetadata,
+        MalformedId,
+        MalformedPhysicalName,
+        WrongId,
+        WrongPhysicalName,
+        WrongType,
+        WrongNullability,
+        OtherPartitionIdentity,
+    }
+
+    #[rstest]
+    #[case::canonical(PartitionProjectionMutation::Canonical, None)]
+    #[case::unrelated_metadata(PartitionProjectionMutation::UnrelatedMetadata, None)]
+    #[case::missing_mapping_metadata(
+        PartitionProjectionMutation::MissingMappingMetadata,
+        Some("expected delta.columnMapping.id Some(1), found None")
+    )]
+    #[case::malformed_id(
+        PartitionProjectionMutation::MalformedId,
+        Some("non-numeric `delta.columnMapping.id` annotation")
+    )]
+    #[case::malformed_physical_name(
+        PartitionProjectionMutation::MalformedPhysicalName,
+        Some("non-string `delta.columnMapping.physicalName` annotation")
+    )]
+    #[case::wrong_id(
+        PartitionProjectionMutation::WrongId,
+        Some("expected delta.columnMapping.id Some(1), found Some(9)")
+    )]
+    #[case::wrong_physical_name(
+        PartitionProjectionMutation::WrongPhysicalName,
+        Some("expected delta.columnMapping.physicalName Some(\"part-physical\"), found Some(\"wrong\")")
+    )]
+    #[case::wrong_type(
+        PartitionProjectionMutation::WrongType,
+        Some("expected type Primitive(String), found Primitive(Integer)")
+    )]
+    #[case::wrong_nullability(
+        PartitionProjectionMutation::WrongNullability,
+        Some("expected nullable=true, found nullable=false")
+    )]
+    #[case::other_partition_identity(
+        PartitionProjectionMutation::OtherPartitionIdentity,
+        Some("expected delta.columnMapping.id Some(1), found Some(2)")
+    )]
+    fn column_mapped_partition_projection_must_match_snapshot(
+        #[values(ColumnMappingMode::Name, ColumnMappingMode::Id)] mode: ColumnMappingMode,
+        #[case] mutation: PartitionProjectionMutation,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let authoritative_schema = schema_ref! {
+            (cm_field("part", 1, "part-physical", DataType::STRING)),
+            (cm_field("other_part", 2, "other-physical", DataType::STRING)),
+        };
+        let table_configuration = MockTableConfigurationBuilder::new()
+            .with_schema(authoritative_schema)
+            .with_partition_columns(["part", "other_part"])
+            .with_column_mapping(mode)
+            .with_protocol(MockProtocolBuilder::new().with_versions(2, 5).build())
+            .build();
+
+        let mut projected_field = cm_field("part", 1, "part-physical", DataType::STRING);
+        match mutation {
+            PartitionProjectionMutation::Canonical => {}
+            PartitionProjectionMutation::UnrelatedMetadata => {
+                projected_field.metadata.insert(
+                    "comment".to_string(),
+                    MetadataValue::String("caller annotation".to_string()),
+                );
+            }
+            PartitionProjectionMutation::MissingMappingMetadata => {
+                projected_field = StructField::nullable("part", DataType::STRING);
+            }
+            PartitionProjectionMutation::MalformedId => {
+                projected_field.metadata.insert(
+                    ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+                    MetadataValue::String("one".to_string()),
+                );
+            }
+            PartitionProjectionMutation::MalformedPhysicalName => {
+                projected_field.metadata.insert(
+                    ColumnMetadataKey::ColumnMappingPhysicalName
+                        .as_ref()
+                        .to_string(),
+                    MetadataValue::Number(1),
+                );
+            }
+            PartitionProjectionMutation::WrongId => {
+                projected_field.metadata.insert(
+                    ColumnMetadataKey::ColumnMappingId.as_ref().to_string(),
+                    MetadataValue::Number(9),
+                );
+            }
+            PartitionProjectionMutation::WrongPhysicalName => {
+                projected_field.metadata.insert(
+                    ColumnMetadataKey::ColumnMappingPhysicalName
+                        .as_ref()
+                        .to_string(),
+                    MetadataValue::String("wrong".to_string()),
+                );
+            }
+            PartitionProjectionMutation::WrongType => {
+                projected_field.data_type = DataType::INTEGER;
+            }
+            PartitionProjectionMutation::WrongNullability => {
+                projected_field.nullable = false;
+            }
+            PartitionProjectionMutation::OtherPartitionIdentity => {
+                projected_field = cm_field("part", 2, "other-physical", DataType::STRING);
+            }
+        }
+
+        let projected_schema = Arc::new(StructType::try_new([projected_field]).unwrap());
+        let result = StateInfo::try_new(
+            projected_schema,
+            table_configuration.logical_schema(),
+            &table_configuration,
+            None,
+            &StatsOptions::default(),
+            &PartitionValuesOptions::default(),
+            (),
+        );
+
+        if let Some(expected_error) = expected_error {
+            let error = result.unwrap_err();
+            assert!(
+                error.to_string().contains(expected_error),
+                "unexpected error: {error}"
+            );
+            assert!(
+                error.to_string().contains(
+                    "Build the projection from the scan's authoritative schema with Schema::project"
+                ),
+                "unexpected error: {error}"
+            );
+        } else {
+            let state_info = result.unwrap();
+            let transform_spec = state_info.transform_spec.unwrap();
+            let FieldTransformSpec::MetadataDerivedColumn {
+                partition_source: Some(source),
+                ..
+            } = &transform_spec[0]
+            else {
+                panic!("Expected partition source in MetadataDerivedColumn transform")
+            };
+            assert_eq!(source.physical_name, "part-physical");
+            assert_eq!(source.data_type, DataType::STRING);
+        }
     }
 
     #[test]

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -23,6 +23,15 @@ use crate::{DeltaResult, Error};
 // description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
+/// Authoritative information for reading a table partition column from file metadata.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub(crate) struct PartitionColumnSource {
+    /// Physical key used by `partitionValues`.
+    pub(crate) physical_name: String,
+    /// Table data type used to parse the serialized partition value.
+    pub(crate) data_type: DataType,
+}
+
 /// Describes a single field transformation to apply when converting physical data to logical
 /// schema.
 ///
@@ -58,6 +67,10 @@ pub(crate) enum FieldTransformSpec {
         field_index: usize,
         /// Insert after this physical column (None = prepend)
         insert_after: Option<String>,
+        /// Snapshot-derived partition metadata. Absent for non-partition metadata columns and
+        /// serialized transforms that omit the source.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        partition_source: Option<PartitionColumnSource>,
     },
     /// Insert or reorder a dynamic column that may be physical or metadata-derived.
     /// Used for CDF's _change_type column which requires different handling per file type.
@@ -77,14 +90,20 @@ pub(crate) fn parse_partition_value(
     logical_schema: &SchemaRef,
     partition_values: &HashMap<String, String>,
     column_mapping_mode: ColumnMappingMode,
+    partition_source: Option<&PartitionColumnSource>,
 ) -> DeltaResult<(usize, (String, Scalar))> {
-    let Some(field) = logical_schema.field_at_index(field_idx) else {
-        return Err(Error::InternalError(format!(
-            "out of bounds partition column field index {field_idx}"
-        )));
+    let (name, data_type) = match partition_source {
+        Some(source) => (source.physical_name.as_str(), &source.data_type),
+        None => {
+            let Some(field) = logical_schema.field_at_index(field_idx) else {
+                return Err(Error::InternalError(format!(
+                    "out of bounds partition column field index {field_idx}"
+                )));
+            };
+            (field.physical_name(column_mapping_mode), field.data_type())
+        }
     };
-    let name = field.physical_name(column_mapping_mode);
-    let partition_value = parse_partition_value_raw(partition_values.get(name), field.data_type())?;
+    let partition_value = parse_partition_value_raw(partition_values.get(name), data_type)?;
     Ok((field_idx, (name.to_string(), partition_value)))
 }
 
@@ -98,14 +117,17 @@ pub(crate) fn parse_partition_values(
     transform_spec
         .iter()
         .filter_map(|field_transform| match field_transform {
-            FieldTransformSpec::MetadataDerivedColumn { field_index, .. } => {
-                Some(parse_partition_value(
-                    *field_index,
-                    logical_schema,
-                    partition_values,
-                    column_mapping_mode,
-                ))
-            }
+            FieldTransformSpec::MetadataDerivedColumn {
+                field_index,
+                partition_source,
+                ..
+            } => Some(parse_partition_value(
+                *field_index,
+                logical_schema,
+                partition_values,
+                column_mapping_mode,
+                partition_source.as_ref(),
+            )),
             FieldTransformSpec::DynamicColumn { .. }
             | FieldTransformSpec::StaticInsert { .. }
             | FieldTransformSpec::GenerateRowId { .. }
@@ -150,6 +172,7 @@ pub(crate) fn get_transform_expr(
             MetadataDerivedColumn {
                 field_index,
                 insert_after,
+                ..
             } => {
                 let Some((_, partition_value)) = metadata_values.remove(field_index) else {
                     return Err(Error::MissingData(format!(
@@ -244,8 +267,70 @@ mod tests {
         };
         let partition_values = HashMap::new();
 
-        let result = parse_partition_value(5, &schema, &partition_values, ColumnMappingMode::None);
+        let result =
+            parse_partition_value(5, &schema, &partition_values, ColumnMappingMode::None, None);
         assert_result_error_with_message(result, "out of bounds");
+    }
+
+    #[test]
+    fn test_parse_partition_value_uses_authoritative_source() {
+        let schema = schema_ref! {
+            nullable "projected_key": STRING,
+        };
+        let partition_values = HashMap::from([("authoritative_key".to_string(), "42".to_string())]);
+        let source = PartitionColumnSource {
+            physical_name: "authoritative_key".to_string(),
+            data_type: DataType::LONG,
+        };
+
+        let (_, (name, value)) = parse_partition_value(
+            0,
+            &schema,
+            &partition_values,
+            ColumnMappingMode::Name,
+            Some(&source),
+        )
+        .unwrap();
+
+        assert_eq!(name, "authoritative_key");
+        assert_eq!(value, Scalar::Long(42));
+    }
+
+    #[test]
+    fn metadata_derived_column_deserializes_without_partition_source() {
+        let transform: FieldTransformSpec = serde_json::from_value(serde_json::json!({
+            "MetadataDerivedColumn": {
+                "field_index": 1,
+                "insert_after": null
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            transform,
+            FieldTransformSpec::MetadataDerivedColumn {
+                field_index: 1,
+                insert_after: None,
+                partition_source: None,
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_derived_column_round_trips_partition_source() {
+        let transform = FieldTransformSpec::MetadataDerivedColumn {
+            field_index: 1,
+            insert_after: Some("id".to_string()),
+            partition_source: Some(PartitionColumnSource {
+                physical_name: "part-physical".to_string(),
+                data_type: DataType::STRING,
+            }),
+        };
+
+        let serialized = serde_json::to_string(&transform).unwrap();
+        let deserialized = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(transform, deserialized);
     }
 
     // Tests for parse_partition_values function
@@ -260,6 +345,7 @@ mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index: 1,
                 insert_after: Some("id".to_string()),
+                partition_source: None,
             },
             FieldTransformSpec::StaticDrop {
                 field_name: "unused".to_string(),
@@ -267,6 +353,7 @@ mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index: 0,
                 insert_after: None,
+                partition_source: None,
             },
             FieldTransformSpec::DynamicColumn {
                 field_index: 2,
@@ -382,6 +469,7 @@ mod tests {
         let transform_spec = vec![FieldTransformSpec::MetadataDerivedColumn {
             field_index: 0,
             insert_after: None,
+            partition_source: None,
         }];
         let partition_values = HashMap::new(); // Missing required partition value
 
@@ -535,6 +623,7 @@ mod tests {
         let transform_spec = vec![FieldTransformSpec::MetadataDerivedColumn {
             field_index: 1,
             insert_after: Some("id".to_string()),
+            partition_source: None,
         }];
 
         let physical_schema = schema! { nullable "id": STRING };

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -215,6 +215,7 @@ mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index: 4, // _commit_version
                 insert_after: Some("id".to_string()),
+                partition_source: None,
             },
         ];
 
@@ -305,6 +306,7 @@ mod tests {
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index: 1, // age partition
                 insert_after: Some("id".to_string()),
+                partition_source: None,
             },
             FieldTransformSpec::DynamicColumn {
                 field_index: 3, // _change_type - physical in CDC files

--- a/kernel/src/table_changes/scan.rs
+++ b/kernel/src/table_changes/scan.rs
@@ -403,7 +403,8 @@ mod tests {
         assert!(transform_spec.iter().any(|t| matches!(t,
             FieldTransformSpec::MetadataDerivedColumn {
                 insert_after: Some(insert_after),
-                field_index
+                field_index,
+                ..
             }
             if insert_after == "id" && *field_index == 3
         )));
@@ -412,7 +413,8 @@ mod tests {
         assert!(transform_spec.iter().any(|t| matches!(t,
             FieldTransformSpec::MetadataDerivedColumn {
                 insert_after: Some(insert_after),
-                field_index
+                field_index,
+                ..
             }
             if insert_after == "id" && *field_index == 4
         )));
@@ -473,7 +475,8 @@ mod tests {
         assert!(matches!(&transform_spec[0],
             FieldTransformSpec::MetadataDerivedColumn {
                 field_index,
-                insert_after: Some(insert_after)
+                insert_after: Some(insert_after),
+                ..
             }
             if *field_index == 1 && insert_after == "id"
         ));

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use std::vec;
 
 use delta_kernel::actions::deletion_vector::split_vector;
-use delta_kernel::arrow::array::{ArrayRef, AsArray as _, RecordBatch, TimestampMicrosecondArray};
+use delta_kernel::arrow::array::{
+    Array as _, ArrayRef, AsArray as _, RecordBatch, TimestampMicrosecondArray,
+};
 use delta_kernel::arrow::compute::{concat_batches, filter_record_batch};
 use delta_kernel::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Int64Type, Schema as ArrowSchema, TimeUnit,
@@ -1023,7 +1025,8 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     // Partition-only predicate: category = 'A' prunes the category=B file
     Arc::new(Pred::eq(col!("category"), lit("A"))),
     None,
-    1
+    1,
+    false
 )]
 #[case::mixed_partition_and_data(
     // Mixed predicate: category = 'A' OR val > 'z'. Category=A kept by partition match.
@@ -1033,7 +1036,8 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
         Pred::gt(col!("val"), lit("z")),
     )),
     None,
-    1
+    1,
+    false
 )]
 #[case::predicate_on_unprojected_data_column(
     // Project only "category"; predicate references unprojected "val" (logical) whose
@@ -1041,7 +1045,8 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     // schema and prune both files: max(phys_val)='z' is NOT > 'z'.
     Arc::new(Pred::gt(col!("val"), lit("z"))),
     Some(vec!["category"]),
-    0
+    0,
+    false
 )]
 #[case::predicate_on_unprojected_partition_column(
     // Project only "val"; predicate references unprojected partition column "category"
@@ -1049,13 +1054,21 @@ fn mixed_predicate_with_checkpoint_parsed_columns(
     // using the physical partition name, keeping only the category=A file.
     Arc::new(Pred::eq(col!("category"), lit("A"))),
     Some(vec!["val"]),
-    1
+    1,
+    false
+)]
+#[case::bare_projected_partition_column(
+    Arc::new(Pred::eq(col!("category"), lit("A"))),
+    Some(vec!["category", "val"]),
+    1,
+    true
 )]
 #[tokio::test]
 async fn test_partition_pruning_with_column_mapping(
     #[case] predicate: Arc<Pred>,
     #[case] select_cols: Option<Vec<&'static str>>,
     #[case] expected_files: usize,
+    #[case] bare_projection: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let batch = generate_batch(vec![("phys_val", vec!["x", "y", "z"].into_arrow_array())])?;
 
@@ -1102,15 +1115,41 @@ async fn test_partition_pruning_with_column_mapping(
     // Predicates use logical column names -- kernel must map to physical names. The
     // optional projection narrows the output schema; when set, the predicate may still
     // reference columns outside it
-    let projection = select_cols
-        .as_ref()
-        .map(|cols| snapshot.schema().project(cols))
-        .transpose()?;
-    let scan = snapshot
+    let projection = if bare_projection {
+        let val = snapshot
+            .schema()
+            .field("val")
+            .cloned()
+            .ok_or("missing val field")?;
+        Some(Arc::new(Schema::try_new([
+            StructField::nullable("category", DataType::STRING),
+            val,
+        ])?))
+    } else {
+        select_cols
+            .as_ref()
+            .map(|cols| snapshot.schema().project(cols))
+            .transpose()?
+    };
+    let scan_result = snapshot
         .scan_builder()
         .with_schema_opt(projection)
         .with_predicate(predicate)
-        .build()?;
+        .build();
+    if bare_projection {
+        let error = match scan_result {
+            Ok(_) => return Err("bare column-mapped partition projection must fail".into()),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains(
+                "Build the projection from the scan's authoritative schema with Schema::project"
+            ),
+            "unexpected error: {error}"
+        );
+        return Ok(());
+    }
+    let scan = scan_result?;
 
     let stream = scan.execute(engine)?;
     let mut files_scanned = 0;
@@ -1131,6 +1170,10 @@ async fn test_partition_pruning_with_column_mapping(
                 );
                 let category_col = result_batch.column(category_idx).as_string::<i32>();
                 for i in 0..result_batch.num_rows() {
+                    assert!(
+                        !category_col.is_null(i),
+                        "category row {i} must not be null"
+                    );
                     assert_eq!(category_col.value(i), "A");
                 }
             }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #2469.

A manually built scan projection could lose the column-mapping metadata for a partition column.
Kernel would then look up the partition value using the logical column name and return null.

This PR validates projected partition fields when the scan is built and uses the snapshot's
physical name and data type when reading partition values. The error also tells callers to build
projections with `snapshot.schema().project(...)`. The user guide now uses that pattern too.

#3196 tracks making this automatic for all projected fields, including FFI projections.

## How was this change tested?

- `cargo test -p delta_kernel --lib --all-features`
- `cargo test -p delta_kernel --test integration --all-features`
- Workspace clippy, rustdoc, no-default-feature checks, and mdBook tests
