### PR TITLE
fix: resolve NeedsCast at apply_schema leaves so timestamp stats survive

### DIFF
--- a/kernel/src/engine/arrow_expression/tests.rs
+++ b/kernel/src/engine/arrow_expression/tests.rs
@@ -6,13 +6,15 @@ use Predicate as Pred;
 
 use super::*;
 use crate::arrow::array::{
-    create_array, Array, ArrayRef, BinaryViewArray, BooleanArray, GenericStringArray, Int32Array,
-    Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames, StringArray,
-    StringBuilder, StringViewArray, StructArray,
+    create_array, Array, ArrayRef, AsArray, BinaryViewArray, BooleanArray, GenericStringArray,
+    Int32Array, Int32Builder, ListArray, ListViewArray, MapArray, MapBuilder, MapFieldNames,
+    StringArray, StringBuilder, StringViewArray, StructArray, TimestampNanosecondArray,
 };
 use crate::arrow::buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use crate::arrow::compute::kernels::cmp::{gt_eq, lt};
-use crate::arrow::datatypes::{DataType, Field, Fields, Schema};
+use crate::arrow::datatypes::{
+    DataType, Field, Fields, Schema, TimeUnit, TimestampMicrosecondType,
+};
 use crate::engine::arrow_data::{ArrowEngineData, EngineDataArrowExt as _};
 use crate::engine::arrow_expression::evaluate_expression::to_json;
 use crate::engine::arrow_expression::opaque::{
@@ -389,7 +391,10 @@ fn test_invalid_array_sides() {
 
     let in_result = evaluate_predicate(&in_op, &batch, false);
 
-    assert_result_error_with_message(in_result, "Invalid expression evaluation: Invalid right value for (NOT) IN comparison, left is: Column(item) right is: Column(item)");
+    assert_result_error_with_message(
+        in_result,
+        "Invalid expression evaluation: Invalid right value for (NOT) IN comparison, left is: Column(item) right is: Column(item)",
+    );
 }
 
 #[test]
@@ -1289,6 +1294,63 @@ fn test_evaluator_mixed_string_types_struct_expression() {
         .unwrap()
         .evaluate(&engine_data)
         .unwrap();
+}
+
+/// End-to-end through `ExpressionEvaluator`, on the shape that actually breaks: a `stats_parsed`
+/// struct read from a Spark-written checkpoint. Spark writes timestamps as Parquet INT96, arrow
+/// decodes INT96 as `Timestamp(Nanosecond, None)`, and kernel's `TIMESTAMP` is
+/// `Timestamp(Microsecond, "UTC")`. An engine that asks the evaluator for `TIMESTAMP` min/max
+/// columns and gets nanosecond columns back downcasts by the type it requested, gets nothing, and
+/// reads that as null min/max. The result is no file skipping at all, with no error anywhere.
+#[test]
+fn test_evaluator_output_schema_honors_timestamp_cast() {
+    let min_ts: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![
+        1_700_000_000_123_456_000i64,
+    ]));
+    let max_ts: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![
+        1_700_000_003_987_654_000i64,
+    ]));
+    let nanos = min_ts.data_type().clone();
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("minTs", nanos.clone(), true),
+            Field::new("maxTs", nanos, true),
+        ])),
+        vec![min_ts, max_ts],
+    )
+    .unwrap();
+
+    let input_schema = schema_ref! {
+        nullable "minTs": TIMESTAMP,
+        nullable "maxTs": TIMESTAMP,
+    };
+    let output_type = KernelDataType::from(schema! {
+        nullable "minTs": TIMESTAMP,
+        nullable "maxTs": TIMESTAMP,
+    });
+    let expression: ExpressionRef = Arc::new(Expr::struct_from([col!("minTs"), col!("maxTs")]));
+
+    let output = ArrowEvaluationHandler
+        .new_expression_evaluator(input_schema, expression, output_type)
+        .unwrap()
+        .evaluate(&ArrowEngineData::new(batch))
+        .unwrap()
+        .try_into_record_batch()
+        .unwrap();
+
+    let micros = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+    for (col, expected) in [(0, 1_700_000_000_123_456i64), (1, 1_700_000_003_987_654)] {
+        // The schema the engine sees must be the schema it asked for.
+        assert_eq!(output.schema().field(col).data_type(), &micros);
+        // And the values must survive the cast.
+        assert_eq!(
+            output
+                .column(col)
+                .as_primitive::<TimestampMicrosecondType>()
+                .value(0),
+            expected
+        );
+    }
 }
 
 // helper to build a RecordBatch via `create_many` and assert it equals `expected`

