### PR TITLE
fix: omit the dv column when scanning v2 checkpoint sidecars

### DIFF
--- a/kernel/src/engine/sync/plan.rs
+++ b/kernel/src/engine/sync/plan.rs
@@ -285,20 +285,28 @@ fn dynamic_scan_files(
                     last_modified.data_type()
                 ))
             })?;
-        let dv_path = dynamic_scan.dv_column.path();
-        let dv = extract_column(batch, dv_path)?;
-        let dv_ancestors: Vec<_> = (1..dv_path.len())
-            .map(|len| extract_column(batch, &dv_path[..len]))
-            .try_collect()?;
+        let dv = match &dynamic_scan.dv_column {
+            Some(dv_column) => {
+                let dv_path = dv_column.path();
+                let dv = extract_column(batch, dv_path)?;
+                let dv_ancestors: Vec<_> = (1..dv_path.len())
+                    .map(|len| extract_column(batch, &dv_path[..len]))
+                    .try_collect()?;
+                Some((dv, dv_ancestors))
+            }
+            None => None,
+        };
 
         for row in 0..batch.num_rows() {
             if path.is_null(row) {
                 return Err(Error::generic("DynamicScan path must not be null"));
             }
-            if dv.is_valid(row) && dv_ancestors.iter().all(|ancestor| ancestor.is_valid(row)) {
-                return Err(Error::unsupported(
-                    "SyncPlanExecutor DynamicScan with deletion vectors",
-                ));
+            if let Some((dv, dv_ancestors)) = &dv {
+                if dv.is_valid(row) && dv_ancestors.iter().all(|ancestor| ancestor.is_valid(row)) {
+                    return Err(Error::unsupported(
+                        "SyncPlanExecutor DynamicScan with deletion vectors",
+                    ));
+                }
             }
             let path = path.value(row);
             let location = dynamic_scan.base_url.join(path)?;
@@ -564,7 +572,7 @@ mod tests {
             path_column: column_name!("path"),
             file_size_column: column_name!("size"),
             last_modified_column: column_name!("filemod"),
-            dv_column: column_name!("dv"),
+            dv_column: Some(column_name!("dv")),
         };
 
         dynamic_scan_files(&dynamic_scan, &[input])
@@ -650,6 +658,33 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_scan_executor_accepts_no_dv_column() {
+        let input_schema = schema_ref! {
+            nullable "path": STRING,
+            nullable "size": LONG,
+            nullable "filemod": LONG,
+        };
+        let input = values_to_record_batch(Values::new(
+            input_schema,
+            vec![vec!["file.parquet".into(), 1_i64.into(), 42_i64.into()]],
+        ))
+        .unwrap();
+        let dynamic_scan = DynamicScan {
+            schema: schema_ref! {},
+            file_type: FileType::Parquet,
+            base_url: Url::parse("memory:///").unwrap(),
+            file_constant_columns: vec![],
+            path_column: column_name!("path"),
+            file_size_column: column_name!("size"),
+            last_modified_column: column_name!("filemod"),
+            dv_column: None,
+        };
+        let files = dynamic_scan_files(&dynamic_scan, &[input]).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].meta.last_modified, 42);
+    }
+
+    #[test]
     fn dynamic_scan_treats_dv_under_null_ancestor_as_null() {
         let metadata_type = schema! {
             nullable "dv": (DeletionVectorDescriptor::to_schema()),
@@ -685,7 +720,7 @@ mod tests {
             path_column: column_name!("path"),
             file_size_column: column_name!("size"),
             last_modified_column: column_name!("filemod"),
-            dv_column: column_name!("metadata.dv"),
+            dv_column: Some(column_name!("metadata.dv")),
         };
 
         assert_eq!(

--- a/kernel/src/plans/builder.rs
+++ b/kernel/src/plans/builder.rs
@@ -1111,7 +1111,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            column_name!("dv"),
+            Some(column_name!("dv")),
         )
     }
 
@@ -1179,6 +1179,23 @@ mod tests {
         vals(input).dynamic_scan(dynamic_scan)
     }
 
+    #[test]
+    fn dynamic_scan_accepts_no_dv_column() {
+        let input = dynamic_scan_input_missing("dv");
+        let node = DynamicScan::try_new(
+            &input,
+            dynamic_scan_output_schema(),
+            FileType::Parquet,
+            url::Url::parse("memory:///").unwrap(),
+            ["version"],
+            column_name!("path"),
+            column_name!("size"),
+            column_name!("filemod"),
+            None,
+        );
+        assert!(node.is_ok(), "None dv should validate: {:?}", node.err());
+    }
+
     #[rstest::rstest]
     #[case::path("path", 0)]
     #[case::size("size", 1)]
@@ -1218,7 +1235,7 @@ mod tests {
             path_column,
             file_size_column,
             last_modified_column,
-            column_name!("dv"),
+            Some(column_name!("dv")),
         )
         .and_then(|dynamic_scan| vals(input).dynamic_scan(dynamic_scan));
 
@@ -1254,7 +1271,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            column_name!("metadata.dv"),
+            Some(column_name!("metadata.dv")),
         )
         .unwrap();
     }
