### PR TITLE
feat: optimize checkpoint shape resolution using sidecarSchema tag

### DIFF
--- a/kernel/src/actions/mod.rs
+++ b/kernel/src/actions/mod.rs
@@ -66,6 +66,9 @@ pub(crate) const CDC_NAME: &str = "cdc";
 pub(crate) const SIDECAR_NAME: &str = "sidecar";
 #[internal_api]
 pub(crate) const CHECKPOINT_METADATA_NAME: &str = "checkpointMetadata";
+/// Optional `checkpointMetadata.tags` key whose value is the JSON-encoded `StructType` of the
+/// checkpoint's sidecar files
+pub(crate) const SIDECAR_FILE_SCHEMA_TAG: &str = "sidecarFileSchema";
 #[internal_api]
 pub(crate) const DOMAIN_METADATA_NAME: &str = "domainMetadata";
 #[cfg(feature = "adaptive-metadata-in-dev")]

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -13,7 +13,7 @@ use crate::engine_data::RowVisitor;
 use crate::log_segment::LogSegment;
 use crate::plans::ir::nodes::FileType;
 use crate::plans::{Operation, PlanBuilder, PlanExecutor};
-use crate::schema::SchemaRef;
+use crate::schema::{SchemaRef, StructType};
 use crate::snapshot::Snapshot;
 use crate::{DeltaResult, FileMeta};
 