--- a/kernel/src/engine/arrow_utils/apply_schema.rs
+++ b/kernel/src/engine/arrow_utils/apply_schema.rs
@@ -12,10 +12,11 @@ use super::make_arrow_error;
 use crate::arrow::array::{
     Array, ArrayRef, AsArray, ListArray, MapArray, RecordBatch, StructArray,
 };
+use crate::arrow::compute::cast;
 use crate::arrow::datatypes::{
     DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema,
 };
-use crate::engine::ensure_data_types::{ensure_data_types, ValidationMode};
+use crate::engine::ensure_data_types::{ensure_data_types, DataTypeCompat, ValidationMode};
 use crate::error::{DeltaResult, Error};
 use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use crate::schema::{ArrayType, ColumnMetadataKey, DataType, MapType, Schema, StructField};
@@ -368,10 +369,15 @@ fn apply_schema_to_inner(
         Struct(stype) => Arc::new(apply_schema_to_struct(array, stype)?),
         Array(atype) => Arc::new(apply_schema_to_list(array, atype, ancestor, relative_path)?),
         Map(mtype) => Arc::new(apply_schema_to_map(array, mtype, ancestor, relative_path)?),
-        _ => {
-            ensure_data_types(schema, array.data_type(), ValidationMode::Full)?;
-            array.clone()
-        }
+        // A leaf whose arrow type is only cast-compatible with the kernel type must actually be
+        // cast, the same way `reorder_struct_array` resolves `NeedsCast` on the parquet read
+        // path. Skipping the cast here would hand back an array whose type contradicts the
+        // schema this function was asked to apply, and callers derive the output field type from
+        // the returned array, so the mismatch is silent.
+        _ => match ensure_data_types(schema, array.data_type(), ValidationMode::Full)? {
+            DataTypeCompat::NeedsCast(target) => cast(array, &target)?,
+            DataTypeCompat::Identical | DataTypeCompat::Nested => array.clone(),
+        },
     };
     Ok(array)
 }
@@ -384,11 +390,13 @@ mod apply_schema_validation_tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::arrow::array::{ArrayRef, BinaryArray, Int32Array, RecordBatch, StructArray};
+    use crate::arrow::array::{
+        ArrayRef, BinaryArray, Int32Array, RecordBatch, StructArray, TimestampNanosecondArray,
+    };
     use crate::arrow::buffer::{BooleanBuffer, NullBuffer};