@@ -1360,7 +1377,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            column_name!("dv"),
+            Some(column_name!("dv")),
         )
     })]
     #[case::base_url_without_trailing_slash("must be hierarchical and end in `/`", || {
@@ -1374,7 +1391,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            column_name!("dv"),
+            Some(column_name!("dv")),
         )
     })]
     fn dynamic_scan_constructor_rejects_invalid_configuration(

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -383,8 +383,7 @@ pub enum FileType {
 /// [`DeletionVectorDescriptor`] struct. The engine resolves it into a roaring bitmap
 /// and drops file rows whose row index appears in the DV. A NULL value for a given
 /// input row means "no DV for this file", so all file rows are emitted. `None` means the
-/// scan has no deletion-vector column at all (e.g. a V2-checkpoint sidecar scan), so no DV
-/// is applied and every file row is emitted.
+/// scan has no deletion-vector column at all, so no DV is applied and every file row is emitted.
 ///
 /// [`DeletionVectorDescriptor`]: crate::actions::deletion_vector::DeletionVectorDescriptor
 ///
@@ -445,7 +444,7 @@ pub struct DynamicScan {
     /// Non-nullable input column with the last-modified timestamp in milliseconds since epoch.
     pub last_modified_column: ColumnName,
     /// Optional nullable input column with the schema of [`DeletionVectorDescriptor`]; `None`
-    /// when the scanned files never carry deletion vectors (e.g. V2-checkpoint sidecars).
+    /// when the scanned files never carry deletion vectors.
     pub dv_column: Option<ColumnName>,
 }
 
@@ -458,10 +457,9 @@ impl DynamicScan {
     /// # Errors
     ///
     /// Returns an error when `base_url` is not hierarchical or does not end in `/`; when a required
-    /// metadata column is absent from `input_schema`, has an incompatible type, or has invalid
-    /// nullability; when a configured deletion-vector column has an incompatible type or is
-    /// non-nullable; or when a file-constant column is absent from either schema, is a metadata
-    /// column, or has different input and output types or nullability.
+    /// metadata column or a configured deletion-vector column is absent, has an incompatible type,
+    /// or has invalid nullability; or when a file-constant column is absent from either schema, is
+    /// a metadata column, or has different input and output types or nullability.
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         input_schema: &SchemaRef,
@@ -501,10 +499,9 @@ impl DynamicScan {
     /// # Errors
     ///
     /// Returns an error when `base_url` is not hierarchical or does not end in `/`; when a required
-    /// metadata column is absent, has an incompatible type, or has invalid nullability; when a
-    /// configured deletion-vector column has an incompatible type or is non-nullable; or when a
-    /// file-constant column is absent from either schema, is a metadata column, or has different
-    /// input and output types or nullability.
+    /// metadata column or a configured deletion-vector column is absent, has an incompatible type,
+    /// or has invalid nullability; or when a file-constant column is absent from either schema, is
+    /// a metadata column, or has different input and output types or nullability.
     pub fn validate_input(&self, input_schema: &SchemaRef) -> DeltaResult<()> {
         static DELETION_VECTOR_DATA_TYPE: LazyLock<DataType> =
             LazyLock::new(|| DataType::from(DeletionVectorDescriptor::to_schema()));

--- a/kernel/src/plans/ir/nodes.rs
+++ b/kernel/src/plans/ir/nodes.rs
@@ -379,10 +379,12 @@ pub enum FileType {
 /// [`ScanParquet::file_constant_columns`]. Each named input field must have the same type and
 /// nullability as its output field. See the example below.
 ///
-/// `dv_column` names a nullable column on the upstream row holding a Delta
+/// `dv_column`, when set, names a nullable column on the upstream row holding a Delta
 /// [`DeletionVectorDescriptor`] struct. The engine resolves it into a roaring bitmap
 /// and drops file rows whose row index appears in the DV. A NULL value for a given
-/// input row means "no DV for this file", so all file rows are emitted.
+/// input row means "no DV for this file", so all file rows are emitted. `None` means the
+/// scan has no deletion-vector column at all (e.g. a V2-checkpoint sidecar scan), so no DV
+/// is applied and every file row is emitted.
 ///
 /// [`DeletionVectorDescriptor`]: crate::actions::deletion_vector::DeletionVectorDescriptor
 ///
@@ -442,8 +444,9 @@ pub struct DynamicScan {
     pub file_size_column: ColumnName,
     /// Non-nullable input column with the last-modified timestamp in milliseconds since epoch.
     pub last_modified_column: ColumnName,
-    /// Nullable input column with the schema of [`DeletionVectorDescriptor`].
-    pub dv_column: ColumnName,
+    /// Optional nullable input column with the schema of [`DeletionVectorDescriptor`]; `None`
+    /// when the scanned files never carry deletion vectors (e.g. V2-checkpoint sidecars).
+    pub dv_column: Option<ColumnName>,
 }
 
 impl DynamicScan {
@@ -455,9 +458,10 @@ impl DynamicScan {
     /// # Errors
     ///
     /// Returns an error when `base_url` is not hierarchical or does not end in `/`; when a required
-    /// metadata or deletion-vector column is absent from `input_schema`, has an incompatible type,
-    /// or has invalid nullability; or when a file-constant column is absent from either schema, is
-    /// a metadata column, or has different input and output types or nullability.
+    /// metadata column is absent from `input_schema`, has an incompatible type, or has invalid
+    /// nullability; when a configured deletion-vector column has an incompatible type or is
+    /// non-nullable; or when a file-constant column is absent from either schema, is a metadata
+    /// column, or has different input and output types or nullability.
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         input_schema: &SchemaRef,
@@ -468,7 +472,7 @@ impl DynamicScan {
         path_column: ColumnName,
         file_size_column: ColumnName,
         last_modified_column: ColumnName,
-        dv_column: ColumnName,
+        dv_column: Option<ColumnName>,
     ) -> DeltaResult<Self> {
         let schema = output_schema.into();
         let file_constant_columns = file_constant_columns
@@ -497,9 +501,10 @@ impl DynamicScan {
     /// # Errors
     ///
     /// Returns an error when `base_url` is not hierarchical or does not end in `/`; when a required
-    /// metadata or deletion-vector column is absent, has an incompatible type, or has invalid
-    /// nullability; or when a file-constant column is absent from either schema, is a metadata
-    /// column, or has different input and output types or nullability.
+    /// metadata column is absent, has an incompatible type, or has invalid nullability; when a
+    /// configured deletion-vector column has an incompatible type or is non-nullable; or when a
+    /// file-constant column is absent from either schema, is a metadata column, or has different
+    /// input and output types or nullability.
     pub fn validate_input(&self, input_schema: &SchemaRef) -> DeltaResult<()> {
         static DELETION_VECTOR_DATA_TYPE: LazyLock<DataType> =
             LazyLock::new(|| DataType::from(DeletionVectorDescriptor::to_schema()));
@@ -520,30 +525,28 @@ impl DynamicScan {
             &self.file_constant_columns,
         )?;
 
-        let fields = input_schema
-            .fields_of_path(&self.dv_column)
-            .map_err(|err| {
+        if let Some(dv_column) = &self.dv_column {
+            let fields = input_schema.fields_of_path(dv_column).map_err(|err| {
                 Error::generic(format!(
-                    "dynamic scan: deletion-vector column `{}` is invalid: {err}",
-                    self.dv_column
+                    "dynamic scan: deletion-vector column `{dv_column}` is invalid: {err}"
                 ))
             })?;
-        let Some((field, _ancestors)) = fields.split_last() else {
-            return Err(Error::internal_error("fields_of_path returned no fields"));
-        };
-        let expected = &*DELETION_VECTOR_DATA_TYPE;
-        if field.data_type() != expected {
-            return Err(Error::generic(format!(
-                "dynamic scan: deletion-vector column `{}` must have type {expected}, found {}",
-                self.dv_column,
-                field.data_type()
-            )));
-        }
-        if !field.is_nullable() {
-            return Err(Error::generic(format!(
-                "dynamic scan: deletion-vector column `{}` must be nullable",
-                self.dv_column
-            )));
+            let Some((field, _ancestors)) = fields.split_last() else {
+                return Err(Error::internal_error("fields_of_path returned no fields"));
+            };
+            let expected = &*DELETION_VECTOR_DATA_TYPE;
+            if field.data_type() != expected {
+                return Err(Error::generic(format!(
+                    "dynamic scan: deletion-vector column `{dv_column}` must have type \
+                     {expected}, found {}",
+                    field.data_type()
+                )));
+            }
+            if !field.is_nullable() {
+                return Err(Error::generic(format!(
+                    "dynamic scan: deletion-vector column `{dv_column}` must be nullable"
+                )));
+            }
         }
 
         Ok(())

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -228,7 +228,7 @@ impl From<&DynamicScan> for proto_plan::DynamicScanNode {
             path_column: Some((&node.path_column).into()),
             file_size_column: Some((&node.file_size_column).into()),
             last_modified_column: Some((&node.last_modified_column).into()),
-            dv_column: Some((&node.dv_column).into()),
+            dv_column: node.dv_column.as_ref().map(Into::into),
         }
     }
 }
@@ -1309,7 +1309,7 @@ mod tests {
             path_column: column_name!("path"),
             file_size_column: column_name!("size"),
             last_modified_column: column_name!("filemod"),
-            dv_column: column_name!("dv"),
+            dv_column: Some(column_name!("dv")),
         }),
         "dynamic_scan"
     )]
@@ -1428,6 +1428,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn from_dynamic_scan_omits_dv_column_when_none() {
+        let input_schema = schema_ref! {
+            not_null "path": STRING,
+            not_null "size": LONG,
+            not_null "filemod": LONG,
+            nullable "c": INTEGER,
+        };
+        let node = DynamicScan::try_new(
+            &input_schema,
+            sample_dynamic_scan_output_schema(),
+            FileType::Parquet,
+            Url::parse("memory:///base/").unwrap(),
+            ["c"],
+            column_name!("path"),
+            column_name!("size"),
+            column_name!("filemod"),
+            None,
+        )
+        .unwrap();
+        assert!(proto_plan::DynamicScanNode::from(&node).dv_column.is_none());
+    }
+
     #[rstest]
     #[case(
         FileType::Json,
@@ -1453,7 +1476,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            column_name!("dv"),
+            Some(column_name!("dv")),
         )?;
         let proto = proto_plan::DynamicScanNode::from(&node);
         assert!(proto.schema.is_some());

--- a/kernel/src/plans/proto/convert.rs
+++ b/kernel/src/plans/proto/convert.rs
@@ -976,10 +976,10 @@ mod tests {
     use super::EdgeAlgo;
     use crate::actions::deletion_vector::DeletionVectorDescriptor;
     use crate::expressions::{
-        col, column_name, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp, DecimalData,
-        Expression, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData, OpaqueExpressionOp,
-        OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator, StructData,
-        UnaryExpressionOp, UnaryPredicateOp, VariadicExpressionOp,
+        col, column_name, lit, ArrayData, BinaryExpressionOp, BinaryPredicateOp, ColumnName,
+        DecimalData, Expression, ExpressionStructPatchBuilder, JunctionPredicateOp, MapData,
+        OpaqueExpressionOp, OpaquePredicateOp, Predicate, Scalar, ScalarExpressionEvaluator,
+        StructData, UnaryExpressionOp, UnaryPredicateOp, VariadicExpressionOp,
     };
     use crate::kernel_predicates::{
         DirectDataSkippingPredicateEvaluator, DirectPredicateEvaluator,
@@ -1428,45 +1428,32 @@ mod tests {
         }
     }
 
-    #[test]
-    fn from_dynamic_scan_omits_dv_column_when_none() {
-        let input_schema = schema_ref! {
-            not_null "path": STRING,
-            not_null "size": LONG,
-            not_null "filemod": LONG,
-            nullable "c": INTEGER,
-        };
-        let node = DynamicScan::try_new(
-            &input_schema,
-            sample_dynamic_scan_output_schema(),
-            FileType::Parquet,
-            Url::parse("memory:///base/").unwrap(),
-            ["c"],
-            column_name!("path"),
-            column_name!("size"),
-            column_name!("filemod"),
-            None,
-        )
-        .unwrap();
-        assert!(proto_plan::DynamicScanNode::from(&node).dv_column.is_none());
-    }
-
     #[rstest]
     #[case(
         FileType::Json,
         Url::parse("memory:///base/").unwrap(),
-        "memory:///base/"
+        "memory:///base/",
+        Some(column_name!("dv"))
     )]
     #[case(
         FileType::Parquet,
         Url::parse("file:///table/").unwrap(),
-        "file:///table/"
+        "file:///table/",
+        Some(column_name!("dv"))
+    )]
+    #[case(
+        FileType::Parquet,
+        Url::parse("memory:///base/").unwrap(),
+        "memory:///base/",
+        None
     )]
     fn from_dynamic_scan(
         #[case] file_type: FileType,
         #[case] base_url: Url,
         #[case] expected_base_url: &str,
+        #[case] dv_column: Option<ColumnName>,
     ) -> DeltaResult<()> {
+        let expect_dv_column = dv_column.is_some();
         let node = DynamicScan::try_new(
             &sample_dynamic_scan_input_schema(),
             sample_dynamic_scan_output_schema(),
@@ -1476,7 +1463,7 @@ mod tests {
             column_name!("path"),
             column_name!("size"),
             column_name!("filemod"),
-            Some(column_name!("dv")),
+            dv_column,
         )?;
         let proto = proto_plan::DynamicScanNode::from(&node);
         assert!(proto.schema.is_some());
@@ -1486,7 +1473,7 @@ mod tests {
         );
         assert_eq!(proto.base_url, expected_base_url);
         assert_eq!(proto.file_constant_columns.len(), 1);
-        assert!(proto.dv_column.is_some());
+        assert_eq!(proto.dv_column.is_some(), expect_dv_column);
 
         assert_eq!(
             proto.path_column.expect("path column present").path,

--- a/kernel/src/scan/scan_plan.rs
+++ b/kernel/src/scan/scan_plan.rs
@@ -11,21 +11,20 @@ use url::Url;
 use super::data_skipping::as_sql_data_skipping_predicate_with_stats_columns;
 use super::state_info::StateInfo;
 use super::{PhysicalPredicate, Scan};
-use crate::actions::deletion_vector::DeletionVectorDescriptor;
 use crate::actions::{
     ADD_FIELD, ADD_NAME, ADD_SCHEMA, REMOVE_FIELD, SIDECAR_FIELD, SIDECAR_NAME, STATS_PARSED,
 };
 use crate::checkpoint::{CheckpointShape, CheckpointType};
 use crate::expressions::{
-    col, column_name, joined_column_expr, lit, null_lit, ColumnName, Expression as Expr,
-    ExpressionRef, Predicate,
+    col, column_name, joined_column_expr, lit, ColumnName, Expression as Expr, ExpressionRef,
+    Predicate,
 };
 use crate::plans::ir::nodes::{DynamicScan, FileType, ScanFile};
 use crate::plans::ir::plan::Plan;
 use crate::scan::log_replay::{PARTITION_VALUES_PARSED_NAME, STATS_PARSED_NAME};
 use crate::schema::{
     lazy_schema_ref, schema, schema_ref, DataType, SchemaRef, SchemaStructPatchBuilder,
-    StructField, StructType, ToSchema as _,
+    StructField, StructType,
 };
 use crate::struct_patch::ProjectionStructPatchBuilder;
 use crate::transforms::{transform_output_type, ExpressionTransform};
@@ -340,7 +339,6 @@ fn sidecar_actions(
     const FILE_PATH: &str = "path";
     const FILE_SIZE: &str = "size";
     const FILE_MOD: &str = "filemod";
-    const DV: &str = "dv";
     const SIDECAR_SIZE: &str = "sizeInBytes";
     const SIDECAR_FILE_MOD: &str = "modificationTime";
 
@@ -348,7 +346,6 @@ fn sidecar_actions(
         not_null FILE_PATH: STRING,
         not_null FILE_SIZE: LONG,
         not_null FILE_MOD: LONG,
-        nullable DV: (DeletionVectorDescriptor::to_schema()),
         nullable VERSION: LONG,
     };
 
@@ -368,7 +365,6 @@ fn sidecar_actions(
                 col!(SIDECAR_NAME, FILE_PATH),
                 col!(SIDECAR_NAME, SIDECAR_SIZE),
                 col!(SIDECAR_NAME, SIDECAR_FILE_MOD),
-                null_lit(DeletionVectorDescriptor::to_schema()),
                 col!(VERSION),
             ]),
             SIDECAR_FILE_META_SCHEMA.clone(),
@@ -383,7 +379,7 @@ fn sidecar_actions(
         column_name!(FILE_PATH),
         column_name!(FILE_SIZE),
         column_name!(FILE_MOD),
-        column_name!(DV),
+        None,
     )?;
 
     sidecar_files.dynamic_scan(dynamic_scan)
@@ -832,6 +828,10 @@ mod tests {
                 .field(PARTITION_VALUES_PARSED)
                 .is_none(),
             "native parsed partition values are not requested yet"
+        );
+        assert!(
+            dynamic_scan.dv_column.is_none(),
+            "sidecar scan sets no dv column"
         );
         Ok(())
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Declarative plans metadata scans for V2 checkpoint sidecars use a `DynamicScan` whose `dv_column` was set. Sidecar files never hold data with deletion vectors. A plan that routes sidecar reads through a dv aware parquet reader can fail. This change makes `DynamicScan.dv_column` optional and omits it for sidecar reads.

## How was this change tested?

New assertion in existing UT. Existing UTs pass.