### PR TITLE
feat: expose commit protocol metadata

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -322,8 +322,7 @@ impl Default for Format {
     Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, IntoStructData,
 )]
 #[serde(rename_all = "camelCase")]
-#[internal_api]
-pub(crate) struct Metadata {
+pub struct Metadata {
     /// Unique identifier for this table
     id: String,
     /// User-provided identifier for this table
@@ -564,10 +563,9 @@ impl IntoEngineData for Metadata {
 // validated by `try_new`, like the JSON-replay path. Otherwise a CRC file could load a malformed
 // feature shape that log replay would reject.
 #[serde(rename_all = "camelCase", try_from = "ProtocolRaw")]
-#[internal_api]
 // TODO move to another module so that we disallow constructing this struct without using the
 // try_new function.
-pub(crate) struct Protocol {
+pub struct Protocol {
     /// The minimum version of the Delta read protocol that a client must implement
     /// in order to correctly read this table
     min_reader_version: i32,
@@ -1523,8 +1521,7 @@ pub(crate) struct CheckpointMetadata {
 #[derive(
     Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, IntoStructData, IntoEngineData,
 )]
-#[internal_api]
-pub(crate) struct DomainMetadata {
+pub struct DomainMetadata {
     domain: String,
     configuration: String,
     removed: bool,
@@ -1557,18 +1554,16 @@ impl DomainMetadata {
         self.domain.starts_with(INTERNAL_DOMAIN_PREFIX)
     }
 
-    #[internal_api]
-    pub(crate) fn domain(&self) -> &str {
+    pub fn domain(&self) -> &str {
         &self.domain
     }
 
-    #[internal_api]
-    pub(crate) fn configuration(&self) -> &str {
+    pub fn configuration(&self) -> &str {
         &self.configuration
     }
 
     /// Returns `true` if this action is a tombstone (marking domain removal).
-    pub(crate) fn is_removed(&self) -> bool {
+    pub fn is_removed(&self) -> bool {
         self.removed
     }
 }

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -53,7 +53,7 @@ impl CommitType {
 /// The protocol and metadata state for this commit. Groups the read snapshot state (if any)
 /// and the new state being committed (if any).
 #[derive(Debug)]
-pub(crate) struct CommitProtocolMetadata {
+pub struct CommitProtocolMetadata {
     /// Existing table protocol from read snapshot. `None` for create-table.
     read_protocol: Option<Protocol>,
     /// Existing table metadata from read snapshot. `None` for create-table.
@@ -92,6 +92,26 @@ impl CommitProtocolMetadata {
             new_protocol,
             new_metadata,
         })
+    }
+
+    /// Returns the protocol read by the transaction, or `None` for table creation.
+    pub fn read_protocol(&self) -> Option<&Protocol> {
+        self.read_protocol.as_ref()
+    }
+
+    /// Returns the metadata read by the transaction, or `None` for table creation.
+    pub fn read_metadata(&self) -> Option<&Metadata> {
+        self.read_metadata.as_ref()
+    }
+
+    /// Returns the protocol written by the transaction, if it changed.
+    pub fn new_protocol(&self) -> Option<&Protocol> {
+        self.new_protocol.as_ref()
+    }
+
+    /// Returns the metadata written by the transaction, if it changed.
+    pub fn new_metadata(&self) -> Option<&Metadata> {
+        self.new_metadata.as_ref()
     }
 }
 
@@ -181,6 +201,16 @@ impl CommitMetadata {
     /// The root URL of the table being committed to.
     pub fn table_root(&self) -> &Url {
         self.log_root.table_root()
+    }
+
+    /// Returns the protocol and metadata state read and written by this transaction.
+    pub fn protocol_metadata(&self) -> &CommitProtocolMetadata {
+        &self.protocol_metadata
+    }
+
+    /// Returns the domain metadata additions and removals written by this transaction.
+    pub fn domain_metadata_changes(&self) -> &[DomainMetadata] {
+        &self.domain_metadata_changes
     }
 
     /// Returns the effective protocol for this commit. Prefers new_protocol (create-table / ALTER
@@ -363,6 +393,17 @@ mod tests {
         // in_commit_timestamp
         assert_eq!(commit_metadata.in_commit_timestamp(), 1234);
         assert_eq!(commit_metadata.max_published_version(), Some(42));
+        assert!(commit_metadata
+            .protocol_metadata()
+            .read_protocol()
+            .is_some());
+        assert!(commit_metadata
+            .protocol_metadata()
+            .read_metadata()
+            .is_some());
+        assert!(commit_metadata.protocol_metadata().new_protocol().is_none());
+        assert!(commit_metadata.protocol_metadata().new_metadata().is_none());
+        assert!(commit_metadata.domain_metadata_changes().is_empty());
 
         // published commit path
         let published_path = commit_metadata.published_commit_path().unwrap();
@@ -392,5 +433,24 @@ mod tests {
             .and_then(|s| s.strip_suffix(".json"))
             .expect("Staged path should have expected format");
         uuid::Uuid::parse_str(uuid_str).expect("Staged path should contain a valid UUID");
+    }
+
+    #[test]
+    fn test_commit_protocol_metadata_changes() {
+        let protocol = Protocol::try_new_modern(Vec::<&str>::new(), Vec::<&str>::new()).unwrap();
+        let metadata =
+            Metadata::try_new(None, None, schema_ref! {}, vec![], 0, HashMap::new()).unwrap();
+        let protocol_metadata = CommitProtocolMetadata::try_new(
+            Some(protocol.clone()),
+            Some(metadata.clone()),
+            Some(protocol),
+            Some(metadata),
+        )
+        .unwrap();
+
+        assert!(protocol_metadata.read_protocol().is_some());
+        assert!(protocol_metadata.read_metadata().is_some());
+        assert!(protocol_metadata.new_protocol().is_some());
+        assert!(protocol_metadata.new_metadata().is_some());
     }
 }

--- a/kernel/src/committer/commit_types.rs
+++ b/kernel/src/committer/commit_types.rs
@@ -215,7 +215,7 @@ impl CommitMetadata {
 
     /// Returns the effective protocol for this commit. Prefers new_protocol (create-table / ALTER
     /// TABLE), falling back to the read snapshot's protocol.
-    pub(crate) fn effective_protocol(&self) -> DeltaResult<&Protocol> {
+    pub fn effective_protocol(&self) -> DeltaResult<&Protocol> {
         let pm = &self.protocol_metadata;
         pm.new_protocol
             .as_ref()
@@ -229,7 +229,7 @@ impl CommitMetadata {
 
     /// Returns the effective metadata for this commit. Prefers new_metadata (create-table / ALTER
     /// TABLE), falling back to the read snapshot's metadata.
-    pub(crate) fn effective_metadata(&self) -> DeltaResult<&Metadata> {
+    pub fn effective_metadata(&self) -> DeltaResult<&Metadata> {
         let pm = &self.protocol_metadata;
         pm.new_metadata
             .as_ref()
@@ -452,5 +452,23 @@ mod tests {
         assert!(protocol_metadata.read_metadata().is_some());
         assert!(protocol_metadata.new_protocol().is_some());
         assert!(protocol_metadata.new_metadata().is_some());
+
+        let commit_metadata = CommitMetadata::new(
+            LogRoot::new(Url::parse("s3://my-bucket/path/to/table/").unwrap()).unwrap(),
+            1,
+            CommitType::PathBasedWrite,
+            0,
+            Some(0),
+            protocol_metadata,
+            vec![],
+        );
+        assert!(std::ptr::eq(
+            commit_metadata.effective_protocol().unwrap(),
+            commit_metadata.protocol_metadata().new_protocol().unwrap()
+        ));
+        assert!(std::ptr::eq(
+            commit_metadata.effective_metadata().unwrap(),
+            commit_metadata.protocol_metadata().new_metadata().unwrap()
+        ));
     }
 }

--- a/kernel/src/committer/mod.rs
+++ b/kernel/src/committer/mod.rs
@@ -29,8 +29,7 @@ mod commit_types;
 mod filesystem;
 mod publish_types;
 
-pub(crate) use commit_types::CommitProtocolMetadata;
-pub use commit_types::{CommitMetadata, CommitResponse, CommitType};
+pub use commit_types::{CommitMetadata, CommitProtocolMetadata, CommitResponse, CommitType};
 pub use filesystem::FileSystemCommitter;
 pub use publish_types::{CatalogCommit, PublishMetadata};
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose the protocol and metadata state already carried by `CommitMetadata`, including the values read by the transaction, values written by the transaction, effective values for the commit, and domain metadata additions and removals. This lets catalog committers consume typed transaction metadata instead of deriving it from serialized commit actions.

### This PR affects the following public APIs

This exposes `CommitProtocolMetadata` and accessors for:

- The protocol and metadata read by the transaction
- The new protocol and metadata written by the transaction
- The effective protocol and metadata, preferring new values and falling back to the read snapshot
- Domain metadata additions and removals

`Protocol`, `Metadata`, and `DomainMetadata` are also made public so callers can use these values without enabling the `internal-api` feature.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo check -p delta_kernel --no-default-features`
- `cargo nextest run -p delta_kernel --all-features committer::commit_types`
- `cargo clippy --workspace --benches --tests --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`
