### PR TITLE
fix: improve DataFusion expression semantics

### DIFF
--- a/datafusion-executor/Cargo.toml
+++ b/datafusion-executor/Cargo.toml
@@ -21,5 +21,8 @@ datafusion = "54"
 itertools = "0.14"
 
 [dev-dependencies]
+delta_kernel = { path = "../kernel", default-features = false, features = [
+  "expression-conformance-tests",
+] }
 rstest = "0.23"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/datafusion-executor/src/conformance_tests.rs
+++ b/datafusion-executor/src/conformance_tests.rs
@@ -1,0 +1,514 @@
+//! Runs the shared standard-expression fixtures through DataFusion.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, AsArray};
+use datafusion::arrow::error::ArrowError;
+use datafusion::common::{DFSchema, DataFusionError};
+use datafusion::execution::context::{SessionConfig, SessionContext};
+use datafusion::logical_expr::{EmptyRelation, Expr as DFExpr, LogicalPlan, LogicalPlanBuilder};
+use delta_kernel::engine::arrow_conversion::TryIntoKernel;
+use delta_kernel::expressions::semantics::conformance::{
+    all_cases, project_assignment_cases, ConformanceRequirement, ExpectedError, ExpectedResult,
+    ExpressionSemanticsCase, ProjectAssignmentCase, ResolvedOutput, CONFORMANCE_SESSION_TIME_ZONE,
+};
+use delta_kernel::expressions::{Expression, Scalar};
+use delta_kernel::plans::ir::nodes::{Operator as KernelOperator, Values as KernelValues};
+use delta_kernel::schema::{DataType, StructField, StructType};
+use delta_kernel::Error as KernelError;
+
+use crate::expression::to_df_expr;
+use crate::operator::lower_operator;
+
+// Valid standard expressions that DataFusion currently rejects during lowering or planning. A
+// returned value is a harness failure.
+const UNSUPPORTED_STANDARD_CASES: &[&str] = &[
+    // Recursive common-type conversion.
+    "map_common_type_widens_values_and_nullability",
+    "map_common_type_widens_keys",
+    "empty_map_void_key_widens_to_concrete_key",
+    "struct_common_type_unions_field_nullability",
+    "coalesce_struct_field_names_match_case_insensitively",
+    // Decimal result adjustment.
+    "decimal_scale_reduction_rounds_half_up",
+    "decimal_scale_reduction_negative_midpoint_rounds_away_from_zero",
+    // Nested and interval comparison.
+    "comparison_ignores_struct_field_names_after_positional_alignment",
+    "year_month_intervals_use_signed_ordering",
+    "day_time_intervals_use_signed_ordering",
+    "distinct_ignores_struct_field_names_after_positional_alignment",
+    // Nested and decimal IN coercion.
+    "literal_in_ignores_struct_field_names_after_positional_alignment",
+    "literal_in_coerces_nested_array_elements",
+    "column_in_decimal_uses_minimum_integral_literal_precision",
+    "column_in_aligns_structs_with_different_field_nullability",
+    "column_in_case_insensitive_struct_names_allow_leaf_widening",
+    "column_in_ignores_struct_field_names_after_positional_alignment",
+];
+
+// Standard expressions that DataFusion executes with behavior different from Kernel's contract.
+// A case that starts conforming must be removed from this list.
+const STANDARD_DIVERGENCES: &[&str] = &[
+    // Common types and ARRAY nullability.
+    "coalesce_decimal_and_float_returns_double",
+    "array_int_and_long",
+    "array_nullable_element",
+    "array_int_and_void",
+    "array_with_column_child",
+    "array_empty",
+    "date_and_timestamp_ntz_use_temporal_common_type",
+    "date_to_timestamp_ntz_max_safe_day",
+    "date_to_timestamp_ntz_min_safe_day",
+    "date_and_timestamp_use_utc_temporal_common_type",
+    "date_to_timestamp_max_safe_day",
+    "date_to_timestamp_min_safe_day",
+    "decimal_common_type_scale_reduction_rounds_half_up",
+    "decimal_common_type_negative_midpoint_rounds_away_from_zero",
+    // Arithmetic coercion, overflow, and decimal result types.
+    "long_and_float_promote_to_double",
+    "year_month_interval_arithmetic_is_rejected",
+    "day_time_interval_arithmetic_is_rejected",
+    "int_plus_overflow",
+    "int_minus_overflow",
+    "int_multiply_overflow",
+    "decimal_plus_float_returns_double",
+    "decimal_add_rounds_exact_result_once",
+    "decimal_add_negative_rounds_exact_result_once",
+    "decimal_subtract_rounds_exact_result_once",
+    "decimal_adjusted_scale_preserves_available_fractional_digits",
+    "decimal_add_overflow",
+    "decimal_plus_minimum_precision_int_literal",
+    "decimal_plus_zero_literal_uses_one_digit_precision",
+    "decimal_division_result_type",
+    "decimal_division_rounds_half_up",
+    "negative_decimal_division_rounds_away_from_zero",
+    "untyped_null_divided_by_decimal",
+    // Comparison validity and floating-point ordering.
+    "decimal_comparison_uses_full_integral_column_precision",
+    "structs_containing_maps_are_not_comparable",
+    "map_comparison_is_rejected",
+    "interval_cross_family_comparison_is_rejected",
+    "differently_named_structs_requiring_leaf_widening_are_rejected",
+    "different_nan_payloads_compare_equal",
+    "signed_zeroes_compare_equal",
+    "negative_zero_is_not_less_than_positive_zero",
+    "array_comparison_uses_nan_equality",
+    "two_nulls_are_not_distinct",
+    "null_and_value_are_distinct",
+    "nan_values_are_not_distinct",
+    "signed_zeroes_are_not_distinct",
+    // IN evaluation and operand validation.
+    "empty_in_array_does_not_suppress_left_child_error",
+    "literal_in_uses_signed_zero_equality",
+    "column_in_integral_and_float_promote_to_double",
+    "column_in_uses_signed_zero_equality",
+    "in_array_expression_rhs_matches",
+    "map_membership_is_rejected",
+];
+
+// Valid Project assignments that DataFusion currently rejects because it cannot perform the
+// recursive or positional cast. A returned value is a harness failure.
+const UNSUPPORTED_PROJECT_CASES: &[&str] = &[
+    "project_struct_assignment_is_recursive_and_positional",
+    "project_struct_fields_align_positionally",
+];
+
+// Project assignments that DataFusion accepts or evaluates differently from Kernel's contract. A
+// case that starts conforming must be removed from this list.
+const PROJECT_DIVERGENCES: &[&str] = &["project_nullable_to_required_is_rejected"];
+
+#[tokio::test]
+async fn standard_cases_match_datafusion_support_inventory() {
+    let unsupported: HashSet<_> = UNSUPPORTED_STANDARD_CASES.iter().copied().collect();
+    let divergences: HashSet<_> = STANDARD_DIVERGENCES.iter().copied().collect();
+    assert_eq!(unsupported.len(), UNSUPPORTED_STANDARD_CASES.len());
+    assert_eq!(divergences.len(), STANDARD_DIVERGENCES.len());
+
+    let mut seen_unsupported = HashSet::new();
+    let mut seen_divergences = HashSet::new();
+    let mut failures = Vec::new();
+    for case in all_cases().unwrap() {
+        let expectation = if case.requirement == ConformanceRequirement::ExtensionBoundary {
+            CaseExpectation::ExtensionBoundary
+        } else if unsupported.contains(case.name) {
+            seen_unsupported.insert(case.name);
+            CaseExpectation::Unsupported
+        } else if divergences.contains(case.name) {
+            seen_divergences.insert(case.name);
+            CaseExpectation::Diverges
+        } else {
+            CaseExpectation::Conform
+        };
+        if expectation == CaseExpectation::Unsupported
+            && matches!(
+                case.expected,
+                ExpectedResult::Error(ExpectedError::InvalidExpression)
+            )
+        {
+            failures.push(format!(
+                "{} is invalid and must not be inventoried as unsupported",
+                case.name
+            ));
+            continue;
+        }
+
+        let result = evaluate_expression_case(&case).await;
+        if let Some(failure) =
+            check_result(result, &case.expected, case.output.as_ref(), expectation)
+        {
+            failures.push(format!("{}: {failure}", case.name));
+        }
+    }
+
+    inventory_failure(
+        "unsupported standard",
+        &unsupported,
+        &seen_unsupported,
+        &mut failures,
+    );
+    inventory_failure(
+        "standard divergence",
+        &divergences,
+        &seen_divergences,
+        &mut failures,
+    );
+    assert!(
+        failures.is_empty(),
+        "standard-expression conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[tokio::test]
+async fn project_cases_match_datafusion_support_inventory() {
+    let unsupported: HashSet<_> = UNSUPPORTED_PROJECT_CASES.iter().copied().collect();
+    let divergences: HashSet<_> = PROJECT_DIVERGENCES.iter().copied().collect();
+    assert_eq!(unsupported.len(), UNSUPPORTED_PROJECT_CASES.len());
+    assert_eq!(divergences.len(), PROJECT_DIVERGENCES.len());
+
+    let mut seen_unsupported = HashSet::new();
+    let mut seen_divergences = HashSet::new();
+    let mut failures = Vec::new();
+    for case in project_assignment_cases().unwrap() {
+        let expectation = if unsupported.contains(case.name) {
+            seen_unsupported.insert(case.name);
+            CaseExpectation::Unsupported
+        } else if divergences.contains(case.name) {
+            seen_divergences.insert(case.name);
+            CaseExpectation::Diverges
+        } else {
+            CaseExpectation::Conform
+        };
+        if expectation == CaseExpectation::Unsupported
+            && matches!(
+                case.expected,
+                ExpectedResult::Error(ExpectedError::InvalidExpression)
+            )
+        {
+            failures.push(format!(
+                "{} is invalid and must not be inventoried as unsupported",
+                case.name
+            ));
+            continue;
+        }
+
+        let result = evaluate_project_case(&case).await;
+        if let Some(failure) = check_result(result, &case.expected, Some(&case.target), expectation)
+        {
+            failures.push(format!("{}: {failure}", case.name));
+        }
+    }
+
+    inventory_failure(
+        "unsupported Project",
+        &unsupported,
+        &seen_unsupported,
+        &mut failures,
+    );
+    inventory_failure(
+        "Project divergence",
+        &divergences,
+        &seen_divergences,
+        &mut failures,
+    );
+    assert!(
+        failures.is_empty(),
+        "Project-assignment conformance failures:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CaseExpectation {
+    // The case must return exactly the documented type, nullability, value, or error.
+    Conform,
+    // A valid expression must explicitly report that the executor does not support it.
+    Unsupported,
+    // The executor is known to return the wrong value, type, nullability, or error.
+    Diverges,
+    // Strict rejection or executor-specific behavior is allowed outside Kernel's contract.
+    ExtensionBoundary,
+}
+
+struct EvaluatedValue {
+    output: ResolvedOutput,
+    value: ArrayRef,
+}
+
+async fn evaluate_expression_case(
+    case: &ExpressionSemanticsCase,
+) -> Result<EvaluatedValue, DataFusionError> {
+    let input = lower_input(case.input_schema.as_ref(), case.input_row.clone())?;
+    let expression = to_df_expr(
+        &case.expression,
+        case.input_schema.as_ref(),
+        case.output.as_ref().map(|output| &output.data_type),
+    )
+    .map_err(|error| DataFusionError::External(Box::new(error)))?;
+    evaluate_projection(input, expression).await
+}
+
+async fn evaluate_project_case(
+    case: &ProjectAssignmentCase,
+) -> Result<EvaluatedValue, DataFusionError> {
+    let input = Arc::new(lower_input(
+        case.input_schema.as_ref(),
+        case.input_row.clone(),
+    )?);
+    let target = Arc::new(StructType::new_unchecked([StructField::new(
+        "output",
+        case.target.data_type.clone(),
+        case.target.nullable,
+    )]));
+    let project = delta_kernel::plans::ir::nodes::Project {
+        expr: Expression::struct_from([case.expression.clone()]).into(),
+        schema: target,
+    };
+    let plan = lower_operator(&KernelOperator::Project(project), &[input])?;
+    evaluate_plan(plan).await
+}
+
+fn lower_input(schema: &StructType, row: Vec<Scalar>) -> Result<LogicalPlan, DataFusionError> {
+    if schema.num_fields() == 0 {
+        return Ok(LogicalPlan::EmptyRelation(EmptyRelation {
+            produce_one_row: true,
+            schema: Arc::new(DFSchema::empty()),
+        }));
+    }
+    lower_operator(
+        &KernelOperator::Values(KernelValues::new(schema.clone(), vec![row])),
+        &[],
+    )
+}
+
+async fn evaluate_projection(
+    input: LogicalPlan,
+    expression: DFExpr,
+) -> Result<EvaluatedValue, DataFusionError> {
+    let plan = LogicalPlanBuilder::from(input)
+        .project([expression.alias("output")])?
+        .build()?;
+    evaluate_plan(plan).await
+}
+
+async fn evaluate_plan(plan: LogicalPlan) -> Result<EvaluatedValue, DataFusionError> {
+    let field = plan.schema().field(0);
+    let data_type: DataType = field.data_type().try_into_kernel()?;
+    let output = ResolvedOutput {
+        data_type,
+        nullable: field.is_nullable(),
+    };
+    let batches = session_context()
+        .execute_logical_plan(plan)
+        .await?
+        .collect()
+        .await?;
+    if batches.len() != 1 || batches[0].num_columns() != 1 || batches[0].num_rows() != 1 {
+        return Err(DataFusionError::Execution(format!(
+            "expected one value, got {} batch(es)",
+            batches.len()
+        )));
+    }
+    Ok(EvaluatedValue {
+        output,
+        value: batches[0].column(0).clone(),
+    })
+}
+
+fn session_context() -> SessionContext {
+    let mut config = SessionConfig::new().with_enable_ansi_mode(true);
+    config.options_mut().execution.time_zone = Some(CONFORMANCE_SESSION_TIME_ZONE.to_string());
+    SessionContext::new_with_config(config)
+}
+
+fn check_result(
+    result: Result<EvaluatedValue, DataFusionError>,
+    expected: &ExpectedResult,
+    output: Option<&ResolvedOutput>,
+    expectation: CaseExpectation,
+) -> Option<String> {
+    match expectation {
+        CaseExpectation::Unsupported => match result {
+            Err(error) if is_analysis_rejection(&error) => None,
+            Err(error) => Some(format!("expected a planning rejection, returned {error}")),
+            Ok(_) => Some("expected a planning rejection, returned a value".to_string()),
+        },
+        CaseExpectation::ExtensionBoundary => match result {
+            Ok(_) => None,
+            Err(error)
+                if is_unsupported(&error)
+                    || error_matches(&error, ExpectedError::InvalidExpression) =>
+            {
+                None
+            }
+            Err(error) => Some(format!("unexpected extension-boundary error: {error}")),
+        },
+        CaseExpectation::Conform => conforming_result_failure(result, expected, output),
+        CaseExpectation::Diverges => conforming_result_failure(result, expected, output)
+            .is_none()
+            .then(|| "case now conforms; remove it from the divergence inventory".to_string()),
+    }
+}
+
+fn conforming_result_failure(
+    result: Result<EvaluatedValue, DataFusionError>,
+    expected: &ExpectedResult,
+    output: Option<&ResolvedOutput>,
+) -> Option<String> {
+    match (result, expected) {
+        (Ok(actual), ExpectedResult::Value(expected)) => {
+            if Some(&actual.output) != output {
+                return Some(format!(
+                    "expected output {output:?}, got {:?}",
+                    actual.output
+                ));
+            }
+            let expected = match expected.to_array(1) {
+                Ok(expected) => expected,
+                Err(error) => return Some(format!("invalid expected value: {error}")),
+            };
+            (!arrays_equal(&actual.value, &expected))
+                .then(|| format!("expected {expected:?}, got {:?}", actual.value))
+        }
+        (Err(error), ExpectedResult::Value(_)) => Some(format!("returned error: {error}")),
+        (Ok(_), ExpectedResult::Error(expected)) => {
+            Some(format!("expected {expected:?}, returned a value"))
+        }
+        (Err(error), ExpectedResult::Error(expected)) => (!error_matches(&error, *expected))
+            .then(|| format!("expected {expected:?}, returned {error}")),
+    }
+}
+
+fn error_matches(error: &DataFusionError, expected: ExpectedError) -> bool {
+    match (error, expected) {
+        (DataFusionError::ArrowError(error, _), ExpectedError::ArithmeticOverflow)
+            if matches!(error.as_ref(), ArrowError::ArithmeticOverflow(_)) =>
+        {
+            true
+        }
+        (DataFusionError::ArrowError(error, _), ExpectedError::DivideByZero)
+            if matches!(error.as_ref(), ArrowError::DivideByZero) =>
+        {
+            true
+        }
+        (DataFusionError::Execution(message), ExpectedError::ArithmeticOverflow)
+            if message.contains("converted value exceeds the representable i64 range") =>
+        {
+            true
+        }
+        (
+            DataFusionError::Plan(_)
+            | DataFusionError::SchemaError(_, _)
+            | DataFusionError::External(_),
+            ExpectedError::InvalidExpression,
+        ) if !is_unsupported(error) => true,
+        (DataFusionError::Context(_, source) | DataFusionError::Diagnostic(_, source), _) => {
+            error_matches(source, expected)
+        }
+        (DataFusionError::Shared(source), _) => error_matches(source, expected),
+        (DataFusionError::Collection(errors), _) => {
+            errors.iter().any(|error| error_matches(error, expected))
+        }
+        _ => false,
+    }
+}
+
+fn is_analysis_rejection(error: &DataFusionError) -> bool {
+    match error {
+        DataFusionError::Plan(_)
+        | DataFusionError::SchemaError(_, _)
+        | DataFusionError::NotImplemented(_) => true,
+        DataFusionError::External(_) => is_unsupported(error),
+        DataFusionError::Context(_, source) | DataFusionError::Diagnostic(_, source) => {
+            is_analysis_rejection(source)
+        }
+        DataFusionError::Shared(source) => is_analysis_rejection(source),
+        DataFusionError::Collection(errors) => errors.iter().any(is_analysis_rejection),
+        _ => false,
+    }
+}
+
+fn is_unsupported(error: &DataFusionError) -> bool {
+    match error {
+        DataFusionError::NotImplemented(_) => true,
+        DataFusionError::External(source) => source
+            .downcast_ref::<KernelError>()
+            .is_some_and(is_kernel_unsupported),
+        DataFusionError::Context(_, source) | DataFusionError::Diagnostic(_, source) => {
+            is_unsupported(source)
+        }
+        DataFusionError::Shared(source) => is_unsupported(source),
+        DataFusionError::Collection(errors) => errors.iter().any(is_unsupported),
+        _ => false,
+    }
+}
+
+fn is_kernel_unsupported(error: &KernelError) -> bool {
+    match error {
+        KernelError::Unsupported(_) => true,
+        KernelError::Backtraced { source, .. } => is_kernel_unsupported(source),
+        _ => false,
+    }
+}
+
+fn inventory_failure<'a>(
+    label: &str,
+    expected: &HashSet<&'a str>,
+    seen: &HashSet<&'a str>,
+    failures: &mut Vec<String>,
+) {
+    let mut missing: Vec<_> = expected.difference(seen).copied().collect();
+    missing.sort_unstable();
+    if !missing.is_empty() {
+        failures.push(format!(
+            "stale {label} inventory entries: {}",
+            missing.join(", ")
+        ));
+    }
+}
+
+fn arrays_equal(actual: &ArrayRef, expected: &ArrayRef) -> bool {
+    if actual.data_type() != expected.data_type() || actual.len() != expected.len() {
+        return false;
+    }
+    match actual.data_type() {
+        datafusion::arrow::datatypes::DataType::Float32 => {
+            let actual = actual.as_primitive::<datafusion::arrow::datatypes::Float32Type>();
+            let expected = expected.as_primitive::<datafusion::arrow::datatypes::Float32Type>();
+            actual.iter().zip(expected).all(|(actual, expected)| {
+                matches!((actual, expected), (None, None))
+                    || matches!((actual, expected), (Some(actual), Some(expected)) if actual == expected || (actual.is_nan() && expected.is_nan()))
+            })
+        }
+        datafusion::arrow::datatypes::DataType::Float64 => {
+            let actual = actual.as_primitive::<datafusion::arrow::datatypes::Float64Type>();
+            let expected = expected.as_primitive::<datafusion::arrow::datatypes::Float64Type>();
+            actual.iter().zip(expected).all(|(actual, expected)| {
+                matches!((actual, expected), (None, None))
+                    || matches!((actual, expected), (Some(actual), Some(expected)) if actual == expected || (actual.is_nan() && expected.is_nan()))
+            })
+        }
+        _ => actual.to_data() == expected.to_data(),
+    }
+}

--- a/datafusion-executor/src/expression.rs
+++ b/datafusion-executor/src/expression.rs
@@ -2,15 +2,22 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::array::{new_null_array, ArrayRef, RecordBatch, StructArray};
-use datafusion::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
+use datafusion::arrow::array::{
+    new_null_array, ArrayRef, AsArray, Float64Builder, RecordBatch, StructArray,
+};
+use datafusion::arrow::datatypes::{
+    DataType as ArrowDataType, Field, FieldRef, Schema as ArrowSchema,
+};
+use datafusion::arrow::error::ArrowError;
 use datafusion::common::utils::take_function_args;
-use datafusion::common::{Column as DFColumn, DataFusionError, ScalarValue as DFScalarValue};
+use datafusion::common::{
+    Column as DFColumn, DFSchema, DataFusionError, ScalarValue as DFScalarValue,
+};
 use datafusion::functions::core::expr_fn::{coalesce, get_field, named_struct, nullif};
 use datafusion::functions_nested::expr_fn::make_array;
 use datafusion::logical_expr::{
-    binary_expr, cast, lit, Case, ColumnarValue, Expr as DFExpr, Operator, ScalarFunctionArgs,
-    ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+    binary_expr, cast, lit, Case, ColumnarValue, Expr as DFExpr, ExprSchemable, Operator,
+    ReturnFieldArgs, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -113,22 +120,122 @@ pub(crate) fn to_df_struct_columns(
     }
 }
 
-/// Lowers an arithmetic binary expression (`Plus`/`Minus`/`Multiply`/`Divide`) to an
-/// `Expr::BinaryExpr`. Comparison and `IN` operators are modeled as predicates, not expressions,
-/// so they never reach this arm.
+/// Lowers an arithmetic binary expression. Comparison and `IN` operators are modeled as
+/// predicates, not expressions, so they never reach this arm.
 fn binary_expr_to_df_expr(
     binary: &BinaryExpression,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
+    let left = to_df_expr(&binary.left, input_schema, None)?;
+    let right = to_df_expr(&binary.right, input_schema, None)?;
     let op = match binary.op {
         BinaryExpressionOp::Plus => Operator::Plus,
         BinaryExpressionOp::Minus => Operator::Minus,
         BinaryExpressionOp::Multiply => Operator::Multiply,
-        BinaryExpressionOp::Divide => Operator::Divide,
+        BinaryExpressionOp::Divide => return divide_to_df_expr(left, right, input_schema),
     };
-    let left = to_df_expr(&binary.left, input_schema, None)?;
-    let right = to_df_expr(&binary.right, input_schema, None)?;
     Ok(binary_expr(left, op, right))
+}
+
+/// Lowers decimal division to DataFusion's decimal operator and all other numeric division to a
+/// checked `DOUBLE` UDF. The UDF supplies Kernel's fractional result type and zero-divisor error
+/// for integral and floating-point inputs.
+fn divide_to_df_expr(
+    left: DFExpr,
+    right: DFExpr,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    let arrow_schema: ArrowSchema = input_schema.try_into_arrow()?;
+    let df_schema = DFSchema::try_from(arrow_schema).map_err(Error::generic_err)?;
+    let left_type = left.get_type(&df_schema).map_err(Error::generic_err)?;
+    let right_type = right.get_type(&df_schema).map_err(Error::generic_err)?;
+
+    if left_type == ArrowDataType::Null && right_type == ArrowDataType::Null {
+        return Err(Error::invalid_expression(
+            "division cannot infer a numeric type from two untyped nulls",
+        ));
+    }
+    let decimal_or_null = |data_type: &ArrowDataType| {
+        matches!(
+            data_type,
+            ArrowDataType::Decimal128(_, _) | ArrowDataType::Null
+        )
+    };
+    if decimal_or_null(&left_type)
+        && decimal_or_null(&right_type)
+        && (matches!(left_type, ArrowDataType::Decimal128(_, _))
+            || matches!(right_type, ArrowDataType::Decimal128(_, _)))
+    {
+        return Ok(binary_expr(left, Operator::Divide, right));
+    }
+
+    let udf = ScalarUDF::new_from_impl(StandardDivisionUdf::new());
+    Ok(udf.call(vec![left, right]))
+}
+
+/// Checked non-decimal division for Kernel's standard expression contract.
+#[derive(Debug, PartialEq, Eq)]
+struct StandardDivisionUdf {
+    signature: Signature,
+}
+
+impl std::hash::Hash for StandardDivisionUdf {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+    }
+}
+
+impl StandardDivisionUdf {
+    fn new() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![ArrowDataType::Float64, ArrowDataType::Float64],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for StandardDivisionUdf {
+    fn name(&self) -> &str {
+        "kernel_divide"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> Result<ArrowDataType, DataFusionError> {
+        Ok(ArrowDataType::Float64)
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef, DataFusionError> {
+        let nullable = args.arg_fields.iter().any(|field| field.is_nullable());
+        Ok(Field::new(self.name(), ArrowDataType::Float64, nullable).into())
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue, DataFusionError> {
+        let num_rows = args.number_rows;
+        let [left, right] = take_function_args(self.name(), args.args)?;
+        let left = left.into_array(num_rows)?;
+        let right = right.into_array(num_rows)?;
+        let left = left.as_primitive::<datafusion::arrow::datatypes::Float64Type>();
+        let right = right.as_primitive::<datafusion::arrow::datatypes::Float64Type>();
+        let mut result = Float64Builder::with_capacity(num_rows);
+        for (left, right) in left.iter().zip(right) {
+            match (left, right) {
+                (None, _) | (_, None) => result.append_null(),
+                (Some(_), Some(0.0)) => {
+                    return Err(DataFusionError::ArrowError(
+                        Box::new(ArrowError::DivideByZero),
+                        None,
+                    ));
+                }
+                (Some(left), Some(right)) => result.append_value(left / right),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(result.finish())))
+    }
 }
 
 /// Lowers a variadic expression: `Coalesce` to `coalesce(..)` and `Array` to `make_array(..)`, each
@@ -601,7 +708,7 @@ mod tests {
     #[case::plus(col!("a") + lit(1i64), "a + Int64(1)")]
     #[case::minus(col!("a") - lit(1i64), "a - Int64(1)")]
     #[case::multiply(col!("a") * lit(2i64), "a * Int64(2)")]
-    #[case::divide(col!("a") / lit(2i64), "a / Int64(2)")]
+    #[case::divide(col!("a") / lit(2i64), "kernel_divide(a, Int64(2))")]
     fn arithmetic_binary_lowers_to_binary_expr(#[case] kernel: KernelExpr, #[case] expected: &str) {
         assert_eq!(lower(kernel), expected);
     }
@@ -614,7 +721,7 @@ mod tests {
     )]
     #[case::nested_field_and_all_ops(
         (col!("a.b.c") * lit(5i64) - (col!("b") + col!("x"))) / lit(20i64),
-        "(get_field(a, Utf8(\"b\"), Utf8(\"c\")) * Int64(5) - b + x) / Int64(20)"
+        "kernel_divide(get_field(a, Utf8(\"b\"), Utf8(\"c\")) * Int64(5) - b + x, Int64(20))"
     )]
     fn nested_arithmetic_lowers_to_operator_tree(
         #[case] kernel: KernelExpr,

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use datafusion::execution::context::SessionContext;
 use delta_kernel::StorageHandler;
 
+// TODO(#3211): Align expression lowering and evaluation with Kernel's standard expression
+// contract.
 mod expression;
 mod operator;
 mod plan;

--- a/datafusion-executor/src/lib.rs
+++ b/datafusion-executor/src/lib.rs
@@ -22,6 +22,9 @@ mod predicate;
 mod scalar;
 mod utils;
 
+#[cfg(test)]
+mod conformance_tests;
+
 pub use expression::to_df_expr;
 pub use predicate::to_df_predicate_expr;
 pub use scalar::to_df_scalar;

--- a/datafusion-executor/src/operator.rs
+++ b/datafusion-executor/src/operator.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use datafusion::arrow::datatypes::Schema as ArrowSchema;
+use datafusion::arrow::datatypes::{DataType as ArrowDataType, Schema as ArrowSchema};
 use datafusion::common::{DFSchema, DataFusionError};
 use datafusion::functions_aggregate::expr_fn::{count, max, min, sum};
 use datafusion::functions_aggregate::first_last::first_value_udaf;
@@ -22,12 +22,14 @@ use datafusion::logical_expr::{
     LogicalPlanBuilder, Projection as DFProjection,
 };
 use delta_kernel::engine::arrow_conversion::{TryIntoArrow, TryIntoKernel};
-use delta_kernel::expressions::{ColumnName as KernelColumnName, Scalar as KernelScalar};
+use delta_kernel::expressions::{
+    ColumnName as KernelColumnName, Expression as KernelExpression, Scalar as KernelScalar,
+};
 use delta_kernel::plans::ir::nodes::{
     Agg as KernelAgg, Aggregate as KernelAggregate, Filter as KernelFilter,
     Operator as KernelOperator, Project as KernelProject, Values as KernelValues,
 };
-use delta_kernel::schema::{StructField, StructType};
+use delta_kernel::schema::{DataType, PrimitiveType, StructField, StructType};
 
 use crate::expression::to_df_struct_columns;
 use crate::predicate::to_df_predicate_expr;
@@ -97,6 +99,7 @@ fn lower_project(
     input: &Arc<DFLogicalPlan>,
 ) -> Result<DFLogicalPlan, DataFusionError> {
     let input_schema: StructType = input.schema().as_arrow().try_into_kernel()?;
+    validate_direct_project_assignments(&input_schema, &project.expr, project.schema.as_ref())?;
     let arrow_schema: ArrowSchema = project.schema.as_ref().try_into_arrow()?;
     let df_schema = Arc::new(DFSchema::try_from(arrow_schema)?);
     let columns = to_df_struct_columns(&project.expr, &input_schema, project.schema.as_ref())
@@ -106,13 +109,125 @@ fn lower_project(
         .into_iter()
         .zip(project.schema.fields())
         .map(|((name, expr), field)| {
+            let source_arrow = expr.get_type(input.schema())?;
             let target = field.data_type().try_into_arrow()?;
+            if source_arrow != target {
+                let source: DataType = (&source_arrow).try_into_kernel()?;
+                if source != *field.data_type()
+                    && !is_valid_project_assignment(&source, field.data_type())
+                {
+                    return Err(invalid_project_assignment(&source, field.data_type()));
+                }
+            }
             let expr = expr.cast_to(&target, input.schema())?.alias(name);
             Ok(expr)
         })
         .collect();
     let projection = DFProjection::try_new_with_schema(exprs?, Arc::clone(input), df_schema)?;
     Ok(DFLogicalPlan::Projection(projection))
+}
+
+/// Rejects invalid Project assignments whose source type is available without general expression
+/// analysis. Complex expressions remain DataFusion's responsibility.
+fn validate_direct_project_assignments(
+    input_schema: &StructType,
+    expression: &KernelExpression,
+    output_schema: &StructType,
+) -> Result<(), DataFusionError> {
+    let KernelExpression::Struct(expressions, _) = expression else {
+        return Ok(());
+    };
+
+    for (expression, target) in expressions.iter().zip(output_schema.fields()) {
+        let source = match expression.as_ref() {
+            KernelExpression::Column(name) => {
+                input_schema.fields_of_path(name).ok().and_then(|fields| {
+                    fields.last().map(|field| {
+                        (
+                            field.data_type().clone(),
+                            fields.iter().any(|field| field.is_nullable()),
+                        )
+                    })
+                })
+            }
+            KernelExpression::Literal(value) => Some((value.data_type(), value.is_null())),
+            _ => None,
+        };
+        let Some((source, source_nullable)) = source else {
+            continue;
+        };
+
+        // Top-level input nullability is not flow-sensitive: an earlier Filter may have removed
+        // nulls before this Project. Nested nullability remains part of DataType and is validated.
+        let source_arrow: ArrowDataType = (&source).try_into_arrow()?;
+        let target_arrow: ArrowDataType = target.data_type().try_into_arrow()?;
+        if source == *target.data_type() || source_arrow == target_arrow {
+            continue;
+        }
+        if source_nullable && !target.is_nullable()
+            || !is_valid_project_assignment(&source, target.data_type())
+        {
+            return Err(invalid_project_assignment(&source, target.data_type()));
+        }
+    }
+    Ok(())
+}
+
+fn invalid_project_assignment(source: &DataType, target: &DataType) -> DataFusionError {
+    DataFusionError::External(Box::new(delta_kernel::Error::invalid_expression(format!(
+        "Project cannot assign {source} to {target} without an explicit cast"
+    ))))
+}
+
+/// Returns whether Kernel permits assigning `source` to `target` without an explicit cast.
+fn is_valid_project_assignment(source: &DataType, target: &DataType) -> bool {
+    use DataType::*;
+    use PrimitiveType::*;
+
+    if source == target {
+        return true;
+    }
+    match (source, target) {
+        (Primitive(Void), _) => true,
+        (Primitive(Byte), Primitive(Short | Integer | Long | Float | Double))
+        | (Primitive(Short), Primitive(Integer | Long | Float | Double))
+        | (Primitive(Integer), Primitive(Long | Double))
+        | (Primitive(Float), Primitive(Double))
+        | (Primitive(Date), Primitive(TimestampNtz)) => true,
+        (Primitive(source), Primitive(Decimal(target))) => {
+            let source_precision = match source {
+                Byte => 3,
+                Short => 5,
+                Integer => 10,
+                Long => 20,
+                Decimal(source) if target.scale() >= source.scale() => {
+                    source.precision() - source.scale()
+                }
+                _ => return false,
+            };
+            target.precision() - target.scale() >= source_precision
+        }
+        (Array(source), Array(target)) => {
+            (!source.contains_null() || target.contains_null())
+                && is_valid_project_assignment(source.element_type(), target.element_type())
+        }
+        (Map(source), Map(target)) => {
+            (!source.value_contains_null || target.value_contains_null)
+                && is_valid_project_assignment(source.key_type(), target.key_type())
+                && is_valid_project_assignment(source.value_type(), target.value_type())
+        }
+        (Struct(source), Struct(target)) => {
+            source.fields().len() == target.fields().len()
+                && source
+                    .fields()
+                    .zip(target.fields())
+                    .all(|(source, target)| {
+                        (!source.is_nullable() || target.is_nullable())
+                            && is_valid_project_assignment(source.data_type(), target.data_type())
+                    })
+        }
+        _ => false,
+    }
 }
 
 /// Lowers an [`Aggregate`](KernelAggregate) to a DataFusion aggregate over its input.
@@ -995,7 +1110,7 @@ mod tests {
     }
 
     #[test]
-    fn project_rejects_uncastable_output_type() {
+    fn project_rejects_invalid_output_assignment() {
         let parent = input_with_schema(test_schema());
         let output =
             StructType::try_new([StructField::nullable("a", DataType::unshredded_variant())])
@@ -1003,11 +1118,8 @@ mod tests {
         let err =
             lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap_err();
         let message = err.to_string();
-        assert!(matches!(&err, DataFusionError::Plan(_)), "{message}");
-        assert!(
-            message.contains("Cannot automatically convert"),
-            "{message}"
-        );
+        assert!(matches!(&err, DataFusionError::External(_)), "{message}");
+        assert!(message.contains("without an explicit cast"), "{message}");
     }
 
     #[rstest]
@@ -1088,7 +1200,7 @@ mod tests {
                 col!("a") * col!("b"),
             ),
             (
-                StructField::nullable("quotient", DataType::LONG),
+                StructField::nullable("quotient", DataType::DOUBLE),
                 col!("a") / col!("b"),
             ),
         ]),
@@ -1096,7 +1208,7 @@ mod tests {
             "+-----+------------+---------+----------+",
             "| sum | difference | product | quotient |",
             "+-----+------------+---------+----------+",
-            "| 12  | 8          | 20      | 5        |",
+            "| 12  | 8          | 20      | 5.0      |",
             "|     |            |         |          |",
             "|     |            |         |          |",
             "+-----+------------+---------+----------+",
@@ -1307,20 +1419,17 @@ mod tests {
         assert_batches_eq!(expected, &batches);
     }
 
-    #[tokio::test]
-    async fn project_rejects_invalid_cast_value_during_execution() {
+    #[test]
+    fn project_rejects_implicit_string_parsing() {
         let input = StructType::try_new([StructField::nullable("a", DataType::STRING)]).unwrap();
         let parent = Arc::new(
             lower_values_node(input, vec![vec![KernelScalar::String("abc".into())]]).unwrap(),
         );
         let output = StructType::try_new([StructField::nullable("a", DataType::INTEGER)]).unwrap();
-        let lowered =
-            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap();
-
-        let err = execute(lowered).await.unwrap_err();
+        let err =
+            lower_project_expr(KernelExpr::struct_from([col!("a")]), output, &parent).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("Cannot cast string 'abc' to value of Int32 type"),
+            err.to_string().contains("without an explicit cast"),
             "{err}"
         );
     }

--- a/datafusion-executor/src/predicate.rs
+++ b/datafusion-executor/src/predicate.rs
@@ -1,38 +1,38 @@
 //! Conversion from a kernel [`Predicate`](KernelPredicate) to a boolean-valued DataFusion
 //! [`Expr`](DFExpr).
 
-use datafusion::functions_nested::expr_fn::array_has;
-use datafusion::logical_expr::expr::InList;
+use datafusion::arrow::datatypes::Schema as ArrowSchema;
+use datafusion::common::DFSchema;
+use datafusion::functions_nested::expr_fn::{array_compact, array_empty, array_has, cardinality};
 use datafusion::logical_expr::utils::{conjunction, disjunction};
-use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, Operator};
+use datafusion::logical_expr::{binary_expr, lit, Expr as DFExpr, ExprSchemable, Operator};
+use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::expressions::{
-    ArrayData as KernelArrayData, BinaryPredicate as KernelBinaryPredicate,
-    BinaryPredicateOp as KernelBinaryPredicateOp, ColumnName as KernelColumnName,
+    BinaryPredicate as KernelBinaryPredicate, BinaryPredicateOp as KernelBinaryPredicateOp,
     Expression as KernelExpression, JunctionPredicate as KernelJunctionPredicate,
     JunctionPredicateOp as KernelJunctionPredicateOp, Predicate as KernelPredicate,
-    Scalar as KernelScalar, UnaryPredicate as KernelUnaryPredicate,
-    UnaryPredicateOp as KernelUnaryPredicateOp,
+    UnaryPredicate as KernelUnaryPredicate, UnaryPredicateOp as KernelUnaryPredicateOp,
 };
-use delta_kernel::schema::{DataType, StructType};
+use delta_kernel::schema::StructType;
 use delta_kernel::{DeltaResult, Error};
 
 use crate::expression::to_df_expr;
-use crate::scalar::to_df_scalar;
 
 /// Converts a kernel [`Predicate`](KernelPredicate) into a boolean-valued DataFusion
 /// [`Expr`](DFExpr), checking column references against `input_schema`.
 ///
 /// # Errors
-/// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or `Unknown` predicates, and for an
-/// `IN` whose right side is neither a literal array nor an array-typed column. Also propagates
-/// errors from child expressions, such as an unresolved column or an interval literal (which has
-/// no Arrow equivalent).
+/// Returns [`Error::unsupported`] for engine-defined (`Opaque`) or `Unknown` predicates. Also
+/// propagates errors from child expressions, such as an unresolved column or an interval literal
+/// that has no Arrow equivalent.
 pub fn to_df_predicate_expr(
     pred: &KernelPredicate,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
     match pred {
-        KernelPredicate::BooleanExpression(expr) => to_df_expr(expr, input_schema, None),
+        KernelPredicate::BooleanExpression(expr) => {
+            boolean_expression_to_df_predicate_expr(expr, input_schema)
+        }
         KernelPredicate::Not(inner) => {
             let df_inner = to_df_predicate_expr(inner, input_schema)?;
             Ok(DFExpr::Not(Box::new(df_inner)))
@@ -49,6 +49,26 @@ pub fn to_df_predicate_expr(
             "cannot convert Unknown predicate {name:?}"
         ))),
     }
+}
+
+/// Lowers an expression used as a predicate and verifies that it resolves to Boolean.
+fn boolean_expression_to_df_predicate_expr(
+    expression: &KernelExpression,
+    input_schema: &StructType,
+) -> DeltaResult<DFExpr> {
+    let expression = to_df_expr(expression, input_schema, None)?;
+    let arrow_schema: ArrowSchema = input_schema.try_into_arrow()?;
+    let df_schema = DFSchema::try_from(arrow_schema).map_err(Error::generic_err)?;
+    if expression
+        .get_type(&df_schema)
+        .map_err(Error::generic_err)?
+        != datafusion::arrow::datatypes::DataType::Boolean
+    {
+        return Err(Error::invalid_expression(
+            "an expression used as a predicate must resolve to Boolean",
+        ));
+    }
+    Ok(expression)
 }
 
 /// Lowers a unary predicate.
@@ -81,87 +101,50 @@ fn binary_to_df_predicate_expr(
     Ok(binary_expr(left, op, right))
 }
 
-/// Lowers an `IN` predicate. Kernel models `x IN (..)` as `Binary(In, value, elements)`, where
-/// `value` is a literal and `elements` is either a literal array (`1 IN (1, 2)`) or an array-typed
-/// column (`1 IN col`). A literal array lowers to DataFusion's [`InList`], whose trailing flag
-/// negates the test; a column lowers to `array_has(col, value)`. Kernel has no negated `IN`
-/// (`NOT IN` arrives as `Not(Binary(In, ..))`, handled by the caller's `Not` arm), so the `InList`
-/// flag is always `false` here.
-///
-/// This accepts exactly the shapes kernel's Arrow evaluator accepts: both of its arms require a
-/// literal left operand, so a column left operand is rejected here as it is there.
-///
-/// Kernel and DataFusion agree once the result is forced non-null. Kernel compares elements with
-/// logical (SQL) equality and reports membership as a plain boolean: a null matches nothing (not
-/// even another null), so `NULL IN (1, 2)` and `NULL IN (1, NULL)` are both false, and the result
-/// is never null. DataFusion's [`InList`] and `array_has` both keep SQL three-valued logic, so a
-/// null on either side yields null. This lowering wraps the test in `IS TRUE`, collapsing that
-/// null to false to match kernel.
-///
-/// `IS TRUE` sits inside the predicate, not around it, because the caller's `Not` arm may negate
-/// the result and a leftover null would change which rows a filter keeps. Kernel reads
-/// `NOT NULL IN (1, 2)` as `NOT false` = true, but an unguarded DataFusion `NOT NULL` stays null
-/// and drops the row.
+/// Lowers Kernel's array-valued `IN` to DataFusion array functions. This accepts any left
+/// expression and any array-valued right expression, while preserving SQL three-valued null
+/// semantics.
 ///
 /// # Errors
-/// Returns [`Error::unsupported`] if the left operand is not a literal, or the right operand is
-/// neither a literal array nor an array-typed column.
+/// Returns an error if either operand cannot be lowered. DataFusion rejects a non-array right
+/// operand or operands without a common comparison type while planning the enclosing expression.
 fn in_to_df_predicate_expr(
     value: &KernelExpression,
     list: &KernelExpression,
     input_schema: &StructType,
 ) -> DeltaResult<DFExpr> {
-    // Kernel's Arrow evaluator accepts `IN` only with a literal left operand (a column left
-    // operand errors), so reject anything else to match it exactly.
-    let KernelExpression::Literal(_) = value else {
-        return Err(Error::unsupported(
-            "converting an IN predicate requires a literal left-hand side",
-        ));
-    };
     let value = to_df_expr(value, input_schema, None)?;
-    let membership =
-        match list {
-            KernelExpression::Literal(KernelScalar::Array(array)) => in_list_expr(value, array)?,
-            KernelExpression::Column(name) => array_has_expr(value, list, name, input_schema)?,
-            _ => return Err(Error::unsupported(
-                "converting an IN predicate requires a literal array or an array-typed column on \
-                 the right-hand side",
-            )),
-        };
-    Ok(membership.is_true())
-}
-
-/// Builds `value IN (<elements>)` from a literal array. Null elements stay in the list: they can
-/// never match under logical equality, and the caller's `IS TRUE` collapses the null they would
-/// otherwise contribute down to false.
-fn in_list_expr(value: DFExpr, array: &KernelArrayData) -> DeltaResult<DFExpr> {
-    let elements: Vec<DFExpr> = array
-        .array_elements()
-        .iter()
-        .map(|scalar| Ok(lit(to_df_scalar(scalar)?)))
-        .collect::<DeltaResult<_>>()?;
-    let in_expr = DFExpr::InList(InList::new(Box::new(value), elements, false));
-    Ok(in_expr)
-}
-
-/// Builds `array_has(<column>, value)` for `value IN <list column>`, which kernel evaluates
-/// element-wise. `column` is the kernel column expression and `name` its resolved name. Note the
-/// flipped argument order: haystack first, needle second.
-///
-/// # Errors
-/// Returns [`Error::unsupported`] if `name` does not resolve to an array-typed column.
-fn array_has_expr(
-    value: DFExpr,
-    column: &KernelExpression,
-    name: &KernelColumnName,
-    input_schema: &StructType,
-) -> DeltaResult<DFExpr> {
-    let DataType::Array(_) = input_schema.field_at(name)?.data_type else {
-        return Err(Error::unsupported(
-            "converting an IN predicate against a column requires an array-typed column",
-        ));
+    let list = to_df_expr(list, input_schema, None)?;
+    let membership = array_has(list.clone(), value.clone());
+    let arrow_schema: ArrowSchema = input_schema.try_into_arrow()?;
+    let df_schema = DFSchema::try_from(arrow_schema).map_err(Error::generic_err)?;
+    let list_type = list.get_type(&df_schema).map_err(Error::generic_err)?;
+    let element_nullable = match list_type {
+        datafusion::arrow::datatypes::DataType::List(field)
+        | datafusion::arrow::datatypes::DataType::LargeList(field) => field.is_nullable(),
+        datafusion::arrow::datatypes::DataType::FixedSizeList(field, _) => field.is_nullable(),
+        _ => true,
     };
-    Ok(array_has(to_df_expr(column, input_schema, None)?, value))
+    let may_return_null = value.nullable(&df_schema).map_err(Error::generic_err)?
+        || list.nullable(&df_schema).map_err(Error::generic_err)?
+        || element_nullable;
+    if !may_return_null {
+        return Ok(membership.is_true());
+    }
+
+    let list_has_null = cardinality(list.clone()).gt(cardinality(array_compact(list.clone())));
+    let null = lit(datafusion::common::ScalarValue::Boolean(None));
+    Ok(DFExpr::Case(datafusion::logical_expr::expr::Case::new(
+        None,
+        vec![
+            (Box::new(membership.is_true()), Box::new(lit(true))),
+            (Box::new(list.clone().is_null()), Box::new(null.clone())),
+            (Box::new(array_empty(list.clone())), Box::new(lit(false))),
+            (Box::new(value.is_null()), Box::new(null.clone())),
+            (Box::new(list_has_null), Box::new(null)),
+        ],
+        Some(Box::new(lit(false))),
+    )))
 }
 
 /// Lowers a junction (`And`/`Or`) by converting each child and combining them with DataFusion's
@@ -196,7 +179,7 @@ mod tests {
     use delta_kernel::engine::arrow_conversion::TryIntoArrow;
     use delta_kernel::expressions::{
         col, lit, null_lit, ArrayData as KernelArrayData, Expression as KernelExpr,
-        Predicate as KernelPred,
+        Predicate as KernelPred, Scalar as KernelScalar,
     };
     use delta_kernel::schema::{schema, ArrayType, DataType};
     use rstest::rstest;
@@ -205,14 +188,14 @@ mod tests {
 
     // === Shared helpers ===
 
-    /// Columns these tests resolve against: top-level `a`, `b`, `c` (all `long`) and `list`
-    /// (an array of nullable `long`, the right-hand side of a list-column `IN`).
+    /// Columns these tests resolve against.
     fn test_schema() -> StructType {
         schema! {
             nullable "a": LONG,
             nullable "b": LONG,
             nullable "c": LONG,
             nullable "list": [ nullable LONG ],
+            nullable "flag": BOOLEAN,
         }
     }
 
@@ -223,8 +206,8 @@ mod tests {
             .to_string()
     }
 
-    /// Lowers a predicate, runs it over one all-null row, and asserts the result is not null.
-    fn evaluate(pred: KernelPred) -> bool {
+    /// Lowers a predicate and runs it over one all-null row.
+    fn evaluate(pred: KernelPred) -> Option<bool> {
         let df_expr = to_df_predicate_expr(&pred, &test_schema()).unwrap();
         let arrow_schema: ArrowSchema = (&test_schema()).try_into_arrow().unwrap();
         let arrow_schema = Arc::new(arrow_schema);
@@ -248,9 +231,7 @@ mod tests {
             .into_array(batch.num_rows())
             .unwrap();
         let result = result.as_boolean();
-
-        assert_eq!(result.null_count(), 0, "predicate evaluated to null");
-        result.value(0)
+        (!result.is_null(0)).then(|| result.value(0))
     }
 
     /// A literal `Scalar::Array` of longs.
@@ -293,40 +274,6 @@ mod tests {
     // Unary.
     #[case::is_null(col!("a").is_null(), "a IS NULL")]
     #[case::is_not_null(col!("a").is_not_null(), "NOT a IS NULL")]
-    // IN / NOT IN. Kernel requires a literal needle. `IS TRUE` turns DataFusion's null into
-    // kernel's false, and sits inside the `Not` so a null value gives `NOT false` instead of
-    // `NOT NULL`.
-    #[case::in_list(
-        KernelPred::binary(KernelBinaryPredicateOp::In, lit(1i64), long_array([1, 2, 3])),
-        "Int64(1) IN ([Int64(1), Int64(2), Int64(3)]) IS TRUE"
-    )]
-    #[case::not_in(
-        KernelPred::not(KernelPred::binary(KernelBinaryPredicateOp::In, lit(1i64), long_array([1, 2]))),
-        "NOT Int64(1) IN ([Int64(1), Int64(2)]) IS TRUE"
-    )]
-    #[case::null_needle_in_list(
-        KernelPred::binary(
-            KernelBinaryPredicateOp::In,
-            null_lit(DataType::LONG),
-            long_array([1, 2]),
-        ),
-        "Int64(NULL) IN ([Int64(1), Int64(2)]) IS TRUE"
-    )]
-    // A null element stays in the list; it can never match under logical equality, and `IS TRUE`
-    // collapses the null it contributes to false.
-    #[case::null_element_in_list(
-        KernelPred::binary(
-            KernelBinaryPredicateOp::In,
-            lit(1i64),
-            nullable_long_array([Some(1), None]),
-        ),
-        "Int64(1) IN ([Int64(1), Int64(NULL)]) IS TRUE"
-    )]
-    // A literal against a list column lowers to `array_has(list, value)` (haystack first).
-    #[case::in_list_column(
-        KernelPred::binary(KernelBinaryPredicateOp::In, lit(1i64), col!("list")),
-        "array_has(list, Int64(1)) IS TRUE"
-    )]
     // Junctions fold left-associatively.
     #[case::and(
         KernelPred::and(col!("a").is_null(), col!("b").is_null()),