@@ -153,25 +153,29 @@ impl CheckpointShape {
     /// only when stats were requested. All sidecars of a checkpoint share one schema, so any one is
     /// sufficient.
     ///
-    /// If the `_last_checkpoint` hint carries a `sidecarFileSchema`, we can use it directly.
-    /// Otherwise we must read the sidecar's footer to get the schema.
+    /// If the `_last_checkpoint` hint carries a `sidecarFileSchema`, use it directly,
+    /// Otherwise read the sidecar's footer to get the schema.
     fn try_new_manifest(
         exec: &dyn PlanExecutor,
         sidecar: FileMeta,
         stats_schema: Option<&SchemaRef>,
-        hint_sidecar_schema: Option<SchemaRef>,
+        hint_sidecar_schema: Option<StructType>,
     ) -> DeltaResult<CheckpointShape> {
         let parsed_stats_schema = match stats_schema {
             Some(stats_schema) => {
-                let sidecar_schema = match hint_sidecar_schema {
-                    Some(schema) => schema,
-                    None => exec.read_parquet_footer(sidecar)?.schema,
+                let compatible = match hint_sidecar_schema {
+                    Some(schema) => {
+                        LogSegment::schema_has_compatible_stats_parsed(&schema, stats_schema)
+                    }
+                    None => {
+                        let footer_schema = exec.read_parquet_footer(sidecar)?.schema;
+                        LogSegment::schema_has_compatible_stats_parsed(
+                            footer_schema.as_ref(),
+                            stats_schema,
+                        )
+                    }
                 };
-                LogSegment::schema_has_compatible_stats_parsed(
-                    sidecar_schema.as_ref(),
-                    stats_schema,
-                )
-                .then(|| stats_schema.clone())
+                compatible.then(|| stats_schema.clone())
             }
             None => None,
         };
@@ -647,7 +651,7 @@ mod tests {
             &exec,
             sidecar,
             Some(&stats_schema),
-            Some(footer_schema),
+            Some(footer_schema.as_ref().clone()),
         )
         .unwrap();
 

--- a/kernel/src/checkpoint/checkpoint_shape.rs
+++ b/kernel/src/checkpoint/checkpoint_shape.rs
@@ -2,7 +2,6 @@
 //! leaf (file actions inline, including multi-part), or manifest (which references sidecar files).
 //! When stats are requested, also reports whether the checkpoint has compatible parsed stats.
 //! Driven through a [`PlanExecutor`].
-
 // No in-crate caller yet; following PRs will use this.
 #![allow(dead_code)]
 
@@ -82,7 +81,12 @@ impl CheckpointShape {
                 // The `sidecar` column may still be all-null (not a manifest), so scan it to
                 // confirm whether a sidecar is actually present.
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
+                    Some(sidecar) => Self::try_new_manifest(
+                        exec,
+                        sidecar,
+                        stats_schema,
+                        segment.checkpoint_hint_sidecar_file_schema(),
+                    ),
                     None => Ok(Self::try_new_leaf(Some(cp_schema), stats_schema)),
                 }
             }
@@ -91,7 +95,12 @@ impl CheckpointShape {
             // hence no parsed stats.
             FileType::Json => {
                 match collect_single_sidecar(exec, root_checkpoint, file_type, &segment.log_root)? {
-                    Some(sidecar) => Self::try_new_manifest(exec, sidecar, stats_schema),
+                    Some(sidecar) => Self::try_new_manifest(
+                        exec,
+                        sidecar,
+                        stats_schema,
+                        segment.checkpoint_hint_sidecar_file_schema(),
+                    ),
                     None => Ok(Self::try_new_leaf(None, stats_schema)),
                 }
             }
@@ -113,7 +122,12 @@ impl CheckpointShape {
         match segment.checkpoint_hint_sidecars().map(Vec::as_slice) {
             Some([sidecar, ..]) => {
                 let sidecar_meta = sidecar.to_filemeta(&segment.log_root)?;
-                let result = Self::try_new_manifest(exec, sidecar_meta, stats_schema)?;
+                let result = Self::try_new_manifest(
+                    exec,
+                    sidecar_meta,
+                    stats_schema,
+                    segment.checkpoint_hint_sidecar_file_schema(),
+                )?;
                 Ok(Some(result))
             }
             Some([]) => {
@@ -135,18 +149,29 @@ impl CheckpointShape {
     }
 
     /// Build the shape for a manifest checkpoint. Its file actions and their stats live in the
-    /// sidecars, so probe a sidecar's (parquet) footer -- but only when stats were requested. All
-    /// sidecars of a checkpoint share one schema, so probing the first is sufficient.
+    /// sidecars, so we need a sidecar's schema to answer the stats-compatibility question -- but
+    /// only when stats were requested. All sidecars of a checkpoint share one schema, so any one is
+    /// sufficient.
+    ///
+    /// If the `_last_checkpoint` hint carries a `sidecarFileSchema`, we can use it directly.
+    /// Otherwise we must read the sidecar's footer to get the schema.
     fn try_new_manifest(
         exec: &dyn PlanExecutor,
         sidecar: FileMeta,
         stats_schema: Option<&SchemaRef>,
+        hint_sidecar_schema: Option<SchemaRef>,
     ) -> DeltaResult<CheckpointShape> {
         let parsed_stats_schema = match stats_schema {
             Some(stats_schema) => {
-                let footer_schema = exec.read_parquet_footer(sidecar)?.schema;
-                LogSegment::schema_has_compatible_stats_parsed(footer_schema.as_ref(), stats_schema)
-                    .then(|| stats_schema.clone())
+                let sidecar_schema = match hint_sidecar_schema {
+                    Some(schema) => schema,
+                    None => exec.read_parquet_footer(sidecar)?.schema,
+                };
+                LogSegment::schema_has_compatible_stats_parsed(
+                    sidecar_schema.as_ref(),
+                    stats_schema,
+                )
+                .then(|| stats_schema.clone())
             }
             None => None,
         };
@@ -211,11 +236,16 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::actions::{MAX_VALUES, MIN_VALUES, NUM_RECORDS};
+    use crate::actions::{
+        CheckpointMetadata, Sidecar, ADD_NAME, MAX_VALUES, MIN_VALUES, NUM_RECORDS,
+        SIDECAR_FILE_SCHEMA_TAG, STATS_PARSED,
+    };
     use crate::engine::sync::plan::SyncPlanExecutor;
+    use crate::last_checkpoint_hint::{HintAction, LastCheckpointHint, LastCheckpointV2};
+    use crate::log_segment_files::LogSegmentFiles;
     use crate::plans::{IoOperation, PlanResult};
     use crate::schema::{schema, schema_ref};
-    use crate::unit_test_utils::load_test_table;
+    use crate::unit_test_utils::{create_log_path, create_log_path_with_size, load_test_table};
 
     /// Counts ops by kind and delegates to `SyncPlanExecutor`, to assert which I/O the fast path
     /// performs.
@@ -400,10 +430,6 @@ mod tests {
     /// empty sidecar list, so this synthetic segment is the only way to exercise the leaf fast
     /// path.
     fn segment_with_empty_sidecars_hint(extension: &str) -> LogSegment {
-        use crate::last_checkpoint_hint::{LastCheckpointHint, LastCheckpointV2};
-        use crate::log_segment_files::LogSegmentFiles;
-        use crate::unit_test_utils::{create_log_path, create_log_path_with_size};
-
         let (_store, log_root) = crate::checkpoint::tests::new_in_memory_store();
         let selected = format!(
             "00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.{extension}"
@@ -479,6 +505,155 @@ mod tests {
         assert_eq!(
             exec.footer_reads.load(Ordering::Relaxed),
             expected_footer_reads
+        );
+    }
+
+    /// Builds a segment whose applicable hint lists one sidecar and carries a `checkpointMetadata`
+    /// action with a synthetic `sidecarFileSchema` tag, exercising the footer-read short-circuit.
+    /// When `compatible`, the tagged schema's `add.stats_parsed` matches [`probe_stats_schema`];
+    /// otherwise `add` has no `stats_parsed` field at all, so the compatibility check fails.
+    fn segment_with_manifest_hint(extension: &str, compatible: bool) -> LogSegment {
+        let columns = || schema! { nullable "id": LONG, nullable "value": STRING };
+        let stats_parsed = schema! {
+            nullable NUM_RECORDS: LONG,
+            nullable MIN_VALUES: (columns()),
+            nullable MAX_VALUES: (columns()),
+        };
+        let add = if compatible {
+            schema! { nullable STATS_PARSED: (stats_parsed) }
+        } else {
+            schema! { nullable "path": STRING }
+        };
+        let sidecar_file_schema =
+            serde_json::to_string(&schema! { nullable ADD_NAME: (add) }).unwrap();
+        let tags = std::collections::HashMap::from([(
+            SIDECAR_FILE_SCHEMA_TAG.to_string(),
+            sidecar_file_schema,
+        )]);
+
+        let (_store, log_root) = crate::checkpoint::tests::new_in_memory_store();
+        let selected = format!(
+            "00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.{extension}"
+        );
+        let checkpoint_file = log_root.join(&selected).unwrap().to_string();
+        let commit = create_log_path(log_root.join("00000000000000000002.json").unwrap().as_str());
+        LogSegment::try_new(
+            LogSegmentFiles {
+                checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, 1)],
+                ascending_commit_files: vec![commit.clone()],
+                latest_commit_file: Some(commit),
+                ..Default::default()
+            },
+            log_root,
+            None,
+            Some(LastCheckpointHint {
+                version: 1,
+                v2_checkpoint: Some(LastCheckpointV2 {
+                    path: selected,
+                    sidecar_files: Some(vec![Sidecar {
+                        path: "sidecar-1.parquet".to_string(),
+                        size_in_bytes: 1,
+                        modification_time: 0,
+                        tags: None,
+                    }]),
+                    non_file_actions: Some(vec![HintAction::CheckpointMetadata(
+                        CheckpointMetadata {
+                            version: 1,
+                            tags: Some(tags),
+                        },
+                    )]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .unwrap()
+    }
+
+    /// A manifest hint carrying a `sidecarFileSchema` answers the stats-compatibility question from
+    /// the hint alone: the checkpoint classifies as a manifest, parsed stats are reported per the
+    /// hint schema's compatibility, and no sidecar footer is read (nor is the checkpoint drained).
+    #[rstest]
+    #[case::compatible_parquet("parquet", true, true)]
+    #[case::compatible_json("json", true, true)]
+    #[case::incompatible_parquet("parquet", false, false)]
+    #[case::incompatible_json("json", false, false)]
+    fn manifest_hint_sidecar_file_schema_skips_footer_read(
+        #[case] extension: &str,
+        #[case] compatible: bool,
+        #[case] expect_parsed: bool,
+    ) {
+        let segment = segment_with_manifest_hint(extension, compatible);
+        let root = &segment.listed.checkpoint_parts[0].location;
+        let file_type = match extension {
+            "json" => FileType::Json,
+            _ => FileType::Parquet,
+        };
+        let stats_schema = probe_stats_schema();
+        let exec = CountingExecutor::new();
+
+        let shape = CheckpointShape::from_v2_checkpoint_hint(
+            &exec,
+            &segment,
+            root,
+            file_type,
+            Some(&stats_schema),
+        )
+        .unwrap()
+        .expect("a sidecar-listing hint must classify as a manifest");
+
+        assert_eq!(shape.checkpoint_type, CheckpointType::Manifest);
+        assert_eq!(shape.parsed_stats_schema.is_some(), expect_parsed);
+        if expect_parsed {
+            assert_eq!(shape.parsed_stats_schema.as_ref(), Some(&stats_schema));
+        }
+        assert_eq!(
+            exec.footer_reads.load(Ordering::Relaxed),
+            0,
+            "sidecarFileSchema hint must skip the sidecar footer read"
+        );
+        assert_eq!(
+            exec.query_scans.load(Ordering::Relaxed),
+            0,
+            "the hint fast path must not drain the checkpoint"
+        );
+    }
+
+    /// The hint schema must yield the same stats-compatibility verdict as reading the sidecar's
+    /// actual parquet footer, so substituting it is behavior-preserving. Uses a real table whose
+    /// parquet sidecars carry compatible struct stats.
+    #[test]
+    fn manifest_hint_schema_matches_footer_read_result() {
+        let (_engine, snapshot, _tempdir) =
+            load_test_table("v2-parquet-sidecars-struct-stats-only").unwrap();
+        let exec = SyncPlanExecutor::default();
+        let stats_schema = probe_stats_schema();
+        let segment = snapshot.log_segment();
+
+        // Full resolution reads the sidecar footer to answer compatibility.
+        let footer_shape =
+            CheckpointShape::try_new(&exec, snapshot.as_ref(), Some(&stats_schema)).unwrap();
+        assert_eq!(footer_shape.checkpoint_type, CheckpointType::Manifest);
+
+        // Read that same footer schema ourselves and feed it as the hint schema.
+        let sidecar = segment
+            .checkpoint_hint_sidecars()
+            .and_then(|s| s.first())
+            .expect("table's hint lists sidecars")
+            .to_filemeta(&segment.log_root)
+            .unwrap();
+        let footer_schema = exec.read_parquet_footer(sidecar.clone()).unwrap().schema;
+        let hinted = CheckpointShape::try_new_manifest(
+            &exec,
+            sidecar,
+            Some(&stats_schema),
+            Some(footer_schema),
+        )
+        .unwrap();
+
+        assert_eq!(
+            hinted.parsed_stats_schema, footer_shape.parsed_stats_schema,
+            "hint-schema verdict must match the footer-read verdict"
         );
     }
 }

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -292,7 +292,7 @@ impl LogSegment {
     /// `None` when the hint is absent/mismatched, carried no `checkpointMetadata`
     /// (e.g. `nonFileActions` was trimmed), lacked the tag, or the value failed to parse.
     #[allow(unused)] // consumed by the scan-shape checkpoint classifier
-    pub(crate) fn checkpoint_hint_sidecar_file_schema(&self) -> Option<SchemaRef> {
+    pub(crate) fn checkpoint_hint_sidecar_file_schema(&self) -> Option<StructType> {
         let non_file_actions = self
             .checkpoint_hint()?
             .v2_checkpoint
@@ -307,7 +307,6 @@ impl LogSegment {
         serde_json::from_str::<StructType>(raw)
             .inspect_err(|e| warn!("Unparseable sidecarFileSchema tag, ignoring: {e}"))
             .ok()
-            .map(Arc::new)
     }
 
     /// Succinct summary string for logging purposes.

--- a/kernel/src/log_segment/mod.rs
+++ b/kernel/src/log_segment/mod.rs
@@ -10,12 +10,13 @@ use url::Url;
 
 use crate::actions::visitors::SidecarVisitor;
 use crate::actions::{
-    action_presence_leaf, schema_contains_file_actions, Sidecar, LOG_ADD_SCHEMA, SIDECAR_NAME,
+    action_presence_leaf, schema_contains_file_actions, Sidecar, LOG_ADD_SCHEMA,
+    SIDECAR_FILE_SCHEMA_TAG, SIDECAR_NAME,
 };
 use crate::cancellation::{CancellableIterator, CancellationTokenRef};
 use crate::committer::CatalogCommit;
 use crate::expressions::ColumnName;
-use crate::last_checkpoint_hint::LastCheckpointHint;
+use crate::last_checkpoint_hint::{HintAction, LastCheckpointHint};
 use crate::log_reader::commit::CommitReader;
 use crate::log_replay::ActionsBatch;
 #[internal_api]
@@ -283,6 +284,30 @@ impl LogSegment {
             .as_ref()?
             .sidecar_files
             .as_ref()
+    }
+
+    /// The sidecar files' schema from the applicable `_last_checkpoint` hint's
+    /// `checkpointMetadata.tags["sidecarFileSchema"]`.
+    ///
+    /// `None` when the hint is absent/mismatched, carried no `checkpointMetadata`
+    /// (e.g. `nonFileActions` was trimmed), lacked the tag, or the value failed to parse.
+    #[allow(unused)] // consumed by the scan-shape checkpoint classifier
+    pub(crate) fn checkpoint_hint_sidecar_file_schema(&self) -> Option<SchemaRef> {
+        let non_file_actions = self
+            .checkpoint_hint()?
+            .v2_checkpoint
+            .as_ref()?
+            .non_file_actions
+            .as_ref()?;
+        let tags = non_file_actions.iter().find_map(|action| match action {
+            HintAction::CheckpointMetadata(cp) => cp.tags.as_ref(),
+            _ => None,
+        })?;
+        let raw = tags.get(SIDECAR_FILE_SCHEMA_TAG)?;
+        serde_json::from_str::<StructType>(raw)
+            .inspect_err(|e| warn!("Unparseable sidecarFileSchema tag, ignoring: {e}"))
+            .ok()
+            .map(Arc::new)
     }
 
     /// Succinct summary string for logging purposes.

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -3126,17 +3126,17 @@ fn checkpoint_sidecars_distinguishes_empty_from_absent() -> DeltaResult<()> {
 
 /// The schema a valid `sidecarFileSchema` tag encodes, used both to build the tag and as the
 /// expected result of parsing it back.
-fn sidecar_hint_schema() -> SchemaRef {
-    schema_ref! { nullable "add": { nullable "path": STRING } }
+fn sidecar_hint_schema() -> StructType {
+    schema! { nullable "add": { nullable "path": STRING } }
 }
 
-/// A `checkpointMetadata` action carrying the given `sidecarFileSchema` tag value (`None` omits the
-/// tag).
-fn checkpoint_metadata_action(tag: Option<&str>) -> HintAction {
+/// A `checkpointMetadata` action carrying the given `(key, value)` tag (`None` omits the `tags`
+/// map entirely).
+fn checkpoint_metadata_action(tag: Option<(&str, &str)>) -> HintAction {
     HintAction::CheckpointMetadata(CheckpointMetadata {
         version: 1,
-        tags: tag.map(|v| {
-            std::collections::HashMap::from([(SIDECAR_FILE_SCHEMA_TAG.to_string(), v.to_string())])
+        tags: tag.map(|(key, value)| {
+            std::collections::HashMap::from([(key.to_string(), value.to_string())])
         }),
     })
 }
@@ -3148,17 +3148,18 @@ fn checkpoint_metadata_action(tag: Option<&str>) -> HintAction {
 #[rstest]
 #[case::valid_tag_applicable(
     true,
-    Some(vec![checkpoint_metadata_action(Some(&serde_json::to_string(&sidecar_hint_schema()).unwrap()))]),
+    Some(vec![checkpoint_metadata_action(Some((SIDECAR_FILE_SCHEMA_TAG, &serde_json::to_string(&sidecar_hint_schema()).unwrap())))]),
     true
 )]
 #[case::valid_tag_mismatched_checkpoint(
     false,
-    Some(vec![checkpoint_metadata_action(Some(&serde_json::to_string(&sidecar_hint_schema()).unwrap()))]),
+    Some(vec![checkpoint_metadata_action(Some((SIDECAR_FILE_SCHEMA_TAG, &serde_json::to_string(&sidecar_hint_schema()).unwrap())))]),
     false
 )]
 #[case::no_checkpoint_metadata(true, Some(vec![]), false)]
 #[case::metadata_without_tag(true, Some(vec![checkpoint_metadata_action(None)]), false)]
-#[case::unparseable_tag(true, Some(vec![checkpoint_metadata_action(Some("not valid json"))]), false)]
+#[case::metadata_with_unrelated_tag(true, Some(vec![checkpoint_metadata_action(Some(("numOfAddFiles", "42")))]), false)]
+#[case::unparseable_tag(true, Some(vec![checkpoint_metadata_action(Some((SIDECAR_FILE_SCHEMA_TAG, "not valid json")))]), false)]
 #[case::absent_non_file_actions(true, None, false)]
 fn checkpoint_hint_sidecar_file_schema_resolution(
     #[case] path_matches: bool,

--- a/kernel/src/log_segment/tests.rs
+++ b/kernel/src/log_segment/tests.rs
@@ -10,9 +10,9 @@ use url::Url;
 use super::*;
 use crate::actions::visitors::{AddVisitor, SidecarVisitor};
 use crate::actions::{
-    get_all_actions_schema, get_commit_schema, Add, Remove, Sidecar, ADD_NAME, COMMIT_INFO_NAME,
-    LOG_METADATA_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS, REMOVE_NAME,
-    SIDECAR_NAME,
+    get_all_actions_schema, get_commit_schema, Add, CheckpointMetadata, Remove, Sidecar, ADD_NAME,
+    COMMIT_INFO_NAME, LOG_METADATA_SCHEMA, MAX_VALUES, METADATA_NAME, MIN_VALUES, NUM_RECORDS,
+    REMOVE_NAME, SIDECAR_FILE_SCHEMA_TAG, SIDECAR_NAME,
 };
 use crate::arrow::array::StringArray;
 use crate::engine::arrow_data::ArrowEngineData;
@@ -20,7 +20,7 @@ use crate::engine::sync::json::SyncJsonHandler;
 use crate::engine::sync::SyncEngine;
 use crate::engine::test_delegating::DelegatingEngine;
 use crate::expressions::{col, column_name};
-use crate::last_checkpoint_hint::{LastCheckpointHint, LastCheckpointV2};
+use crate::last_checkpoint_hint::{HintAction, LastCheckpointHint, LastCheckpointV2};
 use crate::log_replay::ActionsBatch;
 use crate::log_segment::LogSegment;
 use crate::log_segment_files::LogSegmentFiles;
@@ -3122,6 +3122,82 @@ fn checkpoint_sidecars_distinguishes_empty_from_absent() -> DeltaResult<()> {
 
     assert_eq!(log_segment.checkpoint_hint_sidecars(), Some(&vec![]));
     Ok(())
+}
+
+/// The schema a valid `sidecarFileSchema` tag encodes, used both to build the tag and as the
+/// expected result of parsing it back.
+fn sidecar_hint_schema() -> SchemaRef {
+    schema_ref! { nullable "add": { nullable "path": STRING } }
+}
+
+/// A `checkpointMetadata` action carrying the given `sidecarFileSchema` tag value (`None` omits the
+/// tag).
+fn checkpoint_metadata_action(tag: Option<&str>) -> HintAction {
+    HintAction::CheckpointMetadata(CheckpointMetadata {
+        version: 1,
+        tags: tag.map(|v| {
+            std::collections::HashMap::from([(SIDECAR_FILE_SCHEMA_TAG.to_string(), v.to_string())])
+        }),
+    })
+}
+
+/// `checkpoint_hint_sidecar_file_schema` returns the parsed sidecar schema only when the applicable
+/// hint's `checkpointMetadata` carries a valid `sidecarFileSchema` tag. It returns `None` when the
+/// hint is inapplicable, the action or tag is missing, or the value fails to parse -- in which case
+/// the caller falls back to a footer read.
+#[rstest]
+#[case::valid_tag_applicable(
+    true,
+    Some(vec![checkpoint_metadata_action(Some(&serde_json::to_string(&sidecar_hint_schema()).unwrap()))]),
+    true
+)]
+#[case::valid_tag_mismatched_checkpoint(
+    false,
+    Some(vec![checkpoint_metadata_action(Some(&serde_json::to_string(&sidecar_hint_schema()).unwrap()))]),
+    false
+)]
+#[case::no_checkpoint_metadata(true, Some(vec![]), false)]
+#[case::metadata_without_tag(true, Some(vec![checkpoint_metadata_action(None)]), false)]
+#[case::unparseable_tag(true, Some(vec![checkpoint_metadata_action(Some("not valid json"))]), false)]
+#[case::absent_non_file_actions(true, None, false)]
+fn checkpoint_hint_sidecar_file_schema_resolution(
+    #[case] path_matches: bool,
+    #[case] non_file_actions: Option<Vec<HintAction>>,
+    #[case] expect_schema: bool,
+) {
+    // A hint that names a different same-version checkpoint does not apply to the selected one.
+    let (_store, log_root) = new_in_memory_store();
+    let selected = "00000000000000000001.checkpoint.11111111-1111-1111-1111-111111111111.parquet";
+    let other = "00000000000000000001.checkpoint.22222222-2222-2222-2222-222222222222.parquet";
+    let checkpoint_file = log_root.join(selected).unwrap().to_string();
+    let commit = create_log_path(log_root.join("00000000000000000002.json").unwrap().as_str());
+    let log_segment = LogSegment::try_new(
+        LogSegmentFiles {
+            checkpoint_parts: vec![create_log_path_with_size(&checkpoint_file, 1)],
+            ascending_commit_files: vec![commit.clone()],
+            latest_commit_file: Some(commit),
+            ..Default::default()
+        },
+        log_root,
+        None,
+        Some(LastCheckpointHint {
+            version: 1,
+            v2_checkpoint: Some(LastCheckpointV2 {
+                path: if path_matches { selected } else { other }.to_string(),
+                non_file_actions,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+    )
+    .unwrap();
+
+    let resolved = log_segment.checkpoint_hint_sidecar_file_schema();
+    if expect_schema {
+        assert_eq!(resolved, Some(sidecar_hint_schema()));
+    } else {
+        assert!(resolved.is_none());
+    }
 }
 
 /// Checkpoint schema resolution uses the `_last_checkpoint` schema only when the hint's version


### PR DESCRIPTION
## What changes are proposed in this pull request?
While resolving `CheckpointShape` for Scans, we sometimes have to do an IO (parquet footer read) in order to determine sidecar schema for V2 checkpoints. 

However, the Delta protocol actually allows for sidecar's schema to be specified as a tag inside of a `checkpointMetadata` action, stored within the "non-file actions" of the _last_checkpoint hint. See https://github.com/delta-io/delta/blob/master/PROTOCOL.md#checkpoint-metadata

We can leverage this to avoid the parquet footer read when the sidecar schema is specified. This PR implements that optimization in the CheckpointShape resolution logic.

## How was this change tested?
Unit tests
