### PR TITLE
fix: align DefaultEngine expression semantics

### DIFF
--- a/acceptance/tests/acceptance_workloads_reader.rs
+++ b/acceptance/tests/acceptance_workloads_reader.rs
@@ -406,41 +406,6 @@ const EXPECTED_KERNEL_FAILURES: &[(&str, &[&str])] = &[
         "Predicate: _metadata columns not supported",
         &["rt_filter_read/specs/rt_filter_read_read_filtered"],
     ),
-    // Kernel evaluator doesn't support `Column IN (literal_array)` pattern yet.
-    // The predicate parser correctly generates this, but evaluate_expression only handles
-    // `Literal IN Column` (scalar in array column) and `Literal IN Literal(Array)`.
-    (
-        "Kernel: Column IN (literal_array) evaluation not supported",
-        &[
-            "DV-004/specs/DV-004_filter_300_787_239",
-            "cks_dv_in_crc/specs/cks_dv_in_crc_read_remaining",
-            "dpReadPartitionAfterAppend/specs/dpReadPartitionAfterAppend_filterPartInCD",
-            "dpReadPartitionIn/specs/dpReadPartitionIn_filterPartInAC",
-            "dpReadPartitionIn/specs/dpReadPartitionIn_filterPartInBDE",
-            "ds_in_list/specs/ds_in_list_in_list_single_file",
-            "ds_in_list/specs/ds_in_list_in_list",
-            "ds_in_nested/specs/ds_in_nested_hit_code_in_1_2",
-            "ds_in_nested/specs/ds_in_nested_miss_code_in_99",
-            "ds_in_set/specs/ds_in_set_hit_in_1",
-            "ds_in_set/specs/ds_in_set_hit_in_12",
-            "ds_in_set/specs/ds_in_set_hit_in_123",
-            "ds_in_set/specs/ds_in_set_miss_in_456",
-            "ds_in_with_nulls_mixed/specs/ds_in_with_nulls_mixed_hit_in_1_null",
-            "ds_in_with_nulls_mixed/specs/ds_in_with_nulls_mixed_miss_in_99_null",
-            "ds_in_with_nulls_only/specs/ds_in_with_nulls_only_hit_in_1_2",
-            "ds_in_with_nulls_only/specs/ds_in_with_nulls_only_hit_in_5",
-            "ds_in_with_thresholds/specs/ds_in_with_thresholds_hit_in_cross_files",
-            "ds_in_with_thresholds/specs/ds_in_with_thresholds_hit_in_small",
-            "ds_in_with_thresholds/specs/ds_in_with_thresholds_miss_in_no_match",
-            "ds_not_in/specs/ds_not_in_not_in_1_2",
-            "ds_not_in/specs/ds_not_in_not_in_3",
-            "ds_not_in/specs/ds_not_in_not_in_all",
-            "ds_not_in/specs/ds_not_in_not_in_outside",
-            "dsReadInPredicate/specs/dsReadInPredicate_readInSet",
-            "dv_partition_pruning/specs/dv_partition_pruning_prune_north_or_east",
-            "tt_partition_filter/specs/tt_partition_filter_v0_part_0_or_1",
-        ],
-    ),
     // Tests with simple predicates that fail due to timestamp schema mismatch
     // These have predicates like "c1 = 1" that work, but the result comparison fails
     // because kernel uses Timestamp(Microsecond, UTC) while Spark uses Timestamp(Nanosecond, None)

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use datafusion::execution::context::SessionContext;
 use delta_kernel::StorageHandler;
 
+// TODO(#3211): Align expression lowering and evaluation with Kernel's standard expression
+// contract.
 mod expression;
 mod operator;
 mod plan;

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -1,5 +1,7 @@
 // Proto mirror of `kernel/src/expressions/mod.rs` + `scalars.rs` (the Rust IR is the source
-// of truth for these shapes).
+// of truth for this wire schema).
+//
+// Standard operator semantics are defined in `kernel/src/expressions/semantics.md`.
 //
 // Opaque{Expression,Predicate} and Unknown are escape hatches: kernel-rs can't serialise the
 // opaque trait objects, and Unknown is the "do not silently interpret" marker. They appear