@@ -345,7 +292,7 @@ mod tests {
         "a IS NULL AND b IS NULL AND c IS NULL"
     )]
     // A bare boolean expression goes straight to the expression converter.
-    #[case::boolean_expression(KernelPred::from_expr(col!("a")), "a")]
+    #[case::boolean_expression(KernelPred::from_expr(col!("flag")), "flag")]
     // Nested predicates. DataFusion's Display omits parens around the junction under a `Not`, but
     // the `Expr` tree is still `Not(And(..))`.
     #[case::not_of_junction(
@@ -373,41 +320,49 @@ mod tests {
     #[rstest]
     // Engine-defined and unknown predicates have no DataFusion equivalent.
     #[case::unknown(KernelPred::Unknown("mystery".into()))]
-    // Kernel's evaluator rejects a column needle, so we do too, whether the elements are a literal
-    // array or a list column.
-    #[case::column_needle_in_literal_array(
-        KernelPred::binary(KernelBinaryPredicateOp::In, col!("a"), long_array([1, 2]))
-    )]
-    #[case::column_needle_in_list_column(
-        KernelPred::binary(KernelBinaryPredicateOp::In, col!("a"), col!("list"))
-    )]
-    // A literal needle against a non-array column (`b` is `long`) cannot be lowered.
-    #[case::in_non_array_column(
-        KernelPred::binary(KernelBinaryPredicateOp::In, lit(1i64), col!("b"))
-    )]
+    #[case::non_boolean_expression(KernelPred::from_expr(col!("a")))]
     fn unsupported_predicate_is_an_error(#[case] pred: KernelPred) {
         to_df_predicate_expr(&pred, &test_schema()).unwrap_err();
     }
 
