### PR TITLE
fix: preserve scan file modification time

### DIFF
--- a/kernel/src/scan/mod.rs
+++ b/kernel/src/scan/mod.rs
@@ -1323,7 +1323,7 @@ impl Scan {
                     .dv_info
                     .get_selection_vector(engine.as_ref(), &table_root)?;
                 let meta = FileMeta {
-                    last_modified: 0,
+                    last_modified: scan_file.modification_time,
                     size: scan_file.size.try_into().map_err(|_| {
                         Error::generic("Unable to convert scan file size into FileSize")
                     })?,

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -1674,7 +1674,7 @@ fn test_checkpoint_reader_keeps_missing_partition_column(#[case] pred: Pred) {
 
 #[derive(Debug)]
 struct RecordedParquetRead {
-    files: Vec<String>,
+    files: Vec<FileMeta>,
     physical_schema: schema::SchemaRef,
     predicate: Option<PredicateRef>,
 }
@@ -1705,7 +1705,7 @@ impl ParquetHandler for RecordingParquetHandler {
         predicate: Option<PredicateRef>,
     ) -> DeltaResult<FileDataReadResultIterator> {
         self.reads.lock().unwrap().push(RecordedParquetRead {
-            files: files.iter().map(|file| file.location.to_string()).collect(),
+            files: files.to_vec(),
             physical_schema: physical_schema.clone(),
             predicate: predicate.clone(),
         });
@@ -1724,6 +1724,52 @@ impl ParquetHandler for RecordingParquetHandler {
     ) -> DeltaResult<()> {
         self.inner.write_parquet_file(location, data)
     }
+}
+
+#[test_log::test]
+fn scan_execute_passes_scan_file_modification_time_to_parquet_handler() {
+    let path = fs::canonicalize(PathBuf::from("./tests/data/basic_partitioned/")).unwrap();
+    let url = Url::from_directory_path(path).unwrap();
+    let sync = Arc::new(SyncEngine::new());
+    let recorder = Arc::new(RecordingParquetHandler::new(sync.parquet_handler()));
+    let engine = Arc::new(DelegatingEngine::new(sync).with_parquet_handler(recorder.clone()));
+    let snapshot = Snapshot::builder_for(url.clone())
+        .build(engine.as_ref())
+        .unwrap();
+    let scan = snapshot.scan_builder().build().unwrap();
+
+    fn collect_file_modification_times(
+        file_modification_times: &mut Vec<(String, i64)>,
+        scan_file: ScanFile,
+    ) {
+        file_modification_times.push((scan_file.path.to_string(), scan_file.modification_time));
+    }
+
+    let mut expected = Vec::new();
+    for scan_metadata in scan.scan_metadata(engine.as_ref()).unwrap() {
+        expected = scan_metadata
+            .unwrap()
+            .visit_scan_files(expected, collect_file_modification_times)
+            .unwrap();
+    }
+    recorder.take_reads();
+
+    let _: Vec<_> = scan.execute(engine.clone()).unwrap().try_collect().unwrap();
+    let reads = recorder.take_reads();
+    let mut actual: Vec<_> = reads
+        .into_iter()
+        .flat_map(|read| read.files)
+        .filter_map(|file| {
+            file.location
+                .to_string()
+                .strip_prefix(url.as_str())
+                .map(|path| (path.to_string(), file.last_modified))
+        })
+        .collect();
+
+    expected.sort_unstable();
+    actual.sort_unstable();
+    assert_eq!(actual, expected);
 }
 
 #[rstest]
@@ -1781,7 +1827,7 @@ fn test_checkpoint_stats_projection_matches_requested_output(
         .filter(|read| {
             read.files
                 .iter()
-                .any(|file| file.contains(expected_file_fragment))
+                .any(|file| file.location.as_str().contains(expected_file_fragment))
                 && read.physical_schema.field("add").is_some()
         })
         .collect();
@@ -1891,7 +1937,7 @@ fn test_checkpoint_predicate_reaches_parquet_handler(
         reads.iter().any(|read| {
             read.files
                 .iter()
-                .any(|file| file.contains(expected_file_fragment))
+                .any(|file| file.location.as_str().contains(expected_file_fragment))
                 && read
                     .predicate
                     .as_ref()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #930.

`Scan::execute` now passes each scan file's `modification_time` into the `FileMeta` sent to the
engine's parquet handler. Before this, scan execution always sent `0`, even though the log replay
had already read the Add action's timestamp.

The test parquet handler now records the full `FileMeta`, so the regression test can assert both
the selected file path and its modification time.

## How was this change tested?

`cargo nextest run -p delta_kernel --lib scan::tests::scan_execute_passes_scan_file_modification_time_to_parquet_handler`

Pre-commit hook:
`cargo +nightly fmt --check`
`cargo clippy --workspace --benches --tests --all-features -- -D warnings`
`cargo test`
`cargo llvm-cov`
