### PR TITLE
feat: support reading stable row commit version

### DIFF
--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -185,13 +185,13 @@ struct RetryTransformAndDataSkipOutput {
 
 impl ScanLogReplayProcessor {
     // These index positions correspond to the order of columns defined in
-    // `selected_column_names_and_types()`
+    // `AddRemoveDedupVisitor::selected_column_names_and_types()`
     const ADD_PATH_INDEX: usize = 0; // Position of "add.path" in getters
     const ADD_PARTITION_VALUES_INDEX: usize = 1; // Position of "add.partitionValues" in getters
     const ADD_SIZE_INDEX: usize = 2; // Position of "add.size" in getters
     const ADD_DV_START_INDEX: usize = 3; // Start position of add deletion vector columns
     const BASE_ROW_ID_INDEX: usize = 6; // Position of add.baseRowId in getters
-    const DEFAULT_ROW_COMMIT_VERSION_INDEX: usize = 7;
+    const DEFAULT_ROW_COMMIT_VERSION_INDEX: usize = 7; // Position of add.defaultRowCommitVersion in getters
     const REMOVE_PATH_INDEX: usize = 8; // Position of "remove.path" in getters
     const REMOVE_DV_START_INDEX: usize = 9; // Start position of remove deletion vector columns
 
@@ -1181,7 +1181,8 @@ mod tests {
     use crate::log_segment::CheckpointReadInfo;
     use crate::scan::state::ScanFile;
     use crate::scan::state_info::tests::{
-        assert_transform_spec, get_simple_state_info, get_state_info, ROW_TRACKING_FEATURES,
+        assert_transform_spec, get_simple_state_info, get_state_info, RowTrackingState,
+        ROW_TRACKING_FEATURES,
     };
     use crate::scan::state_info::StateInfo;
     use crate::scan::test_utils::{
@@ -1445,35 +1446,35 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_row_commit_version_patch() -> DeltaResult<()> {
+    #[rstest]
+    #[case::supported_not_enabled(RowTrackingState::SupportedNotEnabled)]
+    #[case::enabled(RowTrackingState::Enabled)]
+    #[case::suspended(RowTrackingState::Suspended)]
+    fn test_row_commit_version_patch(
+        #[case] row_tracking_state: RowTrackingState,
+    ) -> DeltaResult<()> {
         let schema: SchemaRef = schema_ref! { nullable "value": INTEGER };
         let state_info = get_state_info(
             schema,
             vec![],
             None,
-            ROW_TRACKING_FEATURES,
-            [
-                ("delta.enableRowTracking", "true"),
-                (
-                    "delta.rowTracking.materializedRowIdColumnName",
-                    "row_id_col",
-                ),
-                (
-                    "delta.rowTracking.materializedRowCommitVersionColumnName",
-                    "row_commit_version_col",
-                ),
-            ]
-            .into_iter()
-            .map(|(key, value)| (key.to_string(), value.to_string()))
-            .collect(),
+            row_tracking_state.features(),
+            row_tracking_state.properties(),
             vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
-        )?;
+        );
+        if row_tracking_state != RowTrackingState::Enabled {
+            assert_result_error_with_message(
+                state_info,
+                "Row commit versions are not enabled on this table",
+            );
+            return Ok(());
+        }
+
         let batch = add_batch_for_row_tracking(get_commit_schema().clone());
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             [Ok(ActionsBatch::new(batch, true))].into_iter(),
-            Arc::new(state_info),
+            Arc::new(state_info?),
             test_checkpoint_info(),
             ScanStatsOptions::default(),
             ScanPartitionValuesOptions::default(),

--- a/kernel/src/scan/log_replay.rs
+++ b/kernel/src/scan/log_replay.rs
@@ -21,7 +21,9 @@ use crate::log_replay::{
     ParallelLogReplayProcessor,
 };
 use crate::log_segment::CheckpointReadInfo;
-use crate::scan::transform_spec::{get_transform_expr, parse_partition_values, TransformSpec};
+use crate::scan::transform_spec::{
+    get_transform_expr, parse_partition_values, FileRowTrackingMetadata, TransformSpec,
+};
 use crate::schema::{
     lazy_schema_ref, ColumnNamesAndTypes, DataType, MapType, SchemaRef, SchemaStructPatchBuilder,
     StructField, StructType, ToSchema as _,
@@ -189,8 +191,9 @@ impl ScanLogReplayProcessor {
     const ADD_SIZE_INDEX: usize = 2; // Position of "add.size" in getters
     const ADD_DV_START_INDEX: usize = 3; // Start position of add deletion vector columns
     const BASE_ROW_ID_INDEX: usize = 6; // Position of add.baseRowId in getters
-    const REMOVE_PATH_INDEX: usize = 7; // Position of "remove.path" in getters
-    const REMOVE_DV_START_INDEX: usize = 8; // Start position of remove deletion vector columns
+    const DEFAULT_ROW_COMMIT_VERSION_INDEX: usize = 7;
+    const REMOVE_PATH_INDEX: usize = 8; // Position of "remove.path" in getters
+    const REMOVE_DV_START_INDEX: usize = 9; // Start position of remove deletion vector columns
 
     /// Create a new [`ScanLogReplayProcessor`] instance
     pub(crate) fn new(
@@ -599,8 +602,8 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         // action type:
         // - For Add actions: path is at index 0, size at 2, then followed by DV fields at indexes
         //   3-5
-        // - For Remove actions (in log batches only): path is at index 7, followed by DV fields at
-        //   indexes 8-10
+        // - For Remove actions (in log batches only): path is at index 8, followed by DV fields at
+        //   indexes 9-11
         // The file extraction logic selects the appropriate indexes based on whether we found a
         // valid path. Remove getters are not included when visiting a non-log batch
         // (checkpoint batch), so do not try to extract remove actions in that case.
@@ -658,6 +661,9 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
         if !self.state_info.skip_row_transforms {
             let base_row_id: Option<i64> =
                 getters[ScanLogReplayProcessor::BASE_ROW_ID_INDEX].get_opt(row, "add.baseRowId")?;
+            let default_row_commit_version: Option<i64> = getters
+                [ScanLogReplayProcessor::DEFAULT_ROW_COMMIT_VERSION_INDEX]
+                .get_opt(row, "add.defaultRowCommitVersion")?;
             let patch_expr = self
                 .state_info
                 .transform_spec
@@ -667,7 +673,10 @@ impl<'a, D: Deduplicator> AddRemoveDedupVisitor<'a, D> {
                         transform_spec,
                         partition_values,
                         &self.state_info.physical_schema,
-                        base_row_id,
+                        FileRowTrackingMetadata {
+                            base_row_id,
+                            default_row_commit_version,
+                        },
                     )
                 })
                 .transpose()?;
@@ -698,6 +707,7 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
                 (STRING, column_name!("add.deletionVector.pathOrInlineDv")),
                 (INTEGER, column_name!("add.deletionVector.offset")),
                 (LONG, column_name!("add.baseRowId")),
+                (LONG, column_name!("add.defaultRowCommitVersion")),
                 (STRING, column_name!("remove.path")),
                 (STRING, column_name!("remove.deletionVector.storageType")),
                 (STRING, column_name!("remove.deletionVector.pathOrInlineDv")),
@@ -721,7 +731,7 @@ impl<D: Deduplicator> RowVisitor for AddRemoveDedupVisitor<'_, D> {
         let start = std::time::Instant::now();
 
         let is_log_batch = self.deduplicator.is_log_batch();
-        let expected_getters = if is_log_batch { 11 } else { 7 };
+        let expected_getters = if is_log_batch { 12 } else { 8 };
         require!(
             getters.len() == expected_getters,
             Error::InternalError(format!(
@@ -1175,7 +1185,7 @@ mod tests {
     };
     use crate::scan::state_info::StateInfo;
     use crate::scan::test_utils::{
-        add_batch_for_row_id, add_batch_simple, add_batch_with_partition_col,
+        add_batch_for_row_tracking, add_batch_simple, add_batch_with_partition_col,
         add_batch_with_remove, add_batch_with_remove_and_partition, run_with_validate_callback,
     };
     use crate::scan::PhysicalPredicate;
@@ -1394,7 +1404,7 @@ mod tests {
             "row_indexes_for_row_id_0",
         );
 
-        let batch = vec![add_batch_for_row_id(get_commit_schema().clone())];
+        let batch = vec![add_batch_for_row_tracking(get_commit_schema().clone())];
         let (iter, _metrics) = scan_action_iter(
             &SyncEngine::new(),
             batch
@@ -1433,6 +1443,61 @@ mod tests {
                 panic!("Should have been a StructPatch expression");
             }
         }
+    }
+
+    #[test]
+    fn test_row_commit_version_patch() -> DeltaResult<()> {
+        let schema: SchemaRef = schema_ref! { nullable "value": INTEGER };
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            ROW_TRACKING_FEATURES,
+            [
+                ("delta.enableRowTracking", "true"),
+                (
+                    "delta.rowTracking.materializedRowIdColumnName",
+                    "row_id_col",
+                ),
+                (
+                    "delta.rowTracking.materializedRowCommitVersionColumnName",
+                    "row_commit_version_col",
+                ),
+            ]
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect(),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        )?;
+        let batch = add_batch_for_row_tracking(get_commit_schema().clone());
+        let (iter, _metrics) = scan_action_iter(
+            &SyncEngine::new(),
+            [Ok(ActionsBatch::new(batch, true))].into_iter(),
+            Arc::new(state_info),
+            test_checkpoint_info(),
+            ScanStatsOptions::default(),
+            ScanPartitionValuesOptions::default(),
+        )?;
+
+        for scan_metadata in iter {
+            let transforms = scan_metadata?.scan_file_transforms;
+            assert_eq!(transforms.len(), 1);
+            let Some(Expr::StructPatch(patch)) = transforms[0].as_ref().map(Arc::as_ref) else {
+                panic!("Expected a StructPatch expression");
+            };
+            let row_commit_version_patch = patch
+                .field_patches
+                .get("row_commit_version_col")
+                .expect("Should have row_commit_version_col patch");
+            assert_eq!(
+                row_commit_version_patch.insertions,
+                [Arc::new(Expr::coalesce([
+                    col!("row_commit_version_col"),
+                    lit(5i64),
+                ]))]
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -13,7 +13,7 @@ use crate::scan::transform_spec::{FieldTransformSpec, TransformSpec};
 use crate::scan::{PartitionValuesOptions, PhysicalPredicate, StatsOptions, StructStats};
 use crate::schema::{DataType, MetadataColumnSpec, SchemaRef, StructType};
 use crate::table_configuration::TableConfiguration;
-use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode};
+use crate::table_features::{get_any_level_column_physical_name, ColumnMappingMode, TableFeature};
 use crate::{DeltaResult, Error, PredicateRef, StructField};
 
 /// All the state needed to process a scan.
@@ -72,6 +72,8 @@ struct MetadataInfo<'a> {
     /// the materializedRowIdColumnName extracted from the table config if row ids are requested,
     /// or None if they are not requested
     materialized_row_id_column_name: Option<&'a String>,
+    /// The physical column containing materialized Row Commit Versions, when requested.
+    materialized_row_commit_version_column_name: Option<&'a String>,
 }
 
 /// This validates that we have sensible metadata columns, and that the requested metadata is
@@ -108,7 +110,23 @@ fn validate_metadata_columns<'a>(
                     .ok_or(Error::generic("No delta.rowTracking.materializedRowIdColumnName key found in metadata configuration"))?;
                 metadata_info.materialized_row_id_column_name = Some(row_id_col);
             }
-            Some(MetadataColumnSpec::RowCommitVersion) => {}
+            Some(MetadataColumnSpec::RowCommitVersion) => {
+                if !table_configuration.is_feature_enabled(&TableFeature::RowTracking) {
+                    return Err(Error::unsupported(
+                        "Row commit versions are not enabled on this table",
+                    ));
+                }
+                let row_commit_version_col = table_configuration
+                    .table_properties()
+                    .materialized_row_commit_version_column_name
+                    .as_ref()
+                    .ok_or(Error::generic(
+                        "No delta.rowTracking.materializedRowCommitVersionColumnName key found in \
+                         metadata configuration",
+                    ))?;
+                metadata_info.materialized_row_commit_version_column_name =
+                    Some(row_commit_version_col);
+            }
             Some(MetadataColumnSpec::FilePath) => {
                 // FilePath metadata column is handled by the parquet reader
             }
@@ -309,7 +327,22 @@ impl StateInfo {
                         });
                     }
                     Some(MetadataColumnSpec::RowCommitVersion) => {
-                        return Err(Error::unsupported("Row commit versions not supported"));
+                        let Some(row_commit_version_col_name) =
+                            metadata_info.materialized_row_commit_version_column_name
+                        else {
+                            return Err(Error::internal_error(
+                                "A materialized Row Commit Version column name must be available \
+                                 when selecting Row Commit Versions",
+                            ));
+                        };
+
+                        read_fields.push(StructField::nullable(
+                            row_commit_version_col_name,
+                            DataType::LONG,
+                        ));
+                        transform_spec.push(FieldTransformSpec::GenerateRowCommitVersion {
+                            field_name: row_commit_version_col_name.to_string(),
+                        });
                     }
                     Some(MetadataColumnSpec::RowIndex)
                     | Some(MetadataColumnSpec::FilePath)
@@ -837,6 +870,47 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn request_row_commit_versions() {
+        let schema = schema_ref! { nullable "id": STRING };
+        let state_info = get_state_info(
+            schema,
+            vec![],
+            None,
+            ROW_TRACKING_FEATURES,
+            get_string_map(&[
+                ("delta.enableRowTracking", "true"),
+                (
+                    "delta.rowTracking.materializedRowIdColumnName",
+                    "some_row_id_col",
+                ),
+                (
+                    "delta.rowTracking.materializedRowCommitVersionColumnName",
+                    "some_row_commit_version_col",
+                ),
+            ]),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            state_info
+                .physical_schema
+                .field("some_row_commit_version_col")
+                .map(StructField::data_type),
+            Some(&DataType::LONG)
+        );
+        assert_eq!(
+            state_info.transform_spec.as_deref().map(Vec::as_slice),
+            Some(
+                [FieldTransformSpec::GenerateRowCommitVersion {
+                    field_name: "some_row_commit_version_col".to_string(),
+                }]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
     fn request_row_ids_conflicting_row_index_col_name() {
         // "row_indexes_for_row_id_0" conflicts with the first generated name for row indexes
         let schema = schema_ref! { nullable "row_indexes_for_row_id_0": STRING };
@@ -935,6 +1009,34 @@ pub(crate) mod tests {
         assert_result_error_with_message(
             res,
             "Generic delta kernel error: No delta.rowTracking.materializedRowIdColumnName key found in metadata configuration",
+        );
+
+        let schema = schema_ref! { nullable "id": STRING };
+        let res = get_state_info(
+            schema.clone(),
+            vec![],
+            None,
+            &[],
+            HashMap::new(),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        );
+        assert_result_error_with_message(
+            res,
+            "Unsupported: Row commit versions are not enabled on this table",
+        );
+
+        let res = get_state_info(
+            schema,
+            vec![],
+            None,
+            ROW_TRACKING_FEATURES,
+            get_string_map(&[("delta.enableRowTracking", "true")]),
+            vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
+        );
+        assert_result_error_with_message(
+            res,
+            "No delta.rowTracking.materializedRowCommitVersionColumnName key found in metadata \
+             configuration",
         );
     }
 

--- a/kernel/src/scan/state_info.rs
+++ b/kernel/src/scan/state_info.rs
@@ -72,7 +72,8 @@ struct MetadataInfo<'a> {
     /// the materializedRowIdColumnName extracted from the table config if row ids are requested,
     /// or None if they are not requested
     materialized_row_id_column_name: Option<&'a String>,
-    /// The physical column containing materialized Row Commit Versions, when requested.
+    /// the materializedRowCommitVersionColumnName extracted from the table config if row commit
+    /// versions are requested, or None if they are not requested
     materialized_row_commit_version_column_name: Option<&'a String>,
 }
 
@@ -331,8 +332,8 @@ impl StateInfo {
                             metadata_info.materialized_row_commit_version_column_name
                         else {
                             return Err(Error::internal_error(
-                                "A materialized Row Commit Version column name must be available \
-                                 when selecting Row Commit Versions",
+                                "missing materialized Row Commit Version column name when row \
+                                 tracking is enabled",
                             ));
                         };
 
@@ -814,6 +815,46 @@ pub(crate) mod tests {
     pub(crate) const ROW_TRACKING_FEATURES: &[TableFeature] =
         &[TableFeature::RowTracking, TableFeature::DomainMetadata];
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum RowTrackingState {
+        Unsupported,
+        SupportedNotEnabled,
+        Enabled,
+        Suspended,
+    }
+
+    impl RowTrackingState {
+        pub(crate) fn features(self) -> &'static [TableFeature] {
+            match self {
+                Self::Unsupported => &[],
+                Self::SupportedNotEnabled | Self::Enabled | Self::Suspended => {
+                    ROW_TRACKING_FEATURES
+                }
+            }
+        }
+
+        pub(crate) fn properties(self) -> HashMap<String, String> {
+            let mut properties = get_string_map(&[
+                (
+                    "delta.rowTracking.materializedRowIdColumnName",
+                    "row_id_col",
+                ),
+                (
+                    "delta.rowTracking.materializedRowCommitVersionColumnName",
+                    "row_commit_version_col",
+                ),
+            ]);
+            if self == Self::Enabled {
+                properties.insert("delta.enableRowTracking".to_string(), "true".to_string());
+            }
+            if self == Self::Suspended {
+                properties.insert("delta.enableRowTracking".to_string(), "false".to_string());
+                properties.insert("delta.rowTrackingSuspended".to_string(), "true".to_string());
+            }
+            properties
+        }
+    }
+
     fn get_string_map(slice: &[(&str, &str)]) -> HashMap<String, String> {
         slice
             .iter()
@@ -983,7 +1024,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn invalid_rowtracking_config() {
+    fn invalid_row_id_config() {
         let schema = schema_ref! { nullable "id": STRING };
 
         // Row IDs requested but row tracking not enabled → error
@@ -1010,21 +1051,33 @@ pub(crate) mod tests {
             res,
             "Generic delta kernel error: No delta.rowTracking.materializedRowIdColumnName key found in metadata configuration",
         );
+    }
 
+    #[rstest]
+    #[case::unsupported(RowTrackingState::Unsupported)]
+    #[case::supported_not_enabled(RowTrackingState::SupportedNotEnabled)]
+    #[case::suspended(RowTrackingState::Suspended)]
+    fn request_row_commit_versions_requires_enabled_row_tracking(
+        #[case] row_tracking_state: RowTrackingState,
+    ) {
         let schema = schema_ref! { nullable "id": STRING };
         let res = get_state_info(
-            schema.clone(),
+            schema,
             vec![],
             None,
-            &[],
-            HashMap::new(),
+            row_tracking_state.features(),
+            row_tracking_state.properties(),
             vec![("row_commit_version", MetadataColumnSpec::RowCommitVersion)],
         );
         assert_result_error_with_message(
             res,
             "Unsupported: Row commit versions are not enabled on this table",
         );
+    }
 
+    #[test]
+    fn request_row_commit_versions_requires_materialized_column_name() {
+        let schema = schema_ref! { nullable "id": STRING };
         let res = get_state_info(
             schema,
             vec![],

--- a/kernel/src/scan/test_utils.rs
+++ b/kernel/src/scan/test_utils.rs
@@ -75,11 +75,11 @@ pub(crate) fn add_batch_simple(output_schema: SchemaRef) -> Box<ArrowEngineData>
 
 // Generates a batch with an add action.
 // The schema is provided as null columns affect equality checks.
-pub(crate) fn add_batch_for_row_id(output_schema: SchemaRef) -> Box<ArrowEngineData> {
+pub(crate) fn add_batch_for_row_tracking(output_schema: SchemaRef) -> Box<ArrowEngineData> {
     parse_batch(
         [
-            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId": 42, "tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
-            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col"},"createdTime":1677811175819}}"#,
+            r#"{"add":{"path":"part-00000-fae5310a-a37d-4e51-827b-c3d5516560ca-c000.snappy.parquet","partitionValues": {"date": "2017-12-10"},"size":635,"modificationTime":1677811178336,"dataChange":true,"stats":"{\"numRecords\":10,\"minValues\":{\"value\":0},\"maxValues\":{\"value\":9},\"nullCount\":{\"value\":0},\"tightBounds\":true}","baseRowId":42,"defaultRowCommitVersion":5,"tags":{"INSERTION_TIME":"1677811178336000","MIN_INSERTION_TIME":"1677811178336000","MAX_INSERTION_TIME":"1677811178336000","OPTIMIZE_TARGET_SIZE":"268435456"},"deletionVector":{"storageType":"u","pathOrInlineDv":"vBn[lx{q8@P<9BNH/isA","offset":1,"sizeInBytes":36,"cardinality":2}}}"#,
+            r#"{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{"delta.enableDeletionVectors":"true","delta.columnMapping.mode":"none", "delta.enableRowTracking": "true", "delta.rowTracking.materializedRowIdColumnName":"row_id_col", "delta.rowTracking.materializedRowCommitVersionColumnName":"row_commit_version_col"},"createdTime":1677811175819}}"#,
         ],
         output_schema,
     )

--- a/kernel/src/scan/tests.rs
+++ b/kernel/src/scan/tests.rs
@@ -524,10 +524,12 @@ fn test_without_row_transforms_rejects_execute() {
     );
 }
 
-/// Row commit version metadata columns are unsupported by scans, so requesting one errors at
-/// build time regardless of `without_row_transforms`.
+/// Row commit version metadata columns require a row-tracking-enabled table, including when row
+/// transforms are disabled.
 #[rstest]
-fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_transforms: bool) {
+fn test_scan_rejects_row_commit_version_when_row_tracking_is_disabled(
+    #[values(false, true)] without_row_transforms: bool,
+) {
     let (_engine, snapshot) = without_transforms_snapshot("./tests/data/basic_partitioned/");
     let schema = Arc::new(
         snapshot
@@ -541,10 +543,10 @@ fn test_scan_rejects_row_commit_version(#[values(false, true)] without_row_trans
     }
     let err = builder
         .build()
-        .expect_err("row commit version columns are unsupported by scans");
+        .expect_err("row commit version columns require row tracking");
     assert!(
         err.to_string()
-            .contains("Row commit versions not supported"),
+            .contains("Row commit versions are not enabled on this table"),
         "unexpected error: {err}"
     );
 }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -23,6 +23,13 @@ use crate::{DeltaResult, Error};
 // description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
+/// File metadata used to reconstruct stable row tracking values.
+#[derive(Debug, Default)]
+pub(crate) struct FileRowTrackingMetadata {
+    pub(crate) base_row_id: Option<i64>,
+    pub(crate) default_row_commit_version: Option<i64>,
+}
+
 /// Describes a single field transformation to apply when converting physical data to logical
 /// schema.
 ///
@@ -49,6 +56,11 @@ pub(crate) enum FieldTransformSpec {
         field_name: String,
         /// column name which contains row indexes
         row_index_field_name: String,
+    },
+    /// Generate the stable Row Commit Version column.
+    GenerateRowCommitVersion {
+        /// Column containing the materialized Row Commit Version.
+        field_name: String,
     },
     /// Insert a partition column after the named input column.
     /// The partition column is identified by its field index in the logical table schema.
@@ -109,6 +121,7 @@ pub(crate) fn parse_partition_values(
             FieldTransformSpec::DynamicColumn { .. }
             | FieldTransformSpec::StaticInsert { .. }
             | FieldTransformSpec::GenerateRowId { .. }
+            | FieldTransformSpec::GenerateRowCommitVersion { .. }
             | FieldTransformSpec::StaticDrop { .. } => None,
         })
         .try_collect()
@@ -123,7 +136,7 @@ pub(crate) fn get_transform_expr(
     transform_spec: &TransformSpec,
     mut metadata_values: HashMap<usize, (String, Scalar)>,
     physical_schema: &StructType,
-    base_row_id: Option<i64>,
+    row_tracking_metadata: FileRowTrackingMetadata,
 ) -> DeltaResult<ExpressionRef> {
     let mut patch = ExpressionStructPatchBuilder::new();
 
@@ -138,12 +151,25 @@ pub(crate) fn get_transform_expr(
                 field_name,
                 row_index_field_name,
             } => {
-                let base_row_id = base_row_id.ok_or_else(|| {
+                let base_row_id = row_tracking_metadata.base_row_id.ok_or_else(|| {
                     Error::generic("Asked to generate RowIds, but no baseRowId found.")
                 })?;
                 let expr = Arc::new(Expression::coalesce([
                     Expression::column([field_name]),
                     lit(base_row_id) + Expression::column([row_index_field_name]),
+                ]));
+                patch.replace(field_name.clone(), expr)
+            }
+            GenerateRowCommitVersion { field_name } => {
+                let missing_default = Error::missing_data(
+                    "Missing defaultRowCommitVersion for Row Commit Version reconstruction",
+                );
+                let default_row_commit_version = row_tracking_metadata
+                    .default_row_commit_version
+                    .ok_or(missing_default)?;
+                let expr = Arc::new(Expression::coalesce([
+                    Expression::column([field_name]),
+                    lit(default_row_commit_version),
                 ]));
                 patch.replace(field_name.clone(), expr)
             }
@@ -391,7 +417,7 @@ mod tests {
             &transform_spec,
             partition_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         assert_result_error_with_message(result, "missing partition value");
     }
@@ -419,7 +445,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         )
         .unwrap();
 
@@ -461,7 +487,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -508,7 +534,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -545,7 +571,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -584,7 +610,7 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            None, /* base_row_id */
+            FileRowTrackingMetadata::default(),
         );
         assert_result_error_with_message(result, "missing partition value for dynamic column");
     }
@@ -607,7 +633,10 @@ mod tests {
             &transform_spec,
             metadata_values,
             &physical_schema,
-            Some(4), /* base_row_id */
+            FileRowTrackingMetadata {
+                base_row_id: Some(4),
+                ..Default::default()
+            },
         );
         let patch_expr = result.expect("StructPatch expression should be created successfully");
 
@@ -649,9 +678,66 @@ mod tests {
                 &transform_spec,
                 metadata_values,
                 &physical_schema,
-                None, /* base_row_id */
+                FileRowTrackingMetadata::default(),
             ),
             "Asked to generate RowIds, but no baseRowId found",
+        );
+    }
+
+    #[test]
+    fn get_transform_expr_generates_stable_row_commit_versions() -> DeltaResult<()> {
+        let transform_spec = vec![FieldTransformSpec::GenerateRowCommitVersion {
+            field_name: "row_commit_version_col".to_string(),
+        }];
+        let physical_schema = schema! {
+            nullable "id": STRING,
+            nullable "row_commit_version_col": LONG,
+        };
+
+        let expression = get_transform_expr(
+            &transform_spec,
+            HashMap::new(),
+            &physical_schema,
+            FileRowTrackingMetadata {
+                default_row_commit_version: Some(5),
+                ..Default::default()
+            },
+        )?;
+        let Expression::StructPatch(patch) = expression.as_ref() else {
+            panic!("Expected StructPatch expression");
+        };
+        let row_commit_version_patch = patch
+            .field_patches
+            .get("row_commit_version_col")
+            .expect("Should have row_commit_version_col patch");
+        assert!(!row_commit_version_patch.keep_input);
+        assert_eq!(
+            row_commit_version_patch.insertions,
+            [Arc::new(Expression::coalesce([
+                col!("row_commit_version_col"),
+                lit(5i64),
+            ]))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn get_transform_expr_rejects_missing_default_row_commit_version() {
+        let transform_spec = vec![FieldTransformSpec::GenerateRowCommitVersion {
+            field_name: "row_commit_version_col".to_string(),
+        }];
+        let physical_schema = schema! {
+            nullable "row_commit_version_col": LONG,
+        };
+
+        assert_result_error_with_message(
+            get_transform_expr(
+                &transform_spec,
+                HashMap::new(),
+                &physical_schema,
+                FileRowTrackingMetadata::default(),
+            ),
+            "Missing defaultRowCommitVersion",
         );
     }
 }

--- a/kernel/src/scan/transform_spec.rs
+++ b/kernel/src/scan/transform_spec.rs
@@ -23,7 +23,6 @@ use crate::{DeltaResult, Error};
 // description for that concept.
 pub(crate) type TransformSpec = Vec<FieldTransformSpec>;
 
-/// File metadata used to reconstruct stable row tracking values.
 #[derive(Debug, Default)]
 pub(crate) struct FileRowTrackingMetadata {
     pub(crate) base_row_id: Option<i64>,
@@ -161,12 +160,11 @@ pub(crate) fn get_transform_expr(
                 patch.replace(field_name.clone(), expr)
             }
             GenerateRowCommitVersion { field_name } => {
-                let missing_default = Error::missing_data(
-                    "Missing defaultRowCommitVersion for Row Commit Version reconstruction",
-                );
                 let default_row_commit_version = row_tracking_metadata
                     .default_row_commit_version
-                    .ok_or(missing_default)?;
+                    .ok_or(Error::missing_data(
+                    "Missing defaultRowCommitVersion for Row Commit Version reconstruction",
+                ))?;
                 let expr = Arc::new(Expression::coalesce([
                     Expression::column([field_name]),
                     lit(default_row_commit_version),

--- a/kernel/src/table_changes/physical_to_logical.rs
+++ b/kernel/src/table_changes/physical_to_logical.rs
@@ -4,7 +4,9 @@ use super::scan_file::{CdfScanFile, CdfScanFileType};
 use super::{CHANGE_TYPE_COL_NAME, COMMIT_TIMESTAMP_COL_NAME, COMMIT_VERSION_COL_NAME};
 use crate::expressions::Scalar;
 use crate::scan::state_info::StateInfo;
-use crate::scan::transform_spec::{get_transform_expr, parse_partition_values};
+use crate::scan::transform_spec::{
+    get_transform_expr, parse_partition_values, FileRowTrackingMetadata,
+};
 use crate::schema::{schema_ref, SchemaRef, StructType};
 use crate::{DeltaResult, Error, ExpressionRef};
 
@@ -121,7 +123,7 @@ pub(crate) fn get_cdf_transform_expr(
         transform_spec,
         partition_values,
         physical_schema,
-        None, /* base_row_id */
+        FileRowTrackingMetadata::default(),
     )
     .map(Some)
 }

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use delta_kernel::actions::deletion_vector_writer::KernelDeletionVector;
 use delta_kernel::arrow::array::{Array, AsArray, Int32Array, Int64Array, StringArray};
-use delta_kernel::arrow::datatypes::{Int32Type, Int64Type, Schema as ArrowSchema};
+use delta_kernel::arrow::datatypes::{
+    DataType as ArrowDataType, Field, Int32Type, Int64Type, Schema as ArrowSchema,
+};
 use delta_kernel::arrow::record_batch::RecordBatch;
 use delta_kernel::engine::arrow_conversion::TryIntoArrow;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -20,9 +22,10 @@ use tempfile::{tempdir, TempDir};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    begin_transaction, collect_row_ids, create_default_engine_mt_executor, create_table,
-    engine_store_setup, load_and_begin_transaction, read_actions_from_commit, read_add_infos,
-    read_scan, test_read,
+    add_commit, begin_transaction, collect_row_ids, create_default_engine_mt_executor,
+    create_table, engine_store_setup, get_materialized_row_tracking_column_names,
+    load_and_begin_transaction, read_actions_from_commit, read_add_infos, read_scan,
+    record_batch_to_bytes, test_read,
 };
 use url::Url;
 
@@ -866,6 +869,19 @@ fn read_row_id_scan(
     read_scan(&scan, engine)
 }
 
+fn read_row_commit_version_scan(
+    snapshot: Arc<Snapshot>,
+    engine: Arc<dyn delta_kernel::Engine>,
+) -> DeltaResult<Vec<RecordBatch>> {
+    let scan_schema = Arc::new(
+        snapshot
+            .schema()
+            .add_metadata_column("row_commit_version", MetadataColumnSpec::RowCommitVersion)?,
+    );
+    let scan = snapshot.scan_builder().with_schema(scan_schema).build()?;
+    read_scan(&scan, engine)
+}
+
 /// Basic read: write one file with 3 rows, verify row IDs are sequential starting from 0.
 #[tokio::test]
 async fn test_read_row_ids_basic() -> DeltaResult<()> {
@@ -886,6 +902,101 @@ async fn test_read_row_ids_basic() -> DeltaResult<()> {
     row_ids.sort_unstable();
     assert_eq!(row_ids, vec![0, 1, 2], "Row IDs must be sequential from 0");
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_read_row_commit_versions_use_add_action_defaults() -> DeltaResult<()> {
+    let tmp_dir = tempdir()?;
+    let (schema, table_url, engine, _store) =
+        setup_number_table(&tmp_dir, "test_read_row_commit_versions").await?;
+
+    let first_commit = generate_data(schema.clone(), [vec![int32_array(vec![10, 20])]])?;
+    write_data_to_table(&table_url, engine.clone(), first_commit)
+        .await?
+        .unwrap_committed();
+    let second_commit = generate_data(schema, [vec![int32_array(vec![30])]])?;
+    write_data_to_table(&table_url, engine.clone(), second_commit)
+        .await?
+        .unwrap_committed();
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let batches = read_row_commit_version_scan(snapshot, engine)?;
+    let mut actual = HashMap::new();
+    for batch in batches {
+        let numbers = batch
+            .column_by_name("number")
+            .expect("number column not found")
+            .as_primitive::<Int32Type>();
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        for row in 0..batch.num_rows() {
+            actual.insert(numbers.value(row), row_commit_versions.value(row));
+        }
+    }
+
+    assert_eq!(actual, HashMap::from([(10, 1), (20, 1), (30, 2)]));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_read_row_commit_versions_prefer_materialized_values(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempdir()?;
+    let (_schema, table_url, engine, store) =
+        setup_number_table(&tmp_dir, "test_read_materialized_row_commit_versions").await?;
+    let materialized_column_name = get_materialized_row_tracking_column_names(&table_url, 0)?
+        .row_commit_version_column_name
+        .ok_or_else(|| Error::generic("Materialized Row Commit Version column name not found"))?;
+    let batch = RecordBatch::try_new(
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("number", ArrowDataType::Int32, true),
+            Field::new(&materialized_column_name, ArrowDataType::Int64, true),
+        ])),
+        vec![
+            Arc::new(Int32Array::from(vec![10, 20])),
+            Arc::new(Int64Array::from(vec![Some(7), None])),
+        ],
+    )?;
+    let parquet_bytes = record_batch_to_bytes(&batch);
+    let parquet_size = parquet_bytes.len();
+    let data_path = "materialized-row-commit-versions.parquet";
+    let data_url = table_url.join(data_path)?;
+    store
+        .put(&Path::from_url_path(data_url.path())?, parquet_bytes.into())
+        .await?;
+    add_commit(
+        table_url.as_str(),
+        store.as_ref(),
+        1,
+        format!(
+            r#"{{"domainMetadata":{{"domain":"delta.rowTracking","configuration":"{{\"rowIdHighWaterMark\":1}}","removed":false}}}}
+{{"add":{{"path":"{data_path}","partitionValues":{{}},"size":{},"modificationTime":0,"dataChange":true,"baseRowId":0,"defaultRowCommitVersion":1}}}}"#,
+            parquet_size
+        ),
+    )
+    .await?;
+
+    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
+    let batches = read_row_commit_version_scan(snapshot, engine)?;
+    let mut actual = HashMap::new();
+    for batch in batches {
+        let numbers = batch
+            .column_by_name("number")
+            .expect("number column not found")
+            .as_primitive::<Int32Type>();
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        for row in 0..batch.num_rows() {
+            actual.insert(numbers.value(row), row_commit_versions.value(row));
+        }
+    }
+
+    assert_eq!(actual, HashMap::from([(10, 7), (20, 1)]));
     Ok(())
 }
 
@@ -1088,7 +1199,8 @@ async fn test_read_row_ids_multiple_commits() -> DeltaResult<()> {
     Ok(())
 }
 
-/// After checkpoint: row IDs survive a checkpoint and new writes continue from the high watermark.
+/// Row IDs and Row Commit Versions survive a checkpoint, and later writes continue from the high
+/// watermark.
 ///
 /// Uses a multi-threaded runtime and `TokioMultiThreadExecutor` for checkpoint because
 /// `checkpoint()` consumes a lazy iterator inside a `block_on()` future where each item read
@@ -1097,7 +1209,7 @@ async fn test_read_row_ids_multiple_commits() -> DeltaResult<()> {
 /// instead, which requires a multi-threaded runtime to delegate work to other workers.
 /// Writes use the standard `TokioBackgroundExecutor` engine, matching all other tests in this file.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
+async fn test_read_row_tracking_values_after_checkpoint() -> DeltaResult<()> {
     let _ = tracing_subscriber::fmt::try_init();
     let tmp_dir = tempdir()?;
     let (schema, table_url, engine, _store) =
@@ -1117,7 +1229,7 @@ async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
 
     // Fresh snapshot loaded from the checkpoint must return the same row IDs.
     let fresh_snapshot = Snapshot::builder_for(table_url.clone()).build(mt_engine.as_ref())?;
-    let batches = read_row_id_scan(fresh_snapshot, mt_engine.clone())?;
+    let batches = read_row_id_scan(fresh_snapshot.clone(), mt_engine.clone())?;
 
     let mut ids_after_ckpt = collect_row_ids(&batches);
     ids_after_ckpt.sort_unstable();
@@ -1126,6 +1238,16 @@ async fn test_read_row_ids_after_checkpoint() -> DeltaResult<()> {
         vec![0, 1, 2],
         "Row IDs must be unchanged after loading from checkpoint"
     );
+
+    let row_commit_version_batches =
+        read_row_commit_version_scan(fresh_snapshot, mt_engine.clone())?;
+    for batch in row_commit_version_batches {
+        let row_commit_versions = batch
+            .column_by_name("row_commit_version")
+            .expect("row_commit_version column not found")
+            .as_primitive::<Int64Type>();
+        assert!(row_commit_versions.iter().all(|version| version == Some(1)));
+    }
 
     // Write 2 more rows -> must continue from watermark, no resets or duplicates.
     let data2 = generate_data(schema.clone(), [vec![int32_array(vec![4, 5])]])?;

--- a/kernel/tests/integration/features/row_tracking.rs
+++ b/kernel/tests/integration/features/row_tracking.rs
@@ -22,15 +22,17 @@ use tempfile::{tempdir, TempDir};
 use test_utils::delta_kernel_default_engine::executor::tokio::TokioBackgroundExecutor;
 use test_utils::delta_kernel_default_engine::DefaultEngine;
 use test_utils::{
-    add_commit, begin_transaction, collect_row_ids, create_default_engine_mt_executor,
-    create_table, engine_store_setup, get_materialized_row_tracking_column_names,
-    load_and_begin_transaction, read_actions_from_commit, read_add_infos, read_scan,
-    record_batch_to_bytes, test_read,
+    add_commit, assert_result_error_with_message, begin_transaction, collect_row_ids,
+    create_default_engine_mt_executor, create_table, create_table_and_load_snapshot,
+    engine_store_setup, get_materialized_row_tracking_column_names, load_and_begin_transaction,
+    read_actions_from_commit, read_add_infos, read_scan, record_batch_to_bytes, test_read,
+    test_table_setup,
 };
 use url::Url;
 
 use crate::common::write_utils::{
-    create_dv_update_transaction, get_scan_files, write_deletion_vector_to_store,
+    create_dv_update_transaction, get_scan_files, set_table_properties,
+    write_deletion_vector_to_store,
 };
 
 /// Helper function to create a simple table with row tracking enabled.
@@ -905,11 +907,44 @@ async fn test_read_row_ids_basic() -> DeltaResult<()> {
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RowTrackingTestCase {
+    Enabled,
+    Unsupported,
+    Supported,
+    Suspended,
+}
+
+impl RowTrackingTestCase {
+    fn create_table_properties(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            // Create-table rejects suspension, so suspend this case after writing.
+            Self::Enabled | Self::Suspended => &[("delta.enableRowTracking", "true")],
+            Self::Supported => &[("delta.feature.rowTracking", "supported")],
+            Self::Unsupported => &[],
+        }
+    }
+}
+
+#[rstest]
+#[case::enabled(RowTrackingTestCase::Enabled)]
+#[case::unsupported(RowTrackingTestCase::Unsupported)]
+#[case::supported(RowTrackingTestCase::Supported)]
+#[case::suspended(RowTrackingTestCase::Suspended)]
 #[tokio::test]
-async fn test_read_row_commit_versions_use_add_action_defaults() -> DeltaResult<()> {
-    let tmp_dir = tempdir()?;
-    let (schema, table_url, engine, _store) =
-        setup_number_table(&tmp_dir, "test_read_row_commit_versions").await?;
+async fn test_read_row_commit_versions_use_add_action_defaults(
+    #[case] test_case: RowTrackingTestCase,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (_temp_dir, table_path, engine) = test_table_setup()?;
+    let schema = schema_ref! { nullable "number": INTEGER };
+    let table_url = Url::from_directory_path(&table_path)
+        .map_err(|_| Error::generic("Failed to convert table path to URL"))?;
+    create_table_and_load_snapshot(
+        &table_path,
+        schema.clone(),
+        engine.as_ref(),
+        test_case.create_table_properties(),
+    )?;
 
     let first_commit = generate_data(schema.clone(), [vec![int32_array(vec![10, 20])]])?;
     write_data_to_table(&table_url, engine.clone(), first_commit)
@@ -920,10 +955,31 @@ async fn test_read_row_commit_versions_use_add_action_defaults() -> DeltaResult<
         .await?
         .unwrap_committed();
 
-    let snapshot = Snapshot::builder_for(table_url).build(engine.as_ref())?;
-    let batches = read_row_commit_version_scan(snapshot, engine)?;
+    let snapshot = if test_case == RowTrackingTestCase::Suspended {
+        set_table_properties(
+            &table_path,
+            &table_url,
+            engine.as_ref(),
+            2, /* current_version */
+            &[
+                ("delta.enableRowTracking", "false"),
+                ("delta.rowTrackingSuspended", "true"),
+            ],
+        )?
+    } else {
+        Snapshot::builder_for(table_url).build(engine.as_ref())?
+    };
+    let batches = read_row_commit_version_scan(snapshot, engine);
+    if test_case != RowTrackingTestCase::Enabled {
+        assert_result_error_with_message(
+            batches,
+            "Row commit versions are not enabled on this table",
+        );
+        return Ok(());
+    }
+
     let mut actual = HashMap::new();
-    for batch in batches {
+    for batch in batches? {
         let numbers = batch
             .column_by_name("number")
             .expect("number column not found")
@@ -1199,8 +1255,8 @@ async fn test_read_row_ids_multiple_commits() -> DeltaResult<()> {
     Ok(())
 }
 
-/// Row IDs and Row Commit Versions survive a checkpoint, and later writes continue from the high
-/// watermark.
+/// Row IDs and Row Commit Versions survive a checkpoint, and Row IDs from later writes continue
+/// from the high watermark.
 ///
 /// Uses a multi-threaded runtime and `TokioMultiThreadExecutor` for checkpoint because
 /// `checkpoint()` consumes a lazy iterator inside a `block_on()` future where each item read

--- a/kernel/tests/integration/read/mod.rs
+++ b/kernel/tests/integration/read/mod.rs
@@ -2000,7 +2000,7 @@ async fn test_unsupported_metadata_columns() -> Result<(), Box<dyn std::error::E
         (
             "row_commit_version",
             MetadataColumnSpec::RowCommitVersion,
-            "Row commit versions not supported",
+            "Row commit versions are not enabled on this table",
         ),
     ];
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Support reading [stable row commit version](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-commit-versions) by generating the column in physical-to-logical transform
<!--
**Uncomment** this section if there are any changes affecting public APIs. Else, **delete** this section.
### This PR affects the following public APIs
If there are breaking changes, please ensure the `breaking-changes` label gets added by CI, and describe why the changes are needed.
Note that _new_ public APIs are not considered breaking.
-->

## How was this change tested?
