### PR TITLE
ci: route AI review models through gateway

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -377,9 +377,9 @@ jobs:
           import json, os, pathlib
           gw = os.environ['GATEWAY_BASE_URL'].rstrip('/')
           model = os.environ.get('MODEL') or 'claude-opus-4-1'
-          claude_maintainer_model = os.environ.get('CLAUDE_MAINTAINER_MODEL') or 'claude-opus-4-8'
+          claude_maintainer_model = os.environ.get('CLAUDE_MAINTAINER_MODEL') or model
           codex_maintainer_model = os.environ.get('CODEX_MAINTAINER_MODEL') or 'gpt-5-codex'
-          disprove_model = os.environ.get('DISPROVE_MODEL') or 'gpt-5.6-sol'
+          disprove_model = os.environ.get('DISPROVE_MODEL') or 'gpt-5-6-sol'
           cfg = {
               'providers': {
                   'gateway': {
@@ -406,6 +406,39 @@ jobs:
           }
           pathlib.Path.home().joinpath('.omnigent', 'config.yaml').write_text(json.dumps(cfg, indent=2))
           "
+
+      - name: Materialize reviewer model config
+        if: steps.creds.outputs.available == 'true'
+        env:
+          CLAUDE_MAINTAINER_MODEL: ${{ vars.CLAUDE_MAINTAINER_MODEL }}
+          CODEX_MAINTAINER_MODEL: ${{ vars.CODEX_MAINTAINER_MODEL }}
+          DISPROVE_MODEL: ${{ vars.DISPROVE_MODEL }}
+          MODEL: ${{ vars.MODEL }}
+        run: |
+          set -euo pipefail
+          python3 -u <<'PYEOF'
+          import os
+          import pathlib
+          import yaml
+
+          model = os.environ.get("MODEL") or "claude-opus-4-1"
+          replacements = {
+              "default": model,
+              "maintainer-claude": os.environ.get("CLAUDE_MAINTAINER_MODEL") or model,
+              "maintainer-codex": os.environ.get("CODEX_MAINTAINER_MODEL") or "gpt-5-codex",
+              "disprove": os.environ.get("DISPROVE_MODEL") or "gpt-5-6-sol",
+          }
+
+          for path in pathlib.Path(".github/omnigent/reviewer").rglob("config.yaml"):
+              cfg = yaml.safe_load(path.read_text())
+              executor = cfg.get("executor", {})
+              old_model = executor.get("model")
+              if old_model in replacements:
+                  executor["model"] = replacements[old_model]
+                  path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+          print("Materialized AI reviewer model aliases for CI runtime.")
+          PYEOF
 
       - name: Collect PR context and build review prompt
         if: steps.creds.outputs.available == 'true'
@@ -498,17 +531,38 @@ jobs:
         if: steps.creds.outputs.available == 'true'
         id: review
         env:
+          GATEWAY_BASE_URL: ${{ secrets.GATEWAY_BASE_URL }}
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          MODEL: ${{ vars.MODEL }}
         run: |
           set -euo pipefail
           prompt=$(cat /tmp/review_prompt.txt)
+          model="${MODEL:-claude-opus-4-1}"
 
+          export ANTHROPIC_AUTH_TOKEN="$LLM_API_KEY"
+          export ANTHROPIC_BASE_URL="${GATEWAY_BASE_URL%/}/anthropic"
+          export ANTHROPIC_MODEL="$model"
+          export ANTHROPIC_DEFAULT_MODEL="$model"
+          export ANTHROPIC_DEFAULT_OPUS_MODEL="$model"
+          export ANTHROPIC_DEFAULT_SONNET_MODEL="$model"
+          export OPENAI_API_KEY="$LLM_API_KEY"
+          export OPENAI_BASE_URL="${GATEWAY_BASE_URL%/}/openai"
+
+          set +e
           omnigent run .github/omnigent/reviewer/ \
             -p "$prompt" \
             --no-session \
             2>review-stderr.log \
-            | tee /tmp/review_output.txt \
-            || { echo "::warning::AI review exited non-zero"; cat review-stderr.log; }
+            | tee /tmp/review_output.txt
+          review_status="${PIPESTATUS[0]}"
+          set -e
+
+          if [ "$review_status" -ne 0 ]; then
+            echo "::warning::AI review exited with status ${review_status}."
+            if [ -s review-stderr.log ]; then
+              cat review-stderr.log
+            fi
+          fi
 
           python3 -c "
           import pathlib
@@ -528,15 +582,31 @@ jobs:
           echo "review_text<<${delim}" >> "$GITHUB_OUTPUT"
           cat /tmp/review_output.txt >> "$GITHUB_OUTPUT"
           echo "${delim}" >> "$GITHUB_OUTPUT"
+          echo "review_status=${review_status}" >> "$GITHUB_OUTPUT"
 
       - name: Scan review output for secrets before publishing
-        if: steps.creds.outputs.available == 'true'
+        if: always() && steps.creds.outputs.available == 'true'
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: |
           set -euo pipefail
           if [ -n "$LLM_API_KEY" ] && grep -qF "$LLM_API_KEY" /tmp/review_output.txt 2>/dev/null; then
             echo "::error::Review output contains LLM_API_KEY; aborting publish."
+            exit 1
+          fi
+
+      - name: Validate review output
+        if: always() && steps.creds.outputs.available == 'true'
+        env:
+          REVIEW_STATUS: ${{ steps.review.outputs.review_status }}
+        run: |
+          set -euo pipefail
+          if [ "${REVIEW_STATUS:-1}" -ne 0 ]; then
+            echo "::error::AI review exited with status ${REVIEW_STATUS:-unknown}."
+            exit 1
+          fi
+          if [ ! -s /tmp/review_output.txt ]; then
+            echo "::error::AI review produced no publishable output."
             exit 1
           fi
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes the AI PR Review workflow so the Claude-based reviewer runs through the configured gateway instead of falling back to direct Anthropic egress. It also materializes reviewer model aliases at runtime and fails artifact-mode runs when the review command exits nonzero or produces an empty output file.

## How was this change tested?

- Parsed the workflow YAML with PyYAML.
- Parsed the reviewer YAML configs.
- Ran git diff --check.
- Ran the full pre-commit hook: fmt, clippy, cargo test, and coverage.