-    /// `IN` answers true or false but never null, so it still works under a `NOT`. Membership uses
-    /// logical (SQL) equality, so a null matches nothing -- not even another null -- matching
-    /// kernel's evaluator.
+    #[test]
+    fn in_accepts_expression_operands() {
+        for pred in [
+            KernelPred::binary(KernelBinaryPredicateOp::In, col!("a"), long_array([1, 2])),
+            KernelPred::binary(KernelBinaryPredicateOp::In, col!("a"), col!("list")),
+        ] {
+            to_df_predicate_expr(&pred, &test_schema()).unwrap();
+        }
+    }
+
+    #[test]
+    fn in_rejects_non_array_right_operand_during_datafusion_planning() {
+        let pred = KernelPred::binary(KernelBinaryPredicateOp::In, lit(1i64), col!("b"));
+        let expression = to_df_predicate_expr(&pred, &test_schema()).unwrap();
+        let arrow_schema: ArrowSchema = (&test_schema()).try_into_arrow().unwrap();
+        let df_schema = DFSchema::try_from(arrow_schema).unwrap();
+        SessionContext::new()
+            .create_physical_expr(expression, &df_schema)
+            .unwrap_err();
+    }
+
+    /// `IN` follows SQL three-valued logic, and `NOT IN` negates the resulting Boolean or null.
     #[rstest]