--- a/kernel/src/engine/arrow_expression/conformance_tests.rs
+++ b/kernel/src/engine/arrow_expression/conformance_tests.rs
@@ -1,0 +1,653 @@
+//! Runs the shared expression fixtures against the Arrow evaluation handler.
+//!
+//! The shared module owns the executor-independent inputs and expected results. This module adapts
+//! each case to Arrow data, invokes `EvaluationHandler`, and compares the returned value or error.
+//! Unsupported, divergent, and untestable cases are listed explicitly so fixture additions cannot
+//! be skipped silently. `EvaluationHandler` accepts a caller-resolved output type and exposes no
+//! analysis result, so this harness verifies eventual values and errors but cannot verify inferred
+//! types, nullability, or when an invalid expression is rejected. See #3210.
+
+use std::collections::HashSet;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
+
+use super::{ArrowEvaluationHandler, StructArray};
+use crate::arrow::array::{ArrayRef, AsArray};
+use crate::arrow::error::ArrowError;
+use crate::engine::arrow_data::extract_record_batch;
+use crate::expressions::semantics::conformance::{
+    all_cases, project_assignment_cases, ConformanceRequirement, ExpectedError, ExpectedResult,
+};
+use crate::expressions::{Expression, Predicate, Scalar};
+use crate::schema::{schema_ref, DataType, StructField, StructType};
+use crate::{EngineData, Error, EvaluationHandler};
+
+// These cases need expression analysis without a caller-provided output type. EvaluationHandler
+// has no such entry point, so its Arrow implementation cannot execute them directly.
+const UNTESTABLE_ANALYSIS_CASES: &[&str] = &[
+    "coalesce_string_and_int_is_extension_boundary",
+    "empty_coalesce_is_rejected",
+    "coalesce_boolean_and_int_is_rejected",
+    "coalesce_analyzes_unselected_invalid_child",
+    "coalesce_struct_field_name_mismatch_is_rejected",
+    "coalesce_struct_field_count_mismatch_is_rejected",
+    "string_plus_int_is_extension_boundary",
+    "untyped_null_division_is_rejected",
+    "boolean_arithmetic_is_rejected",
+    "date_arithmetic_is_rejected",
+    "year_month_interval_arithmetic_is_rejected",
+    "day_time_interval_arithmetic_is_rejected",
+];
+
+// Portable cases that require functionality the Arrow evaluator does not provide. Each case still
+// runs and must return `Error::Unsupported`; returning a value or another error fails the harness.
+const UNSUPPORTED_STANDARD_CASES: &[&str] = &[
+    // Common-type conversion.
+    "coalesce_int_and_long",
+    "coalesce_all_null",
+    "coalesce_void_and_int",
+    "coalesce_byte_and_short",
+    "coalesce_short_and_int",
+    "coalesce_float_and_double",
+    "coalesce_decimal_and_float_returns_double",
+    "array_int_and_long",
+    "array_int_and_void",
+    "array_common_type_is_recursive",
+    "array_common_type_unions_element_nullability",
+    "map_common_type_widens_values_and_nullability",
+    "map_common_type_widens_keys",
+    "empty_map_void_key_widens_to_concrete_key",
+    "struct_common_type_is_recursive",
+    "struct_common_type_unions_field_nullability",
+    "coalesce_struct_field_names_match_case_insensitively",
+    "date_and_timestamp_ntz_use_temporal_common_type",
+    "date_to_timestamp_ntz_max_safe_day",
+    "date_to_timestamp_ntz_min_safe_day",
+    "date_to_timestamp_ntz_positive_overflow",
+    "date_to_timestamp_ntz_negative_overflow",
+    "date_and_timestamp_use_utc_temporal_common_type",
+    "date_to_timestamp_max_safe_day",
+    "date_to_timestamp_min_safe_day",
+    "date_to_timestamp_positive_overflow",
+    "date_to_timestamp_negative_overflow",
+    "timestamp_ntz_and_timestamp_use_utc",
+    "coalesce_decimal_and_byte_uses_full_integral_precision",
+    "coalesce_decimal_and_short_uses_full_integral_precision",
+    "coalesce_decimal_and_int_literal_uses_full_integral_precision",
+    "coalesce_decimal_and_long_uses_full_integral_precision",
+    "decimal_common_type_uses_maximum_scale_and_integer_digits",
+    "decimal_common_type_scale_reduction_rounds_half_up",
+    "decimal_common_type_negative_midpoint_rounds_away_from_zero",
+    "coalesce_stops_before_error",
+    // Arithmetic coercion and decimal result adjustment.
+    "decimal_add_rounds_exact_result_once",
+    "decimal_add_negative_rounds_exact_result_once",
+    "decimal_subtract_rounds_exact_result_once",
+    "decimal_scale_reduction_rounds_half_up",
+    "decimal_scale_reduction_negative_midpoint_rounds_away_from_zero",
+    "decimal_adjusted_scale_preserves_available_fractional_digits",
+    "decimal_plus_int_column",
+    "decimal_plus_minimum_precision_int_literal",
+    "decimal_plus_zero_literal_uses_one_digit_precision",
+    "decimal_plus_non_literal_int_uses_full_precision",
+    "decimal_division_result_type",
+    "decimal_division_rounds_half_up",
+    "negative_decimal_division_rounds_away_from_zero",
+    // Common-type and nested comparison.
+    "date_and_timestamp_compare_in_utc",
+    "decimal_comparison_uses_minimum_integral_literal_precision",
+    "decimal_comparison_uses_full_integral_column_precision",
+    "comparison_ignores_struct_field_names_after_positional_alignment",
+    "comparison_aligns_struct_field_nullability",
+    "nested_null_struct_fields_compare_equal",
+    "nested_null_struct_field_sorts_first",
+    "nested_null_array_elements_compare_equal",
+    "nested_null_array_element_sorts_first",
+    "arrays_compare_lexicographically",
+    "array_comparison_coerces_nested_struct_fields",
+    "structs_compare_in_field_order",
+    "array_comparison_uses_nan_equality",
+    "distinct_ignores_struct_field_names_after_positional_alignment",
+    // IN common-type and nested comparison.
+    "literal_in_uses_numeric_common_type",
+    "literal_in_ignores_struct_field_names_after_positional_alignment",
+    "literal_in_coerces_nested_array_elements",
+    "column_in_uses_numeric_common_type",
+    "column_in_integral_and_float_promote_to_double",
+    "column_in_decimal_uses_minimum_integral_literal_precision",
+    "column_in_aligns_structs_with_different_field_nullability",
+    "column_in_case_insensitive_struct_names_allow_leaf_widening",
+    "column_in_ignores_struct_field_names_after_positional_alignment",
+];
+
+// Portable cases that execute but return the wrong value or error category. The harness requires
+// the mismatch to remain visible and fails when a fixed case is not removed from this inventory.
+const STANDARD_DIVERGENCES: &[&str] = &["interval_cross_family_comparison_is_rejected"];
+
+// Valid Project assignments that the Arrow evaluator cannot perform. Each case must return
+// `Error::Unsupported`, rather than being rejected as an invalid assignment.
+const UNSUPPORTED_PROJECT_CASES: &[&str] = &[
+    "project_byte_to_short",
+    "project_byte_to_int",
+    "project_byte_to_long",
+    "project_byte_to_float",
+    "project_byte_to_double",
+    "project_short_to_int",
+    "project_short_to_long",
+    "project_short_to_float",
+    "project_short_to_double",
+    "project_int_to_long",
+    "project_int_to_double",
+    "project_float_to_double",
+    "project_date_to_timestamp_ntz",
+    "project_date_to_timestamp_ntz_max_safe_day",
+    "project_date_to_timestamp_ntz_min_safe_day",
+    "project_date_to_timestamp_ntz_positive_overflow",
+    "project_date_to_timestamp_ntz_negative_overflow",
+    "project_void_to_nullable",
+    "project_int_to_decimal",
+    "project_decimal_to_wider_decimal",
+    "project_array_decimal_assignment_is_recursive",
+    "project_array_element_widens",
+    "project_map_value_widens",
+    "project_map_key_widens",
+    "project_struct_assignment_is_recursive_and_positional",
+    "project_empty_void_array_element_to_required_target",
+    "project_empty_void_map_value_to_required_target",
+    "project_empty_void_map_key_to_concrete_target",
+    "project_void_array_element_to_nullable_target",
+    "project_void_map_value_to_nullable_target",
+    "project_void_struct_field_to_nullable_target",
+    "project_struct_fields_align_positionally",
+];
+
+// Project cases that execute but differ from the contract. Input-schema nullability is not
+// flow-sensitive, so the evaluator cannot distinguish an unsafe assignment from a projection
+// reached after a filter has established a non-null value.
+const PROJECT_DIVERGENCES: &[&str] = &[
+    "project_nullable_to_required_is_rejected",
+    "project_target_does_not_change_decimal_arithmetic_inference",
+];
+
+#[test]
+fn standard_cases_match_arrow_support_inventory() {
+    let unsupported: HashSet<_> = UNSUPPORTED_STANDARD_CASES.iter().copied().collect();
+    let divergences: HashSet<_> = STANDARD_DIVERGENCES.iter().copied().collect();
+    let analysis_gaps: HashSet<_> = UNTESTABLE_ANALYSIS_CASES.iter().copied().collect();
+    assert_eq!(unsupported.len(), UNSUPPORTED_STANDARD_CASES.len());
+    assert_eq!(divergences.len(), STANDARD_DIVERGENCES.len());
+    assert_eq!(analysis_gaps.len(), UNTESTABLE_ANALYSIS_CASES.len());
+
+    let mut seen_unsupported = HashSet::new();
+    let mut seen_divergences = HashSet::new();
+    let mut seen_analysis_gaps = HashSet::new();
+    let mut failures = Vec::new();
+    for case in all_cases().unwrap() {
+        let expectation = if analysis_gaps.contains(case.name) {
+            seen_analysis_gaps.insert(case.name);
+            CaseExpectation::AnalysisApiGap
+        } else if case.requirement == ConformanceRequirement::ExtensionBoundary {
+            CaseExpectation::ExtensionBoundary
+        } else if unsupported.contains(case.name) {
+            seen_unsupported.insert(case.name);
+            CaseExpectation::Unsupported
+        } else if divergences.contains(case.name) {
+            seen_divergences.insert(case.name);
+            CaseExpectation::Diverges
+        } else {
+            CaseExpectation::Conform
+        };
+
+        if expectation == CaseExpectation::AnalysisApiGap {
+            if case.output.is_some() || matches!(case.expression, Expression::Predicate(_)) {
+                failures.push(format!(
+                    "{} is executable and should not be an API gap",
+                    case.name
+                ));
+            }
+            continue;
+        }
+
+        if expectation == CaseExpectation::Unsupported
+            && matches!(
+                &case.expected,
+                ExpectedResult::Error(ExpectedError::InvalidExpression)
+            )
+        {
+            failures.push(format!(
+                "{} is invalid and must not be inventoried as unsupported",
+                case.name
+            ));
+        }
+
+        let mut executed = false;
+        if let Some(output) = &case.output {
+            executed = true;
+            if let Some(failure) = capture_failure(|| {
+                expression_failure(
+                    case.input_schema.clone(),
+                    case.input_row.clone(),
+                    case.expression.clone(),
+                    output.data_type.clone(),
+                    &case.expected,
+                    expectation,
+                )
+            }) {
+                failures.push(format!("{} [expression]: {failure}", case.name));
+            }
+        }
+
+        if let Expression::Predicate(predicate) = &case.expression {
+            executed = true;
+            if let Some(failure) = capture_failure(|| {
+                predicate_failure(
+                    case.input_schema,
+                    case.input_row,
+                    predicate,
+                    &case.expected,
+                    expectation,
+                )
+            }) {
+                failures.push(format!("{} [predicate]: {failure}", case.name));
+            }
+        }
+        if !executed {
+            failures.push(format!("{} was not executed or inventoried", case.name));
+        }
+    }
+
+    inventory_failure(
+        "unsupported standard",
+        &unsupported,
+        &seen_unsupported,
+        &mut failures,
+    );
+    inventory_failure(
+        "standard divergence",
+        &divergences,
+        &seen_divergences,
+        &mut failures,
+    );
+    inventory_failure(
+        "untestable analysis",
+        &analysis_gaps,
+        &seen_analysis_gaps,
+        &mut failures,
+    );
+    assert!(
+        failures.is_empty(),
+        "standard-expression conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn project_cases_match_arrow_support_inventory() {
+    let unsupported: HashSet<_> = UNSUPPORTED_PROJECT_CASES.iter().copied().collect();
+    let divergences: HashSet<_> = PROJECT_DIVERGENCES.iter().copied().collect();
+    assert_eq!(unsupported.len(), UNSUPPORTED_PROJECT_CASES.len());
+    assert_eq!(divergences.len(), PROJECT_DIVERGENCES.len());
+
+    let mut seen_unsupported = HashSet::new();
+    let mut seen_divergences = HashSet::new();
+    let mut failures = Vec::new();
+    for case in project_assignment_cases().unwrap() {
+        let expectation = if unsupported.contains(case.name) {
+            seen_unsupported.insert(case.name);
+            CaseExpectation::Unsupported
+        } else if divergences.contains(case.name) {
+            seen_divergences.insert(case.name);
+            CaseExpectation::Diverges
+        } else {
+            CaseExpectation::Conform
+        };
+        if expectation == CaseExpectation::Unsupported
+            && matches!(
+                &case.expected,
+                ExpectedResult::Error(ExpectedError::InvalidExpression)
+            )
+        {
+            failures.push(format!(
+                "{} is invalid and must not be inventoried as unsupported",
+                case.name
+            ));
+        }
+        let target_schema = Arc::new(StructType::new_unchecked([StructField::new(
+            "output",
+            case.target.data_type.clone(),
+            case.target.nullable,
+        )]));
+        if let Some(failure) = capture_failure(|| {
+            let result = evaluate(
+                case.input_schema,
+                case.input_row,
+                Expression::struct_from([case.expression]),
+                DataType::from(target_schema),
+            );
+            check_result(result, &case.expected, &case.target.data_type, expectation)
+        }) {
+            failures.push(format!("{}: {failure}", case.name));
+        }
+    }
+
+    inventory_failure(
+        "unsupported Project",
+        &unsupported,
+        &seen_unsupported,
+        &mut failures,
+    );
+    inventory_failure(
+        "Project divergence",
+        &divergences,
+        &seen_divergences,
+        &mut failures,
+    );
+    assert!(
+        failures.is_empty(),
+        "Project-assignment conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn coalesce_per_row_short_circuit_divergence_is_inventoried() {
+    let handler = ArrowEvaluationHandler;
+    let input_schema = schema_ref! {
+        nullable "a": DOUBLE,
+        not_null "d": DOUBLE,
+    };
+    let rows = [
+        [Scalar::Double(1.0), Scalar::Double(0.0)],
+        [Scalar::Null(DataType::DOUBLE), Scalar::Double(2.0)],
+    ];
+    let row_refs: Vec<_> = rows.iter().map(|row| row.as_slice()).collect();
+    let input = handler
+        .create_many(input_schema.clone(), &row_refs)
+        .unwrap();
+    let expression = Expression::coalesce([
+        crate::expressions::col!("a"),
+        Expression::binary(
+            crate::expressions::BinaryExpressionOp::Divide,
+            Expression::Literal(Scalar::Double(1.0)),
+            crate::expressions::col!("d"),
+        ),
+    ]);
+    let evaluator = handler
+        .new_expression_evaluator(input_schema, expression.into(), DataType::DOUBLE)
+        .unwrap();
+
+    assert!(matches!(
+        evaluator.evaluate(input.as_ref()),
+        Err(Error::Arrow(ArrowError::DivideByZero))
+    ));
+}
+
+#[test]
+fn interval_arithmetic_analysis_gap_is_inventoried() {
+    let cases = [
+        (
+            Scalar::IntervalYearMonth(1),
+            Scalar::IntervalYearMonth(2),
+            DataType::INTERVAL_YEAR_MONTH,
+        ),
+        (
+            Scalar::IntervalDayTime(1),
+            Scalar::IntervalDayTime(2),
+            DataType::INTERVAL_DAY_TIME,
+        ),
+    ];
+    for (left, right, output_type) in cases {
+        let expression = Expression::binary(
+            crate::expressions::BinaryExpressionOp::Plus,
+            Expression::Literal(left),
+            Expression::Literal(right),
+        );
+        assert!(evaluate(schema_ref! {}, vec![], expression, output_type).is_ok());
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CaseExpectation {
+    // A portable case must return exactly the documented value or error.
+    Conform,
+    // A valid portable case must explicitly report missing evaluator support.
+    Unsupported,
+    // An executed portable case is known to return the wrong value or error category.
+    Diverges,
+    // Behavior is outside the portable contract; strict rejection or an extension is allowed.
+    ExtensionBoundary,
+    // The handler API cannot expose the analysis result needed to run this case.
+    AnalysisApiGap,
+}
+
+fn inventory_failure<'a>(
+    label: &str,
+    expected: &HashSet<&'a str>,
+    seen: &HashSet<&'a str>,
+    failures: &mut Vec<String>,
+) {
+    let mut missing: Vec<_> = expected.difference(seen).copied().collect();
+    missing.sort_unstable();
+    if !missing.is_empty() {
+        failures.push(format!(
+            "stale {label} inventory entries: {}",
+            missing.join(", ")
+        ));
+    }
+}
+
+fn capture_failure(run: impl FnOnce() -> Option<String>) -> Option<String> {
+    // Capture panics so one broken fixture does not hide failures from the remaining fixtures.
+    match catch_unwind(AssertUnwindSafe(run)) {
+        Ok(failure) => failure,
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown panic");
+            Some(format!("panicked: {message}"))
+        }
+    }
+}
+
+fn expression_failure(
+    input_schema: crate::schema::SchemaRef,
+    input_row: Vec<Scalar>,
+    expression: Expression,
+    output_type: DataType,
+    expected: &ExpectedResult,
+    expectation: CaseExpectation,
+) -> Option<String> {
+    check_result(
+        evaluate(input_schema, input_row, expression, output_type.clone()),
+        expected,
+        &output_type,
+        expectation,
+    )
+}
+
+fn predicate_failure(
+    input_schema: crate::schema::SchemaRef,
+    input_row: Vec<Scalar>,
+    predicate: &Predicate,
+    expected: &ExpectedResult,
+    expectation: CaseExpectation,
+) -> Option<String> {
+    let handler = ArrowEvaluationHandler;
+    let input = match handler.create_many(input_schema.clone(), &[input_row.as_slice()]) {
+        Ok(input) => input,
+        Err(error) => return Some(format!("could not create input: {error}")),
+    };
+    let evaluator = match handler.new_predicate_evaluator(input_schema, predicate.clone().into()) {
+        Ok(evaluator) => evaluator,
+        Err(error) => return check_error(error, expected, expectation),
+    };
+    check_result(
+        evaluator.evaluate(input.as_ref()),
+        expected,
+        &DataType::BOOLEAN,
+        expectation,
+    )
+}
+
+fn evaluate(
+    input_schema: crate::schema::SchemaRef,
+    input_row: Vec<Scalar>,
+    expression: Expression,
+    output_type: DataType,
+) -> Result<Box<dyn EngineData>, Error> {
+    let handler = ArrowEvaluationHandler;
+    let input = handler.create_many(input_schema.clone(), &[input_row.as_slice()])?;
+    let evaluator =
+        handler.new_expression_evaluator(input_schema, expression.into(), output_type)?;
+    evaluator.evaluate(input.as_ref())
+}
+
+fn check_result(
+    result: Result<Box<dyn EngineData>, Error>,
+    expected: &ExpectedResult,
+    output_type: &DataType,
+    expectation: CaseExpectation,
+) -> Option<String> {
+    match expectation {
+        CaseExpectation::Unsupported => match result {
+            Err(error) if is_unsupported(&error) => None,
+            Err(error) => Some(format!("expected Unsupported, returned {error}")),
+            Ok(_) => Some("expected Unsupported, returned a value".to_string()),
+        },
+        CaseExpectation::ExtensionBoundary => match result {
+            Ok(_) => None,
+            Err(error)
+                if is_unsupported(&error)
+                    || error_matches(&error, ExpectedError::InvalidExpression) =>
+            {
+                None
+            }
+            Err(error) => Some(format!("unexpected extension-boundary error: {error}")),
+        },
+        CaseExpectation::Conform => conforming_result_failure(result, expected, output_type),
+        CaseExpectation::Diverges => conforming_result_failure(result, expected, output_type)
+            .is_none()
+            .then(|| "case now conforms; remove it from the divergence inventory".to_string()),
+        CaseExpectation::AnalysisApiGap => Some("analysis API gap was executed".to_string()),
+    }
+}
+
+fn check_error(
+    error: Error,
+    expected: &ExpectedResult,
+    expectation: CaseExpectation,
+) -> Option<String> {
+    match expectation {
+        CaseExpectation::Unsupported if is_unsupported(&error) => None,
+        CaseExpectation::ExtensionBoundary
+            if is_unsupported(&error)
+                || error_matches(&error, ExpectedError::InvalidExpression) =>
+        {
+            None
+        }
+        CaseExpectation::Conform => match expected {
+            ExpectedResult::Error(expected) => error_failure(error, *expected),
+            ExpectedResult::Value(_) => Some(format!("returned error: {error}")),
+        },
+        CaseExpectation::Diverges => match expected {
+            ExpectedResult::Error(expected) if error_failure(error, *expected).is_none() => {
+                Some("case now conforms; remove it from the divergence inventory".to_string())
+            }
+            _ => None,
+        },
+        _ => Some(format!("unexpected evaluator-construction error: {error}")),
+    }
+}
+
+fn conforming_result_failure(
+    result: Result<Box<dyn EngineData>, Error>,
+    expected: &ExpectedResult,
+    output_type: &DataType,
+) -> Option<String> {
+    match (result, expected) {
+        (Ok(output), ExpectedResult::Value(expected)) => {
+            let actual = output_array(output.as_ref(), output_type);
+            let expected = match expected.to_array(1) {
+                Ok(expected) => expected,
+                Err(error) => return Some(format!("invalid expected value: {error}")),
+            };
+            (!arrays_equal(&actual, &expected))
+                .then(|| format!("expected {expected:?}, got {actual:?}"))
+        }
+        (Err(error), ExpectedResult::Value(_)) => Some(format!("returned error: {error}")),
+        (Ok(_), ExpectedResult::Error(expected)) => {
+            Some(format!("expected {expected:?}, returned a value"))
+        }
+        (Err(error), ExpectedResult::Error(expected)) => error_failure(error, *expected),
+    }
+}
+
+fn error_failure(error: Error, expected: ExpectedError) -> Option<String> {
+    (!error_matches(&error, expected)).then(|| format!("expected {expected:?}, returned {error}"))
+}
+
+fn error_matches(error: &Error, expected: ExpectedError) -> bool {
+    match (error, expected) {
+        (Error::InvalidExpressionEvaluation(_), ExpectedError::InvalidExpression) => true,
+        (
+            Error::Arrow(ArrowError::InvalidArgumentError(message)),
+            ExpectedError::InvalidExpression,
+        ) if is_arrow_analysis_error(message) => true,
+        (Error::Arrow(ArrowError::ArithmeticOverflow(_)), ExpectedError::ArithmeticOverflow) => {
+            true
+        }
+        (Error::Arrow(ArrowError::DivideByZero), ExpectedError::DivideByZero) => true,
+        (Error::Backtraced { source, .. }, _) => error_matches(source, expected),
+        _ => false,
+    }
+}
+
+fn is_arrow_analysis_error(message: &str) -> bool {
+    message.starts_with("Incorrect datatype.")
+        || message.starts_with("Invalid arithmetic operation:")
+        || message.starts_with("Missing Struct fields ")
+        || message.starts_with("Requested result type ")
+}
+
+fn is_unsupported(error: &Error) -> bool {
+    match error {
+        Error::Unsupported(_) => true,
+        Error::Backtraced { source, .. } => is_unsupported(source),
+        _ => false,
+    }
+}
+
+fn arrays_equal(actual: &ArrayRef, expected: &ArrayRef) -> bool {
+    if actual.data_type() != expected.data_type() || actual.len() != expected.len() {
+        return false;
+    }
+    match actual.data_type() {
+        crate::arrow::datatypes::DataType::Float32 => {
+            let actual = actual.as_primitive::<crate::arrow::datatypes::Float32Type>();
+            let expected = expected.as_primitive::<crate::arrow::datatypes::Float32Type>();
+            actual.iter().zip(expected).all(|(actual, expected)| {
+                matches!((actual, expected), (None, None))
+                    || matches!((actual, expected), (Some(actual), Some(expected)) if actual == expected || (actual.is_nan() && expected.is_nan()))
+            })
+        }
+        crate::arrow::datatypes::DataType::Float64 => {
+            let actual = actual.as_primitive::<crate::arrow::datatypes::Float64Type>();
+            let expected = expected.as_primitive::<crate::arrow::datatypes::Float64Type>();
+            actual.iter().zip(expected).all(|(actual, expected)| {
+                matches!((actual, expected), (None, None))
+                    || matches!((actual, expected), (Some(actual), Some(expected)) if actual == expected || (actual.is_nan() && expected.is_nan()))
+            })
+        }
+        _ => actual.to_data() == expected.to_data(),
+    }
+}
+
+fn output_array(output: &dyn EngineData, output_type: &DataType) -> ArrayRef {
+    let batch = extract_record_batch(output).unwrap();
+    match output_type {
+        DataType::Struct(_) => Arc::new(StructArray::from(batch.clone())),
+        _ => batch.column(0).clone(),
+    }
+}

--- a/kernel/src/engine/arrow_expression/evaluate_expression.rs
+++ b/kernel/src/engine/arrow_expression/evaluate_expression.rs
@@ -9,21 +9,19 @@ use tracing::warn;
 
 use crate::arrow::array::types::*;
 use crate::arrow::array::{
-    self as arrow_array, make_array, new_null_array, Array, ArrayBuilder, ArrayData, ArrayRef,
-    AsArray, BooleanArray, Datum, ListArray, MapArray, MutableArrayData, NullBufferBuilder,
-    RecordBatch, StringArray, StructArray,
+    self as arrow_array, make_array, new_empty_array, new_null_array, Array, ArrayBuilder,
+    ArrayData, ArrayRef, AsArray, BooleanArray, Datum, GenericListArray, ListArray, MapArray,
+    MutableArrayData, NullBufferBuilder, OffsetSizeTrait, RecordBatch, StringArray, StructArray,
 };
 use crate::arrow::buffer::{NullBuffer, OffsetBuffer};
 use crate::arrow::compute::kernels::cast_utils::{string_to_datetime, Parser};
-use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, gt_eq, lt, lt_eq, neq, not_distinct};
-use crate::arrow::compute::kernels::comparison::in_list_utf8;
+use crate::arrow::compute::kernels::cmp::{distinct, eq, gt, lt};
 use crate::arrow::compute::kernels::numeric::{add, div, mul, sub};
 use crate::arrow::compute::{
     and_kleene, can_cast_types, cast, is_not_null, is_null, not, or_kleene,
 };
 use crate::arrow::datatypes::{
-    DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, IntervalUnit,
-    Schema as ArrowSchema, TimeUnit,
+    DataType as ArrowDataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
 };
 use crate::arrow::error::ArrowError;
 use crate::arrow::json::writer::{make_encoder, EncoderOptions};
@@ -33,7 +31,7 @@ use crate::engine::arrow_conversion::{TryFromKernel, TryIntoArrow, LIST_ARRAY_RO
 use crate::engine::arrow_expression::opaque::{
     ArrowOpaqueExpressionOpAdaptor, ArrowOpaquePredicateOpAdaptor,
 };
-use crate::engine::arrow_utils::{parse_json_impl, prim_array_cmp};
+use crate::engine::arrow_utils::parse_json_impl;
 use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{
@@ -316,8 +314,39 @@ pub fn evaluate_expression(
             ))),
         },
         (Binary(BinaryExpression { op, left, right }), _) => {
-            let left_arr = evaluate_expression(left.as_ref(), batch, None)?;
-            let right_arr = evaluate_expression(right.as_ref(), batch, None)?;
+            let mut left_arr = evaluate_expression(left.as_ref(), batch, None)?;
+            let mut right_arr = evaluate_expression(right.as_ref(), batch, None)?;
+
+            if *op == Divide {
+                return evaluate_division(&left_arr, &right_arr, result_type);
+            }
+
+            if !is_numeric_or_null(left_arr.data_type())
+                || !is_numeric_or_null(right_arr.data_type())
+                || (left_arr.data_type() == &ArrowDataType::Null
+                    && right_arr.data_type() == &ArrowDataType::Null)
+            {
+                return Err(Error::invalid_expression(format!(
+                    "Arithmetic requires numeric operands, got {:?} and {:?}",
+                    left_arr.data_type(),
+                    right_arr.data_type()
+                )));
+            }
+            let Some(common_type) =
+                simple_numeric_common_type(left_arr.data_type(), right_arr.data_type())
+            else {
+                return Err(Error::unsupported(format!(
+                    "Arrow evaluator does not yet support arithmetic coercion between {:?} and {:?}",
+                    left_arr.data_type(),
+                    right_arr.data_type()
+                )));
+            };
+            if left_arr.data_type() != &common_type {
+                left_arr = cast(&left_arr, &common_type)?;
+            }
+            if right_arr.data_type() != &common_type {
+                right_arr = cast(&right_arr, &common_type)?;
+            }
 
             type Operation = fn(&dyn Datum, &dyn Datum) -> Result<ArrayRef, ArrowError>;
             let eval: Operation = match op {
@@ -327,7 +356,15 @@ pub fn evaluate_expression(
                 Divide => div,
             };
 
-            validate_array_type(eval(&left_arr, &right_arr)?, result_type)
+            let result = eval(&left_arr, &right_arr).map_err(|error| match error {
+                ArrowError::ArithmeticOverflow(_) | ArrowError::DivideByZero => Error::from(error),
+                error => Error::unsupported(format!(
+                    "Arrow evaluator does not yet support this arithmetic operation: {error}"
+                )),
+            })?;
+            validate_decimal_bounds(&result)?;
+            validate_array_type(result, result_type)
+                .map_err(|error| unsupported_type_conversion("arithmetic result adjustment", error))
         }
         (
             Variadic(VariadicExpression {
@@ -339,7 +376,9 @@ pub fn evaluate_expression(
             let mut arrays: Vec<ArrayRef> = Vec::with_capacity(exprs.len());
 
             for expr in exprs {
-                let array = evaluate_expression(expr, batch, result_type)?;
+                let array = evaluate_expression(expr, batch, result_type).map_err(|error| {
+                    unsupported_type_conversion("COALESCE common-type conversion", error)
+                })?;
                 let null_count = array.null_count();
                 arrays.push(array);
                 // Short-circuit: if this array has no nulls, we can stop evaluating
@@ -350,10 +389,13 @@ pub fn evaluate_expression(
             }
 
             // Coalesce accumulated arrays
-            Ok(coalesce_arrays(&arrays, result_type)?)
+            coalesce_arrays(&arrays, result_type).map_err(|error| {
+                unsupported_type_conversion("COALESCE common-type conversion", error.into())
+            })
         }
         (Variadic(VariadicExpression { op: Array, exprs }), result_type) => {
             evaluate_array_expression(exprs, batch, result_type)
+                .map_err(|error| unsupported_type_conversion("ARRAY common-type conversion", error))
         }
         (Opaque(OpaqueExpression { op, exprs }), _) => {
             match op
@@ -411,12 +453,207 @@ pub fn evaluate_expression(
     }
 }
 
+/// Reclassifies a missing Arrow conversion as unsupported without hiding invalid expressions or
+/// runtime errors such as overflow and division by zero.
+fn unsupported_type_conversion(context: &str, error: Error) -> Error {
+    let is_type_mismatch = match &error {
+        Error::Arrow(ArrowError::InvalidArgumentError(message)) => {
+            message.starts_with("Incorrect datatype.")
+                || message.starts_with("Requested result type ")
+        }
+        Error::Generic(message) => {
+            message.starts_with("Array expression inputs must share the same element type")
+        }
+        _ => false,
+    };
+    if is_type_mismatch {
+        Error::unsupported(format!(
+            "Arrow evaluator does not support {context}: {error}"
+        ))
+    } else {
+        error
+    }
+}
+
+/// Resolves the numeric common types implemented directly by this evaluator.
+///
+/// Decimal/integral coercion and decimal result-type adjustment require expression analysis and
+/// therefore return `None` here.
+fn simple_numeric_common_type(
+    left: &ArrowDataType,
+    right: &ArrowDataType,
+) -> Option<ArrowDataType> {
+    use ArrowDataType::*;
+
+    if left == right && is_numeric_type(left) {
+        return Some(left.clone());
+    }
+    if left == &Null && is_numeric_type(right) {
+        return Some(right.clone());
+    }
+    if right == &Null && is_numeric_type(left) {
+        return Some(left.clone());
+    }
+    if matches!(left, Decimal128(_, _)) || matches!(right, Decimal128(_, _)) {
+        return (matches!(left, Float32 | Float64) || matches!(right, Float32 | Float64))
+            .then_some(Float64);
+    }
+    if matches!(left, Float32 | Float64) || matches!(right, Float32 | Float64) {
+        return Some(if left == &Float32 && right == &Float32 {
+            Float32
+        } else {
+            Float64
+        });
+    }
+    let integral_rank = |data_type: &ArrowDataType| match data_type {
+        Int8 => Some(0),
+        Int16 => Some(1),
+        Int32 => Some(2),
+        Int64 => Some(3),
+        _ => None,
+    };
+    match integral_rank(left)?.max(integral_rank(right)?) {
+        0 => Some(Int8),
+        1 => Some(Int16),
+        2 => Some(Int32),
+        3 => Some(Int64),
+        _ => None,
+    }
+}
+
+/// Implements fractional SQL division for the numeric cases supported by the Arrow evaluator.
+///
+/// Non-decimal operands use `DOUBLE`, positive or negative zero raises divide-by-zero, and
+/// decimal-only division remains unsupported until its resolved precision and scale are available.
+fn evaluate_division(
+    left: &ArrayRef,
+    right: &ArrayRef,
+    result_type: Option<&DataType>,
+) -> DeltaResult<ArrayRef> {
+    use ArrowDataType::*;
+
+    if left.len() != right.len() {
+        return Err(Error::internal_error(format!(
+            "Division operands have different lengths: {} and {}",
+            left.len(),
+            right.len()
+        )));
+    }
+
+    if left.data_type() == &Null && right.data_type() == &Null {
+        return Err(Error::invalid_expression(
+            "Division requires at least one typed numeric operand",
+        ));
+    }
+    if left.data_type() == &Null || right.data_type() == &Null {
+        let other_type = if left.data_type() == &Null {
+            right.data_type()
+        } else {
+            left.data_type()
+        };
+        if !is_numeric_type(other_type) {
+            return Err(Error::invalid_expression(format!(
+                "Division requires numeric operands, got {other_type:?}"
+            )));
+        }
+        if matches!(other_type, ArrowDataType::Decimal128(_, _)) {
+            let Some(result_type @ DataType::Primitive(PrimitiveType::Decimal(_))) = result_type
+            else {
+                return Err(Error::unsupported(
+                    "Arrow evaluator requires the resolved decimal type for NULL division",
+                ));
+            };
+            return Ok(new_null_array(&result_type.try_into_arrow()?, left.len()));
+        }
+        return validate_array_type(
+            new_null_array(&ArrowDataType::Float64, left.len()),
+            result_type,
+        );
+    }
+    if let (ArrowDataType::Decimal128(_, _), ArrowDataType::Decimal128(_, _)) =
+        (left.data_type(), right.data_type())
+    {
+        let left_values = left.as_primitive::<Decimal128Type>();
+        let right_values = right.as_primitive::<Decimal128Type>();
+        for index in 0..left.len() {
+            if left_values.is_valid(index)
+                && right_values.is_valid(index)
+                && right_values.value(index) == 0
+            {
+                return Err(ArrowError::DivideByZero.into());
+            }
+        }
+    }
+    if !is_numeric_type(left.data_type()) || !is_numeric_type(right.data_type()) {
+        return Err(Error::invalid_expression(format!(
+            "Division requires numeric operands, got {:?} and {:?}",
+            left.data_type(),
+            right.data_type()
+        )));
+    }
+    let has_decimal = matches!(left.data_type(), ArrowDataType::Decimal128(_, _))
+        || matches!(right.data_type(), ArrowDataType::Decimal128(_, _));
+    let has_float = matches!(
+        left.data_type(),
+        ArrowDataType::Float32 | ArrowDataType::Float64
+    ) || matches!(
+        right.data_type(),
+        ArrowDataType::Float32 | ArrowDataType::Float64
+    );
+    if has_decimal && !has_float {
+        return Err(Error::unsupported(format!(
+            "Arrow evaluator does not support division between {:?} and {:?}",
+            left.data_type(),
+            right.data_type()
+        )));
+    }
+
+    let left = cast(left, &ArrowDataType::Float64)?;
+    let right = cast(right, &ArrowDataType::Float64)?;
+    let left_values = left.as_primitive::<Float64Type>();
+    let right_values = right.as_primitive::<Float64Type>();
+    for index in 0..left.len() {
+        if left_values.is_valid(index)
+            && right_values.is_valid(index)
+            && right_values.value(index) == 0.0
+        {
+            return Err(ArrowError::DivideByZero.into());
+        }
+    }
+
+    validate_array_type(div(&left, &right)?, result_type)
+}
+
+/// Enforces declared decimal precision after Arrow arithmetic, which may produce an out-of-range
+/// physical value without reporting overflow.
+fn validate_decimal_bounds(array: &ArrayRef) -> DeltaResult<()> {
+    let ArrowDataType::Decimal128(precision, _) = array.data_type() else {
+        return Ok(());
+    };
+    let bound = 10_u128.checked_pow(u32::from(*precision)).ok_or_else(|| {
+        Error::internal_error(format!("Invalid Decimal128 precision: {precision}"))
+    })?;
+    let values = array.as_primitive::<Decimal128Type>();
+    if values
+        .iter()
+        .flatten()
+        .any(|value| value.unsigned_abs() >= bound)
+    {
+        return Err(ArrowError::ArithmeticOverflow(format!(
+            "Decimal128 result exceeds precision {precision}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 /// Evaluate an `ARRAY(e0, e1, ..., eN-1)` constructor expression into an Arrow `ListArray`.
 ///
 /// Each input expression produces one column of length M (rows in the batch); the output
 /// is an `Array<element_type>` column of length M where row i holds
 /// `[arr_0[i], ..., arr_{N-1}[i]]`. The element type is inferred from the inputs (which must
-/// all evaluate to the same Arrow element type); at least one input is required.
+/// all evaluate to the same Arrow element type). An empty constructor requires `result_type` to
+/// supply the element type.
 ///
 /// When provided, `result_type` must be a [`DataType::Array`]. Its element type is forwarded
 /// to the children as a schema hint (struct/nested-array elements need their schema to
@@ -447,11 +684,17 @@ fn evaluate_array_expression(
         .map(|expr| evaluate_expression(expr, batch, element_kernel_type))
         .try_collect()?;
 
-    let element_type = element_arrays
-        .first()
-        .ok_or_else(|| Error::generic("Array expression requires at least one element"))?
-        .data_type()
-        .clone();
+    let element_type = match element_arrays.first() {
+        Some(element) => element.data_type().clone(),
+        None => match element_kernel_type {
+            Some(data_type) => data_type.try_into_arrow()?,
+            None => {
+                return Err(Error::invalid_expression(
+                    "Cannot infer the element type of an empty ARRAY expression",
+                ));
+            }
+        },
+    };
     // Single pass over the evaluated inputs: every input must evaluate to the shared element
     // type, and (when the element field is declared non-nullable) must not contain nulls --
     // otherwise the output's field metadata would lie about the values it holds.
@@ -476,19 +719,23 @@ fn evaluate_array_expression(
     // Build the flat values buffer in row-major order: row r is [arr_0[r], ..., arr_{n-1}[r]].
     // `MutableArrayData` is type-erased (works for any element type) and avoids the
     // (num_rows * n)-sized indices buffer that `arrow_select::interleave` would require.
-    let array_data: Vec<ArrayData> = element_arrays.iter().map(|a| a.to_data()).collect();
     let total_len = num_rows.checked_mul(n).ok_or_else(|| {
         Error::generic(format!(
             "Array expression length overflows usize: num_rows={num_rows} * inputs={n}"
         ))
     })?;
-    let mut mutable = MutableArrayData::new(array_data.iter().collect(), false, total_len);
-    for row in 0..num_rows {
-        for col in 0..n {
-            mutable.extend(col, row, row + 1);
+    let values = if element_arrays.is_empty() {
+        new_empty_array(&element_type)
+    } else {
+        let array_data: Vec<ArrayData> = element_arrays.iter().map(|a| a.to_data()).collect();
+        let mut mutable = MutableArrayData::new(array_data.iter().collect(), false, total_len);
+        for row in 0..num_rows {
+            for col in 0..n {
+                mutable.extend(col, row, row + 1);
+            }
         }
-    }
-    let values = make_array(mutable.freeze());
+        make_array(mutable.freeze())
+    };
 
     // Every row's list has exactly `n` elements. `from_lengths` builds `[0, n, 2n, ..., M*n]`
     // but panics on i32 overflow, so guard first (`LargeListArray` would be needed beyond
@@ -512,14 +759,14 @@ fn evaluate_array_expression(
     validate_array_type(Arc::new(list), result_type)
 }
 
-/// Direction for casting between Arrow view and non-view string/binary types.
+/// Target representation for string and binary normalization.
 #[derive(Clone, Copy)]
 enum ViewCast {
     ToView,
     ToNonView,
 }
 
-/// Casts list element types between view and non-view string/binary variants.
+/// Normalizes list elements to a canonical string or binary representation.
 ///
 /// When [`ViewCast::ToView`], non-view string/binary element types are converted to their view
 /// equivalents (e.g. `List<Utf8>` -> `List<Utf8View>`). View container types (`ListView`,
@@ -543,8 +790,17 @@ fn cast_list_elements(
             _ => return Ok(vals.clone()),
         },
         ViewCast::ToNonView => match field.data_type() {
-            ArrowDataType::Utf8View => ArrowDataType::Utf8,
-            ArrowDataType::BinaryView => ArrowDataType::Binary,
+            ArrowDataType::Utf8View | ArrowDataType::LargeUtf8 => ArrowDataType::Utf8,
+            ArrowDataType::BinaryView
+            | ArrowDataType::LargeBinary
+            | ArrowDataType::FixedSizeBinary(_) => ArrowDataType::Binary,
+            ArrowDataType::Dictionary(_, value) => match value.as_ref() {
+                ArrowDataType::LargeUtf8 | ArrowDataType::Utf8View => ArrowDataType::Utf8,
+                ArrowDataType::LargeBinary
+                | ArrowDataType::BinaryView
+                | ArrowDataType::FixedSizeBinary(_) => ArrowDataType::Binary,
+                value => value.clone(),
+            },
             other => {
                 if !matches!(
                     vals.data_type(),
@@ -579,9 +835,7 @@ fn cast_list_elements(
     Ok(cast(vals, &container)?)
 }
 
-/// This function converts ArrowView types to their non-view type equivalents. This is used for
-/// [`evaluate_predicate`] conversion, currently does not support nested conversion. This only
-/// supports limited conversions (see code for exactly which).
+/// Normalizes supported physical encodings to non-view string, binary, or list types.
 fn arrow_convert_to_non_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array>> {
     match vals.data_type() {
         ArrowDataType::List(field) => cast_list_elements(&vals, field, ViewCast::ToNonView),
@@ -590,15 +844,20 @@ fn arrow_convert_to_non_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn A
         ArrowDataType::LargeListView(field) => {
             cast_list_elements(&vals, field, ViewCast::ToNonView)
         }
-        ArrowDataType::Utf8View => Ok(cast(&vals, &ArrowDataType::Utf8)?),
-        ArrowDataType::BinaryView => Ok(cast(&vals, &ArrowDataType::Binary)?),
+        ArrowDataType::Utf8View | ArrowDataType::LargeUtf8 => {
+            Ok(cast(&vals, &ArrowDataType::Utf8)?)
+        }
+        ArrowDataType::BinaryView
+        | ArrowDataType::LargeBinary
+        | ArrowDataType::FixedSizeBinary(_) => Ok(cast(&vals, &ArrowDataType::Binary)?),
+        ArrowDataType::Dictionary(_, value) => {
+            arrow_convert_to_non_view_type(cast(&vals, value.as_ref())?)
+        }
         _ => Ok(vals),
     }
 }
 
-/// This function converts  Arrow types to their Arrow view type equivalents. This is used for
-/// [`evaluate_predicate`] conversion, currently does not support nested conversion. This only
-/// supports limited conversions (see code for exactly which).
+/// Normalizes supported physical encodings to view string, binary, or list types.
 fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array>> {
     match vals.data_type() {
         ArrowDataType::List(field) => cast_list_elements(&vals, field, ViewCast::ToView),
@@ -612,6 +871,424 @@ fn arrow_convert_to_view_type(vals: Arc<dyn Array>) -> DeltaResult<Arc<dyn Array
             Ok(cast(&vals, &ArrowDataType::BinaryView)?)
         }
         _ => Ok(vals),
+    }
+}
+
+fn is_nested_type(data_type: &ArrowDataType) -> bool {
+    matches!(
+        data_type,
+        ArrowDataType::List(_)
+            | ArrowDataType::LargeList(_)
+            | ArrowDataType::ListView(_)
+            | ArrowDataType::LargeListView(_)
+            | ArrowDataType::FixedSizeList(_, _)
+            | ArrowDataType::Map(_, _)
+            | ArrowDataType::Struct(_)
+    )
+}
+
+fn is_numeric_type(data_type: &ArrowDataType) -> bool {
+    matches!(
+        data_type,
+        ArrowDataType::Int8
+            | ArrowDataType::Int16
+            | ArrowDataType::Int32
+            | ArrowDataType::Int64
+            | ArrowDataType::Float32
+            | ArrowDataType::Float64
+            | ArrowDataType::Decimal128(_, _)
+    )
+}
+
+fn is_numeric_or_null(data_type: &ArrowDataType) -> bool {
+    data_type == &ArrowDataType::Null || is_numeric_type(data_type)
+}
+
+/// Returns whether the comparison contract can align two operand types.
+///
+/// The evaluator uses this only to distinguish a valid but unimplemented coercion from an invalid
+/// comparison; it does not perform the coercion here.
+fn comparison_types_may_share_common_type(left: &ArrowDataType, right: &ArrowDataType) -> bool {
+    use ArrowDataType::*;
+
+    if left == right {
+        return is_orderable_type(left);
+    }
+    if left == &Null {
+        return is_orderable_type(right);
+    }
+    if right == &Null {
+        return is_orderable_type(left);
+    }
+    let is_temporal =
+        |data_type: &ArrowDataType| matches!(data_type, Date32 | Date64 | Timestamp(_, _));
+
+    if is_numeric_type(left) && is_numeric_type(right) || is_temporal(left) && is_temporal(right) {
+        return true;
+    }
+    match (left, right) {
+        (List(left), List(right))
+        | (LargeList(left), LargeList(right))
+        | (ListView(left), ListView(right))
+        | (LargeListView(left), LargeListView(right)) => {
+            comparison_types_may_share_common_type(left.data_type(), right.data_type())
+        }
+        (FixedSizeList(left, left_len), FixedSizeList(right, right_len)) => {
+            left_len == right_len
+                && comparison_types_may_share_common_type(left.data_type(), right.data_type())
+        }
+        (Struct(left), Struct(right)) => {
+            left.len() == right.len()
+                && left.iter().zip(right).all(|(left, right)| {
+                    let leaf_types_match = left.data_type() == right.data_type();
+                    comparison_types_may_share_common_type(left.data_type(), right.data_type())
+                        && (leaf_types_match || left.name().eq_ignore_ascii_case(right.name()))
+                })
+        }
+        _ => false,
+    }
+}
+
+/// Applies Kernel's recursive orderability rules before dispatching to Arrow comparison kernels.
+fn is_orderable_type(data_type: &ArrowDataType) -> bool {
+    use ArrowDataType::*;
+
+    match data_type {
+        Null
+        | Boolean
+        | Int8
+        | Int16
+        | Int32
+        | Int64
+        | Float32
+        | Float64
+        | Decimal128(_, _)
+        | Utf8
+        | LargeUtf8
+        | Utf8View
+        | Binary
+        | LargeBinary
+        | BinaryView
+        | FixedSizeBinary(_)
+        | Date32
+        | Date64
+        | Timestamp(_, _)
+        | Interval(_) => true,
+        List(field) | LargeList(field) | ListView(field) | LargeListView(field) => {
+            is_orderable_type(field.data_type())
+        }
+        FixedSizeList(field, _) => is_orderable_type(field.data_type()),
+        Struct(fields) => fields
+            .iter()
+            .all(|field| is_orderable_type(field.data_type())),
+        _ => false,
+    }
+}
+
+/// Identifies Arrow encodings whose mismatch is an unsupported representation, not an invalid SQL
+/// operand type.
+fn is_alternate_physical_type(data_type: &ArrowDataType) -> bool {
+    matches!(
+        data_type,
+        ArrowDataType::LargeUtf8
+            | ArrowDataType::LargeBinary
+            | ArrowDataType::FixedSizeBinary(_)
+            | ArrowDataType::Dictionary(_, _)
+    )
+}
+
+fn ordering_matches(op: BinaryPredicateOp, ordering: std::cmp::Ordering) -> bool {
+    use std::cmp::Ordering::{Equal as OrdEqual, Greater, Less};
+
+    use BinaryPredicateOp::*;
+
+    match op {
+        LessThan => ordering == Less,
+        GreaterThan => ordering == Greater,
+        Equal => ordering == OrdEqual,
+        Distinct => ordering != OrdEqual,
+        In => false,
+    }
+}
+
+/// Applies SQL float ordering: NaN equals NaN and sorts after every non-NaN value, while signed
+/// zeros compare equal.
+fn evaluate_float_comparison(
+    op: BinaryPredicateOp,
+    left: &ArrayRef,
+    right: &ArrayRef,
+) -> Option<BooleanArray> {
+    macro_rules! compare {
+        ($arrow_type:ty) => {{
+            let left = left.as_primitive::<$arrow_type>();
+            let right = right.as_primitive::<$arrow_type>();
+            let values = (0..left.len()).map(|index| {
+                let (left_valid, right_valid) = (left.is_valid(index), right.is_valid(index));
+                if op == BinaryPredicateOp::Distinct {
+                    return match (left_valid, right_valid) {
+                        (false, false) => Some(false),
+                        (false, true) | (true, false) => Some(true),
+                        (true, true) => {
+                            let (left, right) = (left.value(index), right.value(index));
+                            let ordering = match (left.is_nan(), right.is_nan()) {
+                                (true, true) => std::cmp::Ordering::Equal,
+                                (true, false) => std::cmp::Ordering::Greater,
+                                (false, true) => std::cmp::Ordering::Less,
+                                (false, false) => left
+                                    .partial_cmp(&right)
+                                    .unwrap_or(std::cmp::Ordering::Equal),
+                            };
+                            Some(ordering_matches(op, ordering))
+                        }
+                    };
+                }
+                if !left_valid || !right_valid {
+                    return None;
+                }
+                let (left, right) = (left.value(index), right.value(index));
+                let ordering = match (left.is_nan(), right.is_nan()) {
+                    (true, true) => std::cmp::Ordering::Equal,
+                    (true, false) => std::cmp::Ordering::Greater,
+                    (false, true) => std::cmp::Ordering::Less,
+                    (false, false) => left
+                        .partial_cmp(&right)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                };
+                Some(ordering_matches(op, ordering))
+            });
+            BooleanArray::from_iter(values)
+        }};
+    }
+
+    match left.data_type() {
+        ArrowDataType::Float32 => Some(compare!(Float32Type)),
+        ArrowDataType::Float64 => Some(compare!(Float64Type)),
+        _ => None,
+    }
+}
+
+/// Validates comparison operands, applies the supported common-type conversions, and evaluates
+/// scalar comparisons. Valid nested or coercible cases without Arrow support return `Unsupported`.
+fn evaluate_comparison(
+    op: BinaryPredicateOp,
+    left: ArrayRef,
+    right: ArrayRef,
+    inverted: bool,
+) -> DeltaResult<BooleanArray> {
+    if !is_orderable_type(left.data_type()) || !is_orderable_type(right.data_type()) {
+        return Err(Error::invalid_expression(format!(
+            "Comparison requires orderable operands, got {:?} and {:?}",
+            left.data_type(),
+            right.data_type()
+        )));
+    }
+    if matches!(left.data_type(), ArrowDataType::Interval(_))
+        && matches!(right.data_type(), ArrowDataType::Interval(_))
+        && left.data_type() != right.data_type()
+    {
+        return Err(Error::invalid_expression(
+            "Intervals from different families are not comparable",
+        ));
+    }
+    let (left, right) = if left.data_type() == right.data_type() {
+        (left, right)
+    } else if left.data_type() == &ArrowDataType::Null && !is_nested_type(right.data_type()) {
+        (cast(&left, right.data_type())?, right)
+    } else if right.data_type() == &ArrowDataType::Null && !is_nested_type(left.data_type()) {
+        let common_type = left.data_type().clone();
+        (left, cast(&right, &common_type)?)
+    } else if let Some(common_type) =
+        simple_numeric_common_type(left.data_type(), right.data_type())
+    {
+        (cast(&left, &common_type)?, cast(&right, &common_type)?)
+    } else {
+        (
+            arrow_convert_to_view_type(left)?,
+            arrow_convert_to_view_type(right)?,
+        )
+    };
+    if left.data_type() != right.data_type() {
+        let message = format!(
+            "Comparison operands have incompatible types {:?} and {:?}",
+            left.data_type(),
+            right.data_type()
+        );
+        return if comparison_types_may_share_common_type(left.data_type(), right.data_type()) {
+            Err(Error::unsupported(format!(
+                "Arrow evaluator does not support common-type conversion: {message}"
+            )))
+        } else {
+            Err(Error::invalid_expression(message))
+        };
+    }
+    if is_nested_type(left.data_type()) {
+        return Err(Error::unsupported(format!(
+            "Arrow evaluator does not support nested comparison for {:?}",
+            left.data_type()
+        )));
+    }
+
+    let result = if let Some(result) = evaluate_float_comparison(op, &left, &right) {
+        result
+    } else {
+        match op {
+            BinaryPredicateOp::LessThan => lt(&left, &right)?,
+            BinaryPredicateOp::GreaterThan => gt(&left, &right)?,
+            BinaryPredicateOp::Equal => eq(&left, &right)?,
+            BinaryPredicateOp::Distinct => distinct(&left, &right)?,
+            BinaryPredicateOp::In => {
+                return Err(Error::internal_error(
+                    "IN reached the standard comparison evaluator",
+                ));
+            }
+        }
+    };
+    Ok(if inverted { not(&result)? } else { result })
+}
+
+/// Compares one membership candidate using SQL equality. A null operand returns `None`, and two
+/// NaNs compare equal.
+fn sql_equal_at(
+    left: &ArrayRef,
+    left_index: usize,
+    right: &ArrayRef,
+    right_index: usize,
+) -> DeltaResult<Option<bool>> {
+    if left.is_null(left_index) || right.is_null(right_index) {
+        return Ok(None);
+    }
+    match left.data_type() {
+        ArrowDataType::Float32 => {
+            let left = left.as_primitive::<Float32Type>().value(left_index);
+            let right = right.as_primitive::<Float32Type>().value(right_index);
+            Ok(Some((left.is_nan() && right.is_nan()) || left == right))
+        }
+        ArrowDataType::Float64 => {
+            let left = left.as_primitive::<Float64Type>().value(left_index);
+            let right = right.as_primitive::<Float64Type>().value(right_index);
+            Ok(Some((left.is_nan() && right.is_nan()) || left == right))
+        }
+        _ => {
+            let left = left.slice(left_index, 1);
+            let right = right.slice(right_index, 1);
+            Ok(Some(eq(&left, &right)?.value(0)))
+        }
+    }
+}
+
+/// Evaluates one candidate array per input row using SQL three-valued membership semantics.
+/// Empty candidate arrays return false before inspecting a null left operand.
+fn evaluate_in_list<O: OffsetSizeTrait>(
+    left: &ArrayRef,
+    right: &GenericListArray<O>,
+) -> DeltaResult<BooleanArray> {
+    if left.len() != right.len() {
+        return Err(Error::internal_error(format!(
+            "IN operands have different lengths: {} and {}",
+            left.len(),
+            right.len()
+        )));
+    }
+    let values = right.values();
+    if matches!(values.data_type(), ArrowDataType::Map(_, _)) {
+        return Err(Error::invalid_expression(
+            "IN does not support MAP operands",
+        ));
+    }
+    if left.data_type() != values.data_type()
+        && left.data_type() != &ArrowDataType::Null
+        && values.data_type() != &ArrowDataType::Null
+    {
+        let message = format!(
+            "IN operands have incompatible types {:?} and {:?}",
+            left.data_type(),
+            values.data_type()
+        );
+        return if is_nested_type(left.data_type()) && is_nested_type(values.data_type()) {
+            Err(Error::unsupported(format!(
+                "Arrow evaluator does not support nested common-type conversion: {message}"
+            )))
+        } else if is_numeric_type(left.data_type()) && is_numeric_type(values.data_type()) {
+            Err(Error::unsupported(format!(
+                "Arrow evaluator does not yet support common-type conversion: {message}"
+            )))
+        } else if is_alternate_physical_type(left.data_type())
+            || is_alternate_physical_type(values.data_type())
+        {
+            Err(Error::unsupported(format!(
+                "Arrow evaluator does not support this physical representation: {message}"
+            )))
+        } else {
+            Err(Error::invalid_expression(message))
+        };
+    }
+    if is_nested_type(left.data_type()) || is_nested_type(values.data_type()) {
+        return Err(Error::unsupported(format!(
+            "Arrow evaluator does not support nested IN operands {:?} and {:?}",
+            left.data_type(),
+            values.data_type()
+        )));
+    }
+
+    let mut output = Vec::with_capacity(left.len());
+    for row in 0..left.len() {
+        if right.is_null(row) {
+            output.push(None);
+            continue;
+        }
+        let candidates = right.value(row);
+        if candidates.is_empty() {
+            output.push(Some(false));
+            continue;
+        }
+        if left.is_null(row) {
+            output.push(None);
+            continue;
+        }
+
+        let mut saw_null = false;
+        let mut matched = false;
+        for candidate in 0..candidates.len() {
+            match sql_equal_at(left, row, &candidates, candidate)? {
+                Some(true) => {
+                    matched = true;
+                    break;
+                }
+                Some(false) => {}
+                None => saw_null = true,
+            }
+        }
+        output.push(
+            matched
+                .then_some(true)
+                .or_else(|| (!saw_null).then_some(false)),
+        );
+    }
+    Ok(BooleanArray::from(output))
+}
+
+/// Evaluates any left expression against an array-valued right expression after normalizing the
+/// supported Arrow string, binary, and list encodings.
+fn evaluate_in(
+    left: &Expression,
+    right: &Expression,
+    batch: &RecordBatch,
+) -> DeltaResult<BooleanArray> {
+    let left = arrow_convert_to_non_view_type(evaluate_expression(left, batch, None)?)?;
+    let right = arrow_convert_to_non_view_type(evaluate_expression(right, batch, None)?)?;
+    if let Some(right) = right.as_list_opt::<i32>() {
+        evaluate_in_list(&left, right)
+    } else if let Some(right) = right.as_list_opt::<i64>() {
+        evaluate_in_list(&left, right)
+    } else if matches!(right.data_type(), ArrowDataType::FixedSizeList(_, _)) {
+        Err(Error::unsupported(
+            "Arrow evaluator does not support IN with FixedSizeList right operands",
+        ))
+    } else {
+        Err(Error::invalid_expression(format!(
+            "IN requires an array-valued right operand, got {:?}",
+            right.data_type()
+        )))
     }
 }
 
@@ -652,101 +1329,14 @@ pub fn evaluate_predicate(
         }
         Binary(BinaryPredicate { op, left, right }) => {
             let (left, right) = (left.as_ref(), right.as_ref());
-
-            // IN is different from all the others, and also quite complex, so factor it out.
-            //
-            // TODO: Factor out as a stand-alone function instead of a closure?
-            let eval_in = || match (left, right) {
-                (Expression::Literal(_), Expression::Column(_)) => {
-                    let left = evaluate_expression(left, batch, None)?;
-                    let left = arrow_convert_to_non_view_type(left)?;
-
-                    let right = evaluate_expression(right, batch, None)?;
-                    let right = arrow_convert_to_non_view_type(right)?;
-                    if let Some(string_arr) = left.as_string_opt::<i32>() {
-                        if let Some(list_arr) = right.as_list_opt::<i32>() {
-                            if list_arr.value_type() == ArrowDataType::Utf8 {
-                                let result = in_list_utf8(string_arr, list_arr)?;
-                                return Ok(result);
-                            }
-                        }
-                    }
-
-                    use ArrowDataType::*;
-                    prim_array_cmp! {
-                        left, right,
-                        (Int8, Int8Type),
-                        (Int16, Int16Type),
-                        (Int32, Int32Type),
-                        (Int64, Int64Type),
-                        (UInt8, UInt8Type),
-                        (UInt16, UInt16Type),
-                        (UInt32, UInt32Type),
-                        (UInt64, UInt64Type),
-                        (Float16, Float16Type),
-                        (Float32, Float32Type),
-                        (Float64, Float64Type),
-                        (Timestamp(TimeUnit::Second, _), TimestampSecondType),
-                        (Timestamp(TimeUnit::Millisecond, _), TimestampMillisecondType),
-                        (Timestamp(TimeUnit::Microsecond, _), TimestampMicrosecondType),
-                        (Timestamp(TimeUnit::Nanosecond, _), TimestampNanosecondType),
-                        (Date32, Date32Type),
-                        (Date64, Date64Type),
-                        (Time32(TimeUnit::Second), Time32SecondType),
-                        (Time32(TimeUnit::Millisecond), Time32MillisecondType),
-                        (Time64(TimeUnit::Microsecond), Time64MicrosecondType),
-                        (Time64(TimeUnit::Nanosecond), Time64NanosecondType),
-                        (Duration(TimeUnit::Second), DurationSecondType),
-                        (Duration(TimeUnit::Millisecond), DurationMillisecondType),
-                        (Duration(TimeUnit::Microsecond), DurationMicrosecondType),
-                        (Duration(TimeUnit::Nanosecond), DurationNanosecondType),
-                        (Interval(IntervalUnit::DayTime), IntervalDayTimeType),
-                        (Interval(IntervalUnit::YearMonth), IntervalYearMonthType),
-                        (Interval(IntervalUnit::MonthDayNano), IntervalMonthDayNanoType),
-                        (Decimal128(_, _), Decimal128Type),
-                        (Decimal256(_, _), Decimal256Type)
-                    }
-                }
-                (Expression::Literal(lit), Expression::Literal(Scalar::Array(ad))) => {
-                    // Logical (SQL) equality, so a NULL never matches another NULL. Struct, array,
-                    // and map elements/needles are unsupported: `logical_eq` returns `false` for
-                    // them, so they never match, not even a structurally identical value.
-                    let exists = ad.array_elements().iter().any(|e| lit.logical_eq(e));
-                    Ok(BooleanArray::from(vec![exists]))
-                }
-                (l, r) => Err(Error::invalid_expression(format!(
-                    "Invalid right value for (NOT) IN comparison, left is: {l} right is: {r}"
-                ))),
-            };
-
-            let eval_fn = match (op, inverted) {
-                (LessThan, false) => lt,
-                (LessThan, true) => gt_eq,
-                (GreaterThan, false) => gt,
-                (GreaterThan, true) => lt_eq,
-                (Equal, false) => eq,
-                (Equal, true) => neq,
-                (Distinct, false) => distinct,
-                (Distinct, true) => not_distinct,
-                (In, _) => return Ok(maybe_inverted(Cow::Owned(eval_in()?))?),
-            };
-
+            if *op == In {
+                return Ok(maybe_inverted(Cow::Owned(evaluate_in(
+                    left, right, batch,
+                )?))?);
+            }
             let left = evaluate_expression(left, batch, None)?;
             let right = evaluate_expression(right, batch, None)?;
-
-            // If the types differ (e.g. one side is a view type and the other is not),
-            // normalize both to view types since benchamrking results show that casting from
-            // non-view to view type is faster than casting from view type to non-view
-            // type.
-            let (left, right) = if left.data_type() == right.data_type() {
-                (left, right)
-            } else {
-                (
-                    arrow_convert_to_view_type(left)?,
-                    arrow_convert_to_view_type(right)?,
-                )
-            };
-            Ok(eval_fn(&left, &right)?)
+            evaluate_comparison(*op, left, right, inverted)
         }
         Junction(JunctionPredicate { op, preds }) => {
             // Leverage de Morgan's laws (invert the children and swap the operator):
@@ -1914,9 +2504,8 @@ mod tests {
         assert_eq!(result.value(0), expected);
     }
 
-    /// The two element sources `IN` accepts, both holding `elements`: a literal `Array` scalar
-    /// and a single-row `list` column. The batch also carries an `n` column (always `1`) so the
-    /// needle can be a column in the operand-shape rejection test.
+    /// Build equivalent literal-array and list-column right operands, plus a one-row `n` column
+    /// for tests that need a column-valued left operand.
     fn in_element_sources(elements: &[Option<i32>]) -> (Expr, Expr, RecordBatch) {
         let scalars = elements
             .iter()
@@ -1944,40 +2533,45 @@ mod tests {
         (literal, col!("list"), batch)
     }
 
-    /// NULL never matches because logical equality treats it as incomparable, including to itself.
+    /// IN uses SQL three-valued logic: a match wins, otherwise a NULL operand makes the result
+    /// NULL.
     #[rstest]
-    #[case::present(Some(2), &[Some(1), Some(2)], true)]
-    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
-    #[case::null_needle(None, &[Some(1), Some(2)], false)]
-    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
-    #[case::null_needle_with_only_null_element(None, &[None], false)]
-    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
-    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
-    fn test_in_membership_never_nulls(
-        #[case] needle: Option<i32>,
+    #[case::present(Some(2), &[Some(1), Some(2)], Some(true))]
+    #[case::absent(Some(9), &[Some(1), Some(2)], Some(false))]
+    #[case::null_value(None, &[Some(1), Some(2)], None)]
+    #[case::null_value_and_element(None, &[Some(1), None], None)]
+    #[case::null_value_with_only_null_element(None, &[None], None)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], Some(true))]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], None)]
+    fn test_in_membership_uses_three_valued_logic(
+        #[case] value: Option<i32>,
         #[case] elements: &[Option<i32>],
-        #[case] expected: bool,
+        #[case] expected: Option<bool>,
     ) {
         let (literal_source, column_source, batch) = in_element_sources(elements);
-        let needle = match needle {
+        let value = match value {
             Some(n) => lit(n),
             None => null_lit(DataType::INTEGER),
         };
-        for elements in [literal_source, column_source] {
-            let pred = Pred::binary(BinaryPredicateOp::In, needle.clone(), elements);
+        for (source, elements) in [("literal", literal_source), ("column", column_source)] {
+            let pred = Pred::binary(BinaryPredicateOp::In, value.clone(), elements);
             let result = evaluate_predicate(&pred, &batch, false).unwrap();
-            assert_eq!(result.null_count(), 0);
-            assert_eq!(result.value(0), expected);
+            assert_eq!(
+                result.is_valid(0).then(|| result.value(0)),
+                expected,
+                "{source} right operand"
+            );
 
-            // `IN` never produces NULL, so `NOT IN` is always its exact complement.
             let result = evaluate_predicate(&Pred::not(pred), &batch, false).unwrap();
-            assert_eq!(result.null_count(), 0);
-            assert_eq!(result.value(0), !expected);
+            assert_eq!(
+                result.is_valid(0).then(|| result.value(0)),
+                expected.map(|value| !value),
+                "{source} right operand"
+            );
         }
     }
 
-    /// Nested elements (struct, array, map) have no logical comparison, See
-    /// [`Scalar::logical_partial_cmp`].
+    /// The Arrow evaluator does not yet implement `IN` for array or struct elements.
     #[rstest]
     #[case::struct_element(Scalar::Struct(
         StructData::try_new(
@@ -1989,45 +2583,104 @@ mod tests {
     #[case::array_element(Scalar::Array(
         ArrayData::try_new(ArrayType::new(DataType::INTEGER, true), vec![1, 2]).unwrap(),
     ))]
-    #[case::map_element(Scalar::Map(
-        MapData::try_new(
-            MapType::new(DataType::STRING, DataType::INTEGER, false),
-            vec![("k", 1)],
-        )
-        .unwrap(),
-    ))]
-    fn test_in_nested_element_never_matches(#[case] needle: Scalar) {
-        // A single-element literal array holding a structurally identical copy of the needle.
-        let elements = ArrayData::try_new(
-            ArrayType::new(needle.data_type(), true),
-            vec![needle.clone()],
-        )
-        .unwrap();
+    fn test_nested_in_is_unsupported(#[case] value: Scalar) {
+        // A single-element literal array holding a structurally identical copy of the value.
+        let elements =
+            ArrayData::try_new(ArrayType::new(value.data_type(), true), vec![value.clone()])
+                .unwrap();
 
         let (_, _, batch) = in_element_sources(&[Some(1)]);
         let pred = Pred::binary(
             BinaryPredicateOp::In,
-            Expr::Literal(needle),
+            Expr::Literal(value),
             Expr::Literal(Scalar::Array(elements)),
         );
-        let result = evaluate_predicate(&pred, &batch, false).unwrap();
-        assert_eq!(result.null_count(), 0);
-        assert!(!result.value(0));
+        assert!(matches!(
+            evaluate_predicate(&pred, &batch, false),
+            Err(Error::Unsupported(_))
+        ));
     }
 
-    /// Only a literal left operand is supported, so a column needle is rejected regardless of where
-    /// the elements come from, as is a right operand that holds no elements at all.
-    #[rstest]
-    #[case::column_in_literal_array(in_element_sources(&[Some(1), Some(2)]).0)]
-    #[case::column_in_column(in_element_sources(&[Some(1), Some(2)]).1)]
-    #[case::non_array_right_operand(lit(1))]
-    fn test_in_rejects_unsupported_operand_shapes(#[case] right: Expr) {
+    #[test]
+    fn test_map_in_is_invalid() {
+        let value = Scalar::Map(
+            MapData::try_new(
+                MapType::new(DataType::STRING, DataType::INTEGER, false),
+                vec![("k", 1)],
+            )
+            .unwrap(),
+        );
+        let elements =
+            ArrayData::try_new(ArrayType::new(value.data_type(), true), vec![value.clone()])
+                .unwrap();
+        let (_, _, batch) = in_element_sources(&[Some(1)]);
+        let pred = Pred::binary(
+            BinaryPredicateOp::In,
+            Expr::Literal(value),
+            Expr::Literal(Scalar::Array(elements)),
+        );
+
+        assert!(matches!(
+            evaluate_predicate(&pred, &batch, false),
+            Err(Error::InvalidExpressionEvaluation(_))
+        ));
+    }
+
+    #[test]
+    fn test_in_rejects_non_array_right_operand() {
         let (.., batch) = in_element_sources(&[Some(1), Some(2)]);
-        let pred = Pred::binary(BinaryPredicateOp::In, col!("n"), right);
+        let pred = Pred::binary(BinaryPredicateOp::In, col!("n"), lit(1));
         assert_result_error_with_message(
             evaluate_predicate(&pred, &batch, false),
-            "Invalid right value for (NOT) IN comparison",
+            "IN requires an array-valued right operand",
         );
+    }
+
+    #[test]
+    fn test_in_normalizes_large_utf8_elements() {
+        let item = Arc::new(ArrowField::new("item", ArrowDataType::LargeUtf8, false));
+        let values = Arc::new(LargeStringArray::from(vec!["a", "b", "c"]));
+        let lists = ListArray::new(
+            Arc::clone(&item),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0, 2, 3])),
+            values,
+            None,
+        );
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "items",
+            ArrowDataType::List(item),
+            false,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lists)]).unwrap();
+        let predicate = Pred::binary(BinaryPredicateOp::In, lit("a"), col!("items"));
+
+        assert_eq!(
+            evaluate_predicate(&predicate, &batch, false).unwrap(),
+            BooleanArray::from(vec![true, false])
+        );
+    }
+
+    #[test]
+    fn test_in_with_fixed_size_list_is_unsupported() {
+        let item = Arc::new(ArrowField::new("item", ArrowDataType::Int32, false));
+        let lists = crate::arrow::array::FixedSizeListArray::new(
+            Arc::clone(&item),
+            2,
+            Arc::new(Int32Array::from(vec![1, 2])),
+            None,
+        );
+        let schema = ArrowSchema::new(vec![ArrowField::new(
+            "items",
+            lists.data_type().clone(),
+            false,
+        )]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(lists)]).unwrap();
+        let predicate = Pred::binary(BinaryPredicateOp::In, lit(1), col!("items"));
+
+        assert!(matches!(
+            evaluate_predicate(&predicate, &batch, false),
+            Err(Error::Unsupported(_))
+        ));
     }
 
     #[rstest]
@@ -2079,7 +2732,7 @@ mod tests {
     }
 
     #[test]
-    fn test_divide_integer_truncates_and_rejects_zero_divisor() {
+    fn test_divide_integer_is_fractional_and_rejects_zero_divisor() {
         let schema = ArrowSchema::new(vec![
             ArrowField::new("n", ArrowDataType::Int32, false),
             ArrowField::new("d", ArrowDataType::Int32, false),
@@ -2098,24 +2751,24 @@ mod tests {
         let quotient = evaluate_expression(
             &divide(col!("n"), col!("d")),
             &batch,
-            Some(&DataType::INTEGER),
+            Some(&DataType::DOUBLE),
         )
         .unwrap();
         assert_eq!(
-            quotient.as_any().downcast_ref::<Int32Array>().unwrap(),
-            &Int32Array::from(vec![3])
+            quotient.as_any().downcast_ref::<Float64Array>().unwrap(),
+            &Float64Array::from(vec![3.5])
         );
 
         let result = evaluate_expression(
             &divide(col!("n"), col!("zero")),
             &batch,
-            Some(&DataType::INTEGER),
+            Some(&DataType::DOUBLE),
         );
         assert_result_error_with_message(result, "Divide by zero");
     }
 
     #[test]
-    fn test_divide_float_by_zero_yields_infinity_and_nan() {
+    fn test_divide_float_by_zero_returns_error() {
         let schema = ArrowSchema::new(vec![
             ArrowField::new("n", ArrowDataType::Float64, false),
             ArrowField::new("zero", ArrowDataType::Float64, false),
@@ -2129,18 +2782,26 @@ mod tests {
         )
         .unwrap();
 
-        let eval = |expr| {
-            let array = evaluate_expression(&expr, &batch, Some(&DataType::DOUBLE)).unwrap();
-            assert_eq!(array.null_count(), 0);
-            array
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .unwrap()
-                .value(0)
-        };
+        for expression in [
+            divide(col!("n"), col!("zero")),
+            divide(col!("zero"), col!("zero")),
+        ] {
+            assert_result_error_with_message(
+                evaluate_expression(&expression, &batch, Some(&DataType::DOUBLE)),
+                "Divide by zero",
+            );
+        }
+    }
 
-        assert!(eval(divide(col!("n"), col!("zero"))).is_infinite());
-        assert!(eval(divide(col!("zero"), col!("zero"))).is_nan());
+    #[test]
+    fn test_divide_untyped_null_by_untyped_null_is_invalid() {
+        let batch = RecordBatch::new_empty(Arc::new(ArrowSchema::empty()));
+        let expression = divide(null_lit(DataType::VOID), null_lit(DataType::VOID));
+
+        assert!(matches!(
+            evaluate_expression(&expression, &batch, Some(&DataType::DOUBLE)),
+            Err(Error::InvalidExpressionEvaluation(_))
+        ));
     }
 
     fn create_json_batch() -> RecordBatch {
@@ -3438,13 +4099,12 @@ mod tests {
     // All validation paths in `evaluate_array_expression` share the shape "expr + batch +
     // result_type -> error containing substring". Each case targets a different guard.
     #[rstest]
-    // Empty Array() is rejected regardless of result_type -- the element type is inferred
-    // from the inputs, so there must be at least one.
+    // Without a result type, an empty ARRAY has no element type to use.
     #[case::empty_inputs(
         create_test_batch(),
         Expr::array(Vec::<Expr>::new()),
         None,
-        "requires at least one element",
+        "Cannot infer the element type",
     )]
     #[case::non_array_result_type(
         create_test_batch(),

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -246,6 +246,8 @@ impl ArrayData {
 #[derive(Debug)]
 pub struct ArrowEvaluationHandler;
 
+// TODO(#3210): Align expression analysis and evaluation with Kernel's standard expression
+// contract.
 impl EvaluationHandler for ArrowEvaluationHandler {
     fn new_expression_evaluator(
         &self,

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -7,7 +7,9 @@ use itertools::Itertools;
 use tracing::debug;
 
 use super::arrow_conversion::{TryFromKernel as _, TryIntoArrow as _};
-use crate::arrow::array::{self, ArrayBuilder, ArrayRef, RecordBatch, StructArray};
+use crate::arrow::array::{
+    self, ArrayBuilder, ArrayRef, RecordBatch, RecordBatchOptions, StructArray,
+};
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
@@ -15,12 +17,15 @@ use crate::engine::arrow_data::{extract_record_batch, ArrowEngineData};
 use crate::engine::arrow_utils::apply_schema::{apply_schema, apply_schema_to};
 use crate::error::{DeltaResult, Error};
 use crate::expressions::{ArrayData, Expression, ExpressionRef, PredicateRef, Scalar};
-use crate::schema::{DataType, PrimitiveType, SchemaRef};
+use crate::schema::{DataType, PrimitiveType, SchemaRef, StructType};
 use crate::utils::require;
 use crate::{EngineData, EvaluationHandler, ExpressionEvaluator, PredicateEvaluator};
 
 pub mod evaluate_expression;
 pub mod opaque;
+
+#[cfg(test)]
+mod conformance_tests;
 
 #[cfg(test)]
 mod tests;
@@ -256,7 +261,7 @@ impl EvaluationHandler for ArrowEvaluationHandler {
         output_type: DataType,
     ) -> DeltaResult<Arc<dyn ExpressionEvaluator>> {
         Ok(Arc::new(DefaultExpressionEvaluator {
-            _input_schema: schema,
+            input_schema: schema,
             expression,
             output_type,
         }))
@@ -334,16 +339,19 @@ impl EvaluationHandler for ArrowEvaluationHandler {
 
         let arrays: Vec<ArrayRef> = builders.into_iter().map(|mut b| b.finish()).collect();
 
-        Ok(Box::new(ArrowEngineData::new(RecordBatch::try_new(
-            arrow_schema,
-            arrays,
-        )?)))
+        Ok(Box::new(ArrowEngineData::new(
+            RecordBatch::try_new_with_options(
+                arrow_schema,
+                arrays,
+                &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+            )?,
+        )))
     }
 }
 
 #[derive(Debug)]
 pub struct DefaultExpressionEvaluator {
-    _input_schema: SchemaRef,
+    input_schema: SchemaRef,
     expression: ExpressionRef,
     output_type: DataType,
 }
@@ -351,6 +359,11 @@ pub struct DefaultExpressionEvaluator {
 impl ExpressionEvaluator for DefaultExpressionEvaluator {
     fn evaluate(&self, batch: &dyn EngineData) -> DeltaResult<Box<dyn EngineData>> {
         debug!("Arrow evaluator evaluating: {:#?}", self.expression);
+        validate_direct_project_assignments(
+            &self.input_schema,
+            &self.expression,
+            &self.output_type,
+        )?;
         let batch = extract_record_batch(batch)?;
         // TODO: make sure we have matching schemas for validation
         // if batch.schema().as_ref() != &input_schema {
@@ -385,6 +398,122 @@ impl ExpressionEvaluator for DefaultExpressionEvaluator {
         };
 
         Ok(Box::new(ArrowEngineData::new(batch)))
+    }
+}
+
+/// Validates contract-level assignments for Project fields that directly reference a column or
+/// literal. Valid assignments that need an unimplemented conversion return `Unsupported`; invalid
+/// assignments return `InvalidExpressionEvaluation`. Complex expressions require full analysis.
+fn validate_direct_project_assignments(
+    input_schema: &StructType,
+    expression: &Expression,
+    output_type: &DataType,
+) -> DeltaResult<()> {
+    let (Expression::Struct(expressions, _), DataType::Struct(output_schema)) =
+        (expression, output_type)
+    else {
+        return Ok(());
+    };
+
+    let mut unsupported_assignment = None;
+    for (expression, target) in expressions.iter().zip(output_schema.fields()) {
+        let source = match expression.as_ref() {
+            Expression::Column(name) => input_schema.fields_of_path(name).ok().and_then(|fields| {
+                fields.last().map(|field| {
+                    (
+                        field.data_type().clone(),
+                        fields.iter().any(|field| field.is_nullable()),
+                    )
+                })
+            }),
+            Expression::Literal(value) => Some((value.data_type(), value.is_null())),
+            _ => None,
+        };
+        let Some((source_type, source_nullable)) = source else {
+            continue;
+        };
+
+        // Input schemas are not flow-sensitive: a preceding filter may prove that a nullable
+        // column is non-null before this projection reaches the evaluator.
+        if source_type == *target.data_type() {
+            continue;
+        }
+
+        let assignment = format!(
+            "Project assignment from {source_type}{} to {}{}",
+            if source_nullable { " (nullable)" } else { "" },
+            target.data_type(),
+            if target.is_nullable() {
+                " (nullable)"
+            } else {
+                ""
+            }
+        );
+        if source_nullable && !target.is_nullable()
+            || !is_valid_project_assignment(&source_type, target.data_type())
+        {
+            return Err(Error::invalid_expression(assignment));
+        }
+        unsupported_assignment.get_or_insert(assignment);
+    }
+    if let Some(assignment) = unsupported_assignment {
+        return Err(Error::unsupported(format!(
+            "Arrow evaluator does not yet support {assignment}"
+        )));
+    }
+    Ok(())
+}
+
+/// Returns whether Kernel's Project contract permits assigning `source` to `target` without an
+/// explicit cast. This tests semantic validity, not whether the Arrow evaluator implements the
+/// required conversion.
+fn is_valid_project_assignment(source: &DataType, target: &DataType) -> bool {
+    use DataType::*;
+    use PrimitiveType::*;
+
+    if source == target {
+        return true;
+    }
+    match (source, target) {
+        (Primitive(Void), _) => true,
+        (Primitive(Byte), Primitive(Short | Integer | Long | Float | Double))
+        | (Primitive(Short), Primitive(Integer | Long | Float | Double))
+        | (Primitive(Integer), Primitive(Long | Double))
+        | (Primitive(Float), Primitive(Double))
+        | (Primitive(Date), Primitive(TimestampNtz)) => true,
+        (Primitive(source), Primitive(Decimal(target))) => {
+            let source_precision = match source {
+                Byte => 3,
+                Short => 5,
+                Integer => 10,
+                Long => 20,
+                Decimal(source) if target.scale() >= source.scale() => {
+                    source.precision() - source.scale()
+                }
+                _ => return false,
+            };
+            target.precision() - target.scale() >= source_precision
+        }
+        (Array(source), Array(target)) => {
+            (!source.contains_null() || target.contains_null())
+                && is_valid_project_assignment(source.element_type(), target.element_type())
+        }
+        (Map(source), Map(target)) => {
+            (!source.value_contains_null || target.value_contains_null)
+                && is_valid_project_assignment(source.key_type(), target.key_type())
+                && is_valid_project_assignment(source.value_type(), target.value_type())
+        }
+        (Struct(source), Struct(target)) => {
+            source.fields().len() == target.fields().len()
+                && source
+                    .fields()
+                    .zip(target.fields())
+                    .all(|(source, target)| {
+                        (!source.is_nullable() || target.is_nullable())
+                            && is_valid_project_assignment(source.data_type(), target.data_type())
+                    })
+        }
+        _ => false,
     }
 }
 

--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -7,8 +7,8 @@ use Predicate as Pred;
 use super::*;
 use crate::arrow::array::{
     create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
-    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames, StringArray,
-    StringBuilder, StringViewArray, StructArray,
+    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames,
+    RecordBatchOptions, StringArray, StringBuilder, StringViewArray, StructArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
@@ -68,20 +68,17 @@ fn test_array_column() {
 }
 
 #[test]
-fn test_bad_right_type_array() {
+fn test_in_rejects_non_array_column() {
     let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
     let field = Arc::new(Field::new("item", DataType::Int32, true));
     let schema = Schema::new([field.clone()]);
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(values.clone())]).unwrap();
 
-    let in_op = Pred::not(Pred::binary(BinaryPredicateOp::In, lit(5), col!("item")));
+    let in_op = Pred::binary(BinaryPredicateOp::In, lit(5), col!("item"));
 
     let in_result = evaluate_predicate(&in_op, &batch, false);
 
-    assert_result_error_with_message(
-        in_result,
-        "Invalid expression evaluation: Cannot cast to list array: Int32",
-    );
+    assert_result_error_with_message(in_result, "IN requires an array-valued right operand");
 }
 
 #[test]
@@ -223,10 +220,14 @@ fn test_binary_predicate_with_view_types(
 }
 
 #[test]
-fn test_literal_type_array() {
-    let field = Arc::new(Field::new("item", DataType::Int32, true));
-    let schema = Schema::new([field.clone()]);
-    let batch = RecordBatch::new_empty(Arc::new(schema));
+fn test_literal_array_membership_on_columnless_batch() {
+    // Literal-only predicates still derive their row count from a columnless batch.
+    let batch = RecordBatch::try_new_with_options(
+        Arc::new(Schema::empty()),
+        vec![],
+        &RecordBatchOptions::new().with_row_count(Some(1)),
+    )
+    .unwrap();
 
     let not_in_op = Pred::not(Pred::binary(
         BinaryPredicateOp::In,
@@ -370,7 +371,7 @@ fn test_literal_complex_type_array() {
 }
 
 #[test]
-fn test_invalid_array_sides() {
+fn test_in_rejects_array_value_against_scalar_elements() {
     let values = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
     let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, 3, 6, 9]));
     let field = Arc::new(Field::new("item", DataType::Int32, true));
@@ -389,7 +390,10 @@ fn test_invalid_array_sides() {
 
     let in_result = evaluate_predicate(&in_op, &batch, false);
 
-    assert_result_error_with_message(in_result, "Invalid expression evaluation: Invalid right value for (NOT) IN comparison, left is: Column(item) right is: Column(item)");
+    assert!(matches!(
+        in_result,
+        Err(Error::InvalidExpressionEvaluation(_))
+    ));
 }
 
 #[test]
@@ -482,10 +486,9 @@ fn test_binary_op_scalar() {
     let expected = Arc::new(Int32Array::from(vec![2, 4, 6]));
     assert_eq!(results.as_ref(), expected.as_ref());
 
-    // TODO handle type casting
     let expression = column.div(lit(1));
     let results = evaluate_expression(&expression, &batch, None).unwrap();
-    let expected = Arc::new(Int32Array::from(vec![1, 2, 3]));
+    let expected = Arc::new(crate::arrow::array::Float64Array::from(vec![1.0, 2.0, 3.0]));
     assert_eq!(results.as_ref(), expected.as_ref())
 }
 
@@ -1335,6 +1338,17 @@ fn test_create_many_empty_rows_returns_zero_row_batch() {
     let rb = result.try_into_record_batch().unwrap();
     assert_eq!(rb.num_rows(), 0);
     assert_eq!(rb.num_columns(), 2);
+}
+
+#[test]
+fn test_create_many_preserves_row_count_for_empty_schema() {
+    let handler = ArrowEvaluationHandler;
+    let rows: &[&[Scalar]] = &[&[], &[], &[]];
+    let result = handler.create_many(schema_ref! {}, rows).unwrap();
+    let batch = result.try_into_record_batch().unwrap();
+
+    assert_eq!(batch.num_rows(), rows.len());
+    assert_eq!(batch.num_columns(), 0);
 }
 
 #[test]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -42,35 +42,6 @@ use crate::transforms::{transform_output_type, SchemaTransform};
 use crate::utils::require;
 use crate::{DeltaResult, EngineData, Error};
 
-macro_rules! prim_array_cmp {
-    ( $left_arr: ident, $right_arr: ident, $(($data_ty: pat, $prim_ty: ty)),+ ) => {
-
-        return match $left_arr.data_type() {
-        $(
-            $data_ty => {
-                let prim_array = $left_arr.as_primitive_opt::<$prim_ty>()
-                        .ok_or(Error::invalid_expression(
-                            format!("Cannot cast to primitive array: {}", $left_arr.data_type()))
-                        )?;
-                    let list_array = $right_arr.as_list_opt::<i32>()
-                        .ok_or(Error::invalid_expression(
-                            format!("Cannot cast to list array: {}", $right_arr.data_type()))
-                        )?;
-                crate::arrow::compute::kernels::comparison::in_list(prim_array, list_array)
-            }
-        )+
-            _ => Err(ArrowError::CastError(
-                        format!("Bad Comparison between: {:?} and {:?}",
-                            $left_arr.data_type(),
-                            $right_arr.data_type())
-                        )
-                )
-        }.map_err(Error::generic_err);
-    };
-}
-
-pub(crate) use prim_array_cmp;
-
 type FieldIndex = usize;
 type FlattenedRangeIterator<T> = std::iter::Flatten<std::vec::IntoIter<Range<T>>>;
 

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -32,7 +32,10 @@ mod sql;
 pub(crate) use self::sql::parse_sql;
 
 #[doc = include_str!("semantics.md")]
-pub mod semantics {}
+pub mod semantics {
+    #[cfg(any(test, feature = "test-utils"))]
+    pub mod conformance;
+}
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -31,6 +31,9 @@ mod scalars;
 mod sql;
 pub(crate) use self::sql::parse_sql;
 
+#[doc = include_str!("semantics.md")]
+pub mod semantics {}
+
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;
 
@@ -77,43 +80,36 @@ pub type ExpressionStructPatchBuilder = crate::struct_patch::StructPatchBuilder<
 /// A unary predicate operator.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum UnaryPredicateOp {
-    /// SQL `expr IS NULL`: `true` when the input is null and `false` otherwise, never null itself.
-    /// A wrapping `NOT` inverts it to `IS NOT NULL`.
+    /// SQL `expr IS NULL`.
+    ///
+    /// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
     IsNull,
 }
 
-/// A binary predicate operator.
-///
-/// The ordering and equality comparisons follow SQL three-valued logic, so a NULL operand yields
-/// NULL rather than `false`. [`Distinct`](Self::Distinct) and [`In`](Self::In) instead tolerate
-/// NULL and always answer `true` or `false`.
+/// A SQL comparison or membership operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryPredicateOp {
-    /// `left < right`.
+    /// SQL `left < right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     LessThan,
-    /// `left > right`.
+    /// SQL `left > right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     GreaterThan,
-    /// `left = right`.
+    /// SQL `left = right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     Equal,
-    /// SQL `left IS DISTINCT FROM right`: null-safe inequality, treating NULL as an ordinary
-    /// value. `DISTINCT(1, 1)` and `DISTINCT(NULL, NULL)` are `false`; `DISTINCT(NULL, 1)` is
-    /// `true`.
+    /// SQL `left IS DISTINCT FROM right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     Distinct,
-    /// SQL `left IN (elements)`: returns `false` when `left` is NULL. Otherwise, it returns `true`
-    /// when `left` equals any element and `false` when none match. NULL elements never match.
-    /// `left` must be a literal, and the elements are either a list-typed column or an
-    /// [`Expression::Literal`] holding a [`Scalar::Array`], never a list of expressions or a
-    /// subquery:
+    /// Tests whether `left` equals any element of an array-valued `right` expression, using SQL
+    /// `IN` null semantics. This IR node does not represent a parenthesized SQL value list or
+    /// subquery.
     ///
-    /// ```sql
-    /// 2 IN (1, 2, 3)         -- literal elements
-    /// 2 IN (SELECT ...)      -- unsupported: no subquery form
-    /// col IN (1, 2, 3)       -- unsupported: the left operand must be a literal
-    /// ```
-    ///
-    /// Testing a literal against a list column is the shape data skipping uses, and it is the
-    /// reason the operands sit this way around rather than the more familiar
-    /// column-on-the-left form.
+    /// See the [`IN` contract](semantics#in).
     In,
 }
 
@@ -144,60 +140,45 @@ pub enum UnaryExpressionOp {
     ToJson,
 }
 
-/// A binary arithmetic operator over two numeric operands.
+/// A binary SQL arithmetic operator.
 ///
-/// Both operands share a numeric type and the result takes that type. Kernel inserts no implicit
-/// casts, so widening a result (decimal precision or scale, for instance) needs an explicit
-/// [`Expression::cast`] to match a declared output type.
+/// See the [arithmetic contract](semantics#numeric-addition-subtraction-and-multiplication).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryExpressionOp {
-    /// `left + right`.
+    /// SQL `left + right`.
     Plus,
-    /// `left - right`.
+    /// SQL `left - right`.
     Minus,
-    /// `left * right`.
+    /// SQL `left * right`.
     Multiply,
-    /// `left / right`. A zero divisor never yields NULL.
+    /// SQL `left / right`: fractional numeric division. Integer inputs do not truncate.
     ///
-    /// Integer operands divide truncating toward zero, and a zero divisor fails. Float operands
-    /// follow IEEE 754: `+/-inf` for a non-zero numerator, `NaN` for `0.0 / 0.0`. In a dialect
-    /// whose `/` is always fractional, the integer case is the other division operator:
-    ///
-    /// ```sql
-    /// 7 DIV 2      -- 3, this operator over integers
-    /// 7 / 2        -- 3.5, NOT this operator
-    /// ```
+    /// See the [division contract](semantics#division).
     Divide,
 }
 
-/// A variadic expression operator.
+/// A variadic SQL expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum VariadicExpressionOp {
-    /// SQL `COALESCE(exprs...)`: the first non-null value, or null when every input is null. All
-    /// inputs share one type, which is also the result type. Requires at least one input.
-    Coalesce,
-    /// SQL `ARRAY(exprs...)`: an array built by evaluating each input per row, so
-    /// `ARRAY(1, 1 + 2, my_int_col)` yields `[1, 3, <my_int_col value>]`. All inputs must share
-    /// the same element type. Requires at least one element; the element type is inferred from
-    /// the inputs.
+    /// SQL `COALESCE(exprs...)`.
     ///
-    /// For static array literals whose elements are all compile-time constants, use
-    /// [`Scalar::Array`] instead. The difference is that `Array` is evaluated at runtime, while
-    /// `Scalar::Array` is evaluated at compile time.
+    /// See the [`COALESCE` contract](semantics#coalesce).
+    Coalesce,
+    /// SQL `ARRAY(exprs...)`, producing one array per input row.
+    ///
+    /// Use [`Scalar::Array`] for an array literal that is constant across input rows. See the
+    /// [`ARRAY` contract](semantics#array).
     Array,
 }
 
 /// A junction (AND/OR) predicate operator over N child predicates.
 ///
-/// Both use SQL three-valued (Kleene) logic, treating a NULL child as unknown rather than false: a
-/// decisive child wins over a NULL sibling, so `AND` is `false` and `OR` is `true` despite the
-/// NULL, and only an undecided junction yields NULL. [`Predicate::junction`] folds an empty
-/// junction to its operator's identity, `true` for `AND` and `false` for `OR`.
+/// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum JunctionPredicateOp {
-    /// SQL `a AND b AND ...`: true when every child is true.
+    /// SQL `a AND b AND ...`.
     And,
-    /// SQL `a OR b OR ...`: true when any child is true.
+    /// SQL `a OR b OR ...`.
     Or,
 }
 
@@ -474,11 +455,17 @@ where
     Err(de::Error::custom("Cannot deserialize an Opaque Expression"))
 }
 
-/// A SQL expression.
+/// An expression in Kernel's intermediate representation.
 ///
-/// These expressions do not track or validate data types, other than the type
-/// of literals. It is up to the expression evaluator to validate the
-/// expression against a schema and add appropriate casts as required.
+/// Expressions do not store resolved types other than the type of literals. Before evaluation, an
+/// expression is analyzed against its input schema using the common-type, result-type, nullability,
+/// and error rules in the [SQL expression contract](semantics). A surrounding `Project` may also
+/// supply a declared output type; that assignment happens after the expression's own type is
+/// resolved.
+///
+/// An evaluator may reject a valid expression it does not support. If it evaluates the expression,
+/// its result must follow the contract. Input outside the contract is not portable, even when a
+/// particular evaluator accepts it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Expression {
     /// A literal value.
@@ -491,7 +478,7 @@ pub enum Expression {
     /// A struct computed from one expression per output field, in field order.
     ///
     /// Field names and nullability come from the surrounding output schema (the evaluator's
-    /// `result_type`, such as a [`Project`]'s target field), and each field expression's type is
+    /// `result_type`, such as a `Project`'s target field), and each field expression's type is
     /// validated against the schema, so building a struct takes both. The expression count must
     /// equal the output field count.
     ///
@@ -501,8 +488,6 @@ pub enum Expression {
     /// ```sql
     /// CASE WHEN keep_pred THEN struct(expr1, expr2, ...) END
     /// ```
-    ///
-    /// [`Project`]: crate::plans::ir::nodes::Project
     Struct(Vec<ExpressionRef>, Option<ExpressionRef>),
     /// A sparse patch of a struct. More efficient than `Struct` for wide schemas
     /// where only a few fields change, achieving O(changes) instead of O(schema_width) complexity.
@@ -539,16 +524,18 @@ pub enum Expression {
     Cast(CastExpression),
 }
 
-/// A SQL predicate.
+/// A predicate in Kernel's intermediate representation.
 ///
-/// These predicates do not track or validate data types, other than the type
-/// of literals. It is up to the predicate evaluator to validate the
-/// predicate against a schema and add appropriate casts as required.
+/// Predicates do not store resolved input types. Before evaluation, a predicate is analyzed against
+/// its input schema using the [SQL expression contract](semantics). Boolean predicates require
+/// Boolean inputs; Kernel does not define numeric or string truthiness.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Predicate {
-    /// A boolean-valued expression, useful for e.g. `AND(<boolean_col1>, <boolean_col2>)`.
+    /// A Boolean-valued expression used as a predicate.
+    ///
+    /// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
     BooleanExpression(Expression),
-    /// Boolean inversion (true <-> false)
+    /// SQL Boolean inversion.
     ///
     /// NOTE: NOT is not a normal unary predicate, because it requires a predicate as input (not an
     /// expression), and is never directly evaluated. Instead, observing that all predicates are
@@ -559,7 +546,7 @@ pub enum Predicate {
     Unary(UnaryPredicate),
     /// A binary operation.
     Binary(BinaryPredicate),
-    /// A junction operation (AND/OR).
+    /// SQL `AND` or `OR` over Boolean predicates.
     Junction(JunctionPredicate),
     /// A predicate that the engine defines and implements. Kernel interacts with the predicate
     /// only through methods provided by the [`OpaquePredicateOp`] trait.

--- a/kernel/src/expressions/semantics.md
+++ b/kernel/src/expressions/semantics.md
@@ -1,0 +1,437 @@
+# Standard SQL expression semantics
+
+This page defines the SQL semantics for Kernel's standard expression operators. It fixes choices
+that vary across SQL implementations, including decimal precision, floating-point comparisons,
+temporal conversions, and empty `IN` sets. Evaluation settings do not change these rules.
+
+An evaluator may reject a valid expression as unsupported. If it evaluates one, the result type,
+value, null behavior, and errors must follow this contract. An expression outside the contract is
+not portable, even when an evaluator accepts it.
+
+Expression nodes with specialized behavior document their contracts on their Rust types.
+
+## Analysis and common types
+
+The expression tree is unresolved. Before evaluation, an implementation resolves column
+references, validates each operator's operands, finds required common types, and inserts casts.
+Failure to find a permitted type is an analysis error.
+
+Kernel does not implicitly parse `STRING` as a number or Boolean. For example, `long_col + '1'`,
+`long_col = '1'`, and `COALESCE(long_col, '0')` are outside the contract. An evaluator may accept
+such expressions as an extension, but their behavior is not portable.
+
+`VOID` is the type of an untyped null. `VOID` and `T` have common type `T`; inputs that are all
+`VOID` retain that type. Identical scalar types have themselves as their common type. The following
+rules handle differing types. Arithmetic whose operands are all `VOID` is invalid because no
+numeric type can be inferred.
+
+### Numeric common types
+
+Among non-decimal numeric types, the precedence order is:
+
+```text
+TINYINT -> SMALLINT -> INT -> BIGINT -> FLOAT -> DOUBLE
+```
+
+Kernel names these types `BYTE`, `SHORT`, `INTEGER`, `LONG`, `FLOAT`, and `DOUBLE` in its Rust API.
+Normally, the type farther to the right is the common type. An integral type combined with `FLOAT`
+resolves to `DOUBLE`. Decimal operands follow separate rules:
+
+- A decimal combined with `FLOAT` or `DOUBLE` resolves to `DOUBLE`.
+- A decimal combined with an integral type stays decimal. The integral operand first becomes
+  `DECIMAL(3,0)`, `DECIMAL(5,0)`, `DECIMAL(10,0)`, or `DECIMAL(20,0)`, respectively.
+
+For common-type resolution outside arithmetic, two decimals use:
+
+```text
+scale          = max(s1, s2)
+integer_digits = max(p1 - s1, p2 - s2)
+precision      = integer_digits + scale
+```
+
+If `precision` exceeds 38, reduce `scale` by `precision - 38`, without taking it below zero, and
+use precision 38. This retains the available integer digits before fractional digits. Any scale
+reduction in an implicit decimal conversion rounds half up, with a midpoint rounded away from
+zero. A value whose integer part does not fit raises an arithmetic-overflow error.
+
+For decimal arithmetic and numeric comparisons, an integral literal combined with a decimal uses
+only the digits needed by its value, with one digit for zero. Any other integral expression uses
+the full decimal precision listed above. Other common-type operations, including `COALESCE`, use
+the full precision of the integral type for both literals and non-literal expressions.
+
+Examples:
+
+```sql
+COALESCE(int_col, bigint_col)  -- BIGINT
+bigint_col + float_col         -- DOUBLE
+decimal_col = int_col          -- compare as a DECIMAL common type
+decimal_col + double_col       -- DOUBLE
+```
+
+### Other scalar and complex types
+
+`DATE`, `TIMESTAMP_NTZ`, and `TIMESTAMP` widen in that order. A date becomes midnight. When a date
+or timezone-free timestamp widens to `TIMESTAMP`, Kernel interprets it in UTC. A session time zone
+must not alter the conversion. Converting a date to either timestamp type raises a runtime
+arithmetic-overflow error when its midnight microsecond offset does not fit in an `i64`.
+
+Strings use binary UTF-8 ordering: their encoded bytes compare lexicographically with no case
+folding or Unicode normalization. Binary values compare lexicographically by unsigned byte,
+`FALSE` sorts before `TRUE`, and intervals compare by their signed month or microsecond count
+within the same interval family. Binary, Boolean, and interval values require an exact type match.
+Other scalar types also require an exact type match.
+
+Complex types resolve recursively:
+
+- Arrays widen their element types. The result allows null elements when either input does.
+- Maps widen keys and values separately. `VOID` may widen as a key type because it can occur only in
+  an empty map. The result allows null values when either input does.
+- Structs must have the same field count and case-insensitively matching field names. Corresponding
+  fields widen recursively, and the result field is nullable when either input field is nullable.
+  The result preserves the first input's field-name spelling.
+
+```text
+common_type(ARRAY<INT>, ARRAY<BIGINT>) -> ARRAY<BIGINT>
+
+common_type(
+  STRUCT<a: INT, b: STRING>,
+  STRUCT<a: BIGINT, b: STRING>
+) -> STRUCT<a: BIGINT, b: STRING>
+```
+
+## Declared `Project` output types
+
+Operator analysis determines an expression's result before a surrounding `Project` assigns it to
+a declared output field. The declared schema cannot change an operator's inference. In particular,
+it cannot make integer `/` truncate or force decimal arithmetic to keep an operand's precision.
+
+After inference, a `Project` may keep the exact type or apply one of these implicit assignments:
+
+```text
+TINYINT  -> SMALLINT, INT, BIGINT, FLOAT, DOUBLE
+SMALLINT -> INT, BIGINT, FLOAT, DOUBLE
+INT      -> BIGINT, DOUBLE
+FLOAT    -> DOUBLE
+DATE     -> TIMESTAMP_NTZ
+```
+
+Together with the `VOID` and decimal rules below, these are the only implicit `Project`
+assignments. Common-type promotion does not add assignments to this list.
+
+`VOID` may take any target type, subject to nullability at the same position. A top-level `VOID`
+expression is nullable and therefore cannot be assigned to a non-null field. Recursively, a
+`VOID` array element or map value may take a non-null target type when the source container says
+that position cannot contain null. An empty `ARRAY<VOID>` with `containsNull = false`, an empty map
+with a `VOID` key, and an empty map with a `VOID` value whose `valueContainsNull` is false may
+therefore adopt concrete target types.
+
+An integral or decimal value may be assigned to `DECIMAL(p2,s2)` when the target has at least the
+source scale and enough added precision to preserve every integer digit. Integral sources use the
+full decimal precision listed under numeric common types. The same rule applies recursively to
+array elements, map keys and values, and corresponding struct fields. Map keys and values are
+checked independently. Struct fields are aligned positionally; the target field names replace the
+source names. A nullable result cannot be assigned to a non-null field. Recursively, an array that
+may contain null elements cannot be assigned to one that forbids them, a map whose values may be
+null cannot be assigned to one whose values may not be null, and a nullable struct field cannot be
+assigned to a non-null field.
+
+Other conversions need an explicit `Cast` expression. Narrowing, parsing a string, or rounding a
+decimal at the `Project` boundary is not an implicit assignment.
+
+The numeric assignments above preserve every source value. `DATE` to `TIMESTAMP_NTZ` is also
+allowed, but it raises an arithmetic-overflow error when the date's midnight microsecond offset
+does not fit in an `i64`.
+
+## `COALESCE`
+
+`COALESCE` requires at least one child. It casts every child to their common type and returns that
+type. Its result is nullable only when every child is nullable.
+
+Every child must analyze successfully. Runtime evaluation then proceeds from left to right and
+stops at the first non-null value. An unselected child is not evaluated, so its runtime errors are
+not raised.
+
+```sql
+COALESCE(CAST(NULL AS INT), CAST(7 AS BIGINT))  -- BIGINT 7
+COALESCE(NULL, 7, 9)                            -- INT 7
+COALESCE(2, 5 / 0)                              -- DOUBLE 2.0; no DIVIDE_BY_ZERO error
+```
+
+## `ARRAY`
+
+`ARRAY` casts every element to their common type and returns `ARRAY<common type>`. The array itself
+is never null. Its `containsNull` flag is true exactly when an element expression can return null.
+`ARRAY()` is an empty, non-null `ARRAY<VOID>` with `containsNull = false`.
+
+```sql
+ARRAY(CAST(1 AS INT), CAST(2 AS BIGINT))  -- ARRAY<BIGINT>[1, 2]
+ARRAY(1, NULL)                            -- ARRAY<INT>[1, NULL], containsNull = true
+ARRAY()                                   -- ARRAY<VOID>[], containsNull = false
+```
+
+For an array literal that is constant across input rows, use
+[`Scalar::Array`](crate::expressions::Scalar::Array). The
+[`VariadicExpressionOp::Array`](crate::expressions::VariadicExpressionOp::Array) node evaluates its
+elements for each input row.
+
+## Numeric addition, subtraction, and multiplication
+
+`+`, `-`, and `*` accept numeric operands only. When the common type is not decimal, it is also the
+result type. When the common type is decimal, results use the formulas below. A decimal combined
+with `FLOAT` or `DOUBLE` therefore returns `DOUBLE`, not a decimal. The result is nullable when
+either operand is nullable.
+
+Integral and decimal arithmetic is checked. A value outside the result type raises a runtime
+arithmetic-overflow error instead of wrapping or becoming null. Floating-point arithmetic keeps
+IEEE 754 results, including infinities and NaNs.
+
+```sql
+CAST(1 AS INT) + CAST(2 AS BIGINT)    -- BIGINT 3
+CAST(3 AS BIGINT) - CAST(1 AS INT)    -- BIGINT 2
+CAST(3 AS INT) * CAST(2 AS BIGINT)    -- BIGINT 6
+CAST(2147483647 AS INT) + 1           -- arithmetic overflow error
+CAST(1e308 AS DOUBLE) * 1e308         -- positive infinity
+NULL + CAST(1 AS INT)                 -- NULL
+```
+
+### Decimal result types
+
+For `DECIMAL(p1,s1)` and `DECIMAL(p2,s2)`, first compute an unbounded result type:
+
+```text
+Add/Subtract:
+  scale     = max(s1, s2)
+  precision = max(p1 - s1, p2 - s2) + scale + 1
+
+Multiply:
+  scale     = s1 + s2
+  precision = p1 + p2 + 1
+
+Divide:
+  scale     = max(6, s1 + p2 + 1)
+  precision = p1 - s1 + s2 + scale
+```
+
+When `precision` exceeds 38, adjust it as follows:
+
+```text
+integer_digits = precision - scale
+minimum_scale  = min(scale, 6)
+adjusted_scale = max(38 - integer_digits, minimum_scale)
+result         = DECIMAL(38, adjusted_scale)
+```
+
+Scale reduction rounds half up. A midpoint rounds away from zero. If the integer part still does
+not fit, evaluation raises an arithmetic-overflow error.
+
+```text
+DECIMAL(10,2) + DECIMAL(10,2) -> DECIMAL(11,2)
+DECIMAL(10,2) - DECIMAL(10,2) -> DECIMAL(11,2)
+DECIMAL(10,2) * DECIMAL(10,2) -> DECIMAL(21,4)
+DECIMAL(10,2) / DECIMAL(10,2) -> DECIMAL(23,13)
+```
+
+A non-literal integral expression uses its type's full decimal precision during decimal arithmetic:
+3 digits for `TINYINT`, 5 for `SMALLINT`, 10 for `INT`, and 20 for `BIGINT`. An integral literal
+uses only the digits needed for its value.
+
+```text
+DECIMAL(10,2) column + INT column -> DECIMAL(13,2)
+DECIMAL(10,2) column + literal 1  -> DECIMAL(11,2)
+```
+
+Kernel caps decimal precision at 38, permits the scale reduction above, preserves at least
+`min(original scale, 6)` fractional digits, and gives each integral literal the smallest precision
+that represents its value. Evaluation settings do not alter these choices.
+
+## Division
+
+`/` accepts numeric operands and always means fractional division. Inputs whose common type is not
+decimal become `DOUBLE`, so integer inputs do not truncate. Inputs whose common type is decimal use
+the decimal division formula. A decimal combined with `FLOAT` or `DOUBLE` therefore returns
+`DOUBLE`. The result is nullable when either operand is nullable.
+
+A divisor of positive or negative zero raises `DIVIDE_BY_ZERO` for integral, decimal, or
+floating-point operands when the dividend is non-null. A null operand produces null, so `NULL / 0`
+is null rather than an error. This is the deliberate exception to raw IEEE 754 division. Kernel
+has no truncating `DIV` operator.
+
+```sql
+3 / 2                                            -- DOUBLE 1.5
+CAST(3 AS DECIMAL(10,2)) /
+  CAST(2 AS DECIMAL(10,2))                       -- DECIMAL(23,13) 1.5000000000000
+CAST(1 AS DOUBLE) / CAST(0.0 AS DOUBLE)          -- DIVIDE_BY_ZERO error
+CAST(1 AS DOUBLE) / CAST('-0.0' AS DOUBLE)       -- DIVIDE_BY_ZERO error
+NULL / 0                                         -- NULL; no DIVIDE_BY_ZERO error
+```
+
+## Comparisons
+
+`=`, `<`, `>`, and `IS DISTINCT FROM` cast both operands to one common orderable type. Numeric,
+string, binary, Boolean, temporal, and interval values are orderable. Arrays and structs are
+orderable when every nested value is orderable. Maps are not orderable, and this contract does not
+define comparisons for `VARIANT` or geospatial values. `VOID` operands follow the untyped-null
+rules above and require no non-null ordering.
+
+When nested types have identical leaf types but struct field names or nested nullability differ,
+comparison may align them positionally without a cast. Field names do not affect the aligned value
+comparison. Ordinary widening still requires case-insensitively matching names, so differently
+named structs whose corresponding leaf types differ are invalid.
+
+```text
+STRUCT<a: INT>(1) = STRUCT<b: INT>(1)       -> TRUE
+STRUCT<a: INT>(1) = STRUCT<b: BIGINT>(1)    -> analysis error
+```
+
+Ordinary comparisons use three-valued logic. If either operand is null, the result is null.
+`IS DISTINCT FROM` is null-safe inequality and never returns null.
+
+```sql
+CAST(1 AS INT) = CAST(1 AS BIGINT)  -- TRUE after widening to BIGINT
+NULL = NULL                         -- NULL
+NULL < 1                            -- NULL
+
+1 IS DISTINCT FROM 1                -- FALSE
+1 IS DISTINCT FROM 2                -- TRUE
+NULL IS DISTINCT FROM NULL          -- FALSE
+NULL IS DISTINCT FROM 1             -- TRUE
+```
+
+Floating-point comparisons treat all NaN payloads as one value that sorts after every non-NaN.
+Positive and negative zero compare equal. These rules also apply inside arrays and structs and to
+`IN`.
+
+Arrays and structs compare lexicographically. Array elements are visited in index order and struct
+fields in declared order. A nested null equals another nested null and sorts before a non-null
+value. This nested-null rule does not change the top-level three-valued result: a null array or
+struct operand still makes an ordinary comparison null.
+
+```sql
+CAST('NaN' AS DOUBLE) = CAST('NaN' AS DOUBLE)  -- TRUE
+CAST('NaN' AS DOUBLE) > 1.0                    -- TRUE
+1.0 < CAST('NaN' AS DOUBLE)                    -- TRUE
+CAST('-0.0' AS DOUBLE) = CAST('0.0' AS DOUBLE)  -- TRUE
+CAST('-0.0' AS DOUBLE) < CAST('0.0' AS DOUBLE)  -- FALSE
+CAST('-0.0' AS DOUBLE) > CAST('0.0' AS DOUBLE)  -- FALSE
+```
+
+## `IN`
+
+Kernel's `IN` node compares any left expression with the elements of one array-valued right
+expression. The right expression is not a parenthesized SQL value list or subquery.
+
+The left operand and the array element type resolve to one common orderable type, or use the same
+positional structural alignment permitted by comparisons when their leaf types already match.
+Membership uses the same equality relation as `=`, including its NaN and signed-zero behavior. A
+null array returns null. For a non-empty array:
+
+| Condition | Result |
+|---|---|
+| At least one element matches | `TRUE` |
+| No match and the left operand is null | `NULL` |
+| No match and an element is null | `NULL` |
+| No match and no null is involved | `FALSE` |
+
+In SQL, a column on the left is the common form. For example, `customer_id IN (1, 2, 3)` maps to a
+Kernel `IN` node whose left expression is `customer_id` and whose right expression is
+`ARRAY(1, 2, 3)`. The parenthesized SQL list is not itself a Kernel expression node.
+
+```sql
+customer_id IN (1, 2, 3)                         -- valid: left side is a column
+1 IN (1, 2)                                      -- TRUE
+1 IN (2, 3)                                      -- FALSE
+1 IN (2, NULL)                                   -- NULL
+NULL IN (1, 2)                                   -- NULL
+CAST('NaN' AS DOUBLE) IN (CAST('NaN' AS DOUBLE))  -- TRUE
+CAST('-0.0' AS DOUBLE) IN (CAST('0.0' AS DOUBLE))  -- TRUE
+```
+
+SQL text does not permit `IN ()`, but an `IN` subquery can return no rows. Kernel likewise returns
+false for an empty array, including when the left value is null:
+
+```text
+1    IN [] -> FALSE
+NULL IN [] -> FALSE
+```
+
+This fixes the result, but it does not require an evaluator to skip the left expression. `IN` does
+not suppress errors from its children.
+
+`NOT IN` applies SQL `NOT` to the membership result, so it preserves null. Data-skipping consumers
+must treat a null predicate result as unknown and keep the file.
+
+The inferred result is nullable when the left operand, array, or array element is nullable. This
+remains true for an empty array even though that row's value is always false.
+
+## Boolean predicates and nulls
+
+`BooleanExpression`, `AND`, `OR`, and `NOT` require Boolean inputs. Kernel does not define numeric
+or string truthiness. `AND`, `OR`, and `NOT` use SQL three-valued logic. `IS NULL` accepts any type
+and always returns a non-null Boolean.
+
+`BooleanExpression` keeps its input nullability, and `NOT` keeps its child's nullability. An `AND`
+or `OR` result is nullable when any child is nullable, even when a decisive child determines a
+non-null value for a particular row.
+
+```sql
+TRUE  AND TRUE   -- TRUE
+TRUE  AND FALSE  -- FALSE
+TRUE  AND NULL   -- NULL
+FALSE AND NULL   -- FALSE
+
+TRUE  OR FALSE   -- TRUE
+FALSE OR FALSE   -- FALSE
+TRUE  OR NULL    -- TRUE
+FALSE OR NULL    -- NULL
+
+NOT TRUE         -- FALSE
+NOT FALSE        -- TRUE
+NOT NULL         -- NULL
+
+NULL IS NULL     -- TRUE
+1 IS NULL        -- FALSE
+```
+
+The normalized empty junctions use their Boolean identities: `AND()` is true and `OR()` is false.
+
+## Evaluation order and errors
+
+Only `COALESCE` guarantees left-to-right evaluation and stops after the first non-null value.
+Kernel does not promise evaluation order or error suppression for Boolean junctions, arithmetic,
+comparisons, or `IN`; an evaluator may rewrite or reorder them.
+
+Failures fall into these categories:
+
+| Situation | Required result |
+|---|---|
+| Operand types have no permitted common type | Analysis error |
+| An operator has the wrong number or kind of operands | Analysis error |
+| The expression is valid but the evaluator cannot implement it | Explicit unsupported error |
+| Checked numeric operation or temporal conversion overflows | Runtime arithmetic-overflow error |
+| A non-null value is divided by positive or negative zero | Runtime `DIVIDE_BY_ZERO` error |
+| A nullable operand is null | Null according to the operator rules |
+| An unselected later `COALESCE` child would fail | No error; the child is not evaluated |
+
+An evaluator must not use a legacy, permissive, or `TRY` mode for the standard operators covered
+here. Such a mode must not make overflow wrap or turn an error into null.
+
+## Sources
+
+The common-type, decimal-arithmetic, overflow, null, and floating-point rules use public
+[Apache Spark ANSI semantics], [SQL data types], and [NULL semantics] as a baseline. The Apache
+Spark implementations of [ANSI type coercion], [arithmetic expressions], [predicates],
+[`COALESCE`], [floating-point ordering], and the [default binary string type] cover details that
+the SQL reference does not spell out.
+
+The operator sections above define Kernel's fixed choices where SQL implementations vary.
+`Project` assignment is Kernel-specific and limited to the conversions listed above.
+
+[Apache Spark ANSI semantics]: https://spark.apache.org/docs/4.0.1/sql-ref-ansi-compliance.html
+[SQL data types]: https://spark.apache.org/docs/4.0.1/sql-ref-datatypes.html
+[NULL semantics]: https://spark.apache.org/docs/4.0.1/sql-ref-null-semantics.html
+[ANSI type coercion]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+[arithmetic expressions]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+[predicates]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+[`COALESCE`]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala#L52-L93
+[floating-point ordering]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/SQLOrderingUtil.scala#L20-L40
+[default binary string type]: https://github.com/apache/spark/blob/v4.0.1/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala#L108-L121

--- a/kernel/src/expressions/semantics.md
+++ b/kernel/src/expressions/semantics.md
@@ -18,7 +18,9 @@ Failure to find a permitted type is an analysis error.
 
 Kernel does not implicitly parse `STRING` as a number or Boolean. For example, `long_col + '1'`,
 `long_col = '1'`, and `COALESCE(long_col, '0')` are outside the contract. An evaluator may accept
-such expressions as an extension, but their behavior is not portable.
+such expressions as an extension, but their behavior is not portable. Conformance fixtures mark
+these inputs as extension boundaries: rejection is valid, but acceptance is not a conformance
+failure and does not give the result portable semantics.
 
 `VOID` is the type of an untyped null. `VOID` and `T` have common type `T`; inputs that are all
 `VOID` retain that type. Identical scalar types have themselves as their common type. The following

--- a/kernel/src/expressions/semantics/conformance.rs
+++ b/kernel/src/expressions/semantics/conformance.rs
@@ -1,0 +1,3315 @@
+//! Executor-independent cases for Kernel's standard SQL expression semantics.
+//!
+//! Each case supplies one input row, an unresolved Kernel expression, its resolved output, and the
+//! required result. A harness analyzes and executes each case according to Kernel's standard SQL
+//! expression contract, then classifies the observed result as follows:
+//!
+//! - A portable case that matches is a pass. An explicit unsupported result is reported as
+//!   unsupported, not as a pass. Any other result is a failure.
+//! - An extension-boundary case rejected as invalid enforces the strict Kernel boundary. A value is
+//!   reported as an executor extension, and an unsupported result as unsupported. Neither is a
+//!   portable pass or a conformance failure because the input is outside Kernel's contract.
+//!
+//! Harnesses for executors with a configurable session time zone must configure
+//! [`CONFORMANCE_SESSION_TIME_ZONE`] before analysis and execution. Its non-UTC offset makes the
+//! temporal cases verify that common-type conversion does not depend on that setting. Executors
+//! with no session time zone can ignore it.
+//!
+//! Case order is unspecified. Harnesses should identify cases by the stable `name` on
+//! [`ExpressionSemanticsCase`] or [`ProjectAssignmentCase`].
+//!
+//! [`project_assignment_cases`] separately covers the declared output-schema boundary after
+//! expression inference. A complete harness runs both suites.
+
+use std::sync::Arc;
+
+use super::super::{
+    ArrayData, BinaryExpressionOp, BinaryPredicateOp, Expression, MapData, Predicate, Scalar,
+    StructData,
+};
+use crate::schema::{schema_ref, ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
+use crate::DeltaResult;
+
+/// Non-UTC session time zone required while running the conformance cases.
+pub const CONFORMANCE_SESSION_TIME_ZONE: &str = "America/Los_Angeles";
+
+/// The portable result or strict extension-boundary rejection for a conformance case.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExpectedResult {
+    /// Evaluation succeeds with this scalar value, including a typed [`Scalar::Null`].
+    Value(Scalar),
+    /// Analysis or evaluation fails with this contract-level error. An extension-boundary case
+    /// may instead be accepted with executor-specific behavior.
+    Error(ExpectedError),
+}
+
+/// Contract-level errors that an executor maps to its own error types and messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpectedError {
+    /// Expression analysis or declared-output assignment fails, including unresolved columns and
+    /// invalid arity or types.
+    InvalidExpression,
+    /// Checked integral or decimal arithmetic, or a temporal conversion, overflows during
+    /// evaluation.
+    ArithmeticOverflow,
+    /// A numeric divisor is positive or negative zero.
+    DivideByZero,
+}
+
+/// Whether a case has portable behavior or marks the edge of Kernel's contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConformanceRequirement {
+    /// The contract specifies this outcome, including required analysis errors.
+    Portable,
+    /// The expression is outside Kernel's contract. Rejection is expected from a strict executor,
+    /// but an executor may accept it as a non-portable extension.
+    ExtensionBoundary,
+}
+
+/// Type and nullability inferred before assignment to a declared output field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedOutput {
+    /// Inferred expression result type.
+    pub data_type: DataType,
+    /// Whether the inferred result may be null.
+    pub nullable: bool,
+}
+
+impl ResolvedOutput {
+    fn new(data_type: impl Into<DataType>, nullable: bool) -> Self {
+        Self {
+            data_type: data_type.into(),
+            nullable,
+        }
+    }
+}
+
+/// One input row and the expected analysis and evaluation result for an expression.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExpressionSemanticsCase {
+    /// Stable case name suitable for a test identifier.
+    pub name: &'static str,
+    /// Schema used to analyze the expression and interpret `input_row`.
+    pub input_schema: SchemaRef,
+    /// One input row, in `input_schema` field order.
+    pub input_row: Vec<Scalar>,
+    /// Unresolved expression to analyze and evaluate.
+    pub expression: Expression,
+    /// Expected analysis result before any surrounding `Project` assignment. Extension-boundary
+    /// expressions have no portable resolved output.
+    pub output: Option<ResolvedOutput>,
+    /// Required value or contract-level error.
+    pub expected: ExpectedResult,
+    /// Whether acceptance is required to follow the expected portable result.
+    pub requirement: ConformanceRequirement,
+}
+
+/// One expression and the expected result of assigning it to a declared `Project` output.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectAssignmentCase {
+    /// Stable case name suitable for a test identifier.
+    pub name: &'static str,
+    /// Schema used to analyze the source expression and interpret `input_row`.
+    pub input_schema: SchemaRef,
+    /// One input row, in `input_schema` field order.
+    pub input_row: Vec<Scalar>,
+    /// Unresolved expression to analyze before assigning it to `target`.
+    pub expression: Expression,
+    /// Type and nullability inferred for the source expression before assignment.
+    pub source: ResolvedOutput,
+    /// Declared output type and nullability.
+    pub target: ResolvedOutput,
+    /// Required assigned value or contract-level error.
+    pub expected: ExpectedResult,
+}
+
+/// Cases for common-type resolution, [`COALESCE`](super::super::VariadicExpressionOp::Coalesce),
+/// and [`ARRAY`](super::super::VariadicExpressionOp::Array).
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn common_type_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let nullable_int = StructField::nullable("i", DataType::INTEGER);
+    let required_long = StructField::not_null("l", DataType::LONG);
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let nullable_long_array = ArrayType::new(DataType::LONG, true);
+    let int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let nullable_long_value_map = MapType::new(DataType::STRING, DataType::LONG, true);
+    let empty_void_key_map = MapType::new(DataType::VOID, DataType::STRING, false);
+    let int_key_map = MapType::new(DataType::INTEGER, DataType::STRING, false);
+    let long_key_map = MapType::new(DataType::LONG, DataType::STRING, false);
+    let int_struct_field = StructField::not_null("value", DataType::INTEGER);
+    let long_struct_field = StructField::not_null("value", DataType::LONG);
+    let long_struct_type = StructType::try_new([long_struct_field.clone()])?;
+    let nullable_int_struct_field = StructField::nullable("value", DataType::INTEGER);
+    let nullable_long_struct_field = StructField::nullable("value", DataType::LONG);
+    let nullable_long_struct_type = StructType::try_new([nullable_long_struct_field.clone()])?;
+
+    Ok(vec![
+        ExpressionSemanticsCase {
+            name: "coalesce_int_and_long",
+            input_schema: Arc::new(StructType::try_new([nullable_int, required_long])?),
+            input_row: vec![Scalar::Null(DataType::INTEGER), Scalar::Long(7)],
+            expression: Expression::coalesce([
+                crate::expressions::col!("i"),
+                crate::expressions::col!("l"),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::LONG, false)),
+            expected: ExpectedResult::Value(Scalar::Long(7)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_all_null",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::LONG)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::LONG, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::LONG)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_all_void",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::VOID, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::VOID)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_void_and_int",
+            Scalar::Null(DataType::VOID),
+            Scalar::Integer(7),
+            DataType::INTEGER,
+            false,
+            Scalar::Integer(7),
+        ),
+        coalesce_value_case(
+            "coalesce_byte_and_short",
+            Scalar::Byte(1),
+            Scalar::Short(2),
+            DataType::SHORT,
+            false,
+            Scalar::Short(1),
+        ),
+        coalesce_value_case(
+            "coalesce_short_and_int",
+            Scalar::Short(1),
+            Scalar::Integer(2),
+            DataType::INTEGER,
+            false,
+            Scalar::Integer(1),
+        ),
+        coalesce_value_case(
+            "coalesce_float_and_double",
+            Scalar::Float(1.5),
+            Scalar::Double(2.5),
+            DataType::DOUBLE,
+            false,
+            Scalar::Double(1.5),
+        ),
+        coalesce_value_case(
+            "coalesce_decimal_and_float_returns_double",
+            decimal(100, 10, 2)?,
+            Scalar::Float(2.0),
+            DataType::DOUBLE,
+            false,
+            Scalar::Double(1.0),
+        ),
+        ExpressionSemanticsCase {
+            name: "array_int_and_long",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Long(2)),
+            ]),
+            output: Some(ResolvedOutput::new(long_array.clone(), false)),
+            expected: ExpectedResult::Value(array(long_array.clone(), [1i64.into(), 2i64.into()])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_nullable_element",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::INTEGER, true),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::INTEGER, true),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_int_and_void",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::INTEGER, true),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::INTEGER, true),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_with_column_child",
+            input_schema: schema_ref! { not_null "i": INTEGER },
+            input_row: vec![Scalar::Integer(7)],
+            expression: Expression::array([crate::expressions::col!("i")]),
+            output: Some(ResolvedOutput::new(int_array.clone(), false)),
+            expected: ExpectedResult::Value(array(int_array.clone(), [Scalar::Integer(7)])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_empty",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([] as [Expression; 0]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::VOID, false),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::VOID, false),
+                [] as [Scalar; 0],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(2)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        ExpressionSemanticsCase {
+            name: "empty_coalesce_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([] as [Expression; 0]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_boolean_and_int_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Boolean(true)),
+                Expression::Literal(Scalar::Integer(1)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_analyzes_unselected_invalid_child",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::binary(
+                    BinaryExpressionOp::Plus,
+                    Expression::Literal(Scalar::Boolean(true)),
+                    Expression::Literal(Scalar::Integer(1)),
+                ),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_common_type_is_recursive",
+            input_schema: schema_ref! {
+                not_null "ints": (int_array.clone()),
+                not_null "longs": (long_array.clone()),
+            },
+            input_row: vec![
+                array(int_array.clone(), [Scalar::Integer(1)])?,
+                array(long_array.clone(), [Scalar::Long(2)])?,
+            ],
+            expression: Expression::coalesce([
+                crate::expressions::col!("ints"),
+                crate::expressions::col!("longs"),
+            ]),
+            output: Some(ResolvedOutput::new(long_array.clone(), false)),
+            expected: ExpectedResult::Value(array(long_array, [Scalar::Long(1)])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "array_common_type_unions_element_nullability",
+            array(int_array.clone(), [Scalar::Integer(1)])?,
+            array(nullable_long_array.clone(), [Scalar::Null(DataType::LONG)])?,
+            nullable_long_array.clone().into(),
+            false,
+            array(nullable_long_array, [Scalar::Long(1)])?,
+        ),
+        ExpressionSemanticsCase {
+            name: "map_common_type_widens_values_and_nullability",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    int_value_map,
+                    [("key", Scalar::Integer(1))],
+                )?)),
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    nullable_long_value_map.clone(),
+                    [("key", Scalar::Long(2))],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(nullable_long_value_map.clone(), false)),
+            expected: ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                nullable_long_value_map,
+                [("key", Scalar::Long(1))],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "map_common_type_widens_keys",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    int_key_map.clone(),
+                    [(Scalar::Integer(1), "first")],
+                )?)),
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    long_key_map.clone(),
+                    [(Scalar::Long(2), "second")],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(long_key_map.clone(), false)),
+            expected: ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_key_map,
+                [(Scalar::Long(1), "first")],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "empty_map_void_key_widens_to_concrete_key",
+            Scalar::Map(MapData::try_new(
+                empty_void_key_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [(Scalar::Integer(1), "value")],
+            )?),
+            int_key_map.clone().into(),
+            false,
+            Scalar::Map(MapData::try_new(int_key_map, [] as [(Scalar, Scalar); 0])?),
+        ),
+        ExpressionSemanticsCase {
+            name: "struct_common_type_is_recursive",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![int_struct_field],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![long_struct_field.clone()],
+                    vec![Scalar::Long(2)],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(long_struct_type, false)),
+            expected: ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                vec![long_struct_field.clone()],
+                vec![Scalar::Long(1)],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "struct_common_type_unions_field_nullability",
+            Scalar::Struct(StructData::try_new(
+                vec![nullable_int_struct_field],
+                vec![Scalar::Integer(1)],
+            )?),
+            Scalar::Struct(StructData::try_new(
+                vec![long_struct_field.clone()],
+                vec![Scalar::Long(2)],
+            )?),
+            nullable_long_struct_type.clone().into(),
+            false,
+            Scalar::Struct(StructData::try_new(
+                vec![nullable_long_struct_field],
+                vec![Scalar::Long(1)],
+            )?),
+        ),
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_name_mismatch_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(2)],
+                )?)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_count_mismatch_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("value", DataType::INTEGER),
+                        StructField::not_null("extra", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_names_match_case_insensitively",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("Value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::LONG)],
+                    vec![Scalar::Long(2)],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                StructType::try_new([StructField::not_null("Value", DataType::LONG)])?,
+                false,
+            )),
+            expected: ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("Value", DataType::LONG)],
+                vec![Scalar::Long(1)],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        date_to_timestamp_ntz_case(
+            "date_and_timestamp_ntz_use_temporal_common_type",
+            1,
+            ExpectedResult::Value(Scalar::TimestampNtz(86_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_max_safe_day",
+            106_751_991,
+            ExpectedResult::Value(Scalar::TimestampNtz(9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_min_safe_day",
+            -106_751_991,
+            ExpectedResult::Value(Scalar::TimestampNtz(-9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_positive_overflow",
+            106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_negative_overflow",
+            -106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_case(
+            "date_and_timestamp_use_utc_temporal_common_type",
+            1,
+            ExpectedResult::Value(Scalar::Timestamp(86_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_max_safe_day",
+            106_751_991,
+            ExpectedResult::Value(Scalar::Timestamp(9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_min_safe_day",
+            -106_751_991,
+            ExpectedResult::Value(Scalar::Timestamp(-9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_positive_overflow",
+            106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_negative_overflow",
+            -106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        ExpressionSemanticsCase {
+            name: "timestamp_ntz_and_timestamp_use_utc",
+            input_schema: schema_ref! {
+                not_null "ntz": TIMESTAMP_NTZ,
+                nullable "ts": TIMESTAMP,
+            },
+            input_row: vec![
+                Scalar::TimestampNtz(86_400_000_000),
+                Scalar::Null(DataType::TIMESTAMP),
+            ],
+            expression: Expression::coalesce([
+                crate::expressions::col!("ntz"),
+                crate::expressions::col!("ts"),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::TIMESTAMP, false)),
+            expected: ExpectedResult::Value(Scalar::Timestamp(86_400_000_000)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_decimal_and_byte_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Byte(2),
+            DataType::decimal(5, 2)?,
+            false,
+            decimal(1, 5, 2)?,
+        ),
+        coalesce_value_case(
+            "coalesce_decimal_and_short_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Short(2),
+            DataType::decimal(7, 2)?,
+            false,
+            decimal(1, 7, 2)?,
+        ),
+        ExpressionSemanticsCase {
+            name: "coalesce_decimal_and_int_literal_uses_full_integral_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(1, 2, 2)?),
+                Expression::Literal(Scalar::Integer(2)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(12, 2)?, false)),
+            expected: ExpectedResult::Value(decimal(1, 12, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_decimal_and_long_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Long(2),
+            DataType::decimal(22, 2)?,
+            false,
+            decimal(1, 22, 2)?,
+        ),
+        coalesce_value_case(
+            "decimal_common_type_uses_maximum_scale_and_integer_digits",
+            decimal(125, 5, 2)?,
+            decimal(2250, 4, 3)?,
+            DataType::decimal(6, 3)?,
+            false,
+            decimal(1250, 6, 3)?,
+        ),
+        ExpressionSemanticsCase {
+            name: "decimal_common_type_scale_reduction_rounds_half_up",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(123_456_500_000_000_000_000, 38, 20)?),
+                Expression::Literal(decimal(0, 38, 5)?),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 5)?, false)),
+            expected: ExpectedResult::Value(decimal(123_457, 38, 5)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_common_type_negative_midpoint_rounds_away_from_zero",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(-123_456_500_000_000_000_000, 38, 20)?),
+                Expression::Literal(decimal(0, 38, 5)?),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 5)?, false)),
+            expected: ExpectedResult::Value(decimal(-123_457, 38, 5)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_stops_before_error",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::binary(
+                    BinaryExpressionOp::Divide,
+                    Expression::Literal(Scalar::Integer(5)),
+                    Expression::Literal(Scalar::Integer(0)),
+                ),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(2.0)),
+            requirement: ConformanceRequirement::Portable,
+        },
+    ])
+}
+
+/// Cases for numeric addition, subtraction, multiplication, decimal result types, and division.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or decimal value is internally inconsistent.
+pub fn arithmetic_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let decimal_10_2 = DataType::decimal(10, 2)?;
+    let decimal_11_2 = DataType::decimal(11, 2)?;
+    let decimal_13_2 = DataType::decimal(13, 2)?;
+    let decimal_21_4 = DataType::decimal(21, 4)?;
+    let decimal_23_13 = DataType::decimal(23, 13)?;
+    let decimal_38_6 = DataType::decimal(38, 6)?;
+    let decimal_38_17 = DataType::decimal(38, 17)?;
+
+    Ok(vec![
+        arithmetic_case(
+            "mixed_int_long_plus",
+            [
+                (StructField::not_null("i", DataType::INTEGER), 1i32.into()),
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+            ],
+            BinaryExpressionOp::Plus,
+            DataType::LONG,
+            Scalar::Long(3),
+        )?,
+        arithmetic_case(
+            "mixed_long_int_minus",
+            [
+                (StructField::not_null("l", DataType::LONG), 3i64.into()),
+                (StructField::not_null("i", DataType::INTEGER), 1i32.into()),
+            ],
+            BinaryExpressionOp::Minus,
+            DataType::LONG,
+            Scalar::Long(2),
+        )?,
+        arithmetic_case(
+            "mixed_int_long_multiply",
+            [
+                (StructField::not_null("i", DataType::INTEGER), 3i32.into()),
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+            ],
+            BinaryExpressionOp::Multiply,
+            DataType::LONG,
+            Scalar::Long(6),
+        )?,
+        arithmetic_case(
+            "long_and_float_promote_to_double",
+            [
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+                (StructField::not_null("f", DataType::FLOAT), 0.5f32.into()),
+            ],
+            BinaryExpressionOp::Plus,
+            DataType::DOUBLE,
+            Scalar::Double(2.5),
+        )?,
+        ExpressionSemanticsCase {
+            name: "null_arithmetic_propagates",
+            input_schema: schema_ref! {
+                nullable "n": INTEGER,
+                not_null "one": INTEGER,
+            },
+            input_row: vec![Scalar::Null(DataType::INTEGER), Scalar::Integer(1)],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                crate::expressions::col!("n"),
+                crate::expressions::col!("one"),
+            ),
+            output: Some(ResolvedOutput::new(DataType::INTEGER, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_arithmetic_uses_other_operand_type",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::INTEGER, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        invalid_arithmetic_case(
+            "boolean_arithmetic_is_rejected",
+            Scalar::Boolean(true),
+            Scalar::Boolean(false),
+        ),
+        invalid_arithmetic_case(
+            "date_arithmetic_is_rejected",
+            Scalar::Date(1),
+            Scalar::Date(2),
+        ),
+        invalid_arithmetic_case(
+            "year_month_interval_arithmetic_is_rejected",
+            Scalar::IntervalYearMonth(1),
+            Scalar::IntervalYearMonth(2),
+        ),
+        invalid_arithmetic_case(
+            "day_time_interval_arithmetic_is_rejected",
+            Scalar::IntervalDayTime(1),
+            Scalar::IntervalDayTime(2),
+        ),
+        integer_overflow_case("int_plus_overflow", BinaryExpressionOp::Plus, i32::MAX, 1),
+        integer_overflow_case("int_minus_overflow", BinaryExpressionOp::Minus, i32::MIN, 1),
+        integer_overflow_case(
+            "int_multiply_overflow",
+            BinaryExpressionOp::Multiply,
+            i32::MAX,
+            2,
+        ),
+        ExpressionSemanticsCase {
+            name: "double_multiply_overflow_is_infinity",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Multiply,
+                Expression::Literal(Scalar::Double(1e308)),
+                Expression::Literal(Scalar::Double(1e308)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(f64::INFINITY)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "double_arithmetic_preserves_nan",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Minus,
+                Expression::Literal(Scalar::Double(f64::INFINITY)),
+                Expression::Literal(Scalar::Double(f64::INFINITY)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(f64::NAN)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_double_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Double(2.5)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_float_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Float(2.5)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        decimal_arithmetic_case(
+            "decimal_add_result_type",
+            BinaryExpressionOp::Plus,
+            (125, 10, 2),
+            (225, 10, 2),
+            decimal_11_2.clone(),
+            decimal(350, 11, 2)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_minus_result_type",
+            BinaryExpressionOp::Minus,
+            (350, 10, 2),
+            (125, 10, 2),
+            decimal_11_2.clone(),
+            decimal(225, 11, 2)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_add_rounds_exact_result_once",
+            BinaryExpressionOp::Plus,
+            (4, 38, 7),
+            (4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_add_negative_rounds_exact_result_once",
+            BinaryExpressionOp::Plus,
+            (-4, 38, 7),
+            (-4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(-1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_subtract_rounds_exact_result_once",
+            BinaryExpressionOp::Minus,
+            (4, 38, 7),
+            (-4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_multiply_result_type",
+            BinaryExpressionOp::Multiply,
+            (150, 10, 2),
+            (200, 10, 2),
+            decimal_21_4,
+            decimal(30_000, 21, 4)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_scale_reduction_rounds_half_up",
+            BinaryExpressionOp::Multiply,
+            (123_456_750_000_000_000_000, 38, 20),
+            (100_000_000_000_000_000_000, 38, 20),
+            decimal_38_6.clone(),
+            decimal(1_234_568, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_scale_reduction_negative_midpoint_rounds_away_from_zero",
+            BinaryExpressionOp::Multiply,
+            (-123_456_750_000_000_000_000, 38, 20),
+            (100_000_000_000_000_000_000, 38, 20),
+            decimal_38_6,
+            decimal(-1_234_568, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_adjusted_scale_preserves_available_fractional_digits",
+            BinaryExpressionOp::Multiply,
+            (10_000_000_000, 20, 10),
+            (10_000_000_000, 20, 10),
+            decimal_38_17,
+            decimal(100_000_000_000_000_000, 38, 17)?,
+        )?,
+        ExpressionSemanticsCase {
+            name: "decimal_add_overflow",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(
+                    99_999_999_999_999_999_999_999_999_999_999_999_999,
+                    38,
+                    0,
+                )?),
+                Expression::Literal(decimal(1, 38, 0)?),
+            ),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 0)?, false)),
+            expected: ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_int_column",
+            input_schema: Arc::new(StructType::try_new([
+                StructField::not_null("d", decimal_10_2.clone()),
+                StructField::not_null("i", DataType::INTEGER),
+            ])?),
+            input_row: vec![decimal(100, 10, 2)?, Scalar::Integer(1)],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                crate::expressions::col!("d"),
+                crate::expressions::col!("i"),
+            ),
+            output: Some(ResolvedOutput::new(decimal_13_2, false)),
+            expected: ExpectedResult::Value(decimal(200, 13, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_minimum_precision_int_literal",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            output: Some(ResolvedOutput::new(decimal_11_2.clone(), false)),
+            expected: ExpectedResult::Value(decimal(200, 11, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_zero_literal_uses_one_digit_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(decimal_11_2.clone(), false)),
+            expected: ExpectedResult::Value(decimal(100, 11, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_non_literal_int_uses_full_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::binary(
+                    BinaryExpressionOp::Plus,
+                    Expression::Literal(Scalar::Integer(1)),
+                    Expression::Literal(Scalar::Integer(1)),
+                ),
+            ),
+            output: Some(ResolvedOutput::new(DataType::decimal(13, 2)?, false)),
+            expected: ExpectedResult::Value(decimal(300, 13, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "integer_division_is_fractional",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(7)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "float_division_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Float(7.0)),
+                Expression::Literal(Scalar::Float(2.0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        decimal_arithmetic_case(
+            "decimal_division_result_type",
+            BinaryExpressionOp::Divide,
+            (300, 10, 2),
+            (200, 10, 2),
+            decimal_23_13.clone(),
+            decimal(15_000_000_000_000, 23, 13)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_division_rounds_half_up",
+            BinaryExpressionOp::Divide,
+            (1, 1, 0),
+            (128, 3, 0),
+            DataType::decimal(7, 6)?,
+            decimal(7_813, 7, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "negative_decimal_division_rounds_away_from_zero",
+            BinaryExpressionOp::Divide,
+            (-1, 1, 0),
+            (128, 3, 0),
+            DataType::decimal(7, 6)?,
+            decimal(-7_813, 7, 6)?,
+        )?,
+        ExpressionSemanticsCase {
+            name: "decimal_divided_by_double_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(decimal(300, 10, 2)?),
+                Expression::Literal(Scalar::Double(2.0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(1.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        divide_by_zero_case(
+            "integer_divide_by_zero",
+            Scalar::Integer(1),
+            Scalar::Integer(0),
+            DataType::DOUBLE,
+        ),
+        divide_by_zero_case(
+            "decimal_divide_by_zero",
+            decimal(100, 10, 2)?,
+            decimal(0, 10, 2)?,
+            DataType::decimal(23, 13)?,
+        ),
+        divide_by_zero_case(
+            "double_divide_by_positive_zero",
+            Scalar::Double(1.0),
+            Scalar::Double(0.0),
+            DataType::DOUBLE,
+        ),
+        divide_by_zero_case(
+            "double_divide_by_negative_zero",
+            Scalar::Double(1.0),
+            Scalar::Double(-0.0),
+            DataType::DOUBLE,
+        ),
+        ExpressionSemanticsCase {
+            name: "null_dividend_propagates",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "null_divisor_propagates",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "null_dividend_wins_over_zero_divisor",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_dividend_wins_over_zero_divisor",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_division_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_divided_by_decimal",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(decimal(200, 10, 2)?),
+            ),
+            output: Some(ResolvedOutput::new(decimal_23_13.clone(), true)),
+            expected: ExpectedResult::Value(Scalar::Null(decimal_23_13)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "string_plus_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+    ])
+}
+
+/// Cases for comparison coercion, nulls, distinctness, NaNs, and signed zero.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn comparison_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let double_array = ArrayType::new(DataType::DOUBLE, false);
+    let int_struct = StructType::try_new([StructField::not_null("value", DataType::INTEGER)])?;
+    let long_struct = StructType::try_new([StructField::not_null("value", DataType::LONG)])?;
+    let int_struct_array = ArrayType::new(int_struct.clone(), false);
+    let long_struct_array = ArrayType::new(long_struct.clone(), false);
+    let map_type = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let map = Scalar::Map(MapData::try_new(map_type.clone(), [("key", 1i32)])?);
+    let decimal_38_30 = DataType::decimal(38, 30)?;
+    let alternate_nan = f64::from_bits(0x7ff8_0000_0000_0001);
+
+    Ok(vec![
+        ExpressionSemanticsCase {
+            name: "comparison_uses_numeric_common_type",
+            input_schema: schema_ref! {
+                not_null "i": INTEGER,
+                not_null "l": LONG,
+            },
+            input_row: vec![Scalar::Integer(1), Scalar::Long(1)],
+            expression: Expression::from_pred(Predicate::eq(
+                crate::expressions::col!("i"),
+                crate::expressions::col!("l"),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "date_and_timestamp_compare_in_utc",
+            Predicate::eq(
+                Expression::Literal(Scalar::Date(1)),
+                Expression::Literal(Scalar::Timestamp(86_400_000_000)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "decimal_comparison_uses_minimum_integral_literal_precision",
+            Predicate::eq(
+                Expression::Literal(decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(false),
+        ),
+        ExpressionSemanticsCase {
+            name: "decimal_comparison_uses_full_integral_column_precision",
+            input_schema: schema_ref! {
+                not_null "d": (decimal_38_30),
+                not_null "i": INTEGER,
+            },
+            input_row: vec![
+                decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?,
+                Scalar::Integer(1),
+            ],
+            expression: Expression::from_pred(Predicate::eq(
+                crate::expressions::col!("d"),
+                crate::expressions::col!("i"),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "null_equals_null_is_null",
+            Predicate::eq(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_less_than_value_is_null",
+            Predicate::lt(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            true,
+            None,
+        ),
+        ExpressionSemanticsCase {
+            name: "comparison_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        ExpressionSemanticsCase {
+            name: "boolean_and_int_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Boolean(true)),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_and_struct_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1)],
+                )?),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "arrays_with_no_common_type_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::BOOLEAN, false),
+                    [Scalar::Boolean(true)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1)],
+                )?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "structs_with_different_field_counts_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("a", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("a", DataType::INTEGER),
+                        StructField::not_null("b", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "structs_containing_maps_are_not_comparable",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("m", map_type.clone())],
+                    vec![map.clone()],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("m", map_type.clone())],
+                    vec![map.clone()],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "untyped_null_comparison_adopts_other_operand_type",
+            Predicate::eq(
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::String("value".into())),
+            ),
+            true,
+            None,
+        ),
+        ExpressionSemanticsCase {
+            name: "map_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(map.clone()),
+                Expression::Literal(map),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "interval_cross_family_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::lt(
+                Expression::Literal(Scalar::IntervalYearMonth(1)),
+                Expression::Literal(Scalar::IntervalDayTime(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "differently_named_structs_requiring_leaf_widening_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::LONG)],
+                    vec![Scalar::Long(1)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "comparison_ignores_struct_field_names_after_positional_alignment",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "comparison_aligns_struct_field_nullability",
+            Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_struct_fields_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_struct_field_sorts_first",
+            Predicate::lt(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "string_comparison_uses_binary_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::String("A".into())),
+                Expression::Literal(Scalar::String("a".into())),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "string_comparison_does_not_normalize_unicode",
+            Predicate::lt(
+                Expression::Literal(Scalar::String("e\u{301}".into())),
+                Expression::Literal(Scalar::String("\u{e9}".into())),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "binary_comparison_uses_unsigned_lexicographic_order",
+            Predicate::lt(
+                Expression::Literal(Scalar::Binary(vec![0x7f])),
+                Expression::Literal(Scalar::Binary(vec![0x80])),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_sorts_before_true",
+            Predicate::lt(
+                Expression::Literal(Scalar::Boolean(false)),
+                Expression::Literal(Scalar::Boolean(true)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "year_month_intervals_use_signed_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::IntervalYearMonth(-1)),
+                Expression::Literal(Scalar::IntervalYearMonth(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "day_time_intervals_use_signed_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::IntervalDayTime(-1)),
+                Expression::Literal(Scalar::IntervalDayTime(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_array_elements_compare_equal",
+            Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_array_element_sorts_first",
+            Predicate::lt(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Integer(1)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "arrays_compare_lexicographically",
+            Predicate::lt(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1), Scalar::Integer(2)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1), Scalar::Integer(3)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "array_comparison_coerces_nested_struct_fields",
+            Predicate::eq(
+                Expression::Literal(array(
+                    int_struct_array,
+                    [Scalar::Struct(StructData::try_new(
+                        int_struct.fields().cloned().collect(),
+                        vec![Scalar::Integer(1)],
+                    )?)],
+                )?),
+                Expression::Literal(array(
+                    long_struct_array,
+                    [Scalar::Struct(StructData::try_new(
+                        long_struct.fields().cloned().collect(),
+                        vec![Scalar::Long(1)],
+                    )?)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "structs_compare_in_field_order",
+            Predicate::lt(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("first", DataType::INTEGER),
+                        StructField::not_null("second", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("first", DataType::INTEGER),
+                        StructField::not_null("second", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(3)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "different_nan_payloads_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(alternate_nan)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nan_sorts_after_finite_value",
+            Predicate::gt(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(1.0)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "finite_value_sorts_before_nan",
+            Predicate::lt(
+                Expression::Literal(Scalar::Double(1.0)),
+                Expression::Literal(Scalar::Double(f64::NAN)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "signed_zeroes_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "negative_zero_is_not_less_than_positive_zero",
+            Predicate::lt(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "negative_zero_is_not_greater_than_positive_zero",
+            Predicate::gt(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "array_comparison_uses_nan_equality",
+            Predicate::eq(
+                Expression::Literal(array(double_array.clone(), [Scalar::Double(f64::NAN)])?),
+                Expression::Literal(array(double_array, [Scalar::Double(alternate_nan)])?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "equal_values_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "distinct_ignores_struct_field_names_after_positional_alignment",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "unequal_values_are_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "two_nulls_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_value_are_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nan_values_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(alternate_nan)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "signed_zeroes_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+    ])
+}
+
+/// Cases for `IN` over array-valued expressions.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn in_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let nullable_int_array = ArrayType::new(DataType::INTEGER, true);
+    let boolean_array = ArrayType::new(DataType::BOOLEAN, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let float_array = ArrayType::new(DataType::FLOAT, false);
+    let double_array = ArrayType::new(DataType::DOUBLE, false);
+    let decimal_38_30_array = ArrayType::new(DataType::decimal(38, 30)?, false);
+    let map_type = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let map_array = ArrayType::new(map_type.clone(), false);
+    let map = Scalar::Map(MapData::try_new(map_type, [("key", Scalar::Integer(1))])?);
+    let right_struct_field = StructField::not_null("right", DataType::INTEGER);
+    let right_struct_array =
+        ArrayType::new(StructType::try_new([right_struct_field.clone()])?, false);
+    let lowercase_long_struct_field = StructField::not_null("value", DataType::LONG);
+    let lowercase_long_struct_array = ArrayType::new(
+        StructType::try_new([lowercase_long_struct_field.clone()])?,
+        false,
+    );
+    let int_array_struct =
+        StructType::try_new([StructField::not_null("values", int_array.clone())])?;
+    let long_array_struct =
+        StructType::try_new([StructField::not_null("values", long_array.clone())])?;
+    let long_array_struct_array = ArrayType::new(long_array_struct.clone(), false);
+
+    Ok(vec![
+        literal_in_case(
+            "literal_in_matches_without_null",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [Scalar::Integer(1), Scalar::Integer(2)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_match_wins_over_null_element",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            true,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_no_match_with_null_element_is_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            true,
+            None,
+        )?,
+        literal_in_case(
+            "literal_in_declared_nullable_elements_is_nullable_without_present_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Integer(3)],
+            true,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_null_left_operand_is_null",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [Scalar::Integer(1), Scalar::Integer(2)],
+            true,
+            None,
+        )?,
+        literal_in_case(
+            "literal_in_no_match_without_null_is_false",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [Scalar::Integer(2), Scalar::Integer(3)],
+            false,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_array_is_false",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            false,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_declared_nullable_array_is_nullable",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        ExpressionSemanticsCase {
+            name: "literal_in_empty_array_still_checks_declared_element_type",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(array(boolean_array, [] as [Scalar; 0])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        literal_in_case(
+            "literal_in_empty_array_with_null_left_operand_is_false",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_array_with_untyped_null_left_operand_is_false",
+            Scalar::Null(DataType::VOID),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        ExpressionSemanticsCase {
+            name: "empty_in_array_does_not_suppress_left_child_error",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::binary(
+                    BinaryExpressionOp::Divide,
+                    Expression::Literal(Scalar::Integer(1)),
+                    Expression::Literal(Scalar::Integer(0)),
+                ),
+                Expression::Literal(array(double_array.clone(), [] as [Scalar; 0])?),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Error(ExpectedError::DivideByZero),
+            requirement: ConformanceRequirement::Portable,
+        },
+        literal_not_in_case(
+            "literal_not_in_empty_array_with_null_left_operand_is_true",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_uses_numeric_common_type",
+            Scalar::Integer(1),
+            long_array.clone(),
+            [Scalar::Long(1)],
+            false,
+            Some(true),
+        )?,
+        ExpressionSemanticsCase {
+            name: "literal_in_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(array(int_array.clone(), [Scalar::Integer(1)])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        literal_in_case(
+            "literal_in_uses_nan_equality",
+            Scalar::Double(f64::NAN),
+            double_array.clone(),
+            [Scalar::Double(f64::NAN)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_uses_signed_zero_equality",
+            Scalar::Double(-0.0),
+            double_array.clone(),
+            [Scalar::Double(0.0)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_ignores_struct_field_names_after_positional_alignment",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            right_struct_array.clone(),
+            [Scalar::Struct(StructData::try_new(
+                vec![right_struct_field.clone()],
+                vec![Scalar::Integer(1)],
+            )?)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_coerces_nested_array_elements",
+            Scalar::Struct(StructData::try_new(
+                int_array_struct.fields().cloned().collect(),
+                vec![array(int_array.clone(), [Scalar::Integer(1)])?],
+            )?),
+            long_array_struct_array.clone(),
+            [Scalar::Struct(StructData::try_new(
+                long_array_struct.fields().cloned().collect(),
+                vec![array(long_array.clone(), [Scalar::Long(1)])?],
+            )?)],
+            false,
+            Some(true),
+        )?,
+        literal_not_in_case(
+            "literal_not_in_preserves_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_matches_without_null",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(1), Scalar::Integer(2)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_match_wins_over_null_element",
+            Scalar::Integer(1),
+            StructField::not_null("items", nullable_int_array.clone()),
+            array(
+                nullable_int_array.clone(),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?,
+            true,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_no_match_with_null_element_is_null",
+            Scalar::Integer(1),
+            StructField::not_null("items", nullable_int_array.clone()),
+            array(
+                nullable_int_array.clone(),
+                [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            )?,
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_null_left_operand_is_null",
+            Scalar::Null(DataType::INTEGER),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(1), Scalar::Integer(2)])?,
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_no_match_without_null_is_false",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(2), Scalar::Integer(3)])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_empty_list_is_false",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [] as [Scalar; 0])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_empty_list_with_null_left_operand_is_false",
+            Scalar::Null(DataType::INTEGER),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [] as [Scalar; 0])?,
+            true,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_null_collection_is_null",
+            Scalar::Integer(1),
+            StructField::nullable("items", int_array.clone()),
+            Scalar::Null(int_array.clone().into()),
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_uses_numeric_common_type",
+            Scalar::Integer(1),
+            StructField::not_null("items", long_array.clone()),
+            array(long_array, [Scalar::Long(1)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_integral_and_float_promote_to_double",
+            Scalar::Long(16_777_217),
+            StructField::not_null("items", float_array.clone()),
+            array(float_array, [Scalar::Float(16_777_216.0)])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_decimal_uses_minimum_integral_literal_precision",
+            Scalar::Integer(1),
+            StructField::not_null("items", decimal_38_30_array.clone()),
+            array(
+                decimal_38_30_array,
+                [decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?],
+            )?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_aligns_structs_with_different_field_nullability",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::nullable("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", right_struct_array.clone()),
+            array(
+                right_struct_array.clone(),
+                [Scalar::Struct(StructData::try_new(
+                    vec![right_struct_field.clone()],
+                    vec![Scalar::Integer(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_case_insensitive_struct_names_allow_leaf_widening",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("Value", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", lowercase_long_struct_array.clone()),
+            array(
+                lowercase_long_struct_array,
+                [Scalar::Struct(StructData::try_new(
+                    vec![lowercase_long_struct_field],
+                    vec![Scalar::Long(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_ignores_struct_field_names_after_positional_alignment",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", right_struct_array.clone()),
+            array(
+                right_struct_array,
+                [Scalar::Struct(StructData::try_new(
+                    vec![right_struct_field],
+                    vec![Scalar::Integer(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_uses_nan_equality",
+            Scalar::Double(f64::NAN),
+            StructField::not_null("items", double_array.clone()),
+            array(double_array.clone(), [Scalar::Double(f64::NAN)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_uses_signed_zero_equality",
+            Scalar::Double(-0.0),
+            StructField::not_null("items", double_array.clone()),
+            array(double_array, [Scalar::Double(0.0)])?,
+            false,
+            Some(true),
+        )?,
+        ExpressionSemanticsCase {
+            name: "in_column_left_operand_matches",
+            input_schema: schema_ref! { not_null "value": INTEGER },
+            input_row: vec![Scalar::Integer(1)],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                crate::expressions::col!("value"),
+                Expression::Literal(array(int_array.clone(), [Scalar::Integer(1)])?),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "in_array_expression_rhs_matches",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::array([Expression::Literal(Scalar::Integer(1))]),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "in_scalar_rhs_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "map_membership_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(map.clone()),
+                Expression::Literal(array(map_array, [map])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+    ])
+}
+
+/// Cases for Boolean input validation, three-valued logic, and `IS NULL`.
+pub fn boolean_cases() -> Vec<ExpressionSemanticsCase> {
+    vec![
+        ExpressionSemanticsCase {
+            name: "non_null_boolean_expression_preserves_value",
+            input_schema: schema_ref! { not_null "b": BOOLEAN },
+            input_row: vec![Scalar::Boolean(true)],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                crate::expressions::col!("b"),
+            ))),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "nullable_boolean_expression_preserves_null",
+            input_schema: schema_ref! { nullable "b": BOOLEAN },
+            input_row: vec![Scalar::Null(DataType::BOOLEAN)],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                crate::expressions::col!("b"),
+            ))),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::BOOLEAN)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "integer_boolean_expression_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                Expression::Literal(Scalar::Integer(1)),
+            ))),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "string_boolean_expression_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                Expression::Literal(Scalar::String("true".into())),
+            ))),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        predicate_value_case(
+            "not_true_is_false",
+            Predicate::not(Predicate::TRUE),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "not_false_is_true",
+            Predicate::not(Predicate::FALSE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "not_null_is_null",
+            Predicate::not(Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_is_null_is_true",
+            Predicate::is_null(Expression::Literal(Scalar::Null(DataType::INTEGER))),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "value_is_null_is_false",
+            Predicate::is_null(Expression::Literal(Scalar::Integer(1))),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_null_is_null",
+            Predicate::and(Predicate::TRUE, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "false_and_null_is_false",
+            Predicate::and(Predicate::FALSE, Predicate::NULL),
+            true,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_false_is_false",
+            Predicate::and(Predicate::NULL, Predicate::FALSE),
+            true,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_null_is_null",
+            Predicate::and(Predicate::NULL, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "true_or_null_is_true",
+            Predicate::or(Predicate::TRUE, Predicate::NULL),
+            true,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_null_is_null",
+            Predicate::or(Predicate::FALSE, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_or_true_is_true",
+            Predicate::or(Predicate::NULL, Predicate::TRUE),
+            true,
+            Some(true),
+        ),
+        predicate_value_case(
+            "null_or_null_is_null",
+            Predicate::or(Predicate::NULL, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "empty_and_is_true",
+            Predicate::and_from([] as [Predicate; 0]),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "empty_or_is_false",
+            Predicate::or_from([] as [Predicate; 0]),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_false_is_false",
+            Predicate::and(Predicate::TRUE, Predicate::FALSE),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_true_is_true",
+            Predicate::and(Predicate::TRUE, Predicate::TRUE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_true_is_true",
+            Predicate::or(Predicate::FALSE, Predicate::TRUE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_false_is_false",
+            Predicate::or(Predicate::FALSE, Predicate::FALSE),
+            false,
+            Some(false),
+        ),
+    ]
+}
+
+/// Cases for assignment from an inferred expression result to a declared `Project` field.
+///
+/// These cases are separate from [`all_cases`] because they test the schema boundary after
+/// expression analysis rather than operator inference itself.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's decimal or complex value is internally inconsistent.
+pub fn project_assignment_cases() -> DeltaResult<Vec<ProjectAssignmentCase>> {
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let nullable_long_array = ArrayType::new(DataType::LONG, true);
+    let nullable_int_array = ArrayType::new(DataType::INTEGER, true);
+    let required_int_array = ArrayType::new(DataType::INTEGER, false);
+    let decimal_10_2_array = ArrayType::new(DataType::decimal(10, 2)?, false);
+    let decimal_12_4_array = ArrayType::new(DataType::decimal(12, 4)?, false);
+    let decimal_10_1_array = ArrayType::new(DataType::decimal(10, 1)?, false);
+
+    let int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let long_value_map = MapType::new(DataType::STRING, DataType::LONG, false);
+    let int_key_map = MapType::new(DataType::INTEGER, DataType::STRING, false);
+    let long_key_map = MapType::new(DataType::LONG, DataType::STRING, false);
+    let nullable_int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, true);
+    let required_int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+
+    let required_int_struct =
+        StructType::try_new([StructField::not_null("value", DataType::INTEGER)])?;
+    let nullable_int_struct =
+        StructType::try_new([StructField::nullable("value", DataType::INTEGER)])?;
+    let nested_int_struct =
+        StructType::try_new([StructField::not_null("source", int_array.clone())])?;
+    let nested_long_struct =
+        StructType::try_new([StructField::nullable("target", nullable_long_array.clone())])?;
+    let differently_named_int_struct =
+        StructType::try_new([StructField::not_null("other", DataType::INTEGER)])?;
+
+    let empty_void_array = ArrayType::new(DataType::VOID, false);
+    let void_array = ArrayType::new(DataType::VOID, true);
+    let empty_void_key_map = MapType::new(DataType::VOID, DataType::STRING, false);
+    let empty_void_value_map = MapType::new(DataType::STRING, DataType::VOID, false);
+    let void_value_map = MapType::new(DataType::STRING, DataType::VOID, true);
+    let void_struct = StructType::try_new([StructField::nullable("value", DataType::VOID)])?;
+
+    Ok(vec![
+        project_assignment_case(
+            "project_exact_type",
+            Scalar::Integer(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_required_to_nullable",
+            Scalar::Integer(1),
+            false,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_nullable_to_nullable",
+            Scalar::Null(DataType::INTEGER),
+            true,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+        ),
+        ProjectAssignmentCase {
+            name: "project_target_does_not_change_integer_division_inference",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(3)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            source: ResolvedOutput::new(DataType::DOUBLE, false),
+            target: ResolvedOutput::new(DataType::LONG, false),
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        },
+        ProjectAssignmentCase {
+            name: "project_target_does_not_change_decimal_arithmetic_inference",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(decimal(200, 10, 2)?),
+            ),
+            source: ResolvedOutput::new(DataType::decimal(11, 2)?, false),
+            target: ResolvedOutput::new(DataType::decimal(10, 2)?, false),
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        },
+        project_assignment_case(
+            "project_byte_to_short",
+            Scalar::Byte(1),
+            false,
+            DataType::SHORT,
+            false,
+            ExpectedResult::Value(Scalar::Short(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_int",
+            Scalar::Byte(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_long",
+            Scalar::Byte(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_float",
+            Scalar::Byte(1),
+            false,
+            DataType::FLOAT,
+            false,
+            ExpectedResult::Value(Scalar::Float(1.0)),
+        ),
+        project_assignment_case(
+            "project_byte_to_double",
+            Scalar::Byte(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_short_to_int",
+            Scalar::Short(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_short_to_long",
+            Scalar::Short(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_short_to_float",
+            Scalar::Short(1),
+            false,
+            DataType::FLOAT,
+            false,
+            ExpectedResult::Value(Scalar::Float(1.0)),
+        ),
+        project_assignment_case(
+            "project_short_to_double",
+            Scalar::Short(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_int_to_long",
+            Scalar::Integer(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_int_to_double",
+            Scalar::Integer(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_float_to_double",
+            Scalar::Float(1.5),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.5)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz",
+            Scalar::Date(1),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(86_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_max_safe_day",
+            Scalar::Date(106_751_991),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(9_223_372_022_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_min_safe_day",
+            Scalar::Date(-106_751_991),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(-9_223_372_022_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_positive_overflow",
+            Scalar::Date(106_751_992),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_negative_overflow",
+            Scalar::Date(-106_751_992),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        project_assignment_case(
+            "project_void_to_nullable",
+            Scalar::Null(DataType::VOID),
+            true,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+        ),
+        project_assignment_case(
+            "project_int_to_decimal",
+            Scalar::Integer(1),
+            false,
+            DataType::decimal(10, 0)?,
+            false,
+            ExpectedResult::Value(decimal(1, 10, 0)?),
+        ),
+        project_assignment_case(
+            "project_decimal_to_wider_decimal",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(12, 4)?,
+            false,
+            ExpectedResult::Value(decimal(12_300, 12, 4)?),
+        ),
+        project_assignment_case(
+            "project_array_decimal_assignment_is_recursive",
+            array(decimal_10_2_array.clone(), [decimal(123, 10, 2)?])?,
+            false,
+            decimal_12_4_array.clone(),
+            false,
+            ExpectedResult::Value(array(decimal_12_4_array, [decimal(12_300, 12, 4)?])?),
+        ),
+        project_assignment_case(
+            "project_array_element_widens",
+            array(int_array.clone(), [Scalar::Integer(1)])?,
+            false,
+            long_array.clone(),
+            false,
+            ExpectedResult::Value(array(long_array, [Scalar::Long(1)])?),
+        ),
+        project_assignment_case(
+            "project_map_value_widens",
+            Scalar::Map(MapData::try_new(
+                int_value_map.clone(),
+                [("key", Scalar::Integer(1))],
+            )?),
+            false,
+            long_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_value_map,
+                [("key", Scalar::Long(1))],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_map_key_widens",
+            Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [(Scalar::Integer(1), "value")],
+            )?),
+            false,
+            long_key_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_key_map,
+                [(Scalar::Long(1), "value")],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_struct_assignment_is_recursive_and_positional",
+            Scalar::Struct(StructData::try_new(
+                nested_int_struct.fields().cloned().collect(),
+                vec![array(int_array.clone(), [Scalar::Integer(1)])?],
+            )?),
+            false,
+            nested_long_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                nested_long_struct.fields().cloned().collect(),
+                vec![array(nullable_long_array, [Scalar::Long(1)])?],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_empty_void_array_element_to_required_target",
+            array(empty_void_array, [] as [Scalar; 0])?,
+            false,
+            required_int_array.clone(),
+            false,
+            ExpectedResult::Value(array(required_int_array.clone(), [] as [Scalar; 0])?),
+        ),
+        project_assignment_case(
+            "project_empty_void_map_value_to_required_target",
+            Scalar::Map(MapData::try_new(
+                empty_void_value_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            false,
+            required_int_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                required_int_value_map.clone(),
+                [] as [(Scalar, Scalar); 0],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_empty_void_map_key_to_concrete_target",
+            Scalar::Map(MapData::try_new(
+                empty_void_key_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            false,
+            int_key_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [] as [(Scalar, Scalar); 0],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_void_array_element_to_nullable_target",
+            array(void_array, [Scalar::Null(DataType::VOID)])?,
+            false,
+            nullable_int_array.clone(),
+            false,
+            ExpectedResult::Value(array(
+                nullable_int_array.clone(),
+                [Scalar::Null(DataType::INTEGER)],
+            )?),
+        ),
+        project_assignment_case(
+            "project_void_map_value_to_nullable_target",
+            Scalar::Map(MapData::try_new(
+                void_value_map,
+                [("key", Scalar::Null(DataType::VOID))],
+            )?),
+            false,
+            nullable_int_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                nullable_int_value_map.clone(),
+                [("key", Scalar::Null(DataType::INTEGER))],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_void_struct_field_to_nullable_target",
+            Scalar::Struct(StructData::try_new(
+                void_struct.fields().cloned().collect(),
+                vec![Scalar::Null(DataType::VOID)],
+            )?),
+            false,
+            nullable_int_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                nullable_int_struct.fields().cloned().collect(),
+                vec![Scalar::Null(DataType::INTEGER)],
+            )?)),
+        ),
+        rejected_project_assignment_case(
+            "project_void_to_required_is_rejected",
+            Scalar::Null(DataType::VOID),
+            true,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_to_required_is_rejected",
+            Scalar::Integer(1),
+            true,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_narrowing_is_rejected",
+            Scalar::Long(1),
+            false,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_int_to_float_is_rejected",
+            Scalar::Integer(1),
+            false,
+            DataType::FLOAT,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_long_to_double_is_rejected",
+            Scalar::Long(1),
+            false,
+            DataType::DOUBLE,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_date_to_timestamp_is_rejected",
+            Scalar::Date(1),
+            false,
+            DataType::TIMESTAMP,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_timestamp_ntz_to_timestamp_is_rejected",
+            Scalar::TimestampNtz(1),
+            false,
+            DataType::TIMESTAMP,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_string_parsing_is_rejected",
+            Scalar::String("1".into()),
+            false,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_decimal_rounding_is_rejected",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(10, 1)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_int_to_insufficient_decimal_is_rejected",
+            Scalar::Integer(1),
+            false,
+            DataType::decimal(9, 0)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_decimal_integer_loss_is_rejected",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(9, 2)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_array_decimal_rounding_is_rejected",
+            array(decimal_10_2_array, [decimal(123, 10, 2)?])?,
+            false,
+            decimal_10_1_array,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_array_element_to_required_is_rejected",
+            array(nullable_int_array, [Scalar::Integer(1)])?,
+            false,
+            required_int_array,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_map_value_to_required_is_rejected",
+            Scalar::Map(MapData::try_new(
+                nullable_int_value_map,
+                [("key", Scalar::Integer(1))],
+            )?),
+            false,
+            required_int_value_map,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_struct_field_to_required_is_rejected",
+            Scalar::Struct(StructData::try_new(
+                nullable_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?),
+            false,
+            required_int_struct.clone(),
+            false,
+        ),
+        project_assignment_case(
+            "project_struct_fields_align_positionally",
+            Scalar::Struct(StructData::try_new(
+                required_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?),
+            false,
+            differently_named_int_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                differently_named_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?)),
+        ),
+    ])
+}
+
+/// All standard-expression cases published by this module, in unspecified order.
+///
+/// # Errors
+///
+/// Returns an error if any fixture is internally inconsistent.
+pub fn all_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let mut cases = common_type_cases()?;
+    cases.extend(arithmetic_cases()?);
+    cases.extend(comparison_cases()?);
+    cases.extend(in_cases()?);
+    cases.extend(boolean_cases());
+    Ok(cases)
+}
+
+fn date_to_timestamp_ntz_case(
+    name: &'static str,
+    days: i32,
+    expected: ExpectedResult,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {
+            not_null "d": DATE,
+            nullable "ts": TIMESTAMP_NTZ,
+        },
+        input_row: vec![Scalar::Date(days), Scalar::Null(DataType::TIMESTAMP_NTZ)],
+        expression: Expression::coalesce([
+            crate::expressions::col!("d"),
+            crate::expressions::col!("ts"),
+        ]),
+        output: Some(ResolvedOutput::new(DataType::TIMESTAMP_NTZ, false)),
+        expected,
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn date_to_timestamp_case(
+    name: &'static str,
+    days: i32,
+    expected: ExpectedResult,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {
+            not_null "d": DATE,
+            nullable "ts": TIMESTAMP,
+        },
+        input_row: vec![Scalar::Date(days), Scalar::Null(DataType::TIMESTAMP)],
+        expression: Expression::coalesce([
+            crate::expressions::col!("d"),
+            crate::expressions::col!("ts"),
+        ]),
+        output: Some(ResolvedOutput::new(DataType::TIMESTAMP, false)),
+        expected,
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn project_assignment_case(
+    name: &'static str,
+    source_value: Scalar,
+    source_nullable: bool,
+    target_type: impl Into<DataType>,
+    target_nullable: bool,
+    expected: ExpectedResult,
+) -> ProjectAssignmentCase {
+    let source_type = source_value.data_type();
+    ProjectAssignmentCase {
+        name,
+        input_schema: Arc::new(StructType::new_unchecked([StructField::new(
+            "input",
+            source_type.clone(),
+            source_nullable,
+        )])),
+        input_row: vec![source_value],
+        expression: Expression::column(["input"]),
+        source: ResolvedOutput::new(source_type, source_nullable),
+        target: ResolvedOutput::new(target_type, target_nullable),
+        expected,
+    }
+}
+
+fn rejected_project_assignment_case(
+    name: &'static str,
+    source_value: Scalar,
+    source_nullable: bool,
+    target_type: impl Into<DataType>,
+    target_nullable: bool,
+) -> ProjectAssignmentCase {
+    project_assignment_case(
+        name,
+        source_value,
+        source_nullable,
+        target_type,
+        target_nullable,
+        ExpectedResult::Error(ExpectedError::InvalidExpression),
+    )
+}
+
+fn literal_in_case(
+    name: &'static str,
+    value: Scalar,
+    array_type: ArrayType,
+    elements: impl IntoIterator<Item = Scalar>,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(predicate_value_case(
+        name,
+        Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            Expression::Literal(array(array_type, elements)?),
+        ),
+        output_nullable,
+        expected,
+    ))
+}
+
+fn literal_not_in_case(
+    name: &'static str,
+    value: Scalar,
+    array_type: ArrayType,
+    elements: impl IntoIterator<Item = Scalar>,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(predicate_value_case(
+        name,
+        Predicate::not(Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            Expression::Literal(array(array_type, elements)?),
+        )),
+        output_nullable,
+        expected,
+    ))
+}
+
+fn column_in_case(
+    name: &'static str,
+    value: Scalar,
+    collection_field: StructField,
+    collection: Scalar,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: Arc::new(StructType::try_new([collection_field])?),
+        input_row: vec![collection],
+        expression: Expression::from_pred(Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            crate::expressions::col!("items"),
+        )),
+        output: Some(ResolvedOutput::new(DataType::BOOLEAN, output_nullable)),
+        expected: ExpectedResult::Value(match expected {
+            Some(value) => Scalar::Boolean(value),
+            None => Scalar::Null(DataType::BOOLEAN),
+        }),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn predicate_value_case(
+    name: &'static str,
+    predicate: Predicate,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::from_pred(predicate),
+        output: Some(ResolvedOutput::new(DataType::BOOLEAN, output_nullable)),
+        expected: ExpectedResult::Value(match expected {
+            Some(value) => Scalar::Boolean(value),
+            None => Scalar::Null(DataType::BOOLEAN),
+        }),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn coalesce_value_case(
+    name: &'static str,
+    left: Scalar,
+    right: Scalar,
+    output_type: DataType,
+    output_nullable: bool,
+    expected: Scalar,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::coalesce([Expression::Literal(left), Expression::Literal(right)]),
+        output: Some(ResolvedOutput::new(output_type, output_nullable)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn arithmetic_case(
+    name: &'static str,
+    fields_and_values: [(StructField, Scalar); 2],
+    op: BinaryExpressionOp,
+    output_type: DataType,
+    expected: Scalar,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    let [(left_field, left_value), (right_field, right_value)] = fields_and_values;
+    let left = Expression::column([left_field.name()]);
+    let right = Expression::column([right_field.name()]);
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: Arc::new(StructType::try_new([left_field, right_field])?),
+        input_row: vec![left_value, right_value],
+        expression: Expression::binary(op, left, right),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn invalid_arithmetic_case(
+    name: &'static str,
+    left: Scalar,
+    right: Scalar,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            BinaryExpressionOp::Plus,
+            Expression::Literal(left),
+            Expression::Literal(right),
+        ),
+        output: None,
+        expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn integer_overflow_case(
+    name: &'static str,
+    op: BinaryExpressionOp,
+    left: i32,
+    right: i32,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            op,
+            Expression::Literal(Scalar::Integer(left)),
+            Expression::Literal(Scalar::Integer(right)),
+        ),
+        output: Some(ResolvedOutput::new(DataType::INTEGER, false)),
+        expected: ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn decimal_arithmetic_case(
+    name: &'static str,
+    op: BinaryExpressionOp,
+    left: (i128, u8, u8),
+    right: (i128, u8, u8),
+    output_type: DataType,
+    expected: Scalar,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            op,
+            Expression::Literal(decimal(left.0, left.1, left.2)?),
+            Expression::Literal(decimal(right.0, right.1, right.2)?),
+        ),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn divide_by_zero_case(
+    name: &'static str,
+    numerator: Scalar,
+    denominator: Scalar,
+    output_type: DataType,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            BinaryExpressionOp::Divide,
+            Expression::Literal(numerator),
+            Expression::Literal(denominator),
+        ),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Error(ExpectedError::DivideByZero),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn decimal(bits: i128, precision: u8, scale: u8) -> DeltaResult<Scalar> {
+    Scalar::decimal(bits, precision, scale)
+}
+
+fn array(array_type: ArrayType, elements: impl IntoIterator<Item = Scalar>) -> DeltaResult<Scalar> {
+    Ok(Scalar::Array(ArrayData::try_new(array_type, elements)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn all_cases_are_well_formed() {
+        let mut names = HashSet::new();
+        for case in all_cases().unwrap() {
+            assert!(
+                names.insert(case.name),
+                "duplicate case name: {}",
+                case.name
+            );
+            assert_eq!(case.input_schema.num_fields(), case.input_row.len());
+
+            for (field, value) in case.input_schema.fields().zip(&case.input_row) {
+                assert_eq!(field.data_type(), &value.data_type(), "case: {}", case.name);
+                assert!(
+                    field.is_nullable() || !value.is_null(),
+                    "case: {}",
+                    case.name
+                );
+            }
+
+            if let ExpectedResult::Value(value) = &case.expected {
+                let output = case.output.as_ref().expect("value case must resolve");
+                assert_eq!(output.data_type, value.data_type(), "case: {}", case.name);
+                assert!(!value.is_null() || output.nullable, "case: {}", case.name);
+            }
+
+            match (case.requirement, &case.expected, &case.output) {
+                (
+                    ConformanceRequirement::ExtensionBoundary,
+                    ExpectedResult::Error(ExpectedError::InvalidExpression),
+                    None,
+                ) => {}
+                (ConformanceRequirement::Portable, ExpectedResult::Value(_), Some(_)) => {}
+                (
+                    ConformanceRequirement::Portable,
+                    ExpectedResult::Error(ExpectedError::InvalidExpression),
+                    None,
+                ) => {}
+                (
+                    ConformanceRequirement::Portable,
+                    ExpectedResult::Error(
+                        ExpectedError::ArithmeticOverflow | ExpectedError::DivideByZero,
+                    ),
+                    Some(_),
+                ) => {}
+                state => panic!("inconsistent expected state for {}: {state:?}", case.name),
+            }
+        }
+    }
+
+    #[test]
+    fn boolean_expression_cases_preserve_predicate_context() {
+        let cases = boolean_cases();
+        for name in [
+            "non_null_boolean_expression_preserves_value",
+            "nullable_boolean_expression_preserves_null",
+            "integer_boolean_expression_is_rejected",
+            "string_boolean_expression_is_extension_boundary",
+        ] {
+            let case = cases
+                .iter()
+                .find(|case| case.name == name)
+                .expect("Boolean expression case");
+            assert!(matches!(
+                &case.expression,
+                Expression::Predicate(predicate)
+                    if matches!(predicate.as_ref(), Predicate::BooleanExpression(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn project_assignment_cases_are_well_formed() {
+        let mut names: HashSet<_> = all_cases()
+            .unwrap()
+            .into_iter()
+            .map(|case| case.name)
+            .collect();
+
+        for case in project_assignment_cases().unwrap() {
+            assert!(
+                names.insert(case.name),
+                "duplicate case name: {}",
+                case.name
+            );
+            assert_eq!(case.input_schema.num_fields(), case.input_row.len());
+
+            for (field, value) in case.input_schema.fields().zip(&case.input_row) {
+                assert_eq!(field.data_type(), &value.data_type(), "case: {}", case.name);
+                assert!(
+                    field.is_nullable() || !value.is_null(),
+                    "case: {}",
+                    case.name
+                );
+            }
+
+            match &case.expected {
+                ExpectedResult::Value(value) => {
+                    assert_eq!(
+                        case.target.data_type,
+                        value.data_type(),
+                        "case: {}",
+                        case.name
+                    );
+                    assert!(
+                        !value.is_null() || case.target.nullable,
+                        "case: {}",
+                        case.name
+                    );
+                }
+                ExpectedResult::Error(
+                    ExpectedError::InvalidExpression | ExpectedError::ArithmeticOverflow,
+                ) => {}
+                error => panic!("invalid assignment result for {}: {error:?}", case.name),
+            }
+        }
+    }
+}

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -318,7 +318,10 @@ where
 /// `expr` must be a struct constructor or struct patch whose fields match `schema`. It is
 /// evaluated with `schema` as its output struct type: the struct's fields are the output
 /// columns, `schema` supplies names and nullability, and any type or arity mismatch is an error.
-/// Downstream nodes see the logical field names declared in `schema`.
+/// Standard child expressions first resolve their own result types according to the [SQL
+/// expression contract](crate::expressions::semantics). The declared field type is then an
+/// assignment target; it does not change operator inference. Downstream nodes see the logical
+/// field names declared in `schema`.
 ///
 /// A struct patch carries the input struct through field by field, naming only the columns that
 /// change -- replacing or dropping existing fields and injecting new ones -- while everything else

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -34,10 +34,10 @@
 //! - [`Operation::QueryPlan`] is a [`Plan`](ir::plan::Plan), returning [`PlanResult::Data`]. Either
 //!   evaluate [`Plan::nodes`](ir::plan::Plan::nodes) in slice order, which is topologically sorted
 //!   so a node's inputs are already evaluated, or compile the DAG into the engine's own plan.
+//!   Standard expressions follow the [SQL expression contract](crate::expressions::semantics).
 //!
 //! Every operator, expression, and predicate a plan contains must be handled; returning an error
-//! for an unsupported one is fine, and kernel surfaces it to the caller. The sync engine's
-//! `SyncPlanExecutor` is a complete reference implementation.
+//! for an unsupported one is fine, and kernel surfaces it to the caller.
 //!
 //! # Consuming terminal results
 //!

--- a/workloads/src/predicate_parser.rs
+++ b/workloads/src/predicate_parser.rs
@@ -143,16 +143,23 @@ fn synthesize_expr(schema: &Schema, expr: &PExpr) -> Option<(KExpr, DataType)> {
                 PBinOp::Minus => KExpr::binary(KBinOp::Minus, l, r),
                 PBinOp::Multiply => KExpr::binary(KBinOp::Multiply, l, r),
                 PBinOp::Divide => KExpr::binary(KBinOp::Divide, l, r),
-                // Modulo: a % b = a - (b * (a / b))
-                // This relies on kernel's Divide producing integer division for integer types,
-                // which truncates toward zero (like Rust/C, matching Spark behavior).
-                // Examples:
-                //   7 % 3  =  7 - (3 * (7 / 3))  =  7 - (3 * 2)  =  1
-                //  -7 % 3  = -7 - (3 * (-7 / 3)) = -7 - (3 * -2) = -1
-                //   7 % -3 =  7 - (-3 * (7 / -3)) = 7 - (-3 * -2) = 1
+                // The expression IR has no modulo operator. For integral operands, casting the
+                // fractional quotient back to the resolved type truncates it toward zero.
                 PBinOp::Modulo => {
+                    if !matches!(
+                        &ty,
+                        DataType::Primitive(
+                            PrimitiveType::Byte
+                                | PrimitiveType::Short
+                                | PrimitiveType::Integer
+                                | PrimitiveType::Long
+                        )
+                    ) {
+                        return None;
+                    }
                     let a_div_b = KExpr::binary(KBinOp::Divide, l.clone(), r.clone());
-                    let b_times_quotient = KExpr::binary(KBinOp::Multiply, r, a_div_b);
+                    let quotient = KExpr::cast(a_div_b, ty.clone());
+                    let b_times_quotient = KExpr::binary(KBinOp::Multiply, r, quotient);
                     KExpr::binary(KBinOp::Minus, l, b_times_quotient)
                 }
                 _ => return None,
@@ -762,6 +769,8 @@ mod tests {
     // IS NULL on non-column expressions
     #[case("(a > 0) IS NULL")]
     #[case("(a > 0 AND b > 1) IS NULL")]
+    // The expression IR can lower integral modulo but has no general remainder operator.
+    #[case("double_col % 2.0 > 0.0")]
     fn unsupported_predicates_fail_gracefully(#[case] sql: &str) {
         let schema = test_schema();
         let result = parse_predicate(sql, &schema);
@@ -841,7 +850,10 @@ mod tests {
                     KExpr::binary(
                         KBinOp::Multiply,
                         Long(100),
-                        KExpr::binary(KBinOp::Divide, col!("a"), Long(100))
+                        KExpr::cast(
+                            KExpr::binary(KBinOp::Divide, col!("a"), Long(100)),
+                            DataType::LONG
+                        )
                     )
                 ),
                 Long(10)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3213/files/653d092d2bb1f1562bbec7b8030ebe70be457418..38b4ef3df37dcecbc926f793cbed635a64f255c1) to review incremental changes.
- [stack/improve_expression_ansi_semantics](https://github.com/delta-io/delta-kernel-rs/pull/3203) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3203/files)]
  - [stack/expression_semantics_conformance](https://github.com/delta-io/delta-kernel-rs/pull/3212) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3212/files/afd4f771d2447dd2b5f7ece8bc8877b158fee712..653d092d2bb1f1562bbec7b8030ebe70be457418)]
    - [**stack/arrow_expression_semantics**](https://github.com/delta-io/delta-kernel-rs/pull/3213) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3213/files/653d092d2bb1f1562bbec7b8030ebe70be457418..38b4ef3df37dcecbc926f793cbed635a64f255c1)] ← _this PR_
    - [stack/datafusion_expression_semantics](https://github.com/delta-io/delta-kernel-rs/pull/3214) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3214/files/653d092d2bb1f1562bbec7b8030ebe70be457418..b819801a97ad62ecbbebd40db8b5733d01bf1a3e)]

---------
## What changes are proposed in this pull request?

Runs the shared expression cases from #3212 against `ArrowEvaluationHandler`. The harness records
each case as:

- `Conform`: returns the value or error required by Kernel's expression contract.
- `Unsupported`: the expression is valid, but this evaluator must return `Error::Unsupported`.
- `Diverges`: the evaluator runs the expression but returns a different value or error.
- `ExtensionBoundary`: the expression is outside Kernel's contract, so an engine may reject it or
  provide engine-specific behavior.
- `AnalysisApiGap`: the case cannot run because `EvaluationHandler` does not expose expression
  analysis.

Remaining work is tracked by #3210 under #3207.

### Semantics fixed

- Fractional division and zero errors: `5 / 2 -> 2.5`; `1.0 / 0.0 -> DIVIDE_BY_ZERO`.
- Simple numeric coercion for arithmetic and comparison: `INT + BIGINT -> BIGINT`;
  `INT = BIGINT -> TRUE`.
- SQL float comparison: `NaN = NaN -> TRUE`, `NaN > 1.0 -> TRUE`, and
  `-0.0 = 0.0 -> TRUE`.
- Three-valued `IN` for any left expression and array-valued right expression:
  `(a + 1) IN (2, 3)` works; `9 IN (1, NULL) -> NULL`; `NULL IN () -> FALSE`.
- Invalid operands and runtime errors: `TRUE + 1` and `MAP(...) = MAP(...)` are invalid,
  decimal overflow reports overflow, and `VOID / DECIMAL` returns a typed null. This also removes
  27 `IN`/`NOT IN` DAT expected failures.

### Existing Arrow evaluator limitations

The harness records these behaviors, which predate this change. Unsupported cases fail explicitly.
Divergent cases can affect expression or filter results if invoked, but they do not modify stored
table data.

- Recursive common-type conversion for `COALESCE`, `ARRAY`, maps, structs, and temporal values.
  Example: `COALESCE(INT, BIGINT)`.
- Decimal/integral coercion, decimal result adjustment, and decimal division. Example:
  `DECIMAL / DECIMAL`.
- Nested comparison and nested `IN`. Example: `ARRAY(STRUCT(...)) = ARRAY(STRUCT(...))`.
- Execution of most valid implicit `Project` widenings, such as `INT -> BIGINT`;
  nullable-to-required validation also remains divergent.
- Per-row `COALESCE` short-circuiting and interval-family validation where Arrow erases the
  logical interval type.
- Analysis-only cases and specialized nodes such as `Cast`, `MapToStruct`, and `ParseJson`, which
  are outside this fixture suite.

### Issue to fix before merge

- `%` in the workload parser loses precision for `BIGINT` values above `2^53` because it lowers
  through `DOUBLE`.

## How was this change tested?

- `cargo nextest run -p delta_kernel --all-features conformance_tests`
- `cargo nextest run --workspace --all-features` (13,235 tests)
- Workspace Clippy with warnings denied and rustdoc
