### PR TITLE
fix: avoid tokio blocking pool handoff deadlock

### DIFF
--- a/default-engine/src/executor.rs
+++ b/default-engine/src/executor.rs
@@ -155,11 +155,9 @@ pub mod tokio {
 
             let fut = Box::pin(async move {
                 let task_output = task.await;
-                tokio::task::spawn_blocking(move || {
-                    sender.send(task_output).ok();
-                })
-                .await
-                .unwrap();
+                // `std::sync::mpsc::Sender::send` never waits for channel capacity, so this
+                // synchronous handoff is safe to do directly from the async task.
+                sender.send(task_output).ok();
             });
 
             self.send_future(fut);
@@ -255,9 +253,6 @@ pub mod tokio {
     impl TaskExecutor for TokioMultiThreadExecutor {
         type Guard<'a> = EnterGuard<'a>;
 
-        // `block_on` uses `block_in_place`; If concurrent `block_on` calls exceed Tokio's
-        // `max_blocking_threads`, this can deadlock See:
-        // https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.max_blocking_threads
         fn block_on<T>(&self, task: T) -> T::Output
         where
             T: Future + Send + 'static,
@@ -270,11 +265,9 @@ pub mod tokio {
 
             let fut = Box::pin(async move {
                 let task_output = task.await;
-                tokio::task::spawn_blocking(move || {
-                    sender.send(task_output).ok();
-                })
-                .await
-                .unwrap();
+                // `std::sync::mpsc::Sender::send` never waits for channel capacity, so this
+                // synchronous handoff is safe to do directly from the async task.
+                sender.send(task_output).ok();
             });
 
             // We throw away the handle, but it should continue on.
@@ -414,47 +407,51 @@ pub mod tokio {
         }
 
         #[test]
-        fn test_owned_runtime_small_pool_nested_block_on_deadlocks() {
+        fn test_owned_runtime_small_blocking_pool_completes_many_block_on_calls() {
             use std::sync::Arc;
             use std::time::Duration;
 
-            // Create a small pool
             let executor = Arc::new(
-                TokioMultiThreadExecutor::new_owned_runtime(Some(1), Some(1))
+                TokioMultiThreadExecutor::new_owned_runtime(Some(2), Some(1))
                     .expect("Failed to create executor"),
             );
-            let e1 = executor.clone();
-            let e2 = executor.clone();
-            let e3 = executor.clone();
 
             let (tx, rx) = channel::<i32>();
-
-            // Spawn a thread to do deeply nested block_on calls
-            std::thread::spawn(move || {
-                let result = executor.block_on(async move {
-                    e1.block_on(async move {
-                        e2.block_on(async move {
-                            e3.block_on(async {
+            let handles = executor.block_on({
+                let executor = executor.clone();
+                let tx = tx.clone();
+                async move {
+                    let mut handles = Vec::new();
+                    for value in 0..8 {
+                        let executor = executor.clone();
+                        let tx = tx.clone();
+                        handles.push(tokio::task::spawn_blocking(move || {
+                            let result = executor.block_on(async move {
                                 tokio::time::sleep(Duration::from_millis(1)).await;
-                                42
-                            })
-                        })
-                    })
-                });
-                tx.send(result).ok();
+                                value
+                            });
+                            tx.send(result).ok();
+                        }));
+                    }
+                    handles
+                }
             });
+            drop(tx);
 
-            // With 1 worker thread, 1 blocking thread and 4 nested block_on calls, this should
-            // deadlock
-            let timeout = Duration::from_millis(500);
-            let result = rx.recv_timeout(timeout);
+            let mut results = Vec::new();
+            for _ in 0..handles.len() {
+                results.push(
+                    rx.recv_timeout(Duration::from_secs(5))
+                        .expect("Timeout - likely deadlock in TokioMultiThreadExecutor::block_on"),
+                );
+            }
 
-            // Test passes if we got a timeout (deadlock occurred as expected)
-            // Test fails if we got a result (no deadlock - unexpected)
-            assert!(
-                result.is_err(),
-                "Expected deadlock with 1 worker thread, 1 blocking thread and 4 nested block_on calls",
-            );
+            for handle in handles {
+                executor.block_on(handle).expect("blocking task panicked");
+            }
+
+            results.sort_unstable();
+            assert_eq!(results, (0..8).collect::<Vec<_>>());
         }
 
         #[test]


### PR DESCRIPTION
## What changes are proposed in this pull request?

`TokioMultiThreadExecutor::block_on` and `TokioBackgroundExecutor::block_on` already run the
requested future on the executor runtime and park the synchronous caller on an unbounded std
channel. After the future completes, they do not need to bounce the channel send through
`tokio::task::spawn_blocking`.

That extra `spawn_blocking` can deadlock when callers are already running inside Tokio's blocking
pool. For example, https://github.com/ryzhyk/delta-rs-dv-deadlock demonstrates a delta-rs scan
planning path that starts one blocking task per deletion-vector file. Each task calls back into
kernel's synchronous storage API, which uses this `block_on` bridge. If the deletion-vector tasks
fill Tokio's blocking pool, the completion handoff cannot get a second blocking-pool thread to send
the result back, so every blocking thread remains parked forever.

This PR sends the completed result directly from the async task instead. `std::sync::mpsc::Sender`
is unbounded, so the send does not need a blocking-pool slot.

It also replaces the old expected-deadlock test with a regression test that runs multiple
`block_on` calls from a Tokio blocking pool configured with `max_blocking_threads = 1`.

## How was this change tested?

- `cargo +nightly fmt`
- `cargo test -p delta_kernel_default_engine executor::tokio::test:: --features rustls --lib`
- `cargo clippy -p delta_kernel_default_engine --features rustls --lib -- -D warnings`
- `git diff --check`