-    use crate::arrow::compute::cast;
     use crate::arrow::datatypes::{
-        DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema,
+        DataType as ArrowDataType, Field as ArrowField, Fields, Schema as ArrowSchema, TimeUnit,
+        TimestampMicrosecondType,
     };
     use crate::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
     use crate::schema::{
@@ -426,6 +434,73 @@ mod apply_schema_validation_tests {
         let result = apply_schema_to(&variant, &DataType::unshredded_variant()).unwrap();
 
         assert_eq!(result.data_type(), variant.data_type());
+    }
+
+    // Build a `stats_parsed`-shaped struct whose timestamp leaves are nanoseconds, which is what
+    // arrow hands back for the INT96 timestamps Spark writes by default. Kernel's `TIMESTAMP` is
+    // `Timestamp(Microsecond, "UTC")`, so every leaf here is `NeedsCast`.
+    fn nanosecond_stats_input() -> StructArray {
+        // Micro-aligned values: a Delta table stores micros, so the INT96 Spark writes for it
+        // carries a zero sub-microsecond remainder and the cast is exact.
+        let min_ts: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![
+            1_700_000_000_123_456_000i64,
+        ]));
+        let max_ts: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![
+            1_700_000_003_987_654_000i64,
+        ]));
+        let leaf = |a: &ArrayRef| -> ArrayRef {
+            Arc::new(
+                StructArray::try_new(
+                    vec![ArrowField::new("ts", a.data_type().clone(), true)].into(),
+                    vec![a.clone()],
+                    None,
+                )
+                .unwrap(),
+            )
+        };
+        let (min_values, max_values) = (leaf(&min_ts), leaf(&max_ts));
+        StructArray::try_new(
+            vec![
+                ArrowField::new("minValues", min_values.data_type().clone(), true),
+                ArrowField::new("maxValues", max_values.data_type().clone(), true),
+            ]
+            .into(),
+            vec![min_values, max_values],
+            None,
+        )
+        .unwrap()
+    }
+
+    fn nanosecond_stats_target() -> DataType {
+        DataType::from(schema! {
+            nullable "minValues": (schema! { nullable "ts": TIMESTAMP }),
+            nullable "maxValues": (schema! { nullable "ts": TIMESTAMP }),
+        })
+    }
+
+    // `apply_schema` must return data that actually matches the schema it was asked to apply.
+    // `transform_struct` derives each output field's arrow type from the *returned array*, so a
+    // leaf that is left uncast makes `apply_schema` emit `Timestamp(Nanosecond, None)` for a field
+    // the caller asked to be `TIMESTAMP`. No error is raised, which is why the reported symptom is
+    // null min/max and no file skipping rather than a failure.
+    #[test]
+    fn apply_schema_casts_cast_compatible_timestamp_leaf() {
+        let result = apply_schema(&nanosecond_stats_input(), &nanosecond_stats_target()).unwrap();
+
+        let expected = ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+        for (col, expected_value) in [(0, 1_700_000_000_123_456i64), (1, 1_700_000_003_987_654)] {
+            let ts = result.column(col).as_struct().column(0);
+            assert_eq!(ts.data_type(), &expected);
+            assert_eq!(
+                ts.as_primitive::<TimestampMicrosecondType>().value(0),
+                expected_value
+            );
+            // The declared field type must agree with the array it describes.
+            assert_eq!(
+                result.schema().field(col).data_type(),
+                &ArrowDataType::Struct(vec![ArrowField::new("ts", expected.clone(), true)].into())
+            );
+        }
     }
 
     #[test]

--- a/kernel/src/engine/arrow_utils/mod.rs
+++ b/kernel/src/engine/arrow_utils/mod.rs
@@ -197,9 +197,11 @@ impl RowIndexBuilder {
 ///   via `ArrowSchema::new`).
 ///
 /// **Type validation.** `apply_schema_to_struct` runs `ensure_data_types(.., Full)` at every
-/// primitive leaf. This is safe because `reorder_struct_array` above has already resolved every
+/// primitive leaf. On this path `reorder_struct_array` above has already resolved every
 /// `DataTypeCompat::NeedsCast` into an actual `arrow::compute::cast`, so post-reorder leaf types
-/// are `Identical` to the kernel target.
+/// are `Identical` to the kernel target and the leaf cast is a no-op. Note that `apply_schema` has
+/// other callers (the expression evaluator) with no such pre-cast step, so it resolves
+/// `NeedsCast` itself rather than relying on this invariant.
 ///
 /// **Cost.** O(F) per batch where F is the total number of fields (including nested). Row data
 /// (Arrow buffers, offsets, null buffers) is shared via `Arc` and never copied.
@@ -649,7 +651,7 @@ fn get_indices(
                         DataTypeCompat::Nested => {
                             return Err(Error::internal_error(
                                 "Comparing nested types in get_indices",
-                            ))
+                            ));
                         }
                     }
                     found_fields.insert(requested_field.name());


### PR DESCRIPTION
Addresses #921. No closing keyword on purpose, since the open question below may mean you want the issue to outlive this patch.

apply_schema_to_inner validates a primitive leaf and then throws the result away. So a leaf that ensure_data_types reports as NeedsCast, which is every timestamp-to-timestamp pair, comes back uncast. Nothing catches it, because one frame up transform_struct builds each output field from the array it just received rather than from the type it was asked for. apply_schema can therefore return a RecordBatch whose schema contradicts the schema it was given, silently.

The effect is that an engine asking for TIMESTAMP min and max gets Timestamp(Nanosecond, None) back. It downcasts using the type it requested, finds nothing, and treats the stats as null. That means no data skipping at all, and no error anywhere, which matches the report. This change resolves the cast at the leaf so the returned batch matches the requested schema.

One call I would like from you. I resolved it to stay consistent with the existing read path, because that is the smallest defensible change, not because narrowing timestamp casts are always safe. If you would rather check_cast_compat reject narrowing outright, say so and I will move the change there and fix the read path expectations instead. Also worth flagging that the test fixture is synthetic. It reproduces the arrow types from the thread rather than a real Spark-generated checkpoint.