-    #[case::present(Some(2), &[Some(1), Some(2)], true)]
-    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
-    #[case::null_needle_without_null_element(None, &[Some(1), Some(2)], false)]
-    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
-    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
-    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
-    #[case::only_null_element(None, &[None], false)]
-    fn in_predicate_matches_membership_and_never_nulls(
-        #[case] needle: Option<i64>,
+    #[case::present(Some(2), &[Some(1), Some(2)], Some(true))]
+    #[case::absent(Some(9), &[Some(1), Some(2)], Some(false))]
+    #[case::null_value_without_null_element(None, &[Some(1), Some(2)], None)]
+    #[case::null_value_with_null_element(None, &[Some(1), None], None)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], Some(true))]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], None)]
+    #[case::only_null_element(None, &[None], None)]
+    fn in_predicate_uses_three_valued_logic(
+        #[case] value: Option<i64>,
         #[case] elements: &[Option<i64>],
-        #[case] expected: bool,
+        #[case] expected: Option<bool>,
     ) {
         let in_pred = KernelPred::binary(
             KernelBinaryPredicateOp::In,
-            match needle {
+            match value {
                 Some(n) => lit(n),
                 None => null_lit(DataType::LONG),
             },
@@ -415,28 +370,29 @@ mod tests {
         );
 
         assert_eq!(evaluate(in_pred.clone()), expected);
-        assert_eq!(evaluate(KernelPred::not(in_pred)), !expected);
+        assert_eq!(
+            evaluate(KernelPred::not(in_pred)),
+            expected.map(|value| !value)
+        );
     }
 
-    /// A literal `IN <list column>` lowers to `array_has` and follows the same never-null,
-    /// logical-equality rule as the literal-array form: a null needle or a null element matches
-    /// nothing, and the result is always a plain boolean, so `NOT IN` is its exact complement.
+    /// An array-valued column follows the same SQL null behavior as a literal array.
     #[rstest]
-    #[case::present(Some(2), &[Some(1), Some(2)], true)]
-    #[case::absent(Some(9), &[Some(1), Some(2)], false)]
-    #[case::null_needle_without_null_element(None, &[Some(1), Some(2)], false)]
-    #[case::null_needle_with_null_element(None, &[Some(1), None], false)]
-    #[case::present_alongside_null_element(Some(1), &[Some(1), None], true)]
-    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], false)]
-    #[case::only_null_element(None, &[None], false)]
-    fn in_list_column_matches_membership_and_never_nulls(
-        #[case] needle: Option<i64>,
+    #[case::present(Some(2), &[Some(1), Some(2)], Some(true))]
+    #[case::absent(Some(9), &[Some(1), Some(2)], Some(false))]
+    #[case::null_value_without_null_element(None, &[Some(1), Some(2)], None)]
+    #[case::null_value_with_null_element(None, &[Some(1), None], None)]
+    #[case::present_alongside_null_element(Some(1), &[Some(1), None], Some(true))]
+    #[case::absent_alongside_null_element(Some(9), &[Some(1), None], None)]
+    #[case::only_null_element(None, &[None], None)]
+    fn in_list_column_uses_three_valued_logic(
+        #[case] value: Option<i64>,
         #[case] elements: &[Option<i64>],
-        #[case] expected: bool,
+        #[case] expected: Option<bool>,
     ) {
         let in_pred = KernelPred::binary(
             KernelBinaryPredicateOp::In,
-            match needle {
+            match value {
                 Some(n) => lit(n),
                 None => null_lit(DataType::LONG),
             },
@@ -446,12 +402,14 @@ mod tests {
         let batch = list_column_batch(elements);
 
         assert_eq!(evaluate_over(in_pred.clone(), &batch), expected);
-        assert_eq!(evaluate_over(KernelPred::not(in_pred), &batch), !expected);
+        assert_eq!(
+            evaluate_over(KernelPred::not(in_pred), &batch),
+            expected.map(|value| !value)
+        );
     }
 
-    /// Lowers `pred` against [`test_schema`], evaluates it over the single-row `batch`, and asserts
-    /// the one result is not null.
-    fn evaluate_over(pred: KernelPred, batch: &RecordBatch) -> bool {
+    /// Lowers `pred` against [`test_schema`] and evaluates it over the single-row `batch`.
+    fn evaluate_over(pred: KernelPred, batch: &RecordBatch) -> Option<bool> {
         let df_expr = to_df_predicate_expr(&pred, &test_schema()).unwrap();
         let df_schema = DFSchema::try_from(batch.schema()).unwrap();
         let result = SessionContext::new()
@@ -464,8 +422,7 @@ mod tests {
         let result = result.as_boolean();
 
         assert_eq!(result.len(), 1, "expected a single-row result");
-        assert_eq!(result.null_count(), 0, "predicate evaluated to null");
-        result.value(0)
+        (!result.is_null(0)).then(|| result.value(0))
     }
 
     /// A one-row batch whose single `list` column holds `elements`.

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -93,6 +93,8 @@ optional = true
 [features]
 # no default features
 default = []
+# exposes executor-independent expression fixtures to downstream test harnesses
+expression-conformance-tests = []
 # internal-api will make everything marked #[internal_api] public.
 internal-api = []
 # prettyprint enables Arrow pretty-print helpers (test/example oriented).

--- a/kernel/proto/expressions.proto
+++ b/kernel/proto/expressions.proto
@@ -1,5 +1,7 @@
 // Proto mirror of `kernel/src/expressions/mod.rs` + `scalars.rs` (the Rust IR is the source
-// of truth for these shapes).
+// of truth for this wire schema).
+//
+// Standard operator semantics are defined in `kernel/src/expressions/semantics.md`.
 //
 // Opaque{Expression,Predicate} and Unknown are escape hatches: kernel-rs can't serialise the
 // opaque trait objects, and Unknown is the "do not silently interpret" marker. They appear

--- a/kernel/src/engine/arrow_expression/mod.rs
+++ b/kernel/src/engine/arrow_expression/mod.rs
@@ -246,6 +246,8 @@ impl ArrayData {
 #[derive(Debug)]
 pub struct ArrowEvaluationHandler;
 
+// TODO(#3210): Align expression analysis and evaluation with Kernel's standard expression
+// contract.
 impl EvaluationHandler for ArrowEvaluationHandler {
     fn new_expression_evaluator(
         &self,

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -32,7 +32,10 @@ mod sql;
 pub(crate) use self::sql::parse_sql;
 
 #[doc = include_str!("semantics.md")]
-pub mod semantics {}
+pub mod semantics {
+    #[cfg(any(test, feature = "test-utils"))]
+    pub mod conformance;
+}
 
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -31,6 +31,9 @@ mod scalars;
 mod sql;
 pub(crate) use self::sql::parse_sql;
 
+#[doc = include_str!("semantics.md")]
+pub mod semantics {}
+
 pub type ExpressionRef = std::sync::Arc<Expression>;
 pub type PredicateRef = std::sync::Arc<Predicate>;
 
@@ -77,43 +80,36 @@ pub type ExpressionStructPatchBuilder = crate::struct_patch::StructPatchBuilder<
 /// A unary predicate operator.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum UnaryPredicateOp {
-    /// SQL `expr IS NULL`: `true` when the input is null and `false` otherwise, never null itself.
-    /// A wrapping `NOT` inverts it to `IS NOT NULL`.
+    /// SQL `expr IS NULL`.
+    ///
+    /// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
     IsNull,
 }
 
-/// A binary predicate operator.
-///
-/// The ordering and equality comparisons follow SQL three-valued logic, so a NULL operand yields
-/// NULL rather than `false`. [`Distinct`](Self::Distinct) and [`In`](Self::In) instead tolerate
-/// NULL and always answer `true` or `false`.
+/// A SQL comparison or membership operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryPredicateOp {
-    /// `left < right`.
+    /// SQL `left < right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     LessThan,
-    /// `left > right`.
+    /// SQL `left > right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     GreaterThan,
-    /// `left = right`.
+    /// SQL `left = right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     Equal,
-    /// SQL `left IS DISTINCT FROM right`: null-safe inequality, treating NULL as an ordinary
-    /// value. `DISTINCT(1, 1)` and `DISTINCT(NULL, NULL)` are `false`; `DISTINCT(NULL, 1)` is
-    /// `true`.
+    /// SQL `left IS DISTINCT FROM right`.
+    ///
+    /// See the [comparison contract](semantics#comparisons).
     Distinct,
-    /// SQL `left IN (elements)`: returns `false` when `left` is NULL. Otherwise, it returns `true`
-    /// when `left` equals any element and `false` when none match. NULL elements never match.
-    /// `left` must be a literal, and the elements are either a list-typed column or an
-    /// [`Expression::Literal`] holding a [`Scalar::Array`], never a list of expressions or a
-    /// subquery:
+    /// Tests whether `left` equals any element of an array-valued `right` expression, using SQL
+    /// `IN` null semantics. This IR node does not represent a parenthesized SQL value list or
+    /// subquery.
     ///
-    /// ```sql
-    /// 2 IN (1, 2, 3)         -- literal elements
-    /// 2 IN (SELECT ...)      -- unsupported: no subquery form
-    /// col IN (1, 2, 3)       -- unsupported: the left operand must be a literal
-    /// ```
-    ///
-    /// Testing a literal against a list column is the shape data skipping uses, and it is the
-    /// reason the operands sit this way around rather than the more familiar
-    /// column-on-the-left form.
+    /// See the [`IN` contract](semantics#in).
     In,
 }
 
@@ -144,60 +140,45 @@ pub enum UnaryExpressionOp {
     ToJson,
 }
 
-/// A binary arithmetic operator over two numeric operands.
+/// A binary SQL arithmetic operator.
 ///
-/// Both operands share a numeric type and the result takes that type. Kernel inserts no implicit
-/// casts, so widening a result (decimal precision or scale, for instance) needs an explicit
-/// [`Expression::cast`] to match a declared output type.
+/// See the [arithmetic contract](semantics#numeric-addition-subtraction-and-multiplication).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryExpressionOp {
-    /// `left + right`.
+    /// SQL `left + right`.
     Plus,
-    /// `left - right`.
+    /// SQL `left - right`.
     Minus,
-    /// `left * right`.
+    /// SQL `left * right`.
     Multiply,
-    /// `left / right`. A zero divisor never yields NULL.
+    /// SQL `left / right`: fractional numeric division. Integer inputs do not truncate.
     ///
-    /// Integer operands divide truncating toward zero, and a zero divisor fails. Float operands
-    /// follow IEEE 754: `+/-inf` for a non-zero numerator, `NaN` for `0.0 / 0.0`. In a dialect
-    /// whose `/` is always fractional, the integer case is the other division operator:
-    ///
-    /// ```sql
-    /// 7 DIV 2      -- 3, this operator over integers
-    /// 7 / 2        -- 3.5, NOT this operator
-    /// ```
+    /// See the [division contract](semantics#division).
     Divide,
 }
 
-/// A variadic expression operator.
+/// A variadic SQL expression operator.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum VariadicExpressionOp {
-    /// SQL `COALESCE(exprs...)`: the first non-null value, or null when every input is null. All
-    /// inputs share one type, which is also the result type. Requires at least one input.
-    Coalesce,
-    /// SQL `ARRAY(exprs...)`: an array built by evaluating each input per row, so
-    /// `ARRAY(1, 1 + 2, my_int_col)` yields `[1, 3, <my_int_col value>]`. All inputs must share
-    /// the same element type. Requires at least one element; the element type is inferred from
-    /// the inputs.
+    /// SQL `COALESCE(exprs...)`.
     ///
-    /// For static array literals whose elements are all compile-time constants, use
-    /// [`Scalar::Array`] instead. The difference is that `Array` is evaluated at runtime, while
-    /// `Scalar::Array` is evaluated at compile time.
+    /// See the [`COALESCE` contract](semantics#coalesce).
+    Coalesce,
+    /// SQL `ARRAY(exprs...)`, producing one array per input row.
+    ///
+    /// Use [`Scalar::Array`] for an array literal that is constant across input rows. See the
+    /// [`ARRAY` contract](semantics#array).
     Array,
 }
 
 /// A junction (AND/OR) predicate operator over N child predicates.
 ///
-/// Both use SQL three-valued (Kleene) logic, treating a NULL child as unknown rather than false: a
-/// decisive child wins over a NULL sibling, so `AND` is `false` and `OR` is `true` despite the
-/// NULL, and only an undecided junction yields NULL. [`Predicate::junction`] folds an empty
-/// junction to its operator's identity, `true` for `AND` and `false` for `OR`.
+/// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub enum JunctionPredicateOp {
-    /// SQL `a AND b AND ...`: true when every child is true.
+    /// SQL `a AND b AND ...`.
     And,
-    /// SQL `a OR b OR ...`: true when any child is true.
+    /// SQL `a OR b OR ...`.
     Or,
 }
 
@@ -474,11 +455,17 @@ where
     Err(de::Error::custom("Cannot deserialize an Opaque Expression"))
 }
 
-/// A SQL expression.
+/// An expression in Kernel's intermediate representation.
 ///
-/// These expressions do not track or validate data types, other than the type
-/// of literals. It is up to the expression evaluator to validate the
-/// expression against a schema and add appropriate casts as required.
+/// Expressions do not store resolved types other than the type of literals. Before evaluation, an
+/// expression is analyzed against its input schema using the common-type, result-type, nullability,
+/// and error rules in the [SQL expression contract](semantics). A surrounding `Project` may also
+/// supply a declared output type; that assignment happens after the expression's own type is
+/// resolved.
+///
+/// An evaluator may reject a valid expression it does not support. If it evaluates the expression,
+/// its result must follow the contract. Input outside the contract is not portable, even when a
+/// particular evaluator accepts it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Expression {
     /// A literal value.
@@ -491,7 +478,7 @@ pub enum Expression {
     /// A struct computed from one expression per output field, in field order.
     ///
     /// Field names and nullability come from the surrounding output schema (the evaluator's
-    /// `result_type`, such as a [`Project`]'s target field), and each field expression's type is
+    /// `result_type`, such as a `Project`'s target field), and each field expression's type is
     /// validated against the schema, so building a struct takes both. The expression count must
     /// equal the output field count.
     ///
@@ -501,8 +488,6 @@ pub enum Expression {
     /// ```sql
     /// CASE WHEN keep_pred THEN struct(expr1, expr2, ...) END
     /// ```
-    ///
-    /// [`Project`]: crate::plans::ir::nodes::Project
     Struct(Vec<ExpressionRef>, Option<ExpressionRef>),
     /// A sparse patch of a struct. More efficient than `Struct` for wide schemas
     /// where only a few fields change, achieving O(changes) instead of O(schema_width) complexity.
@@ -539,16 +524,18 @@ pub enum Expression {
     Cast(CastExpression),
 }
 
-/// A SQL predicate.
+/// A predicate in Kernel's intermediate representation.
 ///
-/// These predicates do not track or validate data types, other than the type
-/// of literals. It is up to the predicate evaluator to validate the
-/// predicate against a schema and add appropriate casts as required.
+/// Predicates do not store resolved input types. Before evaluation, a predicate is analyzed against
+/// its input schema using the [SQL expression contract](semantics). Boolean predicates require
+/// Boolean inputs; Kernel does not define numeric or string truthiness.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Predicate {
-    /// A boolean-valued expression, useful for e.g. `AND(<boolean_col1>, <boolean_col2>)`.
+    /// A Boolean-valued expression used as a predicate.
+    ///
+    /// See the [Boolean and null semantics](semantics#boolean-predicates-and-nulls).
     BooleanExpression(Expression),
-    /// Boolean inversion (true <-> false)
+    /// SQL Boolean inversion.
     ///
     /// NOTE: NOT is not a normal unary predicate, because it requires a predicate as input (not an
     /// expression), and is never directly evaluated. Instead, observing that all predicates are
@@ -559,7 +546,7 @@ pub enum Predicate {
     Unary(UnaryPredicate),
     /// A binary operation.
     Binary(BinaryPredicate),
-    /// A junction operation (AND/OR).
+    /// SQL `AND` or `OR` over Boolean predicates.
     Junction(JunctionPredicate),
     /// A predicate that the engine defines and implements. Kernel interacts with the predicate
     /// only through methods provided by the [`OpaquePredicateOp`] trait.

--- a/kernel/src/expressions/mod.rs
+++ b/kernel/src/expressions/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use self::sql::parse_sql;
 
 #[doc = include_str!("semantics.md")]
 pub mod semantics {
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(any(test, feature = "test-utils", feature = "expression-conformance-tests"))]
     pub mod conformance;
 }
 

--- a/kernel/src/expressions/semantics.md
+++ b/kernel/src/expressions/semantics.md
@@ -1,0 +1,437 @@
+# Standard SQL expression semantics
+
+This page defines the SQL semantics for Kernel's standard expression operators. It fixes choices
+that vary across SQL implementations, including decimal precision, floating-point comparisons,
+temporal conversions, and empty `IN` sets. Evaluation settings do not change these rules.
+
+An evaluator may reject a valid expression as unsupported. If it evaluates one, the result type,
+value, null behavior, and errors must follow this contract. An expression outside the contract is
+not portable, even when an evaluator accepts it.
+
+Expression nodes with specialized behavior document their contracts on their Rust types.
+
+## Analysis and common types
+
+The expression tree is unresolved. Before evaluation, an implementation resolves column
+references, validates each operator's operands, finds required common types, and inserts casts.
+Failure to find a permitted type is an analysis error.
+
+Kernel does not implicitly parse `STRING` as a number or Boolean. For example, `long_col + '1'`,
+`long_col = '1'`, and `COALESCE(long_col, '0')` are outside the contract. An evaluator may accept
+such expressions as an extension, but their behavior is not portable.
+
+`VOID` is the type of an untyped null. `VOID` and `T` have common type `T`; inputs that are all
+`VOID` retain that type. Identical scalar types have themselves as their common type. The following
+rules handle differing types. Arithmetic whose operands are all `VOID` is invalid because no
+numeric type can be inferred.
+
+### Numeric common types
+
+Among non-decimal numeric types, the precedence order is:
+
+```text
+TINYINT -> SMALLINT -> INT -> BIGINT -> FLOAT -> DOUBLE
+```
+
+Kernel names these types `BYTE`, `SHORT`, `INTEGER`, `LONG`, `FLOAT`, and `DOUBLE` in its Rust API.
+Normally, the type farther to the right is the common type. An integral type combined with `FLOAT`
+resolves to `DOUBLE`. Decimal operands follow separate rules:
+
+- A decimal combined with `FLOAT` or `DOUBLE` resolves to `DOUBLE`.
+- A decimal combined with an integral type stays decimal. The integral operand first becomes
+  `DECIMAL(3,0)`, `DECIMAL(5,0)`, `DECIMAL(10,0)`, or `DECIMAL(20,0)`, respectively.
+
+For common-type resolution outside arithmetic, two decimals use:
+
+```text
+scale          = max(s1, s2)
+integer_digits = max(p1 - s1, p2 - s2)
+precision      = integer_digits + scale
+```
+
+If `precision` exceeds 38, reduce `scale` by `precision - 38`, without taking it below zero, and
+use precision 38. This retains the available integer digits before fractional digits. Any scale
+reduction in an implicit decimal conversion rounds half up, with a midpoint rounded away from
+zero. A value whose integer part does not fit raises an arithmetic-overflow error.
+
+For decimal arithmetic and numeric comparisons, an integral literal combined with a decimal uses
+only the digits needed by its value, with one digit for zero. Any other integral expression uses
+the full decimal precision listed above. Other common-type operations, including `COALESCE`, use
+the full precision of the integral type for both literals and non-literal expressions.
+
+Examples:
+
+```sql
+COALESCE(int_col, bigint_col)  -- BIGINT
+bigint_col + float_col         -- DOUBLE
+decimal_col = int_col          -- compare as a DECIMAL common type
+decimal_col + double_col       -- DOUBLE
+```
+
+### Other scalar and complex types
+
+`DATE`, `TIMESTAMP_NTZ`, and `TIMESTAMP` widen in that order. A date becomes midnight. When a date
+or timezone-free timestamp widens to `TIMESTAMP`, Kernel interprets it in UTC. A session time zone
+must not alter the conversion. Converting a date to either timestamp type raises a runtime
+arithmetic-overflow error when its midnight microsecond offset does not fit in an `i64`.
+
+Strings use binary UTF-8 ordering: their encoded bytes compare lexicographically with no case
+folding or Unicode normalization. Binary values compare lexicographically by unsigned byte,
+`FALSE` sorts before `TRUE`, and intervals compare by their signed month or microsecond count
+within the same interval family. Binary, Boolean, and interval values require an exact type match.
+Other scalar types also require an exact type match.
+
+Complex types resolve recursively:
+
+- Arrays widen their element types. The result allows null elements when either input does.
+- Maps widen keys and values separately. `VOID` may widen as a key type because it can occur only in
+  an empty map. The result allows null values when either input does.
+- Structs must have the same field count and case-insensitively matching field names. Corresponding
+  fields widen recursively, and the result field is nullable when either input field is nullable.
+  The result preserves the first input's field-name spelling.
+
+```text
+common_type(ARRAY<INT>, ARRAY<BIGINT>) -> ARRAY<BIGINT>
+
+common_type(
+  STRUCT<a: INT, b: STRING>,
+  STRUCT<a: BIGINT, b: STRING>
+) -> STRUCT<a: BIGINT, b: STRING>
+```
+
+## Declared `Project` output types
+
+Operator analysis determines an expression's result before a surrounding `Project` assigns it to
+a declared output field. The declared schema cannot change an operator's inference. In particular,
+it cannot make integer `/` truncate or force decimal arithmetic to keep an operand's precision.
+
+After inference, a `Project` may keep the exact type or apply one of these implicit assignments:
+
+```text
+TINYINT  -> SMALLINT, INT, BIGINT, FLOAT, DOUBLE
+SMALLINT -> INT, BIGINT, FLOAT, DOUBLE
+INT      -> BIGINT, DOUBLE
+FLOAT    -> DOUBLE
+DATE     -> TIMESTAMP_NTZ
+```
+
+Together with the `VOID` and decimal rules below, these are the only implicit `Project`
+assignments. Common-type promotion does not add assignments to this list.
+
+`VOID` may take any target type, subject to nullability at the same position. A top-level `VOID`
+expression is nullable and therefore cannot be assigned to a non-null field. Recursively, a
+`VOID` array element or map value may take a non-null target type when the source container says
+that position cannot contain null. An empty `ARRAY<VOID>` with `containsNull = false`, an empty map
+with a `VOID` key, and an empty map with a `VOID` value whose `valueContainsNull` is false may
+therefore adopt concrete target types.
+
+An integral or decimal value may be assigned to `DECIMAL(p2,s2)` when the target has at least the
+source scale and enough added precision to preserve every integer digit. Integral sources use the
+full decimal precision listed under numeric common types. The same rule applies recursively to
+array elements, map keys and values, and corresponding struct fields. Map keys and values are
+checked independently. Struct fields are aligned positionally; the target field names replace the
+source names. A nullable result cannot be assigned to a non-null field. Recursively, an array that
+may contain null elements cannot be assigned to one that forbids them, a map whose values may be
+null cannot be assigned to one whose values may not be null, and a nullable struct field cannot be
+assigned to a non-null field.
+
+Other conversions need an explicit `Cast` expression. Narrowing, parsing a string, or rounding a
+decimal at the `Project` boundary is not an implicit assignment.
+
+The numeric assignments above preserve every source value. `DATE` to `TIMESTAMP_NTZ` is also
+allowed, but it raises an arithmetic-overflow error when the date's midnight microsecond offset
+does not fit in an `i64`.
+
+## `COALESCE`
+
+`COALESCE` requires at least one child. It casts every child to their common type and returns that
+type. Its result is nullable only when every child is nullable.
+
+Every child must analyze successfully. Runtime evaluation then proceeds from left to right and
+stops at the first non-null value. An unselected child is not evaluated, so its runtime errors are
+not raised.
+
+```sql
+COALESCE(CAST(NULL AS INT), CAST(7 AS BIGINT))  -- BIGINT 7
+COALESCE(NULL, 7, 9)                            -- INT 7
+COALESCE(2, 5 / 0)                              -- DOUBLE 2.0; no DIVIDE_BY_ZERO error
+```
+
+## `ARRAY`
+
+`ARRAY` casts every element to their common type and returns `ARRAY<common type>`. The array itself
+is never null. Its `containsNull` flag is true exactly when an element expression can return null.
+`ARRAY()` is an empty, non-null `ARRAY<VOID>` with `containsNull = false`.
+
+```sql
+ARRAY(CAST(1 AS INT), CAST(2 AS BIGINT))  -- ARRAY<BIGINT>[1, 2]
+ARRAY(1, NULL)                            -- ARRAY<INT>[1, NULL], containsNull = true
+ARRAY()                                   -- ARRAY<VOID>[], containsNull = false
+```
+
+For an array literal that is constant across input rows, use
+[`Scalar::Array`](crate::expressions::Scalar::Array). The
+[`VariadicExpressionOp::Array`](crate::expressions::VariadicExpressionOp::Array) node evaluates its
+elements for each input row.
+
+## Numeric addition, subtraction, and multiplication
+
+`+`, `-`, and `*` accept numeric operands only. When the common type is not decimal, it is also the
+result type. When the common type is decimal, results use the formulas below. A decimal combined
+with `FLOAT` or `DOUBLE` therefore returns `DOUBLE`, not a decimal. The result is nullable when
+either operand is nullable.
+
+Integral and decimal arithmetic is checked. A value outside the result type raises a runtime
+arithmetic-overflow error instead of wrapping or becoming null. Floating-point arithmetic keeps
+IEEE 754 results, including infinities and NaNs.
+
+```sql
+CAST(1 AS INT) + CAST(2 AS BIGINT)    -- BIGINT 3
+CAST(3 AS BIGINT) - CAST(1 AS INT)    -- BIGINT 2
+CAST(3 AS INT) * CAST(2 AS BIGINT)    -- BIGINT 6
+CAST(2147483647 AS INT) + 1           -- arithmetic overflow error
+CAST(1e308 AS DOUBLE) * 1e308         -- positive infinity
+NULL + CAST(1 AS INT)                 -- NULL
+```
+
+### Decimal result types
+
+For `DECIMAL(p1,s1)` and `DECIMAL(p2,s2)`, first compute an unbounded result type:
+
+```text
+Add/Subtract:
+  scale     = max(s1, s2)
+  precision = max(p1 - s1, p2 - s2) + scale + 1
+
+Multiply:
+  scale     = s1 + s2
+  precision = p1 + p2 + 1
+
+Divide:
+  scale     = max(6, s1 + p2 + 1)
+  precision = p1 - s1 + s2 + scale
+```
+
+When `precision` exceeds 38, adjust it as follows:
+
+```text
+integer_digits = precision - scale
+minimum_scale  = min(scale, 6)
+adjusted_scale = max(38 - integer_digits, minimum_scale)
+result         = DECIMAL(38, adjusted_scale)
+```
+
+Scale reduction rounds half up. A midpoint rounds away from zero. If the integer part still does
+not fit, evaluation raises an arithmetic-overflow error.
+
+```text
+DECIMAL(10,2) + DECIMAL(10,2) -> DECIMAL(11,2)
+DECIMAL(10,2) - DECIMAL(10,2) -> DECIMAL(11,2)
+DECIMAL(10,2) * DECIMAL(10,2) -> DECIMAL(21,4)
+DECIMAL(10,2) / DECIMAL(10,2) -> DECIMAL(23,13)
+```
+
+A non-literal integral expression uses its type's full decimal precision during decimal arithmetic:
+3 digits for `TINYINT`, 5 for `SMALLINT`, 10 for `INT`, and 20 for `BIGINT`. An integral literal
+uses only the digits needed for its value.
+
+```text
+DECIMAL(10,2) column + INT column -> DECIMAL(13,2)
+DECIMAL(10,2) column + literal 1  -> DECIMAL(11,2)
+```
+
+Kernel caps decimal precision at 38, permits the scale reduction above, preserves at least
+`min(original scale, 6)` fractional digits, and gives each integral literal the smallest precision
+that represents its value. Evaluation settings do not alter these choices.
+
+## Division
+
+`/` accepts numeric operands and always means fractional division. Inputs whose common type is not
+decimal become `DOUBLE`, so integer inputs do not truncate. Inputs whose common type is decimal use
+the decimal division formula. A decimal combined with `FLOAT` or `DOUBLE` therefore returns
+`DOUBLE`. The result is nullable when either operand is nullable.
+
+A divisor of positive or negative zero raises `DIVIDE_BY_ZERO` for integral, decimal, or
+floating-point operands when the dividend is non-null. A null operand produces null, so `NULL / 0`
+is null rather than an error. This is the deliberate exception to raw IEEE 754 division. Kernel
+has no truncating `DIV` operator.
+
+```sql
+3 / 2                                            -- DOUBLE 1.5
+CAST(3 AS DECIMAL(10,2)) /
+  CAST(2 AS DECIMAL(10,2))                       -- DECIMAL(23,13) 1.5000000000000
+CAST(1 AS DOUBLE) / CAST(0.0 AS DOUBLE)          -- DIVIDE_BY_ZERO error
+CAST(1 AS DOUBLE) / CAST('-0.0' AS DOUBLE)       -- DIVIDE_BY_ZERO error
+NULL / 0                                         -- NULL; no DIVIDE_BY_ZERO error
+```
+
+## Comparisons
+
+`=`, `<`, `>`, and `IS DISTINCT FROM` cast both operands to one common orderable type. Numeric,
+string, binary, Boolean, temporal, and interval values are orderable. Arrays and structs are
+orderable when every nested value is orderable. Maps are not orderable, and this contract does not
+define comparisons for `VARIANT` or geospatial values. `VOID` operands follow the untyped-null
+rules above and require no non-null ordering.
+
+When nested types have identical leaf types but struct field names or nested nullability differ,
+comparison may align them positionally without a cast. Field names do not affect the aligned value
+comparison. Ordinary widening still requires case-insensitively matching names, so differently
+named structs whose corresponding leaf types differ are invalid.
+
+```text
+STRUCT<a: INT>(1) = STRUCT<b: INT>(1)       -> TRUE
+STRUCT<a: INT>(1) = STRUCT<b: BIGINT>(1)    -> analysis error
+```
+
+Ordinary comparisons use three-valued logic. If either operand is null, the result is null.
+`IS DISTINCT FROM` is null-safe inequality and never returns null.
+
+```sql
+CAST(1 AS INT) = CAST(1 AS BIGINT)  -- TRUE after widening to BIGINT
+NULL = NULL                         -- NULL
+NULL < 1                            -- NULL
+
+1 IS DISTINCT FROM 1                -- FALSE
+1 IS DISTINCT FROM 2                -- TRUE
+NULL IS DISTINCT FROM NULL          -- FALSE
+NULL IS DISTINCT FROM 1             -- TRUE
+```
+
+Floating-point comparisons treat all NaN payloads as one value that sorts after every non-NaN.
+Positive and negative zero compare equal. These rules also apply inside arrays and structs and to
+`IN`.
+
+Arrays and structs compare lexicographically. Array elements are visited in index order and struct
+fields in declared order. A nested null equals another nested null and sorts before a non-null
+value. This nested-null rule does not change the top-level three-valued result: a null array or
+struct operand still makes an ordinary comparison null.
+
+```sql
+CAST('NaN' AS DOUBLE) = CAST('NaN' AS DOUBLE)  -- TRUE
+CAST('NaN' AS DOUBLE) > 1.0                    -- TRUE
+1.0 < CAST('NaN' AS DOUBLE)                    -- TRUE
+CAST('-0.0' AS DOUBLE) = CAST('0.0' AS DOUBLE)  -- TRUE
+CAST('-0.0' AS DOUBLE) < CAST('0.0' AS DOUBLE)  -- FALSE
+CAST('-0.0' AS DOUBLE) > CAST('0.0' AS DOUBLE)  -- FALSE
+```
+
+## `IN`
+
+Kernel's `IN` node compares any left expression with the elements of one array-valued right
+expression. The right expression is not a parenthesized SQL value list or subquery.
+
+The left operand and the array element type resolve to one common orderable type, or use the same
+positional structural alignment permitted by comparisons when their leaf types already match.
+Membership uses the same equality relation as `=`, including its NaN and signed-zero behavior. A
+null array returns null. For a non-empty array:
+
+| Condition | Result |
+|---|---|
+| At least one element matches | `TRUE` |
+| No match and the left operand is null | `NULL` |
+| No match and an element is null | `NULL` |
+| No match and no null is involved | `FALSE` |
+
+In SQL, a column on the left is the common form. For example, `customer_id IN (1, 2, 3)` maps to a
+Kernel `IN` node whose left expression is `customer_id` and whose right expression is
+`ARRAY(1, 2, 3)`. The parenthesized SQL list is not itself a Kernel expression node.
+
+```sql
+customer_id IN (1, 2, 3)                         -- valid: left side is a column
+1 IN (1, 2)                                      -- TRUE
+1 IN (2, 3)                                      -- FALSE
+1 IN (2, NULL)                                   -- NULL
+NULL IN (1, 2)                                   -- NULL
+CAST('NaN' AS DOUBLE) IN (CAST('NaN' AS DOUBLE))  -- TRUE
+CAST('-0.0' AS DOUBLE) IN (CAST('0.0' AS DOUBLE))  -- TRUE
+```
+
+SQL text does not permit `IN ()`, but an `IN` subquery can return no rows. Kernel likewise returns
+false for an empty array, including when the left value is null:
+
+```text
+1    IN [] -> FALSE
+NULL IN [] -> FALSE
+```
+
+This fixes the result, but it does not require an evaluator to skip the left expression. `IN` does
+not suppress errors from its children.
+
+`NOT IN` applies SQL `NOT` to the membership result, so it preserves null. Data-skipping consumers
+must treat a null predicate result as unknown and keep the file.
+
+The inferred result is nullable when the left operand, array, or array element is nullable. This
+remains true for an empty array even though that row's value is always false.
+
+## Boolean predicates and nulls
+
+`BooleanExpression`, `AND`, `OR`, and `NOT` require Boolean inputs. Kernel does not define numeric
+or string truthiness. `AND`, `OR`, and `NOT` use SQL three-valued logic. `IS NULL` accepts any type
+and always returns a non-null Boolean.
+
+`BooleanExpression` keeps its input nullability, and `NOT` keeps its child's nullability. An `AND`
+or `OR` result is nullable when any child is nullable, even when a decisive child determines a
+non-null value for a particular row.
+
+```sql
+TRUE  AND TRUE   -- TRUE
+TRUE  AND FALSE  -- FALSE
+TRUE  AND NULL   -- NULL
+FALSE AND NULL   -- FALSE
+
+TRUE  OR FALSE   -- TRUE
+FALSE OR FALSE   -- FALSE
+TRUE  OR NULL    -- TRUE
+FALSE OR NULL    -- NULL
+
+NOT TRUE         -- FALSE
+NOT FALSE        -- TRUE
+NOT NULL         -- NULL
+
+NULL IS NULL     -- TRUE
+1 IS NULL        -- FALSE
+```
+
+The normalized empty junctions use their Boolean identities: `AND()` is true and `OR()` is false.
+
+## Evaluation order and errors
+
+Only `COALESCE` guarantees left-to-right evaluation and stops after the first non-null value.
+Kernel does not promise evaluation order or error suppression for Boolean junctions, arithmetic,
+comparisons, or `IN`; an evaluator may rewrite or reorder them.
+
+Failures fall into these categories:
+
+| Situation | Required result |
+|---|---|
+| Operand types have no permitted common type | Analysis error |
+| An operator has the wrong number or kind of operands | Analysis error |
+| The expression is valid but the evaluator cannot implement it | Explicit unsupported error |
+| Checked numeric operation or temporal conversion overflows | Runtime arithmetic-overflow error |
+| A non-null value is divided by positive or negative zero | Runtime `DIVIDE_BY_ZERO` error |
+| A nullable operand is null | Null according to the operator rules |
+| An unselected later `COALESCE` child would fail | No error; the child is not evaluated |
+
+An evaluator must not use a legacy, permissive, or `TRY` mode for the standard operators covered
+here. Such a mode must not make overflow wrap or turn an error into null.
+
+## Sources
+
+The common-type, decimal-arithmetic, overflow, null, and floating-point rules use public
+[Apache Spark ANSI semantics], [SQL data types], and [NULL semantics] as a baseline. The Apache
+Spark implementations of [ANSI type coercion], [arithmetic expressions], [predicates],
+[`COALESCE`], [floating-point ordering], and the [default binary string type] cover details that
+the SQL reference does not spell out.
+
+The operator sections above define Kernel's fixed choices where SQL implementations vary.
+`Project` assignment is Kernel-specific and limited to the conversions listed above.
+
+[Apache Spark ANSI semantics]: https://spark.apache.org/docs/4.0.1/sql-ref-ansi-compliance.html
+[SQL data types]: https://spark.apache.org/docs/4.0.1/sql-ref-datatypes.html
+[NULL semantics]: https://spark.apache.org/docs/4.0.1/sql-ref-null-semantics.html
+[ANSI type coercion]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+[arithmetic expressions]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+[predicates]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+[`COALESCE`]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala#L52-L93
+[floating-point ordering]: https://github.com/apache/spark/blob/v4.0.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/SQLOrderingUtil.scala#L20-L40
+[default binary string type]: https://github.com/apache/spark/blob/v4.0.1/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala#L108-L121

--- a/kernel/src/expressions/semantics.md
+++ b/kernel/src/expressions/semantics.md
@@ -18,7 +18,9 @@ Failure to find a permitted type is an analysis error.
 
 Kernel does not implicitly parse `STRING` as a number or Boolean. For example, `long_col + '1'`,
 `long_col = '1'`, and `COALESCE(long_col, '0')` are outside the contract. An evaluator may accept
-such expressions as an extension, but their behavior is not portable.
+such expressions as an extension, but their behavior is not portable. Conformance fixtures mark
+these inputs as extension boundaries: rejection is valid, but acceptance is not a conformance
+failure and does not give the result portable semantics.
 
 `VOID` is the type of an untyped null. `VOID` and `T` have common type `T`; inputs that are all
 `VOID` retain that type. Identical scalar types have themselves as their common type. The following

--- a/kernel/src/expressions/semantics/conformance.rs
+++ b/kernel/src/expressions/semantics/conformance.rs
@@ -1,0 +1,3315 @@
+//! Executor-independent cases for Kernel's standard SQL expression semantics.
+//!
+//! Each case supplies one input row, an unresolved Kernel expression, its resolved output, and the
+//! required result. A harness analyzes and executes each case according to Kernel's standard SQL
+//! expression contract, then classifies the observed result as follows:
+//!
+//! - A portable case that matches is a pass. An explicit unsupported result is reported as
+//!   unsupported, not as a pass. Any other result is a failure.
+//! - An extension-boundary case rejected as invalid enforces the strict Kernel boundary. A value is
+//!   reported as an executor extension, and an unsupported result as unsupported. Neither is a
+//!   portable pass or a conformance failure because the input is outside Kernel's contract.
+//!
+//! Harnesses for executors with a configurable session time zone must configure
+//! [`CONFORMANCE_SESSION_TIME_ZONE`] before analysis and execution. Its non-UTC offset makes the
+//! temporal cases verify that common-type conversion does not depend on that setting. Executors
+//! with no session time zone can ignore it.
+//!
+//! Case order is unspecified. Harnesses should identify cases by the stable `name` on
+//! [`ExpressionSemanticsCase`] or [`ProjectAssignmentCase`].
+//!
+//! [`project_assignment_cases`] separately covers the declared output-schema boundary after
+//! expression inference. A complete harness runs both suites.
+
+use std::sync::Arc;
+
+use super::super::{
+    ArrayData, BinaryExpressionOp, BinaryPredicateOp, Expression, MapData, Predicate, Scalar,
+    StructData,
+};
+use crate::schema::{schema_ref, ArrayType, DataType, MapType, SchemaRef, StructField, StructType};
+use crate::DeltaResult;
+
+/// Non-UTC session time zone required while running the conformance cases.
+pub const CONFORMANCE_SESSION_TIME_ZONE: &str = "America/Los_Angeles";
+
+/// The portable result or strict extension-boundary rejection for a conformance case.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExpectedResult {
+    /// Evaluation succeeds with this scalar value, including a typed [`Scalar::Null`].
+    Value(Scalar),
+    /// Analysis or evaluation fails with this contract-level error. An extension-boundary case
+    /// may instead be accepted with executor-specific behavior.
+    Error(ExpectedError),
+}
+
+/// Contract-level errors that an executor maps to its own error types and messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpectedError {
+    /// Expression analysis or declared-output assignment fails, including unresolved columns and
+    /// invalid arity or types.
+    InvalidExpression,
+    /// Checked integral or decimal arithmetic, or a temporal conversion, overflows during
+    /// evaluation.
+    ArithmeticOverflow,
+    /// A numeric divisor is positive or negative zero.
+    DivideByZero,
+}
+
+/// Whether a case has portable behavior or marks the edge of Kernel's contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConformanceRequirement {
+    /// The contract specifies this outcome, including required analysis errors.
+    Portable,
+    /// The expression is outside Kernel's contract. Rejection is expected from a strict executor,
+    /// but an executor may accept it as a non-portable extension.
+    ExtensionBoundary,
+}
+
+/// Type and nullability inferred before assignment to a declared output field.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedOutput {
+    /// Inferred expression result type.
+    pub data_type: DataType,
+    /// Whether the inferred result may be null.
+    pub nullable: bool,
+}
+
+impl ResolvedOutput {
+    fn new(data_type: impl Into<DataType>, nullable: bool) -> Self {
+        Self {
+            data_type: data_type.into(),
+            nullable,
+        }
+    }
+}
+
+/// One input row and the expected analysis and evaluation result for an expression.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExpressionSemanticsCase {
+    /// Stable case name suitable for a test identifier.
+    pub name: &'static str,
+    /// Schema used to analyze the expression and interpret `input_row`.
+    pub input_schema: SchemaRef,
+    /// One input row, in `input_schema` field order.
+    pub input_row: Vec<Scalar>,
+    /// Unresolved expression to analyze and evaluate.
+    pub expression: Expression,
+    /// Expected analysis result before any surrounding `Project` assignment. Extension-boundary
+    /// expressions have no portable resolved output.
+    pub output: Option<ResolvedOutput>,
+    /// Required value or contract-level error.
+    pub expected: ExpectedResult,
+    /// Whether acceptance is required to follow the expected portable result.
+    pub requirement: ConformanceRequirement,
+}
+
+/// One expression and the expected result of assigning it to a declared `Project` output.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectAssignmentCase {
+    /// Stable case name suitable for a test identifier.
+    pub name: &'static str,
+    /// Schema used to analyze the source expression and interpret `input_row`.
+    pub input_schema: SchemaRef,
+    /// One input row, in `input_schema` field order.
+    pub input_row: Vec<Scalar>,
+    /// Unresolved expression to analyze before assigning it to `target`.
+    pub expression: Expression,
+    /// Type and nullability inferred for the source expression before assignment.
+    pub source: ResolvedOutput,
+    /// Declared output type and nullability.
+    pub target: ResolvedOutput,
+    /// Required assigned value or contract-level error.
+    pub expected: ExpectedResult,
+}
+
+/// Cases for common-type resolution, [`COALESCE`](super::super::VariadicExpressionOp::Coalesce),
+/// and [`ARRAY`](super::super::VariadicExpressionOp::Array).
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn common_type_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let nullable_int = StructField::nullable("i", DataType::INTEGER);
+    let required_long = StructField::not_null("l", DataType::LONG);
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let nullable_long_array = ArrayType::new(DataType::LONG, true);
+    let int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let nullable_long_value_map = MapType::new(DataType::STRING, DataType::LONG, true);
+    let empty_void_key_map = MapType::new(DataType::VOID, DataType::STRING, false);
+    let int_key_map = MapType::new(DataType::INTEGER, DataType::STRING, false);
+    let long_key_map = MapType::new(DataType::LONG, DataType::STRING, false);
+    let int_struct_field = StructField::not_null("value", DataType::INTEGER);
+    let long_struct_field = StructField::not_null("value", DataType::LONG);
+    let long_struct_type = StructType::try_new([long_struct_field.clone()])?;
+    let nullable_int_struct_field = StructField::nullable("value", DataType::INTEGER);
+    let nullable_long_struct_field = StructField::nullable("value", DataType::LONG);
+    let nullable_long_struct_type = StructType::try_new([nullable_long_struct_field.clone()])?;
+
+    Ok(vec![
+        ExpressionSemanticsCase {
+            name: "coalesce_int_and_long",
+            input_schema: Arc::new(StructType::try_new([nullable_int, required_long])?),
+            input_row: vec![Scalar::Null(DataType::INTEGER), Scalar::Long(7)],
+            expression: Expression::coalesce([
+                crate::expressions::col!("i"),
+                crate::expressions::col!("l"),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::LONG, false)),
+            expected: ExpectedResult::Value(Scalar::Long(7)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_all_null",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::LONG)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::LONG, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::LONG)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_all_void",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::VOID, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::VOID)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_void_and_int",
+            Scalar::Null(DataType::VOID),
+            Scalar::Integer(7),
+            DataType::INTEGER,
+            false,
+            Scalar::Integer(7),
+        ),
+        coalesce_value_case(
+            "coalesce_byte_and_short",
+            Scalar::Byte(1),
+            Scalar::Short(2),
+            DataType::SHORT,
+            false,
+            Scalar::Short(1),
+        ),
+        coalesce_value_case(
+            "coalesce_short_and_int",
+            Scalar::Short(1),
+            Scalar::Integer(2),
+            DataType::INTEGER,
+            false,
+            Scalar::Integer(1),
+        ),
+        coalesce_value_case(
+            "coalesce_float_and_double",
+            Scalar::Float(1.5),
+            Scalar::Double(2.5),
+            DataType::DOUBLE,
+            false,
+            Scalar::Double(1.5),
+        ),
+        coalesce_value_case(
+            "coalesce_decimal_and_float_returns_double",
+            decimal(100, 10, 2)?,
+            Scalar::Float(2.0),
+            DataType::DOUBLE,
+            false,
+            Scalar::Double(1.0),
+        ),
+        ExpressionSemanticsCase {
+            name: "array_int_and_long",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Long(2)),
+            ]),
+            output: Some(ResolvedOutput::new(long_array.clone(), false)),
+            expected: ExpectedResult::Value(array(long_array.clone(), [1i64.into(), 2i64.into()])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_nullable_element",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::INTEGER, true),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::INTEGER, true),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_int_and_void",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::INTEGER, true),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::INTEGER, true),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_with_column_child",
+            input_schema: schema_ref! { not_null "i": INTEGER },
+            input_row: vec![Scalar::Integer(7)],
+            expression: Expression::array([crate::expressions::col!("i")]),
+            output: Some(ResolvedOutput::new(int_array.clone(), false)),
+            expected: ExpectedResult::Value(array(int_array.clone(), [Scalar::Integer(7)])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_empty",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::array([] as [Expression; 0]),
+            output: Some(ResolvedOutput::new(
+                ArrayType::new(DataType::VOID, false),
+                false,
+            )),
+            expected: ExpectedResult::Value(array(
+                ArrayType::new(DataType::VOID, false),
+                [] as [Scalar; 0],
+            )?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(2)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        ExpressionSemanticsCase {
+            name: "empty_coalesce_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([] as [Expression; 0]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_boolean_and_int_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Boolean(true)),
+                Expression::Literal(Scalar::Integer(1)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_analyzes_unselected_invalid_child",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::binary(
+                    BinaryExpressionOp::Plus,
+                    Expression::Literal(Scalar::Boolean(true)),
+                    Expression::Literal(Scalar::Integer(1)),
+                ),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_common_type_is_recursive",
+            input_schema: schema_ref! {
+                not_null "ints": (int_array.clone()),
+                not_null "longs": (long_array.clone()),
+            },
+            input_row: vec![
+                array(int_array.clone(), [Scalar::Integer(1)])?,
+                array(long_array.clone(), [Scalar::Long(2)])?,
+            ],
+            expression: Expression::coalesce([
+                crate::expressions::col!("ints"),
+                crate::expressions::col!("longs"),
+            ]),
+            output: Some(ResolvedOutput::new(long_array.clone(), false)),
+            expected: ExpectedResult::Value(array(long_array, [Scalar::Long(1)])?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "array_common_type_unions_element_nullability",
+            array(int_array.clone(), [Scalar::Integer(1)])?,
+            array(nullable_long_array.clone(), [Scalar::Null(DataType::LONG)])?,
+            nullable_long_array.clone().into(),
+            false,
+            array(nullable_long_array, [Scalar::Long(1)])?,
+        ),
+        ExpressionSemanticsCase {
+            name: "map_common_type_widens_values_and_nullability",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    int_value_map,
+                    [("key", Scalar::Integer(1))],
+                )?)),
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    nullable_long_value_map.clone(),
+                    [("key", Scalar::Long(2))],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(nullable_long_value_map.clone(), false)),
+            expected: ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                nullable_long_value_map,
+                [("key", Scalar::Long(1))],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "map_common_type_widens_keys",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    int_key_map.clone(),
+                    [(Scalar::Integer(1), "first")],
+                )?)),
+                Expression::Literal(Scalar::Map(MapData::try_new(
+                    long_key_map.clone(),
+                    [(Scalar::Long(2), "second")],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(long_key_map.clone(), false)),
+            expected: ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_key_map,
+                [(Scalar::Long(1), "first")],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "empty_map_void_key_widens_to_concrete_key",
+            Scalar::Map(MapData::try_new(
+                empty_void_key_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [(Scalar::Integer(1), "value")],
+            )?),
+            int_key_map.clone().into(),
+            false,
+            Scalar::Map(MapData::try_new(int_key_map, [] as [(Scalar, Scalar); 0])?),
+        ),
+        ExpressionSemanticsCase {
+            name: "struct_common_type_is_recursive",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![int_struct_field],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![long_struct_field.clone()],
+                    vec![Scalar::Long(2)],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(long_struct_type, false)),
+            expected: ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                vec![long_struct_field.clone()],
+                vec![Scalar::Long(1)],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "struct_common_type_unions_field_nullability",
+            Scalar::Struct(StructData::try_new(
+                vec![nullable_int_struct_field],
+                vec![Scalar::Integer(1)],
+            )?),
+            Scalar::Struct(StructData::try_new(
+                vec![long_struct_field.clone()],
+                vec![Scalar::Long(2)],
+            )?),
+            nullable_long_struct_type.clone().into(),
+            false,
+            Scalar::Struct(StructData::try_new(
+                vec![nullable_long_struct_field],
+                vec![Scalar::Long(1)],
+            )?),
+        ),
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_name_mismatch_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(2)],
+                )?)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_count_mismatch_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("value", DataType::INTEGER),
+                        StructField::not_null("extra", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+            ]),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_struct_field_names_match_case_insensitively",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("Value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::LONG)],
+                    vec![Scalar::Long(2)],
+                )?)),
+            ]),
+            output: Some(ResolvedOutput::new(
+                StructType::try_new([StructField::not_null("Value", DataType::LONG)])?,
+                false,
+            )),
+            expected: ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("Value", DataType::LONG)],
+                vec![Scalar::Long(1)],
+            )?)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        date_to_timestamp_ntz_case(
+            "date_and_timestamp_ntz_use_temporal_common_type",
+            1,
+            ExpectedResult::Value(Scalar::TimestampNtz(86_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_max_safe_day",
+            106_751_991,
+            ExpectedResult::Value(Scalar::TimestampNtz(9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_min_safe_day",
+            -106_751_991,
+            ExpectedResult::Value(Scalar::TimestampNtz(-9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_positive_overflow",
+            106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_ntz_case(
+            "date_to_timestamp_ntz_negative_overflow",
+            -106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_case(
+            "date_and_timestamp_use_utc_temporal_common_type",
+            1,
+            ExpectedResult::Value(Scalar::Timestamp(86_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_max_safe_day",
+            106_751_991,
+            ExpectedResult::Value(Scalar::Timestamp(9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_min_safe_day",
+            -106_751_991,
+            ExpectedResult::Value(Scalar::Timestamp(-9_223_372_022_400_000_000)),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_positive_overflow",
+            106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        date_to_timestamp_case(
+            "date_to_timestamp_negative_overflow",
+            -106_751_992,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        ExpressionSemanticsCase {
+            name: "timestamp_ntz_and_timestamp_use_utc",
+            input_schema: schema_ref! {
+                not_null "ntz": TIMESTAMP_NTZ,
+                nullable "ts": TIMESTAMP,
+            },
+            input_row: vec![
+                Scalar::TimestampNtz(86_400_000_000),
+                Scalar::Null(DataType::TIMESTAMP),
+            ],
+            expression: Expression::coalesce([
+                crate::expressions::col!("ntz"),
+                crate::expressions::col!("ts"),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::TIMESTAMP, false)),
+            expected: ExpectedResult::Value(Scalar::Timestamp(86_400_000_000)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_decimal_and_byte_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Byte(2),
+            DataType::decimal(5, 2)?,
+            false,
+            decimal(1, 5, 2)?,
+        ),
+        coalesce_value_case(
+            "coalesce_decimal_and_short_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Short(2),
+            DataType::decimal(7, 2)?,
+            false,
+            decimal(1, 7, 2)?,
+        ),
+        ExpressionSemanticsCase {
+            name: "coalesce_decimal_and_int_literal_uses_full_integral_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(1, 2, 2)?),
+                Expression::Literal(Scalar::Integer(2)),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(12, 2)?, false)),
+            expected: ExpectedResult::Value(decimal(1, 12, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        coalesce_value_case(
+            "coalesce_decimal_and_long_uses_full_integral_precision",
+            decimal(1, 2, 2)?,
+            Scalar::Long(2),
+            DataType::decimal(22, 2)?,
+            false,
+            decimal(1, 22, 2)?,
+        ),
+        coalesce_value_case(
+            "decimal_common_type_uses_maximum_scale_and_integer_digits",
+            decimal(125, 5, 2)?,
+            decimal(2250, 4, 3)?,
+            DataType::decimal(6, 3)?,
+            false,
+            decimal(1250, 6, 3)?,
+        ),
+        ExpressionSemanticsCase {
+            name: "decimal_common_type_scale_reduction_rounds_half_up",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(123_456_500_000_000_000_000, 38, 20)?),
+                Expression::Literal(decimal(0, 38, 5)?),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 5)?, false)),
+            expected: ExpectedResult::Value(decimal(123_457, 38, 5)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_common_type_negative_midpoint_rounds_away_from_zero",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(decimal(-123_456_500_000_000_000_000, 38, 20)?),
+                Expression::Literal(decimal(0, 38, 5)?),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 5)?, false)),
+            expected: ExpectedResult::Value(decimal(-123_457, 38, 5)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "coalesce_stops_before_error",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::coalesce([
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::binary(
+                    BinaryExpressionOp::Divide,
+                    Expression::Literal(Scalar::Integer(5)),
+                    Expression::Literal(Scalar::Integer(0)),
+                ),
+            ]),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(2.0)),
+            requirement: ConformanceRequirement::Portable,
+        },
+    ])
+}
+
+/// Cases for numeric addition, subtraction, multiplication, decimal result types, and division.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or decimal value is internally inconsistent.
+pub fn arithmetic_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let decimal_10_2 = DataType::decimal(10, 2)?;
+    let decimal_11_2 = DataType::decimal(11, 2)?;
+    let decimal_13_2 = DataType::decimal(13, 2)?;
+    let decimal_21_4 = DataType::decimal(21, 4)?;
+    let decimal_23_13 = DataType::decimal(23, 13)?;
+    let decimal_38_6 = DataType::decimal(38, 6)?;
+    let decimal_38_17 = DataType::decimal(38, 17)?;
+
+    Ok(vec![
+        arithmetic_case(
+            "mixed_int_long_plus",
+            [
+                (StructField::not_null("i", DataType::INTEGER), 1i32.into()),
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+            ],
+            BinaryExpressionOp::Plus,
+            DataType::LONG,
+            Scalar::Long(3),
+        )?,
+        arithmetic_case(
+            "mixed_long_int_minus",
+            [
+                (StructField::not_null("l", DataType::LONG), 3i64.into()),
+                (StructField::not_null("i", DataType::INTEGER), 1i32.into()),
+            ],
+            BinaryExpressionOp::Minus,
+            DataType::LONG,
+            Scalar::Long(2),
+        )?,
+        arithmetic_case(
+            "mixed_int_long_multiply",
+            [
+                (StructField::not_null("i", DataType::INTEGER), 3i32.into()),
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+            ],
+            BinaryExpressionOp::Multiply,
+            DataType::LONG,
+            Scalar::Long(6),
+        )?,
+        arithmetic_case(
+            "long_and_float_promote_to_double",
+            [
+                (StructField::not_null("l", DataType::LONG), 2i64.into()),
+                (StructField::not_null("f", DataType::FLOAT), 0.5f32.into()),
+            ],
+            BinaryExpressionOp::Plus,
+            DataType::DOUBLE,
+            Scalar::Double(2.5),
+        )?,
+        ExpressionSemanticsCase {
+            name: "null_arithmetic_propagates",
+            input_schema: schema_ref! {
+                nullable "n": INTEGER,
+                not_null "one": INTEGER,
+            },
+            input_row: vec![Scalar::Null(DataType::INTEGER), Scalar::Integer(1)],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                crate::expressions::col!("n"),
+                crate::expressions::col!("one"),
+            ),
+            output: Some(ResolvedOutput::new(DataType::INTEGER, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_arithmetic_uses_other_operand_type",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::INTEGER, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        invalid_arithmetic_case(
+            "boolean_arithmetic_is_rejected",
+            Scalar::Boolean(true),
+            Scalar::Boolean(false),
+        ),
+        invalid_arithmetic_case(
+            "date_arithmetic_is_rejected",
+            Scalar::Date(1),
+            Scalar::Date(2),
+        ),
+        invalid_arithmetic_case(
+            "year_month_interval_arithmetic_is_rejected",
+            Scalar::IntervalYearMonth(1),
+            Scalar::IntervalYearMonth(2),
+        ),
+        invalid_arithmetic_case(
+            "day_time_interval_arithmetic_is_rejected",
+            Scalar::IntervalDayTime(1),
+            Scalar::IntervalDayTime(2),
+        ),
+        integer_overflow_case("int_plus_overflow", BinaryExpressionOp::Plus, i32::MAX, 1),
+        integer_overflow_case("int_minus_overflow", BinaryExpressionOp::Minus, i32::MIN, 1),
+        integer_overflow_case(
+            "int_multiply_overflow",
+            BinaryExpressionOp::Multiply,
+            i32::MAX,
+            2,
+        ),
+        ExpressionSemanticsCase {
+            name: "double_multiply_overflow_is_infinity",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Multiply,
+                Expression::Literal(Scalar::Double(1e308)),
+                Expression::Literal(Scalar::Double(1e308)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(f64::INFINITY)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "double_arithmetic_preserves_nan",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Minus,
+                Expression::Literal(Scalar::Double(f64::INFINITY)),
+                Expression::Literal(Scalar::Double(f64::INFINITY)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(f64::NAN)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_double_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Double(2.5)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_float_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Float(2.5)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        decimal_arithmetic_case(
+            "decimal_add_result_type",
+            BinaryExpressionOp::Plus,
+            (125, 10, 2),
+            (225, 10, 2),
+            decimal_11_2.clone(),
+            decimal(350, 11, 2)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_minus_result_type",
+            BinaryExpressionOp::Minus,
+            (350, 10, 2),
+            (125, 10, 2),
+            decimal_11_2.clone(),
+            decimal(225, 11, 2)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_add_rounds_exact_result_once",
+            BinaryExpressionOp::Plus,
+            (4, 38, 7),
+            (4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_add_negative_rounds_exact_result_once",
+            BinaryExpressionOp::Plus,
+            (-4, 38, 7),
+            (-4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(-1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_subtract_rounds_exact_result_once",
+            BinaryExpressionOp::Minus,
+            (4, 38, 7),
+            (-4, 38, 7),
+            decimal_38_6.clone(),
+            decimal(1, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_multiply_result_type",
+            BinaryExpressionOp::Multiply,
+            (150, 10, 2),
+            (200, 10, 2),
+            decimal_21_4,
+            decimal(30_000, 21, 4)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_scale_reduction_rounds_half_up",
+            BinaryExpressionOp::Multiply,
+            (123_456_750_000_000_000_000, 38, 20),
+            (100_000_000_000_000_000_000, 38, 20),
+            decimal_38_6.clone(),
+            decimal(1_234_568, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_scale_reduction_negative_midpoint_rounds_away_from_zero",
+            BinaryExpressionOp::Multiply,
+            (-123_456_750_000_000_000_000, 38, 20),
+            (100_000_000_000_000_000_000, 38, 20),
+            decimal_38_6,
+            decimal(-1_234_568, 38, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_adjusted_scale_preserves_available_fractional_digits",
+            BinaryExpressionOp::Multiply,
+            (10_000_000_000, 20, 10),
+            (10_000_000_000, 20, 10),
+            decimal_38_17,
+            decimal(100_000_000_000_000_000, 38, 17)?,
+        )?,
+        ExpressionSemanticsCase {
+            name: "decimal_add_overflow",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(
+                    99_999_999_999_999_999_999_999_999_999_999_999_999,
+                    38,
+                    0,
+                )?),
+                Expression::Literal(decimal(1, 38, 0)?),
+            ),
+            output: Some(ResolvedOutput::new(DataType::decimal(38, 0)?, false)),
+            expected: ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_int_column",
+            input_schema: Arc::new(StructType::try_new([
+                StructField::not_null("d", decimal_10_2.clone()),
+                StructField::not_null("i", DataType::INTEGER),
+            ])?),
+            input_row: vec![decimal(100, 10, 2)?, Scalar::Integer(1)],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                crate::expressions::col!("d"),
+                crate::expressions::col!("i"),
+            ),
+            output: Some(ResolvedOutput::new(decimal_13_2, false)),
+            expected: ExpectedResult::Value(decimal(200, 13, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_minimum_precision_int_literal",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            output: Some(ResolvedOutput::new(decimal_11_2.clone(), false)),
+            expected: ExpectedResult::Value(decimal(200, 11, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_zero_literal_uses_one_digit_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(decimal_11_2.clone(), false)),
+            expected: ExpectedResult::Value(decimal(100, 11, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "decimal_plus_non_literal_int_uses_full_precision",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::binary(
+                    BinaryExpressionOp::Plus,
+                    Expression::Literal(Scalar::Integer(1)),
+                    Expression::Literal(Scalar::Integer(1)),
+                ),
+            ),
+            output: Some(ResolvedOutput::new(DataType::decimal(13, 2)?, false)),
+            expected: ExpectedResult::Value(decimal(300, 13, 2)?),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "integer_division_is_fractional",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(7)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "float_division_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Float(7.0)),
+                Expression::Literal(Scalar::Float(2.0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(3.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        decimal_arithmetic_case(
+            "decimal_division_result_type",
+            BinaryExpressionOp::Divide,
+            (300, 10, 2),
+            (200, 10, 2),
+            decimal_23_13.clone(),
+            decimal(15_000_000_000_000, 23, 13)?,
+        )?,
+        decimal_arithmetic_case(
+            "decimal_division_rounds_half_up",
+            BinaryExpressionOp::Divide,
+            (1, 1, 0),
+            (128, 3, 0),
+            DataType::decimal(7, 6)?,
+            decimal(7_813, 7, 6)?,
+        )?,
+        decimal_arithmetic_case(
+            "negative_decimal_division_rounds_away_from_zero",
+            BinaryExpressionOp::Divide,
+            (-1, 1, 0),
+            (128, 3, 0),
+            DataType::decimal(7, 6)?,
+            decimal(-7_813, 7, 6)?,
+        )?,
+        ExpressionSemanticsCase {
+            name: "decimal_divided_by_double_returns_double",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(decimal(300, 10, 2)?),
+                Expression::Literal(Scalar::Double(2.0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, false)),
+            expected: ExpectedResult::Value(Scalar::Double(1.5)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        divide_by_zero_case(
+            "integer_divide_by_zero",
+            Scalar::Integer(1),
+            Scalar::Integer(0),
+            DataType::DOUBLE,
+        ),
+        divide_by_zero_case(
+            "decimal_divide_by_zero",
+            decimal(100, 10, 2)?,
+            decimal(0, 10, 2)?,
+            DataType::decimal(23, 13)?,
+        ),
+        divide_by_zero_case(
+            "double_divide_by_positive_zero",
+            Scalar::Double(1.0),
+            Scalar::Double(0.0),
+            DataType::DOUBLE,
+        ),
+        divide_by_zero_case(
+            "double_divide_by_negative_zero",
+            Scalar::Double(1.0),
+            Scalar::Double(-0.0),
+            DataType::DOUBLE,
+        ),
+        ExpressionSemanticsCase {
+            name: "null_dividend_propagates",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "null_divisor_propagates",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(2)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "null_dividend_wins_over_zero_divisor",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_dividend_wins_over_zero_divisor",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Integer(0)),
+            ),
+            output: Some(ResolvedOutput::new(DataType::DOUBLE, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::DOUBLE)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_division_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+            ),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "untyped_null_divided_by_decimal",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(decimal(200, 10, 2)?),
+            ),
+            output: Some(ResolvedOutput::new(decimal_23_13.clone(), true)),
+            expected: ExpectedResult::Value(Scalar::Null(decimal_23_13)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "string_plus_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+    ])
+}
+
+/// Cases for comparison coercion, nulls, distinctness, NaNs, and signed zero.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn comparison_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let double_array = ArrayType::new(DataType::DOUBLE, false);
+    let int_struct = StructType::try_new([StructField::not_null("value", DataType::INTEGER)])?;
+    let long_struct = StructType::try_new([StructField::not_null("value", DataType::LONG)])?;
+    let int_struct_array = ArrayType::new(int_struct.clone(), false);
+    let long_struct_array = ArrayType::new(long_struct.clone(), false);
+    let map_type = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let map = Scalar::Map(MapData::try_new(map_type.clone(), [("key", 1i32)])?);
+    let decimal_38_30 = DataType::decimal(38, 30)?;
+    let alternate_nan = f64::from_bits(0x7ff8_0000_0000_0001);
+
+    Ok(vec![
+        ExpressionSemanticsCase {
+            name: "comparison_uses_numeric_common_type",
+            input_schema: schema_ref! {
+                not_null "i": INTEGER,
+                not_null "l": LONG,
+            },
+            input_row: vec![Scalar::Integer(1), Scalar::Long(1)],
+            expression: Expression::from_pred(Predicate::eq(
+                crate::expressions::col!("i"),
+                crate::expressions::col!("l"),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "date_and_timestamp_compare_in_utc",
+            Predicate::eq(
+                Expression::Literal(Scalar::Date(1)),
+                Expression::Literal(Scalar::Timestamp(86_400_000_000)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "decimal_comparison_uses_minimum_integral_literal_precision",
+            Predicate::eq(
+                Expression::Literal(decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(false),
+        ),
+        ExpressionSemanticsCase {
+            name: "decimal_comparison_uses_full_integral_column_precision",
+            input_schema: schema_ref! {
+                not_null "d": (decimal_38_30),
+                not_null "i": INTEGER,
+            },
+            input_row: vec![
+                decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?,
+                Scalar::Integer(1),
+            ],
+            expression: Expression::from_pred(Predicate::eq(
+                crate::expressions::col!("d"),
+                crate::expressions::col!("i"),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "null_equals_null_is_null",
+            Predicate::eq(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_less_than_value_is_null",
+            Predicate::lt(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            true,
+            None,
+        ),
+        ExpressionSemanticsCase {
+            name: "comparison_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        ExpressionSemanticsCase {
+            name: "boolean_and_int_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Boolean(true)),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "array_and_struct_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1)],
+                )?),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "arrays_with_no_common_type_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::BOOLEAN, false),
+                    [Scalar::Boolean(true)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1)],
+                )?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "structs_with_different_field_counts_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("a", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("a", DataType::INTEGER),
+                        StructField::not_null("b", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "structs_containing_maps_are_not_comparable",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("m", map_type.clone())],
+                    vec![map.clone()],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("m", map_type.clone())],
+                    vec![map.clone()],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "untyped_null_comparison_adopts_other_operand_type",
+            Predicate::eq(
+                Expression::Literal(Scalar::Null(DataType::VOID)),
+                Expression::Literal(Scalar::String("value".into())),
+            ),
+            true,
+            None,
+        ),
+        ExpressionSemanticsCase {
+            name: "map_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(map.clone()),
+                Expression::Literal(map),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "interval_cross_family_comparison_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::lt(
+                Expression::Literal(Scalar::IntervalYearMonth(1)),
+                Expression::Literal(Scalar::IntervalDayTime(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "differently_named_structs_requiring_leaf_widening_are_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::LONG)],
+                    vec![Scalar::Long(1)],
+                )?)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "comparison_ignores_struct_field_names_after_positional_alignment",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        predicate_value_case(
+            "comparison_aligns_struct_field_nullability",
+            Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_struct_fields_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_struct_field_sorts_first",
+            Predicate::lt(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Null(DataType::INTEGER)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::nullable("value", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "string_comparison_uses_binary_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::String("A".into())),
+                Expression::Literal(Scalar::String("a".into())),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "string_comparison_does_not_normalize_unicode",
+            Predicate::lt(
+                Expression::Literal(Scalar::String("e\u{301}".into())),
+                Expression::Literal(Scalar::String("\u{e9}".into())),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "binary_comparison_uses_unsigned_lexicographic_order",
+            Predicate::lt(
+                Expression::Literal(Scalar::Binary(vec![0x7f])),
+                Expression::Literal(Scalar::Binary(vec![0x80])),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_sorts_before_true",
+            Predicate::lt(
+                Expression::Literal(Scalar::Boolean(false)),
+                Expression::Literal(Scalar::Boolean(true)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "year_month_intervals_use_signed_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::IntervalYearMonth(-1)),
+                Expression::Literal(Scalar::IntervalYearMonth(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "day_time_intervals_use_signed_ordering",
+            Predicate::lt(
+                Expression::Literal(Scalar::IntervalDayTime(-1)),
+                Expression::Literal(Scalar::IntervalDayTime(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_array_elements_compare_equal",
+            Predicate::eq(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nested_null_array_element_sorts_first",
+            Predicate::lt(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Null(DataType::INTEGER)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, true),
+                    [Scalar::Integer(1)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "arrays_compare_lexicographically",
+            Predicate::lt(
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1), Scalar::Integer(2)],
+                )?),
+                Expression::Literal(array(
+                    ArrayType::new(DataType::INTEGER, false),
+                    [Scalar::Integer(1), Scalar::Integer(3)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "array_comparison_coerces_nested_struct_fields",
+            Predicate::eq(
+                Expression::Literal(array(
+                    int_struct_array,
+                    [Scalar::Struct(StructData::try_new(
+                        int_struct.fields().cloned().collect(),
+                        vec![Scalar::Integer(1)],
+                    )?)],
+                )?),
+                Expression::Literal(array(
+                    long_struct_array,
+                    [Scalar::Struct(StructData::try_new(
+                        long_struct.fields().cloned().collect(),
+                        vec![Scalar::Long(1)],
+                    )?)],
+                )?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "structs_compare_in_field_order",
+            Predicate::lt(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("first", DataType::INTEGER),
+                        StructField::not_null("second", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(2)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![
+                        StructField::not_null("first", DataType::INTEGER),
+                        StructField::not_null("second", DataType::INTEGER),
+                    ],
+                    vec![Scalar::Integer(1), Scalar::Integer(3)],
+                )?)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "different_nan_payloads_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(alternate_nan)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nan_sorts_after_finite_value",
+            Predicate::gt(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(1.0)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "finite_value_sorts_before_nan",
+            Predicate::lt(
+                Expression::Literal(Scalar::Double(1.0)),
+                Expression::Literal(Scalar::Double(f64::NAN)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "signed_zeroes_compare_equal",
+            Predicate::eq(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "negative_zero_is_not_less_than_positive_zero",
+            Predicate::lt(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "negative_zero_is_not_greater_than_positive_zero",
+            Predicate::gt(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "array_comparison_uses_nan_equality",
+            Predicate::eq(
+                Expression::Literal(array(double_array.clone(), [Scalar::Double(f64::NAN)])?),
+                Expression::Literal(array(double_array, [Scalar::Double(alternate_nan)])?),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "equal_values_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "distinct_ignores_struct_field_names_after_positional_alignment",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("left", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+                Expression::Literal(Scalar::Struct(StructData::try_new(
+                    vec![StructField::not_null("right", DataType::INTEGER)],
+                    vec![Scalar::Integer(1)],
+                )?)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "unequal_values_are_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "two_nulls_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_value_are_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Null(DataType::INTEGER)),
+                Expression::Literal(Scalar::Integer(1)),
+            ),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "nan_values_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Double(f64::NAN)),
+                Expression::Literal(Scalar::Double(alternate_nan)),
+            ),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "signed_zeroes_are_not_distinct",
+            Predicate::distinct(
+                Expression::Literal(Scalar::Double(-0.0)),
+                Expression::Literal(Scalar::Double(0.0)),
+            ),
+            false,
+            Some(false),
+        ),
+    ])
+}
+
+/// Cases for `IN` over array-valued expressions.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's schema or array value is internally inconsistent.
+pub fn in_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let nullable_int_array = ArrayType::new(DataType::INTEGER, true);
+    let boolean_array = ArrayType::new(DataType::BOOLEAN, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let float_array = ArrayType::new(DataType::FLOAT, false);
+    let double_array = ArrayType::new(DataType::DOUBLE, false);
+    let decimal_38_30_array = ArrayType::new(DataType::decimal(38, 30)?, false);
+    let map_type = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let map_array = ArrayType::new(map_type.clone(), false);
+    let map = Scalar::Map(MapData::try_new(map_type, [("key", Scalar::Integer(1))])?);
+    let right_struct_field = StructField::not_null("right", DataType::INTEGER);
+    let right_struct_array =
+        ArrayType::new(StructType::try_new([right_struct_field.clone()])?, false);
+    let lowercase_long_struct_field = StructField::not_null("value", DataType::LONG);
+    let lowercase_long_struct_array = ArrayType::new(
+        StructType::try_new([lowercase_long_struct_field.clone()])?,
+        false,
+    );
+    let int_array_struct =
+        StructType::try_new([StructField::not_null("values", int_array.clone())])?;
+    let long_array_struct =
+        StructType::try_new([StructField::not_null("values", long_array.clone())])?;
+    let long_array_struct_array = ArrayType::new(long_array_struct.clone(), false);
+
+    Ok(vec![
+        literal_in_case(
+            "literal_in_matches_without_null",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [Scalar::Integer(1), Scalar::Integer(2)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_match_wins_over_null_element",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            true,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_no_match_with_null_element_is_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            true,
+            None,
+        )?,
+        literal_in_case(
+            "literal_in_declared_nullable_elements_is_nullable_without_present_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Integer(3)],
+            true,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_null_left_operand_is_null",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [Scalar::Integer(1), Scalar::Integer(2)],
+            true,
+            None,
+        )?,
+        literal_in_case(
+            "literal_in_no_match_without_null_is_false",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [Scalar::Integer(2), Scalar::Integer(3)],
+            false,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_array_is_false",
+            Scalar::Integer(1),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            false,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_declared_nullable_array_is_nullable",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        ExpressionSemanticsCase {
+            name: "literal_in_empty_array_still_checks_declared_element_type",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(array(boolean_array, [] as [Scalar; 0])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        literal_in_case(
+            "literal_in_empty_array_with_null_left_operand_is_false",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        literal_in_case(
+            "literal_in_empty_array_with_untyped_null_left_operand_is_false",
+            Scalar::Null(DataType::VOID),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(false),
+        )?,
+        ExpressionSemanticsCase {
+            name: "empty_in_array_does_not_suppress_left_child_error",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::binary(
+                    BinaryExpressionOp::Divide,
+                    Expression::Literal(Scalar::Integer(1)),
+                    Expression::Literal(Scalar::Integer(0)),
+                ),
+                Expression::Literal(array(double_array.clone(), [] as [Scalar; 0])?),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Error(ExpectedError::DivideByZero),
+            requirement: ConformanceRequirement::Portable,
+        },
+        literal_not_in_case(
+            "literal_not_in_empty_array_with_null_left_operand_is_true",
+            Scalar::Null(DataType::INTEGER),
+            int_array.clone(),
+            [] as [Scalar; 0],
+            true,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_uses_numeric_common_type",
+            Scalar::Integer(1),
+            long_array.clone(),
+            [Scalar::Long(1)],
+            false,
+            Some(true),
+        )?,
+        ExpressionSemanticsCase {
+            name: "literal_in_string_and_int_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::String("1".into())),
+                Expression::Literal(array(int_array.clone(), [Scalar::Integer(1)])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        literal_in_case(
+            "literal_in_uses_nan_equality",
+            Scalar::Double(f64::NAN),
+            double_array.clone(),
+            [Scalar::Double(f64::NAN)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_uses_signed_zero_equality",
+            Scalar::Double(-0.0),
+            double_array.clone(),
+            [Scalar::Double(0.0)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_ignores_struct_field_names_after_positional_alignment",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            right_struct_array.clone(),
+            [Scalar::Struct(StructData::try_new(
+                vec![right_struct_field.clone()],
+                vec![Scalar::Integer(1)],
+            )?)],
+            false,
+            Some(true),
+        )?,
+        literal_in_case(
+            "literal_in_coerces_nested_array_elements",
+            Scalar::Struct(StructData::try_new(
+                int_array_struct.fields().cloned().collect(),
+                vec![array(int_array.clone(), [Scalar::Integer(1)])?],
+            )?),
+            long_array_struct_array.clone(),
+            [Scalar::Struct(StructData::try_new(
+                long_array_struct.fields().cloned().collect(),
+                vec![array(long_array.clone(), [Scalar::Long(1)])?],
+            )?)],
+            false,
+            Some(true),
+        )?,
+        literal_not_in_case(
+            "literal_not_in_preserves_null",
+            Scalar::Integer(1),
+            nullable_int_array.clone(),
+            [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_matches_without_null",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(1), Scalar::Integer(2)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_match_wins_over_null_element",
+            Scalar::Integer(1),
+            StructField::not_null("items", nullable_int_array.clone()),
+            array(
+                nullable_int_array.clone(),
+                [Scalar::Integer(1), Scalar::Null(DataType::INTEGER)],
+            )?,
+            true,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_no_match_with_null_element_is_null",
+            Scalar::Integer(1),
+            StructField::not_null("items", nullable_int_array.clone()),
+            array(
+                nullable_int_array.clone(),
+                [Scalar::Integer(2), Scalar::Null(DataType::INTEGER)],
+            )?,
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_null_left_operand_is_null",
+            Scalar::Null(DataType::INTEGER),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(1), Scalar::Integer(2)])?,
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_no_match_without_null_is_false",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [Scalar::Integer(2), Scalar::Integer(3)])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_empty_list_is_false",
+            Scalar::Integer(1),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [] as [Scalar; 0])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_empty_list_with_null_left_operand_is_false",
+            Scalar::Null(DataType::INTEGER),
+            StructField::not_null("items", int_array.clone()),
+            array(int_array.clone(), [] as [Scalar; 0])?,
+            true,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_null_collection_is_null",
+            Scalar::Integer(1),
+            StructField::nullable("items", int_array.clone()),
+            Scalar::Null(int_array.clone().into()),
+            true,
+            None,
+        )?,
+        column_in_case(
+            "column_in_uses_numeric_common_type",
+            Scalar::Integer(1),
+            StructField::not_null("items", long_array.clone()),
+            array(long_array, [Scalar::Long(1)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_integral_and_float_promote_to_double",
+            Scalar::Long(16_777_217),
+            StructField::not_null("items", float_array.clone()),
+            array(float_array, [Scalar::Float(16_777_216.0)])?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_decimal_uses_minimum_integral_literal_precision",
+            Scalar::Integer(1),
+            StructField::not_null("items", decimal_38_30_array.clone()),
+            array(
+                decimal_38_30_array,
+                [decimal(1_000_000_000_000_000_000_000_000_000_001, 38, 30)?],
+            )?,
+            false,
+            Some(false),
+        )?,
+        column_in_case(
+            "column_in_aligns_structs_with_different_field_nullability",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::nullable("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", right_struct_array.clone()),
+            array(
+                right_struct_array.clone(),
+                [Scalar::Struct(StructData::try_new(
+                    vec![right_struct_field.clone()],
+                    vec![Scalar::Integer(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_case_insensitive_struct_names_allow_leaf_widening",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("Value", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", lowercase_long_struct_array.clone()),
+            array(
+                lowercase_long_struct_array,
+                [Scalar::Struct(StructData::try_new(
+                    vec![lowercase_long_struct_field],
+                    vec![Scalar::Long(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_ignores_struct_field_names_after_positional_alignment",
+            Scalar::Struct(StructData::try_new(
+                vec![StructField::not_null("left", DataType::INTEGER)],
+                vec![Scalar::Integer(1)],
+            )?),
+            StructField::not_null("items", right_struct_array.clone()),
+            array(
+                right_struct_array,
+                [Scalar::Struct(StructData::try_new(
+                    vec![right_struct_field],
+                    vec![Scalar::Integer(1)],
+                )?)],
+            )?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_uses_nan_equality",
+            Scalar::Double(f64::NAN),
+            StructField::not_null("items", double_array.clone()),
+            array(double_array.clone(), [Scalar::Double(f64::NAN)])?,
+            false,
+            Some(true),
+        )?,
+        column_in_case(
+            "column_in_uses_signed_zero_equality",
+            Scalar::Double(-0.0),
+            StructField::not_null("items", double_array.clone()),
+            array(double_array, [Scalar::Double(0.0)])?,
+            false,
+            Some(true),
+        )?,
+        ExpressionSemanticsCase {
+            name: "in_column_left_operand_matches",
+            input_schema: schema_ref! { not_null "value": INTEGER },
+            input_row: vec![Scalar::Integer(1)],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                crate::expressions::col!("value"),
+                Expression::Literal(array(int_array.clone(), [Scalar::Integer(1)])?),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "in_array_expression_rhs_matches",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::array([Expression::Literal(Scalar::Integer(1))]),
+            )),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "in_scalar_rhs_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(Scalar::Integer(1)),
+                Expression::Literal(Scalar::Integer(1)),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "map_membership_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::from_pred(Predicate::binary(
+                BinaryPredicateOp::In,
+                Expression::Literal(map.clone()),
+                Expression::Literal(array(map_array, [map])?),
+            )),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+    ])
+}
+
+/// Cases for Boolean input validation, three-valued logic, and `IS NULL`.
+pub fn boolean_cases() -> Vec<ExpressionSemanticsCase> {
+    vec![
+        ExpressionSemanticsCase {
+            name: "non_null_boolean_expression_preserves_value",
+            input_schema: schema_ref! { not_null "b": BOOLEAN },
+            input_row: vec![Scalar::Boolean(true)],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                crate::expressions::col!("b"),
+            ))),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, false)),
+            expected: ExpectedResult::Value(Scalar::Boolean(true)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "nullable_boolean_expression_preserves_null",
+            input_schema: schema_ref! { nullable "b": BOOLEAN },
+            input_row: vec![Scalar::Null(DataType::BOOLEAN)],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                crate::expressions::col!("b"),
+            ))),
+            output: Some(ResolvedOutput::new(DataType::BOOLEAN, true)),
+            expected: ExpectedResult::Value(Scalar::Null(DataType::BOOLEAN)),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "integer_boolean_expression_is_rejected",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                Expression::Literal(Scalar::Integer(1)),
+            ))),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::Portable,
+        },
+        ExpressionSemanticsCase {
+            name: "string_boolean_expression_is_extension_boundary",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::Predicate(Box::new(Predicate::BooleanExpression(
+                Expression::Literal(Scalar::String("true".into())),
+            ))),
+            output: None,
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+            requirement: ConformanceRequirement::ExtensionBoundary,
+        },
+        predicate_value_case(
+            "not_true_is_false",
+            Predicate::not(Predicate::TRUE),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "not_false_is_true",
+            Predicate::not(Predicate::FALSE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "not_null_is_null",
+            Predicate::not(Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_is_null_is_true",
+            Predicate::is_null(Expression::Literal(Scalar::Null(DataType::INTEGER))),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "value_is_null_is_false",
+            Predicate::is_null(Expression::Literal(Scalar::Integer(1))),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_null_is_null",
+            Predicate::and(Predicate::TRUE, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "false_and_null_is_false",
+            Predicate::and(Predicate::FALSE, Predicate::NULL),
+            true,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_false_is_false",
+            Predicate::and(Predicate::NULL, Predicate::FALSE),
+            true,
+            Some(false),
+        ),
+        predicate_value_case(
+            "null_and_null_is_null",
+            Predicate::and(Predicate::NULL, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "true_or_null_is_true",
+            Predicate::or(Predicate::TRUE, Predicate::NULL),
+            true,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_null_is_null",
+            Predicate::or(Predicate::FALSE, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "null_or_true_is_true",
+            Predicate::or(Predicate::NULL, Predicate::TRUE),
+            true,
+            Some(true),
+        ),
+        predicate_value_case(
+            "null_or_null_is_null",
+            Predicate::or(Predicate::NULL, Predicate::NULL),
+            true,
+            None,
+        ),
+        predicate_value_case(
+            "empty_and_is_true",
+            Predicate::and_from([] as [Predicate; 0]),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "empty_or_is_false",
+            Predicate::or_from([] as [Predicate; 0]),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_false_is_false",
+            Predicate::and(Predicate::TRUE, Predicate::FALSE),
+            false,
+            Some(false),
+        ),
+        predicate_value_case(
+            "true_and_true_is_true",
+            Predicate::and(Predicate::TRUE, Predicate::TRUE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_true_is_true",
+            Predicate::or(Predicate::FALSE, Predicate::TRUE),
+            false,
+            Some(true),
+        ),
+        predicate_value_case(
+            "false_or_false_is_false",
+            Predicate::or(Predicate::FALSE, Predicate::FALSE),
+            false,
+            Some(false),
+        ),
+    ]
+}
+
+/// Cases for assignment from an inferred expression result to a declared `Project` field.
+///
+/// These cases are separate from [`all_cases`] because they test the schema boundary after
+/// expression analysis rather than operator inference itself.
+///
+/// # Errors
+///
+/// Returns an error if a fixture's decimal or complex value is internally inconsistent.
+pub fn project_assignment_cases() -> DeltaResult<Vec<ProjectAssignmentCase>> {
+    let int_array = ArrayType::new(DataType::INTEGER, false);
+    let long_array = ArrayType::new(DataType::LONG, false);
+    let nullable_long_array = ArrayType::new(DataType::LONG, true);
+    let nullable_int_array = ArrayType::new(DataType::INTEGER, true);
+    let required_int_array = ArrayType::new(DataType::INTEGER, false);
+    let decimal_10_2_array = ArrayType::new(DataType::decimal(10, 2)?, false);
+    let decimal_12_4_array = ArrayType::new(DataType::decimal(12, 4)?, false);
+    let decimal_10_1_array = ArrayType::new(DataType::decimal(10, 1)?, false);
+
+    let int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+    let long_value_map = MapType::new(DataType::STRING, DataType::LONG, false);
+    let int_key_map = MapType::new(DataType::INTEGER, DataType::STRING, false);
+    let long_key_map = MapType::new(DataType::LONG, DataType::STRING, false);
+    let nullable_int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, true);
+    let required_int_value_map = MapType::new(DataType::STRING, DataType::INTEGER, false);
+
+    let required_int_struct =
+        StructType::try_new([StructField::not_null("value", DataType::INTEGER)])?;
+    let nullable_int_struct =
+        StructType::try_new([StructField::nullable("value", DataType::INTEGER)])?;
+    let nested_int_struct =
+        StructType::try_new([StructField::not_null("source", int_array.clone())])?;
+    let nested_long_struct =
+        StructType::try_new([StructField::nullable("target", nullable_long_array.clone())])?;
+    let differently_named_int_struct =
+        StructType::try_new([StructField::not_null("other", DataType::INTEGER)])?;
+
+    let empty_void_array = ArrayType::new(DataType::VOID, false);
+    let void_array = ArrayType::new(DataType::VOID, true);
+    let empty_void_key_map = MapType::new(DataType::VOID, DataType::STRING, false);
+    let empty_void_value_map = MapType::new(DataType::STRING, DataType::VOID, false);
+    let void_value_map = MapType::new(DataType::STRING, DataType::VOID, true);
+    let void_struct = StructType::try_new([StructField::nullable("value", DataType::VOID)])?;
+
+    Ok(vec![
+        project_assignment_case(
+            "project_exact_type",
+            Scalar::Integer(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_required_to_nullable",
+            Scalar::Integer(1),
+            false,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_nullable_to_nullable",
+            Scalar::Null(DataType::INTEGER),
+            true,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+        ),
+        ProjectAssignmentCase {
+            name: "project_target_does_not_change_integer_division_inference",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Divide,
+                Expression::Literal(Scalar::Integer(3)),
+                Expression::Literal(Scalar::Integer(2)),
+            ),
+            source: ResolvedOutput::new(DataType::DOUBLE, false),
+            target: ResolvedOutput::new(DataType::LONG, false),
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        },
+        ProjectAssignmentCase {
+            name: "project_target_does_not_change_decimal_arithmetic_inference",
+            input_schema: schema_ref! {},
+            input_row: vec![],
+            expression: Expression::binary(
+                BinaryExpressionOp::Plus,
+                Expression::Literal(decimal(100, 10, 2)?),
+                Expression::Literal(decimal(200, 10, 2)?),
+            ),
+            source: ResolvedOutput::new(DataType::decimal(11, 2)?, false),
+            target: ResolvedOutput::new(DataType::decimal(10, 2)?, false),
+            expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        },
+        project_assignment_case(
+            "project_byte_to_short",
+            Scalar::Byte(1),
+            false,
+            DataType::SHORT,
+            false,
+            ExpectedResult::Value(Scalar::Short(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_int",
+            Scalar::Byte(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_long",
+            Scalar::Byte(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_byte_to_float",
+            Scalar::Byte(1),
+            false,
+            DataType::FLOAT,
+            false,
+            ExpectedResult::Value(Scalar::Float(1.0)),
+        ),
+        project_assignment_case(
+            "project_byte_to_double",
+            Scalar::Byte(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_short_to_int",
+            Scalar::Short(1),
+            false,
+            DataType::INTEGER,
+            false,
+            ExpectedResult::Value(Scalar::Integer(1)),
+        ),
+        project_assignment_case(
+            "project_short_to_long",
+            Scalar::Short(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_short_to_float",
+            Scalar::Short(1),
+            false,
+            DataType::FLOAT,
+            false,
+            ExpectedResult::Value(Scalar::Float(1.0)),
+        ),
+        project_assignment_case(
+            "project_short_to_double",
+            Scalar::Short(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_int_to_long",
+            Scalar::Integer(1),
+            false,
+            DataType::LONG,
+            false,
+            ExpectedResult::Value(Scalar::Long(1)),
+        ),
+        project_assignment_case(
+            "project_int_to_double",
+            Scalar::Integer(1),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.0)),
+        ),
+        project_assignment_case(
+            "project_float_to_double",
+            Scalar::Float(1.5),
+            false,
+            DataType::DOUBLE,
+            false,
+            ExpectedResult::Value(Scalar::Double(1.5)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz",
+            Scalar::Date(1),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(86_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_max_safe_day",
+            Scalar::Date(106_751_991),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(9_223_372_022_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_min_safe_day",
+            Scalar::Date(-106_751_991),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Value(Scalar::TimestampNtz(-9_223_372_022_400_000_000)),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_positive_overflow",
+            Scalar::Date(106_751_992),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        project_assignment_case(
+            "project_date_to_timestamp_ntz_negative_overflow",
+            Scalar::Date(-106_751_992),
+            false,
+            DataType::TIMESTAMP_NTZ,
+            false,
+            ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        ),
+        project_assignment_case(
+            "project_void_to_nullable",
+            Scalar::Null(DataType::VOID),
+            true,
+            DataType::INTEGER,
+            true,
+            ExpectedResult::Value(Scalar::Null(DataType::INTEGER)),
+        ),
+        project_assignment_case(
+            "project_int_to_decimal",
+            Scalar::Integer(1),
+            false,
+            DataType::decimal(10, 0)?,
+            false,
+            ExpectedResult::Value(decimal(1, 10, 0)?),
+        ),
+        project_assignment_case(
+            "project_decimal_to_wider_decimal",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(12, 4)?,
+            false,
+            ExpectedResult::Value(decimal(12_300, 12, 4)?),
+        ),
+        project_assignment_case(
+            "project_array_decimal_assignment_is_recursive",
+            array(decimal_10_2_array.clone(), [decimal(123, 10, 2)?])?,
+            false,
+            decimal_12_4_array.clone(),
+            false,
+            ExpectedResult::Value(array(decimal_12_4_array, [decimal(12_300, 12, 4)?])?),
+        ),
+        project_assignment_case(
+            "project_array_element_widens",
+            array(int_array.clone(), [Scalar::Integer(1)])?,
+            false,
+            long_array.clone(),
+            false,
+            ExpectedResult::Value(array(long_array, [Scalar::Long(1)])?),
+        ),
+        project_assignment_case(
+            "project_map_value_widens",
+            Scalar::Map(MapData::try_new(
+                int_value_map.clone(),
+                [("key", Scalar::Integer(1))],
+            )?),
+            false,
+            long_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_value_map,
+                [("key", Scalar::Long(1))],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_map_key_widens",
+            Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [(Scalar::Integer(1), "value")],
+            )?),
+            false,
+            long_key_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                long_key_map,
+                [(Scalar::Long(1), "value")],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_struct_assignment_is_recursive_and_positional",
+            Scalar::Struct(StructData::try_new(
+                nested_int_struct.fields().cloned().collect(),
+                vec![array(int_array.clone(), [Scalar::Integer(1)])?],
+            )?),
+            false,
+            nested_long_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                nested_long_struct.fields().cloned().collect(),
+                vec![array(nullable_long_array, [Scalar::Long(1)])?],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_empty_void_array_element_to_required_target",
+            array(empty_void_array, [] as [Scalar; 0])?,
+            false,
+            required_int_array.clone(),
+            false,
+            ExpectedResult::Value(array(required_int_array.clone(), [] as [Scalar; 0])?),
+        ),
+        project_assignment_case(
+            "project_empty_void_map_value_to_required_target",
+            Scalar::Map(MapData::try_new(
+                empty_void_value_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            false,
+            required_int_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                required_int_value_map.clone(),
+                [] as [(Scalar, Scalar); 0],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_empty_void_map_key_to_concrete_target",
+            Scalar::Map(MapData::try_new(
+                empty_void_key_map,
+                [] as [(Scalar, Scalar); 0],
+            )?),
+            false,
+            int_key_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                int_key_map.clone(),
+                [] as [(Scalar, Scalar); 0],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_void_array_element_to_nullable_target",
+            array(void_array, [Scalar::Null(DataType::VOID)])?,
+            false,
+            nullable_int_array.clone(),
+            false,
+            ExpectedResult::Value(array(
+                nullable_int_array.clone(),
+                [Scalar::Null(DataType::INTEGER)],
+            )?),
+        ),
+        project_assignment_case(
+            "project_void_map_value_to_nullable_target",
+            Scalar::Map(MapData::try_new(
+                void_value_map,
+                [("key", Scalar::Null(DataType::VOID))],
+            )?),
+            false,
+            nullable_int_value_map.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Map(MapData::try_new(
+                nullable_int_value_map.clone(),
+                [("key", Scalar::Null(DataType::INTEGER))],
+            )?)),
+        ),
+        project_assignment_case(
+            "project_void_struct_field_to_nullable_target",
+            Scalar::Struct(StructData::try_new(
+                void_struct.fields().cloned().collect(),
+                vec![Scalar::Null(DataType::VOID)],
+            )?),
+            false,
+            nullable_int_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                nullable_int_struct.fields().cloned().collect(),
+                vec![Scalar::Null(DataType::INTEGER)],
+            )?)),
+        ),
+        rejected_project_assignment_case(
+            "project_void_to_required_is_rejected",
+            Scalar::Null(DataType::VOID),
+            true,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_to_required_is_rejected",
+            Scalar::Integer(1),
+            true,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_narrowing_is_rejected",
+            Scalar::Long(1),
+            false,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_int_to_float_is_rejected",
+            Scalar::Integer(1),
+            false,
+            DataType::FLOAT,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_long_to_double_is_rejected",
+            Scalar::Long(1),
+            false,
+            DataType::DOUBLE,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_date_to_timestamp_is_rejected",
+            Scalar::Date(1),
+            false,
+            DataType::TIMESTAMP,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_timestamp_ntz_to_timestamp_is_rejected",
+            Scalar::TimestampNtz(1),
+            false,
+            DataType::TIMESTAMP,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_string_parsing_is_rejected",
+            Scalar::String("1".into()),
+            false,
+            DataType::INTEGER,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_decimal_rounding_is_rejected",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(10, 1)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_int_to_insufficient_decimal_is_rejected",
+            Scalar::Integer(1),
+            false,
+            DataType::decimal(9, 0)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_decimal_integer_loss_is_rejected",
+            decimal(123, 10, 2)?,
+            false,
+            DataType::decimal(9, 2)?,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_array_decimal_rounding_is_rejected",
+            array(decimal_10_2_array, [decimal(123, 10, 2)?])?,
+            false,
+            decimal_10_1_array,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_array_element_to_required_is_rejected",
+            array(nullable_int_array, [Scalar::Integer(1)])?,
+            false,
+            required_int_array,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_map_value_to_required_is_rejected",
+            Scalar::Map(MapData::try_new(
+                nullable_int_value_map,
+                [("key", Scalar::Integer(1))],
+            )?),
+            false,
+            required_int_value_map,
+            false,
+        ),
+        rejected_project_assignment_case(
+            "project_nullable_struct_field_to_required_is_rejected",
+            Scalar::Struct(StructData::try_new(
+                nullable_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?),
+            false,
+            required_int_struct.clone(),
+            false,
+        ),
+        project_assignment_case(
+            "project_struct_fields_align_positionally",
+            Scalar::Struct(StructData::try_new(
+                required_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?),
+            false,
+            differently_named_int_struct.clone(),
+            false,
+            ExpectedResult::Value(Scalar::Struct(StructData::try_new(
+                differently_named_int_struct.fields().cloned().collect(),
+                vec![Scalar::Integer(1)],
+            )?)),
+        ),
+    ])
+}
+
+/// All standard-expression cases published by this module, in unspecified order.
+///
+/// # Errors
+///
+/// Returns an error if any fixture is internally inconsistent.
+pub fn all_cases() -> DeltaResult<Vec<ExpressionSemanticsCase>> {
+    let mut cases = common_type_cases()?;
+    cases.extend(arithmetic_cases()?);
+    cases.extend(comparison_cases()?);
+    cases.extend(in_cases()?);
+    cases.extend(boolean_cases());
+    Ok(cases)
+}
+
+fn date_to_timestamp_ntz_case(
+    name: &'static str,
+    days: i32,
+    expected: ExpectedResult,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {
+            not_null "d": DATE,
+            nullable "ts": TIMESTAMP_NTZ,
+        },
+        input_row: vec![Scalar::Date(days), Scalar::Null(DataType::TIMESTAMP_NTZ)],
+        expression: Expression::coalesce([
+            crate::expressions::col!("d"),
+            crate::expressions::col!("ts"),
+        ]),
+        output: Some(ResolvedOutput::new(DataType::TIMESTAMP_NTZ, false)),
+        expected,
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn date_to_timestamp_case(
+    name: &'static str,
+    days: i32,
+    expected: ExpectedResult,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {
+            not_null "d": DATE,
+            nullable "ts": TIMESTAMP,
+        },
+        input_row: vec![Scalar::Date(days), Scalar::Null(DataType::TIMESTAMP)],
+        expression: Expression::coalesce([
+            crate::expressions::col!("d"),
+            crate::expressions::col!("ts"),
+        ]),
+        output: Some(ResolvedOutput::new(DataType::TIMESTAMP, false)),
+        expected,
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn project_assignment_case(
+    name: &'static str,
+    source_value: Scalar,
+    source_nullable: bool,
+    target_type: impl Into<DataType>,
+    target_nullable: bool,
+    expected: ExpectedResult,
+) -> ProjectAssignmentCase {
+    let source_type = source_value.data_type();
+    ProjectAssignmentCase {
+        name,
+        input_schema: Arc::new(StructType::new_unchecked([StructField::new(
+            "input",
+            source_type.clone(),
+            source_nullable,
+        )])),
+        input_row: vec![source_value],
+        expression: Expression::column(["input"]),
+        source: ResolvedOutput::new(source_type, source_nullable),
+        target: ResolvedOutput::new(target_type, target_nullable),
+        expected,
+    }
+}
+
+fn rejected_project_assignment_case(
+    name: &'static str,
+    source_value: Scalar,
+    source_nullable: bool,
+    target_type: impl Into<DataType>,
+    target_nullable: bool,
+) -> ProjectAssignmentCase {
+    project_assignment_case(
+        name,
+        source_value,
+        source_nullable,
+        target_type,
+        target_nullable,
+        ExpectedResult::Error(ExpectedError::InvalidExpression),
+    )
+}
+
+fn literal_in_case(
+    name: &'static str,
+    value: Scalar,
+    array_type: ArrayType,
+    elements: impl IntoIterator<Item = Scalar>,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(predicate_value_case(
+        name,
+        Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            Expression::Literal(array(array_type, elements)?),
+        ),
+        output_nullable,
+        expected,
+    ))
+}
+
+fn literal_not_in_case(
+    name: &'static str,
+    value: Scalar,
+    array_type: ArrayType,
+    elements: impl IntoIterator<Item = Scalar>,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(predicate_value_case(
+        name,
+        Predicate::not(Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            Expression::Literal(array(array_type, elements)?),
+        )),
+        output_nullable,
+        expected,
+    ))
+}
+
+fn column_in_case(
+    name: &'static str,
+    value: Scalar,
+    collection_field: StructField,
+    collection: Scalar,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: Arc::new(StructType::try_new([collection_field])?),
+        input_row: vec![collection],
+        expression: Expression::from_pred(Predicate::binary(
+            BinaryPredicateOp::In,
+            Expression::Literal(value),
+            crate::expressions::col!("items"),
+        )),
+        output: Some(ResolvedOutput::new(DataType::BOOLEAN, output_nullable)),
+        expected: ExpectedResult::Value(match expected {
+            Some(value) => Scalar::Boolean(value),
+            None => Scalar::Null(DataType::BOOLEAN),
+        }),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn predicate_value_case(
+    name: &'static str,
+    predicate: Predicate,
+    output_nullable: bool,
+    expected: Option<bool>,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::from_pred(predicate),
+        output: Some(ResolvedOutput::new(DataType::BOOLEAN, output_nullable)),
+        expected: ExpectedResult::Value(match expected {
+            Some(value) => Scalar::Boolean(value),
+            None => Scalar::Null(DataType::BOOLEAN),
+        }),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn coalesce_value_case(
+    name: &'static str,
+    left: Scalar,
+    right: Scalar,
+    output_type: DataType,
+    output_nullable: bool,
+    expected: Scalar,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::coalesce([Expression::Literal(left), Expression::Literal(right)]),
+        output: Some(ResolvedOutput::new(output_type, output_nullable)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn arithmetic_case(
+    name: &'static str,
+    fields_and_values: [(StructField, Scalar); 2],
+    op: BinaryExpressionOp,
+    output_type: DataType,
+    expected: Scalar,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    let [(left_field, left_value), (right_field, right_value)] = fields_and_values;
+    let left = Expression::column([left_field.name()]);
+    let right = Expression::column([right_field.name()]);
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: Arc::new(StructType::try_new([left_field, right_field])?),
+        input_row: vec![left_value, right_value],
+        expression: Expression::binary(op, left, right),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn invalid_arithmetic_case(
+    name: &'static str,
+    left: Scalar,
+    right: Scalar,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            BinaryExpressionOp::Plus,
+            Expression::Literal(left),
+            Expression::Literal(right),
+        ),
+        output: None,
+        expected: ExpectedResult::Error(ExpectedError::InvalidExpression),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn integer_overflow_case(
+    name: &'static str,
+    op: BinaryExpressionOp,
+    left: i32,
+    right: i32,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            op,
+            Expression::Literal(Scalar::Integer(left)),
+            Expression::Literal(Scalar::Integer(right)),
+        ),
+        output: Some(ResolvedOutput::new(DataType::INTEGER, false)),
+        expected: ExpectedResult::Error(ExpectedError::ArithmeticOverflow),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn decimal_arithmetic_case(
+    name: &'static str,
+    op: BinaryExpressionOp,
+    left: (i128, u8, u8),
+    right: (i128, u8, u8),
+    output_type: DataType,
+    expected: Scalar,
+) -> DeltaResult<ExpressionSemanticsCase> {
+    Ok(ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            op,
+            Expression::Literal(decimal(left.0, left.1, left.2)?),
+            Expression::Literal(decimal(right.0, right.1, right.2)?),
+        ),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Value(expected),
+        requirement: ConformanceRequirement::Portable,
+    })
+}
+
+fn divide_by_zero_case(
+    name: &'static str,
+    numerator: Scalar,
+    denominator: Scalar,
+    output_type: DataType,
+) -> ExpressionSemanticsCase {
+    ExpressionSemanticsCase {
+        name,
+        input_schema: schema_ref! {},
+        input_row: vec![],
+        expression: Expression::binary(
+            BinaryExpressionOp::Divide,
+            Expression::Literal(numerator),
+            Expression::Literal(denominator),
+        ),
+        output: Some(ResolvedOutput::new(output_type, false)),
+        expected: ExpectedResult::Error(ExpectedError::DivideByZero),
+        requirement: ConformanceRequirement::Portable,
+    }
+}
+
+fn decimal(bits: i128, precision: u8, scale: u8) -> DeltaResult<Scalar> {
+    Scalar::decimal(bits, precision, scale)
+}
+
+fn array(array_type: ArrayType, elements: impl IntoIterator<Item = Scalar>) -> DeltaResult<Scalar> {
+    Ok(Scalar::Array(ArrayData::try_new(array_type, elements)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn all_cases_are_well_formed() {
+        let mut names = HashSet::new();
+        for case in all_cases().unwrap() {
+            assert!(
+                names.insert(case.name),
+                "duplicate case name: {}",
+                case.name
+            );
+            assert_eq!(case.input_schema.num_fields(), case.input_row.len());
+
+            for (field, value) in case.input_schema.fields().zip(&case.input_row) {
+                assert_eq!(field.data_type(), &value.data_type(), "case: {}", case.name);
+                assert!(
+                    field.is_nullable() || !value.is_null(),
+                    "case: {}",
+                    case.name
+                );
+            }
+
+            if let ExpectedResult::Value(value) = &case.expected {
+                let output = case.output.as_ref().expect("value case must resolve");
+                assert_eq!(output.data_type, value.data_type(), "case: {}", case.name);
+                assert!(!value.is_null() || output.nullable, "case: {}", case.name);
+            }
+
+            match (case.requirement, &case.expected, &case.output) {
+                (
+                    ConformanceRequirement::ExtensionBoundary,
+                    ExpectedResult::Error(ExpectedError::InvalidExpression),
+                    None,
+                ) => {}
+                (ConformanceRequirement::Portable, ExpectedResult::Value(_), Some(_)) => {}
+                (
+                    ConformanceRequirement::Portable,
+                    ExpectedResult::Error(ExpectedError::InvalidExpression),
+                    None,
+                ) => {}
+                (
+                    ConformanceRequirement::Portable,
+                    ExpectedResult::Error(
+                        ExpectedError::ArithmeticOverflow | ExpectedError::DivideByZero,
+                    ),
+                    Some(_),
+                ) => {}
+                state => panic!("inconsistent expected state for {}: {state:?}", case.name),
+            }
+        }
+    }
+
+    #[test]
+    fn boolean_expression_cases_preserve_predicate_context() {
+        let cases = boolean_cases();
+        for name in [
+            "non_null_boolean_expression_preserves_value",
+            "nullable_boolean_expression_preserves_null",
+            "integer_boolean_expression_is_rejected",
+            "string_boolean_expression_is_extension_boundary",
+        ] {
+            let case = cases
+                .iter()
+                .find(|case| case.name == name)
+                .expect("Boolean expression case");
+            assert!(matches!(
+                &case.expression,
+                Expression::Predicate(predicate)
+                    if matches!(predicate.as_ref(), Predicate::BooleanExpression(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn project_assignment_cases_are_well_formed() {
+        let mut names: HashSet<_> = all_cases()
+            .unwrap()
+            .into_iter()
+            .map(|case| case.name)
+            .collect();
+
+        for case in project_assignment_cases().unwrap() {
+            assert!(
+                names.insert(case.name),
+                "duplicate case name: {}",
+                case.name
+            );
+            assert_eq!(case.input_schema.num_fields(), case.input_row.len());
+
+            for (field, value) in case.input_schema.fields().zip(&case.input_row) {
+                assert_eq!(field.data_type(), &value.data_type(), "case: {}", case.name);
+                assert!(
+                    field.is_nullable() || !value.is_null(),
+                    "case: {}",
+                    case.name
+                );
+            }
+
+            match &case.expected {
+                ExpectedResult::Value(value) => {
+                    assert_eq!(
+                        case.target.data_type,
+                        value.data_type(),
+                        "case: {}",
+                        case.name
+                    );
+                    assert!(
+                        !value.is_null() || case.target.nullable,
+                        "case: {}",
+                        case.name
+                    );
+                }
+                ExpectedResult::Error(
+                    ExpectedError::InvalidExpression | ExpectedError::ArithmeticOverflow,
+                ) => {}
+                error => panic!("invalid assignment result for {}: {error:?}", case.name),
+            }
+        }
+    }
+}

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -318,7 +318,10 @@ where
 /// `expr` must be a struct constructor or struct patch whose fields match `schema`. It is
 /// evaluated with `schema` as its output struct type: the struct's fields are the output
 /// columns, `schema` supplies names and nullability, and any type or arity mismatch is an error.
-/// Downstream nodes see the logical field names declared in `schema`.
+/// Standard child expressions first resolve their own result types according to the [SQL
+/// expression contract](crate::expressions::semantics). The declared field type is then an
+/// assignment target; it does not change operator inference. Downstream nodes see the logical
+/// field names declared in `schema`.
 ///
 /// A struct patch carries the input struct through field by field, naming only the columns that
 /// change -- replacing or dropping existing fields and injecting new ones -- while everything else

--- a/kernel/src/plans/mod.rs
+++ b/kernel/src/plans/mod.rs
@@ -34,10 +34,10 @@
 //! - [`Operation::QueryPlan`] is a [`Plan`](ir::plan::Plan), returning [`PlanResult::Data`]. Either
 //!   evaluate [`Plan::nodes`](ir::plan::Plan::nodes) in slice order, which is topologically sorted
 //!   so a node's inputs are already evaluated, or compile the DAG into the engine's own plan.
+//!   Standard expressions follow the [SQL expression contract](crate::expressions::semantics).
 //!
 //! Every operator, expression, and predicate a plan contains must be handled; returning an error
-//! for an unsupported one is fine, and kernel surfaces it to the caller. The sync engine's
-//! `SyncPlanExecutor` is a complete reference implementation.
+//! for an unsupported one is fine, and kernel surfaces it to the caller.
 //!
 //! # Consuming terminal results
 //!


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/delta-io/delta-kernel-rs/pull/3214/files/653d092d2bb1f1562bbec7b8030ebe70be457418..b819801a97ad62ecbbebd40db8b5733d01bf1a3e) to review incremental changes.
- [stack/improve_expression_ansi_semantics](https://github.com/delta-io/delta-kernel-rs/pull/3203) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3203/files)]
  - [stack/expression_semantics_conformance](https://github.com/delta-io/delta-kernel-rs/pull/3212) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3212/files/afd4f771d2447dd2b5f7ece8bc8877b158fee712..653d092d2bb1f1562bbec7b8030ebe70be457418)]
    - [stack/arrow_expression_semantics](https://github.com/delta-io/delta-kernel-rs/pull/3213) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3213/files/653d092d2bb1f1562bbec7b8030ebe70be457418..38b4ef3df37dcecbc926f793cbed635a64f255c1)]
    - [**stack/datafusion_expression_semantics**](https://github.com/delta-io/delta-kernel-rs/pull/3214) [[Files changed](https://github.com/delta-io/delta-kernel-rs/pull/3214/files/653d092d2bb1f1562bbec7b8030ebe70be457418..b819801a97ad62ecbbebd40db8b5733d01bf1a3e)] ← _this PR_

---------
## What changes are proposed in this pull request?

Runs all 254 shared expression cases from #3212 through DataFusion lowering and execution. The
current result is:

- 178 cases conform: 129 standard-expression cases and 49 `Project` assignments.
- 19 valid cases are rejected as unsupported during lowering or planning.
- 52 cases have known contract violations: DataFusion returns the wrong value, type, nullability,
  or error.
- 5 extension-boundary cases are outside Kernel's required contract.

The harness keeps these categories explicit and fails when a conforming case regresses or an
inventory entry becomes stale.

### Semantics fixed

- Non-decimal division returns `DOUBLE` and reports division by zero:
  `5 / 2 -> 2.5`; `1.0 / 0.0 -> DIVIDE_BY_ZERO`.
- `IN` accepts expression operands and preserves SQL three-valued logic:
  `(a + 1) IN (2, 3)` works; `9 IN (1, NULL) -> NULL`.
- Expressions used as predicates must resolve to `BOOLEAN`.
- `Project` rejects implicit narrowing, string parsing, lossy decimal conversion, and invalid
  nested nullability conversion.

### Remaining gaps

The 19 unsupported cases and 52 contract violations predate this change. The unsupported cases
fail during lowering or planning. They mostly involve recursive or positional container coercion,
decimal result adjustment, and nested or interval comparison and `IN`.

The contract violations can affect expression or filter results if invoked, but they do not modify
stored table data.

| Remaining contract violations | Count | What differs |
|---|---:|---|
| Common types and containers | 14 | Wrong result type or nullability for mixed and empty arrays, decimal common types, and date/timestamp coercion |
| Arithmetic | 18 | Wrong promotion, overflow behavior, decimal result type or rounding, or acceptance of invalid interval arithmetic |
| Comparison and `DISTINCT` | 13 | Decimal precision, maps and nested values, interval families, `NaN`, signed zero, or null-safe comparison differs |
| `IN` | 6 | Empty-array evaluation, numeric coercion, signed zero, map rejection, or output nullability differs |
| `Project` | 1 | Nullable input can be assigned to a required output |
| **Total** | **52** | |

Further DataFusion work is tracked by #3211 under #3207.

## How was this change tested?

- `cargo test` in `datafusion-executor` (232 tests)
- DataFusion Clippy with all targets and features, with warnings denied
- DataFusion rustdoc with all features
- Kernel conformance fixture tests with all features
