### PR TITLE
chore: apply current nightly rustfmt

### DIFF
--- a/ffi/src/delta_kernel_unity_catalog.rs
+++ b/ffi/src/delta_kernel_unity_catalog.rs
@@ -103,7 +103,8 @@ impl UpdateTableClient for FfiUCCommitClient {
 
             match (self.commit_callback)(self.context, c_commit_request) {
                 OptionalValue::Some(e) => {
-                    let boxed_str = unsafe { e.into_inner() }; // get the string back into Box<String>
+                    let boxed_str = unsafe { e.into_inner() }; // get the string back into
+                                                               // Box<String>
                     let s: String = *boxed_str; // move back onto the stack
                     Err(unity_catalog_delta_client_api::Error::Generic(s))
                 }

--- a/ffi/src/ffi_tracing.rs
+++ b/ffi/src/ffi_tracing.rs
@@ -925,8 +925,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // We cannot run this test if test_enable_log_line_tracing was run before - see comment there,
-              // however this test works if run individually.
+    #[ignore] // We cannot run this test if test_enable_log_line_tracing was run before - see
+              // comment there, however this test works if run individually.
     fn test_enable_event_tracing() {
         let _lock = TEST_LOCK.lock().unwrap();
         setup_events();

--- a/kernel/src/action_reconciliation/log_replay.rs
+++ b/kernel/src/action_reconciliation/log_replay.rs
@@ -1033,7 +1033,8 @@ mod tests {
         let (results, actions_count, add_actions) = run_action_reconciliation_test(input_batches)?;
 
         // Verify results
-        assert_eq!(results.len(), 2); // The third batch should be filtered out since there are no selected actions
+        assert_eq!(results.len(), 2); // The third batch should be filtered out since there are no
+                                      // selected actions
         assert_eq!(results[0].selection_vector(), &vec![true]);
         assert_eq!(results[1].selection_vector(), &vec![false, true]);
         assert_eq!(actions_count, 2);

--- a/kernel/src/expressions/sql.rs
+++ b/kernel/src/expressions/sql.rs
@@ -458,7 +458,8 @@ mod tests {
     #[case("'2024-01-01 12:34:56'", "zoneless")]
     #[case("TIMESTAMP '2024-01-01 12:34:56'", "zoneless")]
     #[case("'2024-06-15T14:30:00+05:00'", "offset")]
-    #[case("'2024-06-15T14:30:00+00:00'", "offset")] // +00:00 is UTC-valued but dropped, so rejected
+    #[case("'2024-06-15T14:30:00+00:00'", "offset")] // +00:00 is UTC-valued but dropped, so
+                                                     // rejected
     fn timestamp_ltz_rejection_distinguishes_zoneless_from_offset(
         #[case] sql: &str,
         #[case] needle: &str,
@@ -491,7 +492,8 @@ mod tests {
     #[rstest]
     #[case("TIMESTAMP_NTZ '1970-01-01T00:00:00Z'", DataType::TIMESTAMP)] // NTZ keyword, LTZ target
     #[case("TIMESTAMP '2024-01-01 12:34:56'", DataType::TIMESTAMP_NTZ)] // LTZ keyword, NTZ target
-    #[case("TIMESTAMP_LTZ '1970-01-01T00:00:00Z'", DataType::TIMESTAMP_NTZ)] // LTZ keyword, NTZ target
+    #[case("TIMESTAMP_LTZ '1970-01-01T00:00:00Z'", DataType::TIMESTAMP_NTZ)] // LTZ keyword, NTZ
+                                                                             // target
     fn rejects_mismatched_timestamp_keyword(#[case] sql: &str, #[case] ty: DataType) {
         let result = parse_sql(sql, &ty);
         assert!(
@@ -508,7 +510,8 @@ mod tests {
     #[case("'2024-06-15T14:30:00Z'", "2024-06-15 14:30:00")]
     #[case("TIMESTAMP '2024-06-15T14:30:00.456Z'", "2024-06-15 14:30:00.456")]
     #[case("TIMESTAMP_LTZ '2024-06-15T14:30:00Z'", "2024-06-15 14:30:00")] // explicit LTZ spelling
-    #[case("TIMESTAMP_LTZ'1970-01-01T00:00:00.123Z'", "1970-01-01 00:00:00.123")] // butted against quote
+    #[case("TIMESTAMP_LTZ'1970-01-01T00:00:00.123Z'", "1970-01-01 00:00:00.123")] // butted against
+                                                                                  // quote
     fn iso_8601_form_accepted_only_for_timestamp(#[case] sql: &str, #[case] equivalent: &str) {
         let got = parse_sql(sql, &DataType::TIMESTAMP).unwrap();
         assert_eq!(got, lit(Scalar::Timestamp(ts_micros(equivalent))));

--- a/kernel/src/snapshot/mod.rs
+++ b/kernel/src/snapshot/mod.rs
@@ -1947,7 +1947,8 @@ mod tests {
                 false,
             ),
         ];
-        commit(table_root, store.as_ref(), 0, commit_data.to_vec()).await; // ICT enabled from version 0
+        commit(table_root, store.as_ref(), 0, commit_data.to_vec()).await; // ICT enabled from
+                                                                           // version 0
 
         // Create commit without ICT despite being enabled (corrupt case)
         let commit_missing_ict = [create_commit_info(1234567890, None)];

--- a/kernel/src/transaction/mod.rs
+++ b/kernel/src/transaction/mod.rs
@@ -2400,7 +2400,8 @@ mod tests {
         assert_eq!(get_column!(rb, names[0], StringArray).value(0), "aa"); // p1 (prepended)
         assert_eq!(get_column!(rb, names[1], Int32Array).value(0), 7); // p2 (prepended)
         assert_eq!(get_column!(rb, names[2], Int32Array).value(0), 10); // d1
-        assert_eq!(get_column!(rb, names[3], StringArray).value(0), "cc"); // p3 (after d1, void skipped)
+        assert_eq!(get_column!(rb, names[3], StringArray).value(0), "cc"); // p3 (after d1, void
+                                                                           // skipped)
         assert_eq!(get_column!(rb, names[4], Int32Array).value(0), 9); // p4 (after d1)
         assert_eq!(get_column!(rb, names[5], Int32Array).value(0), 20); // d2
         Ok(())

--- a/kernel/tests/integration/features/dv.rs
+++ b/kernel/tests/integration/features/dv.rs
@@ -275,7 +275,8 @@ async fn test_write_deletion_vectors_end_to_end() -> Result<(), Box<dyn std::err
     dv_file1_second.add_deleted_row_indexes([FILE1_SECOND_DELETE_INDEX]); // Additional deletion
 
     let mut dv_file2 = KernelDeletionVector::new();
-    dv_file2.add_deleted_row_indexes(FILE2_DELETE_INDEXES); // Delete rows at indices 2 and 5 (ids 12, 15)
+    dv_file2.add_deleted_row_indexes(FILE2_DELETE_INDEXES); // Delete rows at indices 2 and 5 (ids
+                                                            // 12, 15)
 
     // Step 8: Update deletion vectors for both files
     let snapshot = Snapshot::builder_for(table_url.clone()).build(engine.as_ref())?;

--- a/kernel/tests/integration/log/crc.rs
+++ b/kernel/tests/integration/log/crc.rs
@@ -413,7 +413,8 @@ async fn test_post_commit_crc_tracks_file_stats_across_inserts() -> DeltaResult<
     let crc_v2 = write_and_verify_crc(snapshot_v2, &table_path, engine.as_ref());
     let stats_v2 = crc_v2.file_stats().unwrap();
     assert_eq!(stats_v2.num_files(), 2); // <--- 2 files added
-    assert!(stats_v2.table_size_bytes() > stats_v1.table_size_bytes()); // <--- size is greater than after first insert
+    assert!(stats_v2.table_size_bytes() > stats_v1.table_size_bytes()); // <--- size is greater than
+                                                                        // after first insert
 
     // ===== WHEN: Remove all files =====
     let scan = snapshot_v2.clone().scan_builder().build()?;


### PR DESCRIPTION
## What changes are proposed in this pull request?

GitHub Actions uses the floating `nightly` Rust toolchain for the format check. The
2026-08-31 nightly changed rustfmt's wrapping of trailing comments, causing the format job to
fail across unrelated PRs.

This applies the current nightly rustfmt output to the eight affected files. The diff only
rewraps comments and does not change runtime behavior.

## How was this change tested?

- `cargo +nightly-2026-08-31 fmt -- --check`
- Repository pre-commit checks

The dated toolchain reports the same compiler as the GitHub runner:
`rustc 1.100.0-nightly (908501772 2026-08-30)`.
